### PR TITLE
Fail fast on unusable config dirs (Fixes #65)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod messages;
 pub mod persistence;
 pub mod runtime;
 pub mod services;
+pub mod startup;
 pub mod state;
 pub mod theme;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,19 @@ fn write_cli_error(error: &jefe::cli::CliError) {
     let _ = writeln!(handle, "{}", jefe::cli::USAGE);
 }
 
+/// Print a startup persistence error (e.g. an unusable explicit `--config`
+/// directory) to stderr with actionable guidance, then let the caller exit
+/// nonzero.
+fn write_startup_error(error: &jefe::persistence::PersistenceError) {
+    let stderr = std::io::stderr();
+    let mut handle = stderr.lock();
+    let _ = writeln!(handle, "error: {error}");
+    let _ = writeln!(
+        handle,
+        "hint: check that the --config directory exists, is a directory, and is writable"
+    );
+}
+
 fn main() {
     let Some(cli_args) = parse_cli_or_exit() else {
         return;
@@ -90,14 +103,22 @@ fn main() {
     // Initialize managers. An explicit `--config <dir>` isolates settings,
     // state, and themes under that directory; otherwise fall back to the
     // default platform paths and environment variable overrides.
+    //
+    // An explicit config directory is validated fail-fast: if it cannot be
+    // created or written to (e.g. an unwritable path from a `--config` typo),
+    // surface a clear error and exit instead of starting a session whose state
+    // will silently fail to persist.
     let mut theme_manager = FileThemeManager::new();
-    let persistence = if let Some(dir) = cli_args.config_dir.as_deref() {
-        let paths = jefe::persistence::resolve_paths_from_dir(dir);
-        theme_manager.load_from_dir(&dir.join("themes"));
-        jefe::persistence::FilePersistenceManager::with_paths(paths)
-    } else {
-        jefe::persistence::FilePersistenceManager::new()
+    let persistence = match jefe::startup::build_persistence(cli_args.config_dir.as_deref()) {
+        Ok(manager) => manager,
+        Err(error) => {
+            write_startup_error(&error);
+            std::process::exit(1);
+        }
     };
+    if let Some(dir) = cli_args.config_dir.as_deref() {
+        theme_manager.load_from_dir(&dir.join("themes"));
+    }
     let runtime = TmuxRuntimeManager::new(pty_rows, pty_cols);
 
     let context = Arc::new(std::sync::Mutex::new(AppContext {

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -22,7 +22,19 @@ pub enum PersistenceError {
     IoError(String),
     ParseError(String),
     SerializeError(String),
-    SchemaVersionMismatch { expected: u32, found: u32 },
+    SchemaVersionMismatch {
+        expected: u32,
+        found: u32,
+    },
+    /// An explicit configuration directory cannot be used for persistence.
+    ///
+    /// `path` is the directory supplied to `--config`; `reason` explains why it
+    /// is unusable (not a directory, unwritable, etc.). Surfaced fail-fast at
+    /// startup so silent data loss cannot occur mid-session.
+    InvalidConfigDir {
+        path: PathBuf,
+        reason: String,
+    },
 }
 
 impl std::fmt::Display for PersistenceError {
@@ -35,6 +47,13 @@ impl std::fmt::Display for PersistenceError {
                 write!(
                     f,
                     "schema version mismatch: expected {expected}, found {found}"
+                )
+            }
+            Self::InvalidConfigDir { path, reason } => {
+                write!(
+                    f,
+                    "configuration directory '{}' is unusable: {reason}",
+                    path.display()
                 )
             }
         }
@@ -135,6 +154,221 @@ pub fn resolve_paths_from_dir(dir: &std::path::Path) -> PersistencePaths {
         settings_path: dir.join("settings.toml"),
         state_path: dir.join("state.json"),
     }
+}
+
+/// Validate that an explicit config directory can persist `settings.toml` and
+/// `state.json`.
+///
+/// This performs fail-fast startup validation so that a typo (e.g. an
+/// unwritable path from `--config="$pwd/.config/jefe"`) produces a clear,
+/// actionable error instead of silent apparent data loss after the first
+/// session.
+///
+/// Validation steps:
+/// 1. Create the directory (and parents) if it does not already exist.
+/// 2. Confirm the path is actually a directory.
+/// 3. Reject any persistence target (`settings.toml`/`state.json`) that already
+///    exists as a directory or non-regular file, since [`FilePersistenceManager`]
+///    cannot atomically write to such a path (its `atomic_write` does
+///    `File::create` on a temp sibling then `rename`, which cannot replace a
+///    directory with a file). Existing regular files are left untouched.
+/// 4. Probe write capability for both `settings.toml` and `state.json` by
+///    creating a temporary probe file next to each, then removing it. Any probe
+///    file left behind on failure is best-effort cleaned up.
+///
+/// # Errors
+///
+/// Returns [`PersistenceError::InvalidConfigDir`] when the directory cannot be
+/// created, is not a directory, a persistence target already exists as a
+/// non-regular path, or either persistence file cannot be written.
+pub fn validate_config_dir(dir: &std::path::Path) -> Result<(), PersistenceError> {
+    use std::fs;
+
+    // 1. If the path exists, confirm it is actually a directory. A common
+    //    failure mode is `--config` pointing at an existing regular file.
+    if dir.exists() {
+        let metadata = fs::metadata(dir).map_err(|e| PersistenceError::InvalidConfigDir {
+            path: dir.to_path_buf(),
+            reason: format!("could not read directory metadata: {e}"),
+        })?;
+        if !metadata.is_dir() {
+            return Err(PersistenceError::InvalidConfigDir {
+                path: dir.to_path_buf(),
+                reason: "path exists but is not a directory".to_string(),
+            });
+        }
+    } else {
+        // 2. Create the directory (and parents) if missing.
+        fs::create_dir_all(dir).map_err(|e| PersistenceError::InvalidConfigDir {
+            path: dir.to_path_buf(),
+            reason: format!("could not create directory: {e}"),
+        })?;
+    }
+
+    // 3. Validate the actual persistence targets. `resolve_paths_from_dir`
+    //    mirrors exactly how `build_persistence` roots the files, so this
+    //    proves the real atomic_write targets are usable rather than only the
+    //    sibling probe paths.
+    let targets = resolve_paths_from_dir(dir);
+    validate_persistence_target(dir, &targets.settings_path)?;
+    validate_persistence_target(dir, &targets.state_path)?;
+    validate_atomic_temp_target(dir, &targets.settings_path.with_extension("tmp"))?;
+    validate_atomic_temp_target(dir, &targets.state_path.with_extension("tmp"))?;
+
+    // 4. Probe write capability for both persistence files.
+    for file_name in ["settings.toml", "state.json"] {
+        probe_write(dir, file_name)?;
+    }
+
+    Ok(())
+}
+
+/// Validate that a single persistence target path can receive an
+/// [`FilePersistenceManager`] atomic write.
+///
+/// `atomic_write` creates a temp sibling (e.g. `settings.tmp`) and renames it
+/// over `target`. That rename can only succeed when `target` either does not
+/// exist or is a regular file; if `target` already exists as a directory (or
+/// any non-regular file) the rename fails at runtime. Such targets are
+/// rejected here, fail-fast, without modifying or removing the user's path.
+///
+/// `config_dir` is the directory supplied to `--config`; it is used as the
+/// `InvalidConfigDir` path so callers always see the config directory they
+/// passed, while `reason` names the specific target file that is unusable.
+///
+/// A missing target is allowed (the file will be created on first save), and a
+/// pre-existing regular file is allowed (atomic_write will overwrite it).
+///
+/// # Errors
+///
+/// Returns [`PersistenceError::InvalidConfigDir`] when the target exists as a
+/// directory or non-regular file, or when its metadata cannot be read.
+fn validate_persistence_target(
+    config_dir: &std::path::Path,
+    target: &std::path::Path,
+) -> Result<(), PersistenceError> {
+    use std::fs;
+
+    // Only inspect targets that already exist. Missing targets are fine: they
+    // will be created on the first atomic_write.
+    let metadata = match fs::symlink_metadata(target) {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(PersistenceError::InvalidConfigDir {
+                path: config_dir.to_path_buf(),
+                reason: format!("could not read target metadata: {e}"),
+            });
+        }
+    };
+
+    if metadata.is_file() {
+        // A regular file can be overwritten by atomic_write's rename; allow it
+        // without touching it.
+        return Ok(());
+    }
+
+    // Anything else (directory, symlink to a dir, device, fifo, socket, etc.)
+    // blocks atomic_write. Surface a clear, target-specific reason including
+    // the file name so the user knows exactly which target is unusable.
+    let file_name = target
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("persistence file");
+    Err(PersistenceError::InvalidConfigDir {
+        path: config_dir.to_path_buf(),
+        reason: format!("{file_name} exists but is not a regular file (likely a directory)"),
+    })
+}
+
+fn validate_atomic_temp_target(
+    config_dir: &std::path::Path,
+    target: &std::path::Path,
+) -> Result<(), PersistenceError> {
+    validate_persistence_target(config_dir, target)?;
+
+    match std::fs::OpenOptions::new().write(true).open(target) {
+        Ok(_) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => {
+            let file_name = target
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .unwrap_or("temporary persistence file");
+            Err(PersistenceError::InvalidConfigDir {
+                path: config_dir.to_path_buf(),
+                reason: format!("{file_name} exists but cannot be opened for atomic writes: {e}"),
+            })
+        }
+    }
+}
+
+/// Write and remove a temporary probe file under `dir` to confirm writes to
+/// `file_name` will succeed during the session.
+///
+/// # Data-loss safety
+///
+/// The probe uses a process-unique filename and `create_new(true)` so that it:
+/// - Never truncates or overwrites an existing file (the open fails instead).
+/// - Never removes a file it did not just create (cleanup only runs on the
+///   exact probe path this call created).
+fn probe_write(dir: &std::path::Path, file_name: &str) -> Result<(), PersistenceError> {
+    use std::fs;
+    use std::io::Write;
+
+    // Unique probe filename: avoids colliding with any user file and makes it
+    // safe to remove only the file this validation created.
+    let probe_name = format!(
+        ".{file_name}.jefe-probe-{}-{}",
+        std::process::id(),
+        probe_counter()
+    );
+    let probe_path = dir.join(&probe_name);
+
+    let mut file = match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe_path)
+    {
+        Ok(file) => file,
+        Err(e) => {
+            return Err(PersistenceError::InvalidConfigDir {
+                path: dir.to_path_buf(),
+                reason: format!("cannot create {file_name}: {e}"),
+            });
+        }
+    };
+    if let Err(e) = file.write_all(b"jefe probe") {
+        let _ = fs::remove_file(&probe_path);
+        return Err(PersistenceError::InvalidConfigDir {
+            path: dir.to_path_buf(),
+            reason: format!("cannot write {file_name}: {e}"),
+        });
+    }
+    if let Err(e) = file.sync_all() {
+        let _ = fs::remove_file(&probe_path);
+        return Err(PersistenceError::InvalidConfigDir {
+            path: dir.to_path_buf(),
+            reason: format!("cannot sync {file_name}: {e}"),
+        });
+    }
+    drop(file);
+
+    if let Err(e) = fs::remove_file(&probe_path) {
+        return Err(PersistenceError::InvalidConfigDir {
+            path: dir.to_path_buf(),
+            reason: format!("cannot remove probe for {file_name}: {e}"),
+        });
+    }
+
+    Ok(())
+}
+
+/// Monotonic counter for generating unique probe filenames within a process.
+fn probe_counter() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
 }
 
 fn resolve_settings_path() -> PathBuf {
@@ -268,6 +502,12 @@ impl FilePersistenceManager {
         Self { paths }
     }
 
+    /// Borrow the resolved persistence paths (for inspection/diagnostics).
+    #[must_use]
+    pub fn paths_ref(&self) -> &PersistencePaths {
+        &self.paths
+    }
+
     /// Atomic write: write to temp file, then rename.
     fn atomic_write(path: &std::path::Path, content: &str) -> Result<(), PersistenceError> {
         use std::fs;
@@ -358,237 +598,4 @@ impl PersistenceManager for FilePersistenceManager {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    trait TestResultExt<T> {
-        fn value_or_panic(self, context: &str) -> T;
-    }
-
-    impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
-        fn value_or_panic(self, context: &str) -> T {
-            match self {
-                Ok(value) => value,
-                Err(error) => panic!("{context}: {error:?}"),
-            }
-        }
-    }
-
-    fn cleanup_root(path: &std::path::Path) -> Option<&std::path::Path> {
-        path.parent().and_then(std::path::Path::parent)
-    }
-    #[test]
-    fn settings_default_has_green_screen_theme() {
-        let settings = Settings::default_with_version();
-        assert_eq!(settings.theme, "green-screen");
-        assert_eq!(settings.schema_version, SETTINGS_SCHEMA_VERSION);
-    }
-
-    #[test]
-    fn state_default_has_version() {
-        let state = State::default_with_version();
-        assert_eq!(state.schema_version, STATE_SCHEMA_VERSION);
-    }
-
-    #[test]
-    fn resolve_paths_returns_valid_paths() {
-        let paths = resolve_paths();
-        assert!(paths.settings_path.ends_with("settings.toml"));
-        assert!(paths.state_path.ends_with("state.json"));
-    }
-
-    #[test]
-    fn resolve_paths_from_dir_roots_both_files_under_dir() {
-        let dir = std::path::Path::new("/tmp/jefe-dev-instance");
-        let paths = resolve_paths_from_dir(dir);
-        assert_eq!(paths.settings_path, dir.join("settings.toml"));
-        assert_eq!(paths.state_path, dir.join("state.json"));
-    }
-
-    #[test]
-    fn stub_persistence_returns_defaults() {
-        let mgr = StubPersistenceManager::new();
-        let settings = mgr.load_settings().value_or_panic("should load settings");
-        assert_eq!(settings.theme, "green-screen");
-    }
-
-    #[test]
-    fn file_persistence_returns_defaults_when_missing() {
-        let temp = std::env::temp_dir().join("jefe_test_missing");
-        let paths = PersistencePaths {
-            settings_path: temp.join("settings.toml"),
-            state_path: temp.join("state.json"),
-        };
-        let mgr = FilePersistenceManager::with_paths(paths);
-
-        let settings = mgr.load_settings().value_or_panic("should load defaults");
-        assert_eq!(settings.theme, "green-screen");
-
-        let state = mgr.load_state().value_or_panic("should load defaults");
-        assert!(state.repositories.is_empty());
-    }
-
-    #[test]
-    fn file_persistence_roundtrip_settings() {
-        let temp = std::env::temp_dir().join("jefe_test_roundtrip_settings");
-        let _ = std::fs::remove_dir_all(&temp);
-        let paths = PersistencePaths {
-            settings_path: temp.join("settings.toml"),
-            state_path: temp.join("state.json"),
-        };
-        let mgr = FilePersistenceManager::with_paths(paths);
-
-        let settings = Settings {
-            schema_version: SETTINGS_SCHEMA_VERSION,
-            theme: "dracula".into(),
-        };
-
-        mgr.save_settings(&settings).value_or_panic("should save");
-        let loaded = mgr.load_settings().value_or_panic("should load");
-
-        assert_eq!(loaded.theme, "dracula");
-        assert_eq!(loaded.schema_version, SETTINGS_SCHEMA_VERSION);
-
-        // Cleanup
-        let _ = std::fs::remove_dir_all(&temp);
-    }
-
-    #[test]
-    fn file_persistence_roundtrip_state() {
-        let temp = std::env::temp_dir().join("jefe_test_roundtrip_state");
-        let _ = std::fs::remove_dir_all(&temp);
-        let paths = PersistencePaths {
-            settings_path: temp.join("settings.toml"),
-            state_path: temp.join("state.json"),
-        };
-        let mgr = FilePersistenceManager::with_paths(paths);
-
-        let state = State {
-            schema_version: STATE_SCHEMA_VERSION,
-            repositories: vec![],
-            agents: vec![],
-            selected_repository_index: Some(2),
-            selected_agent_index: None,
-            hide_idle_repositories: true,
-            last_selected_agent_by_repo: vec![],
-        };
-
-        mgr.save_state(&state).value_or_panic("should save");
-        let loaded = mgr.load_state().value_or_panic("should load");
-
-        assert_eq!(loaded.selected_repository_index, Some(2));
-        assert!(loaded.hide_idle_repositories);
-
-        // Cleanup
-        let _ = std::fs::remove_dir_all(&temp);
-    }
-
-    #[test]
-    fn file_persistence_atomic_write_creates_parent_dirs() {
-        let temp = std::env::temp_dir()
-            .join("jefe_test_atomic")
-            .join("nested")
-            .join("dirs");
-        if let Some(root) = cleanup_root(&temp) {
-            let _ = std::fs::remove_dir_all(root);
-        }
-
-        let paths = PersistencePaths {
-            settings_path: temp.join("settings.toml"),
-            state_path: temp.join("state.json"),
-        };
-        let mgr = FilePersistenceManager::with_paths(paths);
-
-        mgr.save_settings(&Settings::default_with_version())
-            .value_or_panic("should create dirs and save");
-
-        // Cleanup
-        if let Some(root) = cleanup_root(&temp) {
-            let _ = std::fs::remove_dir_all(root);
-        }
-    }
-
-    /// Test P13-1: State with repo having issue_base_prompt round-trips through JSON serialization.
-    ///
-    /// @plan PLAN-20260329-ISSUES-MODE.P13
-    /// @requirement REQ-ISS-012
-    #[test]
-    fn test_issue_base_prompt_state_round_trip() {
-        use crate::domain::{RemoteRepositorySettings, Repository, RepositoryId};
-        use std::path::PathBuf;
-
-        let repo = Repository {
-            id: RepositoryId("repo-issues".to_string()),
-            name: "Issues Repo".to_string(),
-            slug: "issues-repo".to_string(),
-            base_dir: PathBuf::from("/tmp/issues-repo"),
-            default_profile: String::new(),
-            github_repo: String::new(),
-            remote: RemoteRepositorySettings::default(),
-            issue_base_prompt: "Always reproduce the bug first".to_string(),
-            agent_ids: vec![],
-        };
-
-        let state = State {
-            schema_version: STATE_SCHEMA_VERSION,
-            repositories: vec![repo],
-            agents: vec![],
-            selected_repository_index: Some(0),
-            selected_agent_index: None,
-            hide_idle_repositories: false,
-            last_selected_agent_by_repo: vec![],
-        };
-
-        let temp = std::env::temp_dir().join("jefe_test_p13_issue_base_prompt_roundtrip");
-        let _ = std::fs::remove_dir_all(&temp);
-        let paths = PersistencePaths {
-            settings_path: temp.join("settings.toml"),
-            state_path: temp.join("state.json"),
-        };
-        let mgr = FilePersistenceManager::with_paths(paths);
-
-        mgr.save_state(&state).value_or_panic("should save state");
-        let loaded = mgr.load_state().value_or_panic("should load state");
-
-        assert_eq!(loaded.repositories.len(), 1);
-        assert_eq!(
-            loaded.repositories[0].issue_base_prompt,
-            "Always reproduce the bug first"
-        );
-
-        let _ = std::fs::remove_dir_all(&temp);
-    }
-
-    /// Test P13-2: Deserializing legacy JSON without issue_base_prompt defaults to empty string.
-    ///
-    /// @plan PLAN-20260329-ISSUES-MODE.P13
-    /// @requirement REQ-ISS-012
-    #[test]
-    fn test_issue_base_prompt_state_backward_compat() {
-        // Simulate legacy JSON that predates the issue_base_prompt field
-        let legacy_json = serde_json::json!({
-            "schema_version": 1,
-            "repositories": [
-                {
-                    "id": "repo-legacy",
-                    "name": "Legacy Repo",
-                    "slug": "legacy-repo",
-                    "base_dir": "/tmp/legacy-repo",
-                    "default_profile": "",
-                    "agent_ids": []
-                    // Note: no issue_base_prompt field
-                }
-            ],
-            "agents": [],
-            "selected_repository_index": null,
-            "selected_agent_index": null
-        });
-
-        let state: State =
-            serde_json::from_value(legacy_json).value_or_panic("legacy JSON should deserialize");
-
-        assert_eq!(state.repositories.len(), 1);
-        // Must default to empty string, not error
-        assert_eq!(state.repositories[0].issue_base_prompt, "");
-    }
-}
+mod tests;

--- a/src/persistence/tests.rs
+++ b/src/persistence/tests.rs
@@ -1,0 +1,593 @@
+use super::*;
+
+trait TestResultExt<T> {
+    fn value_or_panic(self, context: &str) -> T;
+}
+
+impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
+    fn value_or_panic(self, context: &str) -> T {
+        match self {
+            Ok(value) => value,
+            Err(error) => panic!("{context}: {error:?}"),
+        }
+    }
+}
+
+trait TestResultErrorExt<E> {
+    fn error_or_panic(self, context: &str) -> E;
+}
+
+impl<E: std::fmt::Debug> TestResultErrorExt<E> for Result<(), E> {
+    fn error_or_panic(self, context: &str) -> E {
+        match self {
+            Ok(()) => panic!("{context}: expected error"),
+            Err(error) => error,
+        }
+    }
+}
+
+fn cleanup_root(path: &std::path::Path) -> Option<&std::path::Path> {
+    path.parent().and_then(std::path::Path::parent)
+}
+
+/// Collect all entries under `dir` whose names contain `jefe-probe`.
+fn leftover_probe_files(dir: &std::path::Path) -> Vec<String> {
+    std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            name.contains("jefe-probe").then_some(name)
+        })
+        .collect()
+}
+
+/// RAII guard that restores writable permissions (0o755) on a directory
+/// when dropped, so cleanup always succeeds even if an assertion panics
+/// while the directory is read-only.
+#[cfg(unix)]
+struct ReadOnlyDirGuard<'a> {
+    dir: &'a std::path::Path,
+    active: bool,
+}
+
+#[cfg(unix)]
+impl Drop for ReadOnlyDirGuard<'_> {
+    fn drop(&mut self) {
+        if self.active {
+            use std::os::unix::fs::PermissionsExt;
+            let writable = std::fs::Permissions::from_mode(0o755);
+            let _ = std::fs::set_permissions(self.dir, writable);
+        }
+    }
+}
+#[test]
+fn settings_default_has_green_screen_theme() {
+    let settings = Settings::default_with_version();
+    assert_eq!(settings.theme, "green-screen");
+    assert_eq!(settings.schema_version, SETTINGS_SCHEMA_VERSION);
+}
+
+#[test]
+fn state_default_has_version() {
+    let state = State::default_with_version();
+    assert_eq!(state.schema_version, STATE_SCHEMA_VERSION);
+}
+
+#[test]
+fn resolve_paths_returns_valid_paths() {
+    let paths = resolve_paths();
+    assert!(paths.settings_path.ends_with("settings.toml"));
+    assert!(paths.state_path.ends_with("state.json"));
+}
+
+#[test]
+fn resolve_paths_from_dir_roots_both_files_under_dir() {
+    let dir = std::path::Path::new("/tmp/jefe-dev-instance");
+    let paths = resolve_paths_from_dir(dir);
+    assert_eq!(paths.settings_path, dir.join("settings.toml"));
+    assert_eq!(paths.state_path, dir.join("state.json"));
+}
+
+#[test]
+fn stub_persistence_returns_defaults() {
+    let mgr = StubPersistenceManager::new();
+    let settings = mgr.load_settings().value_or_panic("should load settings");
+    assert_eq!(settings.theme, "green-screen");
+}
+
+#[test]
+fn file_persistence_returns_defaults_when_missing() {
+    let temp = unique_temp_root("missing_defaults");
+    let _ = std::fs::remove_dir_all(&temp);
+    let paths = PersistencePaths {
+        settings_path: temp.join("settings.toml"),
+        state_path: temp.join("state.json"),
+    };
+    let mgr = FilePersistenceManager::with_paths(paths);
+
+    let settings = mgr.load_settings().value_or_panic("should load defaults");
+    assert_eq!(settings.theme, "green-screen");
+
+    let state = mgr.load_state().value_or_panic("should load defaults");
+    assert!(state.repositories.is_empty());
+
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn file_persistence_roundtrip_settings() {
+    let temp = std::env::temp_dir().join("jefe_test_roundtrip_settings");
+    let _ = std::fs::remove_dir_all(&temp);
+    let paths = PersistencePaths {
+        settings_path: temp.join("settings.toml"),
+        state_path: temp.join("state.json"),
+    };
+    let mgr = FilePersistenceManager::with_paths(paths);
+
+    let settings = Settings {
+        schema_version: SETTINGS_SCHEMA_VERSION,
+        theme: "dracula".into(),
+    };
+
+    mgr.save_settings(&settings).value_or_panic("should save");
+    let loaded = mgr.load_settings().value_or_panic("should load");
+
+    assert_eq!(loaded.theme, "dracula");
+    assert_eq!(loaded.schema_version, SETTINGS_SCHEMA_VERSION);
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn file_persistence_roundtrip_state() {
+    let temp = std::env::temp_dir().join("jefe_test_roundtrip_state");
+    let _ = std::fs::remove_dir_all(&temp);
+    let paths = PersistencePaths {
+        settings_path: temp.join("settings.toml"),
+        state_path: temp.join("state.json"),
+    };
+    let mgr = FilePersistenceManager::with_paths(paths);
+
+    let state = State {
+        schema_version: STATE_SCHEMA_VERSION,
+        repositories: vec![],
+        agents: vec![],
+        selected_repository_index: Some(2),
+        selected_agent_index: None,
+        hide_idle_repositories: true,
+        last_selected_agent_by_repo: vec![],
+    };
+
+    mgr.save_state(&state).value_or_panic("should save");
+    let loaded = mgr.load_state().value_or_panic("should load");
+
+    assert_eq!(loaded.selected_repository_index, Some(2));
+    assert!(loaded.hide_idle_repositories);
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn file_persistence_atomic_write_creates_parent_dirs() {
+    let temp = std::env::temp_dir()
+        .join("jefe_test_atomic")
+        .join("nested")
+        .join("dirs");
+    if let Some(root) = cleanup_root(&temp) {
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    let paths = PersistencePaths {
+        settings_path: temp.join("settings.toml"),
+        state_path: temp.join("state.json"),
+    };
+    let mgr = FilePersistenceManager::with_paths(paths);
+
+    mgr.save_settings(&Settings::default_with_version())
+        .value_or_panic("should create dirs and save");
+
+    // Cleanup
+    if let Some(root) = cleanup_root(&temp) {
+        let _ = std::fs::remove_dir_all(root);
+    }
+}
+
+/// Test P13-1: State with repo having issue_base_prompt round-trips through JSON serialization.
+///
+/// @plan PLAN-20260329-ISSUES-MODE.P13
+/// @requirement REQ-ISS-012
+#[test]
+fn test_issue_base_prompt_state_round_trip() {
+    use crate::domain::{RemoteRepositorySettings, Repository, RepositoryId};
+    use std::path::PathBuf;
+
+    let repo = Repository {
+        id: RepositoryId("repo-issues".to_string()),
+        name: "Issues Repo".to_string(),
+        slug: "issues-repo".to_string(),
+        base_dir: PathBuf::from("/tmp/issues-repo"),
+        default_profile: String::new(),
+        github_repo: String::new(),
+        remote: RemoteRepositorySettings::default(),
+        issue_base_prompt: "Always reproduce the bug first".to_string(),
+        agent_ids: vec![],
+    };
+
+    let state = State {
+        schema_version: STATE_SCHEMA_VERSION,
+        repositories: vec![repo],
+        agents: vec![],
+        selected_repository_index: Some(0),
+        selected_agent_index: None,
+        hide_idle_repositories: false,
+        last_selected_agent_by_repo: vec![],
+    };
+
+    let temp = std::env::temp_dir().join("jefe_test_p13_issue_base_prompt_roundtrip");
+    let _ = std::fs::remove_dir_all(&temp);
+    let paths = PersistencePaths {
+        settings_path: temp.join("settings.toml"),
+        state_path: temp.join("state.json"),
+    };
+    let mgr = FilePersistenceManager::with_paths(paths);
+
+    mgr.save_state(&state).value_or_panic("should save state");
+    let loaded = mgr.load_state().value_or_panic("should load state");
+
+    assert_eq!(loaded.repositories.len(), 1);
+    assert_eq!(
+        loaded.repositories[0].issue_base_prompt,
+        "Always reproduce the bug first"
+    );
+
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+/// Test P13-2: Deserializing legacy JSON without issue_base_prompt defaults to empty string.
+///
+/// @plan PLAN-20260329-ISSUES-MODE.P13
+/// @requirement REQ-ISS-012
+#[test]
+fn test_issue_base_prompt_state_backward_compat() {
+    // Simulate legacy JSON that predates the issue_base_prompt field
+    let legacy_json = serde_json::json!({
+        "schema_version": 1,
+        "repositories": [
+            {
+                "id": "repo-legacy",
+                "name": "Legacy Repo",
+                "slug": "legacy-repo",
+                "base_dir": "/tmp/legacy-repo",
+                "default_profile": "",
+                "agent_ids": []
+                // Note: no issue_base_prompt field
+            }
+        ],
+        "agents": [],
+        "selected_repository_index": null,
+        "selected_agent_index": null
+    });
+
+    let state: State =
+        serde_json::from_value(legacy_json).value_or_panic("legacy JSON should deserialize");
+
+    assert_eq!(state.repositories.len(), 1);
+    // Must default to empty string, not error
+    assert_eq!(state.repositories[0].issue_base_prompt, "");
+}
+
+#[test]
+fn validate_config_dir_rejects_regular_file() {
+    // A path that exists as a regular file (not a directory) must be
+    // rejected with a clear, context-rich error mentioning the config path.
+    let temp = std::env::temp_dir().join("jefe_test_validate_regular_file");
+    let _ = std::fs::remove_file(&temp);
+    let _ = std::fs::remove_dir_all(&temp);
+
+    std::fs::write(&temp, "not a directory").value_or_panic("should seed regular file");
+
+    let error = validate_config_dir(&temp).error_or_panic("should reject regular file");
+    let PersistenceError::InvalidConfigDir { path, reason } = &error else {
+        panic!("expected InvalidConfigDir, got {error:?}");
+    };
+    assert_eq!(path, &temp, "error must mention the config path");
+    assert!(
+        reason.contains("not a directory"),
+        "reason should explain it is not a directory, got: {reason}"
+    );
+
+    let _ = std::fs::remove_file(&temp);
+}
+
+#[test]
+fn validate_config_dir_succeeds_for_fresh_temp_dir_and_leaves_no_probe() {
+    // A freshly-created writable temp directory should validate
+    // successfully and must not leave any probe file behind.
+    let temp = std::env::temp_dir().join("jefe_test_validate_fresh_dir");
+    let _ = std::fs::remove_dir_all(&temp);
+
+    validate_config_dir(&temp).value_or_panic("fresh writable dir should validate");
+
+    assert!(temp.is_dir(), "directory should exist after validation");
+
+    // No probe file of any kind should remain after a successful validation.
+    let leftover_probes = leftover_probe_files(&temp);
+    assert!(
+        leftover_probes.is_empty(),
+        "no probe files should remain, found: {leftover_probes:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn validate_config_dir_creates_missing_directory() {
+    // A non-existent nested directory should be created and validate.
+    let temp = std::env::temp_dir().join("jefe_test_validate_create_missing");
+    let nested = temp.join("a").join("b");
+    let _ = std::fs::remove_dir_all(&temp);
+
+    validate_config_dir(&nested).value_or_panic("should create nested dir and validate");
+    assert!(nested.is_dir(), "nested directory should be created");
+
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+/// Behavioral test for the core issue #65 scenario: an explicit config
+/// directory that exists but cannot be written to must be rejected
+/// fail-fast with a clear, actionable error.
+///
+/// This is Unix-gated because it relies on POSIX permission semantics
+/// (chmod). When tests run as effective root, chmod restrictions are
+/// bypassed (root can write anywhere), so the test detects this by probing
+/// whether the read-only directory actually rejects a write and skips if
+/// not.
+#[cfg(unix)]
+#[test]
+fn validate_config_dir_rejects_unwritable_directory() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = std::env::temp_dir().join("jefe_test_validate_unwritable");
+    let _ = std::fs::remove_dir_all(&temp);
+    std::fs::create_dir_all(&temp).value_or_panic("should create test dir");
+
+    // Set the directory to read-only (no write for anyone).
+    let read_only = std::fs::Permissions::from_mode(0o555);
+    std::fs::set_permissions(&temp, read_only).value_or_panic("should set read-only permissions");
+
+    // Guard restores writability on drop so cleanup always succeeds, even
+    // if an assertion panics.
+    let guard = ReadOnlyDirGuard {
+        dir: &temp,
+        active: true,
+    };
+
+    // Detect environments where chmod does not enforce writability (e.g.
+    // effective root). If a write succeeds despite 0o555, skip rather than
+    // produce a false negative.
+    let probe = temp.join("writability-check");
+    let chmod_enforced = std::fs::File::create(&probe).is_err();
+    let _ = std::fs::remove_file(&probe);
+    if !chmod_enforced {
+        // chmod did not prevent writes (likely running as root); skip.
+        return;
+    }
+
+    let error = validate_config_dir(&temp).error_or_panic("unwritable dir should fail validation");
+    let PersistenceError::InvalidConfigDir { path, reason } = &error else {
+        panic!("expected InvalidConfigDir, got {error:?}");
+    };
+    assert_eq!(path, &temp, "error must mention the config path");
+    assert!(
+        reason.contains("settings.toml")
+            || reason.contains("state.json")
+            || reason.contains("create"),
+        "reason should reference the persistence file or creation, got: {reason}"
+    );
+
+    drop(guard);
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+/// Regression test for the probe-write data-loss hazard: `probe_write`
+/// must never truncate or remove a pre-existing user file. Even if a file
+/// matching a probe-like name exists, validation must fail (via
+/// `create_new`) without touching the pre-existing file's contents.
+#[test]
+fn validate_config_dir_does_not_truncate_or_remove_existing_files() {
+    let temp = std::env::temp_dir().join("jefe_test_validate_no_truncate");
+    let _ = std::fs::remove_dir_all(&temp);
+    std::fs::create_dir_all(&temp).value_or_panic("should create test dir");
+
+    // The real persistence files (settings.toml/state.json) must be left
+    // untouched by validation. Seed a settings.toml with real content.
+    let settings_path = temp.join("settings.toml");
+    let original_content = "important user data";
+    std::fs::write(&settings_path, original_content).value_or_panic("should seed settings.toml");
+
+    // Validation should succeed (the dir is writable) and must not alter
+    // the pre-existing settings.toml.
+    validate_config_dir(&temp).value_or_panic("writable dir with existing files should validate");
+
+    let after = std::fs::read_to_string(&settings_path)
+        .value_or_panic("settings.toml should still be readable");
+    assert_eq!(
+        after, original_content,
+        "probe_write must not truncate or alter a pre-existing settings.toml"
+    );
+
+    // No probe file should remain.
+    let leftover_probes = leftover_probe_files(&temp);
+    assert!(
+        leftover_probes.is_empty(),
+        "no probe files should remain, found: {leftover_probes:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+/// Helper that creates a unique temp root for a test under the system temp
+/// directory, tagged with a label and the current process id so concurrent
+/// test runs never collide. The returned path does not yet exist.
+fn unique_temp_root(label: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "jefe_test_validate_target_{label}_{}_{}",
+        std::process::id(),
+        probe_counter()
+    ))
+}
+
+/// Regression: validation must reject the case where the actual
+/// `settings.toml` target already exists as a directory under an otherwise
+/// writable explicit config dir. Without this check, `atomic_write`
+/// (`File::create` on a `.tmp` sibling then `rename` onto the directory)
+/// would fail at runtime while `build_persistence` would have already
+/// succeeded, leaving persistence silently broken.
+#[test]
+fn validate_config_dir_rejects_settings_toml_as_directory() {
+    let temp = unique_temp_root("settings_is_dir");
+    std::fs::create_dir_all(&temp).value_or_panic("should create config dir");
+
+    // Create settings.toml as a directory, blocking the real atomic_write
+    // target.
+    let settings_dir = temp.join("settings.toml");
+    std::fs::create_dir_all(&settings_dir)
+        .value_or_panic("should seed settings.toml as a directory");
+
+    let error = validate_config_dir(&temp)
+        .error_or_panic("should reject when settings.toml target is a directory");
+    let PersistenceError::InvalidConfigDir { path, reason } = &error else {
+        panic!("expected InvalidConfigDir, got {error:?}");
+    };
+    assert_eq!(path, &temp, "error must mention the config path");
+    assert!(
+        reason.contains("settings.toml"),
+        "reason should name the settings.toml target, got: {reason}"
+    );
+    assert!(
+        reason.contains("directory") || reason.contains("not a regular file"),
+        "reason should explain the target is not a regular file, got: {reason}"
+    );
+
+    // The blocking directory the test created must not be removed by
+    // validation (it is user data, not a probe).
+    assert!(
+        settings_dir.is_dir(),
+        "validation must not remove the user-created settings.toml directory"
+    );
+
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+/// Regression: validation must reject the case where the actual
+/// `state.json` target already exists as a directory under an otherwise
+/// writable explicit config dir. Same rationale as the settings.toml case.
+#[test]
+fn validate_config_dir_rejects_state_json_as_directory() {
+    let temp = unique_temp_root("state_is_dir");
+    std::fs::create_dir_all(&temp).value_or_panic("should create config dir");
+
+    let state_dir = temp.join("state.json");
+    std::fs::create_dir_all(&state_dir).value_or_panic("should seed state.json as a directory");
+
+    let error = validate_config_dir(&temp)
+        .error_or_panic("should reject when state.json target is a directory");
+    let PersistenceError::InvalidConfigDir { path, reason } = &error else {
+        panic!("expected InvalidConfigDir, got {error:?}");
+    };
+    assert_eq!(path, &temp, "error must mention the config path");
+    assert!(
+        reason.contains("state.json"),
+        "reason should name the state.json target, got: {reason}"
+    );
+    assert!(
+        reason.contains("directory") || reason.contains("not a regular file"),
+        "reason should explain the target is not a regular file, got: {reason}"
+    );
+
+    assert!(
+        state_dir.is_dir(),
+        "validation must not remove the user-created state.json directory"
+    );
+
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+/// Regression: validation must reject atomic-write temporary siblings that
+/// already exist as directories. Otherwise startup would pass, but each save
+/// would fail while creating the deterministic temp file.
+#[test]
+fn validate_config_dir_rejects_atomic_tmp_targets_as_directories() {
+    for tmp_name in ["settings.tmp", "state.tmp"] {
+        let temp = unique_temp_root(tmp_name);
+        std::fs::create_dir_all(&temp).value_or_panic("should create config dir");
+
+        let tmp_dir = temp.join(tmp_name);
+        std::fs::create_dir_all(&tmp_dir).value_or_panic("should seed tmp target as a directory");
+
+        let error = validate_config_dir(&temp)
+            .error_or_panic("should reject when tmp target is a directory");
+        let PersistenceError::InvalidConfigDir { path, reason } = &error else {
+            panic!("expected InvalidConfigDir, got {error:?}");
+        };
+        assert_eq!(path, &temp, "error must mention the config path");
+        assert!(
+            reason.contains(tmp_name),
+            "reason should name the {tmp_name} target, got: {reason}"
+        );
+        assert!(
+            tmp_dir.is_dir(),
+            "validation must not remove the user-created {tmp_name} directory"
+        );
+
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn validate_config_dir_rejects_unwritable_atomic_tmp_files() {
+    use std::os::unix::fs::PermissionsExt;
+
+    for tmp_name in ["settings.tmp", "state.tmp"] {
+        let temp = unique_temp_root(tmp_name);
+        std::fs::create_dir_all(&temp).value_or_panic("should create config dir");
+
+        let tmp_path = temp.join(tmp_name);
+        std::fs::write(&tmp_path, "existing temp file").value_or_panic("should seed tmp file");
+        std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o444))
+            .value_or_panic("should set tmp file read-only");
+
+        let chmod_enforced = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&tmp_path)
+            .is_err();
+        if !chmod_enforced {
+            let _ = std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o644));
+            let _ = std::fs::remove_dir_all(&temp);
+            continue;
+        }
+
+        let error = validate_config_dir(&temp)
+            .error_or_panic("should reject when tmp target cannot be opened for writing");
+        let PersistenceError::InvalidConfigDir { path, reason } = &error else {
+            panic!("expected InvalidConfigDir, got {error:?}");
+        };
+        assert_eq!(path, &temp, "error must mention the config path");
+        assert!(
+            reason.contains(tmp_name),
+            "reason should name the {tmp_name} target, got: {reason}"
+        );
+        assert!(
+            reason.contains("atomic writes") || reason.contains("Permission denied"),
+            "reason should explain the temp target is not writable, got: {reason}"
+        );
+
+        let _ = std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o644));
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+}

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,0 +1,142 @@
+//! Startup-boundary helpers for wiring persistence and managers.
+//!
+//! These functions keep the TUI-launching `main` thin by moving testable
+//! construction/validation logic into the library. In particular,
+//! [`build_persistence`] performs fail-fast validation of an explicit
+//! `--config` directory so that an unwritable path produces a clear, actionable
+//! error instead of silent apparent data loss mid-session.
+//!
+//! @requirement REQ-TECH-005
+
+use crate::persistence::{
+    FilePersistenceManager, PersistenceError, PersistencePaths, resolve_paths,
+    resolve_paths_from_dir, validate_config_dir,
+};
+
+/// Build the persistence manager for the resolved config directory.
+///
+/// When `config_dir` is `Some(dir)` (i.e. `--config <dir>` was supplied) the
+/// directory is validated fail-fast via [`validate_config_dir`]: it is created
+/// if missing, confirmed to be a directory, and probed for writability of both
+/// `settings.toml` and `state.json`. When `config_dir` is `None` the default
+/// platform/env paths are used with no extra validation, matching the existing
+/// behavior for the implicit config location.
+///
+/// # Errors
+///
+/// Returns [`PersistenceError::InvalidConfigDir`] when an explicit config
+/// directory cannot be created or written to.
+pub fn build_persistence(
+    config_dir: Option<&std::path::Path>,
+) -> Result<FilePersistenceManager, PersistenceError> {
+    let paths = resolve_persistence_paths(config_dir)?;
+    Ok(FilePersistenceManager::with_paths(paths))
+}
+
+/// Resolve [`PersistencePaths`] for the given config directory, validating an
+/// explicit directory before returning.
+fn resolve_persistence_paths(
+    config_dir: Option<&std::path::Path>,
+) -> Result<PersistencePaths, PersistenceError> {
+    match config_dir {
+        Some(dir) => {
+            validate_config_dir(dir)?;
+            Ok(resolve_paths_from_dir(dir))
+        }
+        None => Ok(resolve_paths()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistence::PersistenceError;
+
+    trait TestResultExt<T> {
+        fn value_or_panic(self, context: &str) -> T;
+    }
+
+    impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
+        fn value_or_panic(self, context: &str) -> T {
+            match self {
+                Ok(value) => value,
+                Err(error) => panic!("{context}: {error:?}"),
+            }
+        }
+    }
+
+    fn expect_error<E: std::fmt::Debug>(result: Result<(), E>, context: &str) -> E {
+        match result {
+            Ok(()) => panic!("{context}: expected error"),
+            Err(error) => error,
+        }
+    }
+
+    fn unique_dir(label: &str) -> std::path::PathBuf {
+        let root =
+            std::env::temp_dir().join(format!("jefe_test_startup_{label}_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&root);
+        root.join(label)
+    }
+
+    #[test]
+    fn build_persistence_validates_explicit_dir_and_rejects_regular_file() {
+        // A path that exists as a regular file must be rejected fail-fast with
+        // a context-rich error mentioning the config path.
+        let temp = unique_dir("regular_file");
+        let root = temp.parent().map(std::path::Path::to_path_buf);
+        let _ = std::fs::remove_file(&temp);
+        let _ = std::fs::remove_dir_all(&temp);
+        std::fs::write(&temp, "not a directory").value_or_panic("should seed regular file");
+
+        let error = expect_error(
+            build_persistence(Some(&temp)).map(|_| ()),
+            "should reject regular file at startup",
+        );
+        let PersistenceError::InvalidConfigDir { path, reason } = &error else {
+            panic!("expected InvalidConfigDir, got {error:?}");
+        };
+        assert_eq!(path, &temp, "error must mention the config path");
+        assert!(
+            reason.contains("not a directory"),
+            "reason should explain it is not a directory, got: {reason}"
+        );
+
+        let _ = std::fs::remove_file(&temp);
+        if let Some(root) = root {
+            let _ = std::fs::remove_dir_all(&root);
+        }
+    }
+
+    #[test]
+    fn build_persistence_succeeds_for_valid_explicit_dir() {
+        // A freshly-created writable explicit directory should build a manager
+        // whose paths root under that directory.
+        let temp = unique_dir("valid_dir");
+        let root = temp.parent().map(std::path::Path::to_path_buf);
+        let _ = std::fs::remove_dir_all(&temp);
+
+        let manager =
+            build_persistence(Some(&temp)).value_or_panic("valid dir should build manager");
+
+        assert_eq!(
+            manager.paths_ref().settings_path,
+            temp.join("settings.toml")
+        );
+        assert_eq!(manager.paths_ref().state_path, temp.join("state.json"));
+
+        let _ = std::fs::remove_dir_all(&temp);
+        if let Some(root) = root {
+            let _ = std::fs::remove_dir_all(&root);
+        }
+    }
+
+    #[test]
+    fn build_persistence_none_uses_default_paths() {
+        // No explicit dir must not error and must not validate anything.
+        let manager = build_persistence(None).value_or_panic("None should build default manager");
+        let expected = crate::persistence::resolve_paths();
+        assert_eq!(manager.paths_ref().settings_path, expected.settings_path);
+        assert_eq!(manager.paths_ref().state_path, expected.state_path);
+    }
+}


### PR DESCRIPTION
## Summary

- Validates explicit config directories before starting the TUI so unusable paths fail fast.
- Adds persistence target checks for settings.toml and state.json, including directory and non-regular path rejection.
- Uses safe unique probe files with create-new semantics so validation does not truncate or remove user files.
- Routes startup persistence construction through a testable startup module and prints actionable stderr guidance on failure.

## Verification

- cargo fmt --all --check
- cargo test -q --lib persistence::
- cargo test -q --lib startup::
- CLIPPY_CONF_DIR=.github/clippy rustup run stable cargo clippy --workspace --all-targets --all-features -- -D warnings
- scripts/check-clippy-allows.sh
- make ci-check

Fixes #65
