### PR TITLE
Harden runtime safety and consolidate layout constants (Fixes #32)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "any_key"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +529,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -621,6 +629,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "iocraft",
+ "lru",
  "portable-pty",
  "serde",
  "serde_json",
@@ -698,6 +707,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "matchers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 # Directories (for platform-specific paths)
 dirs = "6.0"
 
+# Bounded cache for dead-session signatures (prevents unbounded memory growth
+# from repeated kill/recreate cycles of different agents).
+lru = "0.12"
+
 [patch.crates-io]
 iocraft = { path = "vendor/iocraft" }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -216,6 +216,16 @@ mod tests {
     use super::*;
 
     #[test]
+    fn column_width_constants_hold_expected_values() {
+        // The UI screens reference these constants for their fixed-width panes,
+        // so changing a value silently here would reshape the dashboard/issues
+        // layout. Lock the contract.
+        assert_eq!(LEFT_COL_WIDTH, 22);
+        assert_eq!(RIGHT_COL_WIDTH, 36);
+        assert_eq!(ISSUES_SIDEBAR_WIDTH, LEFT_COL_WIDTH);
+    }
+
+    #[test]
     fn effective_render_size_fullscreen_passthrough() {
         assert_eq!(effective_render_size_inner(120, 40, true), (120, 40));
         assert_eq!(effective_render_size_inner(80, 24, true), (80, 24));

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -7,8 +7,10 @@
 //! @pseudocode component-002 lines 01-35
 
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::path::Path;
 
+use lru::LruCache;
 use tracing::{debug, info};
 
 use super::attach::AttachedViewer;
@@ -17,6 +19,18 @@ use super::errors::RuntimeError;
 use super::liveness;
 use super::session::{RuntimeSession, TerminalCell, TerminalCellStyle, TerminalSnapshot};
 use crate::domain::{AgentId, LaunchSignature, RemoteRepositorySettings};
+
+/// Maximum number of dead-session launch signatures retained for relaunch.
+///
+/// Repeated kill/recreate cycles of *different* agents would otherwise grow
+/// `dead_signatures` without bound. Bounding it with an LRU cache caps memory
+/// usage while still preserving the most-recently-killed signatures, which are
+/// the ones a user is most likely to relaunch. Constructed via `NonZeroUsize`
+/// so `LruCache::new` never receives a zero capacity.
+const MAX_DEAD_SIGNATURES: NonZeroUsize = match NonZeroUsize::new(100) {
+    Some(n) => n,
+    None => NonZeroUsize::MIN,
+};
 
 /// Lightweight metadata for checking session liveness without holding the runtime lock.
 ///
@@ -262,7 +276,10 @@ pub struct TmuxRuntimeManager {
     /// Agent ID of the currently attached session.
     attached_agent_id: Option<AgentId>,
     /// Dead sessions that can be relaunched (stores signatures).
-    dead_signatures: HashMap<AgentId, LaunchSignature>,
+    ///
+    /// Bounded by [`MAX_DEAD_SIGNATURES`]: once full, the least-recently-used
+    /// dead signature is evicted to make room for newer ones.
+    dead_signatures: LruCache<AgentId, LaunchSignature>,
     /// Terminal dimensions.
     rows: u16,
     cols: u16,
@@ -276,7 +293,7 @@ impl TmuxRuntimeManager {
             sessions: HashMap::new(),
             viewer: None,
             attached_agent_id: None,
-            dead_signatures: HashMap::new(),
+            dead_signatures: LruCache::new(MAX_DEAD_SIGNATURES),
             rows,
             cols,
         }
@@ -334,8 +351,9 @@ impl TmuxRuntimeManager {
             let _ = self.viewer.take();
         }
 
-        self.dead_signatures
-            .insert(agent_id.clone(), session.launch_signature.clone());
+        let _ = self
+            .dead_signatures
+            .put(agent_id.clone(), session.launch_signature.clone());
         true
     }
 
@@ -384,7 +402,7 @@ impl TmuxRuntimeManager {
         self.sessions.insert(agent_id.clone(), session);
 
         // Remove from dead signatures if present.
-        self.dead_signatures.remove(agent_id);
+        let _ = self.dead_signatures.pop(agent_id);
 
         Ok(())
     }
@@ -504,8 +522,9 @@ impl RuntimeManager for TmuxRuntimeManager {
             .ok_or_else(|| RuntimeError::SessionNotFound(agent_id.0.clone()))?;
 
         // Store signature for relaunch
-        self.dead_signatures
-            .insert(agent_id.clone(), session.launch_signature.clone());
+        let _ = self
+            .dead_signatures
+            .put(agent_id.clone(), session.launch_signature.clone());
 
         // If attached, clear attachment and drop viewer.
         if self.attached_agent_id.as_ref() == Some(agent_id) {
@@ -536,7 +555,7 @@ impl RuntimeManager for TmuxRuntimeManager {
         // Get stored signature
         let signature = self
             .dead_signatures
-            .remove(agent_id)
+            .pop(agent_id)
             .ok_or_else(|| RuntimeError::NotRunning(agent_id.clone()))?;
 
         // Spawn with stored signature using force-fresh semantics so runtime
@@ -653,5 +672,55 @@ impl RuntimeManager for TmuxRuntimeManager {
         }
 
         Some(snapshot)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The `dead_signatures` field is private and the real mutating methods
+    // (`mark_session_dead`, `kill`) require a live tmux session to exercise
+    // end-to-end, which is not unit-test friendly. Instead this test targets
+    // the bound directly: it constructs an `LruCache` with the production
+    // capacity constant and proves that exceeding it evicts the oldest entries
+    // while never growing past the cap. This is the property the field relies
+    // on to prevent unbounded memory growth from repeated kill/recreate cycles.
+    #[test]
+    fn dead_signatures_cache_is_bounded_by_max_dead_signatures() {
+        let cap = MAX_DEAD_SIGNATURES.get();
+        let mut cache: LruCache<AgentId, LaunchSignature> = LruCache::new(MAX_DEAD_SIGNATURES);
+
+        // Insert well beyond the capacity.
+        for i in 0..cap + 10 {
+            let id = AgentId(format!("agent-{i}"));
+            let _ = cache.put(
+                id,
+                LaunchSignature {
+                    work_dir: std::path::PathBuf::from("/tmp"),
+                    profile: "default".into(),
+                    mode_flags: vec![],
+                    llxprt_debug: String::new(),
+                    pass_continue: true,
+                    sandbox_enabled: false,
+                    sandbox_engine: crate::domain::SandboxEngine::Podman,
+                    sandbox_flags: crate::domain::DEFAULT_SANDBOX_FLAGS.to_owned(),
+                    remote: crate::domain::RemoteRepositorySettings::default(),
+                },
+            );
+        }
+
+        // The cache must never exceed the configured bound.
+        assert_eq!(cache.len(), cap);
+
+        // The oldest entries (agent-0 .. agent-9) were evicted; the most recent
+        // entries survive because they are the ones most likely to be relaunched.
+        assert!(cache.peek(&AgentId("agent-0".into())).is_none());
+        assert!(cache.peek(&AgentId("agent-9".into())).is_none());
+        assert!(
+            cache
+                .peek(&AgentId(format!("agent-{}", cap + 10 - 1)))
+                .is_some()
+        );
     }
 }

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -35,9 +35,31 @@ impl RuntimeSession {
     }
 
     /// Generate a session name from an agent ID.
+    ///
+    /// tmux session names may only contain ASCII alphanumerics, hyphens, and
+    /// underscores. Any other character in the agent id (spaces, slashes, shell
+    /// metacharacters, non-ASCII code points) is replaced with `_` so the
+    /// resulting name is always safe to use as a tmux target.
+    ///
+    /// Because distinct characters collapse to `_`, two different raw ids could
+    /// in principle map to the same session name. This is acceptable in
+    /// practice: agent ids are unique nanosecond timestamps composed solely of
+    /// ASCII digits, which survive sanitization unchanged and therefore never
+    /// collide.
     #[must_use]
     pub fn session_name_for(agent_id: &AgentId) -> String {
-        format!("jefe-{}", agent_id.0)
+        let sanitized: String = agent_id
+            .0
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+        format!("jefe-{sanitized}")
     }
 }
 
@@ -92,5 +114,80 @@ impl TerminalSnapshot {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.cells.is_empty() || self.cells.iter().all(Vec::is_empty)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_name_preserves_plain_alphanumeric() {
+        // ASCII letters and digits pass through unchanged.
+        assert_eq!(
+            RuntimeSession::session_name_for(&AgentId("abc123".into())),
+            "jefe-abc123"
+        );
+    }
+
+    #[test]
+    fn session_name_preserves_hyphen_and_underscore() {
+        // The existing contract: "my-agent" stays "jefe-my-agent".
+        assert_eq!(
+            RuntimeSession::session_name_for(&AgentId("my-agent".into())),
+            "jefe-my-agent"
+        );
+        assert_eq!(
+            RuntimeSession::session_name_for(&AgentId("my_agent".into())),
+            "jefe-my_agent"
+        );
+        assert_eq!(
+            RuntimeSession::session_name_for(&AgentId("a-b_c".into())),
+            "jefe-a-b_c"
+        );
+    }
+
+    #[test]
+    fn session_name_replaces_spaces_slashes_and_dots() {
+        assert_eq!(
+            RuntimeSession::session_name_for(&AgentId("a b/c.d".into())),
+            "jefe-a_b_c_d"
+        );
+    }
+
+    #[test]
+    fn session_name_replaces_shell_metacharacters() {
+        // Characters that would be dangerous in a tmux session name become '_'.
+        // Input "a*b;c`" keeps a/b/c and maps *, ;, $, ` each to '_'.
+        assert_eq!(
+            RuntimeSession::session_name_for(&AgentId("a*b;c$`".into())),
+            "jefe-a_b_c__"
+        );
+    }
+
+    #[test]
+    fn session_name_replaces_non_ascii_unicode() {
+        // Non-ASCII alphanumeric chars (here 'é') are NOT ascii_alphanumeric.
+        assert_eq!(
+            RuntimeSession::session_name_for(&AgentId("café".into())),
+            "jefe-caf_"
+        );
+    }
+
+    #[test]
+    fn session_name_empty_id_yields_bare_prefix() {
+        assert_eq!(
+            RuntimeSession::session_name_for(&AgentId(String::new())),
+            "jefe-"
+        );
+    }
+
+    #[test]
+    fn session_name_preserves_nanosecond_timestamp_like_id() {
+        // Realistic all-digit agent id (a nanosecond timestamp) is unchanged.
+        assert_eq!(
+            RuntimeSession::session_name_for(&AgentId("1718000000000000000".into())),
+            "jefe-1718000000000000000"
+        );
     }
 }

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -7,7 +7,7 @@
 
 use iocraft::prelude::*;
 
-use crate::layout::dashboard_middle_row_heights;
+use crate::layout::{LEFT_COL_WIDTH, RIGHT_COL_WIDTH, dashboard_middle_row_heights};
 use crate::runtime::TerminalSnapshot;
 use crate::state::{AppState, PaneFocus, ScreenMode};
 use crate::theme::{ResolvedColors, ThemeColors};
@@ -89,6 +89,11 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
     let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((120, 40));
     let (agent_rows, terminal_rows) = dashboard_middle_row_heights(term_cols, term_rows);
 
+    // Single source of truth for fixed column widths: the iocraft width field
+    // expects a u32, so convert the u16 layout constants once here.
+    let sidebar_width = u32::from(LEFT_COL_WIDTH);
+    let preview_width = u32::from(RIGHT_COL_WIDTH);
+
     element! {
         Box(
             flex_direction: FlexDirection::Column,
@@ -114,7 +119,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                 width: 100pct,
             ) {
                 // Sidebar (fixed width)
-                Box(width: 22u32, height: 100pct) {
+                Box(width: sidebar_width, height: 100pct) {
                     Sidebar(
                         repositories: repositories,
                         agent_counts: agent_counts,
@@ -148,7 +153,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                 }
 
                 // Preview pane (fixed width)
-                Box(width: 36u32, height: 100pct) {
+                Box(width: preview_width, height: 100pct) {
                     Preview(
                         agent: selected_agent_data,
                         focused: false,

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -106,6 +106,10 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
     let detail_pane_height = u16::try_from(detail_pane_height).unwrap_or(u16::MAX);
     let list_width = crate::layout::issue_list_content_width(term_cols);
 
+    // Single source of truth for the fixed sidebar width: the layout constant
+    // is u16 but the iocraft width field expects u32.
+    let sidebar_width = u32::from(crate::layout::ISSUES_SIDEBAR_WIDTH);
+
     // Agent chooser overlay
     let agent_chooser = state.and_then(|s| s.issues_state.agent_chooser.clone());
     let chooser_visible = agent_chooser.is_some();
@@ -144,7 +148,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                 width: 100pct,
             ) {
                 // Repos sidebar (fixed 22u, full height)
-                Box(width: 22u32, height: 100pct) {
+                Box(width: sidebar_width, height: 100pct) {
                     Sidebar(
                         repositories: repositories,
                         agent_counts: agent_counts,


### PR DESCRIPTION
## Summary

Closes #32.

Issue #32 is a broad code-quality audit. Since it was filed, the codebase has evolved and several of its premises are already addressed:

- **#1 "God Component" in main.rs** — already resolved. `main.rs` is now 142 lines and the `App` component lives in `src/app_shell.rs`; the `#![allow(clippy::cognitive_complexity)]` the issue cited is gone.
- **#5 Layout module** — already exists at `src/layout.rs`; this PR finishes the job by removing the duplicated literals in the UI screens.

The remaining audit items were triaged. This PR implements the clean, low-risk, test-driven subset and **deliberately leaves the high-risk items out of scope** to avoid regressions (see "Out of scope" below).

## What this PR does

### 1. Sanitize tmux session names (audit item #7)
`RuntimeSession::session_name_for` now replaces any character that is not ASCII-alphanumeric, `-`, or `_` with `_`, keeping the `jefe-` prefix so generated names are always safe tmux targets. Digit-only timestamp ids (the real source of agent ids) are unchanged, so there is no collision risk in practice; this is documented at the call site.

### 2. Bound the dead_signatures map (audit item #4)
The previously unbounded `dead_signatures: HashMap<AgentId, LaunchSignature>` in `TmuxRuntimeManager` is now an `lru::LruCache` capped at `MAX_DEAD_SIGNATURES = 100`, preventing unbounded memory growth across repeated kill/relaunch cycles. The capacity is a panic-free `NonZeroUsize` const (const-eval `match`, no `unwrap`/`expect`). All four sites updated to `put`/`pop`; `relaunch()` still retrieves-and-removes the stored signature.

### 3. Consolidate layout literals (audit item #5)
`src/ui/screens/dashboard.rs` and `src/ui/screens/issues.rs` no longer hardcode the `22`/`36` width literals; they reference the shared `crate::layout` constants (`LEFT_COL_WIDTH`, `RIGHT_COL_WIDTH`, `ISSUES_SIDEBAR_WIDTH`) via lossless `u32::from` conversions — single source of truth.

## Tests (TDD)

- Behavioral unit tests for session-name sanitization: plain alphanumerics preserved, hyphen/underscore preserved, spaces/slashes/dots and shell metacharacters mapped to `_`, non-ASCII (e.g. `é`) mapped to `_`, empty id yields the bare prefix, and a timestamp-like all-digit id is unchanged.
- An LRU eviction-bound test that exercises the production `MAX_DEAD_SIGNATURES` capacity and asserts old entries are evicted at the cap.
- A layout-constant contract test locking the values the UI now depends on.

## Out of scope (intentionally not done)

These audit items were excluded because they are either already done, fight the framework, or carry high regression risk disproportionate to their value:

- **#1 App decomposition** — already completed in the current tree.
- **#2 Remove `Option` from `SharedContext`** — the `Option` is load-bearing: `AppProps` uses iocraft's `#[derive(Props)]` which requires `Default`, and `Arc<Mutex<AppContext>>` has no `Default`.
- **#3 Async sleep** — the three `thread::sleep` calls run inside synchronous dispatch functions invoked from the synchronous `use_terminal_events` handler, not an async context; converting them requires restructuring the input-dispatch path to async (high regression risk).
- **#6 Form macros** — a large speculative abstraction the project standards advise against.
- **deny.toml / `missing_docs` lints** — would create large warning churn under `-D warnings` and add unwired CI dependencies.

## Verification

All green from the workspace root:

- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo build --workspace --all-features --locked
- cargo test --workspace --all-features --locked
- bash scripts/check-clippy-allows.sh
- make ci-check
