### PR TITLE
Add tmux harness runner orchestration (Fixes #101)

### DIFF
--- a/src/bin/jefe-tmux-harness.rs
+++ b/src/bin/jefe-tmux-harness.rs
@@ -1,0 +1,319 @@
+//! Thin CLI entry for the tmux-backed TUI harness.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P04
+//! @requirement REQ-TMUX-HARNESS-004
+
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use jefe::harness::{TmuxPaneSize, TmuxStartRequest, parse_scenario, run_tmux_scenario};
+
+fn main() -> ExitCode {
+    match CliArgs::parse(env::args().skip(1)) {
+        Ok(args) => run(args),
+        Err(ParseError::Help) => {
+            write_stdout(&format!("{}\n", usage()));
+            ExitCode::SUCCESS
+        }
+        Err(ParseError::Message(message)) => {
+            write_stderr(&format!("{message}\n\n{}\n", usage()));
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn run(args: CliArgs) -> ExitCode {
+    let json = match fs::read_to_string(&args.scenario) {
+        Ok(value) => value,
+        Err(err) => {
+            write_stderr(&format!(
+                "failed to read scenario '{}': {err}\n",
+                args.scenario.display()
+            ));
+            return ExitCode::from(1);
+        }
+    };
+    let scenario = match parse_scenario(&json) {
+        Ok(value) => value,
+        Err(err) => {
+            write_stderr(&format!("failed to parse scenario: {err}\n"));
+            return ExitCode::from(1);
+        }
+    };
+    let request = start_request(&scenario, &args);
+    match request.and_then(|req| run_tmux_scenario(&scenario, &req, args.out_dir.as_deref())) {
+        Ok(summary) => {
+            write_stdout(&format!("ok: {} steps\n", summary.steps_run));
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            write_stderr(&format!("scenario failed: {err}\n"));
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn start_request(
+    scenario: &jefe::harness::Scenario,
+    args: &CliArgs,
+) -> Result<TmuxStartRequest, jefe::harness::RunnerError> {
+    let dims = TmuxPaneSize::new(
+        scenario.config.cols,
+        scenario.config.rows,
+        scenario.config.history_limit,
+    );
+    let request = TmuxStartRequest::jefe(
+        args.session.clone(),
+        args.jefe_bin.clone(),
+        args.config_dir.clone(),
+        args.working_dir.clone(),
+        dims,
+    )
+    .map_err(|err| jefe::harness::RunnerError::Driver(err.to_string()))?;
+    Ok(request.with_keep_session(args.keep_session))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CliArgs {
+    scenario: PathBuf,
+    jefe_bin: PathBuf,
+    config_dir: PathBuf,
+    working_dir: PathBuf,
+    session: String,
+    out_dir: Option<PathBuf>,
+    keep_session: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ParseError {
+    Help,
+    Message(String),
+}
+
+impl ParseError {
+    fn message(value: impl Into<String>) -> Self {
+        Self::Message(value.into())
+    }
+
+    #[cfg(test)]
+    fn contains(&self, needle: &str) -> bool {
+        match self {
+            Self::Help => false,
+            Self::Message(message) => message.contains(needle),
+        }
+    }
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Help => f.write_str("help requested"),
+            Self::Message(message) => f.write_str(message),
+        }
+    }
+}
+impl CliArgs {
+    fn parse<I>(mut args: I) -> Result<Self, ParseError>
+    where
+        I: Iterator<Item = String>,
+    {
+        let mut parsed = ParsedOptions::default();
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--scenario" => parsed.scenario = Some(next_value(&mut args, "--scenario")?),
+                "--jefe-bin" => parsed.jefe_bin = Some(next_value(&mut args, "--jefe-bin")?),
+                "--config" => parsed.config_dir = Some(next_value(&mut args, "--config")?),
+                "--working-dir" => {
+                    parsed.working_dir = Some(next_value(&mut args, "--working-dir")?);
+                }
+                "--session" => parsed.session = Some(next_value(&mut args, "--session")?),
+                "--out-dir" => parsed.out_dir = Some(next_value(&mut args, "--out-dir")?),
+                "--keep-session" => parsed.keep_session = true,
+                "--help" | "-h" => return Err(ParseError::Help),
+                other => apply_equals_option(&mut parsed, other)?,
+            }
+        }
+        parsed.finish()
+    }
+}
+
+#[derive(Default)]
+struct ParsedOptions {
+    scenario: Option<String>,
+    jefe_bin: Option<String>,
+    config_dir: Option<String>,
+    working_dir: Option<String>,
+    session: Option<String>,
+    out_dir: Option<String>,
+    keep_session: bool,
+}
+
+impl ParsedOptions {
+    fn finish(self) -> Result<CliArgs, ParseError> {
+        let working_dir = match self.working_dir {
+            Some(value) => PathBuf::from(value),
+            None => env::current_dir().map_err(|err| ParseError::message(err.to_string()))?,
+        };
+        Ok(CliArgs {
+            scenario: required_path(self.scenario, "--scenario")?,
+            jefe_bin: required_path(self.jefe_bin, "--jefe-bin")?,
+            config_dir: required_path(self.config_dir, "--config")?,
+            working_dir,
+            session: self
+                .session
+                .unwrap_or_else(|| "jefe-harness-cli".to_string()),
+            out_dir: self.out_dir.map(PathBuf::from),
+            keep_session: self.keep_session,
+        })
+    }
+}
+
+fn next_value<I>(args: &mut I, flag: &str) -> Result<String, ParseError>
+where
+    I: Iterator<Item = String>,
+{
+    let value = args
+        .next()
+        .ok_or_else(|| ParseError::message(format!("missing value for {flag}")))?;
+    if value.is_empty() || value.starts_with('-') {
+        return Err(ParseError::message(format!("missing value for {flag}")));
+    }
+    Ok(value)
+}
+
+fn apply_equals_option(parsed: &mut ParsedOptions, arg: &str) -> Result<(), ParseError> {
+    let Some((flag, value)) = arg.split_once('=') else {
+        return Err(ParseError::message(format!("unknown argument: {arg}")));
+    };
+    if value.is_empty() || value.starts_with('-') {
+        return Err(ParseError::message(format!("missing value for {flag}")));
+    }
+    match flag {
+        "--scenario" => parsed.scenario = Some(value.to_string()),
+        "--jefe-bin" => parsed.jefe_bin = Some(value.to_string()),
+        "--config" => parsed.config_dir = Some(value.to_string()),
+        "--working-dir" => parsed.working_dir = Some(value.to_string()),
+        "--session" => parsed.session = Some(value.to_string()),
+        "--out-dir" => parsed.out_dir = Some(value.to_string()),
+        other => return Err(ParseError::message(format!("unknown argument: {other}"))),
+    }
+    Ok(())
+}
+
+fn required_path(value: Option<String>, flag: &str) -> Result<PathBuf, ParseError> {
+    value
+        .map(PathBuf::from)
+        .ok_or_else(|| ParseError::message(format!("missing required {flag}")))
+}
+
+fn usage() -> String {
+    "\
+jefe-tmux-harness - run jefe TUI scenarios in tmux
+
+Usage: jefe-tmux-harness --scenario <FILE> --jefe-bin <PATH> --config <DIR> [OPTIONS]
+
+Options:
+  --scenario <FILE>       Scenario JSON file to run
+  --jefe-bin <PATH>       Path to the jefe binary under test
+  --config <DIR>          Isolated jefe config directory for the run
+  --working-dir <DIR>     Working directory for the tmux session
+  --session <NAME>        Tmux session name (default: jefe-harness-cli)
+  --out-dir <DIR>         Artifact output directory
+  --keep-session          Keep tmux session alive after completion
+  -h, --help              Print this help message and exit"
+        .to_string()
+}
+
+fn write_stdout(message: &str) {
+    let _ = std::io::stdout().write_all(message.as_bytes());
+}
+
+fn write_stderr(message: &str) {
+    let _ = std::io::stderr().write_all(message.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CliArgs;
+
+    #[test]
+    fn parses_required_cli_args() {
+        let args = CliArgs::parse(
+            [
+                "--scenario",
+                "scenario.json",
+                "--jefe-bin",
+                "target/debug/jefe",
+                "--config",
+                "tmp-config",
+                "--session",
+                "s",
+                "--out-dir",
+                "artifacts",
+                "--keep-session",
+            ]
+            .into_iter()
+            .map(str::to_string),
+        )
+        .unwrap_or_else(|err| panic!("parse should succeed: {err}"));
+
+        assert_eq!(args.session, "s");
+        assert!(args.keep_session);
+        assert!(args.out_dir.is_some());
+    }
+
+    #[test]
+    fn parses_equals_style_cli_args() {
+        let args = CliArgs::parse(
+            [
+                "--scenario=scenario.json",
+                "--jefe-bin=target/debug/jefe",
+                "--config=tmp-config",
+                "--working-dir=.",
+                "--session=s",
+                "--out-dir=artifacts",
+            ]
+            .into_iter()
+            .map(str::to_string),
+        )
+        .unwrap_or_else(|err| panic!("parse should succeed: {err}"));
+
+        assert_eq!(args.session, "s");
+        assert!(args.out_dir.is_some());
+    }
+
+    #[test]
+    fn value_flag_rejects_following_flag_as_missing_value() {
+        let err = CliArgs::parse(["--scenario", "--jefe-bin"].into_iter().map(str::to_string))
+            .err()
+            .unwrap_or_else(|| panic!("parse should fail"));
+        assert!(err.contains("--scenario"));
+    }
+
+    #[test]
+    fn equals_style_value_rejects_flag_like_value() {
+        let err = CliArgs::parse(std::iter::once("--scenario=--jefe-bin").map(str::to_string))
+            .err()
+            .unwrap_or_else(|| panic!("parse should fail"));
+        assert!(err.contains("--scenario"));
+    }
+
+    #[test]
+    fn value_flag_rejects_help_flag_as_missing_value() {
+        let err = CliArgs::parse(["--scenario", "--help"].into_iter().map(str::to_string))
+            .err()
+            .unwrap_or_else(|| panic!("parse should fail"));
+        assert!(err.contains("--scenario"));
+    }
+
+    #[test]
+    fn missing_required_cli_arg_fails() {
+        let err = CliArgs::parse(std::iter::empty())
+            .err()
+            .unwrap_or_else(|| panic!("parse should fail"));
+        assert!(err.contains("--scenario"));
+    }
+}

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -18,6 +18,7 @@ pub mod expand;
 pub mod macro_def;
 pub mod matchers;
 pub mod parser;
+pub mod runner;
 pub mod scenario;
 pub mod step;
 pub mod tmux_driver;
@@ -33,6 +34,9 @@ pub use matchers::{
     scrollback_count,
 };
 pub use parser::parse_scenario;
+pub use runner::{
+    HarnessDriver, RunSummary, RunnerError, RunnerFailure, run_scenario, run_tmux_scenario,
+};
 pub use scenario::Scenario;
 pub use step::Step;
 pub use tmux_driver::{TmuxDriver, TmuxDriverError, TmuxPaneSize, TmuxSession, TmuxStartRequest};

--- a/src/harness/runner.rs
+++ b/src/harness/runner.rs
@@ -1,0 +1,580 @@
+//! Scenario runner/orchestrator for the tmux harness.
+//!
+//! The runner composes typed scenarios, pure matchers, and a driver seam. It is
+//! intentionally small: terminal and tmux side effects remain behind
+//! [`HarnessDriver`], while scenario execution, polling, and artifact decisions
+//! live here.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P04
+//! @requirement REQ-TMUX-HARNESS-004
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use super::capture::{PaneStatus, ScreenCapture, ScrollbackSample};
+use super::config::AssertMode;
+use super::error::ScenarioError;
+use super::expand_macros;
+use super::matchers::{MatchPattern, history_delta, screen_contains, screen_count};
+use super::scenario::Scenario;
+use super::step::Step;
+use super::tmux_driver::{TmuxDriver, TmuxDriverError, TmuxSession, TmuxStartRequest};
+use tracing::warn;
+
+const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Result of a scenario run.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P04
+/// @requirement REQ-TMUX-HARNESS-004
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunSummary {
+    pub steps_run: usize,
+    pub artifact_dir: Option<PathBuf>,
+    pub soft_failures: Vec<RunnerFailure>,
+}
+
+/// Structured failure details for a step.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P04
+/// @requirement REQ-TMUX-HARNESS-004
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerFailure {
+    pub step_index: usize,
+    pub step_kind: String,
+    pub reason: String,
+}
+
+/// Errors produced by scenario execution.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P04
+/// @requirement REQ-TMUX-HARNESS-004
+#[derive(Debug)]
+pub enum RunnerError {
+    Scenario(ScenarioError),
+    Driver(String),
+    Assertion(RunnerFailure),
+    Artifact { path: PathBuf, reason: String },
+}
+
+impl std::fmt::Display for RunnerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Scenario(err) => write!(f, "scenario error: {err}"),
+            Self::Driver(reason) => write!(f, "driver error: {reason}"),
+            Self::Assertion(failure) => {
+                write!(f, "step {} failed: {}", failure.step_index, failure.reason)
+            }
+            Self::Artifact { path, reason } => {
+                write!(f, "artifact error at '{}': {reason}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for RunnerError {}
+
+impl From<ScenarioError> for RunnerError {
+    fn from(value: ScenarioError) -> Self {
+        Self::Scenario(value)
+    }
+}
+
+/// Driver seam used by the runner.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P04
+/// @requirement REQ-TMUX-HARNESS-004
+pub trait HarnessDriver {
+    type Error: std::fmt::Display;
+
+    fn send_line(&mut self, line: &str) -> Result<(), Self::Error>;
+    fn send_key(&mut self, key: &str) -> Result<(), Self::Error>;
+    fn send_keys(&mut self, keys: &[String]) -> Result<(), Self::Error>;
+    fn capture_screen(&mut self) -> Result<ScreenCapture, Self::Error>;
+    fn capture_scrollback(&mut self, lines: u32) -> Result<ScrollbackSample, Self::Error>;
+    fn pane_status(&mut self) -> Result<PaneStatus, Self::Error>;
+    fn history_size(&mut self) -> Result<u64, Self::Error>;
+    fn copy_mode(&mut self, enabled: bool) -> Result<(), Self::Error>;
+}
+
+/// Concrete adapter from [`TmuxDriver`] plus session handle to the runner seam.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P04
+/// @requirement REQ-TMUX-HARNESS-004
+pub struct TmuxHarnessDriver {
+    driver: TmuxDriver,
+    session: TmuxSession,
+}
+
+impl TmuxHarnessDriver {
+    #[must_use]
+    pub const fn new(driver: TmuxDriver, session: TmuxSession) -> Self {
+        Self { driver, session }
+    }
+}
+
+impl HarnessDriver for TmuxHarnessDriver {
+    type Error = TmuxDriverError;
+
+    fn send_line(&mut self, line: &str) -> Result<(), Self::Error> {
+        self.driver.send_line(&self.session, line)
+    }
+
+    fn send_key(&mut self, key: &str) -> Result<(), Self::Error> {
+        self.driver.send_key(&self.session, key)
+    }
+
+    fn send_keys(&mut self, keys: &[String]) -> Result<(), Self::Error> {
+        self.driver.send_keys(&self.session, keys)
+    }
+
+    fn capture_screen(&mut self) -> Result<ScreenCapture, Self::Error> {
+        self.driver.capture_screen(&self.session)
+    }
+
+    fn capture_scrollback(&mut self, lines: u32) -> Result<ScrollbackSample, Self::Error> {
+        self.driver.capture_scrollback(&self.session, lines)
+    }
+
+    fn pane_status(&mut self) -> Result<PaneStatus, Self::Error> {
+        self.driver.pane_status(&self.session)
+    }
+
+    fn history_size(&mut self) -> Result<u64, Self::Error> {
+        self.driver.history_size(&self.session)
+    }
+
+    fn copy_mode(&mut self, enabled: bool) -> Result<(), Self::Error> {
+        self.driver.copy_mode(&self.session, enabled)
+    }
+}
+
+/// Run a scenario against an already-started driver seam.
+///
+/// # Errors
+///
+/// Returns [`RunnerError`] for invalid scenarios, driver failures, assertion
+/// failures, or artifact write failures.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P04
+/// @requirement REQ-TMUX-HARNESS-004
+pub fn run_scenario<D: HarnessDriver>(
+    scenario: &Scenario,
+    driver: &mut D,
+    artifact_dir: Option<&Path>,
+) -> Result<RunSummary, RunnerError> {
+    let expanded = expand_macros(scenario)?;
+    run_expanded_scenario(&expanded, driver, artifact_dir)
+}
+
+fn run_expanded_scenario<D: HarnessDriver>(
+    scenario: &Scenario,
+    driver: &mut D,
+    artifact_dir: Option<&Path>,
+) -> Result<RunSummary, RunnerError> {
+    let mut context = RunContext::new(
+        artifact_dir
+            .map(Path::to_path_buf)
+            .or_else(|| scenario.config.out_dir.clone()),
+        scenario.config.assert_mode,
+    );
+    sleep_step(scenario.config.initial_wait_ms);
+    run_steps(&scenario.steps, driver, &mut context)
+}
+
+/// Start a tmux session, run a scenario, and clean up according to the request.
+///
+/// # Errors
+///
+/// Returns [`RunnerError`] if the driver cannot start/cleanup or the scenario
+/// run fails.
+///
+/// @plan PLAN-20260629-TMUX-HARNESS.P04
+/// @requirement REQ-TMUX-HARNESS-004
+pub fn run_tmux_scenario(
+    scenario: &Scenario,
+    request: &TmuxStartRequest,
+    artifact_dir: Option<&Path>,
+) -> Result<RunSummary, RunnerError> {
+    let expanded = expand_macros(scenario)?;
+    let tmux = TmuxDriver::new();
+    let effective_request = request
+        .clone()
+        .with_keep_session(request.keep_session || expanded.config.keep_session);
+    let session = tmux
+        .start_session(&effective_request)
+        .map_err(|err| RunnerError::Driver(err.to_string()))?;
+    let mut driver = TmuxHarnessDriver::new(tmux.clone(), session.clone());
+    let result = run_expanded_scenario(&expanded, &mut driver, artifact_dir);
+    let cleanup = tmux.cleanup_session(&session);
+    match (result, cleanup) {
+        (Ok(summary), Ok(())) => Ok(summary),
+        (Err(err), _) => Err(err),
+        (Ok(_), Err(err)) => Err(RunnerError::Driver(err.to_string())),
+    }
+}
+
+struct RunContext {
+    artifact_dir: Option<PathBuf>,
+    assert_mode: AssertMode,
+    history_samples: BTreeMap<String, ScrollbackSample>,
+    soft_failures: Vec<RunnerFailure>,
+}
+
+impl RunContext {
+    fn new(artifact_dir: Option<PathBuf>, assert_mode: AssertMode) -> Self {
+        Self {
+            artifact_dir,
+            assert_mode,
+            history_samples: BTreeMap::new(),
+            soft_failures: Vec::new(),
+        }
+    }
+}
+
+fn run_steps<D: HarnessDriver>(
+    steps: &[Step],
+    driver: &mut D,
+    context: &mut RunContext,
+) -> Result<RunSummary, RunnerError> {
+    for (index, step) in steps.iter().enumerate() {
+        if let Err(err) = execute_step(index, step, driver, context) {
+            if let Err(artifact_err) = write_failure_artifacts(driver, context, index, step, &err) {
+                warn!(%artifact_err, "failed to write harness failure artifacts");
+            }
+            return Err(err);
+        }
+    }
+    Ok(RunSummary {
+        steps_run: steps.len(),
+        artifact_dir: context.artifact_dir.clone(),
+        soft_failures: context.soft_failures.clone(),
+    })
+}
+
+fn execute_step<D: HarnessDriver>(
+    index: usize,
+    step: &Step,
+    driver: &mut D,
+    context: &mut RunContext,
+) -> Result<(), RunnerError> {
+    match step {
+        Step::Wait { milliseconds } => {
+            sleep_step(*milliseconds);
+            Ok(())
+        }
+        Step::Line { text } => driver_call(driver.send_line(text)),
+        Step::Key { key } => driver_call(driver.send_key(key)),
+        Step::Keys { keys } => driver_call(driver.send_keys(keys)),
+        Step::WaitFor { pattern } => wait_for_pattern(index, step, driver, pattern, true),
+        Step::WaitForNot { pattern } => wait_for_pattern(index, step, driver, pattern, false),
+        Step::Expect { pattern } => expect_screen(index, step, driver, context, pattern),
+        Step::ExpectCount { pattern, count } => {
+            expect_count(index, step, driver, context, pattern, *count)
+        }
+        Step::Capture { name } => capture_artifact(driver, context, name),
+        Step::HistorySample { name } => history_sample(driver, context, name),
+        Step::ExpectHistoryDelta { name } => {
+            expect_history_delta(index, step, driver, name, context)
+        }
+        Step::CopyMode { enabled } => driver_call(driver.copy_mode(*enabled)),
+        Step::WaitForExit { timeout_ms } => wait_for_exit(index, step, driver, *timeout_ms),
+        Step::Macro { .. } => Err(RunnerError::Scenario(ScenarioError::InvalidStep {
+            reason: "macro step remained after expansion".to_string(),
+        })),
+    }
+}
+
+fn sleep_step(milliseconds: u64) {
+    std::thread::sleep(Duration::from_millis(milliseconds));
+}
+
+fn wait_for_pattern<D: HarnessDriver>(
+    index: usize,
+    step: &Step,
+    driver: &mut D,
+    pattern: &str,
+    should_match: bool,
+) -> Result<(), RunnerError> {
+    poll_until(index, step, DEFAULT_WAIT_TIMEOUT, || {
+        let capture = driver.capture_screen().map_err(driver_error)?;
+        let matched = screen_contains(&capture, MatchPattern::literal(pattern)).matched;
+        Ok(matched == should_match)
+    })
+}
+
+fn wait_for_exit<D: HarnessDriver>(
+    index: usize,
+    step: &Step,
+    driver: &mut D,
+    timeout_ms: u64,
+) -> Result<(), RunnerError> {
+    poll_until(index, step, Duration::from_millis(timeout_ms), || {
+        let status = driver.pane_status().map_err(driver_error)?;
+        Ok(status.dead)
+    })
+}
+
+fn poll_until<F>(
+    index: usize,
+    step: &Step,
+    timeout: Duration,
+    mut predicate: F,
+) -> Result<(), RunnerError>
+where
+    F: FnMut() -> Result<bool, RunnerError>,
+{
+    let deadline = Instant::now() + timeout;
+    loop {
+        if predicate()? {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(RunnerError::Assertion(failure(
+                index,
+                step,
+                "condition did not become true before timeout".to_string(),
+            )));
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn expect_screen<D: HarnessDriver>(
+    index: usize,
+    step: &Step,
+    driver: &mut D,
+    context: &mut RunContext,
+    pattern: &str,
+) -> Result<(), RunnerError> {
+    let capture = driver.capture_screen().map_err(driver_error)?;
+    let outcome = screen_contains(&capture, MatchPattern::literal(pattern));
+    handle_assertion(
+        context,
+        index,
+        step,
+        outcome.matched,
+        format!("expected screen to contain '{pattern}'"),
+    )
+}
+
+fn expect_count<D: HarnessDriver>(
+    index: usize,
+    step: &Step,
+    driver: &mut D,
+    context: &mut RunContext,
+    pattern: &str,
+    count: u32,
+) -> Result<(), RunnerError> {
+    let capture = driver.capture_screen().map_err(driver_error)?;
+    let outcome = screen_count(&capture, MatchPattern::literal(pattern), count as usize);
+    handle_assertion(
+        context,
+        index,
+        step,
+        outcome.matched,
+        format!(
+            "expected '{pattern}' count {}, got {}",
+            count, outcome.actual
+        ),
+    )
+}
+
+fn history_sample<D: HarnessDriver>(
+    driver: &mut D,
+    context: &mut RunContext,
+    name: &str,
+) -> Result<(), RunnerError> {
+    let history_size = driver.history_size().map_err(driver_error)?;
+    let sample = driver.capture_scrollback(200).map_err(driver_error)?;
+    let snapshot = ScrollbackSample::new(history_size, sample.lines);
+    write_history_sample(context, name, &snapshot)?;
+    context.history_samples.insert(name.to_string(), snapshot);
+    Ok(())
+}
+
+fn expect_history_delta<D: HarnessDriver>(
+    index: usize,
+    step: &Step,
+    driver: &mut D,
+    name: &str,
+    context: &mut RunContext,
+) -> Result<(), RunnerError> {
+    let before = context.history_samples.get(name).ok_or_else(|| {
+        RunnerError::Assertion(failure(
+            index,
+            step,
+            format!("missing history sample '{name}'"),
+        ))
+    })?;
+    let after = ScrollbackSample::new(
+        driver.history_size().map_err(driver_error)?,
+        driver.capture_scrollback(200).map_err(driver_error)?.lines,
+    );
+    let outcome = history_delta(before, &after, 1);
+    handle_assertion(
+        context,
+        index,
+        step,
+        outcome.matched,
+        format!("expected history delta for sample '{name}'"),
+    )
+}
+
+fn capture_artifact<D: HarnessDriver>(
+    driver: &mut D,
+    context: &RunContext,
+    name: &str,
+) -> Result<(), RunnerError> {
+    let Some(dir) = &context.artifact_dir else {
+        return Ok(());
+    };
+    let capture = driver.capture_screen().map_err(driver_error)?;
+    let label = artifact_label(name);
+    write_text(
+        dir.join(format!("{label}.screen.txt")),
+        &capture.lines.join("\n"),
+    )
+}
+
+fn write_history_sample(
+    context: &RunContext,
+    name: &str,
+    sample: &ScrollbackSample,
+) -> Result<(), RunnerError> {
+    let Some(dir) = &context.artifact_dir else {
+        return Ok(());
+    };
+    let label = artifact_label(name);
+    write_text(
+        dir.join(format!("{label}.history.txt")),
+        &sample.lines.join("\n"),
+    )
+}
+
+fn artifact_label(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        "sample".to_string()
+    } else {
+        sanitized
+    }
+}
+fn handle_assertion(
+    context: &mut RunContext,
+    index: usize,
+    step: &Step,
+    matched: bool,
+    reason: String,
+) -> Result<(), RunnerError> {
+    if matched {
+        return Ok(());
+    }
+    let failure = failure(index, step, reason);
+    match context.assert_mode {
+        AssertMode::Soft => {
+            context.soft_failures.push(failure);
+            Ok(())
+        }
+        AssertMode::Strict => Err(RunnerError::Assertion(failure)),
+    }
+}
+
+fn failure(index: usize, step: &Step, reason: String) -> RunnerFailure {
+    RunnerFailure {
+        step_index: index,
+        step_kind: step_kind(step),
+        reason,
+    }
+}
+
+fn write_failure_artifacts<D: HarnessDriver>(
+    driver: &mut D,
+    context: &RunContext,
+    index: usize,
+    step: &Step,
+    err: &RunnerError,
+) -> Result<(), RunnerError> {
+    let Some(dir) = &context.artifact_dir else {
+        return Ok(());
+    };
+    let screen = driver.capture_screen().map_err(driver_error)?;
+    let scrollback = driver.capture_scrollback(200).map_err(driver_error)?;
+    write_text(dir.join("final-screen.txt"), &screen.lines.join("\n"))?;
+    write_text(
+        dir.join("final-scrollback.txt"),
+        &scrollback.lines.join("\n"),
+    )?;
+    write_text(
+        dir.join("error.txt"),
+        &format!(
+            "step={index}\nkind={}\nreason={}\nerror={err}\n",
+            step_kind(step),
+            failure_reason(err)
+        ),
+    )
+}
+
+fn failure_reason(err: &RunnerError) -> String {
+    match err {
+        RunnerError::Assertion(failure) => failure.reason.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn write_text(path: PathBuf, text: &str) -> Result<(), RunnerError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| RunnerError::Artifact {
+            path: parent.to_path_buf(),
+            reason: err.to_string(),
+        })?;
+    }
+    fs::write(&path, text).map_err(|err| RunnerError::Artifact {
+        path,
+        reason: err.to_string(),
+    })
+}
+
+fn driver_call<E: std::fmt::Display>(result: Result<(), E>) -> Result<(), RunnerError> {
+    result.map_err(driver_error)
+}
+
+fn driver_error<E: std::fmt::Display>(err: E) -> RunnerError {
+    RunnerError::Driver(err.to_string())
+}
+
+fn step_kind(step: &Step) -> String {
+    match step {
+        Step::Wait { .. } => "wait",
+        Step::Line { .. } => "line",
+        Step::Key { .. } => "key",
+        Step::Keys { .. } => "keys",
+        Step::WaitFor { .. } => "waitFor",
+        Step::WaitForNot { .. } => "waitForNot",
+        Step::Expect { .. } => "expect",
+        Step::ExpectCount { .. } => "expectCount",
+        Step::Capture { .. } => "capture",
+        Step::HistorySample { .. } => "historySample",
+        Step::ExpectHistoryDelta { .. } => "expectHistoryDelta",
+        Step::CopyMode { .. } => "copyMode",
+        Step::WaitForExit { .. } => "waitForExit",
+        Step::Macro { .. } => "macro",
+    }
+    .to_string()
+}
+
+#[cfg(test)]
+#[path = "runner_tests.rs"]
+mod tests;

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -1,0 +1,453 @@
+//! Behavioral tests for the harness runner/orchestrator.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P04
+//! @requirement REQ-TMUX-HARNESS-004
+
+use std::collections::VecDeque;
+use std::path::PathBuf;
+
+use super::*;
+use crate::harness::capture::{PaneStatus, ScreenCapture, ScrollbackSample};
+use crate::harness::{TmuxDriver, TmuxPaneSize, TmuxStartRequest, parse_scenario, run_scenario};
+
+trait TestResultExt<T> {
+    fn value_or_panic(self, context: &str) -> T;
+}
+
+impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
+    fn value_or_panic(self, context: &str) -> T {
+        match self {
+            Ok(value) => value,
+            Err(error) => panic!("{context}: {error:?}"),
+        }
+    }
+}
+
+fn error_or_panic<T: std::fmt::Debug, E>(result: Result<T, E>, context: &str) -> E {
+    match result {
+        Err(error) => error,
+        Ok(value) => panic!("{context}: unexpectedly succeeded with {value:?}"),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FakeError(String);
+
+impl std::fmt::Display for FakeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Default)]
+struct FakeDriver {
+    screens: VecDeque<ScreenCapture>,
+    scrollbacks: VecDeque<ScrollbackSample>,
+    pane_statuses: VecDeque<PaneStatus>,
+    history_sizes: VecDeque<u64>,
+    lines_sent: Vec<String>,
+    keys_sent: Vec<String>,
+    copy_modes: Vec<bool>,
+    screen_capture_count: usize,
+    fail_screen_after: Option<usize>,
+}
+
+impl FakeDriver {
+    fn with_screens(mut self, lines: &[&str]) -> Self {
+        self.screens = lines
+            .iter()
+            .map(|line| ScreenCapture::new(1, 80, vec![(*line).to_string()]))
+            .collect();
+        self
+    }
+
+    fn with_scrollback(mut self, lines: &[&str]) -> Self {
+        self.scrollbacks = lines
+            .iter()
+            .enumerate()
+            .map(|(idx, line)| ScrollbackSample::new(idx as u64, vec![(*line).to_string()]))
+            .collect();
+        self
+    }
+}
+
+impl HarnessDriver for FakeDriver {
+    type Error = FakeError;
+
+    fn send_line(&mut self, line: &str) -> Result<(), Self::Error> {
+        self.lines_sent.push(line.to_string());
+        Ok(())
+    }
+
+    fn send_key(&mut self, key: &str) -> Result<(), Self::Error> {
+        self.keys_sent.push(key.to_string());
+        Ok(())
+    }
+
+    fn send_keys(&mut self, keys: &[String]) -> Result<(), Self::Error> {
+        self.keys_sent.extend(keys.iter().cloned());
+        Ok(())
+    }
+
+    fn capture_screen(&mut self) -> Result<ScreenCapture, Self::Error> {
+        self.screen_capture_count += 1;
+        if self
+            .fail_screen_after
+            .is_some_and(|threshold| self.screen_capture_count > threshold)
+        {
+            return Err(FakeError("screen capture failed".to_string()));
+        }
+        Ok(self
+            .screens
+            .pop_front()
+            .unwrap_or_else(|| ScreenCapture::new(1, 80, vec![String::new()])))
+    }
+
+    fn capture_scrollback(&mut self, _lines: u32) -> Result<ScrollbackSample, Self::Error> {
+        Ok(self
+            .scrollbacks
+            .pop_front()
+            .unwrap_or_else(|| ScrollbackSample::new(0, Vec::new())))
+    }
+
+    fn pane_status(&mut self) -> Result<PaneStatus, Self::Error> {
+        Ok(self
+            .pane_statuses
+            .pop_front()
+            .unwrap_or(PaneStatus { dead: false }))
+    }
+
+    fn history_size(&mut self) -> Result<u64, Self::Error> {
+        Ok(self.history_sizes.pop_front().unwrap_or(0))
+    }
+
+    fn copy_mode(&mut self, enabled: bool) -> Result<(), Self::Error> {
+        self.copy_modes.push(enabled);
+        Ok(())
+    }
+}
+
+fn scenario(json_steps: &str) -> crate::harness::Scenario {
+    parse_scenario(&format!(
+        r#"{{ "config": {{ "cols": 80, "rows": 24 }}, "steps": {json_steps} }}"#
+    ))
+    .value_or_panic("scenario should parse")
+}
+
+#[test]
+fn expect_passes_when_screen_contains_literal() {
+    let scenario = scenario(r#"[ { "expect": "ready" } ]"#);
+    let mut driver = FakeDriver::default().with_screens(&["system ready"]);
+
+    let summary = run_scenario(&scenario, &mut driver, None).value_or_panic("runner should pass");
+
+    assert_eq!(summary.steps_run, 1);
+    assert!(summary.soft_failures.is_empty());
+}
+
+#[test]
+fn expect_failure_writes_artifacts() {
+    let scenario = scenario(r#"[ { "expect": "ready" } ]"#);
+    let artifact_dir = tempfile::tempdir().value_or_panic("tempdir");
+    let mut driver = FakeDriver::default()
+        .with_screens(&["not yet", "final screen"])
+        .with_scrollback(&["history tail"]);
+
+    let err = error_or_panic(
+        run_scenario(&scenario, &mut driver, Some(artifact_dir.path())),
+        "expect should fail",
+    );
+
+    assert!(matches!(err, RunnerError::Assertion(_)));
+    assert!(artifact_dir.path().join("final-screen.txt").exists());
+    assert!(artifact_dir.path().join("final-scrollback.txt").exists());
+    assert!(artifact_dir.path().join("error.txt").exists());
+}
+
+#[test]
+fn wait_for_succeeds_when_later_capture_matches() {
+    let scenario = scenario(r#"[ { "waitFor": "ready" } ]"#);
+    let mut driver = FakeDriver::default().with_screens(&["loading", "still loading", "ready"]);
+
+    let summary = run_scenario(&scenario, &mut driver, None).value_or_panic("waitFor should pass");
+
+    assert_eq!(summary.steps_run, 1);
+}
+
+#[test]
+fn line_key_keys_and_copy_mode_forward_to_driver() {
+    let scenario = scenario(
+        r#"[
+            { "line": "hello" },
+            { "key": "Enter" },
+            { "keys": ["C-b", "["] },
+            { "copyMode": true },
+            { "copyMode": false }
+        ]"#,
+    );
+    let mut driver = FakeDriver::default();
+
+    let _summary = run_scenario(&scenario, &mut driver, None).value_or_panic("runner should pass");
+
+    assert_eq!(driver.lines_sent, ["hello"]);
+    assert_eq!(driver.keys_sent, ["Enter", "C-b", "["]);
+    assert_eq!(driver.copy_modes, [true, false]);
+}
+
+#[test]
+fn capture_step_writes_named_screen_artifact() {
+    let scenario = scenario(r#"[ { "capture": "first" } ]"#);
+    let artifact_dir = tempfile::tempdir().value_or_panic("tempdir");
+    let mut driver = FakeDriver::default().with_screens(&["first screen"]);
+
+    let summary = run_scenario(&scenario, &mut driver, Some(artifact_dir.path()))
+        .value_or_panic("capture should pass");
+
+    assert_eq!(
+        summary.artifact_dir,
+        Some(PathBuf::from(artifact_dir.path()))
+    );
+    assert!(artifact_dir.path().join("first.screen.txt").exists());
+}
+
+#[test]
+fn capture_name_is_sanitized_inside_artifact_dir() {
+    let scenario = scenario(r#"[ { "capture": "../first" } ]"#);
+    let artifact_dir = tempfile::tempdir().value_or_panic("tempdir");
+    let mut driver = FakeDriver::default().with_screens(&["first screen"]);
+
+    let _summary = run_scenario(&scenario, &mut driver, Some(artifact_dir.path()))
+        .value_or_panic("capture should pass");
+
+    assert!(artifact_dir.path().join("---first.screen.txt").exists());
+    assert!(
+        !artifact_dir
+            .path()
+            .join("..")
+            .join("first.screen.txt")
+            .exists()
+    );
+}
+
+#[test]
+fn scenario_config_out_dir_is_used_when_no_explicit_artifact_dir_is_passed() {
+    let artifact_dir = tempfile::tempdir().value_or_panic("tempdir");
+    let json = format!(
+        r#"{{
+            "config": {{ "cols": 80, "rows": 24, "out_dir": "{}" }},
+            "steps": [ {{ "capture": "screen" }} ]
+        }}"#,
+        artifact_dir.path().display()
+    );
+    let scenario = parse_scenario(&json).value_or_panic("scenario should parse");
+    let mut driver = FakeDriver::default().with_screens(&["from config"]);
+
+    let summary = run_scenario(&scenario, &mut driver, None).value_or_panic("run should pass");
+
+    assert_eq!(
+        summary.artifact_dir,
+        Some(PathBuf::from(artifact_dir.path()))
+    );
+    assert!(artifact_dir.path().join("screen.screen.txt").exists());
+}
+
+#[test]
+fn history_delta_uses_named_sample() {
+    let scenario = scenario(r#"[ { "historySample": "a" }, { "expectHistoryDelta": "a" } ]"#);
+    let mut driver = FakeDriver {
+        history_sizes: VecDeque::from([1, 3]),
+        scrollbacks: VecDeque::from([
+            ScrollbackSample::new(1, vec!["one".to_string()]),
+            ScrollbackSample::new(3, vec!["two".to_string()]),
+        ]),
+        ..FakeDriver::default()
+    };
+
+    let summary = run_scenario(&scenario, &mut driver, None).value_or_panic("delta should pass");
+
+    assert_eq!(summary.steps_run, 2);
+}
+
+#[test]
+fn wait_for_exit_polls_until_pane_dead() {
+    let scenario = scenario(r#"[ { "waitForExit": 500 } ]"#);
+    let mut driver = FakeDriver {
+        pane_statuses: VecDeque::from([PaneStatus { dead: false }, PaneStatus { dead: true }]),
+        ..FakeDriver::default()
+    };
+
+    let summary =
+        run_scenario(&scenario, &mut driver, None).value_or_panic("exit wait should pass");
+
+    assert_eq!(summary.steps_run, 1);
+}
+
+#[test]
+fn wait_for_not_and_expect_count_execute_matchers() {
+    let scenario = scenario(r#"[ { "waitForNot": "gone" }, { "expectCount": "ok", "count": 2 } ]"#);
+    let mut driver = FakeDriver::default().with_screens(&["ready", "ok ok"]);
+
+    let summary = run_scenario(&scenario, &mut driver, None).value_or_panic("matchers should pass");
+
+    assert_eq!(summary.steps_run, 2);
+}
+
+#[test]
+fn timeout_failure_uses_failing_step_context() {
+    let scenario = scenario(r#"[ { "line": "before" }, { "waitForExit": 1 } ]"#);
+    let mut driver = FakeDriver {
+        pane_statuses: VecDeque::from([PaneStatus { dead: false }]),
+        ..FakeDriver::default()
+    };
+
+    let err = error_or_panic(
+        run_scenario(&scenario, &mut driver, None),
+        "waitForExit should fail",
+    );
+
+    match err {
+        RunnerError::Assertion(failure) => {
+            assert_eq!(failure.step_index, 1);
+            assert_eq!(failure.step_kind, "waitForExit");
+            assert!(failure.reason.contains("timeout"));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn soft_assertion_mode_records_failure_and_continues() {
+    let scenario = parse_scenario(
+        r#"{
+            "config": { "cols": 80, "rows": 24, "assert_mode": "soft" },
+            "steps": [ { "expect": "missing" }, { "line": "after" } ]
+        }"#,
+    )
+    .value_or_panic("scenario should parse");
+    let mut driver = FakeDriver::default().with_screens(&["different"]);
+
+    let summary =
+        run_scenario(&scenario, &mut driver, None).value_or_panic("soft run should continue");
+
+    assert_eq!(summary.steps_run, 2);
+    assert_eq!(summary.soft_failures.len(), 1);
+    assert_eq!(driver.lines_sent, ["after"]);
+}
+
+#[test]
+fn history_sample_writes_labeled_artifact() {
+    let scenario = scenario(r#"[ { "historySample": "before/typing" } ]"#);
+    let artifact_dir = tempfile::tempdir().value_or_panic("tempdir");
+    let mut driver = FakeDriver {
+        history_sizes: VecDeque::from([3]),
+        scrollbacks: VecDeque::from([ScrollbackSample::new(3, vec!["history".to_string()])]),
+        ..FakeDriver::default()
+    };
+
+    let _summary = run_scenario(&scenario, &mut driver, Some(artifact_dir.path()))
+        .value_or_panic("history sample should pass");
+
+    assert!(
+        artifact_dir
+            .path()
+            .join("before-typing.history.txt")
+            .exists()
+    );
+}
+
+#[test]
+fn driver_error_during_assertion_is_propagated() {
+    let scenario = scenario(r#"[ { "expect": "ready" } ]"#);
+    let mut driver = FakeDriver {
+        fail_screen_after: Some(0),
+        ..FakeDriver::default()
+    };
+
+    let err = error_or_panic(
+        run_scenario(&scenario, &mut driver, None),
+        "driver should fail",
+    );
+
+    assert!(matches!(err, RunnerError::Driver(_)));
+}
+
+#[test]
+fn artifact_capture_failure_preserves_original_assertion() {
+    let scenario = scenario(r#"[ { "expect": "ready" } ]"#);
+    let artifact_dir = tempfile::tempdir().value_or_panic("tempdir");
+    let mut driver = FakeDriver {
+        screens: VecDeque::from([ScreenCapture::new(1, 80, vec!["nope".to_string()])]),
+        fail_screen_after: Some(1),
+        ..FakeDriver::default()
+    };
+
+    let err = error_or_panic(
+        run_scenario(&scenario, &mut driver, Some(artifact_dir.path())),
+        "expect should fail",
+    );
+
+    assert!(matches!(err, RunnerError::Assertion(_)));
+}
+
+#[test]
+fn guarded_real_jefe_runner_scenario_starts_and_quits() {
+    let tmux = TmuxDriver::new();
+    if !tmux.is_available() {
+        let _ = std::io::Write::write_all(
+            &mut std::io::stderr(),
+            b"skipping real runner test: tmux unavailable\n",
+        );
+        return;
+    }
+    let Some(jefe_binary) = jefe_binary_path() else {
+        let _ = std::io::Write::write_all(
+            &mut std::io::stderr(),
+            b"skipping real runner test: jefe binary unavailable\n",
+        );
+        return;
+    };
+    let config_dir = tempfile::tempdir().value_or_panic("isolated config tempdir");
+    let scenario = scenario(
+        r#"[
+            { "waitFor": "LLxprt Jefe" },
+            { "key": "q" },
+            { "waitForExit": 3000 }
+        ]"#,
+    );
+    let session_name = unique_session("runner-jefe");
+    let request = TmuxStartRequest::jefe(
+        session_name,
+        jefe_binary,
+        config_dir.path(),
+        std::env::current_dir().value_or_panic("current dir"),
+        TmuxPaneSize::new(100, 30, 2_000),
+    )
+    .value_or_panic("jefe request");
+
+    let summary =
+        run_tmux_scenario(&scenario, &request, None).value_or_panic("real runner scenario");
+
+    assert_eq!(summary.steps_run, 3);
+}
+
+fn jefe_binary_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_jefe") {
+        let candidate = PathBuf::from(path);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    let current = std::env::current_exe().ok()?;
+    let deps_dir = current.parent()?;
+    let debug_dir = deps_dir.parent()?;
+    let candidate = debug_dir.join("jefe");
+    candidate.exists().then_some(candidate)
+}
+
+fn unique_session(label: &str) -> String {
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    format!("jefe-runner-{label}-{pid}-{nanos}")
+}


### PR DESCRIPTION
## Summary

- Adds the tmux harness runner/orchestrator layer behind a `HarnessDriver` seam.
- Executes all currently modeled scenario steps and writes structured failure artifacts.
- Adds a thin `jefe-tmux-harness` CLI for running scenarios against an isolated real jefe binary/config.
- Covers runner behavior with deterministic fake-driver tests plus a guarded real tmux/jefe smoke test.

## Verification

- `cargo test --workspace --all-features --locked harness::runner -- --nocapture`
- `cargo test --workspace --all-features --locked --bin jefe-tmux-harness -- --nocapture`
- `make ci-check`
- rustreviewer: APPROVE
- OCR: reviewed 4 files; addressed all comments. Final rerun failed due OCR LLM/config, not source.

Fixes #101
