### PR TITLE
Make sidebar, status bar, and post-delete selection respect active-only visibility filter (Fixes #43)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -132,10 +132,9 @@ fn delete_selected_repository(state: &mut AppState, repository_id: &jefe::domain
 
         let selected_repo_id = state.repositories[next_repo_idx].id.clone();
         state.selected_agent_index = state
-            .agents
-            .iter()
-            .enumerate()
-            .find_map(|(idx, agent)| (agent.repository_id == selected_repo_id).then_some(idx));
+            .agent_indices_for_repository(&selected_repo_id)
+            .first()
+            .copied();
 
         if state.selected_agent_index.is_none() {
             state.pane_focus = PaneFocus::Repositories;
@@ -177,13 +176,9 @@ fn delete_selected_agent(
         .selected_repository_index
         .and_then(|idx| state.repositories.get(idx).map(|r| r.id.clone()));
 
-    state.selected_agent_index = selected_repo_id.as_ref().and_then(|repo_id| {
-        state
-            .agents
-            .iter()
-            .enumerate()
-            .find_map(|(idx, agent)| (&agent.repository_id == repo_id).then_some(idx))
-    });
+    state.selected_agent_index = selected_repo_id
+        .as_ref()
+        .and_then(|repo_id| state.agent_indices_for_repository(repo_id).first().copied());
 
     if state.selected_agent_index.is_none() {
         state.pane_focus = PaneFocus::Repositories;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -222,6 +222,21 @@ impl AppState {
             .collect()
     }
 
+    /// Count of visible agents for a repository, respecting the idle filter.
+    #[must_use]
+    pub fn visible_agent_count_for_repository(&self, repository_id: &RepositoryId) -> usize {
+        self.agent_indices_for_repository(repository_id).len()
+    }
+
+    /// Total count of visible agents across all repositories.
+    #[must_use]
+    pub fn visible_agent_count(&self) -> usize {
+        self.agents
+            .iter()
+            .filter(|agent| self.is_agent_visible_with_idle_filter(agent))
+            .count()
+    }
+
     pub fn rebuild_repository_agent_ids(&mut self) {
         for repository in &mut self.repositories {
             repository.agent_ids.clear();

--- a/src/ui/components/sidebar.rs
+++ b/src/ui/components/sidebar.rs
@@ -13,6 +13,8 @@ use crate::theme::{ResolvedColors, ThemeColors};
 pub struct SidebarProps {
     /// List of repositories.
     pub repositories: Vec<Repository>,
+    /// Visible agent counts per repository (parallel to `repositories`).
+    pub agent_counts: Vec<usize>,
     /// Currently selected repository index.
     pub selected: usize,
     /// Whether this pane is focused.
@@ -55,7 +57,8 @@ pub fn Sidebar(props: &SidebarProps) -> impl Into<AnyElement<'static>> {
                 #(props.repositories.iter().enumerate().map(|(i, repo)| {
                     let selected = i == props.selected;
                     let prefix = if selected { "> " } else { "  " };
-                    let agent_count = repo.agent_ids.len();
+                    let agent_count = props.agent_counts.get(i).copied()
+                        .unwrap_or(repo.agent_ids.len());
                     let label = format!("{}{} ({})", prefix, repo.name, agent_count);
                     if selected {
                         element! {

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -59,9 +59,10 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
     }
 
     // Extract state values with defaults
-    let repo_count = state.map_or(0, |s| s.repositories.len());
+    let visible_repo_indices = state.map_or_else(Vec::new, AppState::visible_repository_indices);
+    let repo_count = visible_repo_indices.len();
     let running_count = state.map_or(0, |s| s.agents.iter().filter(|a| a.is_running()).count());
-    let agent_count = state.map_or(0, |s| s.agents.len());
+    let agent_count = state.map_or(0, AppState::visible_agent_count);
     let selected_repo_idx = state
         .and_then(AppState::selected_repository_visible_index)
         .unwrap_or(0);
@@ -71,10 +72,20 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
     let pane_focus = state.map_or(PaneFocus::Repositories, |s| s.pane_focus);
     let terminal_focused = state.is_some_and(|s| s.terminal_focused);
 
-    let repositories = state.map_or_else(Vec::new, |s| {
-        s.visible_repository_indices()
+    let repositories: Vec<_> = state.map_or_else(Vec::new, |s| {
+        visible_repo_indices
             .iter()
             .filter_map(|idx| s.repositories.get(*idx).cloned())
+            .collect()
+    });
+    let agent_counts: Vec<usize> = state.map_or_else(Vec::new, |s| {
+        visible_repo_indices
+            .iter()
+            .filter_map(|idx| {
+                s.repositories
+                    .get(*idx)
+                    .map(|repo| s.visible_agent_count_for_repository(&repo.id))
+            })
             .collect()
     });
     let agents = state.map_or_else(Vec::new, |s| {
@@ -115,6 +126,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                 Box(width: 22u32, height: 100pct) {
                     Sidebar(
                         repositories: repositories,
+                        agent_counts: agent_counts,
                         selected: selected_repo_idx,
                         focused: !terminal_focused && pane_focus == PaneFocus::Repositories,
                         colors: colors.clone(),

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -38,18 +38,29 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
     let selected_repo_idx = state
         .and_then(AppState::selected_repository_visible_index)
         .unwrap_or(0);
-    let repositories = state.map_or_else(Vec::new, |s| {
-        s.visible_repository_indices()
+    let visible_repo_indices = state.map_or_else(Vec::new, AppState::visible_repository_indices);
+    let repositories: Vec<_> = state.map_or_else(Vec::new, |s| {
+        visible_repo_indices
             .iter()
             .filter_map(|idx| s.repositories.get(*idx).cloned())
+            .collect()
+    });
+    let agent_counts: Vec<usize> = state.map_or_else(Vec::new, |s| {
+        visible_repo_indices
+            .iter()
+            .filter_map(|idx| {
+                s.repositories
+                    .get(*idx)
+                    .map(|repo| s.visible_agent_count_for_repository(&repo.id))
+            })
             .collect()
     });
     let pane_focus = state.map_or(PaneFocus::Repositories, |s| s.pane_focus);
 
     // ── Status bar data ─────────────────────────────────────────────────────
-    let repo_count = state.map_or(0, |s| s.repositories.len());
+    let repo_count = visible_repo_indices.len();
     let running_count = state.map_or(0, |s| s.agents.iter().filter(|a| a.is_running()).count());
-    let agent_count = state.map_or(0, |s| s.agents.len());
+    let agent_count = state.map_or(0, AppState::visible_agent_count);
 
     // ── Issues state ────────────────────────────────────────────────────────
     let issue_focus = state.map_or(IssueFocus::IssueList, |s| s.issues_state.issue_focus);
@@ -119,6 +130,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                 Box(width: 22u32, height: 100pct) {
                     Sidebar(
                         repositories: repositories,
+                        agent_counts: agent_counts,
                         selected: selected_repo_idx,
                         focused: sidebar_focused,
                         colors: colors.clone(),

--- a/src/ui/screens/split.rs
+++ b/src/ui/screens/split.rs
@@ -41,13 +41,24 @@ pub struct SplitScreenProps {
 pub fn SplitScreen(props: &SplitScreenProps) -> impl Into<AnyElement<'static>> {
     let state = props.state.as_ref();
 
-    let repo_count = state.map_or(0, |s| s.repositories.len());
+    let visible_repo_indices = state.map_or_else(Vec::new, AppState::visible_repository_indices);
+    let repo_count = visible_repo_indices.len();
     let running_count = state.map_or(0, |s| s.agents.iter().filter(|a| a.is_running()).count());
-    let agent_count = state.map_or(0, |s| s.agents.len());
-    let repositories = state.map_or_else(Vec::new, |s| {
-        s.visible_repository_indices()
+    let agent_count = state.map_or(0, AppState::visible_agent_count);
+    let repositories: Vec<_> = state.map_or_else(Vec::new, |s| {
+        visible_repo_indices
             .iter()
             .filter_map(|idx| s.repositories.get(*idx).cloned())
+            .collect()
+    });
+    let agent_counts: Vec<usize> = state.map_or_else(Vec::new, |s| {
+        visible_repo_indices
+            .iter()
+            .filter_map(|idx| {
+                s.repositories
+                    .get(*idx)
+                    .map(|repo| s.visible_agent_count_for_repository(&repo.id))
+            })
             .collect()
     });
     let selected_repo_idx = state
@@ -110,7 +121,9 @@ pub fn SplitScreen(props: &SplitScreenProps) -> impl Into<AnyElement<'static>> {
                     #(repositories.iter().enumerate().map(|(i, repo)| {
                         let selected = i == selected_repo_idx;
                         let prefix = if selected { "> " } else { "  " };
-                        let line = format!("{}{} ({} agents)", prefix, repo.name, repo.agent_ids.len());
+                        let visible_count = agent_counts.get(i).copied()
+                            .unwrap_or(repo.agent_ids.len());
+                        let line = format!("{}{} ({} agents)", prefix, repo.name, visible_count);
                         if selected {
                             element! {
                                 Box(height: 1u32, background_color: rc.sel_bg) {

--- a/tests/core/visibility_filter_contracts.rs
+++ b/tests/core/visibility_filter_contracts.rs
@@ -245,3 +245,134 @@ fn delete_targets_correct_agent_when_idle_hidden() {
         other => panic!("expected ConfirmDeleteAgent, got {other:?}"),
     }
 }
+
+#[test]
+fn visible_agent_count_includes_all_when_filter_off() {
+    let state = AppState {
+        repositories: vec![Repository::new(
+            RepositoryId("r1".into()),
+            "R1".into(),
+            "r1".into(),
+            PathBuf::from("/r1"),
+        )],
+        agents: vec![
+            Agent::new(
+                AgentId("idle1".into()),
+                RepositoryId("r1".into()),
+                "Idle A".into(),
+                PathBuf::from("/r1/idle1"),
+            ),
+            {
+                let mut a = Agent::new(
+                    AgentId("run1".into()),
+                    RepositoryId("r1".into()),
+                    "Running B".into(),
+                    PathBuf::from("/r1/run1"),
+                );
+                a.status = AgentStatus::Running;
+                a
+            },
+        ],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Agents,
+        ..AppState::default()
+    };
+
+    assert_eq!(state.visible_agent_count(), 2);
+    assert_eq!(
+        state.visible_agent_count_for_repository(&RepositoryId("r1".into())),
+        2
+    );
+}
+
+#[test]
+fn visible_agent_count_excludes_inactive_when_filter_on() {
+    let state = AppState {
+        repositories: vec![Repository::new(
+            RepositoryId("r1".into()),
+            "R1".into(),
+            "r1".into(),
+            PathBuf::from("/r1"),
+        )],
+        agents: vec![
+            Agent::new(
+                AgentId("idle1".into()),
+                RepositoryId("r1".into()),
+                "Idle A".into(),
+                PathBuf::from("/r1/idle1"),
+            ),
+            {
+                let mut a = Agent::new(
+                    AgentId("run1".into()),
+                    RepositoryId("r1".into()),
+                    "Running B".into(),
+                    PathBuf::from("/r1/run1"),
+                );
+                a.status = AgentStatus::Running;
+                a
+            },
+        ],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(1),
+        pane_focus: PaneFocus::Agents,
+        ..AppState::default()
+    };
+
+    let hidden = state.apply(AppEvent::ToggleHideIdleRepositories);
+    assert_eq!(hidden.visible_agent_count(), 1);
+    assert_eq!(
+        hidden.visible_agent_count_for_repository(&RepositoryId("r1".into())),
+        1
+    );
+}
+
+#[test]
+fn visible_repo_count_matches_visible_repository_indices() {
+    let state = AppState {
+        repositories: vec![
+            Repository::new(
+                RepositoryId("r1".into()),
+                "R1".into(),
+                "r1".into(),
+                PathBuf::from("/r1"),
+            ),
+            Repository::new(
+                RepositoryId("r2".into()),
+                "R2".into(),
+                "r2".into(),
+                PathBuf::from("/r2"),
+            ),
+        ],
+        agents: vec![
+            {
+                let mut a = Agent::new(
+                    AgentId("run1".into()),
+                    RepositoryId("r1".into()),
+                    "Running A".into(),
+                    PathBuf::from("/r1/run1"),
+                );
+                a.status = AgentStatus::Running;
+                a
+            },
+            Agent::new(
+                AgentId("idle1".into()),
+                RepositoryId("r2".into()),
+                "Idle B".into(),
+                PathBuf::from("/r2/idle1"),
+            ),
+        ],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Repositories,
+        ..AppState::default()
+    };
+
+    // Filter off: both repos visible
+    assert_eq!(state.visible_repository_indices().len(), 2);
+
+    // Filter on: only r1 visible (has running agent)
+    let hidden = state.apply(AppEvent::ToggleHideIdleRepositories);
+    assert_eq!(hidden.visible_repository_indices().len(), 1);
+    assert_eq!(hidden.visible_repository_indices()[0], 0);
+}


### PR DESCRIPTION
## Summary

When the `v` active-only filter (`hide_idle_repositories`) was enabled, several UI elements still reflected unfiltered agent/repo data:

1. **Sidebar agent counts** showed total agents per repo (including inactive) instead of visible-only count
2. **Status bar totals** showed all repos and all agents rather than the visibility-filtered counts
3. **Split screen repo counts** had the same unfiltered count issue
4. **Post-delete agent selection** in `main.rs` picked the first agent via a raw `repository_id` scan that ignored the idle-visibility predicate

## Changes

### State layer (`src/state/mod.rs`)
- Added `visible_agent_count_for_repository()` - per-repo count respecting idle filter
- Added `visible_agent_count()` - total visible agents across all repos

### UI components
- **`sidebar.rs`**: Added `agent_counts: Vec<usize>` prop; uses filtered count instead of `repo.agent_ids.len()`
- **`dashboard.rs`**: Computes visible repo indices, filtered agent counts per repo, and passes them to Sidebar/StatusBar
- **`issues.rs`**: Same visibility-aware counting for sidebar and status bar
- **`split.rs`**: Same visibility-aware counting for inline repo list and status bar

### Runtime (`src/main.rs`)
- Post-delete agent selection now uses `agent_indices_for_repository()` instead of raw scan

### Tests
- `visible_agent_count_includes_all_when_filter_off`
- `visible_agent_count_excludes_inactive_when_filter_on`
- `visible_repo_count_matches_visible_repository_indices`

Fixes #43
Relates to #41