### PR TITLE
Remove runtime clippy suppressions (Fixes #71)

### DIFF
--- a/clippy-allowlist.tsv
+++ b/clippy-allowlist.tsv
@@ -10,19 +10,7 @@ src/github/mod.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality
 src/github/mod.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
 src/messages.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
 src/messages.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
-src/runtime/attach.rs	#[allow(clippy::significant_drop_tightening)]	core-maintainers	next quality-cycle ratchet
-src/runtime/attach.rs	#[allow(clippy::significant_drop_tightening)]	core-maintainers	next quality-cycle ratchet
-src/runtime/attach.rs	#[allow(clippy::significant_drop_tightening)]	core-maintainers	next quality-cycle ratchet
-src/runtime/attach.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
-src/runtime/attach.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
-src/runtime/attach.rs	#[allow( clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::cast_sign_loss, clippy::too_many_lines )]	core-maintainers	next quality-cycle ratchet
-src/runtime/commands.rs	#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]	core-maintainers	next quality-cycle ratchet
-src/runtime/commands.rs	#[allow(clippy::too_many_lines)]	core-maintainers	next quality-cycle ratchet
-src/runtime/mod.rs	#![allow(clippy::expect_used)]	core-maintainers	next quality-cycle ratchet
 src/ui/components/issue_list.rs	#[allow(clippy::struct_excessive_bools)]	core-maintainers	next quality-cycle ratchet
-src/ui/components/terminal_view.rs	#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]	core-maintainers	next quality-cycle ratchet
-src/ui/components/terminal_view.rs	#[allow(clippy::cast_possible_wrap)]	core-maintainers	next quality-cycle ratchet
-src/ui/components/terminal_view.rs	#[allow(clippy::cast_possible_wrap)]	core-maintainers	next quality-cycle ratchet
 tests/core/domain_state_contracts.rs	#![allow(clippy::expect_used)]	core-maintainers	next quality-cycle ratchet
 tests/core/domain_state_contracts.rs	#![allow(clippy::unwrap_used)]	core-maintainers	next quality-cycle ratchet
 tests/core/persistence_theme_contracts.rs	#![allow(clippy::expect_used)]	core-maintainers	next quality-cycle ratchet

--- a/src/runtime/attach.rs
+++ b/src/runtime/attach.rs
@@ -12,12 +12,16 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use alacritty_terminal::event::{Event as TermEvent, EventListener};
-use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::grid::{Dimensions, Indexed};
+use alacritty_terminal::selection::SelectionRange;
 use alacritty_terminal::term::Config as TermConfig;
-use alacritty_terminal::term::cell::Flags;
-use alacritty_terminal::term::{Term, TermMode};
+use alacritty_terminal::term::cell::{Cell, Flags};
+use alacritty_terminal::term::color::Colors;
+use alacritty_terminal::term::{RenderableCursor, Term, TermMode};
 use alacritty_terminal::vte::ansi::{self, Processor, StdSyncHandler};
-use portable_pty::{Child as PtyChild, CommandBuilder, MasterPty, PtySize, native_pty_system};
+use portable_pty::{
+    Child as PtyChild, CommandBuilder, MasterPty, PtyPair, PtySize, native_pty_system,
+};
 use tracing::{debug, warn};
 
 use super::commands;
@@ -143,101 +147,111 @@ fn rgb_to_iocraft(rgb: ansi::Rgb) -> iocraft::Color {
 }
 
 const ANSI_COLOR_CUBE_STEPS: [u8; 6] = [0, 95, 135, 175, 215, 255];
+const ANSI_BASE_COLORS: [ansi::Rgb; 16] = [
+    ansi::Rgb { r: 0, g: 0, b: 0 },
+    ansi::Rgb {
+        r: 0xcd,
+        g: 0,
+        b: 0,
+    },
+    ansi::Rgb {
+        r: 0,
+        g: 0xcd,
+        b: 0,
+    },
+    ansi::Rgb {
+        r: 0xcd,
+        g: 0xcd,
+        b: 0,
+    },
+    ansi::Rgb {
+        r: 0,
+        g: 0,
+        b: 0xee,
+    },
+    ansi::Rgb {
+        r: 0xcd,
+        g: 0,
+        b: 0xcd,
+    },
+    ansi::Rgb {
+        r: 0,
+        g: 0xcd,
+        b: 0xcd,
+    },
+    ansi::Rgb {
+        r: 0xe5,
+        g: 0xe5,
+        b: 0xe5,
+    },
+    ansi::Rgb {
+        r: 0x7f,
+        g: 0x7f,
+        b: 0x7f,
+    },
+    ansi::Rgb {
+        r: 0xff,
+        g: 0,
+        b: 0,
+    },
+    ansi::Rgb {
+        r: 0,
+        g: 0xff,
+        b: 0,
+    },
+    ansi::Rgb {
+        r: 0xff,
+        g: 0xff,
+        b: 0,
+    },
+    ansi::Rgb {
+        r: 0x5c,
+        g: 0x5c,
+        b: 0xff,
+    },
+    ansi::Rgb {
+        r: 0xff,
+        g: 0,
+        b: 0xff,
+    },
+    ansi::Rgb {
+        r: 0,
+        g: 0xff,
+        b: 0xff,
+    },
+    ansi::Rgb {
+        r: 0xff,
+        g: 0xff,
+        b: 0xff,
+    },
+];
 
-#[allow(clippy::too_many_lines)]
 fn fallback_ansi_color(index: u8) -> ansi::Rgb {
     match index {
-        0 => ansi::Rgb { r: 0, g: 0, b: 0 },
-        1 => ansi::Rgb {
-            r: 0xcd,
-            g: 0x00,
-            b: 0x00,
-        },
-        2 => ansi::Rgb {
-            r: 0x00,
-            g: 0xcd,
-            b: 0x00,
-        },
-        3 => ansi::Rgb {
-            r: 0xcd,
-            g: 0xcd,
-            b: 0x00,
-        },
-        4 => ansi::Rgb {
-            r: 0x00,
-            g: 0x00,
-            b: 0xee,
-        },
-        5 => ansi::Rgb {
-            r: 0xcd,
-            g: 0x00,
-            b: 0xcd,
-        },
-        6 => ansi::Rgb {
-            r: 0x00,
-            g: 0xcd,
-            b: 0xcd,
-        },
-        7 => ansi::Rgb {
-            r: 0xe5,
-            g: 0xe5,
-            b: 0xe5,
-        },
-        8 => ansi::Rgb {
-            r: 0x7f,
-            g: 0x7f,
-            b: 0x7f,
-        },
-        9 => ansi::Rgb {
-            r: 0xff,
-            g: 0x00,
-            b: 0x00,
-        },
-        10 => ansi::Rgb {
-            r: 0x00,
-            g: 0xff,
-            b: 0x00,
-        },
-        11 => ansi::Rgb {
-            r: 0xff,
-            g: 0xff,
-            b: 0x00,
-        },
-        12 => ansi::Rgb {
-            r: 0x5c,
-            g: 0x5c,
-            b: 0xff,
-        },
-        13 => ansi::Rgb {
-            r: 0xff,
-            g: 0x00,
-            b: 0xff,
-        },
-        14 => ansi::Rgb {
-            r: 0x00,
-            g: 0xff,
-            b: 0xff,
-        },
-        15 => ansi::Rgb {
-            r: 0xff,
-            g: 0xff,
-            b: 0xff,
-        },
-        n @ 16..=231 => {
-            let idx = n - 16;
-            let r = idx / 36;
-            let g = (idx % 36) / 6;
-            let b = idx % 6;
-            ansi::Rgb {
-                r: ANSI_COLOR_CUBE_STEPS[usize::from(r)],
-                g: ANSI_COLOR_CUBE_STEPS[usize::from(g)],
-                b: ANSI_COLOR_CUBE_STEPS[usize::from(b)],
-            }
-        }
-        n @ 232..=255 => {
-            let v = 8 + (n - 232) * 10;
-            ansi::Rgb { r: v, g: v, b: v }
-        }
+        0..=15 => ANSI_BASE_COLORS[usize::from(index)],
+        n @ 16..=231 => ansi_color_cube(n),
+        n @ 232..=255 => ansi_grayscale(n),
+    }
+}
+
+fn ansi_color_cube(index: u8) -> ansi::Rgb {
+    let idx = index - 16;
+    let r = idx / 36;
+    let g = (idx % 36) / 6;
+    let b = idx % 6;
+    ansi::Rgb {
+        r: ANSI_COLOR_CUBE_STEPS[usize::from(r)],
+        g: ANSI_COLOR_CUBE_STEPS[usize::from(g)],
+        b: ANSI_COLOR_CUBE_STEPS[usize::from(b)],
+    }
+}
+
+fn ansi_grayscale(index: u8) -> ansi::Rgb {
+    let value = 8 + (index - 232) * 10;
+    ansi::Rgb {
+        r: value,
+        g: value,
+        b: value,
     }
 }
 
@@ -291,47 +305,83 @@ fn resolve_color(
     }
 }
 
-#[allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
-    clippy::cast_sign_loss,
-    clippy::too_many_lines
-)]
-fn snapshot_from_term(term: &Term<RuntimeListener>) -> TerminalSnapshot {
-    let rows = term.screen_lines();
-    let cols = term.columns();
+fn dim_rgb(rgb: ansi::Rgb) -> ansi::Rgb {
+    ansi::Rgb {
+        r: rgb.r / 2,
+        g: rgb.g / 2,
+        b: rgb.b / 2,
+    }
+}
 
-    let base_style = TerminalCellStyle {
+fn base_terminal_style() -> TerminalCellStyle {
+    TerminalCellStyle {
         fg: rgb_to_iocraft(fallback_ansi_color(7)),
         bg: rgb_to_iocraft(fallback_ansi_color(0)),
         bold: false,
         underline: false,
-    };
-    let mut snapshot = TerminalSnapshot::blank(rows, cols, base_style);
+    }
+}
 
+fn snapshot_position(indexed: &Indexed<&Cell>, rows: usize, cols: usize) -> Option<(usize, usize)> {
+    let line = indexed.point.line.0;
+    if line < 0 {
+        return None;
+    }
+
+    let row = usize::try_from(line).ok()?;
+    let col = indexed.point.column.0;
+    (row < rows && col < cols).then_some((row, col))
+}
+
+fn snapshot_cell_style(
+    indexed: &Indexed<&Cell>,
+    selection: Option<SelectionRange>,
+    cursor: RenderableCursor,
+    term_colors: &Colors,
+) -> TerminalCellStyle {
+    let mut fg = resolve_color(indexed.cell.fg, term_colors);
+    let mut bg = resolve_color(indexed.cell.bg, term_colors);
+    if indexed.cell.flags.intersects(Flags::DIM | Flags::DIM_BOLD) {
+        fg = dim_rgb(fg);
+    }
+    if indexed.cell.flags.contains(Flags::INVERSE) {
+        std::mem::swap(&mut fg, &mut bg);
+    }
+    if selection.is_some_and(|range| range.contains_cell(indexed, cursor.point, cursor.shape)) {
+        fg = fallback_ansi_color(0);
+        bg = fallback_ansi_color(7);
+    }
+    if cursor.shape != ansi::CursorShape::Hidden && indexed.point == cursor.point {
+        std::mem::swap(&mut fg, &mut bg);
+    }
+
+    TerminalCellStyle {
+        fg: rgb_to_iocraft(fg),
+        bg: rgb_to_iocraft(bg),
+        bold: indexed.cell.flags.intersects(Flags::BOLD | Flags::DIM_BOLD),
+        underline: indexed.cell.flags.intersects(Flags::ALL_UNDERLINES),
+    }
+}
+
+fn snapshot_cell(indexed: &Indexed<&Cell>, style: TerminalCellStyle) -> TerminalCell {
+    let ch = if indexed.cell.flags.contains(Flags::HIDDEN) || indexed.cell.c == '\0' {
+        ' '
+    } else {
+        indexed.cell.c
+    };
+    TerminalCell { ch, style }
+}
+
+fn snapshot_from_term(term: &Term<RuntimeListener>) -> TerminalSnapshot {
+    let rows = term.screen_lines();
+    let cols = term.columns();
+    let mut snapshot = TerminalSnapshot::blank(rows, cols, base_terminal_style());
     let renderable = term.renderable_content();
-    let selection = renderable.selection;
-    let cursor = renderable.cursor;
-    let term_colors = renderable.colors;
 
     for indexed in renderable.display_iter {
-        let line_i32 = indexed.point.line.0;
-        if line_i32 < 0 {
-            continue;
-        }
-
-        let Ok(row) = usize::try_from(line_i32) else {
+        let Some((row, col)) = snapshot_position(&indexed, rows, cols) else {
             continue;
         };
-        if row >= rows {
-            continue;
-        }
-
-        let col = indexed.point.column.0;
-        if col >= cols {
-            continue;
-        }
-
         if indexed
             .cell
             .flags
@@ -340,52 +390,46 @@ fn snapshot_from_term(term: &Term<RuntimeListener>) -> TerminalSnapshot {
             continue;
         }
 
-        let mut fg = resolve_color(indexed.cell.fg, term_colors);
-        let mut bg = resolve_color(indexed.cell.bg, term_colors);
-        let bold = indexed.cell.flags.contains(Flags::BOLD)
-            || indexed.cell.flags.contains(Flags::DIM_BOLD);
-        let underline = indexed.cell.flags.intersects(Flags::ALL_UNDERLINES);
-
-        if indexed.cell.flags.contains(Flags::DIM) || indexed.cell.flags.contains(Flags::DIM_BOLD) {
-            fg = fallback_ansi_color(8);
-        }
-
-        if indexed.cell.flags.contains(Flags::INVERSE) {
-            std::mem::swap(&mut fg, &mut bg);
-        }
-
-        let in_selection = selection
-            .is_some_and(|range| range.contains_cell(&indexed, cursor.point, cursor.shape));
-        if in_selection {
-            fg = fallback_ansi_color(0);
-            bg = fallback_ansi_color(7);
-        }
-
-        let is_cursor_cell =
-            cursor.shape != ansi::CursorShape::Hidden && indexed.point == cursor.point;
-        if is_cursor_cell {
-            std::mem::swap(&mut fg, &mut bg);
-        }
-
-        let ch = if indexed.cell.flags.contains(Flags::HIDDEN) {
-            ' '
-        } else {
-            let c = indexed.cell.c;
-            if c == '\0' { ' ' } else { c }
-        };
-
-        snapshot.cells[row][col] = TerminalCell {
-            ch,
-            style: TerminalCellStyle {
-                fg: rgb_to_iocraft(fg),
-                bg: rgb_to_iocraft(bg),
-                bold,
-                underline,
-            },
-        };
+        let style = snapshot_cell_style(
+            &indexed,
+            renderable.selection,
+            renderable.cursor,
+            renderable.colors,
+        );
+        snapshot.cells[row][col] = snapshot_cell(&indexed, style);
     }
 
     snapshot
+}
+
+fn attach_command(session_name: &str, ssh_command: Option<&str>) -> CommandBuilder {
+    let mut cmd = if let Some(ssh_command) = ssh_command {
+        let mut cmd = CommandBuilder::new("sh");
+        cmd.arg("-lc");
+        cmd.arg(ssh_command);
+        cmd
+    } else {
+        let mut cmd = CommandBuilder::new("tmux");
+        cmd.arg("-f");
+        cmd.arg("/dev/null");
+        cmd.arg("attach-session");
+        cmd.arg("-t");
+        cmd.arg(session_name);
+        cmd
+    };
+    cmd.env("TERM", "xterm-256color");
+    cmd
+}
+
+fn open_pty(rows: u16, cols: u16) -> Result<PtyPair, RuntimeError> {
+    native_pty_system()
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| RuntimeError::SpawnFailed(format!("openpty: {e}")))
 }
 
 impl AttachedViewer {
@@ -405,7 +449,6 @@ impl AttachedViewer {
         Self::spawn_command(session_name, rows, cols, Some(ssh_command))
     }
 
-    #[allow(clippy::too_many_lines)]
     fn spawn_command(
         session_name: &str,
         rows: u16,
@@ -418,33 +461,8 @@ impl AttachedViewer {
             debug!(session_name = %session_name, "AttachedViewer::spawn clipboard passthrough enforced");
         }
 
-        let pty_system = native_pty_system();
-
-        let pty_pair = pty_system
-            .openpty(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .map_err(|e| RuntimeError::SpawnFailed(format!("openpty: {e}")))?;
-
-        let mut cmd = if let Some(ssh_command) = ssh_command {
-            let mut cmd = CommandBuilder::new("sh");
-            cmd.arg("-lc");
-            cmd.arg(ssh_command);
-            cmd
-        } else {
-            let mut cmd = CommandBuilder::new("tmux");
-            cmd.arg("-f");
-            cmd.arg("/dev/null");
-            cmd.arg("attach-session");
-            cmd.arg("-t");
-            cmd.arg(session_name);
-            cmd.env("TERM", "xterm-256color");
-            cmd
-        };
-        cmd.env("TERM", "xterm-256color");
+        let pty_pair = open_pty(rows, cols)?;
+        let cmd = attach_command(session_name, ssh_command);
 
         let child = pty_pair
             .slave
@@ -503,7 +521,6 @@ impl AttachedViewer {
     /// Write input bytes to the PTY.
     ///
     /// @pseudocode component-002 lines 18-20
-    #[allow(clippy::significant_drop_tightening)]
     pub fn write_input(&self, bytes: &[u8]) -> Result<(), RuntimeError> {
         if !self.is_alive() {
             return Err(RuntimeError::WriteFailed("viewer not alive".into()));
@@ -521,12 +538,12 @@ impl AttachedViewer {
         writer
             .flush()
             .map_err(|e| RuntimeError::WriteFailed(format!("flush: {e}")))?;
+        drop(writer);
 
         Ok(())
     }
 
     /// Resize the terminal.
-    #[allow(clippy::significant_drop_tightening)]
     pub fn resize(&self, rows: u16, cols: u16) -> Result<(), RuntimeError> {
         let master = self
             .master
@@ -557,7 +574,6 @@ impl AttachedViewer {
     }
 
     /// Get a snapshot of the terminal state.
-    #[allow(clippy::significant_drop_tightening)]
     pub fn snapshot(&self) -> Option<TerminalSnapshot> {
         let term = self.term.lock().ok()?;
         Some(snapshot_from_term(&term))

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -325,36 +325,31 @@ fn resolve_remote_llxprt_command(
     ))
 }
 
-#[allow(clippy::too_many_lines)]
-fn build_remote_launch_command(
-    session_name: &str,
-    work_dir: &Path,
-    signature: &LaunchSignature,
-) -> Result<String, RuntimeError> {
-    let remote = &signature.remote;
-    let work_dir_string = work_dir.to_string_lossy().into_owned();
-    let escaped_work_dir = shell_escape_single(&work_dir_string);
-    let llxprt_command = resolve_remote_llxprt_command(remote, work_dir, remote.setup_env_default)?;
-    let mut launch_args: Vec<String> = Vec::new();
-
+fn launch_args(signature: &LaunchSignature) -> Vec<String> {
+    let mut args = Vec::new();
     if !signature.profile.is_empty() {
-        launch_args.push("--profile-load".to_owned());
-        launch_args.push(signature.profile.clone());
+        args.push("--profile-load".to_owned());
+        args.push(signature.profile.clone());
     }
-    for flag in &signature.mode_flags {
-        if !flag.is_empty() {
-            launch_args.push(flag.clone());
-        }
-    }
+    args.extend(
+        signature
+            .mode_flags
+            .iter()
+            .filter(|flag| !flag.is_empty())
+            .cloned(),
+    );
     if signature.pass_continue {
-        launch_args.push("--continue".to_owned());
+        args.push("--continue".to_owned());
     }
     if signature.sandbox_enabled {
-        launch_args.push("--sandbox".to_owned());
-        launch_args.push("--sandbox-engine".to_owned());
-        launch_args.push(signature.sandbox_engine.as_llxprt_arg().to_owned());
+        args.push("--sandbox".to_owned());
+        args.push("--sandbox-engine".to_owned());
+        args.push(signature.sandbox_engine.as_llxprt_arg().to_owned());
     }
+    args
+}
 
+fn remote_env_exports(signature: &LaunchSignature) -> Vec<String> {
     let mut env_exports = Vec::new();
     if signature.sandbox_enabled {
         env_exports.push(format!(
@@ -374,29 +369,155 @@ fn build_remote_launch_command(
             shell_escape_single(&signature.llxprt_debug)
         ));
     }
+    env_exports
+}
 
-    let cli_command = if llxprt_command.contains(' ') {
-        format!("{} {}", llxprt_command, shell_join(&launch_args))
-    } else if launch_args.is_empty() {
-        llxprt_command
+fn remote_cli_command(llxprt_command: &str, launch_args: &[String]) -> String {
+    let executable = if llxprt_command == "llxprt" {
+        llxprt_command.to_owned()
     } else {
-        format!(
-            "{} {}",
-            shell_escape_single(&llxprt_command),
-            shell_join(&launch_args)
-        )
+        shell_escape_single(llxprt_command)
     };
 
-    let env_prefix = env_exports.join(" ");
+    if launch_args.is_empty() {
+        executable
+    } else {
+        format!("{} {}", executable, shell_join(launch_args))
+    }
+}
+
+fn build_remote_launch_command(
+    session_name: &str,
+    work_dir: &Path,
+    signature: &LaunchSignature,
+) -> Result<String, RuntimeError> {
+    let remote = &signature.remote;
+    let work_dir_string = work_dir.to_string_lossy().into_owned();
+    let escaped_work_dir = shell_escape_single(&work_dir_string);
+    let llxprt_command = resolve_remote_llxprt_command(remote, work_dir, remote.setup_env_default)?;
+    let args = launch_args(signature);
+    let cli_command = remote_cli_command(&llxprt_command, &args);
+    let env_prefix = remote_env_exports(signature).join(" ");
+    let escaped_session = shell_escape_single(session_name);
     let tmux_script = format!(
-        "set -e; mkdir -p {escaped_work_dir}; cd {escaped_work_dir}; {env_prefix} tmux new-session -d -s {} -c {} {} \\; set-option -t {} remain-on-exit on",
-        shell_escape_single(session_name),
-        escaped_work_dir,
-        cli_command,
-        shell_escape_single(session_name),
+        "set -e; mkdir -p {escaped_work_dir}; cd {escaped_work_dir}; {env_prefix} tmux new-session -d -s {escaped_session} -c {escaped_work_dir} {cli_command} \\; set-option -t {escaped_session} remain-on-exit on"
     );
 
     Ok(remote_tmux_command(remote, &tmux_script))
+}
+
+struct LocalLaunchPlan {
+    args: Vec<String>,
+    env: Vec<(String, String)>,
+    warning: Option<String>,
+}
+
+fn local_launch_plan(signature: &LaunchSignature) -> LocalLaunchPlan {
+    let mut env = Vec::new();
+    let warning = if signature.sandbox_enabled {
+        env.push(("SANDBOX_FLAGS".to_owned(), signature.sandbox_flags.clone()));
+        if let Some(image_ref) = std::env::var_os("LLXPRT_SANDBOX_IMAGE") {
+            env.push((
+                "LLXPRT_SANDBOX_IMAGE".to_owned(),
+                image_ref.to_string_lossy().into_owned(),
+            ));
+        }
+        sandbox_ssh_agent_warning()
+    } else {
+        None
+    };
+    if !signature.llxprt_debug.is_empty() {
+        env.push(("LLXPRT_DEBUG".to_owned(), signature.llxprt_debug.clone()));
+    }
+    LocalLaunchPlan {
+        args: launch_args(signature),
+        env,
+        warning,
+    }
+}
+
+fn local_launch_command(session_name: &str, work_dir: &Path, plan: &LocalLaunchPlan) -> Command {
+    let mut cmd = tmux_command();
+    cmd.arg("new-session")
+        .arg("-d")
+        .arg("-s")
+        .arg(session_name)
+        .arg("-c")
+        .arg(work_dir);
+
+    if !plan.env.is_empty() {
+        cmd.arg("env");
+        for (key, value) in &plan.env {
+            cmd.arg(format!("{key}={value}"));
+        }
+    }
+
+    cmd.arg("llxprt");
+    cmd.args(&plan.args);
+    cmd
+}
+
+fn finalize_local_session(session_name: &str, warning: Option<String>) {
+    enforce_clipboard_passthrough(session_name);
+    let _ = tmux_cmd_status(
+        ["set-option", "-t", session_name, "remain-on-exit", "on"].as_ref(),
+        None,
+    );
+    apply_session_style(session_name);
+
+    if let Some(warning) = warning {
+        debug!(session_name = %session_name, warning = %warning, "runtime launch preflight warning");
+        let _ = tmux_cmd_status(
+            [
+                "display-message",
+                "-t",
+                session_name,
+                &format!("[jefe] warning: {warning}"),
+            ]
+            .as_ref(),
+            None,
+        );
+    }
+}
+
+fn try_local_create_session(
+    session_name: &str,
+    work_dir: &Path,
+    signature: &LaunchSignature,
+    attempt: u8,
+) -> Result<(), String> {
+    let plan = local_launch_plan(signature);
+    let mut cmd = local_launch_command(session_name, work_dir, &plan);
+    debug!(session_name = %session_name, attempt, "create_session invoking tmux new-session");
+
+    let output = cmd.output().map_err(|e| format!("tmux new-session: {e}"))?;
+    if output.status.success() {
+        debug!(session_name = %session_name, attempt, "create_session tmux new-session succeeded");
+        finalize_local_session(session_name, plan.warning);
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).to_string())
+    }
+}
+
+fn create_remote_session(
+    session_name: &str,
+    work_dir: &Path,
+    signature: &LaunchSignature,
+) -> Result<(), RuntimeError> {
+    let remote_command = build_remote_launch_command(session_name, work_dir, signature)?;
+    let output = run_remote_ssh(&signature.remote, &remote_command)?;
+    ensure_remote_success(&signature.remote, "remote tmux new-session", output)?;
+    Ok(())
+}
+
+fn is_tmux_fork_broken(stderr: &str) -> bool {
+    stderr.contains("fork failed") || stderr.contains("Device not configured")
+}
+
+fn local_spawn_error(session_name: &str, attempt: u8, stderr: String) -> RuntimeError {
+    debug!(session_name = %session_name, attempt, stderr = %stderr, "create_session tmux new-session failed");
+    RuntimeError::SpawnFailed(format!("tmux new-session failed: {stderr}"))
 }
 
 /// Create a new detached tmux session running llxprt.
@@ -405,158 +526,30 @@ fn build_remote_launch_command(
 /// the tmux session becomes "dead" until explicit relaunch.
 ///
 /// @pseudocode component-002 lines 01-06
-#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
 pub fn create_session(
     session_name: &str,
     work_dir: &Path,
     signature: &LaunchSignature,
 ) -> Result<(), RuntimeError> {
     debug!(session_name = %session_name, work_dir = %work_dir.display(), "create_session start");
-
     if remote_is_enabled(&signature.remote) {
-        let remote_command = build_remote_launch_command(session_name, work_dir, signature)?;
-        let output = run_remote_ssh(&signature.remote, &remote_command)?;
-        ensure_remote_success(&signature.remote, "remote tmux new-session", output)?;
-        return Ok(());
+        return create_remote_session(session_name, work_dir, signature);
     }
 
-    // Kill any stale session with the same name first
     let _ = kill_session(session_name);
-
-    // Retry once if tmux server is in a fork-broken state.
-    for attempt in 0..=1 {
-        let mut llxprt_args: Vec<String> = Vec::new();
-
-        // Add profile if specified.
-        if !signature.profile.is_empty() {
-            llxprt_args.push("--profile-load".to_owned());
-            llxprt_args.push(signature.profile.clone());
-        }
-
-        // Add mode flags (e.g., --yolo).
-        for flag in &signature.mode_flags {
-            if !flag.is_empty() {
-                llxprt_args.push(flag.clone());
-            }
-        }
-
-        // Add --continue if pass_continue is true.
-        if signature.pass_continue {
-            llxprt_args.push("--continue".to_owned());
-        }
-
-        // Sandbox launch parity with llxprt-code: explicit --sandbox and engine,
-        // plus SANDBOX_FLAGS environment support.
-        let mut launch_env: Vec<(String, String)> = Vec::new();
-        let launch_warning: Option<String> = if signature.sandbox_enabled {
-            llxprt_args.push("--sandbox".to_owned());
-            llxprt_args.push("--sandbox-engine".to_owned());
-            llxprt_args.push(signature.sandbox_engine.as_llxprt_arg().to_owned());
-            launch_env.push(("SANDBOX_FLAGS".to_owned(), signature.sandbox_flags.clone()));
-
-            // Let llxprt resolve its own sandbox image — it knows its version
-            // and can give clear errors (e.g. "daemon not running") instead of
-            // the misleading "image missing" that results from jefe pre-resolving
-            // via `manifest inspect` (which queries the registry without a daemon).
-            // The user can still override via LLXPRT_SANDBOX_IMAGE in their env.
-            if let Some(image_ref) = std::env::var_os("LLXPRT_SANDBOX_IMAGE") {
-                launch_env.push((
-                    "LLXPRT_SANDBOX_IMAGE".to_owned(),
-                    image_ref.to_string_lossy().into_owned(),
-                ));
-            }
-
-            sandbox_ssh_agent_warning()
-        } else {
-            None
-        };
-
-        if !signature.llxprt_debug.is_empty() {
-            launch_env.push(("LLXPRT_DEBUG".to_owned(), signature.llxprt_debug.clone()));
-        }
-
-        let mut cmd = tmux_command();
-        cmd.arg("new-session")
-            .arg("-d")
-            .arg("-s")
-            .arg(session_name)
-            .arg("-c")
-            .arg(work_dir.to_str().unwrap_or("."));
-
-        debug!(session_name = %session_name, attempt, "create_session invoking tmux new-session");
-
-        if !launch_env.is_empty() {
-            cmd.arg("env");
-            for (key, value) in &launch_env {
-                // Each .arg() is a single argv entry to tmux.  tmux internally
-                // escapes each argument when joining them for sh -c, so spaces
-                // inside the value are preserved without any extra quoting.
-                // Adding shell_escape_single() here would embed literal quote
-                // characters in the value (double-quoting), breaking consumers
-                // like llxprt's shell-quote parser.
-                cmd.arg(format!("{key}={value}"));
-            }
-        }
-
-        cmd.arg("llxprt");
-        for arg in &llxprt_args {
-            cmd.arg(arg);
-        }
-
-        let output = cmd
-            .output()
-            .map_err(|e| RuntimeError::SpawnFailed(format!("tmux new-session: {e}")))?;
-
-        if output.status.success() {
-            debug!(session_name = %session_name, attempt, "create_session tmux new-session succeeded");
-
-            // Enforce clipboard passthrough for each new session regardless of
-            // user/system tmux defaults.
-            enforce_clipboard_passthrough(session_name);
-
-            // Preserve dead pane output in tmux for post-mortem inspection/relaunch context.
-            let _ = tmux_cmd_status(
-                ["set-option", "-t", session_name, "remain-on-exit", "on"].as_ref(),
-                None,
-            );
-            apply_session_style(session_name);
-
-            if let Some(warning) = launch_warning {
-                debug!(session_name = %session_name, warning = %warning, "runtime launch preflight warning");
-                let _ = tmux_cmd_status(
-                    [
-                        "display-message",
-                        "-t",
-                        session_name,
-                        &format!("[jefe] warning: {warning}"),
-                    ]
-                    .as_ref(),
-                    None,
-                );
-            }
-
-            return Ok(());
-        }
-
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        let fork_broken =
-            stderr.contains("fork failed") || stderr.contains("Device not configured");
-
-        if attempt == 0 && fork_broken {
-            debug!(session_name = %session_name, attempt, stderr = %stderr, "create_session retrying after tmux fork failure");
+    match try_local_create_session(session_name, work_dir, signature, 0) {
+        Ok(()) => return Ok(()),
+        Err(stderr) if is_tmux_fork_broken(&stderr) => {
+            debug!(session_name = %session_name, attempt = 0, stderr = %stderr, "create_session retrying after tmux fork failure");
             reset_tmux_server();
-            continue;
         }
-
-        debug!(session_name = %session_name, attempt, stderr = %stderr, "create_session tmux new-session failed");
-        return Err(RuntimeError::SpawnFailed(format!(
-            "tmux new-session failed: {stderr}"
-        )));
+        Err(stderr) => return Err(local_spawn_error(session_name, 0, stderr)),
     }
 
-    Err(RuntimeError::SpawnFailed(
-        "tmux new-session failed after retry".to_owned(),
-    ))
+    match try_local_create_session(session_name, work_dir, signature, 1) {
+        Ok(()) => Ok(()),
+        Err(stderr) => Err(local_spawn_error(session_name, 1, stderr)),
+    }
 }
 
 /// Check if a tmux session exists.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -26,7 +26,6 @@ pub use session::{RuntimeSession, TerminalCell, TerminalCellStyle, TerminalSnaps
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::expect_used)]
     use std::path::PathBuf;
 
     use super::*;
@@ -49,11 +48,14 @@ mod tests {
             remote: crate::domain::RemoteRepositorySettings::default(),
         };
 
-        mgr.spawn_session(&agent_id, &work_dir, &signature)
-            .expect("spawn should succeed");
+        if let Err(error) = mgr.spawn_session(&agent_id, &work_dir, &signature) {
+            panic!("spawn should succeed: {error}");
+        }
         assert!(mgr.is_alive(&agent_id));
 
-        mgr.attach(&agent_id).expect("attach should succeed");
+        if let Err(error) = mgr.attach(&agent_id) {
+            panic!("attach should succeed: {error}");
+        }
         assert_eq!(mgr.attached_agent(), Some(&agent_id));
     }
 
@@ -74,9 +76,12 @@ mod tests {
             remote: crate::domain::RemoteRepositorySettings::default(),
         };
 
-        mgr.spawn_session(&agent_id, &work_dir, &signature)
-            .expect("spawn should succeed");
-        mgr.kill(&agent_id).expect("kill should succeed");
+        if let Err(error) = mgr.spawn_session(&agent_id, &work_dir, &signature) {
+            panic!("spawn should succeed: {error}");
+        }
+        if let Err(error) = mgr.kill(&agent_id) {
+            panic!("kill should succeed: {error}");
+        }
         assert!(!mgr.is_alive(&agent_id));
     }
 
@@ -104,8 +109,9 @@ mod tests {
             remote: crate::domain::RemoteRepositorySettings::default(),
         };
 
-        mgr.spawn_session(&agent_id, &work_dir, &signature)
-            .expect("first spawn should succeed");
+        if let Err(error) = mgr.spawn_session(&agent_id, &work_dir, &signature) {
+            panic!("first spawn should succeed: {error}");
+        }
         let result = mgr.spawn_session(&agent_id, &work_dir, &signature);
         assert!(result.is_err());
     }
@@ -127,8 +133,9 @@ mod tests {
             remote: crate::domain::RemoteRepositorySettings::default(),
         };
 
-        mgr.spawn_session_fresh(&agent_id, &work_dir, &signature)
-            .expect("fresh spawn should succeed");
+        if let Err(error) = mgr.spawn_session_fresh(&agent_id, &work_dir, &signature) {
+            panic!("fresh spawn should succeed: {error}");
+        }
         assert!(mgr.is_alive(&agent_id));
 
         let duplicate = mgr.spawn_session_fresh(&agent_id, &work_dir, &signature);

--- a/src/ui/components/terminal_view.rs
+++ b/src/ui/components/terminal_view.rs
@@ -158,7 +158,13 @@ impl Component for TerminalGrid {
             .take(self.snapshot.rows.min(max_rows))
             .enumerate()
         {
+            let Some(y) = canvas_coord(row_idx) else {
+                continue;
+            };
             for run in row_to_runs(row, max_cols) {
+                let Some(x) = canvas_coord(run.start_col) else {
+                    continue;
+                };
                 // CanvasTextStyle is #[non_exhaustive]; build via Default then set fields.
                 let mut style = CanvasTextStyle::default();
                 style.color = Some(run.style.fg);
@@ -171,31 +177,46 @@ impl Component for TerminalGrid {
 
                 // Background is painted as a filled region under the run so that
                 // per-cell background colors are preserved.
-                #[allow(clippy::cast_possible_wrap)]
-                canvas.set_background_color(
-                    run.start_col as isize,
-                    row_idx as isize,
-                    run.width,
-                    1,
-                    run.style.bg,
-                );
-                #[allow(clippy::cast_possible_wrap)]
-                canvas.set_text(run.start_col as isize, row_idx as isize, &run.text, style);
+                canvas.set_background_color(x, y, run.width, 1, run.style.bg);
+                canvas.set_text(x, y, &run.text, style);
             }
         }
     }
 }
 
+fn canvas_coord(value: usize) -> Option<isize> {
+    isize::try_from(value).ok()
+}
+
 /// Convert a taffy `f32` layout dimension to a clamped, non-negative `usize`.
 ///
-/// Negative or non-finite values collapse to `0`; large values saturate.
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+/// Negative or non-finite values collapse to `0`; implausibly large values clamp
+/// to a bound far beyond any supported terminal viewport.
+///
+/// The bounded binary search avoids float-to-integer casts so this hot-path
+/// conversion stays compliant with the no-new-clippy-allows policy.
 fn f32_to_usize(value: f32) -> usize {
+    const MAX_VIEWPORT_CELLS: u16 = u16::MAX;
+
     if !value.is_finite() || value <= 0.0 {
-        0
-    } else {
-        value.floor() as usize
+        return 0;
     }
+    if value >= f32::from(MAX_VIEWPORT_CELLS) {
+        return usize::from(MAX_VIEWPORT_CELLS);
+    }
+
+    let target = value.floor();
+    let mut low = 0u16;
+    let mut high = MAX_VIEWPORT_CELLS;
+    while low < high {
+        let mid = low + ((high - low) / 2) + 1;
+        if f32::from(mid) <= target {
+            low = mid;
+        } else {
+            high = mid - 1;
+        }
+    }
+    usize::from(low)
 }
 
 /// A contiguous run of cells sharing the same style within a single row.


### PR DESCRIPTION
## Summary
- Remove runtime and terminal rendering clippy allow suppressions
- Split runtime launch, attach, and snapshot logic into smaller helpers
- Replace terminal coordinate casts with checked conversions

## Verification
- cargo fmt --all --check
- scripts/check-clippy-allows.sh
- strict clippy with warnings denied
- cargo test --workspace --all-features --locked
- make ci-check

Fixes #71