### PR TITLE
Add clippy allow policy gate (Fixes #26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Run clippy (warnings as errors)
         run: rustup run stable cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+  clippy_allow_policy:
+    name: Clippy allow policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Block untracked clippy allow attributes
+        run: scripts/check-clippy-allows.sh
+
   source_file_size:
     name: Source file length checks
     runs-on: ubuntu-latest
@@ -135,7 +143,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [fmt, lint, source_file_size, complexity, coverage]
+    needs: [fmt, lint, clippy_allow_policy, source_file_size, complexity, coverage]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,12 @@ jobs:
   clippy_allow_policy:
     name: Clippy allow policy
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
       - name: Block untracked clippy allow attributes
         run: scripts/check-clippy-allows.sh
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ build: ci-check
 
 ci-check:
 	cargo fmt --all --check
+	scripts/check-clippy-allows.sh
 	CLIPPY_CONF_DIR=.github/clippy rustup run stable cargo clippy --workspace --all-targets --all-features -- -D warnings
 	CLIPPY_CONF_DIR=.github/clippy rustup run stable cargo clippy --workspace --all-targets --all-features -- \
 		-A clippy::all \

--- a/clippy-allowlist.tsv
+++ b/clippy-allowlist.tsv
@@ -1,0 +1,70 @@
+# Existing clippy allow attributes pending removal.
+# Columns are tab-separated: path, exact attribute text, owner, removal target.
+# New #[allow(clippy::...)] or #![allow(clippy::...)] entries must not be added without an approved exception.
+src/app_init.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/app_init.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/app_input/issues_filter.rs	#[allow(clippy::field_reassign_with_default)]	core-maintainers	next quality-cycle ratchet
+src/app_input/issues.rs	#[allow(clippy::match_same_arms)]	core-maintainers	next quality-cycle ratchet
+src/app_input/issues.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/app_input/issues.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/app_input/mod.rs	#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]	core-maintainers	next quality-cycle ratchet
+src/app_input/modal_handlers.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/app_input/modal_handlers.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/app_input/normal.rs	#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]	core-maintainers	next quality-cycle ratchet
+src/app_shell.rs	#[allow(clippy::cognitive_complexity)]	core-maintainers	next quality-cycle ratchet
+src/app_shell.rs	#[allow(clippy::cognitive_complexity)]	core-maintainers	next quality-cycle ratchet
+src/cli.rs	#[allow(clippy::expect_used, clippy::unwrap_used)]	core-maintainers	next quality-cycle ratchet
+src/domain/mod.rs	#[allow(clippy::expect_used, clippy::unwrap_used)]	core-maintainers	next quality-cycle ratchet
+src/github/mod.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/github/mod.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/github/mod.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/lib.rs	#[allow(clippy::expect_used, clippy::unwrap_used, clippy::manual_string_new)]	core-maintainers	next quality-cycle ratchet
+src/logging.rs	#[allow(clippy::print_stderr)]	core-maintainers	next quality-cycle ratchet
+src/main.rs	#![allow(clippy::clone_on_copy)]	core-maintainers	next quality-cycle ratchet
+src/main.rs	#![allow(clippy::collapsible_if)]	core-maintainers	next quality-cycle ratchet
+src/main.rs	#![allow(clippy::print_stderr)]	core-maintainers	next quality-cycle ratchet
+src/main.rs	#![allow(clippy::significant_drop_tightening)]	core-maintainers	next quality-cycle ratchet
+src/main.rs	#[allow(clippy::print_stdout)]	core-maintainers	next quality-cycle ratchet
+src/messages.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/messages.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/persistence/mod.rs	#![allow(clippy::expect_used, clippy::unwrap_used)]	core-maintainers	next quality-cycle ratchet
+src/runtime/attach.rs	#[allow(clippy::significant_drop_tightening)]	core-maintainers	next quality-cycle ratchet
+src/runtime/attach.rs	#[allow(clippy::significant_drop_tightening)]	core-maintainers	next quality-cycle ratchet
+src/runtime/attach.rs	#[allow(clippy::significant_drop_tightening)]	core-maintainers	next quality-cycle ratchet
+src/runtime/attach.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/runtime/attach.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/runtime/attach.rs	#[allow( clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::cast_sign_loss, clippy::too_many_lines )]	core-maintainers	next quality-cycle ratchet
+src/runtime/commands.rs	#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]	core-maintainers	next quality-cycle ratchet
+src/runtime/commands.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/runtime/mod.rs	#![allow(clippy::expect_used)]	core-maintainers	next quality-cycle ratchet
+src/state/form_ops.rs	#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]	core-maintainers	next quality-cycle ratchet
+src/state/form_ops.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/state/issues_ops.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/state/issues_ops.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/state/issues_ops.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/state/issues_ops.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/state/issues_tests_detail.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/state/issues_tests_detail.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+src/state/mod.rs	#[allow( clippy::expect_used, clippy::unwrap_used, clippy::field_reassign_with_default, clippy::manual_string_new, clippy::uninlined_format_args )]	core-maintainers	next quality-cycle ratchet
+src/state/mod.rs	#[allow( clippy::expect_used, clippy::unwrap_used, clippy::field_reassign_with_default, clippy::manual_string_new, clippy::uninlined_format_args )]	core-maintainers	next quality-cycle ratchet
+src/state/mod.rs	#[allow( clippy::expect_used, clippy::unwrap_used, clippy::field_reassign_with_default, clippy::manual_string_new, clippy::uninlined_format_args )]	core-maintainers	next quality-cycle ratchet
+src/state/mod.rs	#[allow( clippy::expect_used, clippy::unwrap_used, clippy::field_reassign_with_default, clippy::manual_string_new, clippy::uninlined_format_args )]	core-maintainers	next quality-cycle ratchet
+src/state/state_ops.rs	#[allow( clippy::expect_used, clippy::unwrap_used, clippy::field_reassign_with_default, clippy::manual_string_new, clippy::uninlined_format_args )]	core-maintainers	next quality-cycle ratchet
+src/state/types.rs	#[allow(clippy::struct_excessive_bools)]	core-maintainers	next quality-cycle ratchet
+src/ui/components/issue_list.rs	#[allow(clippy::struct_excessive_bools)]	core-maintainers	next quality-cycle ratchet
+src/ui/components/terminal_view.rs	#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]	core-maintainers	next quality-cycle ratchet
+src/ui/components/terminal_view.rs	#[allow(clippy::cast_possible_wrap)]	core-maintainers	next quality-cycle ratchet
+src/ui/components/terminal_view.rs	#[allow(clippy::cast_possible_wrap)]	core-maintainers	next quality-cycle ratchet
+tests/core/domain_state_contracts.rs	#![allow(clippy::expect_used)]	core-maintainers	next quality-cycle ratchet
+tests/core/domain_state_contracts.rs	#![allow(clippy::unwrap_used)]	core-maintainers	next quality-cycle ratchet
+tests/core/persistence_theme_contracts.rs	#![allow(clippy::expect_used)]	core-maintainers	next quality-cycle ratchet
+tests/core/visibility_filter_contracts.rs	#![allow(clippy::expect_used)]	core-maintainers	next quality-cycle ratchet
+tests/core/visibility_filter_contracts.rs	#![allow(clippy::unwrap_used)]	core-maintainers	next quality-cycle ratchet
+tests/e2e/end_to_end.rs	#![allow(clippy::unwrap_used, clippy::expect_used)]	core-maintainers	next quality-cycle ratchet
+tests/e2e/recovery_paths.rs	#![allow(clippy::unwrap_used, clippy::expect_used)]	core-maintainers	next quality-cycle ratchet
+tests/runtime/runtime_lifecycle.rs	#![allow(clippy::expect_used)]	core-maintainers	next quality-cycle ratchet
+tests/runtime/runtime_lifecycle.rs	#![allow(clippy::unwrap_used)]	core-maintainers	next quality-cycle ratchet
+tests/runtime/terminal_focus_routing.rs	#![allow(clippy::expect_used)]	core-maintainers	next quality-cycle ratchet
+tests/runtime/terminal_focus_routing.rs	#![allow(clippy::unwrap_used)]	core-maintainers	next quality-cycle ratchet
+toy1/src/data/mock.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
+toy1/src/events/bus.rs	#![allow(clippy::unnecessary_wraps)]	core-maintainers	next quality-cycle ratchet

--- a/dev-docs/project-standards.md
+++ b/dev-docs/project-standards.md
@@ -80,6 +80,7 @@ Contributors must keep project lint config active and respected.
 ## Explicit prohibitions
 - Do not disable lints globally.
 - Do not add blanket `#[allow(...)]` at module/file scope to silence debt.
+- Do not add new `#[allow(clippy::...)]` or `#![allow(clippy::...)]` attributes unless the exception has explicit review approval and is recorded in `clippy-allowlist.tsv` with an owner and removal target.
 - Do not merge code that passes only by muting warnings.
 
 If a local `#[allow]` is unavoidable:

--- a/docs/building.md
+++ b/docs/building.md
@@ -34,6 +34,7 @@ This command runs:
 
 ```bash
 cargo fmt --all --check
+scripts/check-clippy-allows.sh
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo clippy --workspace --all-targets --all-features -- \
   -A clippy::all \

--- a/docs/project-standards.md
+++ b/docs/project-standards.md
@@ -115,6 +115,7 @@ Defined in `clippy.toml`:
 - **DON'T** use `.unwrap()` or `.expect()` in production code paths. These are acceptable ONLY in `#[cfg(test)]` blocks and in `const` contexts where the value is provably `Some`/`Ok`.
 - **DON'T** use `panic!()`, `unreachable!()`, `todo!()`, or `unimplemented!()` in production code paths. If a code path is genuinely unreachable, refactor the types to make that structurally impossible.
 - **DON'T** disable lints with `#[allow(...)]` without a code-review-approved comment explaining why. Every `allow` must have a justification. Blanket `#![allow(...)]` at the module level requires explicit approval and must be temporary.
+- **DON'T** add new `#[allow(clippy::...)]` or `#![allow(clippy::...)]` attributes unless the exception has explicit review approval and is recorded in `clippy-allowlist.tsv` with an owner and removal target.
 - **DON'T** use `HashMap<String, serde_json::Value>` or equivalent weak typing. Define explicit structs with named, typed fields.
 - **DON'T** use `dyn Any` or downcasting for type erasure. Use enums or generics.
 - **DON'T** use wildcard imports (`use foo::*`) except for the `iocraft::prelude::*` import in component files.

--- a/scripts/check-clippy-allows.sh
+++ b/scripts/check-clippy-allows.sh
@@ -30,7 +30,7 @@ expected_file="$(make_temp_file)"
 trap 'rm -f "$actual_file" "$expected_file"' EXIT
 
 scan_actual_allows() {
-  git ls-files --cached --others --exclude-standard '*.rs' ':!vendor/**' \
+  git ls-files --cached '*.rs' ':!vendor/**' \
     | while IFS= read -r file; do
         awk -v file="$file" '
           function trim(value) {

--- a/scripts/check-clippy-allows.sh
+++ b/scripts/check-clippy-allows.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly ALLOWLIST="clippy-allowlist.tsv"
+readonly ROOT_CLIPPY_CONFIG="clippy.toml"
+readonly CI_CLIPPY_CONFIG=".github/clippy/clippy.toml"
+readonly TMP_BASE="${TMPDIR:-/tmp}"
+
+errors=0
+
+fail() {
+  echo "ERROR: $*" >&2
+  errors=$((errors + 1))
+}
+
+require_file() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    fail "required file is missing: $file"
+    return 1
+  fi
+}
+
+make_temp_file() {
+  mktemp "${TMP_BASE%/}/jefe-clippy-allows.XXXXXX"
+}
+
+actual_file="$(make_temp_file)"
+expected_file="$(make_temp_file)"
+trap 'rm -f "$actual_file" "$expected_file"' EXIT
+
+scan_actual_allows() {
+  git ls-files --cached --others --exclude-standard '*.rs' ':!vendor/**' \
+    | while IFS= read -r file; do
+        awk -v file="$file" '
+          function trim(value) {
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            return value
+          }
+          function emit_attr() {
+            attr = trim(buffer)
+            gsub(/[[:space:]]+/, " ", attr)
+            if (attr ~ /^#!?\[(cfg_attr\(.*clippy::|allow\(.*clippy::)/) {
+              print file "\t" attr
+            }
+            buffer = ""
+            collecting = 0
+          }
+          {
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            if (!collecting && line ~ /^#!?\[(cfg_attr\(|allow\()/) {
+              buffer = line
+              collecting = 1
+              if (line ~ /\]/) {
+                emit_attr()
+              }
+              next
+            }
+            if (collecting) {
+              buffer = buffer " " line
+              if (line ~ /\]/) {
+                emit_attr()
+              }
+            }
+          }
+        ' "$file"
+      done \
+    | LC_ALL=C sort
+}
+
+load_expected_allows() {
+  awk -F '\t' '
+    /^#/ || /^[[:space:]]*$/ { next }
+    NF != 4 {
+      printf "ERROR: malformed allowlist row %d: expected 4 tab-separated columns\n", NR > "/dev/stderr"
+      bad = 1
+      next
+    }
+    $1 == "" || $2 == "" || $3 == "" || $4 == "" {
+      printf "ERROR: malformed allowlist row %d: empty columns are not permitted\n", NR > "/dev/stderr"
+      bad = 1
+      next
+    }
+    { print $1 "\t" $2 }
+    END { exit bad }
+  ' "$ALLOWLIST" | LC_ALL=C sort
+}
+
+clippy_config_value() {
+  local file="$1"
+  local key="$2"
+  local line
+
+  line="$(grep -E "^[[:space:]]*${key}[[:space:]]*=" "$file" || true)"
+  if [ -z "$line" ]; then
+    fail "$file is missing clippy threshold: $key"
+    return 1
+  fi
+
+  printf '%s\n' "$line" \
+    | head -n 1 \
+    | sed -E 's/^[^=]+=[[:space:]]*//; s/[[:space:]]*(#.*)?$//'
+}
+
+check_allowlist() {
+  require_file "$ALLOWLIST" || return
+
+  scan_actual_allows > "$actual_file"
+  if ! load_expected_allows > "$expected_file"; then
+    errors=$((errors + 1))
+    return
+  fi
+
+  if ! diff -u "$expected_file" "$actual_file"; then
+    fail "clippy allow attributes must match $ALLOWLIST; remove the allow or update the approved exception record"
+  fi
+}
+
+check_clippy_config_sync() {
+  require_file "$ROOT_CLIPPY_CONFIG" || return
+  require_file "$CI_CLIPPY_CONFIG" || return
+
+  local thresholds=(
+    cognitive-complexity-threshold
+    too-many-lines-threshold
+    too-many-arguments-threshold
+    max-struct-bools
+    type-complexity-threshold
+  )
+
+  local key root_value ci_value
+  for key in "${thresholds[@]}"; do
+    root_value="$(clippy_config_value "$ROOT_CLIPPY_CONFIG" "$key" || true)"
+    ci_value="$(clippy_config_value "$CI_CLIPPY_CONFIG" "$key" || true)"
+    if [ -n "$root_value" ] && [ -n "$ci_value" ] && [ "$root_value" != "$ci_value" ]; then
+      fail "clippy threshold mismatch for $key: $ROOT_CLIPPY_CONFIG=$root_value, $CI_CLIPPY_CONFIG=$ci_value"
+    fi
+  done
+}
+
+check_allowlist
+check_clippy_config_sync
+
+if [ "$errors" -gt 0 ]; then
+  echo "Clippy allow policy failed with $errors error(s)." >&2
+  exit 1
+fi
+
+echo "Clippy allow policy passed."

--- a/tests/core/clippy_allow_policy.rs
+++ b/tests/core/clippy_allow_policy.rs
@@ -1,0 +1,23 @@
+//! Clippy allow policy contract tests.
+
+#[test]
+fn clippy_allow_policy_script_passes() {
+    let output = std::process::Command::new("bash")
+        .arg("scripts/check-clippy-allows.sh")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output();
+    let Ok(output) = output else {
+        panic!("clippy allow policy script should run");
+    };
+
+    assert!(
+        output.status.success(),
+        "clippy allow policy script failed
+stdout:
+{}
+stderr:
+{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -3,6 +3,7 @@
 //! @plan PLAN-20260216-FIRSTVERSION-V1.P04
 //! @requirement REQ-TECH-002
 
+mod clippy_allow_policy;
 mod domain_state_contracts;
 mod message_bus_contracts;
 mod persistence_theme_contracts;


### PR DESCRIPTION
## Summary
- add a clippy allow policy script that compares current allow attributes against a tracked allowlist
- add a CI job and local ci-check step for the policy
- document the no-new-clippy-allow rule and track current exceptions with owners/removal targets

## Verification
- make ci-check
- cargo fmt --all --check
- scripts/check-clippy-allows.sh
- bash scripts/check-architecture.sh
- cargo test -q clippy_allow_policy_script_passes

Fixes #26
