### PR TITLE
Remove app input clippy suppressions (Fixes #69)

### DIFF
--- a/clippy-allowlist.tsv
+++ b/clippy-allowlist.tsv
@@ -3,14 +3,6 @@
 # New #[allow(clippy::...)] or #![allow(clippy::...)] entries must not be added without an approved exception.
 src/app_init.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
 src/app_init.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
-src/app_input/issues_filter.rs	#[allow(clippy::field_reassign_with_default)]	core-maintainers	next quality-cycle ratchet
-src/app_input/issues.rs	#[allow(clippy::match_same_arms)]	core-maintainers	next quality-cycle ratchet
-src/app_input/issues.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
-src/app_input/issues.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
-src/app_input/mod.rs	#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]	core-maintainers	next quality-cycle ratchet
-src/app_input/modal_handlers.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
-src/app_input/modal_handlers.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
-src/app_input/normal.rs	#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]	core-maintainers	next quality-cycle ratchet
 src/app_shell.rs	#[allow(clippy::cognitive_complexity)]	core-maintainers	next quality-cycle ratchet
 src/app_shell.rs	#[allow(clippy::cognitive_complexity)]	core-maintainers	next quality-cycle ratchet
 src/github/mod.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet

--- a/src/app_input/issues.rs
+++ b/src/app_input/issues.rs
@@ -26,189 +26,164 @@ use super::{AppStateHandle, SharedContext};
 /// @plan PLAN-20260329-ISSUES-MODE.P11
 /// @requirement REQ-ISS-002
 /// @pseudocode component-003 lines 01-38
-#[allow(clippy::too_many_lines)]
 pub fn resolve_issues_key_event(state: &AppState, key_event: &KeyEvent) -> Option<AppEvent> {
-    let inline_state = &state.issues_state.inline_state;
-    let has_agent_chooser = state.issues_state.agent_chooser.is_some();
-    let search_focused = state.issues_state.search_input_focused;
-    let filter_open = state.issues_state.filter_controls_open;
-
-    // Priority 1: Inline editor/composer — consumes all keys when active.
-    // @plan PLAN-20260329-ISSUES-MODE.P11
-    // @pseudocode component-003 lines 03-06
-    if *inline_state != InlineState::None {
-        return match key_event.code {
-            KeyCode::Esc => Some(AppEvent::InlineCancelOrEsc),
-            KeyCode::Enter if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-                Some(AppEvent::InlineSubmit)
-            }
-            KeyCode::Enter => Some(AppEvent::InlineNewline),
-            KeyCode::Char(c) => Some(AppEvent::InlineChar(c)),
-            KeyCode::Backspace => Some(AppEvent::InlineBackspace),
-            KeyCode::Delete => Some(AppEvent::InlineDelete),
-            KeyCode::Left => Some(AppEvent::InlineCursorLeft),
-            KeyCode::Right => Some(AppEvent::InlineCursorRight),
-            KeyCode::Up => Some(AppEvent::InlineCursorUp),
-            KeyCode::Down => Some(AppEvent::InlineCursorDown),
-            _ => None, // consumed, no leak
-        };
+    if state.issues_state.inline_state != InlineState::None {
+        return resolve_inline_key_event(key_event);
     }
 
-    // Priority 2: Agent chooser — consumes all keys when open.
-    // @plan PLAN-20260329-ISSUES-MODE.P11
-    // @pseudocode component-003 lines 07-10
-    if has_agent_chooser {
-        return match key_event.code {
-            KeyCode::Up => Some(AppEvent::AgentChooserNavigateUp),
-            KeyCode::Down => Some(AppEvent::AgentChooserNavigateDown),
-            KeyCode::Enter => Some(AppEvent::AgentChooserConfirm),
-            KeyCode::Esc => Some(AppEvent::AgentChooserCancel),
-            _ => None, // consumed
-        };
+    if state.issues_state.agent_chooser.is_some() {
+        return resolve_agent_chooser_key_event(key_event);
     }
 
-    // Priority 3: Search input focused.
-    // @plan PLAN-20260329-ISSUES-MODE.P11
-    // @pseudocode component-003 lines 11-14
-    if search_focused {
-        return match key_event.code {
-            KeyCode::Enter => Some(AppEvent::ApplySearch),
-            KeyCode::Esc => {
-                if state.issues_state.search_query.is_empty() {
-                    Some(AppEvent::BlurSearchInput)
-                } else {
-                    Some(AppEvent::ClearSearch)
-                }
-            }
-            KeyCode::Char(c) => {
-                let mut query = state.issues_state.search_query.clone();
-                query.push(c);
-                Some(AppEvent::SetSearchQuery { query })
-            }
-            KeyCode::Backspace => {
-                let mut query = state.issues_state.search_query.clone();
-                query.pop();
-                Some(AppEvent::SetSearchQuery { query })
-            }
-            _ => None,
-        };
+    if state.issues_state.search_input_focused {
+        return resolve_search_key_event(state, key_event);
     }
 
-    // Priority 4: Filter controls open.
-    // @plan PLAN-20260329-ISSUES-MODE.P11
-    // @pseudocode component-003 lines 15-18
-    // @requirement REQ-ISS-008
-    if filter_open {
+    if state.issues_state.filter_controls_open {
         return resolve_filter_key_event(state, key_event);
     }
 
-    // Priority 5: Issues-global unwind and mode controls.
-    // @plan PLAN-20260329-ISSUES-MODE.P11
-    // @pseudocode component-003 lines 19-26
-    match key_event.code {
-        KeyCode::Char('a') => return Some(AppEvent::ExitIssuesMode),
-        KeyCode::Esc => {
-            // Esc in IssueDetail goes back to IssueList, not all the way out
-            return if state.issues_state.issue_focus == IssueFocus::IssueDetail {
-                Some(AppEvent::RefocusIssueList)
-            } else {
-                Some(AppEvent::ExitIssuesMode)
-            };
-        }
-        KeyCode::Char('i') => return Some(AppEvent::RefocusIssueList),
-        KeyCode::Char('?' | 'h') | KeyCode::F(1) => {
-            return Some(AppEvent::OpenHelp);
-        }
-        _ => {}
-    }
+    resolve_global_issues_key_event(state, key_event)
+        .or_else(|| resolve_focus_key_event(state, key_event))
+        .or_else(|| resolve_pane_cycle_key_event(key_event))
+}
 
-    // Priority 6: Focus-domain handlers.
-    // @plan PLAN-20260329-ISSUES-MODE.P11
-    // @pseudocode component-003 lines 27-72
+fn resolve_inline_key_event(key_event: &KeyEvent) -> Option<AppEvent> {
+    match key_event.code {
+        KeyCode::Esc => Some(AppEvent::InlineCancelOrEsc),
+        KeyCode::Enter if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(AppEvent::InlineSubmit)
+        }
+        KeyCode::Enter => Some(AppEvent::InlineNewline),
+        KeyCode::Char(c) => Some(AppEvent::InlineChar(c)),
+        KeyCode::Backspace => Some(AppEvent::InlineBackspace),
+        KeyCode::Delete => Some(AppEvent::InlineDelete),
+        KeyCode::Left => Some(AppEvent::InlineCursorLeft),
+        KeyCode::Right => Some(AppEvent::InlineCursorRight),
+        KeyCode::Up => Some(AppEvent::InlineCursorUp),
+        KeyCode::Down => Some(AppEvent::InlineCursorDown),
+        _ => None,
+    }
+}
+
+fn resolve_agent_chooser_key_event(key_event: &KeyEvent) -> Option<AppEvent> {
+    match key_event.code {
+        KeyCode::Up => Some(AppEvent::AgentChooserNavigateUp),
+        KeyCode::Down => Some(AppEvent::AgentChooserNavigateDown),
+        KeyCode::Enter => Some(AppEvent::AgentChooserConfirm),
+        KeyCode::Esc => Some(AppEvent::AgentChooserCancel),
+        _ => None,
+    }
+}
+
+fn resolve_search_key_event(state: &AppState, key_event: &KeyEvent) -> Option<AppEvent> {
+    match key_event.code {
+        KeyCode::Enter => Some(AppEvent::ApplySearch),
+        KeyCode::Esc if state.issues_state.search_query.is_empty() => {
+            Some(AppEvent::BlurSearchInput)
+        }
+        KeyCode::Esc => Some(AppEvent::ClearSearch),
+        KeyCode::Char(c) => {
+            let mut query = state.issues_state.search_query.clone();
+            query.push(c);
+            Some(AppEvent::SetSearchQuery { query })
+        }
+        KeyCode::Backspace => {
+            let mut query = state.issues_state.search_query.clone();
+            query.pop();
+            Some(AppEvent::SetSearchQuery { query })
+        }
+        _ => None,
+    }
+}
+
+fn resolve_global_issues_key_event(state: &AppState, key_event: &KeyEvent) -> Option<AppEvent> {
+    match key_event.code {
+        KeyCode::Esc if state.issues_state.issue_focus == IssueFocus::IssueDetail => {
+            Some(AppEvent::RefocusIssueList)
+        }
+        KeyCode::Char('a') | KeyCode::Esc => Some(AppEvent::ExitIssuesMode),
+        KeyCode::Char('i') => Some(AppEvent::RefocusIssueList),
+        KeyCode::Char('?' | 'h') | KeyCode::F(1) => Some(AppEvent::OpenHelp),
+        _ => None,
+    }
+}
+
+fn resolve_focus_key_event(state: &AppState, key_event: &KeyEvent) -> Option<AppEvent> {
     match state.issues_state.issue_focus {
-        IssueFocus::IssueList => match key_event.code {
-            KeyCode::Up => return Some(AppEvent::IssuesNavigateUp),
-            KeyCode::Down => return Some(AppEvent::IssuesNavigateDown),
-            KeyCode::Left => return Some(AppEvent::IssuesCycleFocusReverse),
-            KeyCode::Right => return Some(AppEvent::IssuesCycleFocus),
-            KeyCode::PageUp => return Some(AppEvent::IssuesNavigatePageUp),
-            KeyCode::PageDown => return Some(AppEvent::IssuesNavigatePageDown),
-            KeyCode::Home => return Some(AppEvent::IssuesNavigateHome),
-            KeyCode::End => return Some(AppEvent::IssuesNavigateEnd),
-            KeyCode::Enter => return Some(AppEvent::IssuesEnter),
-            KeyCode::Char('n' | 'N') => return Some(AppEvent::OpenNewIssueComposer),
-            KeyCode::Char('f') => return Some(AppEvent::OpenFilterControls),
-            KeyCode::Char('/') => return Some(AppEvent::FocusSearchInput),
-            _ => {}
-        },
-
-        IssueFocus::IssueDetail => match key_event.code {
-            KeyCode::Up => return Some(AppEvent::IssuesScrollDetailUp),
-            KeyCode::Down => return Some(AppEvent::IssuesScrollDetailDown),
-            KeyCode::Left => return Some(AppEvent::IssuesCycleFocusReverse),
-            KeyCode::PageUp => return Some(AppEvent::IssuesScrollDetailPageUp),
-            KeyCode::PageDown => return Some(AppEvent::IssuesScrollDetailPageDown),
-            KeyCode::Char('e') => {
-                return match state.issues_state.detail_subfocus {
-                    DetailSubfocus::Body => Some(AppEvent::OpenInlineEditor {
-                        target: jefe::state::EditorTarget::IssueBody,
-                    }),
-                    DetailSubfocus::Comment(idx) => Some(AppEvent::OpenInlineEditor {
-                        target: jefe::state::EditorTarget::Comment { comment_index: idx },
-                    }),
-                    DetailSubfocus::NewComment => None,
-                };
-            }
-            KeyCode::Char('c') => {
-                return Some(AppEvent::OpenNewCommentComposer);
-            }
-            KeyCode::Char('r') => {
-                return match state.issues_state.detail_subfocus {
-                    DetailSubfocus::Comment(idx) => {
-                        Some(AppEvent::OpenReplyComposer { comment_index: idx })
-                    }
-                    _ => None,
-                };
-            }
-            KeyCode::Char('S') => {
-                // Only open chooser if agents exist.
-                return if state.agents.is_empty() {
-                    None
-                } else {
-                    Some(AppEvent::OpenAgentChooser)
-                };
-            }
-            KeyCode::Tab => return Some(AppEvent::IssueDetailSubfocusNext),
-            KeyCode::BackTab => return Some(AppEvent::IssueDetailSubfocusPrev),
-            _ => {}
-        },
-
-        IssueFocus::RepoList => match key_event.code {
-            KeyCode::Up => return Some(AppEvent::IssuesNavigateUp),
-            KeyCode::Down => return Some(AppEvent::IssuesNavigateDown),
-            KeyCode::Right => return Some(AppEvent::IssuesCycleFocus),
-            _ => {}
-        },
+        IssueFocus::IssueList => resolve_issue_list_key_event(key_event),
+        IssueFocus::IssueDetail => resolve_issue_detail_key_event(state, key_event),
+        IssueFocus::RepoList => resolve_repo_list_key_event(key_event),
     }
+}
 
-    // Priority 7: Pane focus cycling — catch-all Tab/Shift+Tab when not in detail.
-    // @plan PLAN-20260329-ISSUES-MODE.P11
-    // @pseudocode component-003 lines 73-80
+fn resolve_issue_list_key_event(key_event: &KeyEvent) -> Option<AppEvent> {
     match key_event.code {
-        KeyCode::Tab => return Some(AppEvent::IssuesCycleFocus),
-        KeyCode::BackTab => return Some(AppEvent::IssuesCycleFocusReverse),
-        _ => {}
+        KeyCode::Up => Some(AppEvent::IssuesNavigateUp),
+        KeyCode::Down => Some(AppEvent::IssuesNavigateDown),
+        KeyCode::Left => Some(AppEvent::IssuesCycleFocusReverse),
+        KeyCode::Right => Some(AppEvent::IssuesCycleFocus),
+        KeyCode::PageUp => Some(AppEvent::IssuesNavigatePageUp),
+        KeyCode::PageDown => Some(AppEvent::IssuesNavigatePageDown),
+        KeyCode::Home => Some(AppEvent::IssuesNavigateHome),
+        KeyCode::End => Some(AppEvent::IssuesNavigateEnd),
+        KeyCode::Enter => Some(AppEvent::IssuesEnter),
+        KeyCode::Char('n' | 'N') => Some(AppEvent::OpenNewIssueComposer),
+        KeyCode::Char('f') => Some(AppEvent::OpenFilterControls),
+        KeyCode::Char('/') => Some(AppEvent::FocusSearchInput),
+        _ => None,
     }
+}
 
-    // Priority 8: Suppression — consumed as no-op in issues mode.
-    // @plan PLAN-20260329-ISSUES-MODE.P11
-    // @pseudocode component-003 lines 81-90
-    #[allow(clippy::match_same_arms)]
+fn resolve_issue_detail_key_event(state: &AppState, key_event: &KeyEvent) -> Option<AppEvent> {
     match key_event.code {
-        KeyCode::Char('s') => None,
-        KeyCode::Char('d') if key_event.modifiers.contains(KeyModifiers::CONTROL) => None,
-        KeyCode::Char('k') if key_event.modifiers.contains(KeyModifiers::CONTROL) => None,
-        KeyCode::Char('l') => None,
+        KeyCode::Up => Some(AppEvent::IssuesScrollDetailUp),
+        KeyCode::Down => Some(AppEvent::IssuesScrollDetailDown),
+        KeyCode::Left => Some(AppEvent::IssuesCycleFocusReverse),
+        KeyCode::PageUp => Some(AppEvent::IssuesScrollDetailPageUp),
+        KeyCode::PageDown => Some(AppEvent::IssuesScrollDetailPageDown),
+        KeyCode::Char('e') => editor_event_for_subfocus(state.issues_state.detail_subfocus),
+        KeyCode::Char('c') => Some(AppEvent::OpenNewCommentComposer),
+        KeyCode::Char('r') => reply_event_for_subfocus(state.issues_state.detail_subfocus),
+        KeyCode::Char('S') if !state.agents.is_empty() => Some(AppEvent::OpenAgentChooser),
+        KeyCode::Tab => Some(AppEvent::IssueDetailSubfocusNext),
+        KeyCode::BackTab => Some(AppEvent::IssueDetailSubfocusPrev),
+        _ => None,
+    }
+}
+
+fn editor_event_for_subfocus(subfocus: DetailSubfocus) -> Option<AppEvent> {
+    match subfocus {
+        DetailSubfocus::Body => Some(AppEvent::OpenInlineEditor {
+            target: jefe::state::EditorTarget::IssueBody,
+        }),
+        DetailSubfocus::Comment(idx) => Some(AppEvent::OpenInlineEditor {
+            target: jefe::state::EditorTarget::Comment { comment_index: idx },
+        }),
+        DetailSubfocus::NewComment => None,
+    }
+}
+
+fn reply_event_for_subfocus(subfocus: DetailSubfocus) -> Option<AppEvent> {
+    match subfocus {
+        DetailSubfocus::Comment(idx) => Some(AppEvent::OpenReplyComposer { comment_index: idx }),
+        _ => None,
+    }
+}
+
+fn resolve_repo_list_key_event(key_event: &KeyEvent) -> Option<AppEvent> {
+    match key_event.code {
+        KeyCode::Up => Some(AppEvent::IssuesNavigateUp),
+        KeyCode::Down => Some(AppEvent::IssuesNavigateDown),
+        KeyCode::Right => Some(AppEvent::IssuesCycleFocus),
+        _ => None,
+    }
+}
+
+fn resolve_pane_cycle_key_event(key_event: &KeyEvent) -> Option<AppEvent> {
+    match key_event.code {
+        KeyCode::Tab => Some(AppEvent::IssuesCycleFocus),
+        KeyCode::BackTab => Some(AppEvent::IssuesCycleFocusReverse),
         _ => None,
     }
 }
@@ -219,7 +194,6 @@ pub fn resolve_issues_key_event(state: &AppState, key_event: &KeyEvent) -> Optio
 /// @plan PLAN-20260329-ISSUES-MODE.P11
 /// @requirement REQ-ISS-002
 /// @pseudocode component-003 lines 01-38
-#[allow(clippy::too_many_lines)]
 pub fn handle_issues_mode_key(
     app_state: &AppStateHandle,
     _ctx: &SharedContext,

--- a/src/app_input/issues_filter.rs
+++ b/src/app_input/issues_filter.rs
@@ -62,7 +62,6 @@ fn current_filter_field_value(state: &AppState, field_name: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;
     use iocraft::prelude::{KeyCode, KeyEventKind, KeyModifiers};
@@ -79,12 +78,16 @@ mod tests {
     }
 
     fn filter_state() -> AppState {
-        let mut state = AppState::default();
-        state.screen_mode = ScreenMode::DashboardIssues;
-        state.issues_state.active = true;
-        state.issues_state.filter_controls_open = true;
-        state.issues_state.filter_field_index = 0;
-        state
+        AppState {
+            screen_mode: ScreenMode::DashboardIssues,
+            issues_state: jefe::state::IssuesState {
+                active: true,
+                filter_controls_open: true,
+                filter_field_index: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
     }
 
     #[test]

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -409,445 +409,587 @@ pub fn dispatch_app_event(app_state: &mut AppStateHandle, ctx: &SharedContext, e
     dispatch_app_message(app_state, ctx, evt.into());
 }
 
-#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
 pub fn dispatch_app_message(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
     message: AppMessage,
 ) {
-    let route = message.route();
-    debug!(
-        message_domain = ?route.domain,
-        message = route.name,
-        "dispatching app message"
-    );
+    log_dispatch(&message);
 
     match message {
         AppMessage::UiNavigation(UiNavigationMessage::ToggleTerminalFocus) => {
-            // Keep Enter-in-terminal-pane as a UI focus toggle only.
-            // Runtime attach/detach remains bound to F12.
             apply_and_persist(app_state, ctx, AppEvent::ToggleTerminalFocus);
         }
         AppMessage::Runtime(RuntimeMessage::KillAgent(agent_id)) => {
-            let kill_result = if let Some(ctx_arc) = &ctx {
-                match ctx_arc.lock() {
-                    Ok(mut ctx_guard) => {
-                        ctx_guard.runtime.kill(&agent_id).map_err(|e| e.to_string())
-                    }
-                    Err(e) => Err(format!("application context lock poisoned: {e}")),
-                }
-            } else {
-                Ok(())
-            };
-
-            if let Err(error) = kill_result {
-                warn!(agent_id = %agent_id.0, error = %error, "could not kill runtime session");
-                let mut state = app_state.write();
-                state.error_message = Some(error);
-                let persisted = to_persisted_state(&state);
-                drop(state);
-                persist_state(ctx, &persisted);
-                return;
-            }
-
-            let mut state = app_state.write();
-            *state = std::mem::take(&mut *state).apply(AppEvent::KillAgent(agent_id));
-            state.terminal_focused = false;
-            let persisted = to_persisted_state(&state);
-            drop(state);
-            persist_state(ctx, &persisted);
+            dispatch_kill_agent(app_state, ctx, agent_id);
         }
         AppMessage::Runtime(RuntimeMessage::RelaunchAgent(agent_id)) => {
-            // Run preflight before attempting the relaunch.
-            {
-                let state_ro = app_state.read();
-                if let Some((_agent, signature)) = agent_and_signature(&state_ro, &agent_id) {
-                    drop(state_ro);
-                    if !preflight_or_prompt(app_state, ctx, &agent_id, &signature) {
-                        return;
-                    }
-                }
-            }
-
-            let mut relaunched = false;
-            let relaunch_event = AppEvent::RelaunchAgent(agent_id.clone());
-            if let Some(ctx_arc) = &ctx
-                && let Ok(mut ctx_guard) = ctx_arc.lock()
-            {
-                // Always relaunch from current in-memory agent config so edits made
-                // before relaunch (e.g. LLXPRT_DEBUG changes) are applied.
-                let state_ro = app_state.read();
-                if let Some((agent, signature)) = agent_and_signature(&state_ro, &agent_id) {
-                    match ctx_guard.runtime.spawn_session_fresh(
-                        &agent_id,
-                        &agent.work_dir,
-                        &signature,
-                    ) {
-                        Ok(()) => {
-                            relaunched = true;
-                        }
-                        Err(e) => {
-                            // If the process-local mapping still exists, fall back to runtime relaunch.
-                            // This keeps behavior stable for edge cases while still preferring fresh config.
-                            match e {
-                                RuntimeError::AlreadyRunning(_) => {
-                                    match ctx_guard.runtime.relaunch(&agent_id) {
-                                        Ok(()) => {
-                                            relaunched = true;
-                                        }
-                                        Err(e2) => {
-                                            warn!(
-                                                agent_id = %agent_id.0,
-                                                error = %e2,
-                                                "could not relaunch runtime session"
-                                            );
-                                        }
-                                    }
-                                }
-                                _ => {
-                                    warn!(
-                                        agent_id = %agent_id.0,
-                                        error = %e,
-                                        "could not spawn fresh runtime session for relaunch"
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if relaunched {
-                    // Relaunch should make output visible immediately; focus remains separate.
-                    std::thread::sleep(REMOTE_ATTACH_SETTLE_DELAY);
-                    match ctx_guard.runtime.attach(&agent_id) {
-                        Ok(()) => {}
-                        Err(e) => {
-                            warn!(
-                                agent_id = %agent_id.0,
-                                error = %e,
-                                "could not attach relaunched session"
-                            );
-                            let _ = ctx_guard.runtime.mark_session_dead(&agent_id);
-                            relaunched = false;
-                        }
-                    }
-                }
-            }
-
-            let mut state = app_state.write();
-            if relaunched {
-                if let Some((agent, signature)) = agent_and_signature(&state, &agent_id) {
-                    set_agent_runtime_binding(
-                        &mut state,
-                        &agent_id,
-                        jefe::runtime::RuntimeSession::session_name_for(&agent.id),
-                        signature,
-                    );
-                }
-                *state = std::mem::take(&mut *state).apply(relaunch_event);
-                state.terminal_focused = false;
-                clear_agent_runtime_attachment(&mut state);
-                mark_agent_runtime_attached(&mut state, &agent_id, true);
-                if let Some(warning) = sandbox_ssh_agent_warning() {
-                    state.warning_message = Some(warning);
-                } else {
-                    clear_runtime_warning(&mut state);
-                }
-            } else {
-                *state = std::mem::take(&mut *state).apply(relaunch_event);
-                state.terminal_focused = false;
-                state.pane_focus = PaneFocus::Agents;
-                mark_runtime_session_dead_if_present(&mut state, &agent_id);
-                if let Some(agent) = state.agents.iter_mut().find(|agent| agent.id == agent_id) {
-                    agent.runtime_binding = None;
-                }
-            }
-            let persisted = to_persisted_state(&state);
-            drop(state);
-            persist_state(ctx, &persisted);
+            dispatch_relaunch_agent(app_state, ctx, agent_id);
         }
-
         AppMessage::Issues(message @ (IssuesMessage::NavigateUp | IssuesMessage::NavigateDown)) => {
-            let (focus, prev_repo_idx, prev_issue_idx) = {
-                let state = app_state.read();
-                (
-                    state.issues_state.issue_focus,
-                    state.selected_repository_index,
-                    state.issues_state.selected_issue_index,
-                )
-            };
-
-            apply_and_persist(app_state, ctx, AppEvent::from(message));
-
-            match focus {
-                jefe::state::IssueFocus::RepoList => {
-                    let new_repo_idx = app_state.read().selected_repository_index;
-                    if new_repo_idx != prev_repo_idx {
-                        {
-                            let mut state = app_state.write();
-                            state.issues_state.issues.clear();
-                            state.issues_state.selected_issue_index = None;
-                            state.issues_state.issue_detail = None;
-                            state.issues_state.list_cursor = None;
-                            state.issues_state.has_more_issues = false;
-                            state.issues_state.error = None;
-                            if state.issues_state.inline_state != jefe::state::InlineState::None {
-                                state.issues_state.draft_notice =
-                                    Some("Unsent draft discarded".to_string());
-                            }
-                            state.issues_state.inline_state = jefe::state::InlineState::None;
-                            state.issues_state.agent_chooser = None;
-                            state.issues_state.list_loading = true;
-                        }
-                        // Trigger issue list load; RefocusIssueList changes
-                        // focus to IssueList, so restore RepoList focus after.
-                        dispatch_app_event(app_state, ctx, AppEvent::RefocusIssueList);
-                        app_state.write().issues_state.issue_focus =
-                            jefe::state::IssueFocus::RepoList;
-                    }
-                }
-                jefe::state::IssueFocus::IssueList => {
-                    let new_issue_idx = app_state.read().issues_state.selected_issue_index;
-                    if new_issue_idx != prev_issue_idx {
-                        // Build a lightweight preview from list data (no I/O)
-                        issues_dispatch::preview_issue_from_list(app_state);
-                    }
-                }
-                jefe::state::IssueFocus::IssueDetail => {}
-            }
+            dispatch_issues_navigation(app_state, ctx, message);
         }
-
         AppMessage::Issues(
             message @ (IssuesMessage::EnterMode
             | IssuesMessage::RefocusList
             | IssuesMessage::ApplyFilter
             | IssuesMessage::ClearFilter
             | IssuesMessage::ApplySearch),
-        ) => {
-            let fresh_reload = matches!(
-                &message,
-                IssuesMessage::RefocusList | IssuesMessage::ApplySearch
-            );
-
-            // Apply state transition first (sets list_loading = true, etc.)
-            apply_and_persist(app_state, ctx, AppEvent::from(message));
-
-            // Now perform the actual issue list fetch
-            let (scope_repo_id, owner, repo, filter, cursor, page_size) = {
-                let state = app_state.read();
-                let gh_repo = issues_dispatch::resolve_gh_repo(&state);
-                let filter = state.issues_state.committed_filter.clone();
-                let cursor = if fresh_reload {
-                    None
-                } else {
-                    state.issues_state.list_cursor.clone()
-                };
-                let scope_repo_id = issues_dispatch::current_scope_repo_id(&state);
-                let fetch_params = (scope_repo_id, gh_repo.0, gh_repo.1, filter, cursor, 30u32);
-                drop(state);
-                fetch_params
-            };
-
-            if owner.is_empty() || repo.is_empty() {
-                let mut state = app_state.write();
-                state.issues_state.list_loading = false;
-                state.issues_state.error = Some(
-                    "No GitHub repository configured. Set the GitHub Repo field (owner/repo) in repository settings.".to_string(),
-                );
-                let persisted = to_persisted_state(&state);
-                drop(state);
-                persist_state(ctx, &persisted);
-                return;
-            }
-
-            let result = if let Some(ctx_arc) = &ctx
-                && let Ok(ctx_guard) = ctx_arc.lock()
-            {
-                Some(ctx_guard.gh_client.list_issues(
-                    &owner,
-                    &repo,
-                    &filter,
-                    cursor.as_deref(),
-                    page_size,
-                ))
-            } else {
-                None
-            };
-
-            match result {
-                Some(Ok(response)) => {
-                    let has_issues = !response.issues.is_empty();
-                    let mut state = app_state.write();
-                    *state = std::mem::take(&mut *state).apply(AppEvent::IssueListLoaded {
-                        scope_repo_id: scope_repo_id.clone(),
-                        issues: response.issues,
-                        cursor: response.cursor,
-                        has_more: response.has_more,
-                    });
-                    drop(state);
-                    // Show preview for the first issue (no I/O)
-                    if has_issues {
-                        issues_dispatch::preview_issue_from_list(app_state);
-                    }
-                }
-                Some(Err(e)) => {
-                    let mut state = app_state.write();
-                    *state = std::mem::take(&mut *state).apply(AppEvent::IssueListLoadFailed {
-                        scope_repo_id: scope_repo_id.clone(),
-                        error: e.to_string(),
-                    });
-                }
-                None => {
-                    let mut state = app_state.write();
-                    *state = std::mem::take(&mut *state).apply(AppEvent::IssueListLoadFailed {
-                        scope_repo_id,
-                        error: "Application context unavailable".to_string(),
-                    });
-                }
-            }
-        }
-
+        ) => dispatch_issue_list_reload(app_state, ctx, message),
         AppMessage::Issues(IssuesMessage::Enter) => {
             apply_and_persist(app_state, ctx, AppEvent::IssuesEnter);
             issues_dispatch::load_issue_detail_for_selection(app_state, ctx);
         }
-
         AppMessage::Issues(IssuesMessage::AgentChooserConfirm) => {
-            // Gather chosen agent and issue data before clearing the chooser
-            let send_info = {
-                let state = app_state.read();
-                let chooser = state.issues_state.agent_chooser.as_ref();
-                let detail = state.issues_state.issue_detail.as_ref();
-                let subfocus = state.issues_state.detail_subfocus;
-
-                let send_info = (|| -> Option<_> {
-                    let (ch, det) = chooser.zip(detail)?;
-                    let (agent_id, _) = ch.agents.get(ch.selected_index)?.clone();
-                    let agent = state.agents.iter().find(|a| a.id == agent_id)?.clone();
-                    let repo = state.repository_by_id(&agent.repository_id)?;
-                    let repo_slug = repo.slug.clone();
-                    let base_prompt = repo.issue_base_prompt.clone();
-                    let signature = launch_signature_for_agent(&agent, repo);
-
-                    let focused_comment = match subfocus {
-                        jefe::state::DetailSubfocus::Comment(idx) => det.comments.get(idx).cloned(),
-                        _ => None,
-                    };
-                    let payload = jefe::github::GhClient::build_send_payload(
-                        &repo_slug,
-                        det,
-                        focused_comment.as_ref(),
-                        &base_prompt,
-                    );
-                    Some((agent_id, agent.work_dir.clone(), signature, payload))
-                })();
-                drop(state);
-                send_info
-            };
-
-            // Clear the chooser regardless
-            apply_and_persist(app_state, ctx, AppEvent::AgentChooserConfirm);
-
-            let Some((agent_id, work_dir, signature, payload)) = send_info else {
-                return;
-            };
-
-            // Write the issue prompt to a file in the agent's work dir
-            let prompt_dir = work_dir.join(".jefe");
-            if let Err(e) = std::fs::create_dir_all(&prompt_dir) {
-                let mut state = app_state.write();
-                *state = std::mem::take(&mut *state).apply(AppEvent::SendToAgentFailed {
-                    error: format!("Failed to create .jefe dir: {e}"),
-                });
-                return;
-            }
-            let prompt_path = prompt_dir.join("issue-prompt.md");
-            let prompt_content = issues_dispatch::format_issue_prompt(&payload);
-            if let Err(e) = std::fs::write(&prompt_path, &prompt_content) {
-                let mut state = app_state.write();
-                *state = std::mem::take(&mut *state).apply(AppEvent::SendToAgentFailed {
-                    error: format!("Failed to write issue prompt: {e}"),
-                });
-                return;
-            }
-
-            // Clone signature with -i flag for this launch only
-            let mut launch_sig = signature;
-            launch_sig.mode_flags.push("-i".to_owned());
-            launch_sig.mode_flags.push(
-                "Read and work on the GitHub issue described in .jefe/issue-prompt.md".to_owned(),
-            );
-
-            if !preflight_or_prompt(app_state, ctx, &agent_id, &launch_sig) {
-                return;
-            }
-
-            // Launch the agent
-            let mut launched = false;
-            if let Some(ctx_arc) = &ctx
-                && let Ok(mut ctx_guard) = ctx_arc.lock()
-            {
-                match ctx_guard
-                    .runtime
-                    .spawn_session_fresh(&agent_id, &work_dir, &launch_sig)
-                {
-                    Ok(()) => {
-                        std::thread::sleep(REMOTE_ATTACH_SETTLE_DELAY);
-                        match ctx_guard.runtime.attach(&agent_id) {
-                            Ok(()) => {
-                                launched = true;
-                            }
-                            Err(e) => {
-                                warn!(
-                                    agent_id = %agent_id.0,
-                                    error = %e,
-                                    "could not attach agent after issue send"
-                                );
-                                let _ = ctx_guard.runtime.mark_session_dead(&agent_id);
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        warn!(
-                            agent_id = %agent_id.0,
-                            error = %e,
-                            "could not spawn agent for issue send"
-                        );
-                    }
-                }
-            }
-
-            let mut state = app_state.write();
-            if launched {
-                if let Some(agent) = state.agents.iter_mut().find(|a| a.id == agent_id) {
-                    agent.status = jefe::domain::AgentStatus::Running;
-                    let session_name = jefe::runtime::RuntimeSession::session_name_for(&agent_id);
-                    agent.runtime_binding = Some(jefe::domain::RuntimeBinding {
-                        session_name,
-                        launch_signature: launch_sig,
-                        attached: false,
-                        last_seen: None,
-                    });
-                }
-                clear_agent_runtime_attachment(&mut state);
-                mark_agent_runtime_attached(&mut state, &agent_id, true);
-            } else {
-                *state = std::mem::take(&mut *state).apply(AppEvent::SendToAgentFailed {
-                    error: "Failed to launch agent".to_string(),
-                });
-            }
-            let persisted = to_persisted_state(&state);
-            drop(state);
-            persist_state(ctx, &persisted);
+            dispatch_agent_chooser_confirm(app_state, ctx);
         }
         AppMessage::Issues(IssuesMessage::InlineSubmit) => {
             issues_mutation::handle_inline_submit(app_state, ctx);
         }
+        message => apply_and_persist(app_state, ctx, AppEvent::from(message)),
+    }
+}
 
-        message => {
-            apply_and_persist(app_state, ctx, AppEvent::from(message));
+fn log_dispatch(message: &AppMessage) {
+    let route = message.route();
+    debug!(
+        message_domain = ?route.domain,
+        message = route.name,
+        "dispatching app message"
+    );
+}
+
+fn dispatch_kill_agent(app_state: &mut AppStateHandle, ctx: &SharedContext, agent_id: AgentId) {
+    if let Err(error) = kill_runtime_agent(ctx, &agent_id) {
+        warn!(agent_id = %agent_id.0, error = %error, "could not kill runtime session");
+        persist_error_message(app_state, ctx, error);
+        return;
+    }
+
+    let mut state = app_state.write();
+    *state = std::mem::take(&mut *state).apply(AppEvent::KillAgent(agent_id));
+    state.terminal_focused = false;
+    let persisted = to_persisted_state(&state);
+    drop(state);
+    persist_state(ctx, &persisted);
+}
+
+fn kill_runtime_agent(ctx: &SharedContext, agent_id: &AgentId) -> Result<(), String> {
+    let Some(ctx_arc) = ctx else {
+        return Ok(());
+    };
+    match ctx_arc.lock() {
+        Ok(mut ctx_guard) => ctx_guard.runtime.kill(agent_id).map_err(|e| e.to_string()),
+        Err(error) => Err(format!("application context lock poisoned: {error}")),
+    }
+}
+
+fn persist_error_message(app_state: &mut AppStateHandle, ctx: &SharedContext, error: String) {
+    let mut state = app_state.write();
+    state.error_message = Some(error);
+    let persisted = to_persisted_state(&state);
+    drop(state);
+    persist_state(ctx, &persisted);
+}
+
+fn dispatch_relaunch_agent(app_state: &mut AppStateHandle, ctx: &SharedContext, agent_id: AgentId) {
+    if !relaunch_preflight_passed(app_state, ctx, &agent_id) {
+        return;
+    }
+
+    let relaunched = relaunch_runtime_session(app_state, ctx, &agent_id);
+    persist_relaunch_result(app_state, ctx, agent_id, relaunched);
+}
+
+fn relaunch_preflight_passed(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    agent_id: &AgentId,
+) -> bool {
+    let state_ro = app_state.read();
+    let signature = agent_and_signature(&state_ro, agent_id).map(|(_, signature)| signature);
+    drop(state_ro);
+    match signature {
+        Some(signature) => preflight_or_prompt(app_state, ctx, agent_id, &signature),
+        None => true,
+    }
+}
+
+fn relaunch_runtime_session(
+    app_state: &AppStateHandle,
+    ctx: &SharedContext,
+    agent_id: &AgentId,
+) -> bool {
+    let Some(ctx_arc) = ctx else {
+        return false;
+    };
+    let Ok(mut ctx_guard) = ctx_arc.lock() else {
+        return false;
+    };
+
+    let state_ro = app_state.read();
+    let Some((agent, signature)) = agent_and_signature(&state_ro, agent_id) else {
+        return false;
+    };
+    drop(state_ro);
+
+    if !spawn_relaunch_session(
+        &mut ctx_guard.runtime,
+        agent_id,
+        &agent.work_dir,
+        &signature,
+    ) {
+        return false;
+    }
+    std::thread::sleep(REMOTE_ATTACH_SETTLE_DELAY);
+    attach_relaunched_session(&mut ctx_guard.runtime, agent_id)
+}
+
+fn spawn_relaunch_session(
+    runtime: &mut jefe::runtime::TmuxRuntimeManager,
+    agent_id: &AgentId,
+    work_dir: &std::path::Path,
+    signature: &LaunchSignature,
+) -> bool {
+    match runtime.spawn_session_fresh(agent_id, work_dir, signature) {
+        Ok(()) => true,
+        Err(RuntimeError::AlreadyRunning(_)) => runtime.relaunch(agent_id).is_ok(),
+        Err(error) => {
+            warn!(
+                agent_id = %agent_id.0,
+                error = %error,
+                "could not spawn fresh runtime session for relaunch"
+            );
+            false
         }
     }
+}
+
+fn attach_relaunched_session(
+    runtime: &mut jefe::runtime::TmuxRuntimeManager,
+    agent_id: &AgentId,
+) -> bool {
+    match runtime.attach(agent_id) {
+        Ok(()) => true,
+        Err(error) => {
+            warn!(agent_id = %agent_id.0, error = %error, "could not attach relaunched session");
+            let _ = runtime.mark_session_dead(agent_id);
+            false
+        }
+    }
+}
+
+fn persist_relaunch_result(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    agent_id: AgentId,
+    relaunched: bool,
+) {
+    let relaunch_event = AppEvent::RelaunchAgent(agent_id.clone());
+    let mut state = app_state.write();
+    if relaunched {
+        persist_relaunch_success(&mut state, &agent_id, relaunch_event);
+    } else {
+        persist_relaunch_failure(&mut state, &agent_id, relaunch_event);
+    }
+    let persisted = to_persisted_state(&state);
+    drop(state);
+    persist_state(ctx, &persisted);
+}
+
+fn persist_relaunch_success(state: &mut AppState, agent_id: &AgentId, relaunch_event: AppEvent) {
+    if let Some((agent, signature)) = agent_and_signature(state, agent_id) {
+        set_agent_runtime_binding(
+            state,
+            agent_id,
+            jefe::runtime::RuntimeSession::session_name_for(&agent.id),
+            signature,
+        );
+    }
+    *state = std::mem::take(state).apply(relaunch_event);
+    state.terminal_focused = false;
+    clear_agent_runtime_attachment(state);
+    mark_agent_runtime_attached(state, agent_id, true);
+    if let Some(warning) = sandbox_ssh_agent_warning() {
+        state.warning_message = Some(warning);
+    } else {
+        clear_runtime_warning(state);
+    }
+}
+
+fn persist_relaunch_failure(state: &mut AppState, agent_id: &AgentId, relaunch_event: AppEvent) {
+    *state = std::mem::take(state).apply(relaunch_event);
+    state.terminal_focused = false;
+    state.pane_focus = PaneFocus::Agents;
+    mark_runtime_session_dead_if_present(state, agent_id);
+    if let Some(agent) = state.agents.iter_mut().find(|agent| &agent.id == agent_id) {
+        agent.runtime_binding = None;
+    }
+}
+
+fn dispatch_issues_navigation(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    message: IssuesMessage,
+) {
+    let (focus, prev_repo_idx, prev_issue_idx) = {
+        let state = app_state.read();
+        (
+            state.issues_state.issue_focus,
+            state.selected_repository_index,
+            state.issues_state.selected_issue_index,
+        )
+    };
+
+    apply_and_persist(app_state, ctx, AppEvent::from(message));
+    refresh_issue_navigation(app_state, ctx, focus, prev_repo_idx, prev_issue_idx);
+}
+
+fn refresh_issue_navigation(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    focus: jefe::state::IssueFocus,
+    prev_repo_idx: Option<usize>,
+    prev_issue_idx: Option<usize>,
+) {
+    match focus {
+        jefe::state::IssueFocus::RepoList => {
+            refresh_repo_scope_if_changed(app_state, ctx, prev_repo_idx);
+        }
+        jefe::state::IssueFocus::IssueList => {
+            refresh_issue_preview_if_changed(app_state, prev_issue_idx);
+        }
+        jefe::state::IssueFocus::IssueDetail => {}
+    }
+}
+
+fn refresh_repo_scope_if_changed(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    prev_repo_idx: Option<usize>,
+) {
+    let new_repo_idx = app_state.read().selected_repository_index;
+    if new_repo_idx == prev_repo_idx {
+        return;
+    }
+    reset_issue_list_for_repo_change(app_state);
+    dispatch_app_event(app_state, ctx, AppEvent::RefocusIssueList);
+    app_state.write().issues_state.issue_focus = jefe::state::IssueFocus::RepoList;
+}
+
+fn reset_issue_list_for_repo_change(app_state: &mut AppStateHandle) {
+    let mut state = app_state.write();
+    state.issues_state.issues.clear();
+    state.issues_state.selected_issue_index = None;
+    state.issues_state.issue_detail = None;
+    state.issues_state.list_cursor = None;
+    state.issues_state.has_more_issues = false;
+    state.issues_state.error = None;
+    if state.issues_state.inline_state != jefe::state::InlineState::None {
+        state.issues_state.draft_notice = Some("Unsent draft discarded".to_string());
+    }
+    state.issues_state.inline_state = jefe::state::InlineState::None;
+    state.issues_state.agent_chooser = None;
+    state.issues_state.list_loading = true;
+}
+
+fn refresh_issue_preview_if_changed(app_state: &mut AppStateHandle, prev_issue_idx: Option<usize>) {
+    let new_issue_idx = app_state.read().issues_state.selected_issue_index;
+    if new_issue_idx != prev_issue_idx {
+        issues_dispatch::preview_issue_from_list(app_state);
+    }
+}
+
+fn dispatch_issue_list_reload(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    message: IssuesMessage,
+) {
+    let fresh_reload = matches!(
+        message,
+        IssuesMessage::RefocusList | IssuesMessage::ApplySearch
+    );
+    apply_and_persist(app_state, ctx, AppEvent::from(message));
+    let params = issue_fetch_params(app_state, fresh_reload);
+
+    if params.owner.is_empty() || params.repo.is_empty() {
+        persist_missing_github_repo(app_state, ctx);
+        return;
+    }
+
+    let result = fetch_issue_list(ctx, &params);
+    persist_issue_list_result(app_state, &params.scope_repo_id, result);
+}
+
+struct IssueFetchParams {
+    scope_repo_id: jefe::domain::RepositoryId,
+    owner: String,
+    repo: String,
+    filter: jefe::domain::IssueFilter,
+    cursor: Option<String>,
+    page_size: u32,
+}
+
+fn issue_fetch_params(app_state: &AppStateHandle, fresh_reload: bool) -> IssueFetchParams {
+    let state = app_state.read();
+    let gh_repo = issues_dispatch::resolve_gh_repo(&state);
+    IssueFetchParams {
+        scope_repo_id: issues_dispatch::current_scope_repo_id(&state),
+        owner: gh_repo.0,
+        repo: gh_repo.1,
+        filter: state.issues_state.committed_filter.clone(),
+        cursor: (!fresh_reload)
+            .then(|| state.issues_state.list_cursor.clone())
+            .flatten(),
+        page_size: 30,
+    }
+}
+
+fn persist_missing_github_repo(app_state: &mut AppStateHandle, ctx: &SharedContext) {
+    let mut state = app_state.write();
+    state.issues_state.list_loading = false;
+    state.issues_state.error = Some(
+        "No GitHub repository configured. Set the GitHub Repo field (owner/repo) in repository settings."
+            .to_string(),
+    );
+    let persisted = to_persisted_state(&state);
+    drop(state);
+    persist_state(ctx, &persisted);
+}
+
+fn fetch_issue_list(
+    ctx: &SharedContext,
+    params: &IssueFetchParams,
+) -> Option<Result<jefe::github::IssueListResponse, jefe::github::GhError>> {
+    if let Some(ctx_arc) = ctx
+        && let Ok(ctx_guard) = ctx_arc.lock()
+    {
+        Some(ctx_guard.gh_client.list_issues(
+            &params.owner,
+            &params.repo,
+            &params.filter,
+            params.cursor.as_deref(),
+            params.page_size,
+        ))
+    } else {
+        None
+    }
+}
+
+fn persist_issue_list_result(
+    app_state: &mut AppStateHandle,
+    scope_repo_id: &jefe::domain::RepositoryId,
+    result: Option<Result<jefe::github::IssueListResponse, jefe::github::GhError>>,
+) {
+    match result {
+        Some(Ok(response)) => persist_issue_list_loaded(app_state, scope_repo_id, response),
+        Some(Err(error)) => persist_issue_list_failed(app_state, scope_repo_id, error.to_string()),
+        None => persist_issue_list_failed(
+            app_state,
+            scope_repo_id,
+            "Application context unavailable".to_string(),
+        ),
+    }
+}
+
+fn persist_issue_list_loaded(
+    app_state: &mut AppStateHandle,
+    scope_repo_id: &jefe::domain::RepositoryId,
+    response: jefe::github::IssueListResponse,
+) {
+    let has_issues = !response.issues.is_empty();
+    let mut state = app_state.write();
+    *state = std::mem::take(&mut *state).apply(AppEvent::IssueListLoaded {
+        scope_repo_id: scope_repo_id.clone(),
+        issues: response.issues,
+        cursor: response.cursor,
+        has_more: response.has_more,
+    });
+    drop(state);
+    if has_issues {
+        issues_dispatch::preview_issue_from_list(app_state);
+    }
+}
+
+fn persist_issue_list_failed(
+    app_state: &mut AppStateHandle,
+    scope_repo_id: &jefe::domain::RepositoryId,
+    error: String,
+) {
+    let mut state = app_state.write();
+    *state = std::mem::take(&mut *state).apply(AppEvent::IssueListLoadFailed {
+        scope_repo_id: scope_repo_id.clone(),
+        error,
+    });
+}
+
+fn dispatch_agent_chooser_confirm(app_state: &mut AppStateHandle, ctx: &SharedContext) {
+    let send_info = issue_send_info(app_state);
+    apply_and_persist(app_state, ctx, AppEvent::AgentChooserConfirm);
+
+    let Some(send_info) = send_info else {
+        return;
+    };
+    if let Err(error) = write_issue_prompt(&send_info.work_dir, &send_info.payload) {
+        apply_send_to_agent_failed(app_state, error);
+        return;
+    }
+
+    let mut launch_sig = send_info.signature;
+    launch_sig.mode_flags.push("-i".to_owned());
+    launch_sig
+        .mode_flags
+        .push("Read and work on the GitHub issue described in .jefe/issue-prompt.md".to_owned());
+    if preflight_or_prompt(app_state, ctx, &send_info.agent_id, &launch_sig) {
+        launch_issue_agent(
+            app_state,
+            ctx,
+            send_info.agent_id,
+            send_info.work_dir,
+            launch_sig,
+        );
+    }
+}
+
+struct IssueSendInfo {
+    agent_id: AgentId,
+    work_dir: std::path::PathBuf,
+    signature: LaunchSignature,
+    payload: jefe::github::SendPayload,
+}
+
+fn issue_send_info(app_state: &AppStateHandle) -> Option<IssueSendInfo> {
+    let state = app_state.read();
+    let chooser = state.issues_state.agent_chooser.as_ref()?;
+    let detail = state.issues_state.issue_detail.as_ref()?;
+    let (agent_id, _) = chooser.agents.get(chooser.selected_index)?.clone();
+    let agent = state
+        .agents
+        .iter()
+        .find(|agent| agent.id == agent_id)?
+        .clone();
+    let repo = state.repository_by_id(&agent.repository_id)?;
+    let focused_comment = focused_issue_comment(&state, detail);
+    let work_dir = agent.work_dir.clone();
+    let signature = launch_signature_for_agent(&agent, repo);
+    let payload = jefe::github::GhClient::build_send_payload(
+        &repo.slug,
+        detail,
+        focused_comment.as_ref(),
+        &repo.issue_base_prompt,
+    );
+    drop(state);
+
+    Some(IssueSendInfo {
+        agent_id,
+        work_dir,
+        signature,
+        payload,
+    })
+}
+
+fn focused_issue_comment(
+    state: &AppState,
+    detail: &jefe::domain::IssueDetail,
+) -> Option<jefe::domain::IssueComment> {
+    match state.issues_state.detail_subfocus {
+        jefe::state::DetailSubfocus::Comment(idx) => detail.comments.get(idx).cloned(),
+        _ => None,
+    }
+}
+
+fn write_issue_prompt(
+    work_dir: &std::path::Path,
+    payload: &jefe::github::SendPayload,
+) -> Result<(), String> {
+    let prompt_dir = work_dir.join(".jefe");
+    std::fs::create_dir_all(&prompt_dir)
+        .map_err(|error| format!("Failed to create .jefe dir: {error}"))?;
+    let prompt_path = prompt_dir.join("issue-prompt.md");
+    let prompt_content = issues_dispatch::format_issue_prompt(payload);
+    std::fs::write(&prompt_path, &prompt_content)
+        .map_err(|error| format!("Failed to write issue prompt: {error}"))
+}
+
+fn launch_issue_agent(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    agent_id: AgentId,
+    work_dir: std::path::PathBuf,
+    launch_sig: LaunchSignature,
+) {
+    let launched = spawn_and_attach_fresh_for_issue(ctx, &agent_id, &work_dir, &launch_sig);
+    let mut state = app_state.write();
+    if launched {
+        persist_issue_agent_launch_success(&mut state, &agent_id, launch_sig);
+    } else {
+        *state = std::mem::take(&mut *state).apply(AppEvent::SendToAgentFailed {
+            error: "Failed to launch agent".to_string(),
+        });
+    }
+    let persisted = to_persisted_state(&state);
+    drop(state);
+    persist_state(ctx, &persisted);
+}
+
+fn spawn_and_attach_fresh_for_issue(
+    ctx: &SharedContext,
+    agent_id: &AgentId,
+    work_dir: &std::path::Path,
+    launch_sig: &LaunchSignature,
+) -> bool {
+    let Some(ctx_arc) = ctx else {
+        return false;
+    };
+    let Ok(mut ctx_guard) = ctx_arc.lock() else {
+        return false;
+    };
+    match ctx_guard
+        .runtime
+        .spawn_session_fresh(agent_id, work_dir, launch_sig)
+    {
+        Ok(()) => attach_issue_agent(&mut ctx_guard.runtime, agent_id),
+        Err(error) => {
+            warn!(agent_id = %agent_id.0, error = %error, "could not spawn agent for issue send");
+            false
+        }
+    }
+}
+
+fn attach_issue_agent(runtime: &mut jefe::runtime::TmuxRuntimeManager, agent_id: &AgentId) -> bool {
+    std::thread::sleep(REMOTE_ATTACH_SETTLE_DELAY);
+    match runtime.attach(agent_id) {
+        Ok(()) => true,
+        Err(error) => {
+            warn!(agent_id = %agent_id.0, error = %error, "could not attach agent after issue send");
+            let _ = runtime.mark_session_dead(agent_id);
+            false
+        }
+    }
+}
+
+fn persist_issue_agent_launch_success(
+    state: &mut AppState,
+    agent_id: &AgentId,
+    launch_sig: LaunchSignature,
+) {
+    if let Some(agent) = state.agents.iter_mut().find(|agent| &agent.id == agent_id) {
+        agent.status = jefe::domain::AgentStatus::Running;
+        let session_name = jefe::runtime::RuntimeSession::session_name_for(agent_id);
+        agent.runtime_binding = Some(jefe::domain::RuntimeBinding {
+            session_name,
+            launch_signature: launch_sig,
+            attached: false,
+            last_seen: None,
+        });
+    }
+    clear_agent_runtime_attachment(state);
+    mark_agent_runtime_attached(state, agent_id, true);
+}
+
+fn apply_send_to_agent_failed(app_state: &mut AppStateHandle, error: String) {
+    let mut state = app_state.write();
+    *state = std::mem::take(&mut *state).apply(AppEvent::SendToAgentFailed { error });
 }
 
 #[cfg(test)]

--- a/src/app_input/modal_handlers.rs
+++ b/src/app_input/modal_handlers.rs
@@ -5,7 +5,7 @@
 use iocraft::prelude::*;
 use tracing::warn;
 
-use jefe::domain::{AgentId, SandboxEngine};
+use jefe::domain::{AgentId, LaunchSignature, SandboxEngine};
 use jefe::runtime::{RuntimeError, RuntimeManager};
 use jefe::state::{AgentFormFocus, AppEvent, ModalState, PaneFocus, RepositoryFormFocus};
 
@@ -106,101 +106,14 @@ fn persist_current_state(app_state: &AppStateHandle, ctx: &SharedContext) {
     persist_state(ctx, &persisted);
 }
 
-#[allow(clippy::too_many_lines)]
 pub fn handle_mode_confirm_key(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
     key_event: &KeyEvent,
 ) {
     match key_event.code {
-        KeyCode::Esc => {
-            close_modal_and_persist(app_state, ctx);
-        }
-        KeyCode::Enter => {
-            let modal_snapshot = {
-                let state = app_state.read();
-                state.modal.clone()
-            };
-
-            match modal_snapshot {
-                ModalState::ConfirmDeleteAgent {
-                    id,
-                    delete_work_dir,
-                } => {
-                    if let Some(ctx_arc) = &ctx
-                        && let Ok(mut ctx_guard) = ctx_arc.lock()
-                        && let Err(e) = ctx_guard.runtime.kill(&id)
-                    {
-                        match e {
-                            RuntimeError::SessionNotFound(_) => {}
-                            _ => {
-                                warn!(
-                                    agent_id = %id.0,
-                                    error = %e,
-                                    "could not kill runtime session before delete"
-                                );
-                            }
-                        }
-                    }
-
-                    let mut state = app_state.write();
-                    let _ = jefe::state::delete_selected_agent(&mut state, &id, delete_work_dir);
-                    state.modal = ModalState::None;
-                    let persisted = to_persisted_state(&state);
-                    drop(state);
-                    persist_state(ctx, &persisted);
-                }
-                ModalState::ConfirmDeleteRepository { id } => {
-                    // Read app_state first, then lock context (consistent ordering)
-                    let agent_ids: Vec<AgentId> = {
-                        let state = app_state.read();
-                        state
-                            .agents
-                            .iter()
-                            .filter(|agent| agent.repository_id == id)
-                            .map(|agent| agent.id.clone())
-                            .collect()
-                    };
-
-                    if let Some(ctx_arc) = &ctx
-                        && let Ok(mut ctx_guard) = ctx_arc.lock()
-                    {
-                        for agent_id in &agent_ids {
-                            if let Err(e) = ctx_guard.runtime.kill(agent_id) {
-                                match e {
-                                    RuntimeError::SessionNotFound(_) => {}
-                                    _ => {
-                                        warn!(
-                                            agent_id = %agent_id.0,
-                                            error = %e,
-                                            "could not kill runtime session before repository delete"
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    let mut state = app_state.write();
-                    jefe::state::delete_selected_repository(&mut state, &id);
-                    state.modal = ModalState::None;
-                    let persisted = to_persisted_state(&state);
-                    drop(state);
-                    persist_state(ctx, &persisted);
-                }
-                ModalState::PreflightPrompt {
-                    agent_id,
-                    signature,
-                    issue,
-                    ..
-                } => {
-                    super::preflight::handle_preflight_prompt_enter(
-                        app_state, ctx, agent_id, signature, issue,
-                    );
-                }
-                _ => {}
-            }
-        }
+        KeyCode::Esc => close_modal_and_persist(app_state, ctx),
+        KeyCode::Enter => handle_confirm_enter(app_state, ctx),
         KeyCode::Char(' ' | 'd' | 'D') | KeyCode::Up | KeyCode::Down => {
             apply_and_persist(app_state, ctx, AppEvent::ToggleDeleteWorkDir);
         }
@@ -208,7 +121,87 @@ pub fn handle_mode_confirm_key(
     }
 }
 
-#[allow(clippy::too_many_lines)]
+fn handle_confirm_enter(app_state: &mut AppStateHandle, ctx: &SharedContext) {
+    let modal_snapshot = {
+        let state = app_state.read();
+        state.modal.clone()
+    };
+
+    match modal_snapshot {
+        ModalState::ConfirmDeleteAgent {
+            id,
+            delete_work_dir,
+        } => confirm_delete_agent(app_state, ctx, id, delete_work_dir),
+        ModalState::ConfirmDeleteRepository { id } => confirm_delete_repository(app_state, ctx, id),
+        ModalState::PreflightPrompt {
+            agent_id,
+            signature,
+            issue,
+            ..
+        } => super::preflight::handle_preflight_prompt_enter(
+            app_state, ctx, agent_id, signature, issue,
+        ),
+        _ => {}
+    }
+}
+
+fn confirm_delete_agent(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    id: AgentId,
+    delete_work_dir: bool,
+) {
+    kill_agent_before_delete(ctx, &id);
+
+    let mut state = app_state.write();
+    let _ = jefe::state::delete_selected_agent(&mut state, &id, delete_work_dir);
+    state.modal = ModalState::None;
+    let persisted = to_persisted_state(&state);
+    drop(state);
+    persist_state(ctx, &persisted);
+}
+
+fn confirm_delete_repository(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    id: jefe::domain::RepositoryId,
+) {
+    let agent_ids: Vec<AgentId> = {
+        let state = app_state.read();
+        state
+            .agents
+            .iter()
+            .filter(|agent| agent.repository_id == id)
+            .map(|agent| agent.id.clone())
+            .collect()
+    };
+
+    for agent_id in &agent_ids {
+        kill_agent_before_delete(ctx, agent_id);
+    }
+
+    let mut state = app_state.write();
+    jefe::state::delete_selected_repository(&mut state, &id);
+    state.modal = ModalState::None;
+    let persisted = to_persisted_state(&state);
+    drop(state);
+    persist_state(ctx, &persisted);
+}
+
+fn kill_agent_before_delete(ctx: &SharedContext, agent_id: &AgentId) {
+    if let Some(ctx_arc) = ctx
+        && let Ok(mut ctx_guard) = ctx_arc.lock()
+        && let Err(error) = ctx_guard.runtime.kill(agent_id)
+        && !matches!(error, RuntimeError::SessionNotFound(_))
+    {
+        warn!(
+            agent_id = %agent_id.0,
+            error = %error,
+            "could not kill runtime session before delete"
+        );
+    }
+}
+
 pub fn handle_mode_form_key(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
@@ -217,61 +210,7 @@ pub fn handle_mode_form_key(
     let app_event = match key_event.code {
         KeyCode::Esc => Some(AppEvent::CloseModal),
         KeyCode::Enter => {
-            // Submit form and spawn PTY if new agent.
-            let state_ro = app_state.read();
-            let is_new_agent = matches!(state_ro.modal, ModalState::NewAgent { .. });
-            drop(state_ro);
-
-            let launch_after_submit = {
-                let mut state = app_state.write();
-                *state = std::mem::take(&mut *state).apply(AppEvent::SubmitForm);
-
-                let launch_after_submit = if is_new_agent && state.modal == ModalState::None {
-                    state.selected_agent().cloned().and_then(|agent| {
-                        state
-                            .repository_by_id(&agent.repository_id)
-                            .map(|repository| {
-                                let signature = launch_signature_for_agent(&agent, repository);
-                                (agent.id.clone(), agent.work_dir.clone(), signature)
-                            })
-                    })
-                } else {
-                    None
-                };
-
-                if is_new_agent
-                    && state.modal == ModalState::None
-                    && launch_after_submit.is_none()
-                    && state.selected_agent().is_some()
-                {
-                    state.terminal_focused = false;
-                    state.error_message = Some("selected agent repository not found".to_owned());
-                }
-
-                let persisted = to_persisted_state(&state);
-                drop(state);
-                persist_state(ctx, &persisted);
-                launch_after_submit
-            };
-
-            if let Some((agent_id, work_dir, signature)) = launch_after_submit {
-                // Run preflight checks before spawning.
-                if !preflight_or_prompt(app_state, ctx, &agent_id, &signature) {
-                    return true;
-                }
-
-                // Match toy1 behavior: new agent opens attached and focused.
-                {
-                    let mut state = app_state.write();
-                    state.terminal_focused = true;
-                    let persisted = to_persisted_state(&state);
-                    drop(state);
-                    persist_state(ctx, &persisted);
-                }
-
-                execute_agent_launch(app_state, ctx, &agent_id, &work_dir, &signature, false);
-            }
-
+            handle_form_submit(app_state, ctx);
             return true;
         }
         KeyCode::Tab | KeyCode::Down => Some(AppEvent::FormNextField),
@@ -280,54 +219,7 @@ pub fn handle_mode_form_key(
         KeyCode::Right => Some(AppEvent::FormMoveCursorRight),
         KeyCode::Backspace => Some(AppEvent::FormBackspace),
         KeyCode::Delete => Some(AppEvent::FormDelete),
-        // Space toggles checkbox or cycles sandbox engine on the dedicated controls.
-        KeyCode::Char(' ') => {
-            enum FocusedFormField {
-                Repository(RepositoryFormFocus),
-                Agent(AgentFormFocus),
-                None,
-            }
-
-            let focused = {
-                let state = app_state.read();
-                match &state.modal {
-                    ModalState::NewRepository { focus, .. }
-                    | ModalState::EditRepository { focus, .. } => {
-                        FocusedFormField::Repository(*focus)
-                    }
-                    ModalState::NewAgent { focus, .. } | ModalState::EditAgent { focus, .. } => {
-                        FocusedFormField::Agent(*focus)
-                    }
-                    _ => FocusedFormField::None,
-                }
-            };
-
-            match focused {
-                FocusedFormField::Repository(focus) if repository_focus_toggles_checkbox(focus) => {
-                    Some(AppEvent::FormToggleCheckbox)
-                }
-                FocusedFormField::Agent(
-                    AgentFormFocus::PassContinue
-                    | AgentFormFocus::Sandbox
-                    | AgentFormFocus::Shortcut,
-                ) => Some(AppEvent::FormToggleCheckbox),
-                FocusedFormField::Agent(AgentFormFocus::SandboxEngine) => {
-                    let mut state = app_state.write();
-                    if let ModalState::NewAgent { fields, .. }
-                    | ModalState::EditAgent { fields, .. } = &mut state.modal
-                    {
-                        SandboxEngine::next_from_form_value(&fields.sandbox_engine)
-                            .label()
-                            .clone_into(&mut fields.sandbox_engine);
-                    }
-                    let persisted = to_persisted_state(&state);
-                    drop(state);
-                    persist_state(ctx, &persisted);
-                    return true;
-                }
-                _ => Some(AppEvent::FormChar(' ')),
-            }
-        }
+        KeyCode::Char(' ') => handle_form_space(app_state, ctx),
         KeyCode::Char(c) => Some(AppEvent::FormChar(c)),
         _ => None,
     };
@@ -337,4 +229,113 @@ pub fn handle_mode_form_key(
     }
 
     true
+}
+
+fn handle_form_submit(app_state: &mut AppStateHandle, ctx: &SharedContext) {
+    let is_new_agent = {
+        let state_ro = app_state.read();
+        matches!(state_ro.modal, ModalState::NewAgent { .. })
+    };
+
+    let launch_after_submit = submit_form_and_snapshot_launch(app_state, ctx, is_new_agent);
+    if let Some((agent_id, work_dir, signature)) = launch_after_submit {
+        if !preflight_or_prompt(app_state, ctx, &agent_id, &signature) {
+            return;
+        }
+        focus_terminal_after_submit(app_state, ctx);
+        execute_agent_launch(app_state, ctx, &agent_id, &work_dir, &signature, false);
+    }
+}
+
+fn submit_form_and_snapshot_launch(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    is_new_agent: bool,
+) -> Option<(AgentId, std::path::PathBuf, LaunchSignature)> {
+    let mut state = app_state.write();
+    *state = std::mem::take(&mut *state).apply(AppEvent::SubmitForm);
+
+    let launch_after_submit = if is_new_agent && state.modal == ModalState::None {
+        state.selected_agent().cloned().and_then(|agent| {
+            state
+                .repository_by_id(&agent.repository_id)
+                .map(|repository| {
+                    let signature = launch_signature_for_agent(&agent, repository);
+                    (agent.id.clone(), agent.work_dir.clone(), signature)
+                })
+        })
+    } else {
+        None
+    };
+
+    if is_new_agent
+        && state.modal == ModalState::None
+        && launch_after_submit.is_none()
+        && state.selected_agent().is_some()
+    {
+        state.terminal_focused = false;
+        state.error_message = Some("selected agent repository not found".to_owned());
+    }
+
+    let persisted = to_persisted_state(&state);
+    drop(state);
+    persist_state(ctx, &persisted);
+    launch_after_submit
+}
+
+fn focus_terminal_after_submit(app_state: &mut AppStateHandle, ctx: &SharedContext) {
+    let mut state = app_state.write();
+    state.terminal_focused = true;
+    let persisted = to_persisted_state(&state);
+    drop(state);
+    persist_state(ctx, &persisted);
+}
+
+fn handle_form_space(app_state: &mut AppStateHandle, ctx: &SharedContext) -> Option<AppEvent> {
+    match focused_form_field(app_state) {
+        FocusedFormField::Repository(focus) if repository_focus_toggles_checkbox(focus) => {
+            Some(AppEvent::FormToggleCheckbox)
+        }
+        FocusedFormField::Agent(
+            AgentFormFocus::PassContinue | AgentFormFocus::Sandbox | AgentFormFocus::Shortcut,
+        ) => Some(AppEvent::FormToggleCheckbox),
+        FocusedFormField::Agent(AgentFormFocus::SandboxEngine) => {
+            cycle_sandbox_engine(app_state, ctx);
+            None
+        }
+        _ => Some(AppEvent::FormChar(' ')),
+    }
+}
+
+enum FocusedFormField {
+    Repository(RepositoryFormFocus),
+    Agent(AgentFormFocus),
+    None,
+}
+
+fn focused_form_field(app_state: &AppStateHandle) -> FocusedFormField {
+    let state = app_state.read();
+    match &state.modal {
+        ModalState::NewRepository { focus, .. } | ModalState::EditRepository { focus, .. } => {
+            FocusedFormField::Repository(*focus)
+        }
+        ModalState::NewAgent { focus, .. } | ModalState::EditAgent { focus, .. } => {
+            FocusedFormField::Agent(*focus)
+        }
+        _ => FocusedFormField::None,
+    }
+}
+
+fn cycle_sandbox_engine(app_state: &mut AppStateHandle, ctx: &SharedContext) {
+    let mut state = app_state.write();
+    if let ModalState::NewAgent { fields, .. } | ModalState::EditAgent { fields, .. } =
+        &mut state.modal
+    {
+        SandboxEngine::next_from_form_value(&fields.sandbox_engine)
+            .label()
+            .clone_into(&mut fields.sandbox_engine);
+    }
+    let persisted = to_persisted_state(&state);
+    drop(state);
+    persist_state(ctx, &persisted);
 }

--- a/src/app_input/normal.rs
+++ b/src/app_input/normal.rs
@@ -3,6 +3,7 @@
 use iocraft::prelude::*;
 use tracing::{debug, warn};
 
+use jefe::domain::{AgentId, RepositoryId};
 use jefe::runtime::RuntimeManager;
 use jefe::state::{AppEvent, PaneFocus, ScreenMode};
 use jefe::theme::ThemeManager;
@@ -11,6 +12,19 @@ use super::{
     AppStateHandle, MAC_ALT_DIGIT_SHORTCUTS, QuitHandle, SharedContext, jump_to_shortcut_agent,
     persist_state, to_persisted_state,
 };
+
+#[derive(Clone)]
+struct NormalKeySnapshot {
+    pane_focus: PaneFocus,
+    selected_agent_is_running: bool,
+    selected_repo_id: Option<RepositoryId>,
+    selected_agent_id: Option<AgentId>,
+}
+
+enum KeyHandling {
+    Unhandled,
+    Handled(Option<AppEvent>),
+}
 
 fn mac_alt_digit_slot(c: char) -> Option<u8> {
     MAC_ALT_DIGIT_SHORTCUTS
@@ -44,7 +58,7 @@ fn try_extract_shortcut_slot(key_event: &KeyEvent) -> Option<u8> {
 }
 
 fn relaunch_event_for_selected_agent(
-    selected_agent_id: Option<jefe::domain::AgentId>,
+    selected_agent_id: Option<AgentId>,
     selected_agent_is_running: bool,
 ) -> Option<AppEvent> {
     if selected_agent_is_running {
@@ -67,7 +81,6 @@ pub fn handle_global_shortcut_key(
     false
 }
 
-#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
 pub fn handle_normal_key_event(
     app_state: &mut AppStateHandle,
     should_quit: &mut QuitHandle,
@@ -75,238 +88,340 @@ pub fn handle_normal_key_event(
     key_event: &KeyEvent,
     screen_mode: ScreenMode,
 ) -> Option<AppEvent> {
-    let state_ro = app_state.read();
-    let pane_focus = state_ro.pane_focus;
-    let selected_agent_is_running = state_ro
-        .selected_agent()
-        .is_some_and(jefe::domain::Agent::is_running);
-    let selected_repo_id = state_ro
-        .selected_repository()
-        .map(|repository| repository.id.clone());
-    let selected_agent_id = state_ro.selected_agent().map(|agent| agent.id.clone());
-    drop(state_ro);
+    let snapshot = normal_key_snapshot(app_state);
 
-    // Issues mode routing — route to issues handler when in DashboardIssues.
-    // Quit is handled here (not in the issues resolver) because it uses
-    // the `should_quit` handle which is not an AppEvent.
-    // @plan PLAN-20260329-ISSUES-MODE.P09
-    // @requirement REQ-ISS-002
-    if screen_mode == ScreenMode::DashboardIssues {
-        if matches!(key_event.code, KeyCode::Char('q' | 'Q')) {
-            should_quit.set(true);
-            return None;
-        }
-        return super::issues::handle_issues_mode_key(&*app_state, ctx, key_event);
+    if let KeyHandling::Handled(event) =
+        handle_dashboard_issues_key(app_state, should_quit, ctx, key_event, screen_mode)
+    {
+        return event;
+    }
+    if let KeyHandling::Handled(event) = resolve_quit_key(should_quit, key_event) {
+        return event;
+    }
+    if let KeyHandling::Handled(event) = resolve_navigation_key(key_event) {
+        return event;
+    }
+    if let KeyHandling::Handled(event) = resolve_new_key(app_state, ctx, key_event, &snapshot) {
+        return event;
+    }
+    if let KeyHandling::Handled(event) = resolve_agent_lifecycle_key(key_event, &snapshot) {
+        return event;
+    }
+    if let KeyHandling::Handled(event) = resolve_mode_key(key_event, screen_mode) {
+        return event;
+    }
+    if let KeyHandling::Handled(event) = resolve_help_search_key(key_event) {
+        return event;
+    }
+    if let KeyHandling::Handled(event) = resolve_visibility_key(key_event, screen_mode) {
+        return event;
+    }
+    if let KeyHandling::Handled(event) = handle_direct_pane_focus_key(app_state, ctx, key_event) {
+        return event;
+    }
+    if let KeyHandling::Handled(event) = resolve_enter_key(key_event, &snapshot) {
+        return event;
+    }
+    if let KeyHandling::Handled(event) = handle_theme_key(ctx, key_event) {
+        return event;
     }
 
+    None
+}
+
+fn normal_key_snapshot(app_state: &AppStateHandle) -> NormalKeySnapshot {
+    let state = app_state.read();
+    NormalKeySnapshot {
+        pane_focus: state.pane_focus,
+        selected_agent_is_running: state
+            .selected_agent()
+            .is_some_and(jefe::domain::Agent::is_running),
+        selected_repo_id: state
+            .selected_repository()
+            .map(|repository| repository.id.clone()),
+        selected_agent_id: state.selected_agent().map(|agent| agent.id.clone()),
+    }
+}
+
+fn handle_dashboard_issues_key(
+    app_state: &AppStateHandle,
+    should_quit: &mut QuitHandle,
+    ctx: &SharedContext,
+    key_event: &KeyEvent,
+    screen_mode: ScreenMode,
+) -> KeyHandling {
+    if screen_mode != ScreenMode::DashboardIssues {
+        return KeyHandling::Unhandled;
+    }
+
+    if matches!(key_event.code, KeyCode::Char('q' | 'Q')) {
+        should_quit.set(true);
+        KeyHandling::Handled(None)
+    } else {
+        KeyHandling::Handled(super::issues::handle_issues_mode_key(
+            app_state, ctx, key_event,
+        ))
+    }
+}
+
+fn resolve_quit_key(should_quit: &mut QuitHandle, key_event: &KeyEvent) -> KeyHandling {
+    if matches!(key_event.code, KeyCode::Char('q' | 'Q')) {
+        should_quit.set(true);
+        KeyHandling::Handled(None)
+    } else {
+        KeyHandling::Unhandled
+    }
+}
+
+fn resolve_navigation_key(key_event: &KeyEvent) -> KeyHandling {
     match key_event.code {
-        // Quit
-        KeyCode::Char('q' | 'Q') => {
-            should_quit.set(true);
-            None
-        }
+        KeyCode::Up => KeyHandling::Handled(Some(AppEvent::NavigateUp)),
+        KeyCode::Down => KeyHandling::Handled(Some(AppEvent::NavigateDown)),
+        KeyCode::Left => KeyHandling::Handled(Some(AppEvent::NavigateLeft)),
+        KeyCode::Right => KeyHandling::Handled(Some(AppEvent::NavigateRight)),
+        KeyCode::Tab => KeyHandling::Handled(Some(AppEvent::CyclePaneFocus)),
+        _ => KeyHandling::Unhandled,
+    }
+}
 
-        // Navigation
-        KeyCode::Up => Some(AppEvent::NavigateUp),
-        KeyCode::Down => Some(AppEvent::NavigateDown),
-        KeyCode::Left => Some(AppEvent::NavigateLeft),
-        KeyCode::Right => Some(AppEvent::NavigateRight),
-        KeyCode::Tab => Some(AppEvent::CyclePaneFocus),
-
-        // New (n = new agent, N = new repository)
+fn resolve_new_key(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    key_event: &KeyEvent,
+    snapshot: &NormalKeySnapshot,
+) -> KeyHandling {
+    match key_event.code {
         KeyCode::Char('n') => {
-            debug!(
-                selected_repo_id = ?selected_repo_id,
-                "n pressed: deriving new agent/repo action"
-            );
-            // If no repo is selected but repos exist, auto-select the first visible one.
-            let repo_id = selected_repo_id.clone().or_else(|| {
-                let state = app_state.read();
-                let first_visible_idx = state.visible_repository_indices().first().copied();
-                let first_id = first_visible_idx.and_then(|idx| {
-                    state
-                        .repositories
-                        .get(idx)
-                        .map(|repository| repository.id.clone())
-                });
-                drop(state);
-                if let Some(first_visible_idx) = first_visible_idx {
-                    let mut state_mut = app_state.write();
-                    state_mut.selected_repository_index = Some(first_visible_idx);
-                    state_mut.normalize_selection_indices();
-                    let persisted = to_persisted_state(&state_mut);
-                    drop(state_mut);
-                    persist_state(ctx, &persisted);
-                }
-                first_id
-            });
-            if repo_id.is_none() {
-                debug!("n: no repos → OpenNewRepository");
-                Some(AppEvent::OpenNewRepository)
-            } else {
-                debug!(repo_id = ?repo_id, "n: repo exists → OpenNewAgent");
-                repo_id.map(AppEvent::OpenNewAgent)
-            }
+            KeyHandling::Handled(new_agent_or_repository_event(app_state, ctx, snapshot))
         }
         KeyCode::Char('N') => {
             debug!("N pressed: OpenNewRepository");
-            Some(AppEvent::OpenNewRepository)
+            KeyHandling::Handled(Some(AppEvent::OpenNewRepository))
         }
+        _ => KeyHandling::Unhandled,
+    }
+}
 
-        // Delete
+fn new_agent_or_repository_event(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    snapshot: &NormalKeySnapshot,
+) -> Option<AppEvent> {
+    debug!(
+        selected_repo_id = ?snapshot.selected_repo_id,
+        "n pressed: deriving new agent/repo action"
+    );
+    let repo_id = snapshot
+        .selected_repo_id
+        .clone()
+        .or_else(|| select_first_visible_repository(app_state, ctx));
+    if repo_id.is_none() {
+        debug!("n: no repos → OpenNewRepository");
+        Some(AppEvent::OpenNewRepository)
+    } else {
+        debug!(repo_id = ?repo_id, "n: repo exists → OpenNewAgent");
+        repo_id.map(AppEvent::OpenNewAgent)
+    }
+}
+
+fn select_first_visible_repository(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+) -> Option<RepositoryId> {
+    let state = app_state.read();
+    let first_visible_idx = state.visible_repository_indices().first().copied();
+    let first_id = first_visible_idx.and_then(|idx| {
+        state
+            .repositories
+            .get(idx)
+            .map(|repository| repository.id.clone())
+    });
+    drop(state);
+
+    if let Some(first_visible_idx) = first_visible_idx {
+        let mut state_mut = app_state.write();
+        state_mut.selected_repository_index = Some(first_visible_idx);
+        state_mut.normalize_selection_indices();
+        let persisted = to_persisted_state(&state_mut);
+        drop(state_mut);
+        persist_state(ctx, &persisted);
+    }
+    first_id
+}
+
+fn resolve_agent_lifecycle_key(key_event: &KeyEvent, snapshot: &NormalKeySnapshot) -> KeyHandling {
+    match key_event.code {
         KeyCode::Char('d' | 'D') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-            if pane_focus == PaneFocus::Agents || pane_focus == PaneFocus::Terminal {
-                selected_agent_id.clone().map(AppEvent::OpenDeleteAgent)
-            } else if pane_focus == PaneFocus::Repositories {
-                selected_repo_id.clone().map(AppEvent::OpenDeleteRepository)
-            } else {
-                None
-            }
+            KeyHandling::Handled(delete_event(snapshot))
         }
-
-        // Kill agent
         KeyCode::Char('k' | 'K') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-            selected_agent_id.clone().map(AppEvent::KillAgent)
+            KeyHandling::Handled(snapshot.selected_agent_id.clone().map(AppEvent::KillAgent))
         }
+        KeyCode::Char('l' | 'L') => KeyHandling::Handled(relaunch_event_for_selected_agent(
+            snapshot.selected_agent_id.clone(),
+            snapshot.selected_agent_is_running,
+        )),
+        _ => KeyHandling::Unhandled,
+    }
+}
 
-        // Relaunch agent (dead/non-running only)
-        KeyCode::Char('l' | 'L') => {
-            relaunch_event_for_selected_agent(selected_agent_id.clone(), selected_agent_is_running)
-        }
+fn delete_event(snapshot: &NormalKeySnapshot) -> Option<AppEvent> {
+    match snapshot.pane_focus {
+        PaneFocus::Agents | PaneFocus::Terminal => snapshot
+            .selected_agent_id
+            .clone()
+            .map(AppEvent::OpenDeleteAgent),
+        PaneFocus::Repositories => snapshot
+            .selected_repo_id
+            .clone()
+            .map(AppEvent::OpenDeleteRepository),
+    }
+}
 
-        // Issues mode entry
-        // @plan PLAN-20260329-ISSUES-MODE.P11
-        // @requirement REQ-ISS-001
-        // @pseudocode component-003 lines 01-02
+fn resolve_mode_key(key_event: &KeyEvent, screen_mode: ScreenMode) -> KeyHandling {
+    match key_event.code {
         KeyCode::Char('i' | 'I') if screen_mode == ScreenMode::Dashboard => {
-            Some(AppEvent::EnterIssuesMode)
+            KeyHandling::Handled(Some(AppEvent::EnterIssuesMode))
         }
-
-        // Split mode
         KeyCode::Char('s' | 'S') if screen_mode == ScreenMode::Dashboard => {
-            Some(AppEvent::EnterSplitMode)
+            KeyHandling::Handled(Some(AppEvent::EnterSplitMode))
         }
-        KeyCode::Esc if screen_mode == ScreenMode::Split => Some(AppEvent::ExitSplitMode),
-
-        // Grab mode (in split screen)
+        KeyCode::Esc if screen_mode == ScreenMode::Split => {
+            KeyHandling::Handled(Some(AppEvent::ExitSplitMode))
+        }
         KeyCode::Char('g' | 'G') if screen_mode == ScreenMode::Split => {
-            Some(AppEvent::EnterGrabMode)
+            KeyHandling::Handled(Some(AppEvent::EnterGrabMode))
         }
+        _ => KeyHandling::Unhandled,
+    }
+}
 
-        // Help and search
-        KeyCode::Char('?' | 'h' | 'H') | KeyCode::F(1) => Some(AppEvent::OpenHelp),
-        KeyCode::Char('/') => Some(AppEvent::OpenSearch),
+fn resolve_help_search_key(key_event: &KeyEvent) -> KeyHandling {
+    match key_event.code {
+        KeyCode::Char('?' | 'h' | 'H') | KeyCode::F(1) => {
+            KeyHandling::Handled(Some(AppEvent::OpenHelp))
+        }
+        KeyCode::Char('/') => KeyHandling::Handled(Some(AppEvent::OpenSearch)),
+        _ => KeyHandling::Unhandled,
+    }
+}
 
-        // Repository visibility filter
+fn resolve_visibility_key(key_event: &KeyEvent, screen_mode: ScreenMode) -> KeyHandling {
+    match key_event.code {
         KeyCode::Char('v' | 'V') if screen_mode == ScreenMode::Dashboard => {
-            Some(AppEvent::ToggleHideIdleRepositories)
+            KeyHandling::Handled(Some(AppEvent::ToggleHideIdleRepositories))
         }
+        _ => KeyHandling::Unhandled,
+    }
+}
 
-        // Direct pane focus
+fn handle_direct_pane_focus_key(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    key_event: &KeyEvent,
+) -> KeyHandling {
+    match key_event.code {
         KeyCode::Char('r' | 'R') => {
-            let mut state = app_state.write();
-            state.pane_focus = PaneFocus::Repositories;
-            let persisted = to_persisted_state(&state);
-            drop(state);
-            persist_state(ctx, &persisted);
-            None
+            set_pane_focus(app_state, ctx, PaneFocus::Repositories);
+            KeyHandling::Handled(None)
         }
         KeyCode::Char('a' | 'A') => {
-            let mut state = app_state.write();
-            state.pane_focus = PaneFocus::Agents;
-            let persisted = to_persisted_state(&state);
-            drop(state);
-            persist_state(ctx, &persisted);
-            None
+            set_pane_focus(app_state, ctx, PaneFocus::Agents);
+            KeyHandling::Handled(None)
         }
         KeyCode::Char('t' | 'T') => {
-            let selected_running_agent_id = {
-                let mut state = app_state.write();
-                let running_agent_id = state
-                    .selected_agent()
-                    .filter(|agent| agent.is_running())
-                    .map(|agent| agent.id.clone());
-
-                if running_agent_id.is_some() {
-                    state.pane_focus = PaneFocus::Terminal;
-                    if !state.terminal_focused {
-                        *state = std::mem::take(&mut *state).apply(AppEvent::ToggleTerminalFocus);
-                    }
-                } else {
-                    state.pane_focus = PaneFocus::Agents;
-                    state.terminal_focused = false;
-                }
-
-                running_agent_id
-            };
-
-            if let Some(agent_id) = selected_running_agent_id {
-                if let Some(ctx_arc) = &ctx
-                    && let Ok(mut ctx_guard) = ctx_arc.lock()
-                    && let Err(e) = ctx_guard.runtime.attach(&agent_id)
-                {
-                    warn!(
-                        agent_id = %agent_id.0,
-                        error = %e,
-                        "could not attach session on 't' focus"
-                    );
-                    let mut state = app_state.write();
-                    state.terminal_focused = false;
-                    state.pane_focus = PaneFocus::Agents;
-                    let persisted = to_persisted_state(&state);
-                    drop(state);
-                    persist_state(ctx, &persisted);
-                }
-            } else {
-                let mut state = app_state.write();
-                state.terminal_focused = false;
-                state.pane_focus = PaneFocus::Agents;
-                let persisted = to_persisted_state(&state);
-                drop(state);
-                persist_state(ctx, &persisted);
-            }
-
-            None
+            focus_terminal_pane(app_state, ctx);
+            KeyHandling::Handled(None)
         }
-
-        // Enter selects current item (edit agent/repo)
-        KeyCode::Enter => match pane_focus {
-            PaneFocus::Agents => selected_agent_id.clone().map(AppEvent::OpenEditAgent),
-            PaneFocus::Repositories => selected_repo_id.clone().map(AppEvent::OpenEditRepository),
-            PaneFocus::Terminal => {
-                // Toggle terminal focus on Enter when in terminal pane.
-                Some(AppEvent::ToggleTerminalFocus)
-            }
-        },
-
-        // Theme switching (1/2/3)
-        KeyCode::Char('1') => {
-            if let Some(ctx_arc) = &ctx
-                && let Ok(mut ctx_guard) = ctx_arc.lock()
-            {
-                let _ = ctx_guard.theme_manager.set_active("green-screen");
-            }
-            None
-        }
-        KeyCode::Char('2') => {
-            if let Some(ctx_arc) = &ctx
-                && let Ok(mut ctx_guard) = ctx_arc.lock()
-            {
-                let _ = ctx_guard.theme_manager.set_active("dracula");
-            }
-            None
-        }
-        KeyCode::Char('3') => {
-            if let Some(ctx_arc) = &ctx
-                && let Ok(mut ctx_guard) = ctx_arc.lock()
-            {
-                let _ = ctx_guard.theme_manager.set_active("default-dark");
-            }
-            None
-        }
-
-        _ => None,
+        _ => KeyHandling::Unhandled,
     }
+}
+
+fn set_pane_focus(app_state: &mut AppStateHandle, ctx: &SharedContext, pane_focus: PaneFocus) {
+    let mut state = app_state.write();
+    state.pane_focus = pane_focus;
+    let persisted = to_persisted_state(&state);
+    drop(state);
+    persist_state(ctx, &persisted);
+}
+
+fn focus_terminal_pane(app_state: &mut AppStateHandle, ctx: &SharedContext) {
+    let selected_running_agent_id = prepare_terminal_focus_state(app_state);
+
+    if let Some(agent_id) = selected_running_agent_id {
+        attach_terminal_focus(app_state, ctx, &agent_id);
+    } else {
+        set_pane_focus(app_state, ctx, PaneFocus::Agents);
+    }
+}
+
+fn prepare_terminal_focus_state(app_state: &mut AppStateHandle) -> Option<AgentId> {
+    let mut state = app_state.write();
+    let running_agent_id = state
+        .selected_agent()
+        .filter(|agent| agent.is_running())
+        .map(|agent| agent.id.clone());
+
+    if running_agent_id.is_some() {
+        state.pane_focus = PaneFocus::Terminal;
+        if !state.terminal_focused {
+            *state = std::mem::take(&mut *state).apply(AppEvent::ToggleTerminalFocus);
+        }
+    } else {
+        state.pane_focus = PaneFocus::Agents;
+        state.terminal_focused = false;
+    }
+
+    running_agent_id
+}
+
+fn attach_terminal_focus(app_state: &mut AppStateHandle, ctx: &SharedContext, agent_id: &AgentId) {
+    if let Some(ctx_arc) = &ctx
+        && let Ok(mut ctx_guard) = ctx_arc.lock()
+        && let Err(e) = ctx_guard.runtime.attach(agent_id)
+    {
+        warn!(
+            agent_id = %agent_id.0,
+            error = %e,
+            "could not attach session on 't' focus"
+        );
+        set_pane_focus(app_state, ctx, PaneFocus::Agents);
+    }
+}
+
+fn resolve_enter_key(key_event: &KeyEvent, snapshot: &NormalKeySnapshot) -> KeyHandling {
+    if key_event.code != KeyCode::Enter {
+        return KeyHandling::Unhandled;
+    }
+
+    let event = match snapshot.pane_focus {
+        PaneFocus::Agents => snapshot
+            .selected_agent_id
+            .clone()
+            .map(AppEvent::OpenEditAgent),
+        PaneFocus::Repositories => snapshot
+            .selected_repo_id
+            .clone()
+            .map(AppEvent::OpenEditRepository),
+        PaneFocus::Terminal => Some(AppEvent::ToggleTerminalFocus),
+    };
+    KeyHandling::Handled(event)
+}
+
+fn handle_theme_key(ctx: &SharedContext, key_event: &KeyEvent) -> KeyHandling {
+    let theme = match key_event.code {
+        KeyCode::Char('1') => "green-screen",
+        KeyCode::Char('2') => "dracula",
+        KeyCode::Char('3') => "default-dark",
+        _ => return KeyHandling::Unhandled,
+    };
+
+    if let Some(ctx_arc) = &ctx
+        && let Ok(mut ctx_guard) = ctx_arc.lock()
+    {
+        let _ = ctx_guard.theme_manager.set_active(theme);
+    }
+    KeyHandling::Handled(None)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Remove all clippy allow attributes from first-party app input handlers.
- Split large app input key routing, modal handling, and message dispatch paths into focused helpers.
- Remove app input rows from the temporary clippy allowlist.

## Verification
- cargo fmt --all --check
- scripts/check-clippy-allows.sh
- CLIPPY_CONF_DIR=.github/clippy rustup run stable cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features --locked app_input
- make ci-check
