### PR TITLE
Improve test assertion hygiene and reduce panic-style patterns in tests (Fixes #28)

### DIFF
--- a/dev-docs/RULES.md
+++ b/dev-docs/RULES.md
@@ -79,6 +79,7 @@ Do not create parallel architecture variants (`*_v2`, `new_*`) unless explicitly
 - Pure implementation-detail assertions as primary proof
 - "exists/defined" assertions without behavioral value
 - mock-only theater for integration claims
+- Panic-based control flow for simple variant assertions; prefer `assert!(matches!(...))` (see `docs/project-standards.md` § Test Assertion Style)
 
 Regression tests are required for bug fixes.
 

--- a/dev-docs/project-standards.md
+++ b/dev-docs/project-standards.md
@@ -113,6 +113,7 @@ Every meaningful change must include or update tests that verify behavior.
 - Tests must verify externally meaningful behavior.
 - Tests must be deterministic and non-flaky.
 - Avoid over-mocking core logic; prefer realistic data shape coverage.
+- For assertion style (variant checks, unwrap/expect bans, `matches!` idiom), see `docs/project-standards.md` § Test Assertion Style.
 
 ## Required validation commands
 At minimum before merge:

--- a/docs/project-standards.md
+++ b/docs/project-standards.md
@@ -153,8 +153,16 @@ The embedded terminal view remaps ANSI default/named colors to the active theme'
 - Every module with logic (not just re-exports) must have a `#[cfg(test)] mod tests` block.
 - Tests must cover: happy paths, edge cases, boundary values, and error conditions.
 - Use `pretty_assertions` for struct/collection comparisons where available.
-- Tests may use `.unwrap()` and `.expect()` freely — these are `#[cfg(test)]` contexts.
+- Tests must not use `.unwrap()` or `.expect()` — the project enforces `unwrap_used`/`expect_used` via clippy with `-D warnings`. Use assertion macros, `let-else` extraction with clear `panic!` messages, or small test-only extraction helpers.
 - Test function names must be descriptive: `test_compose_mode_defaults_to_yolo_and_continue_for_empty_input`, not `test1`.
+
+### Test Assertion Style
+
+- Prefer `assert!(matches!(value, Pattern), "expected ..., got {value:?}")` over `match { Pattern => {} _ => panic!() }` for enum-variant discriminant checks.
+- Use `assert_eq!`/`assert!` with descriptive messages for value comparisons.
+- Do NOT use `assert_matches!` — it is nightly-only and not available on the stable toolchain this project uses.
+- Do NOT use `.unwrap()`/`.expect()` in tests; the project bans them via clippy (`unwrap_used`/`expect_used` warn + `-D warnings`). Prefer `let-else` with a clear `panic!` for setup extraction, or assertion macros.
+- Reserve bare `panic!` for unreachable extraction-failure branches in `let-else`/`match` where a value must be destructured.
 
 ### What to Test
 

--- a/docs/project-standards.md
+++ b/docs/project-standards.md
@@ -112,7 +112,7 @@ Defined in `clippy.toml`:
 ### DON'T
 
 - **DON'T** use `unsafe` code. The lint level is `forbid`. This is non-negotiable.
-- **DON'T** use `.unwrap()` or `.expect()` in production code paths. These are acceptable ONLY in `#[cfg(test)]` blocks and in `const` contexts where the value is provably `Some`/`Ok`.
+- **DON'T** use `.unwrap()` or `.expect()` anywhere in first-party code. The clippy lints `unwrap_used`/`expect_used` are enforced with `-D warnings` in both production and test code; the only `const`-context exception is where the value is provably `Some`/`Ok`. In tests, use assertion macros or `let-else` extraction with clear `panic!` messages (see Testing Standards § Test Assertion Style).
 - **DON'T** use `panic!()`, `unreachable!()`, `todo!()`, or `unimplemented!()` in production code paths. If a code path is genuinely unreachable, refactor the types to make that structurally impossible.
 - **DON'T** disable lints with `#[allow(...)]` without a code-review-approved comment explaining why. Every `allow` must have a justification. Blanket `#![allow(...)]` at the module level requires explicit approval and must be temporary.
 - **DON'T** add `#[allow(clippy::...)]`, `#![allow(clippy::...)]`, or `#[cfg_attr(..., allow(clippy::...))]` attributes in first-party code. The policy is zero-tolerance and there is no exception ledger. The gate `scripts/check-clippy-allows.sh` fails CI on any first-party clippy allow attribute (vendor remains ignored).

--- a/src/state/form_ops_tests.rs
+++ b/src/state/form_ops_tests.rs
@@ -44,12 +44,10 @@ fn open_new_agent_initializes_llxprt_debug_blank() {
 
     state = state.apply(AppEvent::OpenNewAgent(RepositoryId("repo-1".to_owned())));
 
-    match state.modal {
-        ModalState::NewAgent { fields, .. } => {
-            assert!(fields.llxprt_debug.is_empty());
-        }
-        _ => panic!("expected new-agent modal"),
-    }
+    let ModalState::NewAgent { fields, .. } = state.modal else {
+        panic!("expected new-agent modal, got {:?}", state.modal);
+    };
+    assert!(fields.llxprt_debug.is_empty());
 }
 
 #[test]
@@ -60,13 +58,12 @@ fn llxprt_debug_is_trimmed_when_creating_agent() {
     };
 
     state = state.apply(AppEvent::OpenNewAgent(RepositoryId("repo-1".to_owned())));
-    if let ModalState::NewAgent { fields, .. } = &mut state.modal {
-        fields.name = "Agent One".to_owned();
-        fields.work_dir = "/tmp/agent-one".to_owned();
-        fields.llxprt_debug = "   trace=1   ".to_owned();
-    } else {
+    let ModalState::NewAgent { fields, .. } = &mut state.modal else {
         panic!("expected new-agent modal");
-    }
+    };
+    fields.name = "Agent One".to_owned();
+    fields.work_dir = "/tmp/agent-one".to_owned();
+    fields.llxprt_debug = "   trace=1   ".to_owned();
 
     state = state.apply(AppEvent::SubmitForm);
     let Some(created) = state.agents.last() else {
@@ -83,13 +80,12 @@ fn llxprt_debug_is_trimmed_to_empty_when_blank() {
     };
 
     state = state.apply(AppEvent::OpenNewAgent(RepositoryId("repo-1".to_owned())));
-    if let ModalState::NewAgent { fields, .. } = &mut state.modal {
-        fields.name = "Agent Two".to_owned();
-        fields.work_dir = "/tmp/agent-two".to_owned();
-        fields.llxprt_debug = "   ".to_owned();
-    } else {
+    let ModalState::NewAgent { fields, .. } = &mut state.modal else {
         panic!("expected new-agent modal");
-    }
+    };
+    fields.name = "Agent Two".to_owned();
+    fields.work_dir = "/tmp/agent-two".to_owned();
+    fields.llxprt_debug = "   ".to_owned();
 
     state = state.apply(AppEvent::SubmitForm);
     let Some(created) = state.agents.last() else {
@@ -106,20 +102,17 @@ fn new_agent_work_dir_slug_excludes_slashes_from_name() {
     };
 
     state = state.apply(AppEvent::OpenNewAgent(RepositoryId("repo-1".to_owned())));
-    if let ModalState::NewAgent { fields, .. } = &mut state.modal {
-        fields.name = "API / Worker".to_owned();
-    } else {
+    let ModalState::NewAgent { fields, .. } = &mut state.modal else {
         panic!("expected new-agent modal");
-    }
+    };
+    fields.name = "API / Worker".to_owned();
 
     state.update_agent_work_dir_from_name();
 
-    match &state.modal {
-        ModalState::NewAgent { fields, .. } => {
-            assert_eq!(fields.work_dir, "/tmp/repo-1/api--worker");
-        }
-        _ => panic!("expected new-agent modal"),
-    }
+    let ModalState::NewAgent { fields, .. } = &state.modal else {
+        panic!("expected new-agent modal, got {:?}", state.modal);
+    };
+    assert_eq!(fields.work_dir, "/tmp/repo-1/api--worker");
 }
 
 #[test]
@@ -251,24 +244,23 @@ fn repository_checkbox_toggle_updates_remote_fields() {
     state = state.apply(AppEvent::FormNextField);
     state = state.apply(AppEvent::FormToggleCheckbox);
 
-    match state.modal {
-        ModalState::NewRepository {
-            fields,
-            focus,
-            cursor,
-        } => {
-            assert_eq!(focus, RepositoryFormFocus::SetupEnvDefault);
-            assert!(fields.remote_enabled);
-            assert_eq!(fields.login_user, "ub");
-            assert_eq!(fields.host, "1.");
-            assert_eq!(fields.run_as_user, "a");
-            assert!(fields.setup_env_default);
-            assert_eq!(cursor.login_user, 2);
-            assert_eq!(cursor.host, 2);
-            assert_eq!(cursor.run_as_user, 1);
-        }
-        _ => panic!("expected new-repository modal"),
-    }
+    let ModalState::NewRepository {
+        fields,
+        focus,
+        cursor,
+    } = state.modal
+    else {
+        panic!("expected new-repository modal, got {:?}", state.modal);
+    };
+    assert_eq!(focus, RepositoryFormFocus::SetupEnvDefault);
+    assert!(fields.remote_enabled);
+    assert_eq!(fields.login_user, "ub");
+    assert_eq!(fields.host, "1.");
+    assert_eq!(fields.run_as_user, "a");
+    assert!(fields.setup_env_default);
+    assert_eq!(cursor.login_user, 2);
+    assert_eq!(cursor.host, 2);
+    assert_eq!(cursor.run_as_user, 1);
 }
 
 #[test]
@@ -487,11 +479,10 @@ fn submit_edit_repository_keeps_modal_open_when_github_repo_invalid() {
     state = state.apply(AppEvent::OpenEditRepository(RepositoryId(
         "repo-1".to_owned(),
     )));
-    if let ModalState::EditRepository { fields, .. } = &mut state.modal {
-        fields.github_repo = "owner/repo/extra".to_owned();
-    } else {
+    let ModalState::EditRepository { fields, .. } = &mut state.modal else {
         panic!("expected edit-repository modal");
-    }
+    };
+    fields.github_repo = "owner/repo/extra".to_owned();
 
     state = state.apply(AppEvent::SubmitForm);
 
@@ -513,11 +504,10 @@ fn submit_edit_repository_closes_modal_when_github_repo_valid() {
     state = state.apply(AppEvent::OpenEditRepository(RepositoryId(
         "repo-1".to_owned(),
     )));
-    if let ModalState::EditRepository { fields, .. } = &mut state.modal {
-        fields.github_repo = "owner/new".to_owned();
-    } else {
+    let ModalState::EditRepository { fields, .. } = &mut state.modal else {
         panic!("expected edit-repository modal");
-    }
+    };
+    fields.github_repo = "owner/new".to_owned();
 
     state = state.apply(AppEvent::SubmitForm);
 

--- a/src/state/issues_tests.rs
+++ b/src/state/issues_tests.rs
@@ -895,7 +895,7 @@ fn test_inline_exclusivity_blocks_second_control() {
     // Should still be Composer, not changed to Editor
     assert!(
         matches!(
-            new_state.issues_state.inline_state,
+            &new_state.issues_state.inline_state,
             InlineState::Composer {
                 target: ComposerTarget::NewComment,
                 ..

--- a/src/state/issues_tests.rs
+++ b/src/state/issues_tests.rs
@@ -893,16 +893,17 @@ fn test_inline_exclusivity_blocks_second_control() {
     });
 
     // Should still be Composer, not changed to Editor
-    match new_state.issues_state.inline_state {
-        InlineState::Composer {
-            target: ComposerTarget::NewComment,
-            ..
-        } => {}
-        _ => panic!(
-            "Expected Composer state to remain, but got {:?}",
-            new_state.issues_state.inline_state
+    assert!(
+        matches!(
+            new_state.issues_state.inline_state,
+            InlineState::Composer {
+                target: ComposerTarget::NewComment,
+                ..
+            }
         ),
-    }
+        "Expected Composer state to remain, but got {:?}",
+        new_state.issues_state.inline_state
+    );
 }
 
 /// Test 24: IssueListLoaded with mismatched scope_repo_id is discarded.

--- a/src/state/issues_tests_components.rs
+++ b/src/state/issues_tests_components.rs
@@ -213,13 +213,17 @@ fn test_issue_detail_inline_composer_visible() {
 
     let state = state.apply(AppEvent::OpenNewCommentComposer);
 
-    match state.issues_state.inline_state {
-        InlineState::Composer {
-            target: ComposerTarget::NewComment,
-            ..
-        } => {} // Correct
-        other => panic!("expected Composer(NewComment), got {other:?}"),
-    }
+    assert!(
+        matches!(
+            state.issues_state.inline_state,
+            InlineState::Composer {
+                target: ComposerTarget::NewComment,
+                ..
+            }
+        ),
+        "expected Composer(NewComment), got {:?}",
+        state.issues_state.inline_state
+    );
 }
 
 /// P13 Test 9b: OpenNewIssueComposer transitions inline_state to Composer(NewIssue).
@@ -234,13 +238,17 @@ fn test_issue_list_new_issue_composer_visible() {
 
     let state = state.apply(AppEvent::OpenNewIssueComposer);
 
-    match state.issues_state.inline_state {
-        InlineState::Composer {
-            target: ComposerTarget::NewIssue,
-            ..
-        } => {}
-        other => panic!("expected Composer(NewIssue), got {other:?}"),
-    }
+    assert!(
+        matches!(
+            state.issues_state.inline_state,
+            InlineState::Composer {
+                target: ComposerTarget::NewIssue,
+                ..
+            }
+        ),
+        "expected Composer(NewIssue), got {:?}",
+        state.issues_state.inline_state
+    );
     assert_eq!(state.issues_state.issue_focus, IssueFocus::IssueList);
 }
 

--- a/src/state/issues_tests_components.rs
+++ b/src/state/issues_tests_components.rs
@@ -240,7 +240,7 @@ fn test_issue_list_new_issue_composer_visible() {
 
     assert!(
         matches!(
-            state.issues_state.inline_state,
+            &state.issues_state.inline_state,
             InlineState::Composer {
                 target: ComposerTarget::NewIssue,
                 ..

--- a/src/state/issues_tests_detail.rs
+++ b/src/state/issues_tests_detail.rs
@@ -175,13 +175,17 @@ fn test_mode_lifecycle_enter_interact_exit() {
 
     // Open inline composer
     let state = state.apply(AppEvent::OpenNewCommentComposer);
-    match &state.issues_state.inline_state {
-        InlineState::Composer {
-            target: ComposerTarget::NewComment,
-            ..
-        } => {}
-        other => panic!("expected Composer(NewComment), got {other:?}"),
-    }
+    assert!(
+        matches!(
+            &state.issues_state.inline_state,
+            InlineState::Composer {
+                target: ComposerTarget::NewComment,
+                ..
+            }
+        ),
+        "expected Composer(NewComment), got {:?}",
+        state.issues_state.inline_state
+    );
 
     // Type some text
     let state = state

--- a/src/state/issues_tests_detail_flow.rs
+++ b/src/state/issues_tests_detail_flow.rs
@@ -489,10 +489,14 @@ fn test_inline_exclusivity_all_combinations() {
     let state = base.clone().apply(AppEvent::OpenInlineEditor {
         target: EditorTarget::IssueBody,
     });
-    match &state.issues_state.inline_state {
-        InlineState::Composer { .. } => {}
-        other => panic!("Composer should block editor open, got {other:?}"),
-    }
+    assert!(
+        matches!(
+            &state.issues_state.inline_state,
+            InlineState::Composer { .. }
+        ),
+        "Composer should block editor open, got {:?}",
+        state.issues_state.inline_state
+    );
 
     // Editor active → OpenNewCommentComposer blocked
     base.issues_state.inline_state = InlineState::Editor {
@@ -501,10 +505,11 @@ fn test_inline_exclusivity_all_combinations() {
         cursor: 4,
     };
     let state = base.clone().apply(AppEvent::OpenNewCommentComposer);
-    match &state.issues_state.inline_state {
-        InlineState::Editor { .. } => {}
-        other => panic!("Editor should block composer open, got {other:?}"),
-    }
+    assert!(
+        matches!(&state.issues_state.inline_state, InlineState::Editor { .. }),
+        "Editor should block composer open, got {:?}",
+        state.issues_state.inline_state
+    );
 
     // Editor active → OpenNewIssueComposer blocked
     base.issues_state.inline_state = InlineState::Editor {
@@ -513,10 +518,11 @@ fn test_inline_exclusivity_all_combinations() {
         cursor: 4,
     };
     let state = base.clone().apply(AppEvent::OpenNewIssueComposer);
-    match &state.issues_state.inline_state {
-        InlineState::Editor { .. } => {}
-        other => panic!("Editor should block new-issue composer open, got {other:?}"),
-    }
+    assert!(
+        matches!(&state.issues_state.inline_state, InlineState::Editor { .. }),
+        "Editor should block new-issue composer open, got {:?}",
+        state.issues_state.inline_state
+    );
 
     // Editor active → OpenReplyComposer blocked
     base.issues_state.inline_state = InlineState::Editor {
@@ -527,10 +533,11 @@ fn test_inline_exclusivity_all_combinations() {
     let state = base
         .clone()
         .apply(AppEvent::OpenReplyComposer { comment_index: 0 });
-    match &state.issues_state.inline_state {
-        InlineState::Editor { .. } => {}
-        other => panic!("Editor should block reply composer open, got {other:?}"),
-    }
+    assert!(
+        matches!(&state.issues_state.inline_state, InlineState::Editor { .. }),
+        "Editor should block reply composer open, got {:?}",
+        state.issues_state.inline_state
+    );
 }
 
 /// P15 Test 16: Build send payload from detail with focused comment — all fields present.

--- a/tests/core/visibility_filter_contracts.rs
+++ b/tests/core/visibility_filter_contracts.rs
@@ -231,16 +231,14 @@ fn delete_targets_correct_agent_when_idle_hidden() {
     assert_eq!(selected_id, AgentId("target".into()));
 
     let with_modal = hidden.apply(AppEvent::OpenDeleteAgent(selected_id));
-    match &with_modal.modal {
-        ModalState::ConfirmDeleteAgent { id, .. } => {
-            assert_eq!(
-                *id,
-                AgentId("target".into()),
-                "delete must target the highlighted agent, not an adjacent one"
-            );
-        }
-        other => panic!("expected ConfirmDeleteAgent, got {other:?}"),
-    }
+    let ModalState::ConfirmDeleteAgent { id, .. } = &with_modal.modal else {
+        panic!("expected ConfirmDeleteAgent, got {:?}", with_modal.modal);
+    };
+    assert_eq!(
+        *id,
+        AgentId("target".into()),
+        "delete must target the highlighted agent, not an adjacent one"
+    );
 }
 
 #[test]

--- a/tests/ui/forms_and_modals.rs
+++ b/tests/ui/forms_and_modals.rs
@@ -229,12 +229,10 @@ fn open_new_agent_form_initializes_llxprt_debug_blank() {
 
     state = state.apply(AppEvent::OpenNewAgent(repo_id));
 
-    match state.modal {
-        ModalState::NewAgent { fields, .. } => {
-            assert!(fields.llxprt_debug.is_empty());
-        }
-        _ => panic!("expected new-agent modal"),
-    }
+    let ModalState::NewAgent { fields, .. } = state.modal else {
+        panic!("expected new-agent modal, got {:?}", state.modal);
+    };
+    assert!(fields.llxprt_debug.is_empty());
 }
 
 #[test]
@@ -246,12 +244,10 @@ fn open_edit_agent_form_copies_llxprt_debug_value() {
 
     state = state.apply(AppEvent::OpenEditAgent(agent_id));
 
-    match state.modal {
-        ModalState::EditAgent { fields, .. } => {
-            assert_eq!(fields.llxprt_debug, "trace=agent");
-        }
-        _ => panic!("expected edit-agent modal"),
-    }
+    let ModalState::EditAgent { fields, .. } = state.modal else {
+        panic!("expected edit-agent modal, got {:?}", state.modal);
+    };
+    assert_eq!(fields.llxprt_debug, "trace=agent");
 }
 
 #[test]
@@ -262,13 +258,12 @@ fn submit_new_agent_form_trims_llxprt_debug() {
 
     state = state.apply(AppEvent::OpenNewAgent(repo_id));
 
-    if let ModalState::NewAgent { fields, .. } = &mut state.modal {
-        fields.name = "Agent With Debug".into();
-        fields.work_dir = "/tmp/agent-with-debug".into();
-        fields.llxprt_debug = "   io=trace   ".into();
-    } else {
+    let ModalState::NewAgent { fields, .. } = &mut state.modal else {
         panic!("expected new-agent modal");
-    }
+    };
+    fields.name = "Agent With Debug".into();
+    fields.work_dir = "/tmp/agent-with-debug".into();
+    fields.llxprt_debug = "   io=trace   ".into();
 
     state = state.apply(AppEvent::SubmitForm);
     let Some(created) = state
@@ -292,18 +287,17 @@ fn repository_form_cursor_moves_and_inserts_in_place() {
     state = state.apply(AppEvent::FormMoveCursorLeft);
     state = state.apply(AppEvent::FormChar('b'));
 
-    match state.modal {
-        ModalState::NewRepository {
-            fields,
-            focus,
-            cursor,
-        } => {
-            assert_eq!(focus, RepositoryFormFocus::Name);
-            assert_eq!(fields.name, "abc");
-            assert_eq!(cursor.name, 2);
-        }
-        _ => panic!("expected new-repository modal"),
-    }
+    let ModalState::NewRepository {
+        fields,
+        focus,
+        cursor,
+    } = state.modal
+    else {
+        panic!("expected new-repository modal, got {:?}", state.modal);
+    };
+    assert_eq!(focus, RepositoryFormFocus::Name);
+    assert_eq!(fields.name, "abc");
+    assert_eq!(cursor.name, 2);
 }
 
 #[test]
@@ -327,24 +321,23 @@ fn repository_form_toggles_remote_fields() {
     state = state.apply(AppEvent::FormNextField); // SetupEnvDefault
     state = state.apply(AppEvent::FormToggleCheckbox);
 
-    match state.modal {
-        ModalState::NewRepository {
-            fields,
-            focus,
-            cursor,
-        } => {
-            assert_eq!(focus, RepositoryFormFocus::SetupEnvDefault);
-            assert!(fields.remote_enabled);
-            assert_eq!(fields.login_user, "op");
-            assert_eq!(fields.host, "10");
-            assert_eq!(fields.run_as_user, "m");
-            assert!(fields.setup_env_default);
-            assert_eq!(cursor.login_user, 2);
-            assert_eq!(cursor.host, 2);
-            assert_eq!(cursor.run_as_user, 1);
-        }
-        _ => panic!("expected new-repository modal"),
-    }
+    let ModalState::NewRepository {
+        fields,
+        focus,
+        cursor,
+    } = state.modal
+    else {
+        panic!("expected new-repository modal, got {:?}", state.modal);
+    };
+    assert_eq!(focus, RepositoryFormFocus::SetupEnvDefault);
+    assert!(fields.remote_enabled);
+    assert_eq!(fields.login_user, "op");
+    assert_eq!(fields.host, "10");
+    assert_eq!(fields.run_as_user, "m");
+    assert!(fields.setup_env_default);
+    assert_eq!(cursor.login_user, 2);
+    assert_eq!(cursor.host, 2);
+    assert_eq!(cursor.run_as_user, 1);
 }
 
 #[test]
@@ -360,17 +353,16 @@ fn agent_form_cursor_delete_and_backspace_are_caret_based() {
     state = state.apply(AppEvent::FormDelete); // remove c => ab|
     state = state.apply(AppEvent::FormBackspace); // remove b => a|
 
-    match state.modal {
-        ModalState::NewAgent {
-            fields,
-            focus,
-            cursor,
-            ..
-        } => {
-            assert_eq!(focus, AgentFormFocus::Name);
-            assert_eq!(fields.name, "a");
-            assert_eq!(cursor.name, 1);
-        }
-        _ => panic!("expected new-agent modal"),
-    }
+    let ModalState::NewAgent {
+        fields,
+        focus,
+        cursor,
+        ..
+    } = state.modal
+    else {
+        panic!("expected new-agent modal, got {:?}", state.modal);
+    };
+    assert_eq!(focus, AgentFormFocus::Name);
+    assert_eq!(fields.name, "a");
+    assert_eq!(cursor.name, 1);
 }


### PR DESCRIPTION
## Summary

Fixes #28.

Replaces avoidable panic-style control flow in tests with focused assertion patterns so failures produce clearer, more consistent diagnostics, and documents the preferred test-assertion style for contributors.

## Background

The issue asked to prefer assertion-focused checks over panic-style branches in tests, and to add contributor guidance. CodeRabbit's auto-generated plan proposed using `std::assert_matches::assert_matches!` and converting some patterns to `.expect()`. Both are incorrect for this project:

- `std::assert_matches::assert_matches!` is **nightly-only** (`#![feature(assert_matches)]`) and will not compile on the project's stable toolchain (rustc 1.92.0, edition 2024).
- `.unwrap()` / `.expect()` are effectively banned: the clippy lints `unwrap_used` and `expect_used` are enabled and CI runs clippy with `-D warnings`. The first-party codebase has zero of either.

This PR therefore uses the stable idiom already present in the codebase: `assert!(matches!(value, Pattern), "msg {value:?}")`.

## Changes

Two refactor idioms applied:

- **Pure discriminant checks** — `match x { Pat => {} _ => panic!(...) }` converted to `assert!(matches!(x, Pat), "msg, got {x:?}")`.
- **Extraction assertions** — `match`/`if let` blocks that destructure and assert on inner values (with a `panic!` fallback) converted to `let-else` extraction with a clear panic message, preserving every inner assertion.

Files refactored:

- `src/state/issues_tests.rs`
- `src/state/issues_tests_components.rs`
- `src/state/issues_tests_detail.rs`
- `src/state/issues_tests_detail_flow.rs`
- `src/state/form_ops_tests.rs`
- `tests/ui/forms_and_modals.rs`
- `tests/core/visibility_filter_contracts.rs`

Documentation:

- `docs/project-standards.md` — adds a "Test Assertion Style" subsection and corrects a contradictory note that previously claimed tests may use `unwrap`/`expect` freely (they cannot, per clippy enforcement).
- `dev-docs/RULES.md` and `dev-docs/project-standards.md` — cross-reference the new assertion-style guidance.

Extraction guards (`let Some(...) = ... else { panic!() }`), the `value_or_panic` test helper, and intentional test-callback panics were deliberately left unchanged — they are not avoidable panic-style discriminant checks.

## Acceptance criteria

- [x] Targeted tests no longer use avoidable panic-style branches.
- [x] Test failures show focused assertion diagnostics (messages include `{:?}` of the actual value).
- [x] Contributor guidance reflects preferred test style.

## Verification

`make ci-check` passes:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --all-features --locked`
- `cargo test --workspace --all-features --locked` (591 tests pass, 0 failed)

No new `.unwrap()`, `.expect()`, or `assert_matches!` were introduced.
