### PR TITLE
Enforce zero clippy allow policy (Fixes #75)

### DIFF
--- a/clippy-allowlist.tsv
+++ b/clippy-allowlist.tsv
@@ -1,3 +1,0 @@
-# Existing clippy allow attributes pending removal.
-# Columns are tab-separated: path, exact attribute text, owner, removal target.
-# New #[allow(clippy::...)] or #![allow(clippy::...)] entries must not be added without an approved exception.

--- a/dev-docs/project-standards.md
+++ b/dev-docs/project-standards.md
@@ -80,7 +80,7 @@ Contributors must keep project lint config active and respected.
 ## Explicit prohibitions
 - Do not disable lints globally.
 - Do not add blanket `#[allow(...)]` at module/file scope to silence debt.
-- Do not add `#[allow(clippy::...)]`, `#![allow(clippy::...)]`, or `#[cfg_attr(..., allow(clippy::...))]` attributes in first-party code. The policy is zero-tolerance and there is no exception ledger. The gate `scripts/check-clippy-allows.sh` fails CI on any first-party clippy allow attribute.
+- Do not add `#[allow(clippy::...)]`, `#![allow(clippy::...)]`, or `#[cfg_attr(..., allow(clippy::...))]` attributes in first-party code (vendor remains ignored). The policy is zero-tolerance and there is no exception ledger. The gate `scripts/check-clippy-allows.sh` fails CI on any first-party clippy allow attribute.
 - Do not merge code that passes only by muting warnings.
 
 If a local non-clippy `#[allow]` is unavoidable:

--- a/dev-docs/project-standards.md
+++ b/dev-docs/project-standards.md
@@ -80,10 +80,10 @@ Contributors must keep project lint config active and respected.
 ## Explicit prohibitions
 - Do not disable lints globally.
 - Do not add blanket `#[allow(...)]` at module/file scope to silence debt.
-- Do not add new `#[allow(clippy::...)]` or `#![allow(clippy::...)]` attributes unless the exception has explicit review approval and is recorded in `clippy-allowlist.tsv` with an owner and removal target.
+- Do not add `#[allow(clippy::...)]`, `#![allow(clippy::...)]`, or `#[cfg_attr(..., allow(clippy::...))]` attributes in first-party code. The policy is zero-tolerance and there is no exception ledger. The gate `scripts/check-clippy-allows.sh` fails CI on any first-party clippy allow attribute.
 - Do not merge code that passes only by muting warnings.
 
-If a local `#[allow]` is unavoidable:
+If a local non-clippy `#[allow]` is unavoidable:
 1. scope it to the smallest possible item,
 2. explain why in code,
 3. reference a tracking issue.

--- a/docs/building.md
+++ b/docs/building.md
@@ -55,6 +55,8 @@ cargo build --workspace --all-features --locked
 cargo test --workspace --all-features --locked
 ```
 
+`scripts/check-clippy-allows.sh` enforces a **zero-tolerance** policy for first-party clippy allow attributes: no tracked Rust file outside `vendor/` may contain `#[allow(clippy::...)]`, `#![allow(clippy::...)]`, or `#[cfg_attr(..., allow(clippy::...))]` in any whitespace variant. The `vendor/` tree is ignored entirely. There is **no exception ledger** — if a suppression is genuinely needed it must be raised as a design discussion, not committed as silent debt. The gate fails closed: a scanner error is treated as a policy failure, never as a clean pass.
+
 Optional local-only speed pass while iterating:
 
 ```bash

--- a/docs/project-standards.md
+++ b/docs/project-standards.md
@@ -115,7 +115,7 @@ Defined in `clippy.toml`:
 - **DON'T** use `.unwrap()` or `.expect()` in production code paths. These are acceptable ONLY in `#[cfg(test)]` blocks and in `const` contexts where the value is provably `Some`/`Ok`.
 - **DON'T** use `panic!()`, `unreachable!()`, `todo!()`, or `unimplemented!()` in production code paths. If a code path is genuinely unreachable, refactor the types to make that structurally impossible.
 - **DON'T** disable lints with `#[allow(...)]` without a code-review-approved comment explaining why. Every `allow` must have a justification. Blanket `#![allow(...)]` at the module level requires explicit approval and must be temporary.
-- **DON'T** add new `#[allow(clippy::...)]` or `#![allow(clippy::...)]` attributes unless the exception has explicit review approval and is recorded in `clippy-allowlist.tsv` with an owner and removal target.
+- **DON'T** add `#[allow(clippy::...)]`, `#![allow(clippy::...)]`, or `#[cfg_attr(..., allow(clippy::...))]` attributes in first-party code. The policy is zero-tolerance and there is no exception ledger. The gate `scripts/check-clippy-allows.sh` fails CI on any first-party clippy allow attribute (vendor remains ignored).
 - **DON'T** use `HashMap<String, serde_json::Value>` or equivalent weak typing. Define explicit structs with named, typed fields.
 - **DON'T** use `dyn Any` or downcasting for type erasure. Use enums or generics.
 - **DON'T** use wildcard imports (`use foo::*`) except for the `iocraft::prelude::*` import in component files.

--- a/scripts/check-clippy-allows.sh
+++ b/scripts/check-clippy-allows.sh
@@ -2,8 +2,8 @@
 # Zero-tolerance clippy allow policy.
 #
 # This gate fails if any tracked first-party Rust file (outside vendor/)
-# contains a clippy allow attribute. There is no exception ledger. If an
-# exception is genuinely required, it must be raised as a design discussion,
+# contains a clippy allow or expect attribute. There is no exception ledger. If
+# an exception is genuinely required, it must be raised as a design discussion,
 # not committed as debt.
 #
 # It also verifies that the root clippy.toml and the CI clippy.toml keep the
@@ -33,12 +33,12 @@ require_file() {
   fi
 }
 
-# Print clippy allow attributes found in the given Rust file, one per line as
-# "<file>\t<attribute>". Handles single-line and multi-line attributes and the
-# three attribute shapes the scanner must catch:
-#   #[allow(clippy::...)]
-#   #![allow(clippy::...)]
-#   #[cfg_attr(..., allow(clippy::...))]
+# Print clippy allow/expect attributes found in the given Rust file, one per
+# line as "<file>\t<attribute>". Handles single-line and multi-line attributes
+# and the three attribute shapes the scanner must catch:
+#   #[allow(clippy::...)] / #[expect(clippy::...)]
+#   #![allow(clippy::...)] / #![expect(clippy::...)]
+#   #[cfg_attr(..., allow(clippy::...))] / #[cfg_attr(..., expect(clippy::...))]
 #
 # Robustness: the scanner uses a small Rust-aware lexer to collect attribute
 # blocks beginning with `#[`, `#![`, `# [`, or `#! [` while ignoring comments
@@ -57,7 +57,7 @@ path = sys.argv[1]
 with open(path, "r", encoding="utf-8") as handle:
     source = handle.read()
 
-CLIPPY_ALLOW = re.compile(r"\ballow\s*\([^)]*(?:r#)?clippy\s*::")
+CLIPPY_ALLOW = re.compile(r"\b(?:allow|expect)\s*\([^)]*(?:r#)?clippy\s*::")
 
 
 def skip_line_comment(text, index):
@@ -270,6 +270,7 @@ check_no_allows() {
     while IFS= read -r line; do
       printf '  %s\n' "$line" >&2
     done <<<"$found"
+    return 1
   fi
 }
 

--- a/scripts/check-clippy-allows.sh
+++ b/scripts/check-clippy-allows.sh
@@ -1,10 +1,22 @@
 #!/usr/bin/env bash
+# Zero-tolerance clippy allow policy.
+#
+# This gate fails if any tracked first-party Rust file (outside vendor/)
+# contains a clippy allow attribute. There is no exception ledger. If an
+# exception is genuinely required, it must be raised as a design discussion,
+# not committed as debt.
+#
+# It also verifies that the root clippy.toml and the CI clippy.toml keep the
+# same complexity thresholds, so CLIPPY_CONF_DIR does not silently fall back
+# to clippy defaults.
 set -euo pipefail
 
-readonly ALLOWLIST="clippy-allowlist.tsv"
 readonly ROOT_CLIPPY_CONFIG="clippy.toml"
 readonly CI_CLIPPY_CONFIG=".github/clippy/clippy.toml"
-readonly TMP_BASE="${TMPDIR:-/tmp}"
+
+# When set, scan that directory tree for *.rs files instead of the
+# git-tracked first-party set. This exists for fixture-based tests.
+readonly SCAN_ROOT="${CLIPPY_ALLOW_SCAN_ROOT:-}"
 
 errors=0
 
@@ -21,71 +33,244 @@ require_file() {
   fi
 }
 
-make_temp_file() {
-  mktemp "${TMP_BASE%/}/jefe-clippy-allows.XXXXXX"
+# Print clippy allow attributes found in the given Rust file, one per line as
+# "<file>\t<attribute>". Handles single-line and multi-line attributes and the
+# three attribute shapes the scanner must catch:
+#   #[allow(clippy::...)]
+#   #![allow(clippy::...)]
+#   #[cfg_attr(..., allow(clippy::...))]
+#
+# Robustness: the scanner uses a small Rust-aware lexer to collect attribute
+# blocks beginning with `#[`, `#![`, `# [`, or `#! [` while ignoring comments
+# and string/char literals. It tracks nested brackets so a `]` inside a string
+# literal (for example `doc = "]"`) cannot end the attribute early. Before
+# matching, comments and literals inside the collected attribute are stripped,
+# internal whitespace is normalized, and clippy paths are matched with optional
+# raw-identifier prefixes and optional whitespace around `::`.
+scan_file() {
+  local file="$1"
+  python3 - "$file" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as handle:
+    source = handle.read()
+
+CLIPPY_ALLOW = re.compile(r"\ballow\s*\([^)]*(?:r#)?clippy\s*::")
+
+
+def skip_line_comment(text, index):
+    newline = text.find("\n", index + 2)
+    return len(text) if newline == -1 else newline + 1
+
+
+def skip_block_comment(text, index):
+    depth = 1
+    index += 2
+    while index < len(text) and depth > 0:
+        if text.startswith("/*", index):
+            depth += 1
+            index += 2
+        elif text.startswith("*/", index):
+            depth -= 1
+            index += 2
+        else:
+            index += 1
+    return index
+
+
+def skip_string(text, index):
+    index += 1
+    while index < len(text):
+        if text[index] == "\\":
+            index += 2
+        elif text[index] == '"':
+            return index + 1
+        else:
+            index += 1
+    return index
+
+
+def skip_char_literal(text, index):
+    # Only skip actual char literals. Lifetimes such as `'a` are tokens too,
+    # but they are not quoted strings; treating them as unterminated strings
+    # would skip the rest of the file and hide later attributes.
+    cursor = index + 1
+    if cursor >= len(text):
+        return index + 1
+    if text[cursor] == "\\":
+        cursor += 2
+    else:
+        cursor += 1
+    return cursor + 1 if cursor < len(text) and text[cursor] == "'" else index + 1
+
+
+def skip_raw_string(text, index):
+    start = index
+    if text.startswith("br", index):
+        index += 2
+    elif text.startswith("r", index):
+        index += 1
+    else:
+        return start
+
+    hashes = 0
+    while index < len(text) and text[index] == "#":
+        hashes += 1
+        index += 1
+    if index >= len(text) or text[index] != '"':
+        return start
+
+    terminator = '"' + ("#" * hashes)
+    end = text.find(terminator, index + 1)
+    return len(text) if end == -1 else end + len(terminator)
+
+
+def sanitize(text):
+    output = []
+    index = 0
+    while index < len(text):
+        if text.startswith("//", index):
+            output.append(" ")
+            index = skip_line_comment(text, index)
+        elif text.startswith("/*", index):
+            output.append(" ")
+            index = skip_block_comment(text, index)
+        else:
+            raw_end = skip_raw_string(text, index)
+            if raw_end != index:
+                output.append(" ")
+                index = raw_end
+            elif text[index] == '"':
+                output.append(" ")
+                index = skip_string(text, index)
+            elif text[index] == "'":
+                output.append(" ")
+                index = skip_char_literal(text, index)
+            else:
+                output.append(text[index])
+                index += 1
+    return re.sub(r"\s+", " ", "".join(output).strip())
+
+
+def collect_attribute(text, start):
+    index = start + 1
+    while index < len(text) and text[index].isspace():
+        index += 1
+    if index < len(text) and text[index] == "!":
+        index += 1
+        while index < len(text) and text[index].isspace():
+            index += 1
+    if index >= len(text) or text[index] != "[":
+        return None
+
+    bracket_depth = 1
+    index += 1
+    while index < len(text) and bracket_depth > 0:
+        if text.startswith("//", index):
+            index = skip_line_comment(text, index)
+        elif text.startswith("/*", index):
+            index = skip_block_comment(text, index)
+        else:
+            raw_end = skip_raw_string(text, index)
+            if raw_end != index:
+                index = raw_end
+            elif text[index] == '"':
+                index = skip_string(text, index)
+            elif text[index] == "'":
+                index = skip_char_literal(text, index)
+            elif text[index] == "[":
+                bracket_depth += 1
+                index += 1
+            elif text[index] == "]":
+                bracket_depth -= 1
+                index += 1
+            else:
+                index += 1
+
+    return text[start:index] if bracket_depth == 0 else None
+
+
+index = 0
+while index < len(source):
+    if source.startswith("//", index):
+        index = skip_line_comment(source, index)
+    elif source.startswith("/*", index):
+        index = skip_block_comment(source, index)
+    else:
+        raw_end = skip_raw_string(source, index)
+        if raw_end != index:
+            index = raw_end
+        elif source[index] == '"':
+            index = skip_string(source, index)
+        elif source[index] == "'":
+            index = skip_char_literal(source, index)
+        elif source[index] == "#":
+            attribute = collect_attribute(source, index)
+            if attribute is None:
+                index += 1
+            else:
+                normalized = sanitize(attribute)
+                if CLIPPY_ALLOW.search(normalized):
+                    print(f"{path}\t{normalized}")
+                index += len(attribute)
+        else:
+            index += 1
+PY
 }
 
-actual_file="$(make_temp_file)"
-expected_file="$(make_temp_file)"
-trap 'rm -f "$actual_file" "$expected_file"' EXIT
+# Emit one "<file>\t<attribute>" record per clippy allow attribute found.
+#
+# Fail closed: the function returns nonzero if the underlying file enumeration
+# (git or find) or any per-file scan fails. This is critical — a scanner
+# failure must NOT be reported as a clean (empty) result, or the zero-
+# tolerance gate would be bypassed. Callers capture the exit status and treat
+# a nonzero status as a policy failure.
+scan_allows() {
+  local file_list
 
-scan_actual_allows() {
-  git ls-files --cached '*.rs' ':!vendor/**' \
-    | while IFS= read -r file; do
-        awk -v file="$file" '
-          function trim(value) {
-            sub(/^[[:space:]]+/, "", value)
-            sub(/[[:space:]]+$/, "", value)
-            return value
-          }
-          function emit_attr() {
-            attr = trim(buffer)
-            gsub(/[[:space:]]+/, " ", attr)
-            if (attr ~ /^#!?\[(cfg_attr\(.*clippy::|allow\(.*clippy::)/) {
-              print file "\t" attr
-            }
-            buffer = ""
-            collecting = 0
-          }
-          {
-            line = $0
-            sub(/^[[:space:]]+/, "", line)
-            if (!collecting && line ~ /^#!?\[(cfg_attr\(|allow\()/) {
-              buffer = line
-              collecting = 1
-              if (line ~ /\]/) {
-                emit_attr()
-              }
-              next
-            }
-            if (collecting) {
-              buffer = buffer " " line
-              if (line ~ /\]/) {
-                emit_attr()
-              }
-            }
-          }
-        ' "$file"
-      done \
-    | LC_ALL=C sort
+  if [ -n "$SCAN_ROOT" ]; then
+    if [ ! -d "$SCAN_ROOT" ]; then
+      echo "ERROR: CLIPPY_ALLOW_SCAN_ROOT does not exist: $SCAN_ROOT" >&2
+      return 1
+    fi
+    # Capture the file list into a variable so a find failure (nonzero exit)
+    # propagates via pipefail rather than being hidden by process
+    # substitution.
+    file_list="$(find "$SCAN_ROOT" -type f -name '*.rs' | sort)" || return 1
+  else
+    file_list="$(git ls-files --cached '*.rs' ':!vendor/**')" || return 1
+  fi
+
+  local status=0
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    scan_file "$file" || status=1
+  done <<<"$file_list"
+  return "$status"
 }
 
-load_expected_allows() {
-  awk -F '\t' '
-    /^#/ || /^[[:space:]]*$/ { next }
-    NF != 4 {
-      printf "ERROR: malformed allowlist row %d: expected 4 tab-separated columns\n", NR > "/dev/stderr"
-      bad = 1
-      next
-    }
-    $1 == "" || $2 == "" || $3 == "" || $4 == "" {
-      printf "ERROR: malformed allowlist row %d: empty columns are not permitted\n", NR > "/dev/stderr"
-      bad = 1
-      next
-    }
-    { print $1 "\t" $2 }
-    END { exit bad }
-  ' "$ALLOWLIST" | LC_ALL=C sort
+check_no_allows() {
+  local found scan_status
+  # Fail closed: capture the scan exit status explicitly. We must NOT mask a
+  # scanner failure with `|| true`, because that would silently let real
+  # errors (e.g. git failure, missing files) pass the gate. If the scanner
+  # itself errors, the policy must fail rather than report a clean result.
+  set +e
+  found="$(scan_allows)"
+  scan_status=$?
+  set -e
+  if [ "$scan_status" -ne 0 ]; then
+    fail "clippy allow scanner failed (exit $scan_status); cannot verify policy — failing closed"
+    return 1
+  fi
+  if [ -n "$found" ]; then
+    fail "first-party clippy allow attributes are forbidden; remove them:"
+    while IFS= read -r line; do
+      printf '  %s\n' "$line" >&2
+    done <<<"$found"
+  fi
 }
 
 clippy_config_value() {
@@ -104,21 +289,11 @@ clippy_config_value() {
     | sed -E 's/^[^=]+=[[:space:]]*//; s/[[:space:]]*(#.*)?$//'
 }
 
-check_allowlist() {
-  require_file "$ALLOWLIST" || return
-
-  scan_actual_allows > "$actual_file"
-  if ! load_expected_allows > "$expected_file"; then
-    errors=$((errors + 1))
-    return
-  fi
-
-  if ! diff -u "$expected_file" "$actual_file"; then
-    fail "clippy allow attributes must match $ALLOWLIST; remove the allow or update the approved exception record"
-  fi
-}
-
 check_clippy_config_sync() {
+  # Fixture mode skips the root/CI sync check (fixtures do not replicate the
+  # repo layout).
+  [ -n "$SCAN_ROOT" ] && return 0
+
   require_file "$ROOT_CLIPPY_CONFIG" || return
   require_file "$CI_CLIPPY_CONFIG" || return
 
@@ -140,7 +315,7 @@ check_clippy_config_sync() {
   done
 }
 
-check_allowlist
+check_no_allows
 check_clippy_config_sync
 
 if [ "$errors" -gt 0 ]; then

--- a/tests/core/clippy_allow_policy.rs
+++ b/tests/core/clippy_allow_policy.rs
@@ -392,3 +392,31 @@ stdout:
         String::from_utf8_lossy(&output.stdout)
     );
 }
+
+#[test]
+fn expect_clippy_path_is_rejected() {
+    let dir = write_fixture("#[expect(clippy::all)]\nfn expect_clippy() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#[expect(clippy::...)] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn cfg_attr_expect_clippy_path_is_rejected() {
+    let dir = write_fixture(
+        "#[cfg_attr(test, expect(dead_code, r#clippy :: all))]\nfn expect_cfg_attr() {}\n",
+    );
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#[cfg_attr(..., expect(dead_code, r#clippy :: ...))] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}

--- a/tests/core/clippy_allow_policy.rs
+++ b/tests/core/clippy_allow_policy.rs
@@ -1,23 +1,394 @@
 //! Clippy allow policy contract tests.
+//!
+//! These tests verify the zero-tolerance clippy allow gate in both
+//! directions:
+//!
+//! - The repository's own first-party Rust code must pass the gate (no
+//!   clippy allow attributes outside vendor).
+//! - The gate must fail when a clippy allow attribute is present, so the
+//!   policy is enforced by design and not by accident.
+//!
+//! Negative tests inject a fixture directory via the `CLIPPY_ALLOW_SCAN_ROOT`
+//! environment variable that the script honors instead of the git-tracked
+//! file set.
+
+use std::fs;
+use std::process::Command;
+
+use crate::support::TestResultExt;
+use tempfile::TempDir;
+
+const SCRIPT: &str = "scripts/check-clippy-allows.sh";
+
+fn run_script(scan_root: Option<&str>) -> std::process::Output {
+    let mut cmd = Command::new("bash");
+    cmd.arg(SCRIPT);
+    cmd.current_dir(env!("CARGO_MANIFEST_DIR"));
+    if let Some(root) = scan_root {
+        cmd.env("CLIPPY_ALLOW_SCAN_ROOT", root);
+    }
+    cmd.output()
+        .test_unwrap("clippy allow policy script should be runnable")
+}
+
+fn write_fixture(contents: &str) -> TempDir {
+    let dir = TempDir::new().test_unwrap("temp dir should be created");
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).test_unwrap("src dir should be created");
+    fs::write(src.join("lib.rs"), contents).test_unwrap("fixture file should be written");
+    dir
+}
 
 #[test]
-fn clippy_allow_policy_script_passes() {
-    let output = std::process::Command::new("bash")
-        .arg("scripts/check-clippy-allows.sh")
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .output();
-    let Ok(output) = output else {
-        panic!("clippy allow policy script should run");
-    };
-
+fn clippy_allow_policy_script_passes_on_repo() {
+    let output = run_script(None);
     assert!(
         output.status.success(),
-        "clippy allow policy script failed
+        "clippy allow policy script failed on repository code
 stdout:
 {}
 stderr:
 {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn clean_fixture_passes() {
+    let dir = write_fixture("//! Clean module.\nfn main() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        output.status.success(),
+        "clean fixture should pass the clippy allow gate
+stderr:
+{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn non_clippy_allow_passes() {
+    // `#[allow(dead_code)]` is not a clippy allow and must not be flagged.
+    let dir = write_fixture("#[allow(dead_code)]\nfn unused() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        output.status.success(),
+        "non-clippy allow should pass the clippy allow gate
+stderr:
+{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn outer_allow_clippy_is_rejected() {
+    let dir = write_fixture("#[allow(clippy::module_inception)]\nmod inner {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#[allow(clippy::...)] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn inner_allow_clippy_is_rejected() {
+    let dir = write_fixture("#![allow(clippy::all)]\nfn main() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#![allow(clippy::...)] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn cfg_attr_allow_clippy_is_rejected() {
+    let dir = write_fixture("#[cfg_attr(test, allow(clippy::all))]\npub fn example() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#[cfg_attr(..., allow(clippy::...))] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn whitespace_outer_allow_clippy_is_rejected() {
+    // `#[ allow(clippy::all)]` — space between `#[` and `allow` — is valid
+    // Rust and must not bypass the gate.
+    let dir = write_fixture("#[ allow(clippy::all)]\nfn spaced() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#[ allow(clippy::...)] (whitespace variant) must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn whitespace_inner_allow_clippy_is_rejected() {
+    // `#![ allow ( clippy::all )]` — spaces around every delimiter — is valid
+    // Rust and must not bypass the gate.
+    let dir = write_fixture("#![ allow ( clippy::all )]\nfn main() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#![ allow ( clippy::... )] (whitespace variant) must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn whitespace_cfg_attr_allow_clippy_is_rejected() {
+    // `#[ cfg_attr(test, allow ( clippy::all )) ]` — spaces around delimiters
+    // inside a cfg_attr — is valid Rust and must not bypass the gate.
+    let dir = write_fixture("#[ cfg_attr(test, allow ( clippy::all )) ]\npub fn example() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#[ cfg_attr(..., allow ( clippy::... )) ] (whitespace variant) must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn whitespace_before_bracket_outer_allow_clippy_is_rejected() {
+    // `# [allow(clippy::all)]` — space between `#` and `[` — is valid Rust
+    // and must not bypass the gate.
+    let dir = write_fixture(
+        "# [allow(clippy::all)]
+fn spaced() {}
+",
+    );
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "# [allow(clippy::...)] (whitespace before bracket) must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn whitespace_before_bracket_inner_allow_clippy_is_rejected() {
+    // `#! [allow(clippy::all)]` — space between `#!` and `[` — is valid Rust
+    // and must not bypass the gate.
+    let dir = write_fixture(
+        "#! [allow(clippy::all)]
+fn main() {}
+",
+    );
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#! [allow(clippy::...)] (whitespace before bracket) must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn whitespace_before_bracket_cfg_attr_allow_clippy_is_rejected() {
+    // `# [cfg_attr(test, allow(clippy::all))]` — space between `#` and `[`
+    // in a cfg_attr — is valid Rust and must not bypass the gate.
+    let dir = write_fixture(
+        "# [cfg_attr(test, allow(clippy::all))]
+pub fn example() {}
+",
+    );
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "# [cfg_attr(..., allow(clippy::...))] (whitespace before bracket) must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn multiline_allow_clippy_is_rejected() {
+    // Multi-line attribute spanning several lines must still be caught.
+    let dir = write_fixture("#[\n    allow(clippy::all)\n]\npub fn example() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "multi-line #[allow(clippy::...)] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn whitespace_in_clippy_path_is_rejected() {
+    // Rust accepts whitespace around path separators in attributes.
+    let dir = write_fixture("#[allow(clippy :: all)]\nfn spaced_path() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#[allow(clippy :: ...)] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn inner_whitespace_in_clippy_path_is_rejected() {
+    let dir = write_fixture("#![allow(clippy :: all)]\nfn main() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#![allow(clippy :: ...)] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn cfg_attr_whitespace_in_clippy_path_is_rejected() {
+    let dir = write_fixture("#[cfg_attr(test, allow(clippy :: all))]\npub fn example() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#[cfg_attr(..., allow(clippy :: ...))] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn multiline_cfg_attr_with_bracket_string_is_rejected() {
+    // A `]` inside a string literal must not end attribute scanning early.
+    let dir = write_fixture(
+        "#[cfg_attr(
+    test,
+    doc = \"]\",
+    allow(clippy::all)
+)]
+pub fn example() {}
+",
+    );
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "multi-line cfg_attr with string bracket and clippy allow must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn raw_identifier_clippy_path_is_rejected() {
+    let dir = write_fixture("#[allow(r#clippy::all)]\nfn raw_clippy() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#[allow(r#clippy::...)] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn inner_raw_identifier_clippy_path_is_rejected() {
+    let dir = write_fixture("#![allow(r#clippy::all)]\nfn main() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#![allow(r#clippy::...)] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn cfg_attr_raw_identifier_clippy_path_is_rejected() {
+    let dir = write_fixture("#[cfg_attr(test, allow(r#clippy :: all))]\npub fn example() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#[cfg_attr(..., allow(r#clippy :: ...))] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn multi_lint_outer_clippy_path_is_rejected() {
+    let dir = write_fixture("#[allow(dead_code, clippy::all)]\nfn multi_lint() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#[allow(dead_code, clippy::...)] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn multi_lint_inner_clippy_path_is_rejected() {
+    let dir = write_fixture("#![allow(dead_code, clippy :: all)]\nfn main() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#![allow(dead_code, clippy :: ...)] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn multi_lint_cfg_attr_clippy_path_is_rejected() {
+    let dir = write_fixture(
+        "#[cfg_attr(test, allow(unused_variables, clippy::module_inception))]
+pub fn example() {}
+",
+    );
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#[cfg_attr(..., allow(unused_variables, clippy::...))] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn multi_lint_raw_identifier_clippy_path_is_rejected() {
+    let dir = write_fixture("#[allow(dead_code, r#clippy :: all)]\nfn raw_multi() {}\n");
+    let output = run_script(dir.path().to_str());
+    assert!(
+        !output.status.success(),
+        "#[allow(dead_code, r#clippy :: ...)] must be rejected, but the gate passed
+stdout:
+{}",
+        String::from_utf8_lossy(&output.stdout)
     );
 }

--- a/tests/core/clippy_allow_policy.rs
+++ b/tests/core/clippy_allow_policy.rs
@@ -397,12 +397,17 @@ stdout:
 fn expect_clippy_path_is_rejected() {
     let dir = write_fixture("#[expect(clippy::all)]\nfn expect_clippy() {}\n");
     let output = run_script(dir.path().to_str());
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !output.status.success(),
-        "#[expect(clippy::...)] must be rejected, but the gate passed
+        !output.status.success()
+            && stderr.contains("first-party clippy allow attributes are forbidden"),
+        "#[expect(clippy::...)] must be rejected by the policy gate, but it was not
 stdout:
+{}
+stderr:
 {}",
-        String::from_utf8_lossy(&output.stdout)
+        String::from_utf8_lossy(&output.stdout),
+        stderr
     );
 }
 
@@ -412,11 +417,16 @@ fn cfg_attr_expect_clippy_path_is_rejected() {
         "#[cfg_attr(test, expect(dead_code, r#clippy :: all))]\nfn expect_cfg_attr() {}\n",
     );
     let output = run_script(dir.path().to_str());
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !output.status.success(),
-        "#[cfg_attr(..., expect(dead_code, r#clippy :: ...))] must be rejected, but the gate passed
+        !output.status.success()
+            && stderr.contains("first-party clippy allow attributes are forbidden"),
+        "#[cfg_attr(..., expect(dead_code, r#clippy :: ...))] must be rejected by the policy gate, but it was not
 stdout:
+{}
+stderr:
 {}",
-        String::from_utf8_lossy(&output.stdout)
+        String::from_utf8_lossy(&output.stdout),
+        stderr
     );
 }


### PR DESCRIPTION
## Summary
- replaces the temporary clippy allowlist ledger with zero-tolerance first-party clippy allow enforcement
- deletes the now-empty clippy allowlist file
- adds policy contract tests for direct, inner, cfg_attr, whitespace, multiline, raw identifier, and multi-lint clippy allow forms
- updates project docs to describe the zero-tolerance policy and vendor exclusion

## Verification
- bash scripts/check-clippy-allows.sh && bash -n scripts/check-clippy-allows.sh && cargo fmt --all --check && cargo test -q --test integration clippy_allow_policy --locked
- make ci-check

Fixes #75
