### PR TITLE
Add pure tmux harness matchers (Fixes #99)

### DIFF
--- a/src/harness/capture.rs
+++ b/src/harness/capture.rs
@@ -1,0 +1,114 @@
+//! Pure screen, scrollback, and pane status capture models.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P02
+//! @requirement REQ-TMUX-HARNESS-002
+
+/// A captured tmux pane screen at a point in time.
+///
+/// The driver owns terminal I/O; this type only stores already-captured text.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScreenCapture {
+    pub rows: u16,
+    pub cols: u16,
+    pub lines: Vec<String>,
+}
+
+impl ScreenCapture {
+    /// Build a screen capture from pre-captured lines.
+    ///
+    /// @plan PLAN-20260629-TMUX-HARNESS.P02
+    /// @requirement REQ-TMUX-HARNESS-002
+    #[must_use]
+    pub fn new(rows: u16, cols: u16, lines: Vec<String>) -> Self {
+        Self { rows, cols, lines }
+    }
+
+    /// Borrow the captured lines for pure matchers.
+    #[must_use]
+    pub fn lines(&self) -> &[String] {
+        &self.lines
+    }
+}
+
+/// A sampled slice of tmux scrollback history.
+///
+/// `history_size` is the full pane history size reported by tmux when the
+/// sample was captured; `lines` is the retained text sample.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScrollbackSample {
+    pub history_size: u64,
+    pub lines: Vec<String>,
+}
+
+impl ScrollbackSample {
+    /// Build a scrollback sample from a tmux history size and captured lines.
+    ///
+    /// @plan PLAN-20260629-TMUX-HARNESS.P02
+    /// @requirement REQ-TMUX-HARNESS-002
+    #[must_use]
+    pub fn new(history_size: u64, lines: Vec<String>) -> Self {
+        Self {
+            history_size,
+            lines,
+        }
+    }
+
+    /// Borrow the sampled lines for pure matchers.
+    #[must_use]
+    pub fn lines(&self) -> &[String] {
+        &self.lines
+    }
+}
+
+/// Parsed tmux pane liveness status.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PaneStatus {
+    pub dead: bool,
+}
+
+impl PaneStatus {
+    /// Parse the output of `tmux display-message -p '#{pane_dead}'`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PaneStatusParseError`] when tmux returns anything other than
+    /// `0` or `1` after trimming whitespace.
+    ///
+    /// @plan PLAN-20260629-TMUX-HARNESS.P02
+    /// @requirement REQ-TMUX-HARNESS-002
+    pub fn parse_tmux_pane_dead(output: &str) -> Result<Self, PaneStatusParseError> {
+        match output.trim() {
+            "0" => Ok(Self { dead: false }),
+            "1" => Ok(Self { dead: true }),
+            other => Err(PaneStatusParseError {
+                value: other.to_string(),
+            }),
+        }
+    }
+}
+
+/// Typed parse error for tmux pane status output.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaneStatusParseError {
+    pub value: String,
+}
+
+impl std::fmt::Display for PaneStatusParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid tmux pane_dead value: '{}'", self.value)
+    }
+}
+
+impl std::error::Error for PaneStatusParseError {}

--- a/src/harness/matchers.rs
+++ b/src/harness/matchers.rs
@@ -1,0 +1,203 @@
+//! Pure literal matchers and predicate outcomes for captured TUI text.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P02
+//! @requirement REQ-TMUX-HARNESS-002
+
+use super::capture::{ScreenCapture, ScrollbackSample};
+
+/// Pattern used by harness predicates.
+///
+/// The first harness milestone intentionally supports literal text only. Regex
+/// support can be added later behind another typed variant if it is justified.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MatchPattern {
+    Literal(String),
+}
+
+impl MatchPattern {
+    /// Construct a literal pattern.
+    ///
+    /// @plan PLAN-20260629-TMUX-HARNESS.P02
+    /// @requirement REQ-TMUX-HARNESS-002
+    #[must_use]
+    pub fn literal(text: impl Into<String>) -> Self {
+        Self::Literal(text.into())
+    }
+
+    /// Text representation used by literal scanning.
+    #[must_use]
+    pub fn text(&self) -> &str {
+        match self {
+            Self::Literal(text) => text,
+        }
+    }
+}
+
+/// Result of a contains/absent predicate.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PredicateOutcome {
+    pub matched: bool,
+    pub pattern: MatchPattern,
+    pub matched_line: Option<usize>,
+}
+
+/// Result of an exact-count predicate.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CountOutcome {
+    pub matched: bool,
+    pub pattern: MatchPattern,
+    pub expected: usize,
+    pub actual: usize,
+}
+
+/// Result of comparing two scrollback history sizes.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryDeltaOutcome {
+    pub matched: bool,
+    pub previous_size: u64,
+    pub current_size: u64,
+    pub min_delta: u64,
+    pub actual_delta: Option<u64>,
+}
+
+/// Evaluate whether a screen capture contains `pattern`.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[must_use]
+pub fn screen_contains(capture: &ScreenCapture, pattern: MatchPattern) -> PredicateOutcome {
+    contains_lines(capture.lines(), pattern)
+}
+
+/// Evaluate whether a screen capture does not contain `pattern`.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[must_use]
+pub fn screen_absent(capture: &ScreenCapture, pattern: MatchPattern) -> PredicateOutcome {
+    absent_lines(capture.lines(), pattern)
+}
+
+/// Count exact literal occurrences in a screen capture.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[must_use]
+pub fn screen_count(
+    capture: &ScreenCapture,
+    pattern: MatchPattern,
+    expected: usize,
+) -> CountOutcome {
+    count_lines(capture.lines(), pattern, expected)
+}
+
+/// Evaluate whether a scrollback sample contains `pattern`.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[must_use]
+pub fn scrollback_contains(sample: &ScrollbackSample, pattern: MatchPattern) -> PredicateOutcome {
+    contains_lines(sample.lines(), pattern)
+}
+
+/// Evaluate whether a scrollback sample does not contain `pattern`.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[must_use]
+pub fn scrollback_absent(sample: &ScrollbackSample, pattern: MatchPattern) -> PredicateOutcome {
+    absent_lines(sample.lines(), pattern)
+}
+
+/// Count exact literal occurrences in a scrollback sample.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[must_use]
+pub fn scrollback_count(
+    sample: &ScrollbackSample,
+    pattern: MatchPattern,
+    expected: usize,
+) -> CountOutcome {
+    count_lines(sample.lines(), pattern, expected)
+}
+
+/// Evaluate whether scrollback history grew by at least `min_delta`.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[must_use]
+pub fn history_delta(
+    before: &ScrollbackSample,
+    after: &ScrollbackSample,
+    min_delta: u64,
+) -> HistoryDeltaOutcome {
+    let actual_delta = after.history_size.checked_sub(before.history_size);
+    let matched = actual_delta.is_some_and(|delta| delta >= min_delta);
+    HistoryDeltaOutcome {
+        matched,
+        previous_size: before.history_size,
+        current_size: after.history_size,
+        min_delta,
+        actual_delta,
+    }
+}
+
+/// Evaluate literal containment over a line slice.
+fn contains_lines(lines: &[String], pattern: MatchPattern) -> PredicateOutcome {
+    let matched_line = first_matching_line(lines, pattern.text());
+    PredicateOutcome {
+        matched: matched_line.is_some(),
+        pattern,
+        matched_line,
+    }
+}
+
+/// Evaluate literal absence over a line slice.
+fn absent_lines(lines: &[String], pattern: MatchPattern) -> PredicateOutcome {
+    let present = first_matching_line(lines, pattern.text());
+    PredicateOutcome {
+        matched: present.is_none(),
+        pattern,
+        matched_line: present,
+    }
+}
+
+/// Count literal occurrences over a line slice.
+fn count_lines(lines: &[String], pattern: MatchPattern, expected: usize) -> CountOutcome {
+    let actual = count_occurrences(lines, pattern.text());
+    CountOutcome {
+        matched: actual == expected,
+        pattern,
+        expected,
+        actual,
+    }
+}
+
+/// Return the first zero-based line index containing a literal.
+fn first_matching_line(lines: &[String], needle: &str) -> Option<usize> {
+    if needle.is_empty() {
+        return None;
+    }
+    lines.iter().position(|line| line.contains(needle))
+}
+
+/// Count all non-overlapping literal occurrences across all lines.
+fn count_occurrences(lines: &[String], needle: &str) -> usize {
+    if needle.is_empty() {
+        return 0;
+    }
+    lines.iter().map(|line| line.matches(needle).count()).sum()
+}

--- a/src/harness/matchers_tests.rs
+++ b/src/harness/matchers_tests.rs
@@ -1,0 +1,215 @@
+//! Behavioral tests for pure capture models and literal matchers.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P02
+//! @requirement REQ-TMUX-HARNESS-002
+
+use super::*;
+
+/// Test-only helper: unwrap a `Result::Ok` or panic with context.
+trait TestResultExt<T> {
+    fn value_or_panic(self, context: &str) -> T;
+}
+
+impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
+    fn value_or_panic(self, context: &str) -> T {
+        match self {
+            Ok(value) => value,
+            Err(error) => panic!("{context}: {error:?}"),
+        }
+    }
+}
+
+/// Test-only helper: assert a `Result::Err` or panic.
+fn error_or_panic<T: std::fmt::Debug, E>(result: Result<T, E>, context: &str) -> E {
+    match result {
+        Err(error) => error,
+        Ok(value) => panic!("{context}: unexpectedly succeeded with {value:?}"),
+    }
+}
+
+/// Build a screen capture for matcher tests.
+fn screen(lines: &[&str]) -> ScreenCapture {
+    ScreenCapture::new(
+        u16::try_from(lines.len()).unwrap_or_else(|_| panic!("too many test lines")),
+        80,
+        lines.iter().map(|line| (*line).to_string()).collect(),
+    )
+}
+
+/// Build a scrollback sample for matcher tests.
+fn history(size: u64, lines: &[&str]) -> ScrollbackSample {
+    ScrollbackSample::new(size, lines.iter().map(|line| (*line).to_string()).collect())
+}
+
+/// Contains succeeds with the first zero-based line containing the literal.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[test]
+fn screen_contains_literal_reports_first_matching_line() {
+    let capture = screen(&["ready", "prompt> run", "prompt> done"]);
+
+    let outcome = screen_contains(&capture, MatchPattern::literal("prompt>"));
+
+    assert!(outcome.matched);
+    assert_eq!(outcome.matched_line, Some(1));
+    assert_eq!(outcome.pattern.text(), "prompt>");
+}
+
+/// Contains fails cleanly for absent literals, including empty captures.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[test]
+fn screen_contains_literal_fails_when_absent() {
+    let empty = screen(&[]);
+    let nonempty = screen(&["alpha", "beta"]);
+
+    let empty_outcome = screen_contains(&empty, MatchPattern::literal("alpha"));
+    let absent_outcome = screen_contains(&nonempty, MatchPattern::literal("gamma"));
+
+    assert!(!empty_outcome.matched);
+    assert_eq!(empty_outcome.matched_line, None);
+    assert!(!absent_outcome.matched);
+    assert_eq!(absent_outcome.matched_line, None);
+}
+
+/// Absent is the complement used by waitForNot: it matches when a literal is gone.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[test]
+fn screen_absent_literal_is_contains_complement() {
+    let capture = screen(&["loading", "prompt"]);
+
+    let missing = screen_absent(&capture, MatchPattern::literal("done"));
+    let present = screen_absent(&capture, MatchPattern::literal("loading"));
+
+    assert!(missing.matched);
+    assert_eq!(missing.matched_line, None);
+    assert!(!present.matched);
+    assert_eq!(present.matched_line, Some(0));
+}
+
+/// Exact-count predicates report zero, multiple, and mismatch counts.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[test]
+fn screen_count_reports_exact_literal_occurrences() {
+    let capture = screen(&["xx", "x y x", "none"]);
+
+    let zero = screen_count(&capture, MatchPattern::literal("z"), 0);
+    let four = screen_count(&capture, MatchPattern::literal("x"), 4);
+    let mismatch = screen_count(&capture, MatchPattern::literal("x"), 3);
+
+    assert!(zero.matched);
+    assert_eq!(zero.actual, 0);
+    assert!(four.matched);
+    assert_eq!(four.actual, 4);
+    assert!(!mismatch.matched);
+    assert_eq!(mismatch.actual, 4);
+    assert_eq!(mismatch.expected, 3);
+}
+
+/// Empty literals are treated as no-match and zero-count for public matcher safety.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[test]
+fn empty_literal_is_no_match_and_zero_count() {
+    let capture = screen(&["abc", ""]);
+    let contains = screen_contains(&capture, MatchPattern::literal(""));
+    let absent = screen_absent(&capture, MatchPattern::literal(""));
+    let count = screen_count(&capture, MatchPattern::literal(""), 0);
+
+    assert!(!contains.matched);
+    assert_eq!(contains.matched_line, None);
+    assert!(absent.matched);
+    assert!(count.matched);
+    assert_eq!(count.actual, 0);
+}
+
+/// Scrollback matchers operate on sampled history text instead of current screen rows.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[test]
+fn scrollback_contains_absent_and_count_scan_history_lines() {
+    let sample = history(30, &["old prompt", "command", "old prompt"]);
+
+    let contains = scrollback_contains(&sample, MatchPattern::literal("command"));
+    let missing = scrollback_absent(&sample, MatchPattern::literal("new prompt"));
+    let present = scrollback_absent(&sample, MatchPattern::literal("command"));
+    let count = scrollback_count(&sample, MatchPattern::literal("old"), 2);
+
+    assert!(contains.matched);
+    assert_eq!(contains.matched_line, Some(1));
+    assert!(missing.matched);
+    assert_eq!(missing.matched_line, None);
+    assert!(!present.matched);
+    assert_eq!(present.matched_line, Some(1));
+    assert!(count.matched);
+    assert_eq!(count.actual, 2);
+}
+
+/// History delta succeeds when history grew by the requested minimum.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[test]
+fn history_delta_accepts_in_range_growth() {
+    let before = history(10, &[]);
+    let after = history(14, &["a", "b"]);
+
+    let outcome = history_delta(&before, &after, 4);
+
+    assert!(outcome.matched);
+    assert_eq!(outcome.actual_delta, Some(4));
+    assert_eq!(outcome.previous_size, 10);
+    assert_eq!(outcome.current_size, 14);
+}
+
+/// History delta fails for too-small growth and backwards history sizes.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[test]
+fn history_delta_rejects_out_of_range_or_backwards_growth() {
+    let before = history(10, &[]);
+    let small = history(12, &[]);
+    let backwards = history(8, &[]);
+
+    let too_small = history_delta(&before, &small, 3);
+    let impossible = history_delta(&before, &backwards, 1);
+
+    assert!(!too_small.matched);
+    assert_eq!(too_small.actual_delta, Some(2));
+    assert!(!impossible.matched);
+    assert_eq!(impossible.actual_delta, None);
+}
+
+/// tmux pane_dead output parses deterministically for live and dead panes.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[test]
+fn pane_status_parses_tmux_dead_values() {
+    let live = PaneStatus::parse_tmux_pane_dead("0\n").value_or_panic("live pane parses");
+    let dead = PaneStatus::parse_tmux_pane_dead(" 1 ").value_or_panic("dead pane parses");
+
+    assert!(!live.dead);
+    assert!(dead.dead);
+}
+
+/// Unexpected pane_dead output is a typed parse error.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P02
+/// @requirement REQ-TMUX-HARNESS-002
+#[test]
+fn pane_status_rejects_unexpected_tmux_output() {
+    let err = error_or_panic(PaneStatus::parse_tmux_pane_dead("maybe"), "bad pane value");
+
+    assert_eq!(err.value, "maybe");
+    assert_eq!(err.to_string(), "invalid tmux pane_dead value: 'maybe'");
+}

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -13,21 +13,33 @@
 //! @plan PLAN-20260629-TMUX-HARNESS.P01
 //! @requirement REQ-TMUX-HARNESS-001
 
+pub mod capture;
 pub mod config;
 pub mod error;
 pub mod expand;
 pub mod macro_def;
+pub mod matchers;
 pub mod parser;
 pub mod scenario;
 pub mod step;
 
+pub use capture::{PaneStatus, PaneStatusParseError, ScreenCapture, ScrollbackSample};
 pub use config::{AssertMode, ScenarioConfig};
 pub use error::ScenarioError;
 pub use expand::expand_macros;
 pub use macro_def::MacroDef;
+pub use matchers::{
+    CountOutcome, HistoryDeltaOutcome, MatchPattern, PredicateOutcome, history_delta,
+    screen_absent, screen_contains, screen_count, scrollback_absent, scrollback_contains,
+    scrollback_count,
+};
 pub use parser::parse_scenario;
 pub use scenario::Scenario;
 pub use step::Step;
+
+#[cfg(test)]
+#[path = "matchers_tests.rs"]
+mod matchers_tests;
 
 #[cfg(test)]
 #[path = "tests.rs"]


### PR DESCRIPTION
## Summary
- Add pure harness capture models for screen rows, scrollback samples, and pane liveness status.
- Add literal-only matchers for contains, absent, exact counts, and history-size deltas.
- Add behavioral tests for screen/scrollback matching, empty captures, empty literals, history deltas, and tmux pane_dead parsing.

## Validation
- cargo test --workspace --all-features --locked harness -- --nocapture
- make ci-check
- rustreviewer: APPROVE
- ocr review --audience agent --timeout 20 (detached), findings addressed

Fixes #99
