### PR TITLE
Add pure tmux harness scenario layer (Fixes #98)

### DIFF
--- a/src/harness/config.rs
+++ b/src/harness/config.rs
@@ -1,0 +1,88 @@
+//! Scenario configuration and assertion mode.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P01
+//! @requirement REQ-TMUX-HARNESS-001
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::error::ScenarioError;
+
+/// How assertion steps (`expect`, `expectCount`, ...) treat a mismatch.
+///
+/// `Soft` records the failure and continues; `Strict` aborts the scenario.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AssertMode {
+    Soft,
+    #[default]
+    Strict,
+}
+
+/// Harness and terminal configuration for a scenario.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScenarioConfig {
+    /// Terminal column count (must be >= 1).
+    pub cols: u16,
+    /// Terminal row count (must be >= 1).
+    pub rows: u16,
+    /// Maximum scrollback lines retained for history sampling.
+    #[serde(default = "default_history_limit")]
+    pub history_limit: u32,
+    /// Milliseconds to wait before the first step runs.
+    #[serde(default)]
+    pub initial_wait_ms: u64,
+    /// Optional directory for captures and artifacts. Absent means ephemeral.
+    #[serde(default)]
+    pub out_dir: Option<PathBuf>,
+    /// When true, keep the tmux session alive after the scenario completes.
+    #[serde(default)]
+    pub keep_session: bool,
+    /// How assertion mismatches are handled.
+    #[serde(default)]
+    pub assert_mode: AssertMode,
+}
+
+fn default_history_limit() -> u32 {
+    10_000
+}
+
+impl ScenarioConfig {
+    /// Validate config bounds. Returns the first violation, if any.
+    ///
+    /// Pseudocode:
+    ///   if cols == 0 -> InvalidConfig("cols", "must be >= 1")
+    ///   if rows == 0 -> InvalidConfig("rows", "must be >= 1")
+    ///
+    /// @plan PLAN-20260629-TMUX-HARNESS.P01
+    /// @requirement REQ-TMUX-HARNESS-001
+    pub fn validate(&self) -> Result<(), ScenarioError> {
+        if self.cols == 0 {
+            return Err(ScenarioError::InvalidConfig {
+                field: "cols".to_string(),
+                reason: "must be >= 1".to_string(),
+            });
+        }
+        if self.rows == 0 {
+            return Err(ScenarioError::InvalidConfig {
+                field: "rows".to_string(),
+                reason: "must be >= 1".to_string(),
+            });
+        }
+        if self.history_limit == 0 {
+            return Err(ScenarioError::InvalidConfig {
+                field: "history_limit".to_string(),
+                reason: "must be >= 1".to_string(),
+            });
+        }
+        Ok(())
+    }
+}

--- a/src/harness/error.rs
+++ b/src/harness/error.rs
@@ -1,0 +1,78 @@
+//! Typed errors for the harness scenario layer.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P01
+//! @requirement REQ-TMUX-HARNESS-001
+
+/// Errors produced by scenario parsing, validation, and macro expansion.
+///
+/// Every variant carries structured context so callers can render actionable
+/// operator feedback without parsing error strings.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScenarioError {
+    /// Malformed JSON or a JSON value that does not match the expected shape.
+    Json { message: String },
+    /// A step object used an unrecognized kind key (e.g. `{"fly": true}`).
+    UnknownStepKind { kind: String },
+    /// A required field was missing from the JSON document.
+    MissingField { field: String, context: String },
+    /// A config field was out of its valid range.
+    InvalidConfig { field: String, reason: String },
+    /// A macro definition was structurally valid JSON but invalid as a model.
+    InvalidMacro { name: String, reason: String },
+    /// A macro invocation referenced a name that is not defined.
+    UnknownMacro { name: String },
+    /// A macro invocation supplied the wrong number of arguments.
+    MacroArityMismatch {
+        name: String,
+        expected: usize,
+        provided: usize,
+    },
+    /// A macro invocation is missing a required argument.
+    MissingMacroArg { name: String, param: String },
+    /// Macro expansion detected a cycle (a macro directly or transitively
+    /// invokes itself).
+    MacroCycle { chain: Vec<String> },
+    /// A step had a structurally valid shape but an invalid argument value.
+    InvalidStep { reason: String },
+}
+
+impl std::fmt::Display for ScenarioError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Json { message } => write!(f, "scenario JSON error: {message}"),
+            Self::UnknownStepKind { kind } => write!(f, "unknown step kind: '{kind}'"),
+            Self::MissingField { field, context } => {
+                write!(f, "missing required field '{field}' in {context}")
+            }
+            Self::InvalidConfig { field, reason } => {
+                write!(f, "invalid config field '{field}': {reason}")
+            }
+            Self::InvalidMacro { name, reason } => {
+                write!(f, "invalid macro '{name}': {reason}")
+            }
+            Self::UnknownMacro { name } => write!(f, "unknown macro: '{name}'"),
+            Self::MacroArityMismatch {
+                name,
+                expected,
+                provided,
+            } => {
+                write!(
+                    f,
+                    "macro '{name}' expects {expected} argument(s), got {provided}"
+                )
+            }
+            Self::MissingMacroArg { name, param } => {
+                write!(f, "macro '{name}' is missing argument '{param}'")
+            }
+            Self::MacroCycle { chain } => {
+                write!(f, "macro cycle detected: {}", chain.join(" -> "))
+            }
+            Self::InvalidStep { reason } => write!(f, "invalid step: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for ScenarioError {}

--- a/src/harness/expand.rs
+++ b/src/harness/expand.rs
@@ -1,0 +1,228 @@
+//! Macro expansion: resolve `Step::Macro` invocations into concrete steps.
+//!
+//! Expansion is deterministic, rejects unknown/cyclic/arity-mismatched macros,
+//! and performs raw (exact) placeholder substitution. No side effects.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P01
+//! @requirement REQ-TMUX-HARNESS-001
+
+use std::collections::BTreeMap;
+
+use super::error::ScenarioError;
+use super::macro_def::MacroDef;
+use super::scenario::Scenario;
+use super::step::Step;
+
+/// Placeholder sigil: `$param` in step text is replaced by the argument.
+const PLACEHOLDER: char = '$';
+
+/// Expand every macro invocation in `scenario.steps` into concrete steps.
+///
+/// Returns a new [`Scenario`] whose `steps` contain only concrete primitives
+/// (no `Step::Macro`). The original `macros` table is retained so re-running
+/// expansion is a no-op.
+///
+/// # Errors
+///
+/// Returns [`ScenarioError::UnknownMacro`], [`ScenarioError::MacroArityMismatch`],
+/// [`ScenarioError::MissingMacroArg`], or [`ScenarioError::MacroCycle`] as
+/// appropriate.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+pub fn expand_macros(scenario: &Scenario) -> Result<Scenario, ScenarioError> {
+    let mut expanded: Vec<Step> = Vec::with_capacity(scenario.steps.len());
+    for step in &scenario.steps {
+        expand_one(&scenario.macros, step, &mut Vec::new(), &mut expanded)?;
+    }
+    Ok(Scenario {
+        config: scenario.config.clone(),
+        macros: scenario.macros.clone(),
+        steps: expanded,
+    })
+}
+
+/// Expand a single step, appending concrete steps to `out`.
+///
+/// `chain` tracks the macro names currently being expanded for cycle
+/// detection. Concrete steps are substituted (in case they were produced by
+/// a parent macro's body) and appended directly.
+fn expand_one(
+    macros: &BTreeMap<String, MacroDef>,
+    step: &Step,
+    chain: &mut Vec<String>,
+    out: &mut Vec<Step>,
+) -> Result<(), ScenarioError> {
+    match step {
+        Step::Macro { name, args } => expand_macro_invocation(macros, name, args, chain, out),
+        other => {
+            out.push(other.clone());
+            Ok(())
+        }
+    }
+}
+
+/// Expand a macro invocation, with cycle detection and arity validation.
+fn expand_macro_invocation(
+    macros: &BTreeMap<String, MacroDef>,
+    name: &str,
+    args: &BTreeMap<String, String>,
+    chain: &mut Vec<String>,
+    out: &mut Vec<Step>,
+) -> Result<(), ScenarioError> {
+    if chain.iter().any(|c| c == name) {
+        let mut cycle = chain.clone();
+        cycle.push(name.to_string());
+        return Err(ScenarioError::MacroCycle { chain: cycle });
+    }
+
+    let def = macros
+        .get(name)
+        .ok_or_else(|| ScenarioError::UnknownMacro {
+            name: name.to_string(),
+        })?;
+
+    validate_arity(name, def, args)?;
+    for body_step in &def.steps {
+        let substituted = substitute_step(body_step, args);
+        chain.push(name.to_string());
+        let result = expand_one(macros, &substituted, chain, out);
+        chain.pop();
+        result?;
+    }
+    Ok(())
+}
+
+/// Validate that the provided arguments match the macro's parameter list.
+fn validate_arity(
+    name: &str,
+    def: &MacroDef,
+    args: &BTreeMap<String, String>,
+) -> Result<(), ScenarioError> {
+    let expected = def.params.len();
+    if args.len() != expected {
+        return Err(ScenarioError::MacroArityMismatch {
+            name: name.to_string(),
+            expected,
+            provided: args.len(),
+        });
+    }
+    for param in &def.params {
+        if !args.contains_key(param) {
+            return Err(ScenarioError::MissingMacroArg {
+                name: name.to_string(),
+                param: param.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Substitute `$param` placeholders in a single step using `args`.
+///
+/// Substitution is exact/raw: the argument string replaces the placeholder
+/// verbatim, so numeric or boolean argument text is spliced without
+/// reinterpretation.
+fn substitute_step(step: &Step, args: &BTreeMap<String, String>) -> Step {
+    match step {
+        Step::Line { text } => Step::Line {
+            text: substitute(text, args),
+        },
+        Step::Key { key } => Step::Key {
+            key: substitute(key, args),
+        },
+        Step::Keys { keys } => Step::Keys {
+            keys: keys.iter().map(|k| substitute(k, args)).collect(),
+        },
+        Step::WaitFor { pattern } => Step::WaitFor {
+            pattern: substitute(pattern, args),
+        },
+        Step::WaitForNot { pattern } => Step::WaitForNot {
+            pattern: substitute(pattern, args),
+        },
+        Step::Expect { pattern } => Step::Expect {
+            pattern: substitute(pattern, args),
+        },
+        Step::ExpectCount { pattern, count } => Step::ExpectCount {
+            pattern: substitute(pattern, args),
+            count: *count,
+        },
+        Step::Capture { name } => Step::Capture {
+            name: substitute(name, args),
+        },
+        Step::HistorySample { name } => Step::HistorySample {
+            name: substitute(name, args),
+        },
+        Step::ExpectHistoryDelta { name } => Step::ExpectHistoryDelta {
+            name: substitute(name, args),
+        },
+        Step::Macro { name, args: margs } => Step::Macro {
+            name: name.clone(),
+            args: substitute_args(margs, args),
+        },
+        other => other.clone(),
+    }
+}
+
+/// Substitute placeholders in each nested macro argument value.
+fn substitute_args(
+    macro_args: &BTreeMap<String, String>,
+    outer_args: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    macro_args
+        .iter()
+        .map(|(name, value)| (name.clone(), substitute(value, outer_args)))
+        .collect()
+}
+
+/// Replace every `$name` placeholder in `text` with the matching argument.
+///
+/// An unknown placeholder is left as-is rather than erroring, so macro authors
+/// can include literal `$` text that is not a parameter.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+fn substitute(text: &str, args: &BTreeMap<String, String>) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = text;
+    while let Some(dollar) = cursor.find(PLACEHOLDER) {
+        out.push_str(&cursor[..dollar]);
+        let after = &cursor[dollar + PLACEHOLDER.len_utf8()..];
+        if let Some((param_len, value)) = match_param(after, args) {
+            out.push_str(&value);
+            cursor = &after[param_len..];
+        } else {
+            out.push(PLACEHOLDER);
+            cursor = after;
+        }
+    }
+    out.push_str(cursor);
+    out
+}
+
+/// Match the longest parameter name occurring at the start of `text`.
+///
+/// Returns the matched name's length and its substitution value. Longest-match
+/// avoids ambiguity between params like `$a` and `$ab`.
+fn match_param(text: &str, args: &BTreeMap<String, String>) -> Option<(usize, String)> {
+    args.iter()
+        .filter_map(|(name, value)| {
+            text.strip_prefix(name.as_str())
+                .filter(|rest| is_placeholder_boundary(rest))
+                .map(|_| (name.len(), value.clone()))
+        })
+        .max_by_key(|(len, _)| *len)
+}
+
+/// A placeholder ends before another identifier character.
+fn is_placeholder_boundary(rest: &str) -> bool {
+    match rest.chars().next() {
+        Some(c) => !is_param_char(c),
+        None => true,
+    }
+}
+
+/// Parameter names use identifier-like characters.
+fn is_param_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}

--- a/src/harness/expand.rs
+++ b/src/harness/expand.rs
@@ -53,6 +53,7 @@ fn expand_one(
     chain: &mut Vec<String>,
     out: &mut Vec<Step>,
 ) -> Result<(), ScenarioError> {
+    step.validate()?;
     match step {
         Step::Macro { name, args } => expand_macro_invocation(macros, name, args, chain, out),
         other => {

--- a/src/harness/macro_def.rs
+++ b/src/harness/macro_def.rs
@@ -1,0 +1,78 @@
+//! Macro definitions for the harness scenario language.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P01
+//! @requirement REQ-TMUX-HARNESS-001
+
+use serde::Deserialize;
+use serde::de::{self, MapAccess, Visitor};
+
+use super::step::Step;
+
+/// The body of a macro definition: its parameter names and the steps it
+/// expands to. Step text may contain `$param` placeholders that are
+/// substituted verbatim during expansion.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[derive(Debug, Clone)]
+pub struct MacroDef {
+    pub params: Vec<String>,
+    pub steps: Vec<Step>,
+}
+
+impl<'de> Deserialize<'de> for MacroDef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(MacroDefVisitor)
+    }
+}
+
+struct MacroDefVisitor;
+
+impl<'de> Visitor<'de> for MacroDefVisitor {
+    type Value = MacroDef;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a macro definition object with params and steps")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut params: Option<Vec<String>> = None;
+        let mut steps: Option<Vec<Step>> = None;
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "params" => {
+                    reject_duplicate_field(params.is_some(), "params")?;
+                    params = Some(map.next_value()?);
+                }
+                "steps" => {
+                    reject_duplicate_field(steps.is_some(), "steps")?;
+                    steps = Some(map.next_value()?);
+                }
+                _ => {
+                    return Err(de::Error::unknown_field(&key, &["params", "steps"]));
+                }
+            }
+        }
+        let params =
+            params.ok_or_else(|| de::Error::custom("missing required field 'params' in macro"))?;
+        let steps =
+            steps.ok_or_else(|| de::Error::custom("missing required field 'steps' in macro"))?;
+        Ok(MacroDef { params, steps })
+    }
+}
+/// Reject a duplicate macro definition field.
+fn reject_duplicate_field<E>(seen: bool, field: &str) -> Result<(), E>
+where
+    E: de::Error,
+{
+    if seen {
+        return Err(E::custom(format!("duplicate field '{field}' in macro")));
+    }
+    Ok(())
+}

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1,0 +1,34 @@
+//! Tmux-backed TUI automation harness — pure scenario layer.
+//!
+//! This module hosts the future tmux-backed scenario automation harness
+//! (parent issue #97). This first phase (#98) delivers only the pure,
+//! side-effect-free layer: strongly typed scenario models, serde-based JSON
+//! deserialization, validation, and macro expansion.
+//!
+//! No tmux interaction, process spawning, terminal I/O, or file I/O occurs
+//! here. Tests may pass JSON strings, but production code is pure. Later
+//! subissues (#99-#102) will add the runtime/execution surface on top of
+//! these typed models.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P01
+//! @requirement REQ-TMUX-HARNESS-001
+
+pub mod config;
+pub mod error;
+pub mod expand;
+pub mod macro_def;
+pub mod parser;
+pub mod scenario;
+pub mod step;
+
+pub use config::{AssertMode, ScenarioConfig};
+pub use error::ScenarioError;
+pub use expand::expand_macros;
+pub use macro_def::MacroDef;
+pub use parser::parse_scenario;
+pub use scenario::Scenario;
+pub use step::Step;
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/src/harness/parser.rs
+++ b/src/harness/parser.rs
@@ -1,0 +1,76 @@
+//! Scenario JSON parsing entry point.
+//!
+//! `parse_scenario` is the single public parse function. It deserializes JSON
+//! into the typed [`Scenario`] model, then validates it. All serde failures
+//! are converted into structured [`ScenarioError`] values.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P01
+//! @requirement REQ-TMUX-HARNESS-001
+
+use super::error::ScenarioError;
+use super::scenario::Scenario;
+
+/// Parse a JSON scenario document into a validated typed [`Scenario`].
+///
+/// # Errors
+///
+/// Returns [`ScenarioError::Json`] for malformed JSON or shape mismatches,
+/// [`ScenarioError::UnknownStepKind`] for unrecognized step discriminators,
+/// and [`ScenarioError::InvalidConfig`] / [`ScenarioError::MissingField`] for
+/// validation violations.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+pub fn parse_scenario(json: &str) -> Result<Scenario, ScenarioError> {
+    let scenario: Scenario = serde_json::from_str(json).map_err(serde_to_scenario_error)?;
+    scenario.validate()?;
+    Ok(scenario)
+}
+
+/// Convert a serde_json error into a context-rich [`ScenarioError`].
+///
+/// serde_json emits `missing field` and type errors as strings. The `Step`
+/// deserializer surfaces its own typed errors through `de::Error::custom`,
+/// whose Display prefixes (`unknown step kind: 'x'`, `invalid step: ...`)
+/// are recognized here so callers still see the most specific variant.
+/// Everything else falls back to `Json`.
+fn serde_to_scenario_error(err: serde_json::Error) -> ScenarioError {
+    let msg = err.to_string();
+    if let Some(field) = extract_between(&msg, "missing field `", '`') {
+        return ScenarioError::MissingField {
+            field,
+            context: "scenario".to_string(),
+        };
+    }
+    if let Some(kind) = extract_between(&msg, "unknown step kind: '", '\'') {
+        return ScenarioError::UnknownStepKind { kind };
+    }
+    if let Some((field, context)) = extract_scoped_missing_field(&msg) {
+        return ScenarioError::MissingField { field, context };
+    }
+    if msg.starts_with("invalid step") {
+        return ScenarioError::InvalidStep { reason: msg };
+    }
+    ScenarioError::Json { message: msg }
+}
+
+/// Recover a structured scoped missing-field error from Display text.
+fn extract_scoped_missing_field(msg: &str) -> Option<(String, String)> {
+    let field = extract_between(msg, "missing required field '", '\'')?;
+    if msg.contains(" in step") {
+        return Some((field, "step".to_string()));
+    }
+    if msg.contains(" in macro") {
+        return Some((field, "macro".to_string()));
+    }
+    None
+}
+
+/// Extract the substring between `open_marker` and the next `close_char`
+/// following the marker, if present.
+fn extract_between(msg: &str, open_marker: &str, close_char: char) -> Option<String> {
+    let start = msg.find(open_marker)? + open_marker.len();
+    let rest = msg.get(start..)?;
+    let end = rest.find(close_char)?;
+    Some(rest.get(..end)?.to_string())
+}

--- a/src/harness/scenario.rs
+++ b/src/harness/scenario.rs
@@ -1,0 +1,64 @@
+//! The top-level [`Scenario`] model.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P01
+//! @requirement REQ-TMUX-HARNESS-001
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Deserialize;
+
+use super::config::ScenarioConfig;
+use super::error::ScenarioError;
+use super::macro_def::MacroDef;
+use super::step::Step;
+
+/// A complete scenario: configuration, macro definitions, and the ordered
+/// step list (which may include macro invocations prior to expansion).
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Scenario {
+    pub config: ScenarioConfig,
+    #[serde(default)]
+    pub macros: BTreeMap<String, MacroDef>,
+    #[serde(default)]
+    pub steps: Vec<Step>,
+}
+
+impl Scenario {
+    /// Validate config bounds and macro definitions.
+    ///
+    /// Macro invocation resolution, arity checks, and cycle detection are
+    /// performed by `expand_macros`.
+    ///
+    /// @plan PLAN-20260629-TMUX-HARNESS.P01
+    /// @requirement REQ-TMUX-HARNESS-001
+    pub fn validate(&self) -> Result<(), ScenarioError> {
+        self.config.validate()?;
+        self.validate_macros()
+    }
+
+    /// Validate macro definitions independent of invocation expansion.
+    fn validate_macros(&self) -> Result<(), ScenarioError> {
+        for (name, macro_def) in &self.macros {
+            reject_duplicate_params(name, &macro_def.params)?;
+        }
+        Ok(())
+    }
+}
+
+/// Reject duplicate parameter names because invocation args are keyed by name.
+fn reject_duplicate_params(name: &str, params: &[String]) -> Result<(), ScenarioError> {
+    let mut seen = BTreeSet::new();
+    for param in params {
+        if !seen.insert(param.as_str()) {
+            return Err(ScenarioError::InvalidMacro {
+                name: name.to_string(),
+                reason: format!("duplicate parameter '{param}'"),
+            });
+        }
+    }
+    Ok(())
+}

--- a/src/harness/scenario.rs
+++ b/src/harness/scenario.rs
@@ -6,6 +6,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Deserialize;
+use serde::de::{self, MapAccess, Visitor};
 
 use super::config::ScenarioConfig;
 use super::error::ScenarioError;
@@ -17,18 +18,15 @@ use super::step::Step;
 ///
 /// @plan PLAN-20260629-TMUX-HARNESS.P01
 /// @requirement REQ-TMUX-HARNESS-001
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone)]
 pub struct Scenario {
     pub config: ScenarioConfig,
-    #[serde(default)]
     pub macros: BTreeMap<String, MacroDef>,
-    #[serde(default)]
     pub steps: Vec<Step>,
 }
 
 impl Scenario {
-    /// Validate config bounds and macro definitions.
+    /// Validate config bounds, step arguments, and macro definitions.
     ///
     /// Macro invocation resolution, arity checks, and cycle detection are
     /// performed by `expand_macros`.
@@ -37,15 +35,130 @@ impl Scenario {
     /// @requirement REQ-TMUX-HARNESS-001
     pub fn validate(&self) -> Result<(), ScenarioError> {
         self.config.validate()?;
+        self.validate_steps()?;
         self.validate_macros()
+    }
+
+    /// Validate top-level concrete step arguments.
+    fn validate_steps(&self) -> Result<(), ScenarioError> {
+        for step in &self.steps {
+            step.validate()?;
+        }
+        Ok(())
     }
 
     /// Validate macro definitions independent of invocation expansion.
     fn validate_macros(&self) -> Result<(), ScenarioError> {
         for (name, macro_def) in &self.macros {
             reject_duplicate_params(name, &macro_def.params)?;
+            for step in &macro_def.steps {
+                step.validate()?;
+            }
         }
         Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for Scenario {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(ScenarioVisitor)
+    }
+}
+
+struct ScenarioVisitor;
+
+impl<'de> Visitor<'de> for ScenarioVisitor {
+    type Value = Scenario;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a scenario object with config, macros, and steps")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut config: Option<ScenarioConfig> = None;
+        let mut macros: Option<MacroMap> = None;
+        let mut steps: Option<Vec<Step>> = None;
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "config" => read_once(&mut map, &mut config, "config")?,
+                "macros" => read_once(&mut map, &mut macros, "macros")?,
+                "steps" => read_once(&mut map, &mut steps, "steps")?,
+                _ => {
+                    map.next_value::<de::IgnoredAny>()?;
+                    return Err(de::Error::unknown_field(
+                        &key,
+                        &["config", "macros", "steps"],
+                    ));
+                }
+            }
+        }
+        Ok(Scenario {
+            config: config.ok_or_else(|| de::Error::missing_field("config"))?,
+            macros: macros.unwrap_or_default().into_inner(),
+            steps: steps.unwrap_or_default(),
+        })
+    }
+}
+
+fn read_once<'de, A, T>(map: &mut A, slot: &mut Option<T>, field: &str) -> Result<(), A::Error>
+where
+    A: MapAccess<'de>,
+    T: Deserialize<'de>,
+{
+    if slot.is_some() {
+        return Err(de::Error::custom(format!(
+            "duplicate field '{field}' in scenario"
+        )));
+    }
+    *slot = Some(map.next_value()?);
+    Ok(())
+}
+
+#[derive(Default)]
+struct MacroMap(BTreeMap<String, MacroDef>);
+
+impl MacroMap {
+    fn into_inner(self) -> BTreeMap<String, MacroDef> {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for MacroMap {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(MacroMapVisitor)
+    }
+}
+
+struct MacroMapVisitor;
+
+impl<'de> Visitor<'de> for MacroMapVisitor {
+    type Value = MacroMap;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a map of macro names to macro definitions")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut macros = BTreeMap::new();
+        while let Some(name) = map.next_key::<String>()? {
+            if macros.contains_key(&name) {
+                return Err(de::Error::custom(format!("duplicate macro name '{name}'")));
+            }
+            macros.insert(name, map.next_value()?);
+        }
+        Ok(MacroMap(macros))
     }
 }
 

--- a/src/harness/step.rs
+++ b/src/harness/step.rs
@@ -1,0 +1,380 @@
+//! Step primitives for the harness scenario language.
+//!
+//! Each step is a single JSON object with a discriminator key naming the
+//! primitive (e.g. `{"wait": 100}`), deserialized into the fully typed
+//! [`Step`] enum. No `serde_json::Value` escapes into the domain model.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P01
+//! @requirement REQ-TMUX-HARNESS-001
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+use serde::de::{self, MapAccess, Visitor};
+
+use super::error::ScenarioError;
+
+/// A single concrete step primitive.
+///
+/// One variant per scenario primitive plus a `Macro` invocation variant that
+/// macro expansion replaces with concrete steps.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Step {
+    /// Pause for `milliseconds` before the next step.
+    Wait { milliseconds: u64 },
+    /// Type a full line of text (implies a trailing Enter in later phases).
+    Line { text: String },
+    /// Send a single named key (e.g. `"Enter"`, `"Escape"`).
+    Key { key: String },
+    /// Send a sequence of named keys.
+    Keys { keys: Vec<String> },
+    /// Block until `pattern` appears on screen.
+    WaitFor { pattern: String },
+    /// Block until `pattern` no longer appears on screen.
+    WaitForNot { pattern: String },
+    /// Assert that `pattern` is currently on screen.
+    Expect { pattern: String },
+    /// Assert that `pattern` appears exactly `count` times.
+    ExpectCount { pattern: String, count: u32 },
+    /// Capture the current screen under `name`.
+    Capture { name: String },
+    /// Sample the scrollback history under `name`.
+    HistorySample { name: String },
+    /// Assert that history changed since the prior sample `name`.
+    ExpectHistoryDelta { name: String },
+    /// Enter (`true`) or exit (`false`) tmux copy mode.
+    CopyMode { enabled: bool },
+    /// Block until the target process exits, up to `timeout_ms`.
+    WaitForExit { timeout_ms: u64 },
+    /// Invoke macro `name` with `args`; expanded away before execution.
+    Macro {
+        name: String,
+        args: BTreeMap<String, String>,
+    },
+}
+
+impl<'de> Deserialize<'de> for Step {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(StepVisitor)
+    }
+}
+
+/// serde visitor that maps a single-key JSON object to a [`Step`] variant.
+///
+/// The object must contain exactly one discriminator key for single-field
+/// steps. `expectCount` additionally requires `count`, and `macro` requires
+/// `args`.
+struct StepVisitor;
+
+impl<'de> Visitor<'de> for StepVisitor {
+    type Value = Step;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a step object with a single kind key")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        // Collect into a typed map keyed by field name. serde_json::Value is
+        // used only transiently here as a parse buffer; it never reaches the
+        // domain model (the returned Step is fully typed).
+        let mut entries: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+        while let Some(key) = map.next_key::<String>()? {
+            let value = map.next_value::<serde_json::Value>()?;
+            if entries.insert(key.clone(), value).is_some() {
+                return Err(de::Error::custom(format!(
+                    "invalid step: duplicate field '{key}' in step"
+                )));
+            }
+        }
+        dispatch_step(&mut entries).map_err(de::Error::custom)
+    }
+}
+
+/// Dispatch a parsed step-object map to the matching [`Step`] variant.
+///
+/// Takes the map by mutable reference so single-field variants can remove
+/// their discriminator and verify that no unexpected keys remain.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+fn dispatch_step(entries: &mut BTreeMap<String, serde_json::Value>) -> Result<Step, ScenarioError> {
+    // The discriminator is whichever key names a known primitive or macro.
+    let kind = step_kind(entries)?;
+    match kind.as_str() {
+        "wait" => single_u64(entries, "wait").map(|v| Step::Wait { milliseconds: v }),
+        "line" => single_string(entries, "line").map(|v| Step::Line { text: v }),
+        "key" => single_string(entries, "key").map(|v| Step::Key { key: v }),
+        "keys" => single_string_vec(entries, "keys").map(|v| Step::Keys { keys: v }),
+        "waitFor" => single_string(entries, "waitFor").map(|v| Step::WaitFor { pattern: v }),
+        "waitForNot" => {
+            single_string(entries, "waitForNot").map(|v| Step::WaitForNot { pattern: v })
+        }
+        "expect" => single_string(entries, "expect").map(|v| Step::Expect { pattern: v }),
+        "expectCount" => build_expect_count(entries),
+        "capture" => single_string(entries, "capture").map(|v| Step::Capture { name: v }),
+        "historySample" => {
+            single_string(entries, "historySample").map(|v| Step::HistorySample { name: v })
+        }
+        "expectHistoryDelta" => single_string(entries, "expectHistoryDelta")
+            .map(|v| Step::ExpectHistoryDelta { name: v }),
+        "copyMode" => single_bool(entries, "copyMode").map(|v| Step::CopyMode { enabled: v }),
+        "waitForExit" => {
+            single_u64(entries, "waitForExit").map(|v| Step::WaitForExit { timeout_ms: v })
+        }
+        "macro" => build_macro(entries),
+        other => Err(ScenarioError::UnknownStepKind {
+            kind: other.to_string(),
+        }),
+    }
+}
+
+/// Determine the discriminator key, rejecting multi-kind or empty step objects.
+fn step_kind(entries: &BTreeMap<String, serde_json::Value>) -> Result<String, ScenarioError> {
+    let known = [
+        "wait",
+        "line",
+        "key",
+        "keys",
+        "waitFor",
+        "waitForNot",
+        "expect",
+        "expectCount",
+        "capture",
+        "historySample",
+        "expectHistoryDelta",
+        "copyMode",
+        "waitForExit",
+        "macro",
+    ];
+    let matches: Vec<&str> = known
+        .iter()
+        .copied()
+        .filter(|k| entries.contains_key(*k))
+        .collect();
+    match matches.as_slice() {
+        [] => unknown_or_empty(entries),
+        [only] => Ok((*only).to_string()),
+        _ => Err(ScenarioError::InvalidStep {
+            reason: format!("step has multiple kind keys: {matches:?}"),
+        }),
+    }
+}
+
+/// Produce the error for a step object with no known kind key.
+fn unknown_or_empty(
+    entries: &BTreeMap<String, serde_json::Value>,
+) -> Result<String, ScenarioError> {
+    if let Some(key) = entries.keys().next() {
+        Err(ScenarioError::UnknownStepKind { kind: key.clone() })
+    } else {
+        Err(ScenarioError::InvalidStep {
+            reason: "step object is empty".to_string(),
+        })
+    }
+}
+
+/// Extract and remove a single u64 field, rejecting any extra keys.
+fn single_u64(
+    entries: &mut BTreeMap<String, serde_json::Value>,
+    field: &str,
+) -> Result<u64, ScenarioError> {
+    reject_extras(entries, field)?;
+    let value = entries.remove(field);
+    value.ok_or_else(|| missing_field(field)).and_then(json_u64)
+}
+
+/// Extract and remove a single string field, rejecting any extra keys.
+fn single_string(
+    entries: &mut BTreeMap<String, serde_json::Value>,
+    field: &str,
+) -> Result<String, ScenarioError> {
+    reject_extras(entries, field)?;
+    let value = entries.remove(field);
+    value
+        .ok_or_else(|| missing_field(field))
+        .and_then(json_string)
+}
+
+/// Extract and remove a single bool field, rejecting any extra keys.
+fn single_bool(
+    entries: &mut BTreeMap<String, serde_json::Value>,
+    field: &str,
+) -> Result<bool, ScenarioError> {
+    reject_extras(entries, field)?;
+    let value = entries.remove(field);
+    value
+        .ok_or_else(|| missing_field(field))
+        .and_then(json_bool)
+}
+
+/// Extract and remove a single string-array field, rejecting any extra keys.
+fn single_string_vec(
+    entries: &mut BTreeMap<String, serde_json::Value>,
+    field: &str,
+) -> Result<Vec<String>, ScenarioError> {
+    reject_extras(entries, field)?;
+    let value = entries.remove(field);
+    value
+        .ok_or_else(|| missing_field(field))
+        .and_then(json_string_vec)
+}
+
+/// Build the two-field `expectCount` step.
+fn build_expect_count(
+    entries: &mut BTreeMap<String, serde_json::Value>,
+) -> Result<Step, ScenarioError> {
+    reject_extras_multi(entries, &["expectCount", "count"])?;
+    let pattern = entries
+        .remove("expectCount")
+        .ok_or_else(|| missing_field("expectCount"))?;
+    let count = entries
+        .remove("count")
+        .ok_or_else(|| missing_field("count"))?;
+    Ok(Step::ExpectCount {
+        pattern: json_string(pattern)?,
+        count: json_u32(count)?,
+    })
+}
+
+/// Build the two-field `macro` invocation step.
+fn build_macro(entries: &mut BTreeMap<String, serde_json::Value>) -> Result<Step, ScenarioError> {
+    reject_extras_multi(entries, &["macro", "args"])?;
+    let name = entries
+        .remove("macro")
+        .ok_or_else(|| missing_field("macro"))?;
+    let args_val = entries
+        .remove("args")
+        .ok_or_else(|| missing_field("args"))?;
+    Ok(Step::Macro {
+        name: json_string(name)?,
+        args: json_args(args_val)?,
+    })
+}
+
+/// Reject any keys beyond `field`.
+fn reject_extras(
+    entries: &BTreeMap<String, serde_json::Value>,
+    field: &str,
+) -> Result<(), ScenarioError> {
+    if let Some(extra) = entries.keys().find(|k| k.as_str() != field) {
+        return Err(ScenarioError::InvalidStep {
+            reason: format!("unexpected key '{extra}' in step"),
+        });
+    }
+    Ok(())
+}
+
+/// Reject any keys beyond the provided allowed set.
+fn reject_extras_multi(
+    entries: &BTreeMap<String, serde_json::Value>,
+    allowed: &[&str],
+) -> Result<(), ScenarioError> {
+    for key in entries.keys() {
+        if !allowed.iter().any(|a| a == key) {
+            return Err(ScenarioError::InvalidStep {
+                reason: format!("unexpected key '{key}' in step"),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Coerce a JSON value to `u64` with a typed error.
+fn json_u64(value: serde_json::Value) -> Result<u64, ScenarioError> {
+    value.as_u64().ok_or_else(|| ScenarioError::InvalidStep {
+        reason: format!("expected a non-negative integer, got {value}"),
+    })
+}
+
+/// Coerce a JSON value to `u32` with a typed error, rejecting truncation.
+fn json_u32(value: serde_json::Value) -> Result<u32, ScenarioError> {
+    let raw = json_u64(value)?;
+    u32::try_from(raw).map_err(|_| ScenarioError::InvalidStep {
+        reason: format!("count {raw} exceeds u32 range"),
+    })
+}
+
+/// Coerce a JSON value to `String` with a typed error.
+fn json_string(value: serde_json::Value) -> Result<String, ScenarioError> {
+    value
+        .as_str()
+        .map(std::string::ToString::to_string)
+        .ok_or_else(|| ScenarioError::InvalidStep {
+            reason: format!("expected a string, got {value}"),
+        })
+}
+
+/// Coerce a JSON value to `bool` with a typed error.
+fn json_bool(value: serde_json::Value) -> Result<bool, ScenarioError> {
+    value.as_bool().ok_or_else(|| ScenarioError::InvalidStep {
+        reason: format!("expected a boolean, got {value}"),
+    })
+}
+
+/// Coerce a JSON array to `Vec<String>` with a typed error.
+fn json_string_vec(value: serde_json::Value) -> Result<Vec<String>, ScenarioError> {
+    value
+        .as_array()
+        .ok_or_else(|| ScenarioError::InvalidStep {
+            reason: format!("expected an array, got {value}"),
+        })
+        .and_then(|arr| {
+            arr.iter()
+                .map(|v| {
+                    v.as_str()
+                        .map(std::string::ToString::to_string)
+                        .ok_or_else(|| ScenarioError::InvalidStep {
+                            reason: format!("expected a string in array, got {v}"),
+                        })
+                })
+                .collect()
+        })
+}
+
+/// Coerce a JSON object to a macro-argument map.
+///
+/// Argument values are accepted as strings or non-string scalars and stored
+/// verbatim as their JSON text so raw substitution can splice them exactly.
+fn json_args(value: serde_json::Value) -> Result<BTreeMap<String, String>, ScenarioError> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| ScenarioError::InvalidStep {
+            reason: format!("expected an object for args, got {value}"),
+        })?;
+    let mut out = BTreeMap::new();
+    for (k, v) in obj {
+        out.insert(k.clone(), arg_to_string(v)?);
+    }
+    Ok(out)
+}
+
+/// Render a scalar argument to its raw substitution string.
+///
+/// Strings use their text; numbers and booleans use their JSON text so the
+/// splice is exact and unambiguous.
+fn arg_to_string(value: &serde_json::Value) -> Result<String, ScenarioError> {
+    match value {
+        serde_json::Value::String(s) => Ok(s.clone()),
+        serde_json::Value::Number(_) | serde_json::Value::Bool(_) => Ok(value.to_string()),
+        other => Err(ScenarioError::InvalidStep {
+            reason: format!("macro argument must be a scalar, got {other}"),
+        }),
+    }
+}
+
+/// Build a `MissingField` error for a step field.
+fn missing_field(field: &str) -> ScenarioError {
+    ScenarioError::MissingField {
+        field: field.to_string(),
+        context: "step".to_string(),
+    }
+}

--- a/src/harness/step.rs
+++ b/src/harness/step.rs
@@ -7,7 +7,7 @@
 //! @plan PLAN-20260629-TMUX-HARNESS.P01
 //! @requirement REQ-TMUX-HARNESS-001
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Deserialize;
 use serde::de::{self, MapAccess, Visitor};
@@ -56,6 +56,32 @@ pub enum Step {
     },
 }
 
+impl Step {
+    /// Validate semantic step arguments after deserialization.
+    ///
+    /// @plan PLAN-20260629-TMUX-HARNESS.P01
+    /// @requirement REQ-TMUX-HARNESS-001
+    pub fn validate(&self) -> Result<(), ScenarioError> {
+        match self {
+            Self::Key { key } => reject_empty("key", key),
+            Self::Keys { keys } => validate_keys(keys),
+            Self::WaitFor { pattern } => reject_empty("waitFor", pattern),
+            Self::WaitForNot { pattern } => reject_empty("waitForNot", pattern),
+            Self::Expect { pattern } | Self::ExpectCount { pattern, .. } => {
+                reject_empty("expect", pattern)
+            }
+            Self::Capture { name }
+            | Self::HistorySample { name }
+            | Self::ExpectHistoryDelta { name } => reject_empty("capture name", name),
+            Self::Macro { name, args } => validate_macro_invocation(name, args),
+            Self::Wait { .. }
+            | Self::Line { .. }
+            | Self::CopyMode { .. }
+            | Self::WaitForExit { .. } => Ok(()),
+        }
+    }
+}
+
 impl<'de> Deserialize<'de> for Step {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -65,11 +91,7 @@ impl<'de> Deserialize<'de> for Step {
     }
 }
 
-/// serde visitor that maps a single-key JSON object to a [`Step`] variant.
-///
-/// The object must contain exactly one discriminator key for single-field
-/// steps. `expectCount` additionally requires `count`, and `macro` requires
-/// `args`.
+/// serde visitor that maps a step object directly to typed fields.
 struct StepVisitor;
 
 impl<'de> Visitor<'de> for StepVisitor {
@@ -83,291 +105,335 @@ impl<'de> Visitor<'de> for StepVisitor {
     where
         A: MapAccess<'de>,
     {
-        // Collect into a typed map keyed by field name. serde_json::Value is
-        // used only transiently here as a parse buffer; it never reaches the
-        // domain model (the returned Step is fully typed).
-        let mut entries: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+        let mut parts = StepParts::default();
         while let Some(key) = map.next_key::<String>()? {
-            let value = map.next_value::<serde_json::Value>()?;
-            if entries.insert(key.clone(), value).is_some() {
+            parts.reject_duplicate::<A::Error>(&key)?;
+            read_step_field(&mut map, &mut parts, key)?;
+        }
+        parts.finish().map_err(de::Error::custom)
+    }
+}
+
+#[derive(Default)]
+struct StepParts {
+    seen: BTreeSet<String>,
+    core: Option<StepCore>,
+    count: Option<u32>,
+    args: Option<BTreeMap<String, String>>,
+}
+
+enum StepCore {
+    Wait(u64),
+    Line(String),
+    Key(String),
+    Keys(Vec<String>),
+    WaitFor(String),
+    WaitForNot(String),
+    Expect(String),
+    ExpectCount(String),
+    Capture(String),
+    HistorySample(String),
+    ExpectHistoryDelta(String),
+    CopyMode(bool),
+    WaitForExit(u64),
+    Macro(String),
+}
+
+impl StepParts {
+    fn reject_duplicate<E>(&mut self, key: &str) -> Result<(), E>
+    where
+        E: de::Error,
+    {
+        if !self.seen.insert(key.to_string()) {
+            return Err(E::custom(format!(
+                "invalid step: duplicate field '{key}' in step"
+            )));
+        }
+        Ok(())
+    }
+
+    fn set_core(&mut self, key: &str, core: StepCore) -> Result<(), ScenarioError> {
+        if self.core.is_some() {
+            return Err(ScenarioError::InvalidStep {
+                reason: format!("step has multiple kind keys including '{key}'"),
+            });
+        }
+        self.core = Some(core);
+        Ok(())
+    }
+
+    fn finish(self) -> Result<Step, ScenarioError> {
+        let Self {
+            seen: _,
+            core,
+            count,
+            args,
+        } = self;
+        match core.ok_or_else(missing_kind)? {
+            StepCore::Wait(milliseconds) => {
+                no_aux(count, args.as_ref()).map(|()| Step::Wait { milliseconds })
+            }
+            StepCore::Line(text) => no_aux(count, args.as_ref()).map(|()| Step::Line { text }),
+            StepCore::Key(key) => no_aux(count, args.as_ref()).map(|()| Step::Key { key }),
+            StepCore::Keys(keys) => no_aux(count, args.as_ref()).map(|()| Step::Keys { keys }),
+            StepCore::WaitFor(pattern) => {
+                no_aux(count, args.as_ref()).map(|()| Step::WaitFor { pattern })
+            }
+            StepCore::WaitForNot(pattern) => {
+                no_aux(count, args.as_ref()).map(|()| Step::WaitForNot { pattern })
+            }
+            StepCore::Expect(pattern) => {
+                no_aux(count, args.as_ref()).map(|()| Step::Expect { pattern })
+            }
+            StepCore::ExpectCount(pattern) => finish_expect_count(pattern, count, args),
+            StepCore::Capture(name) => {
+                no_aux(count, args.as_ref()).map(|()| Step::Capture { name })
+            }
+            StepCore::HistorySample(name) => {
+                no_aux(count, args.as_ref()).map(|()| Step::HistorySample { name })
+            }
+            StepCore::ExpectHistoryDelta(name) => {
+                no_aux(count, args.as_ref()).map(|()| Step::ExpectHistoryDelta { name })
+            }
+            StepCore::CopyMode(enabled) => {
+                no_aux(count, args.as_ref()).map(|()| Step::CopyMode { enabled })
+            }
+            StepCore::WaitForExit(timeout_ms) => {
+                no_aux(count, args.as_ref()).map(|()| Step::WaitForExit { timeout_ms })
+            }
+            StepCore::Macro(name) => finish_macro(name, args, count),
+        }
+    }
+}
+
+fn read_step_field<'de, A>(map: &mut A, parts: &mut StepParts, key: String) -> Result<(), A::Error>
+where
+    A: MapAccess<'de>,
+{
+    match key.as_str() {
+        "wait" => set_core(map, parts, &key, StepCore::Wait)?,
+        "line" => set_core(map, parts, &key, StepCore::Line)?,
+        "key" => set_core(map, parts, &key, StepCore::Key)?,
+        "keys" => set_core(map, parts, &key, StepCore::Keys)?,
+        "waitFor" => set_core(map, parts, &key, StepCore::WaitFor)?,
+        "waitForNot" => set_core(map, parts, &key, StepCore::WaitForNot)?,
+        "expect" => set_core(map, parts, &key, StepCore::Expect)?,
+        "expectCount" => set_core(map, parts, &key, StepCore::ExpectCount)?,
+        "capture" => set_core(map, parts, &key, StepCore::Capture)?,
+        "historySample" => set_core(map, parts, &key, StepCore::HistorySample)?,
+        "expectHistoryDelta" => set_core(map, parts, &key, StepCore::ExpectHistoryDelta)?,
+        "copyMode" => set_core(map, parts, &key, StepCore::CopyMode)?,
+        "waitForExit" => set_core(map, parts, &key, StepCore::WaitForExit)?,
+        "macro" => set_core(map, parts, &key, StepCore::Macro)?,
+        "count" => parts.count = Some(map.next_value()?),
+        "args" => parts.args = Some(map.next_value::<MacroArgs>()?.into_inner()),
+        other => {
+            return Err(de::Error::custom(ScenarioError::UnknownStepKind {
+                kind: other.to_string(),
+            }));
+        }
+    }
+    Ok(())
+}
+
+fn set_core<'de, A, T, F>(
+    map: &mut A,
+    parts: &mut StepParts,
+    key: &str,
+    make_core: F,
+) -> Result<(), A::Error>
+where
+    A: MapAccess<'de>,
+    T: Deserialize<'de>,
+    F: FnOnce(T) -> StepCore,
+{
+    let value = map.next_value::<T>()?;
+    parts
+        .set_core(key, make_core(value))
+        .map_err(de::Error::custom)
+}
+
+fn finish_expect_count(
+    pattern: String,
+    count: Option<u32>,
+    args: Option<BTreeMap<String, String>>,
+) -> Result<Step, ScenarioError> {
+    if args.is_some() {
+        return Err(unexpected_aux("args"));
+    }
+    let count = count.ok_or_else(|| missing_field("count"))?;
+    Ok(Step::ExpectCount { pattern, count })
+}
+
+fn finish_macro(
+    name: String,
+    args: Option<BTreeMap<String, String>>,
+    count: Option<u32>,
+) -> Result<Step, ScenarioError> {
+    if count.is_some() {
+        return Err(unexpected_aux("count"));
+    }
+    let args = args.ok_or_else(|| missing_field("args"))?;
+    Ok(Step::Macro { name, args })
+}
+
+#[derive(Debug)]
+struct MacroArgs(BTreeMap<String, String>);
+
+impl MacroArgs {
+    fn into_inner(self) -> BTreeMap<String, String> {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for MacroArgs {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(MacroArgsVisitor)
+    }
+}
+
+struct MacroArgsVisitor;
+
+impl<'de> Visitor<'de> for MacroArgsVisitor {
+    type Value = MacroArgs;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a macro args object with scalar argument values")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut args = BTreeMap::new();
+        while let Some(key) = map.next_key::<String>()? {
+            if args.contains_key(&key) {
                 return Err(de::Error::custom(format!(
-                    "invalid step: duplicate field '{key}' in step"
+                    "invalid step: duplicate macro argument '{key}'"
                 )));
             }
+            args.insert(key, map.next_value::<ScalarArg>()?.into_inner());
         }
-        dispatch_step(&mut entries).map_err(de::Error::custom)
+        Ok(MacroArgs(args))
     }
 }
 
-/// Dispatch a parsed step-object map to the matching [`Step`] variant.
-///
-/// Takes the map by mutable reference so single-field variants can remove
-/// their discriminator and verify that no unexpected keys remain.
-///
-/// @plan PLAN-20260629-TMUX-HARNESS.P01
-/// @requirement REQ-TMUX-HARNESS-001
-fn dispatch_step(entries: &mut BTreeMap<String, serde_json::Value>) -> Result<Step, ScenarioError> {
-    // The discriminator is whichever key names a known primitive or macro.
-    let kind = step_kind(entries)?;
-    match kind.as_str() {
-        "wait" => single_u64(entries, "wait").map(|v| Step::Wait { milliseconds: v }),
-        "line" => single_string(entries, "line").map(|v| Step::Line { text: v }),
-        "key" => single_string(entries, "key").map(|v| Step::Key { key: v }),
-        "keys" => single_string_vec(entries, "keys").map(|v| Step::Keys { keys: v }),
-        "waitFor" => single_string(entries, "waitFor").map(|v| Step::WaitFor { pattern: v }),
-        "waitForNot" => {
-            single_string(entries, "waitForNot").map(|v| Step::WaitForNot { pattern: v })
-        }
-        "expect" => single_string(entries, "expect").map(|v| Step::Expect { pattern: v }),
-        "expectCount" => build_expect_count(entries),
-        "capture" => single_string(entries, "capture").map(|v| Step::Capture { name: v }),
-        "historySample" => {
-            single_string(entries, "historySample").map(|v| Step::HistorySample { name: v })
-        }
-        "expectHistoryDelta" => single_string(entries, "expectHistoryDelta")
-            .map(|v| Step::ExpectHistoryDelta { name: v }),
-        "copyMode" => single_bool(entries, "copyMode").map(|v| Step::CopyMode { enabled: v }),
-        "waitForExit" => {
-            single_u64(entries, "waitForExit").map(|v| Step::WaitForExit { timeout_ms: v })
-        }
-        "macro" => build_macro(entries),
-        other => Err(ScenarioError::UnknownStepKind {
-            kind: other.to_string(),
-        }),
+struct ScalarArg(String);
+
+impl ScalarArg {
+    fn into_inner(self) -> String {
+        self.0
     }
 }
 
-/// Determine the discriminator key, rejecting multi-kind or empty step objects.
-fn step_kind(entries: &BTreeMap<String, serde_json::Value>) -> Result<String, ScenarioError> {
-    let known = [
-        "wait",
-        "line",
-        "key",
-        "keys",
-        "waitFor",
-        "waitForNot",
-        "expect",
-        "expectCount",
-        "capture",
-        "historySample",
-        "expectHistoryDelta",
-        "copyMode",
-        "waitForExit",
-        "macro",
-    ];
-    let matches: Vec<&str> = known
-        .iter()
-        .copied()
-        .filter(|k| entries.contains_key(*k))
-        .collect();
-    match matches.as_slice() {
-        [] => unknown_or_empty(entries),
-        [only] => Ok((*only).to_string()),
-        _ => Err(ScenarioError::InvalidStep {
-            reason: format!("step has multiple kind keys: {matches:?}"),
-        }),
+impl<'de> Deserialize<'de> for ScalarArg {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(ScalarArgVisitor)
     }
 }
 
-/// Produce the error for a step object with no known kind key.
-fn unknown_or_empty(
-    entries: &BTreeMap<String, serde_json::Value>,
-) -> Result<String, ScenarioError> {
-    if let Some(key) = entries.keys().next() {
-        Err(ScenarioError::UnknownStepKind { kind: key.clone() })
-    } else {
-        Err(ScenarioError::InvalidStep {
-            reason: "step object is empty".to_string(),
-        })
+struct ScalarArgVisitor;
+
+impl Visitor<'_> for ScalarArgVisitor {
+    type Value = ScalarArg;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a string, number, or boolean macro argument")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(ScalarArg(value.to_string()))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(ScalarArg(value.to_string()))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(ScalarArg(value.to_string()))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E> {
+        let text = if value.is_finite() && value.fract() == 0.0 {
+            format!("{value:.1}")
+        } else {
+            value.to_string()
+        };
+        Ok(ScalarArg(text))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(ScalarArg(value.to_string()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(ScalarArg(value))
     }
 }
 
-/// Extract and remove a single u64 field, rejecting any extra keys.
-fn single_u64(
-    entries: &mut BTreeMap<String, serde_json::Value>,
-    field: &str,
-) -> Result<u64, ScenarioError> {
-    reject_extras(entries, field)?;
-    let value = entries.remove(field);
-    value.ok_or_else(|| missing_field(field)).and_then(json_u64)
-}
-
-/// Extract and remove a single string field, rejecting any extra keys.
-fn single_string(
-    entries: &mut BTreeMap<String, serde_json::Value>,
-    field: &str,
-) -> Result<String, ScenarioError> {
-    reject_extras(entries, field)?;
-    let value = entries.remove(field);
-    value
-        .ok_or_else(|| missing_field(field))
-        .and_then(json_string)
-}
-
-/// Extract and remove a single bool field, rejecting any extra keys.
-fn single_bool(
-    entries: &mut BTreeMap<String, serde_json::Value>,
-    field: &str,
-) -> Result<bool, ScenarioError> {
-    reject_extras(entries, field)?;
-    let value = entries.remove(field);
-    value
-        .ok_or_else(|| missing_field(field))
-        .and_then(json_bool)
-}
-
-/// Extract and remove a single string-array field, rejecting any extra keys.
-fn single_string_vec(
-    entries: &mut BTreeMap<String, serde_json::Value>,
-    field: &str,
-) -> Result<Vec<String>, ScenarioError> {
-    reject_extras(entries, field)?;
-    let value = entries.remove(field);
-    value
-        .ok_or_else(|| missing_field(field))
-        .and_then(json_string_vec)
-}
-
-/// Build the two-field `expectCount` step.
-fn build_expect_count(
-    entries: &mut BTreeMap<String, serde_json::Value>,
-) -> Result<Step, ScenarioError> {
-    reject_extras_multi(entries, &["expectCount", "count"])?;
-    let pattern = entries
-        .remove("expectCount")
-        .ok_or_else(|| missing_field("expectCount"))?;
-    let count = entries
-        .remove("count")
-        .ok_or_else(|| missing_field("count"))?;
-    Ok(Step::ExpectCount {
-        pattern: json_string(pattern)?,
-        count: json_u32(count)?,
-    })
-}
-
-/// Build the two-field `macro` invocation step.
-fn build_macro(entries: &mut BTreeMap<String, serde_json::Value>) -> Result<Step, ScenarioError> {
-    reject_extras_multi(entries, &["macro", "args"])?;
-    let name = entries
-        .remove("macro")
-        .ok_or_else(|| missing_field("macro"))?;
-    let args_val = entries
-        .remove("args")
-        .ok_or_else(|| missing_field("args"))?;
-    Ok(Step::Macro {
-        name: json_string(name)?,
-        args: json_args(args_val)?,
-    })
-}
-
-/// Reject any keys beyond `field`.
-fn reject_extras(
-    entries: &BTreeMap<String, serde_json::Value>,
-    field: &str,
-) -> Result<(), ScenarioError> {
-    if let Some(extra) = entries.keys().find(|k| k.as_str() != field) {
+fn reject_empty(field: &str, value: &str) -> Result<(), ScenarioError> {
+    if value.is_empty() {
         return Err(ScenarioError::InvalidStep {
-            reason: format!("unexpected key '{extra}' in step"),
+            reason: format!("{field} must not be empty"),
         });
     }
     Ok(())
 }
 
-/// Reject any keys beyond the provided allowed set.
-fn reject_extras_multi(
-    entries: &BTreeMap<String, serde_json::Value>,
-    allowed: &[&str],
-) -> Result<(), ScenarioError> {
-    for key in entries.keys() {
-        if !allowed.iter().any(|a| a == key) {
-            return Err(ScenarioError::InvalidStep {
-                reason: format!("unexpected key '{key}' in step"),
-            });
-        }
+fn validate_keys(keys: &[String]) -> Result<(), ScenarioError> {
+    if keys.is_empty() {
+        return Err(ScenarioError::InvalidStep {
+            reason: "keys must contain at least one key".to_string(),
+        });
+    }
+    for key in keys {
+        reject_empty("keys item", key)?;
     }
     Ok(())
 }
 
-/// Coerce a JSON value to `u64` with a typed error.
-fn json_u64(value: serde_json::Value) -> Result<u64, ScenarioError> {
-    value.as_u64().ok_or_else(|| ScenarioError::InvalidStep {
-        reason: format!("expected a non-negative integer, got {value}"),
-    })
-}
-
-/// Coerce a JSON value to `u32` with a typed error, rejecting truncation.
-fn json_u32(value: serde_json::Value) -> Result<u32, ScenarioError> {
-    let raw = json_u64(value)?;
-    u32::try_from(raw).map_err(|_| ScenarioError::InvalidStep {
-        reason: format!("count {raw} exceeds u32 range"),
-    })
-}
-
-/// Coerce a JSON value to `String` with a typed error.
-fn json_string(value: serde_json::Value) -> Result<String, ScenarioError> {
-    value
-        .as_str()
-        .map(std::string::ToString::to_string)
-        .ok_or_else(|| ScenarioError::InvalidStep {
-            reason: format!("expected a string, got {value}"),
-        })
-}
-
-/// Coerce a JSON value to `bool` with a typed error.
-fn json_bool(value: serde_json::Value) -> Result<bool, ScenarioError> {
-    value.as_bool().ok_or_else(|| ScenarioError::InvalidStep {
-        reason: format!("expected a boolean, got {value}"),
-    })
-}
-
-/// Coerce a JSON array to `Vec<String>` with a typed error.
-fn json_string_vec(value: serde_json::Value) -> Result<Vec<String>, ScenarioError> {
-    value
-        .as_array()
-        .ok_or_else(|| ScenarioError::InvalidStep {
-            reason: format!("expected an array, got {value}"),
-        })
-        .and_then(|arr| {
-            arr.iter()
-                .map(|v| {
-                    v.as_str()
-                        .map(std::string::ToString::to_string)
-                        .ok_or_else(|| ScenarioError::InvalidStep {
-                            reason: format!("expected a string in array, got {v}"),
-                        })
-                })
-                .collect()
-        })
-}
-
-/// Coerce a JSON object to a macro-argument map.
-///
-/// Argument values are accepted as strings or non-string scalars and stored
-/// verbatim as their JSON text so raw substitution can splice them exactly.
-fn json_args(value: serde_json::Value) -> Result<BTreeMap<String, String>, ScenarioError> {
-    let obj = value
-        .as_object()
-        .ok_or_else(|| ScenarioError::InvalidStep {
-            reason: format!("expected an object for args, got {value}"),
-        })?;
-    let mut out = BTreeMap::new();
-    for (k, v) in obj {
-        out.insert(k.clone(), arg_to_string(v)?);
+fn no_aux(
+    count: Option<u32>,
+    args: Option<&BTreeMap<String, String>>,
+) -> Result<(), ScenarioError> {
+    if count.is_some() {
+        return Err(unexpected_aux("count"));
     }
-    Ok(out)
+    if args.is_some() {
+        return Err(unexpected_aux("args"));
+    }
+    Ok(())
 }
 
-/// Render a scalar argument to its raw substitution string.
-///
-/// Strings use their text; numbers and booleans use their JSON text so the
-/// splice is exact and unambiguous.
-fn arg_to_string(value: &serde_json::Value) -> Result<String, ScenarioError> {
-    match value {
-        serde_json::Value::String(s) => Ok(s.clone()),
-        serde_json::Value::Number(_) | serde_json::Value::Bool(_) => Ok(value.to_string()),
-        other => Err(ScenarioError::InvalidStep {
-            reason: format!("macro argument must be a scalar, got {other}"),
-        }),
+fn unexpected_aux(field: &str) -> ScenarioError {
+    ScenarioError::InvalidStep {
+        reason: format!("unexpected key '{field}' in step"),
+    }
+}
+
+fn validate_macro_invocation(
+    name: &str,
+    args: &BTreeMap<String, String>,
+) -> Result<(), ScenarioError> {
+    reject_empty("macro name", name)?;
+    for key in args.keys() {
+        reject_empty("macro argument name", key)?;
+    }
+    Ok(())
+}
+
+fn missing_kind() -> ScenarioError {
+    ScenarioError::InvalidStep {
+        reason: "step object is missing a step kind".to_string(),
     }
 }
 

--- a/src/harness/tests.rs
+++ b/src/harness/tests.rs
@@ -338,6 +338,58 @@ fn duplicate_multi_field_step_keys_are_rejected() {
     );
 }
 
+/// Empty key names are rejected during semantic validation.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn empty_key_is_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "steps": [ { "key": "" } ]
+    }"#;
+    let err = error_or_panic(parse_scenario(json), "empty key should fail");
+    assert!(matches!(
+        err,
+        ScenarioError::InvalidStep { ref reason } if reason.contains("key")
+    ));
+}
+
+/// Empty key arrays are rejected during semantic validation.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn empty_keys_array_is_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "steps": [ { "keys": [] } ]
+    }"#;
+    let err = error_or_panic(parse_scenario(json), "empty keys array should fail");
+    assert!(matches!(
+        err,
+        ScenarioError::InvalidStep { ref reason } if reason.contains("keys")
+    ));
+}
+
+/// Duplicate macro names are rejected before a map can overwrite earlier definitions.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn duplicate_macro_names_are_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "dup": { "params": [], "steps": [ { "line": "first" } ] },
+            "dup": { "params": [], "steps": [ { "line": "second" } ] }
+        },
+        "steps": []
+    }"#;
+    let err = error_or_panic(parse_scenario(json), "duplicate macro names should fail");
+    assert!(matches!(err, ScenarioError::Json { .. }), "got {err:?}");
+}
+
 /// A macro definition missing `steps` yields a typed missing-field error.
 ///
 /// @plan PLAN-20260629-TMUX-HARNESS.P01
@@ -398,13 +450,7 @@ fn malformed_json_is_rejected() {
 fn invalid_assert_mode_is_rejected() {
     let json = r#"{ "config": { "cols": 80, "rows": 24, "assert_mode": "loud" }, "steps": [] }"#;
     let err = error_or_panic(parse_scenario(json), "bad assert_mode should fail");
-    assert!(
-        matches!(
-            err,
-            ScenarioError::Json { .. } | ScenarioError::MissingField { .. }
-        ),
-        "got {err:?}"
-    );
+    assert!(matches!(err, ScenarioError::Json { .. }), "got {err:?}");
 }
 
 // ---------------------------------------------------------------------------
@@ -571,6 +617,28 @@ fn macro_substitutes_raw_nonstring_values() {
         Step::Line { text } if text == "count=42"
     ));
 }
+
+/// Macro substitution preserves the visible decimal point for integral floats.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn macro_substitutes_integral_float_with_decimal_point() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "say": { "params": ["n"], "steps": [ { "line": "count=$n" } ] }
+        },
+        "steps": [ { "macro": "say", "args": { "n": 1.0 } } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let expanded = expand_macros(&scenario).value_or_panic("should expand");
+
+    assert!(matches!(
+        &expanded.steps[0],
+        Step::Line { text } if text == "count=1.0"
+    ));
+}
 /// Unknown placeholders are preserved rather than partially substituting prefixes.
 ///
 /// @plan PLAN-20260629-TMUX-HARNESS.P01
@@ -664,6 +732,57 @@ fn nested_macro_substitutes_outer_args() {
     ));
 }
 
+/// Macro expansion rejects substituted concrete steps that violate semantic validation.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn macro_expansion_rejects_semantically_invalid_substituted_step() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "press": { "params": ["k"], "steps": [ { "key": "$k" } ] }
+        },
+        "steps": [ { "macro": "press", "args": { "k": "" } } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse before expansion");
+    let err = error_or_panic(expand_macros(&scenario), "invalid expansion should fail");
+
+    assert!(matches!(
+        err,
+        ScenarioError::InvalidStep { ref reason } if reason.contains("key")
+    ));
+}
+/// Programmatically constructed invalid macro invocations cannot bypass expansion validation.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn expand_macros_validates_macro_invocation_steps() {
+    let scenario = Scenario {
+        config: ScenarioConfig {
+            cols: 80,
+            rows: 24,
+            history_limit: 10_000,
+            initial_wait_ms: 0,
+            out_dir: None,
+            keep_session: false,
+            assert_mode: AssertMode::Strict,
+        },
+        macros: std::collections::BTreeMap::new(),
+        steps: vec![Step::Macro {
+            name: String::new(),
+            args: std::collections::BTreeMap::new(),
+        }],
+    };
+
+    let err = error_or_panic(expand_macros(&scenario), "invalid macro step should fail");
+    assert!(matches!(
+        err,
+        ScenarioError::InvalidStep { ref reason } if reason.contains("macro name")
+    ));
+}
+
 /// Multiple top-level steps, with a macro in the middle, expand in order.
 ///
 /// @plan PLAN-20260629-TMUX-HARNESS.P01
@@ -707,6 +826,13 @@ fn expansion_is_idempotent() {
     let scenario = parse_scenario(json).value_or_panic("should parse");
     let once = expand_macros(&scenario).value_or_panic("first expand");
     let twice = expand_macros(&once).value_or_panic("second expand");
-    assert_eq!(once.steps.len(), 1);
-    assert_eq!(twice.steps.len(), 1);
+    assert_eq!(scenario.steps.len(), 1);
+    assert!(matches!(&scenario.steps[0], Step::Macro { name, .. } if name == "greet"));
+    assert_eq!(
+        once.steps,
+        vec![Step::Line {
+            text: "z".to_string()
+        }]
+    );
+    assert_eq!(twice.steps, once.steps);
 }

--- a/src/harness/tests.rs
+++ b/src/harness/tests.rs
@@ -1,0 +1,712 @@
+//! Behavioral tests for the pure harness scenario layer.
+//!
+//! RED phase: these tests define the typed scenario model, JSON parsing,
+//! validation, and macro-expansion contracts before implementation.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P01
+//! @requirement REQ-TMUX-HARNESS-001
+
+use super::*;
+
+/// Test-only helper: unwrap a `Result::Ok` or panic with context.
+///
+/// Mirrors the pattern in `src/github/tests.rs` to avoid `expect_used`.
+trait TestResultExt<T> {
+    fn value_or_panic(self, context: &str) -> T;
+}
+
+impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
+    fn value_or_panic(self, context: &str) -> T {
+        match self {
+            Ok(value) => value,
+            Err(error) => panic!("{context}: {error:?}"),
+        }
+    }
+}
+
+/// Test-only helper: assert a `Result::Err` or panic.
+fn error_or_panic<T: std::fmt::Debug, E>(result: Result<T, E>, context: &str) -> E {
+    match result {
+        Err(error) => error,
+        Ok(value) => panic!("{context}: unexpectedly succeeded with {value:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Known-good scenario deserialization
+// ---------------------------------------------------------------------------
+
+/// A minimal valid scenario with a config block and a single `wait` step
+/// deserializes into the expected typed `Scenario`.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn parses_minimal_valid_scenario() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "steps": [ { "wait": 100 } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("minimal scenario should parse");
+
+    assert_eq!(scenario.config.cols, 80);
+    assert_eq!(scenario.config.rows, 24);
+    assert_eq!(scenario.steps.len(), 1);
+    assert!(matches!(
+        scenario.steps[0],
+        Step::Wait { milliseconds } if milliseconds == 100
+    ));
+}
+
+/// A scenario using every step primitive parses into its typed variant.
+///
+/// Exercises the full `Step` surface so a missing/renamed variant is caught.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn parses_every_step_primitive() {
+    let json = r#"{
+        "config": { "cols": 120, "rows": 40, "history_limit": 5000 },
+        "steps": [
+            { "wait": 50 },
+            { "line": "echo hello" },
+            { "key": "Enter" },
+            { "keys": ["a", "b"] },
+            { "waitFor": "prompt>" },
+            { "waitForNot": "loading" },
+            { "expect": "done" },
+            { "expectCount": "x", "count": 3 },
+            { "capture": "shot1" },
+            { "historySample": "hist1" },
+            { "expectHistoryDelta": "diff1" },
+            { "copyMode": true },
+            { "waitForExit": 5000 }
+        ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("full scenario should parse");
+
+    assert_eq!(scenario.steps.len(), 13);
+    assert_timing_steps(&scenario.steps);
+    assert_text_steps(&scenario.steps);
+    assert_pattern_steps(&scenario.steps);
+    assert_capture_and_mode_steps(&scenario.steps);
+}
+
+/// Assert wait/waitForExit variants.
+fn assert_timing_steps(steps: &[Step]) {
+    assert!(matches!(&steps[0], Step::Wait { milliseconds } if *milliseconds == 50));
+    assert!(matches!(
+        &steps[12],
+        Step::WaitForExit { timeout_ms } if *timeout_ms == 5000
+    ));
+}
+
+/// Assert line/key/keys variants.
+fn assert_text_steps(steps: &[Step]) {
+    assert!(matches!(&steps[1], Step::Line { text } if text == "echo hello"));
+    assert!(matches!(&steps[2], Step::Key { key } if key == "Enter"));
+    assert!(matches!(
+        &steps[3],
+        Step::Keys { keys } if keys.as_slice() == ["a", "b"]
+    ));
+}
+
+/// Assert waitFor/waitForNot/expect/expectCount variants.
+fn assert_pattern_steps(steps: &[Step]) {
+    assert!(matches!(&steps[4], Step::WaitFor { pattern } if pattern == "prompt>"));
+    assert!(matches!(&steps[5], Step::WaitForNot { pattern } if pattern == "loading"));
+    assert!(matches!(&steps[6], Step::Expect { pattern } if pattern == "done"));
+    assert!(matches!(
+        &steps[7],
+        Step::ExpectCount { pattern, count } if pattern == "x" && *count == 3
+    ));
+}
+
+/// Assert capture/historySample/expectHistoryDelta/copyMode variants.
+fn assert_capture_and_mode_steps(steps: &[Step]) {
+    assert!(matches!(&steps[8], Step::Capture { name } if name == "shot1"));
+    assert!(matches!(&steps[9], Step::HistorySample { name } if name == "hist1"));
+    assert!(matches!(
+        &steps[10],
+        Step::ExpectHistoryDelta { name } if name == "diff1"
+    ));
+    assert!(matches!(&steps[11], Step::CopyMode { enabled } if *enabled));
+}
+
+/// Config defaults apply when optional fields are omitted.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn config_defaults_when_optional_fields_omitted() {
+    let json = r#"{ "config": { "cols": 80, "rows": 24 }, "steps": [] }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    assert_eq!(scenario.config.assert_mode, AssertMode::Strict);
+    assert!(!scenario.config.keep_session);
+    assert!(scenario.config.out_dir.is_none());
+    assert_eq!(scenario.config.history_limit, 10_000);
+    assert_eq!(scenario.config.initial_wait_ms, 0);
+}
+
+/// `assert_mode` accepts the typed enum values.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn config_parses_assert_mode() {
+    let json = r#"{ "config": { "cols": 80, "rows": 24, "assert_mode": "soft" }, "steps": [] }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    assert_eq!(scenario.config.assert_mode, AssertMode::Soft);
+}
+
+// ---------------------------------------------------------------------------
+// Malformed scenarios -> typed errors
+// ---------------------------------------------------------------------------
+
+/// An unrecognized step kind yields `ScenarioError::UnknownStepKind`.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn unknown_step_kind_is_rejected() {
+    let json = r#"{ "config": { "cols": 80, "rows": 24 }, "steps": [ { "fly": true } ] }"#;
+    let err = error_or_panic(parse_scenario(json), "unknown step should fail");
+    assert!(matches!(err, ScenarioError::UnknownStepKind { ref kind } if kind == "fly"));
+}
+
+/// A missing required config field (`cols`) yields a typed parse error.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn missing_config_field_is_rejected() {
+    let json = r#"{ "config": { "rows": 24 }, "steps": [] }"#;
+    let err = error_or_panic(parse_scenario(json), "missing cols should fail");
+    assert!(
+        matches!(err, ScenarioError::MissingField { .. }),
+        "got {err:?}"
+    );
+}
+
+/// A zero column count yields `ScenarioError::InvalidConfig`.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn zero_cols_is_rejected() {
+    let json = r#"{ "config": { "cols": 0, "rows": 24 }, "steps": [] }"#;
+    let err = error_or_panic(parse_scenario(json), "zero cols should fail");
+    assert!(
+        matches!(err, ScenarioError::InvalidConfig { .. }),
+        "got {err:?}"
+    );
+}
+
+/// A zero row count yields `ScenarioError::InvalidConfig`.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn zero_rows_is_rejected() {
+    let json = r#"{ "config": { "cols": 80, "rows": 0 }, "steps": [] }"#;
+    let err = error_or_panic(parse_scenario(json), "zero rows should fail");
+    assert!(
+        matches!(err, ScenarioError::InvalidConfig { .. }),
+        "got {err:?}"
+    );
+}
+
+/// A missing `count` field in `expectCount` yields a typed missing-field error.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn missing_expect_count_count_is_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "steps": [ { "expectCount": "done" } ]
+    }"#;
+    let err = error_or_panic(parse_scenario(json), "missing count should fail");
+    assert!(matches!(
+        err,
+        ScenarioError::MissingField { ref field, ref context }
+            if field == "count" && context == "step"
+    ));
+}
+
+/// Unknown config keys are rejected so typos do not silently change scenarios.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn unknown_config_field_is_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24, "colz": 80 },
+        "steps": []
+    }"#;
+    let err = error_or_panic(parse_scenario(json), "unknown config key should fail");
+    assert!(matches!(err, ScenarioError::Json { .. }), "got {err:?}");
+}
+
+/// A zero history limit is rejected as an out-of-range config value.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn zero_history_limit_is_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24, "history_limit": 0 },
+        "steps": []
+    }"#;
+    let err = error_or_panic(parse_scenario(json), "zero history limit should fail");
+    assert!(matches!(
+        err,
+        ScenarioError::InvalidConfig { ref field, .. } if field == "history_limit"
+    ));
+}
+
+/// A missing `args` field in a macro invocation yields a typed missing-field error.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn missing_macro_args_field_is_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "steps": [ { "macro": "greet" } ]
+    }"#;
+    let err = error_or_panic(parse_scenario(json), "missing macro args should fail");
+    assert!(matches!(
+        err,
+        ScenarioError::MissingField { ref field, ref context }
+            if field == "args" && context == "step"
+    ));
+}
+
+/// A macro definition missing `params` yields a typed missing-field error.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn missing_macro_definition_params_is_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "bad": { "steps": [ { "line": "x" } ] }
+        },
+        "steps": []
+    }"#;
+
+    let err = error_or_panic(parse_scenario(json), "missing macro params should fail");
+    assert!(matches!(
+        err,
+        ScenarioError::MissingField { ref field, ref context }
+            if field == "params" && context == "macro"
+    ));
+}
+
+/// Duplicate fields in a single-field step are rejected.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn duplicate_single_field_step_keys_are_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "steps": [ { "line": "first", "line": "second" } ]
+    }"#;
+    let err = error_or_panic(parse_scenario(json), "duplicate step key should fail");
+    assert!(
+        matches!(err, ScenarioError::InvalidStep { ref reason } if reason.contains("duplicate field"))
+    );
+}
+
+/// Duplicate auxiliary fields in a multi-field step are rejected.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn duplicate_multi_field_step_keys_are_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "steps": [ { "expectCount": "done", "count": 1, "count": 2 } ]
+    }"#;
+    let err = error_or_panic(parse_scenario(json), "duplicate auxiliary key should fail");
+    assert!(
+        matches!(err, ScenarioError::InvalidStep { ref reason } if reason.contains("duplicate field"))
+    );
+}
+
+/// A macro definition missing `steps` yields a typed missing-field error.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn missing_macro_definition_steps_is_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "bad": { "params": [] }
+        },
+        "steps": []
+    }"#;
+    let err = error_or_panic(parse_scenario(json), "missing macro steps should fail");
+    assert!(matches!(
+        err,
+        ScenarioError::MissingField { ref field, ref context }
+            if field == "steps" && context == "macro"
+    ));
+}
+
+/// Duplicate parameter names in a macro definition are rejected during validation.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn duplicate_macro_definition_params_are_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "bad": { "params": ["name", "name"], "steps": [ { "line": "$name" } ] }
+        },
+        "steps": []
+    }"#;
+    let err = error_or_panic(parse_scenario(json), "duplicate params should fail");
+    assert!(matches!(
+        err,
+        ScenarioError::InvalidMacro { ref name, ref reason }
+            if name == "bad" && reason.contains("duplicate parameter")
+    ));
+}
+
+/// Malformed JSON yields a typed JSON error, not a panic.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn malformed_json_is_rejected() {
+    let err = error_or_panic(parse_scenario("{ not json"), "malformed json should fail");
+    assert!(matches!(err, ScenarioError::Json { .. }), "got {err:?}");
+}
+
+/// An invalid `assert_mode` value yields a typed parse error.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn invalid_assert_mode_is_rejected() {
+    let json = r#"{ "config": { "cols": 80, "rows": 24, "assert_mode": "loud" }, "steps": [] }"#;
+    let err = error_or_panic(parse_scenario(json), "bad assert_mode should fail");
+    assert!(
+        matches!(
+            err,
+            ScenarioError::Json { .. } | ScenarioError::MissingField { .. }
+        ),
+        "got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Macro expansion
+// ---------------------------------------------------------------------------
+
+/// A macro invocation expands to its body with parameter substitution.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn expands_simple_macro_substitution() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "greet": {
+                "params": ["who"],
+                "steps": [ { "line": "$who" }, { "key": "Enter" } ]
+            }
+        },
+        "steps": [ { "macro": "greet", "args": { "who": "world" } } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let expanded = expand_macros(&scenario).value_or_panic("should expand");
+
+    assert_eq!(expanded.steps.len(), 2, "macro body has 2 steps");
+    assert!(matches!(
+        &expanded.steps[0],
+        Step::Line { text } if text == "world"
+    ));
+    assert!(matches!(&expanded.steps[1], Step::Key { key } if key == "Enter"));
+}
+
+/// A macro invocation with the right count but wrong argument name yields MissingMacroArg.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn wrong_macro_arg_name_is_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "greet": {
+                "params": ["who"],
+                "steps": [ { "line": "$who" } ]
+            }
+        },
+        "steps": [ { "macro": "greet", "args": { "what": "world" } } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let err = error_or_panic(expand_macros(&scenario), "wrong arg name should fail");
+    assert!(matches!(
+        err,
+        ScenarioError::MissingMacroArg { ref name, ref param }
+            if name == "greet" && param == "who"
+    ));
+}
+
+/// An unknown macro name yields `ScenarioError::UnknownMacro`.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn unknown_macro_is_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "steps": [ { "macro": "nope", "args": {} } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let err = error_or_panic(expand_macros(&scenario), "unknown macro should fail");
+    assert!(matches!(
+        err,
+        ScenarioError::UnknownMacro { ref name } if name == "nope"
+    ));
+}
+
+/// A macro invocation with a missing argument yields
+/// `ScenarioError::MacroArityMismatch`.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn missing_macro_arg_is_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "greet": {
+                "params": ["who"],
+                "steps": [ { "line": "$who" } ]
+            }
+        },
+        "steps": [ { "macro": "greet", "args": {} } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let err = error_or_panic(expand_macros(&scenario), "missing arg should fail");
+    assert!(
+        matches!(err, ScenarioError::MacroArityMismatch { .. }),
+        "got {err:?}"
+    );
+}
+
+/// A macro invocation with too many arguments yields
+/// `ScenarioError::MacroArityMismatch`.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn extra_macro_arg_is_rejected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "ping": { "params": [], "steps": [ { "line": "pong" } ] }
+        },
+        "steps": [ { "macro": "ping", "args": { "surprise": "1" } } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let err = error_or_panic(expand_macros(&scenario), "extra arg should fail");
+    assert!(
+        matches!(err, ScenarioError::MacroArityMismatch { .. }),
+        "got {err:?}"
+    );
+}
+
+/// A macro cycle yields `ScenarioError::MacroCycle`.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn macro_cycle_is_detected() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "a": { "params": [], "steps": [ { "macro": "b", "args": {} } ] },
+            "b": { "params": [], "steps": [ { "macro": "a", "args": {} } ] }
+        },
+        "steps": [ { "macro": "a", "args": {} } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let err = error_or_panic(expand_macros(&scenario), "cycle should fail");
+    assert!(
+        matches!(err, ScenarioError::MacroCycle { .. }),
+        "got {err:?}"
+    );
+}
+
+/// Macro substitution is exact/raw: a non-string argument value (here a JSON
+/// number) is spliced verbatim into a text field without reinterpretation.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn macro_substitutes_raw_nonstring_values() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "say": { "params": ["n"], "steps": [ { "line": "count=$n" } ] }
+        },
+        "steps": [ { "macro": "say", "args": { "n": 42 } } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let expanded = expand_macros(&scenario).value_or_panic("should expand");
+    assert!(matches!(
+        &expanded.steps[0],
+        Step::Line { text } if text == "count=42"
+    ));
+}
+/// Unknown placeholders are preserved rather than partially substituting prefixes.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn macro_preserves_unknown_placeholder_prefixes() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "say": { "params": ["n"], "steps": [ { "line": "$name and $n" } ] }
+        },
+        "steps": [ { "macro": "say", "args": { "n": "42" } } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let expanded = expand_macros(&scenario).value_or_panic("should expand");
+    assert!(matches!(
+        &expanded.steps[0],
+        Step::Line { text } if text == "$name and 42"
+    ));
+}
+
+/// Longest matching parameter names win when placeholders share a prefix.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn macro_uses_longest_placeholder_match() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "say": { "params": ["n", "name"], "steps": [ { "line": "$name/$n" } ] }
+        },
+        "steps": [ { "macro": "say", "args": { "n": "42", "name": "alice" } } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let expanded = expand_macros(&scenario).value_or_panic("should expand");
+    assert!(matches!(
+        &expanded.steps[0],
+        Step::Line { text } if text == "alice/42"
+    ));
+}
+
+/// A literal dollar sign remains literal when not followed by a parameter name.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn macro_preserves_literal_dollar_text() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "say": { "params": ["n"], "steps": [ { "line": "cost $$ then $n" } ] }
+        },
+        "steps": [ { "macro": "say", "args": { "n": "42" } } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let expanded = expand_macros(&scenario).value_or_panic("should expand");
+    assert!(matches!(
+        &expanded.steps[0],
+        Step::Line { text } if text == "cost $$ then 42"
+    ));
+}
+
+/// Nested macro invocations receive the outer macro's substituted arguments.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn nested_macro_substitutes_outer_args() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "inner": {
+                "params": ["message"],
+                "steps": [ { "line": "$message" } ]
+            },
+            "outer": {
+                "params": ["who"],
+                "steps": [ { "macro": "inner", "args": { "message": "hello $who" } } ]
+            }
+        },
+        "steps": [ { "macro": "outer", "args": { "who": "world" } } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let expanded = expand_macros(&scenario).value_or_panic("should expand nested macros");
+
+    assert_eq!(expanded.steps.len(), 1);
+    assert!(matches!(
+        &expanded.steps[0],
+        Step::Line { text } if text == "hello world"
+    ));
+}
+
+/// Multiple top-level steps, with a macro in the middle, expand in order.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn expands_macros_preserving_order() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "two": { "params": [], "steps": [ { "line": "x" }, { "line": "y" } ] }
+        },
+        "steps": [
+            { "line": "before" },
+            { "macro": "two", "args": {} },
+            { "line": "after" }
+        ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let expanded = expand_macros(&scenario).value_or_panic("should expand");
+    assert_eq!(expanded.steps.len(), 4);
+    assert!(matches!(&expanded.steps[0], Step::Line { text } if text == "before"));
+    assert!(matches!(&expanded.steps[1], Step::Line { text } if text == "x"));
+    assert!(matches!(&expanded.steps[2], Step::Line { text } if text == "y"));
+    assert!(matches!(&expanded.steps[3], Step::Line { text } if text == "after"));
+}
+
+/// Expansion is idempotent: expanding an already-expanded scenario is a
+/// no-op (no macros remain).
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P01
+/// @requirement REQ-TMUX-HARNESS-001
+#[test]
+fn expansion_is_idempotent() {
+    let json = r#"{
+        "config": { "cols": 80, "rows": 24 },
+        "macros": {
+            "greet": { "params": ["who"], "steps": [ { "line": "$who" } ] }
+        },
+        "steps": [ { "macro": "greet", "args": { "who": "z" } } ]
+    }"#;
+    let scenario = parse_scenario(json).value_or_panic("should parse");
+    let once = expand_macros(&scenario).value_or_panic("first expand");
+    let twice = expand_macros(&once).value_or_panic("second expand");
+    assert_eq!(once.steps.len(), 1);
+    assert_eq!(twice.steps.len(), 1);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,3 +45,4 @@ mod github_tests_pr_detail;
 
 /// Current application version.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub mod harness;


### PR DESCRIPTION
## Summary

- Adds the pure tmux harness scenario layer for the typed JSON scenario model.
- Adds typed config, step, macro definition, parser, validation, and macro expansion types.
- Covers malformed scenarios and macro expansion behavior with behavioral tests.

## Verification

- make ci-check
- rustreviewer: APPROVE
- ocr review --audience agent --timeout 20 (detached), addressed actionable findings

Fixes #98
