### PR TITLE
Add --config runtime argument for isolated config directories (Fixes #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,27 @@ By default, `jefe` resolves settings/state using platform paths, with env var ov
 - `JEFE_STATE_PATH`
 - `JEFE_STATE_DIR`
 
+### Running multiple instances with `--config`
+
+Use the `--config <dir>` (short `-c <dir>`) runtime argument to point an
+instance at an isolated config directory. Both `settings.toml` and `state.json`
+live directly under that directory, and external themes are loaded from
+`<dir>/themes/`:
+
+```bash
+# Default instance
+jefe
+
+# Isolated dev/test instance that won't touch your main config/state
+jefe --config ~/.config/jefe-dev
+```
+
+This is handy when developing `jefe` with `jefe`: run a stable instance in one
+tab while testing changes against a throwaway config in another. The directory
+does not need to exist beforehand — it is created on first write. When
+`--config` is supplied, it takes precedence over the `JEFE_*` path environment
+variables.
+
 Related runtime/env toggles:
 
 - `JEFE_WINDOWED=1` to disable fullscreen mode.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,184 @@
+//! Command-line argument parsing.
+//!
+//! Minimal hand-rolled parser (no external dependency) consistent with the
+//! existing approach. Supports `--version`/`-V`, `--help`/`-h`, and
+//! `--config <dir>`/`-c <dir>` so multiple instances can run against fully
+//! isolated config/state directories.
+
+use std::path::PathBuf;
+
+/// Parsed command-line arguments.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CliArgs {
+    /// `--version` / `-V` was requested.
+    pub version: bool,
+    /// `--help` / `-h` was requested.
+    pub help: bool,
+    /// Explicit config directory from `--config <dir>` / `-c <dir>`.
+    pub config_dir: Option<PathBuf>,
+}
+
+/// Error produced while parsing command-line arguments.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CliError {
+    /// A flag that expects a value was given none.
+    MissingValue(String),
+    /// An unrecognized argument was encountered.
+    UnknownArgument(String),
+}
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingValue(flag) => write!(f, "{flag} requires a path argument"),
+            Self::UnknownArgument(arg) => write!(f, "unknown argument: {arg}"),
+        }
+    }
+}
+
+impl std::error::Error for CliError {}
+
+/// Usage text shown for `--help`.
+pub const USAGE: &str = "\
+jefe - terminal manager for multiple llxprt coding agents
+
+Usage: jefe [OPTIONS]
+
+Options:
+  -c, --config <DIR>  Use <DIR> for settings.toml, state.json, and themes/,
+                      isolating this instance from the default config/state
+  -V, --version       Print version information and exit
+  -h, --help          Print this help message and exit";
+
+/// Parse command-line arguments from an iterator of program arguments
+/// (excluding the program name).
+///
+/// # Errors
+///
+/// Returns [`CliError`] if a value-taking flag is missing its value or if an
+/// unknown argument is supplied.
+pub fn parse_args<I, S>(args: I) -> Result<CliArgs, CliError>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let mut result = CliArgs::default();
+    let mut iter = args.into_iter().map(Into::into);
+
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--version" | "-V" => result.version = true,
+            "--help" | "-h" => result.help = true,
+            "--config" | "-c" => {
+                let value = iter
+                    .next()
+                    .ok_or_else(|| CliError::MissingValue(arg.clone()))?;
+                result.config_dir = Some(PathBuf::from(value));
+            }
+            other => {
+                // Support `--config=<dir>` / `-c=<dir>` forms.
+                if let Some(value) = other
+                    .strip_prefix("--config=")
+                    .or_else(|| other.strip_prefix("-c="))
+                {
+                    if value.is_empty() {
+                        return Err(CliError::MissingValue(
+                            other.split('=').next().unwrap_or(other).to_string(),
+                        ));
+                    }
+                    result.config_dir = Some(PathBuf::from(value));
+                } else {
+                    return Err(CliError::UnknownArgument(other.to_string()));
+                }
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> Result<CliArgs, CliError> {
+        parse_args(args.iter().map(|s| (*s).to_string()))
+    }
+
+    #[test]
+    fn empty_args_yield_defaults() {
+        let parsed = parse(&[]).expect("should parse");
+        assert_eq!(parsed, CliArgs::default());
+        assert!(!parsed.version);
+        assert!(!parsed.help);
+        assert!(parsed.config_dir.is_none());
+    }
+
+    #[test]
+    fn version_long_and_short() {
+        assert!(parse(&["--version"]).expect("parse").version);
+        assert!(parse(&["-V"]).expect("parse").version);
+    }
+
+    #[test]
+    fn help_long_and_short() {
+        assert!(parse(&["--help"]).expect("parse").help);
+        assert!(parse(&["-h"]).expect("parse").help);
+    }
+
+    #[test]
+    fn config_long_with_separate_value() {
+        let parsed = parse(&["--config", "/tmp/jefe-dev"]).expect("parse");
+        assert_eq!(parsed.config_dir, Some(PathBuf::from("/tmp/jefe-dev")));
+    }
+
+    #[test]
+    fn config_short_with_separate_value() {
+        let parsed = parse(&["-c", "/tmp/jefe-dev"]).expect("parse");
+        assert_eq!(parsed.config_dir, Some(PathBuf::from("/tmp/jefe-dev")));
+    }
+
+    #[test]
+    fn config_equals_form() {
+        let parsed = parse(&["--config=/tmp/jefe-dev"]).expect("parse");
+        assert_eq!(parsed.config_dir, Some(PathBuf::from("/tmp/jefe-dev")));
+
+        let parsed = parse(&["-c=/tmp/jefe-dev"]).expect("parse");
+        assert_eq!(parsed.config_dir, Some(PathBuf::from("/tmp/jefe-dev")));
+    }
+
+    #[test]
+    fn config_missing_value_errors() {
+        let err = parse(&["--config"]).expect_err("should error");
+        assert_eq!(err, CliError::MissingValue("--config".to_string()));
+
+        let err = parse(&["-c"]).expect_err("should error");
+        assert_eq!(err, CliError::MissingValue("-c".to_string()));
+    }
+
+    #[test]
+    fn config_empty_equals_value_errors() {
+        let err = parse(&["--config="]).expect_err("should error");
+        assert_eq!(err, CliError::MissingValue("--config".to_string()));
+    }
+
+    #[test]
+    fn unknown_argument_errors() {
+        let err = parse(&["--nope"]).expect_err("should error");
+        assert_eq!(err, CliError::UnknownArgument("--nope".to_string()));
+    }
+
+    #[test]
+    fn combined_flags_parse() {
+        let parsed = parse(&["--config", "/tmp/x", "--version"]).expect("parse");
+        assert!(parsed.version);
+        assert_eq!(parsed.config_dir, Some(PathBuf::from("/tmp/x")));
+    }
+
+    #[test]
+    fn later_config_overrides_earlier() {
+        let parsed = parse(&["-c", "/tmp/a", "-c", "/tmp/b"]).expect("parse");
+        assert_eq!(parsed.config_dir, Some(PathBuf::from("/tmp/b")));
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,6 +73,11 @@ where
                 let value = iter
                     .next()
                     .ok_or_else(|| CliError::MissingValue(arg.clone()))?;
+                // Reject empty values and flag-like tokens (e.g. a following
+                // `--help`) so they aren't silently swallowed as a directory.
+                if value.is_empty() || value.starts_with('-') {
+                    return Err(CliError::MissingValue(arg.clone()));
+                }
                 result.config_dir = Some(PathBuf::from(value));
             }
             other => {
@@ -155,6 +160,23 @@ mod tests {
 
         let err = parse(&["-c"]).expect_err("should error");
         assert_eq!(err, CliError::MissingValue("-c".to_string()));
+    }
+
+    #[test]
+    fn config_rejects_following_flag_as_value() {
+        let err = parse(&["--config", "--help"]).expect_err("should error");
+        assert_eq!(err, CliError::MissingValue("--config".to_string()));
+
+        let err = parse(&["-c", "-V"]).expect_err("should error");
+        assert_eq!(err, CliError::MissingValue("-c".to_string()));
+    }
+
+    #[test]
+    fn config_equals_form_allows_leading_dash_dir() {
+        // The explicit `=value` form is unambiguous, so a directory whose name
+        // starts with a dash is still accepted there.
+        let parsed = parse(&["--config=-weird-dir"]).expect("parse");
+        assert_eq!(parsed.config_dir, Some(PathBuf::from("-weird-dir")));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //! @plan PLAN-20260216-FIRSTVERSION-V1.P09
 //! @requirement REQ-TECH-001
 
+pub mod cli;
 pub mod domain;
 pub mod input;
 pub mod layout;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,29 +31,46 @@ struct AppContext {
     gh_client: jefe::github::GhClient,
 }
 
+/// Parse CLI arguments, handling early-exit flags (`--version`, `--help`).
+///
+/// Returns the parsed [`CliArgs`] when execution should continue, or `None`
+/// when the process has already handled an early-exit flag and `main` should
+/// return.
 #[allow(clippy::print_stdout)]
-fn handle_cli_version_flag() -> bool {
-    let mut args = std::env::args().skip(1);
-    match (args.next().as_deref(), args.next()) {
-        (Some("--version" | "-V"), None) => {
-            let version = jefe::VERSION;
-            println!("jefe {version}");
-            true
+fn parse_cli_or_exit() -> Option<jefe::cli::CliArgs> {
+    match jefe::cli::parse_args(std::env::args().skip(1)) {
+        Ok(args) => {
+            if args.help {
+                println!("{}", jefe::cli::USAGE);
+                return None;
+            }
+            if args.version {
+                let version = jefe::VERSION;
+                println!("jefe {version}");
+                return None;
+            }
+            Some(args)
         }
-        _ => false,
+        Err(e) => {
+            eprintln!("error: {e}");
+            eprintln!();
+            eprintln!("{}", jefe::cli::USAGE);
+            std::process::exit(2);
+        }
     }
 }
 
 fn main() {
-    if handle_cli_version_flag() {
+    let Some(cli_args) = parse_cli_or_exit() else {
         return;
-    }
+    };
 
     // Initialize structured logging (no-op if JEFE_LOG_FILE is unset).
     jefe::logging::init();
     tracing::info!(version = jefe::VERSION, "jefe starting");
     tracing::debug!(
         log_file = ?jefe::logging::log_file_path(),
+        config_dir = ?cli_args.config_dir,
         "logging initialized"
     );
 
@@ -61,9 +78,17 @@ fn main() {
     let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
     let (pty_rows, pty_cols, _, _) = compute_pty_layout(cols, rows);
 
-    // Initialize managers.
-    let persistence = jefe::persistence::FilePersistenceManager::new();
-    let theme_manager = FileThemeManager::new();
+    // Initialize managers. An explicit `--config <dir>` isolates settings,
+    // state, and themes under that directory; otherwise fall back to the
+    // default platform paths and environment variable overrides.
+    let mut theme_manager = FileThemeManager::new();
+    let persistence = if let Some(dir) = cli_args.config_dir.as_deref() {
+        let paths = jefe::persistence::resolve_paths_from_dir(dir);
+        theme_manager.load_from_dir(&dir.join("themes"));
+        jefe::persistence::FilePersistenceManager::with_paths(paths)
+    } else {
+        jefe::persistence::FilePersistenceManager::new()
+    };
     let runtime = TmuxRuntimeManager::new(pty_rows, pty_cols);
 
     let context = Arc::new(std::sync::Mutex::new(AppContext {

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -123,6 +123,20 @@ pub fn resolve_paths() -> PersistencePaths {
     }
 }
 
+/// Resolve persistence paths rooted at an explicit config directory.
+///
+/// Both `settings.toml` and `state.json` live directly under `dir`. This is
+/// used by the `--config <dir>` runtime argument so multiple instances can run
+/// against fully isolated config/state without touching the default paths or
+/// environment variable overrides.
+#[must_use]
+pub fn resolve_paths_from_dir(dir: &std::path::Path) -> PersistencePaths {
+    PersistencePaths {
+        settings_path: dir.join("settings.toml"),
+        state_path: dir.join("state.json"),
+    }
+}
+
 fn resolve_settings_path() -> PathBuf {
     // 1. JEFE_SETTINGS_PATH
     if let Ok(path) = std::env::var("JEFE_SETTINGS_PATH") {
@@ -366,6 +380,14 @@ mod tests {
         let paths = resolve_paths();
         assert!(paths.settings_path.ends_with("settings.toml"));
         assert!(paths.state_path.ends_with("state.json"));
+    }
+
+    #[test]
+    fn resolve_paths_from_dir_roots_both_files_under_dir() {
+        let dir = std::path::Path::new("/tmp/jefe-dev-instance");
+        let paths = resolve_paths_from_dir(dir);
+        assert_eq!(paths.settings_path, dir.join("settings.toml"));
+        assert_eq!(paths.state_path, dir.join("state.json"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a `--config <dir>` (short `-c <dir>`) runtime argument so multiple `jefe`
instances can run against fully isolated config/state. This addresses the
workflow of developing `jefe` with `jefe`: run a stable instance in one tab
while testing changes against a throwaway config in another, without borking
your main instance.

When `--config <dir>` is supplied:

- `settings.toml` and `state.json` live directly under `<dir>`
- external themes are loaded from `<dir>/themes/`
- the flag takes precedence over the `JEFE_*` path environment variables
- the directory is created on first write (no need to pre-create it)

## Changes

- New testable `cli` module with a hand-rolled `parse_args` (no new
  dependency, consistent with the existing manual parsing). Supports:
  - `--config <dir>` / `-c <dir>` and the `--config=<dir>` / `-c=<dir>` forms
  - `--version` / `-V`
  - `--help` / `-h` (prints usage)
  - clear errors for missing values and unknown arguments (exit code 2)
- `persistence::resolve_paths_from_dir(dir)` roots both files under a dir.
- `main.rs` wires the parsed config dir into persistence paths and theme
  loading; replaces the old `--version`-only handler.
- README documents the new flag.

## Testing

- 11 new unit tests for `cli::parse_args` covering all flag forms, error
  cases, combined flags, and override precedence.
- New unit test for `resolve_paths_from_dir`.
- `cargo fmt --all --check`, both `clippy` invocations (with `-D warnings`),
  full test suite (175 tests passing), `llvm-cov` (45.48%, above the 30%
  threshold), and locked build all pass locally.
- Manual smoke tests of `--version`, `--help`, unknown-arg, and
  missing-value paths.

Fixes #62
