### PR TITLE
Fix terminal render lockup by drawing PTY grid on a single canvas node (Fixes #60)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,11 +625,13 @@ dependencies = [
  "serde",
  "serde_json",
  "smol",
+ "taffy",
  "tempfile",
  "thiserror 2.0.18",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ toml = "0.8"
 # Terminal UI
 iocraft = "0.5"
 crossterm = "0.28"
+# Layout + width measurement for the low-level terminal canvas component.
+# Versions are pinned to those iocraft already resolves so the `taffy::Style`
+# type unifies with iocraft's internal layout engine.
+taffy = "0.5"
+unicode-width = "0.2"
 
 # Terminal/PTY
 portable-pty = "0.8"

--- a/src/state/util.rs
+++ b/src/state/util.rs
@@ -6,8 +6,7 @@ pub(super) fn generate_id(prefix: &str) -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_nanos());
     format!("{prefix}-{timestamp:x}")
 }
 

--- a/src/ui/components/scrollable_text.rs
+++ b/src/ui/components/scrollable_text.rs
@@ -53,11 +53,9 @@ fn scrollbar_geometry(total: usize, visible: usize, offset: usize) -> (usize, us
     let thumb_size = (visible * visible / total).max(1).min(visible);
     let max_offset = total.saturating_sub(visible);
     let scrollable_rows = visible.saturating_sub(thumb_size);
-    let thumb_pos = if max_offset > 0 {
-        (offset * scrollable_rows / max_offset).min(scrollable_rows)
-    } else {
-        0
-    };
+    let thumb_pos = (offset * scrollable_rows)
+        .checked_div(max_offset)
+        .map_or(0, |pos| pos.min(scrollable_rows));
     (thumb_pos, thumb_size)
 }
 

--- a/src/ui/components/terminal_view.rs
+++ b/src/ui/components/terminal_view.rs
@@ -3,10 +3,26 @@
 //! @plan PLAN-20260216-FIRSTVERSION-V1.P09
 //! @requirement REQ-FUNC-006
 //! @requirement REQ-TECH-004
+//!
+//! # Rendering strategy
+//!
+//! The PTY grid is drawn by a single low-level [`TerminalGrid`] component that
+//! writes directly to the iocraft [`Canvas`]. This is deliberate: an earlier
+//! implementation built one flex `Box` per terminal row and an additional nested
+//! `Box`/`Text` per contiguous style-run within each row. For a dense, fully
+//! styled snapshot (e.g. a colorful agent TUI where nearly every cell has a
+//! distinct style) that produced thousands of nested flex nodes. Taffy's layout
+//! solver degraded super-linearly and a single render could never finish within
+//! a frame, starving the (single-threaded) input loop and freezing all keyboard
+//! input. See issue #60.
+//!
+//! By collapsing the grid into one taffy leaf node, layout cost is constant and
+//! independent of per-cell style churn, while per-cell foreground/background/
+//! weight/underline styling is preserved by drawing straight to the canvas.
 
 use iocraft::prelude::*;
 
-use crate::runtime::{TerminalCell, TerminalCellStyle, TerminalSnapshot};
+use crate::runtime::{TerminalCell, TerminalSnapshot};
 use crate::theme::{ResolvedColors, ThemeColors};
 
 /// Props for the terminal view component.
@@ -56,95 +72,181 @@ pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>>
                 Text(content: format!(" ({focus_hint})"), color: rc.dim)
             }
 
-            // Terminal content
+            // Terminal content. A single low-level canvas node draws the whole
+            // grid; see module docs for why this is not a flex tree.
             Box(
                 flex_direction: FlexDirection::Column,
                 flex_grow: 1.0,
                 background_color: rc.bg,
             ) {
-                #(if let Some(snapshot) = &props.snapshot {
+                #(if let Some(snapshot) = props.snapshot.clone() {
                     element! {
-                        Box(flex_direction: FlexDirection::Column) {
-                            #(snapshot
-                                .cells
-                                .iter()
-                                .take(snapshot.rows)
-                                .map(|row| {
-                                    element! {
-                                        Box(height: 1u32, width: 100pct, background_color: rc.bg) {
-                                            #(row_to_runs(row)
-                                                .into_iter()
-                                                .map(|run| {
-                                                    let weight = if run.style.bold {
-                                                        Weight::Bold
-                                                    } else {
-                                                        Weight::Normal
-                                                    };
-                                                    let decoration = if run.style.underline {
-                                                        TextDecoration::Underline
-                                                    } else {
-                                                        TextDecoration::None
-                                                    };
-
-                                                    element! {
-                                                        Box(background_color: run.style.bg) {
-                                                            Text(
-                                                                content: run.text,
-                                                                color: run.style.fg,
-                                                                weight: weight,
-                                                                decoration: decoration,
-                                                                wrap: TextWrap::NoWrap,
-                                                            )
-                                                        }
-                                                    }
-                                                }))
-                                        }
-                                    }
-                                }))
-                        }
+                        TerminalGrid(snapshot: snapshot)
                     }
+                    .into_any()
                 } else {
                     element! {
                         Box {
                             Text(content: "No terminal attached", color: rc.dim)
                         }
                     }
+                    .into_any()
                 })
             }
         }
     }
 }
 
-#[derive(Clone)]
-struct TextRun {
-    text: String,
-    style: TerminalCellStyle,
+/// Props for the low-level terminal grid renderer.
+#[derive(Default, Props)]
+struct TerminalGridProps {
+    /// Styled PTY grid to draw.
+    snapshot: TerminalSnapshot,
 }
 
-fn row_to_runs(row: &[TerminalCell]) -> Vec<TextRun> {
-    if row.is_empty() {
-        return vec![];
+/// Low-level component that paints a [`TerminalSnapshot`] directly onto the
+/// canvas as a single layout node.
+///
+/// This keeps the taffy node count constant (one leaf) regardless of how many
+/// distinct style-runs the snapshot contains, which is the fix for the render
+/// lockup described in issue #60.
+#[derive(Default)]
+struct TerminalGrid {
+    snapshot: TerminalSnapshot,
+}
+
+impl Component for TerminalGrid {
+    type Props<'a> = TerminalGridProps;
+
+    fn new(_props: &Self::Props<'_>) -> Self {
+        Self::default()
+    }
+
+    fn update(
+        &mut self,
+        props: &mut Self::Props<'_>,
+        _hooks: Hooks,
+        updater: &mut ComponentUpdater,
+    ) {
+        self.snapshot = props.snapshot.clone();
+
+        // Fill the available space; the parent Box constrains us to the pane.
+        // Build the taffy style directly so node count stays at one leaf.
+        let mut style = taffy::style::Style::default();
+        style.size = taffy::geometry::Size {
+            width: taffy::style::Dimension::Percent(1.0),
+            height: taffy::style::Dimension::Percent(1.0),
+        };
+        updater.set_layout_style(style);
+    }
+
+    fn draw(&mut self, drawer: &mut ComponentDrawer<'_>) {
+        let layout = drawer.layout();
+        // taffy reports sizes as f32; clamp to a sane non-negative integer.
+        let max_rows = f32_to_usize(layout.size.height);
+        let max_cols = f32_to_usize(layout.size.width);
+        if max_rows == 0 || max_cols == 0 {
+            return;
+        }
+
+        let mut canvas = drawer.canvas();
+
+        for (row_idx, row) in self
+            .snapshot
+            .cells
+            .iter()
+            .take(self.snapshot.rows.min(max_rows))
+            .enumerate()
+        {
+            for run in row_to_runs(row, max_cols) {
+                // CanvasTextStyle is #[non_exhaustive]; build via Default then set fields.
+                let mut style = CanvasTextStyle::default();
+                style.color = Some(run.style.fg);
+                style.weight = if run.style.bold {
+                    Weight::Bold
+                } else {
+                    Weight::Normal
+                };
+                style.underline = run.style.underline;
+
+                // Background is painted as a filled region under the run so that
+                // per-cell background colors are preserved.
+                #[allow(clippy::cast_possible_wrap)]
+                canvas.set_background_color(
+                    run.start_col as isize,
+                    row_idx as isize,
+                    run.width,
+                    1,
+                    run.style.bg,
+                );
+                #[allow(clippy::cast_possible_wrap)]
+                canvas.set_text(run.start_col as isize, row_idx as isize, &run.text, style);
+            }
+        }
+    }
+}
+
+/// Convert a taffy `f32` layout dimension to a clamped, non-negative `usize`.
+///
+/// Negative or non-finite values collapse to `0`; large values saturate.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn f32_to_usize(value: f32) -> usize {
+    if !value.is_finite() || value <= 0.0 {
+        0
+    } else {
+        value.floor() as usize
+    }
+}
+
+/// A contiguous run of cells sharing the same style within a single row.
+#[derive(Clone)]
+struct TextRun {
+    /// Column where this run begins (0-based).
+    start_col: usize,
+    /// Display width of the run in cells.
+    width: usize,
+    /// Run text.
+    text: String,
+    /// Shared style for every cell in the run.
+    style: crate::runtime::TerminalCellStyle,
+}
+
+/// Split a styled cell row into contiguous same-style runs, clamped to `max_cols`.
+///
+/// Trailing all-blank runs are dropped so empty line tails don't paint
+/// background fills past meaningful content.
+fn row_to_runs(row: &[TerminalCell], max_cols: usize) -> Vec<TextRun> {
+    if row.is_empty() || max_cols == 0 {
+        return Vec::new();
     }
 
     let mut runs: Vec<TextRun> = Vec::new();
     let mut current_style = row[0].style;
     let mut current_text = String::new();
+    let mut run_start = 0usize;
+    let mut col = 0usize;
 
-    for cell in row {
+    for cell in row.iter().take(max_cols) {
         if cell.style != current_style {
             if !current_text.is_empty() {
                 runs.push(TextRun {
+                    start_col: run_start,
+                    width: col - run_start,
                     text: std::mem::take(&mut current_text),
                     style: current_style,
                 });
             }
             current_style = cell.style;
+            run_start = col;
         }
         current_text.push(cell.ch);
+        col += 1;
     }
 
     if !current_text.is_empty() {
         runs.push(TextRun {
+            start_col: run_start,
+            width: col - run_start,
             text: current_text,
             style: current_style,
         });
@@ -158,4 +260,84 @@ fn row_to_runs(row: &[TerminalCell]) -> Vec<TextRun> {
     }
 
     runs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::TerminalCellStyle;
+    use iocraft::Color;
+
+    fn style(fg: u8) -> TerminalCellStyle {
+        TerminalCellStyle {
+            fg: Color::AnsiValue(fg),
+            bg: Color::Black,
+            bold: false,
+            underline: false,
+        }
+    }
+
+    fn cell(ch: char, fg: u8) -> TerminalCell {
+        TerminalCell {
+            ch,
+            style: style(fg),
+        }
+    }
+
+    #[test]
+    fn empty_row_yields_no_runs() {
+        assert!(row_to_runs(&[], 80).is_empty());
+    }
+
+    #[test]
+    fn zero_width_yields_no_runs() {
+        let row = vec![cell('a', 1)];
+        assert!(row_to_runs(&row, 0).is_empty());
+    }
+
+    #[test]
+    fn single_style_collapses_to_one_run() {
+        let row: Vec<TerminalCell> = "hello".chars().map(|c| cell(c, 1)).collect();
+        let runs = row_to_runs(&row, 80);
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].text, "hello");
+        assert_eq!(runs[0].start_col, 0);
+        assert_eq!(runs[0].width, 5);
+    }
+
+    #[test]
+    fn style_change_splits_runs_with_correct_columns() {
+        let mut row = vec![cell('a', 1), cell('b', 1)];
+        row.push(cell('c', 2));
+        row.push(cell('d', 2));
+        let runs = row_to_runs(&row, 80);
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].text, "ab");
+        assert_eq!(runs[0].start_col, 0);
+        assert_eq!(runs[0].width, 2);
+        assert_eq!(runs[1].text, "cd");
+        assert_eq!(runs[1].start_col, 2);
+        assert_eq!(runs[1].width, 2);
+    }
+
+    #[test]
+    fn trailing_blank_run_is_trimmed() {
+        let mut row: Vec<TerminalCell> = "hi".chars().map(|c| cell(c, 1)).collect();
+        // Different style so blanks form their own trailing run.
+        for _ in 0..5 {
+            row.push(cell(' ', 2));
+        }
+        let runs = row_to_runs(&row, 80);
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].text, "hi");
+    }
+
+    #[test]
+    fn runs_are_clamped_to_max_cols() {
+        let row: Vec<TerminalCell> = "abcdefgh".chars().map(|c| cell(c, 1)).collect();
+        let runs = row_to_runs(&row, 3);
+        let total: usize = runs.iter().map(|r| r.width).sum();
+        assert_eq!(total, 3);
+        assert_eq!(runs[0].text, "abc");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #60.

Jefe could lock up completely (100% CPU, all keyboard input dropped) when it
attached to and rendered a running agent whose PTY contained a dense, fully
styled TUI (e.g. a sandboxed llxprt-code session). The freeze persisted across
restarts because startup restores the previously selected running agent and
re-renders the same snapshot, immediately re-wedging.

## Root cause

The render loop (iocraft) runs synchronously on the same single thread that
services keyboard events. If one render pass never finishes within the frame
budget, the executor never returns to read input, so every keypress is silently
dropped regardless of focus.

The TerminalView rendered the PTY grid as a deep flex tree:

    TerminalView -> Box(column)
      -> one Box per terminal row
        -> one Box per style-run in that row
          -> Text

The node count was roughly pty_rows x style_runs_per_row. row_to_runs starts a
new run whenever the cell style changes. A dense agent TUI gives nearly every
cell a distinct style, fragmenting each row into many runs and pushing taffy into
a pathological regime of thousands of nested flex nodes, each requiring
unicode-width measurement, recomputed every tick (~33ms). Layout could not finish
within a frame, producing a permanent ~96% CPU spin and total input starvation.

A read-only macOS sample of a wedged instance showed 100% of main-thread stack
time inside taffy's flexbox solver (compute_flexbox_layout -> compute_preliminary
-> final_layout_pass -> calculate_flex_item -> compute_child_layout -> ...),
nested dozens of levels deep with leaves in Text::update / UnicodeWidthStr::width.

## Fix

Replace the inner flex tree with a single low-level Component, TerminalGrid, that
occupies one taffy leaf node and paints every cell directly to the iocraft
canvas:

- Layout cost is now constant and independent of per-cell style churn (one leaf
  vs. thousands of nested nodes), eliminating the solver blowup.
- Per-cell styling is preserved: foreground via canvas text color, background via
  set_background_color region fills, plus bold weight and underline.
- row_to_runs now tracks each run's start column and width and clamps to the
  visible width, so runs map to exact canvas coordinates.
- Trailing all-blank runs are still trimmed to avoid painting background past
  meaningful content.

Because the grid is a single leaf with O(1) relayout, no separate
snapshot-diffing render guard was necessary.

The public TerminalView / TerminalViewProps API is unchanged, so dashboard.rs
needs no modification. The title/border chrome is retained.

## Dependencies

Adds two direct dependencies that were already resolved transitively via iocraft,
pinned to the same versions so taffy::Style unifies with iocraft's internal
layout engine:

- taffy (build the leaf's layout Style directly; iocraft's LayoutStyle is not
  Default-constructible from outside the crate)
- unicode-width (already used by the canvas for width-correct drawing)

## Testing

- make build (full verification: build, all tests, clippy, format) passes.
- Added unit tests for row_to_runs: empty/zero-width inputs, single-style
  collapse, style-change splitting with correct columns/widths, trailing-blank
  trimming, and max-cols clamping.
- 164 + new tests pass.

## Notes

- The wedged process in the original report was jefe itself, not any agent.
  Agents run as independent detached tmux sessions and are unaffected.
