### PR TITLE
Document tmux harness scenarios (Fixes #102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,15 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      run_tui_smoke:
+        description: Run optional tmux-backed TUI smoke scenario
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -169,3 +178,45 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --workspace --all-features --locked
+
+  tui_smoke:
+    name: Optional TUI smoke (tmux)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_tui_smoke == 'true' }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install tmux
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! { sudo apt-get update && sudo apt-get install -y tmux; }; then
+            echo "WARNING: tmux installation failed; smoke scenario will be skipped"
+          fi
+      - name: Run startup TUI smoke scenario
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v tmux >/dev/null 2>&1; then
+            echo "tmux unavailable after install attempt; skipping optional TUI smoke"
+            exit 0
+          fi
+          cargo build --locked --all-features --bin jefe --bin jefe-tmux-harness
+          config_dir="$(mktemp -d)"
+          mkdir -p target/tmux-harness/ci-startup
+          target/debug/jefe-tmux-harness \
+            --scenario dev-docs/tmux-scenarios/startup-quit.json \
+            --jefe-bin target/debug/jefe \
+            --config "$config_dir" \
+            --out-dir target/tmux-harness/ci-startup
+      - name: Upload TUI smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tui-smoke-artifacts
+          path: target/tmux-harness
+          if-no-files-found: ignore

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -23,6 +23,10 @@ This directory contains the working rules for planning and implementation in Jef
   - How coordinators execute phase-by-phase work with subagents.
   - Covers strict sequencing, verification gating, and remediation loops.
 
+- [`tmux-harness.md`](./tmux-harness.md)
+  - How to run deterministic real-TTY TUI scenarios through the tmux-backed harness.
+  - Covers scenario JSON, local execution, artifacts, and optional smoke checks.
+
 ## Recommended Reading Order
 
 1. `RULES.md`

--- a/dev-docs/tmux-harness.md
+++ b/dev-docs/tmux-harness.md
@@ -1,0 +1,154 @@
+# Tmux-backed TUI harness
+
+The tmux harness runs `jefe` inside a real terminal session and drives it with
+keyboard input. It exists for deterministic end-to-end checks of behavior that is
+hard to validate with reducer or component tests alone: focus changes, terminal
+geometry, alternate-screen rendering, scrollback, process exit, and failure
+artifacts.
+
+The harness is intentionally split by side-effect boundary:
+
+1. **Scenario model and macro expansion** parse JSON into typed Rust structs.
+2. **Screen and scrollback matchers** evaluate captured text without I/O.
+3. **Tmux driver** owns all `tmux -f /dev/null` process calls.
+4. **Runner/orchestrator** composes the pure layers with the driver seam,
+   bounded polling, and artifact capture.
+5. **CLI and scenarios** provide local/manual entry points and opt-in smoke
+   checks.
+
+The production `jefe` binary does not contain test orchestration logic. The
+separate `jefe-tmux-harness` tool starts a real `jefe` binary with an isolated
+`--config` directory so developer state is never read or mutated.
+
+## Scenario JSON schema
+
+A scenario is a JSON object with `config`, optional `macros`, and `steps`.
+
+```json
+{
+  "config": {
+    "cols": 100,
+    "rows": 32,
+    "history_limit": 2000,
+    "initial_wait_ms": 100,
+    "out_dir": "target/tmux-harness/example",
+    "keep_session": false,
+    "assert_mode": "strict"
+  },
+  "macros": {
+    "quit": {
+      "params": [],
+      "steps": [
+        { "key": "q" },
+        { "waitForExit": 3000 }
+      ]
+    }
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "macro": "quit", "args": {} }
+  ]
+}
+```
+
+### Config fields
+
+- `cols` and `rows`: tmux pane geometry. Use fixed values for deterministic
+  rendering.
+- `history_limit`: retained scrollback lines.
+- `initial_wait_ms`: optional startup pause before the first step.
+- `out_dir`: optional default artifact directory. The CLI `--out-dir` overrides
+  it.
+- `keep_session`: keep tmux alive after completion for manual debugging.
+- `assert_mode`: `strict` aborts on first assertion failure; `soft` records
+  assertion failures and continues.
+
+## Step catalog
+
+Each step object has one primitive key.
+
+| Step | Example | Behavior |
+| --- | --- | --- |
+| `wait` | `{ "wait": 100 }` | Sleep for milliseconds. Prefer `waitFor` where possible. |
+| `line` | `{ "line": "hello" }` | Type a full line and press Enter. |
+| `key` | `{ "key": "?" }` | Send one tmux key token. |
+| `keys` | `{ "keys": ["Tab", "Enter"] }` | Send a sequence of key tokens. |
+| `waitFor` | `{ "waitFor": "Help" }` | Poll the screen until a literal appears. |
+| `waitForNot` | `{ "waitForNot": "Loading" }` | Poll the screen until a literal disappears. |
+| `expect` | `{ "expect": "new-agent" }` | Assert the current screen contains a literal. |
+| `expectCount` | `{ "expectCount": "│", "count": 4 }` | Assert an exact literal count on screen. |
+| `capture` | `{ "capture": "after-help" }` | Write `<label>.screen.txt` to the artifact dir. |
+| `historySample` | `{ "historySample": "before" }` | Save scrollback and history size under a label. |
+| `expectHistoryDelta` | `{ "expectHistoryDelta": "before" }` | Assert scrollback/history changed since the sample. |
+| `copyMode` | `{ "copyMode": true }` | Enter or exit tmux copy mode. |
+| `waitForExit` | `{ "waitForExit": 3000 }` | Poll `pane_dead` until the app exits. |
+| `macro` | `{ "macro": "quit", "args": {} }` | Expand a named macro before execution. |
+
+All screen matching is literal. If future scenarios need regular expressions,
+add that as a typed matcher extension rather than smuggling dynamic behavior
+through JSON.
+
+## Running locally
+
+Build the binary and harness, create an isolated config directory, and run a
+scenario:
+
+```bash
+cargo build --workspace --all-features --locked
+mkdir -p /tmp/jefe-harness-config
+cargo run --bin jefe-tmux-harness -- \
+  --scenario dev-docs/tmux-scenarios/startup-quit.json \
+  --jefe-bin target/debug/jefe \
+  --config /tmp/jefe-harness-config \
+  --out-dir target/tmux-harness/startup-quit
+```
+
+To debug a failing scenario, add `--keep-session` and inspect the named tmux
+session printed by the scenario file or CLI defaults.
+
+## Artifact layout
+
+When an artifact directory is supplied, the runner may write:
+
+- `final-screen.txt`: final screen capture on failure.
+- `final-scrollback.txt`: final scrollback capture on failure.
+- `error.txt`: structured failure context including step index, step kind, and
+  reason.
+- `<label>.screen.txt`: named captures from `capture` steps.
+- `<label>.history.txt`: named scrollback samples from `historySample` steps.
+
+Artifact labels are sanitized before writing, so scenario names cannot escape the
+artifact directory.
+
+## Deterministic scenario guidance
+
+- Pin `cols`, `rows`, and `history_limit`.
+- Always pass an isolated `--config` directory.
+- Prefer `waitFor`/`waitForNot`/`waitForExit` over fixed sleeps.
+- Avoid spinner frames, elapsed-time text, network-backed GitHub lists, or local
+  machine state unless the scenario explicitly sets up that state.
+- Capture useful checkpoints before quitting so alternate-buffer teardown does
+  not hide the interesting screen.
+- Keep scratch/manual scenarios outside required CI until they prove stable.
+
+## Tmux availability and skipping
+
+Unit tests use fake drivers for deterministic runner behavior. Guarded real tmux
+smoke tests skip cleanly when `tmux` is unavailable. The optional CI smoke job is
+manual/opt-in and also skips when `tmux` cannot be installed or found.
+
+## Included scenarios
+
+- [`startup-quit.json`](./tmux-scenarios/startup-quit.json): waits for the
+  dashboard keybind bar, captures the screen, quits, and waits for exit.
+- [`help-modal.json`](./tmux-scenarios/help-modal.json): opens the help modal,
+  verifies its stable title, captures it, closes it, then quits.
+- [`scratch-pr-mode.json`](./tmux-scenarios/scratch-pr-mode.json): manual
+  scratch scenario for PR-mode screen validation. It is intentionally not a CI
+  gate because repository/GitHub configuration can vary by developer machine.
+
+## Future regression scenarios
+
+Once the scratch flows are stable, add scenarios for list viewport following,
+filter controls, and inline composer caret behavior. Keep them local/manual until
+they can be made deterministic with isolated config and predictable data.

--- a/dev-docs/tmux-scenarios/help-modal.json
+++ b/dev-docs/tmux-scenarios/help-modal.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "cols": 100,
+    "rows": 32,
+    "history_limit": 2000,
+    "initial_wait_ms": 100,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "key": "?" },
+    { "waitFor": "Help - Keyboard Shortcuts" },
+    { "expect": "Press any key to close" },
+    { "capture": "help-modal" },
+    { "key": "Escape" },
+    { "waitForNot": "Help - Keyboard Shortcuts" },
+    { "key": "q" },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/dev-docs/tmux-scenarios/scratch-pr-mode.json
+++ b/dev-docs/tmux-scenarios/scratch-pr-mode.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "cols": 120,
+    "rows": 36,
+    "history_limit": 4000,
+    "initial_wait_ms": 100,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "key": "p" },
+    { "waitFor": "Pull Requests" },
+    { "capture": "pr-mode-screen" },
+    { "key": "a" },
+    { "waitFor": "No terminal attached" },
+    { "capture": "dashboard-after-pr-mode" },
+    { "key": "q" },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/dev-docs/tmux-scenarios/startup-quit.json
+++ b/dev-docs/tmux-scenarios/startup-quit.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "cols": 100,
+    "rows": 32,
+    "history_limit": 2000,
+    "initial_wait_ms": 100,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "expect": "No terminal attached" },
+    { "capture": "startup" },
+    { "key": "q" },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -7,4 +7,5 @@ mod clippy_allow_policy;
 mod domain_state_contracts;
 mod message_bus_contracts;
 mod persistence_theme_contracts;
+mod tmux_harness_docs_contracts;
 mod visibility_filter_contracts;

--- a/tests/core/tmux_harness_docs_contracts.rs
+++ b/tests/core/tmux_harness_docs_contracts.rs
@@ -1,0 +1,65 @@
+//! Contracts for tmux harness docs and shipped scenario examples.
+//!
+//! @plan PLAN-20260629-TMUX-HARNESS.P05
+//! @requirement REQ-TMUX-HARNESS-005
+
+use std::path::{Path, PathBuf};
+
+use jefe::harness::{expand_macros, parse_scenario};
+
+/// @plan PLAN-20260629-TMUX-HARNESS.P05
+/// @requirement REQ-TMUX-HARNESS-005
+/// @pseudocode component-001 lines 1-4
+#[test]
+fn dev_docs_index_links_to_tmux_harness_guide() {
+    let readme = read_repo_text("dev-docs/README.md");
+
+    assert!(
+        readme.contains("[`tmux-harness.md`](./tmux-harness.md)"),
+        "dev-docs index should link the tmux harness guide"
+    );
+}
+
+/// @plan PLAN-20260629-TMUX-HARNESS.P05
+/// @requirement REQ-TMUX-HARNESS-005
+/// @pseudocode component-002 lines 1-6
+#[test]
+fn shipped_tmux_scenarios_parse_and_expand() {
+    for path in shipped_scenario_paths() {
+        let json = read_repo_text(&path);
+        let scenario = parse_scenario(&json)
+            .unwrap_or_else(|err| panic!("{} should parse: {err}", path.display()));
+        expand_macros(&scenario)
+            .unwrap_or_else(|err| panic!("{} should expand: {err}", path.display()));
+    }
+}
+
+fn shipped_scenario_paths() -> Vec<PathBuf> {
+    let dir = repo_path("dev-docs/tmux-scenarios");
+    let mut paths = read_json_paths(&dir);
+    assert!(!paths.is_empty(), "no shipped scenario JSON files found");
+    paths.sort();
+    paths
+}
+
+fn read_json_paths(dir: &Path) -> Vec<PathBuf> {
+    std::fs::read_dir(dir)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", dir.display()))
+        .map(|entry| {
+            entry
+                .unwrap_or_else(|err| panic!("failed to read scenario entry: {err}"))
+                .path()
+        })
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .collect()
+}
+
+fn read_repo_text(relative_path: impl AsRef<Path>) -> String {
+    let path = repo_path(relative_path);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()))
+}
+
+fn repo_path(relative_path: impl AsRef<Path>) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path.as_ref())
+}


### PR DESCRIPTION
## Summary
- Adds the tmux harness developer guide and links it from the dev docs index.
- Ships deterministic startup/help scenarios plus a manual scratch PR-mode scenario.
- Adds contract tests that parse and macro-expand every shipped scenario JSON file.
- Adds an opt-in workflow_dispatch TUI smoke job that skips cleanly when tmux is unavailable and uploads artifacts.

## Verification
- Local startup-quit scenario passed with target/debug/jefe and isolated temp config.
- Local help-modal scenario passed with target/debug/jefe and isolated temp config.
- Local scratch-pr-mode scenario passed with target/debug/jefe and isolated temp config.
- cargo fmt --all --check
- CLIPPY_CONF_DIR=.github/clippy cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo build --workspace --all-features --locked
- cargo test --workspace --all-features --locked
- check-clippy-allows, complexity, architecture, coverage, source-length gates passed separately after local make ci-check was SIGTERM-killed late by the harness.
- rustreviewer APPROVE.
- ocr review --audience agent --timeout 20, valid findings addressed.

Fixes #102
