### PR TITLE
Improve Issues mode list and filters (Fixes #95)

### DIFF
--- a/dev-docs/tmux-scenarios/issues-filter-open-close.json
+++ b/dev-docs/tmux-scenarios/issues-filter-open-close.json
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "cols": 120,
+    "rows": 36,
+    "history_limit": 4000,
+    "initial_wait_ms": 100,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "key": "i" },
+    { "waitFor": "Issues" },
+    { "key": "f" },
+    { "waitFor": "Filter:" },
+    { "capture": "issues-filter-open" },
+    { "key": "Escape" },
+    { "waitForNot": "Filter:" },
+    { "key": "a" },
+    { "waitFor": "No terminal attached" },
+    { "capture": "dashboard-after-issues-mode" },
+    { "key": "q" },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/src/app_input/issues_dispatch.rs
+++ b/src/app_input/issues_dispatch.rs
@@ -64,20 +64,10 @@ pub(super) fn preview_issue_from_list(app_state: &mut AppStateHandle) {
                     author_login: issue.author_login.clone(),
                     created_at: String::new(),
                     updated_at: issue.updated_at.clone(),
-                    labels: issue
-                        .labels_summary
-                        .split(", ")
-                        .filter(|s| !s.is_empty())
-                        .map(String::from)
-                        .collect(),
-                    assignees: issue
-                        .assignee_summary
-                        .split(", ")
-                        .filter(|s| !s.is_empty())
-                        .map(String::from)
-                        .collect(),
+                    labels: issue.labels.clone(),
+                    assignees: issue.assignees.clone(),
                     milestone: None,
-                    body: issue.body.clone(),
+                    body: preview_body_from_list(&issue.body),
                     external_url: String::new(),
                     comments: Vec::new(),
                     has_more_comments: false,
@@ -95,6 +85,18 @@ pub(super) fn preview_issue_from_list(app_state: &mut AppStateHandle) {
         state.issues_state.comments_page_pending = None;
         state.issues_state.detail_subfocus = jefe::state::DetailSubfocus::Body;
         state.issues_state.detail_scroll_offset = 0;
+    }
+}
+
+/// Body text for instant issue previews built from lightweight list rows.
+/// @plan PLAN-20260630-ISSUES-REGRESSION.P01
+/// @requirement REQ-ISS-006
+/// @pseudocode component-004 lines 1-5
+fn preview_body_from_list(body: &str) -> String {
+    if body.is_empty() {
+        "Press Enter to load issue body.".to_string()
+    } else {
+        body.to_string()
     }
 }
 
@@ -410,4 +412,22 @@ pub(super) fn format_issue_prompt(payload: &jefe::github::SendPayload) -> String
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::preview_body_from_list;
+
+    #[test]
+    fn empty_list_preview_body_prompts_for_detail_load() {
+        assert_eq!(
+            preview_body_from_list(""),
+            "Press Enter to load issue body."
+        );
+    }
+
+    #[test]
+    fn populated_list_preview_body_is_preserved() {
+        assert_eq!(preview_body_from_list("existing body"), "existing body");
+    }
 }

--- a/src/app_input/issues_filter.rs
+++ b/src/app_input/issues_filter.rs
@@ -2,6 +2,7 @@
 //! @requirement REQ-ISS-008
 
 use iocraft::prelude::*;
+use std::collections::BTreeSet;
 
 use jefe::state::{AppEvent, AppState};
 
@@ -27,6 +28,12 @@ pub(super) fn resolve_filter_key_event(state: &AppState, key_event: &KeyEvent) -
             // State field: cycle through open/closed/all
             Some(AppEvent::CycleFilterState)
         }
+        KeyCode::Right if field_idx == 2 || field_idx == 3 => {
+            choice_cycle_event(state, field_idx, ChoiceDirection::Next)
+        }
+        KeyCode::Left if field_idx == 2 || field_idx == 3 => {
+            choice_cycle_event(state, field_idx, ChoiceDirection::Previous)
+        }
         KeyCode::Char(c) if field_idx > 0 => {
             let &field_name = FILTER_FIELD_NAMES.get(field_idx)?;
             let mut value = current_filter_field_value(state, field_name);
@@ -49,6 +56,114 @@ pub(super) fn resolve_filter_key_event(state: &AppState, key_event: &KeyEvent) -
     }
 }
 
+/// Build an update event that cycles assignee/label fields through choices
+/// already visible in the loaded issue rows.
+/// @plan PLAN-20260630-ISSUES-REGRESSION.P01
+/// @requirement REQ-ISS-008
+/// @pseudocode component-003 lines 120-127
+#[derive(Clone, Copy)]
+enum ChoiceDirection {
+    Next,
+    Previous,
+}
+
+fn choice_cycle_event(
+    state: &AppState,
+    field_idx: usize,
+    direction: ChoiceDirection,
+) -> Option<AppEvent> {
+    let field_name = *FILTER_FIELD_NAMES.get(field_idx)?;
+    let choices = issue_filter_choices(state, field_name);
+    if choices.is_empty() {
+        return None;
+    }
+    let current = current_filter_field_value(state, field_name);
+    let next = if field_idx == 3 {
+        cycle_label_choice(&choices, &current, direction)?
+    } else {
+        adjacent_choice(&choices, &current, direction)?
+    };
+    Some(AppEvent::UpdateDraftFilter {
+        field: field_name.to_string(),
+        value: next,
+    })
+}
+
+/// Collect unique assignee/label choices from currently loaded issue metadata.
+/// @plan PLAN-20260630-ISSUES-REGRESSION.P01
+/// @requirement REQ-ISS-008
+/// @pseudocode component-003 lines 120-127
+fn issue_filter_choices(state: &AppState, field_name: &str) -> Vec<String> {
+    let mut choices = BTreeSet::new();
+    for issue in &state.issues_state.issues {
+        match field_name {
+            "assignee" => choices.extend(issue.assignees.iter().cloned()),
+            "labels" => choices.extend(issue.labels.iter().cloned()),
+            _ => {}
+        }
+    }
+    choices.into_iter().collect()
+}
+
+fn adjacent_choice(
+    choices: &[String],
+    current: &str,
+    direction: ChoiceDirection,
+) -> Option<String> {
+    if current.is_empty() {
+        return choices.first().cloned();
+    }
+    let idx = choices.iter().position(|choice| choice == current)?;
+    let next_idx = match direction {
+        ChoiceDirection::Next => (idx + 1) % choices.len(),
+        ChoiceDirection::Previous => (idx + choices.len() - 1) % choices.len(),
+    };
+
+    Some(choices[next_idx].clone())
+}
+
+fn cycle_label_choice(
+    choices: &[String],
+    current: &str,
+    direction: ChoiceDirection,
+) -> Option<String> {
+    let Some((prefix, active)) = split_label_filter_tail(current) else {
+        return adjacent_choice(choices, current.trim(), direction);
+    };
+    if active.is_empty() {
+        let next = first_unused_label_choice(choices, &prefix)?;
+        return Some(format!("{prefix}{next}"));
+    }
+    let next = adjacent_choice(choices, active, direction)?;
+    Some(format!("{prefix}{next}"))
+}
+
+fn first_unused_label_choice(choices: &[String], prefix: &str) -> Option<String> {
+    choices
+        .iter()
+        .find(|choice| !label_prefix_contains(prefix, choice))
+        .cloned()
+}
+
+fn label_prefix_contains(prefix: &str, label: &str) -> bool {
+    prefix
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .any(|part| part == label)
+}
+
+fn split_label_filter_tail(current: &str) -> Option<(String, &str)> {
+    let comma_idx = current.rfind(',')?;
+    let (_, tail) = current.split_at(comma_idx + 1);
+    let trimmed_tail = tail.trim_start();
+    let whitespace_len = tail.len().saturating_sub(trimmed_tail.len());
+    let visible_prefix_len = comma_idx + 1 + whitespace_len;
+    current
+        .get(..visible_prefix_len)
+        .map(|prefix| (prefix.to_string(), trimmed_tail.trim_end()))
+}
+
 /// Read the current value of a draft filter text field.
 /// For labels, reads the raw editing string to preserve trailing commas.
 fn current_filter_field_value(state: &AppState, field_name: &str) -> String {
@@ -65,6 +180,7 @@ fn current_filter_field_value(state: &AppState, field_name: &str) -> String {
 mod tests {
     use super::*;
     use iocraft::prelude::{KeyCode, KeyEventKind, KeyModifiers};
+    use jefe::domain::{Issue, IssueState};
     use jefe::state::{AppState, IssueFilterUiState, ScreenMode};
 
     fn key(code: KeyCode) -> KeyEvent {
@@ -91,6 +207,29 @@ mod tests {
             },
             ..Default::default()
         }
+    }
+    fn issue(number: u64, assignees: &str, labels: &str) -> Issue {
+        Issue {
+            number,
+            title: format!("Issue {number}"),
+            state: IssueState::Open,
+            author_login: "octocat".to_string(),
+            updated_at: "2026-06-30".to_string(),
+            assignee_summary: assignees.to_string(),
+            labels_summary: labels.to_string(),
+            assignees: summary_vec(assignees),
+            labels: summary_vec(labels),
+            comment_count: 0,
+            body: String::new(),
+        }
+    }
+
+    fn summary_vec(summary: &str) -> Vec<String> {
+        summary
+            .split(", ")
+            .filter(|value| !value.is_empty())
+            .map(String::from)
+            .collect()
     }
 
     #[test]
@@ -200,6 +339,129 @@ mod tests {
                 assert_eq!(value, "bug,");
             }
             _ => panic!("expected UpdateDraftFilter"),
+        }
+    }
+
+    #[test]
+    fn test_filter_right_cycles_assignee_choices_from_loaded_issues() {
+        let mut state = filter_state();
+        state.issues_state.filter_ui.field_index = 2;
+        state.issues_state.issues = vec![issue(1, "zara", "bug"), issue(2, "alice", "ui")];
+
+        let evt = resolve_filter_key_event(&state, &key(KeyCode::Right));
+        match evt {
+            Some(AppEvent::UpdateDraftFilter { field, value }) => {
+                assert_eq!(field, "assignee");
+                assert_eq!(value, "alice");
+            }
+            _ => panic!("expected choice-backed assignee update"),
+        }
+    }
+
+    #[test]
+    fn test_filter_right_cycles_label_choices_from_loaded_issues() {
+        let mut state = filter_state();
+        state.issues_state.filter_ui.field_index = 3;
+        state.issues_state.filter_ui.draft_labels_text = "bug".to_string();
+        state.issues_state.issues = vec![issue(1, "zara", "bug, ui"), issue(2, "alice", "docs")];
+
+        let evt = resolve_filter_key_event(&state, &key(KeyCode::Right));
+        match evt {
+            Some(AppEvent::UpdateDraftFilter { field, value }) => {
+                assert_eq!(field, "labels");
+                assert_eq!(value, "docs");
+            }
+            _ => panic!("expected choice-backed labels update"),
+        }
+    }
+
+    #[test]
+    fn test_filter_space_still_types_in_label_text_field() {
+        let mut state = filter_state();
+        state.issues_state.filter_ui.field_index = 3;
+        state.issues_state.filter_ui.draft_labels_text = "good".to_string();
+        state.issues_state.issues = vec![issue(1, "zara", "good first issue")];
+
+        let evt = resolve_filter_key_event(&state, &key(KeyCode::Char(' ')));
+        match evt {
+            Some(AppEvent::UpdateDraftFilter { field, value }) => {
+                assert_eq!(field, "labels");
+                assert_eq!(value, "good ");
+            }
+            _ => panic!("expected literal space text input"),
+        }
+    }
+
+    #[test]
+    fn test_filter_left_cycles_label_choices_backward() {
+        let mut state = filter_state();
+        state.issues_state.filter_ui.field_index = 3;
+        state.issues_state.filter_ui.draft_labels_text = "docs".to_string();
+        state.issues_state.issues = vec![issue(1, "zara", "bug, ui"), issue(2, "alice", "docs")];
+
+        let evt = resolve_filter_key_event(&state, &key(KeyCode::Left));
+        match evt {
+            Some(AppEvent::UpdateDraftFilter { field, value }) => {
+                assert_eq!(field, "labels");
+                assert_eq!(value, "bug");
+            }
+            _ => panic!("expected backward labels update"),
+        }
+    }
+
+    #[test]
+    fn test_filter_right_cycles_only_last_label_token() {
+        let mut state = filter_state();
+        state.issues_state.filter_ui.field_index = 3;
+        state.issues_state.filter_ui.draft_labels_text = "bug, docs".to_string();
+        state.issues_state.issues = vec![issue(1, "zara", "bug, ui"), issue(2, "alice", "docs")];
+
+        let evt = resolve_filter_key_event(&state, &key(KeyCode::Right));
+        match evt {
+            Some(AppEvent::UpdateDraftFilter { field, value }) => {
+                assert_eq!(field, "labels");
+                assert_eq!(value, "bug, ui");
+            }
+            _ => panic!("expected last-token labels update"),
+        }
+    }
+
+    #[test]
+    fn test_filter_right_preserves_unknown_typed_assignee() {
+        let mut state = filter_state();
+        state.issues_state.filter_ui.field_index = 2;
+        state.issues_state.draft_filter.assignee = "custom-user".to_string();
+        state.issues_state.issues = vec![issue(1, "zara", "bug")];
+
+        let evt = resolve_filter_key_event(&state, &key(KeyCode::Right));
+        assert!(evt.is_none());
+    }
+
+    #[test]
+    fn test_filter_right_preserves_unknown_last_label_token() {
+        let mut state = filter_state();
+        state.issues_state.filter_ui.field_index = 3;
+        state.issues_state.filter_ui.draft_labels_text = "bug, custom".to_string();
+        state.issues_state.issues = vec![issue(1, "zara", "bug, ui")];
+
+        let evt = resolve_filter_key_event(&state, &key(KeyCode::Right));
+        assert!(evt.is_none());
+    }
+
+    #[test]
+    fn test_filter_right_fills_trailing_comma_with_unused_label() {
+        let mut state = filter_state();
+        state.issues_state.filter_ui.field_index = 3;
+        state.issues_state.filter_ui.draft_labels_text = "bug,".to_string();
+        state.issues_state.issues = vec![issue(1, "zara", "bug, ui")];
+
+        let evt = resolve_filter_key_event(&state, &key(KeyCode::Right));
+        match evt {
+            Some(AppEvent::UpdateDraftFilter { field, value }) => {
+                assert_eq!(field, "labels");
+                assert_eq!(value, "bug,ui");
+            }
+            _ => panic!("expected unused label choice after trailing comma"),
         }
     }
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -230,7 +230,11 @@ pub struct Issue {
     pub updated_at: String,
     pub assignee_summary: String,
     pub labels_summary: String,
+    pub assignees: Vec<String>,
+    pub labels: Vec<String>,
     pub comment_count: u64,
+    /// Optional lightweight preview body; list/search fetches may leave this empty
+    /// so full body content is loaded through `IssueDetail` instead.
     pub body: String,
 }
 

--- a/src/github/parse.rs
+++ b/src/github/parse.rs
@@ -128,8 +128,10 @@ fn parse_issue_from_item(item: &Value) -> Result<Issue, GhError> {
         .unwrap_or("")
         .to_string();
 
-    let assignee_summary = join_nodes_field(item, "assignees");
-    let labels_summary = join_nodes_field(item, "labels");
+    let assignees = collect_nodes_field(item, "assignees");
+    let labels = collect_nodes_field(item, "labels");
+    let assignee_summary = assignees.join(", ");
+    let labels_summary = labels.join(", ");
 
     let comment_count = item
         .get("comments")
@@ -151,17 +153,19 @@ fn parse_issue_from_item(item: &Value) -> Result<Issue, GhError> {
         updated_at,
         assignee_summary,
         labels_summary,
+        assignees,
+        labels,
         comment_count,
         body,
     })
 }
 
-/// Read `field.nodes[*].<key>` (defaulting to "login"/"name") joined with ", ".
+/// Read `field.nodes[*].<key>` (defaulting to "login"/"name").
 ///
 /// Supports two JSON shapes returned by the `gh` CLI:
 /// - GraphQL style: `{"nodes": [{"login": ...}, ...]}`.
 /// - REST/direct array style: `[{"login": ...}, ...]` (a bare array of objects).
-fn join_nodes_field(item: &Value, field: &str) -> String {
+fn collect_nodes_field(item: &Value, field: &str) -> Vec<String> {
     // `gh issue list` exposes label names under `name`; user-like nodes use `login`.
     let key = if field == "labels" { "name" } else { "login" };
 
@@ -179,8 +183,8 @@ fn join_nodes_field(item: &Value, field: &str) -> String {
             nodes
                 .iter()
                 .filter_map(|n| n.get(key).and_then(Value::as_str))
-                .collect::<Vec<_>>()
-                .join(", ")
+                .map(String::from)
+                .collect()
         })
         .unwrap_or_default()
 }
@@ -519,7 +523,7 @@ pub fn build_list_issues_args(
         "--repo".to_string(),
         format!("{owner}/{repo}"),
         "--json".to_string(),
-        "number,title,state,author,updatedAt,assignees,labels,comments,body".to_string(),
+        "number,title,state,author,updatedAt,assignees,labels,comments".to_string(),
         "-L".to_string(),
         page_size.to_string(),
     ];
@@ -609,9 +613,9 @@ pub(super) fn build_issue_search_args(
     page_size: u32,
 ) -> Vec<String> {
     let query = if cursor.is_some() {
-        "query($searchQuery: String!, $first: Int!, $after: String) { search(type: ISSUE, query: $searchQuery, first: $first, after: $after) { nodes { ... on Issue { number title state author { login } updatedAt assignees(first: 10) { nodes { login } } labels(first: 20) { nodes { name } } comments { totalCount } body } } pageInfo { hasNextPage endCursor } } }"
+        "query($searchQuery: String!, $first: Int!, $after: String) { search(type: ISSUE, query: $searchQuery, first: $first, after: $after) { nodes { ... on Issue { number title state author { login } updatedAt assignees(first: 10) { nodes { login } } labels(first: 20) { nodes { name } } comments { totalCount } } } pageInfo { hasNextPage endCursor } } }"
     } else {
-        "query($searchQuery: String!, $first: Int!) { search(type: ISSUE, query: $searchQuery, first: $first) { nodes { ... on Issue { number title state author { login } updatedAt assignees(first: 10) { nodes { login } } labels(first: 20) { nodes { name } } comments { totalCount } body } } pageInfo { hasNextPage endCursor } } }"
+        "query($searchQuery: String!, $first: Int!) { search(type: ISSUE, query: $searchQuery, first: $first) { nodes { ... on Issue { number title state author { login } updatedAt assignees(first: 10) { nodes { login } } labels(first: 20) { nodes { name } } comments { totalCount } } } pageInfo { hasNextPage endCursor } } }"
     };
     let mut args = vec![
         "api".to_string(),
@@ -628,4 +632,45 @@ pub(super) fn build_issue_search_args(
         args.push(format!("after={c}"));
     }
     args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_issue_search_args;
+    use crate::domain::IssueFilter;
+
+    fn issue_query_fields(query_arg: &str) -> Vec<&str> {
+        let Some(issue_fields) = query_arg.split("... on Issue {").nth(1) else {
+            return Vec::new();
+        };
+        let Some(before_comments) = issue_fields.split("comments").next() else {
+            return Vec::new();
+        };
+        before_comments
+            .split_whitespace()
+            .filter(|token| token.chars().all(char::is_alphanumeric))
+            .collect()
+    }
+
+    #[test]
+    fn issue_search_args_omit_body_for_fast_first_paint() {
+        let args = build_issue_search_args("owner", "repo", &IssueFilter::default(), None, 30);
+        let query_arg = args
+            .iter()
+            .find(|arg| arg.starts_with("query="))
+            .unwrap_or_else(|| panic!("missing GraphQL query arg: {args:?}"));
+
+        let fields = issue_query_fields(query_arg);
+        assert!(fields.contains(&"title"));
+        assert!(!fields.contains(&"body"));
+
+        let paged_args =
+            build_issue_search_args("owner", "repo", &IssueFilter::default(), Some("cursor"), 30);
+        let paged_query_arg = paged_args
+            .iter()
+            .find(|arg| arg.starts_with("query="))
+            .unwrap_or_else(|| panic!("missing paged GraphQL query arg: {paged_args:?}"));
+        let paged_fields = issue_query_fields(paged_query_arg);
+        assert!(!paged_fields.contains(&"body"));
+    }
 }

--- a/src/github/tests.rs
+++ b/src/github/tests.rs
@@ -111,6 +111,8 @@ fn test_list_issues_sorts_by_updated_desc() {
             updated_at: "2026-03-25T10:00:00Z".to_string(),
             assignee_summary: String::new(),
             labels_summary: String::new(),
+            assignees: Vec::new(),
+            labels: Vec::new(),
             comment_count: 0,
             body: String::new(),
         },
@@ -122,6 +124,8 @@ fn test_list_issues_sorts_by_updated_desc() {
             updated_at: "2026-03-29T10:00:00Z".to_string(),
             assignee_summary: String::new(),
             labels_summary: String::new(),
+            assignees: Vec::new(),
+            labels: Vec::new(),
             comment_count: 0,
             body: String::new(),
         },
@@ -133,6 +137,8 @@ fn test_list_issues_sorts_by_updated_desc() {
             updated_at: "2026-03-29T10:00:00Z".to_string(),
             assignee_summary: String::new(),
             labels_summary: String::new(),
+            assignees: Vec::new(),
+            labels: Vec::new(),
             comment_count: 0,
             body: String::new(),
         },
@@ -173,6 +179,20 @@ fn test_list_issues_filter_args_construction() {
             .any(|a| a == "--state" && state_arg_is_open(&args))
     );
     assert!(args.iter().any(|a| a.contains("limit") || a == "-L"));
+}
+
+#[test]
+fn test_list_issues_args_omit_body_for_fast_first_paint() {
+    let args = build_list_issues_args("owner", "repo", &IssueFilter::default(), None, 30);
+    let json_fields = args
+        .windows(2)
+        .find_map(|pair| (pair[0] == "--json").then_some(pair[1].as_str()))
+        .unwrap_or_else(|| panic!("missing --json fields in args: {args:?}"));
+
+    assert_eq!(
+        json_fields,
+        "number,title,state,author,updatedAt,assignees,labels,comments"
+    );
 }
 
 #[test]

--- a/src/state/issues_tests.rs
+++ b/src/state/issues_tests.rs
@@ -26,6 +26,8 @@ fn make_test_issue(number: u64) -> Issue {
         updated_at: "2024-01-01T00:00:00Z".to_string(),
         assignee_summary: String::new(),
         labels_summary: String::new(),
+        assignees: Vec::new(),
+        labels: Vec::new(),
         comment_count: 0,
         body: String::new(),
     }

--- a/src/state/issues_tests_components.rs
+++ b/src/state/issues_tests_components.rs
@@ -14,6 +14,8 @@ fn make_test_issue(number: u64) -> Issue {
         updated_at: "2024-01-01T00:00:00Z".to_string(),
         assignee_summary: String::new(),
         labels_summary: String::new(),
+        assignees: Vec::new(),
+        labels: Vec::new(),
         comment_count: 0,
         body: String::new(),
     }

--- a/src/state/issues_tests_detail.rs
+++ b/src/state/issues_tests_detail.rs
@@ -23,6 +23,8 @@ fn make_test_issue(number: u64) -> Issue {
         updated_at: "2024-01-01T00:00:00Z".to_string(),
         assignee_summary: String::new(),
         labels_summary: String::new(),
+        assignees: Vec::new(),
+        labels: Vec::new(),
         comment_count: 0,
         body: String::new(),
     }

--- a/src/state/issues_tests_detail_flow.rs
+++ b/src/state/issues_tests_detail_flow.rs
@@ -25,6 +25,8 @@ fn make_test_issue(number: u64) -> Issue {
         updated_at: "2024-01-01T00:00:00Z".to_string(),
         assignee_summary: String::new(),
         labels_summary: String::new(),
+        assignees: Vec::new(),
+        labels: Vec::new(),
         comment_count: 0,
         body: String::new(),
     }
@@ -555,17 +557,7 @@ fn test_send_to_agent_payload_complete() {
             scope_repo_id: RepositoryId("repo-1".to_string()),
             filter: Box::new(IssueFilter::default()),
             request_id: 0,
-            issues: vec![crate::domain::Issue {
-                number: 7,
-                title: "Send payload issue".to_string(),
-                state: crate::domain::IssueState::Open,
-                author_login: "octocat".to_string(),
-                updated_at: "2024-01-01T00:00:00Z".to_string(),
-                labels_summary: String::new(),
-                assignee_summary: String::new(),
-                comment_count: 0,
-                body: String::new(),
-            }],
+            issues: vec![make_test_issue(7)],
             cursor: None,
             has_more: false,
         });

--- a/src/state/issues_tests_filter.rs
+++ b/src/state/issues_tests_filter.rs
@@ -27,6 +27,8 @@ fn make_test_issue(number: u64) -> Issue {
         updated_at: "2024-01-01T00:00:00Z".to_string(),
         assignee_summary: String::new(),
         labels_summary: String::new(),
+        assignees: Vec::new(),
+        labels: Vec::new(),
         comment_count: 0,
         body: String::new(),
     }

--- a/src/state/issues_tests_repo_nav.rs
+++ b/src/state/issues_tests_repo_nav.rs
@@ -19,6 +19,8 @@ fn make_test_issue(number: u64) -> Issue {
         updated_at: "2024-01-01T00:00:00Z".to_string(),
         assignee_summary: String::new(),
         labels_summary: String::new(),
+        assignees: Vec::new(),
+        labels: Vec::new(),
         comment_count: 0,
         body: String::new(),
     }

--- a/src/ui/components/filter_controls.rs
+++ b/src/ui/components/filter_controls.rs
@@ -109,6 +109,7 @@ pub fn FilterControls(props: &FilterControlsProps) -> impl Into<AnyElement<'stat
             // Actions hint row
             Box(height: 1u32) {
                 Text(content: "Tab next  ", color: rc.dim)
+                Text(content: "←/→ choices  ", color: rc.dim)
                 Text(content: "Enter apply  ", color: rc.dim)
                 Text(content: "Ctrl-c clear  ", color: rc.dim)
                 Text(content: "Esc cancel", color: rc.dim)

--- a/src/ui/components/issue_list.rs
+++ b/src/ui/components/issue_list.rs
@@ -12,6 +12,8 @@ use crate::theme::{ResolvedColors, ThemeColors};
 /// Ellipsis character appended when a title is truncated.
 const ELLIPSIS: char = '…';
 
+/// Rows consumed by the bordered list container and title before item content.
+const LIST_CHROME_ROWS: u16 = 3;
 /// Truncate `text` to fit within `max_width` terminal columns, appending an
 /// ellipsis when truncation occurs.
 ///
@@ -68,6 +70,8 @@ pub struct IssueListProps {
     pub issues: Vec<Issue>,
     /// Currently selected index.
     pub selected_index: Option<usize>,
+    /// Issue-list pane height in rows, including border and title chrome.
+    pub list_pane_rows: u16,
     /// Whether this pane is focused.
     pub focused: bool,
     /// Whether issues are loading.
@@ -84,6 +88,123 @@ pub struct IssueListProps {
     pub available_width: Option<u16>,
 }
 
+/// Projected issue-list row exactly as the component renders it.
+/// @plan PLAN-20260630-ISSUES-REGRESSION.P01
+/// @requirement REQ-ISS-006
+/// @pseudocode component-001 lines 1-12
+pub struct IssueListRowView {
+    /// Title line: prefix plus issue number and truncated title.
+    pub title_line: String,
+    /// Metadata line: state, author, updated timestamp, counts, assignees, labels.
+    pub meta_line: String,
+    /// Whether this row is the selected row.
+    pub is_selected: bool,
+}
+
+/// Build the title line for an issue-list row.
+/// @plan PLAN-20260630-ISSUES-REGRESSION.P01
+/// @requirement REQ-ISS-006
+/// @pseudocode component-001 lines 1-12
+fn build_title_line(issue: &Issue, prefix: &str, available_width: Option<u16>) -> String {
+    let number_prefix = format!("{prefix}#{} ", issue.number);
+    let title = match available_width {
+        Some(width) => {
+            let used = UnicodeWidthStr::width(number_prefix.as_str());
+            let budget = (width as usize).saturating_sub(used);
+            truncate_title(&issue.title, budget)
+        }
+        None => issue.title.clone(),
+    };
+    format!("{number_prefix}{title}")
+}
+
+/// Build the metadata line for an issue-list row.
+/// @plan PLAN-20260630-ISSUES-REGRESSION.P01
+/// @requirement REQ-ISS-006
+/// @pseudocode component-001 lines 1-12
+fn build_meta_line(issue: &Issue) -> String {
+    let state_tag = match issue.state {
+        IssueState::Open => "OPEN",
+        IssueState::Closed => "CLSD",
+    };
+    let mut meta_parts = vec![
+        state_tag.to_string(),
+        format!("@{}", issue.author_login),
+        format!("updated:{}", issue.updated_at),
+    ];
+    if issue.comment_count > 0 {
+        meta_parts.push(format!("{} comments", issue.comment_count));
+    }
+    if !issue.assignee_summary.is_empty() {
+        meta_parts.push(format!("assigned:{}", issue.assignee_summary));
+    }
+    if !issue.labels_summary.is_empty() {
+        meta_parts.push(format!("[{}]", issue.labels_summary));
+    }
+    format!("     {}", meta_parts.join("  "))
+}
+
+/// Pure projection of the visible issue rows. The component renders this same
+/// projection, so selection-follow behavior is unit-testable outside iocraft.
+/// @plan PLAN-20260630-ISSUES-REGRESSION.P01
+/// @requirement REQ-ISS-006
+/// @pseudocode component-001 lines 1-12
+pub fn issue_list_visible_rows(
+    issues: &[Issue],
+    selected_index: Option<usize>,
+    list_pane_rows: u16,
+    layout: IssueListLayout,
+    available_width: Option<u16>,
+) -> Vec<IssueListRowView> {
+    let rows_per_item = if layout.is_compact() { 1 } else { 2 };
+    let viewport =
+        (list_pane_rows.saturating_sub(LIST_CHROME_ROWS) / rows_per_item).max(1) as usize;
+    let first_visible = crate::layout::list_first_visible_index(
+        selected_index.unwrap_or(0),
+        issues.len(),
+        viewport,
+    );
+    crate::layout::list_visible_window(issues, selected_index.unwrap_or(0), viewport)
+        .iter()
+        .enumerate()
+        .map(|(window_i, issue)| {
+            let is_selected = selected_index == Some(first_visible + window_i);
+            let prefix = if is_selected { "> " } else { "  " };
+            IssueListRowView {
+                title_line: build_title_line(issue, prefix, available_width),
+                meta_line: if layout.is_compact() {
+                    String::new()
+                } else {
+                    build_meta_line(issue)
+                },
+                is_selected,
+            }
+        })
+        .collect()
+}
+
+/// Loading/empty status line for the issue list. Returns `None` when rows show.
+/// @plan PLAN-20260630-ISSUES-REGRESSION.P01
+/// @requirement REQ-ISS-006
+/// @pseudocode component-001 lines 1-12
+fn issue_list_status_message(
+    loading: bool,
+    is_empty: bool,
+    has_filters: bool,
+) -> Option<&'static str> {
+    if loading {
+        Some("Loading issues...")
+    } else if is_empty {
+        Some(if has_filters {
+            "No issues match filters"
+        } else {
+            "No issues found"
+        })
+    } else {
+        None
+    }
+}
+
 /// Issue list pane — renders issues with selection highlight, loading, and empty states.
 /// @plan PLAN-20260329-ISSUES-MODE.P14
 /// @requirement REQ-ISS-006
@@ -95,6 +216,8 @@ pub fn IssueList(props: &IssueListProps) -> impl Into<AnyElement<'static>> {
     } else {
         BorderStyle::Round
     };
+    let status_msg =
+        issue_list_status_message(props.loading, props.issues.is_empty(), props.has_filters);
 
     element! {
         Box(
@@ -105,77 +228,32 @@ pub fn IssueList(props: &IssueListProps) -> impl Into<AnyElement<'static>> {
             border_color: rc.border,
             background_color: rc.bg,
         ) {
-            // Title row
             Box(height: 1u32, padding_left: 1u32) {
                 Text(content: "Issues", weight: Weight::Bold, color: rc.fg)
             }
-
-            // Content
             Box(
                 flex_direction: FlexDirection::Column,
                 flex_grow: 1.0,
                 background_color: rc.bg,
             ) {
-                #(if props.loading {
-                    vec![element! {
-                        Box(padding_left: 1u32, height: 1u32) {
-                            Text(content: "Loading issues...", color: rc.dim)
-                        }
-                    }]
-                } else if props.issues.is_empty() {
-                    let msg = if props.has_filters {
-                        "No issues match filters"
-                    } else {
-                        "No issues found"
-                    };
+                #(if let Some(msg) = status_msg {
                     vec![element! {
                         Box(padding_left: 1u32, height: 1u32) {
                             Text(content: msg, color: rc.dim)
                         }
                     }]
                 } else {
-                    props.issues.iter().enumerate().map(|(i, issue)| {
-                        let selected = props.selected_index == Some(i);
-                        let prefix = if selected { "> " } else { "  " };
-                        let state_tag = match issue.state {
-                            IssueState::Open => "OPEN",
-                            IssueState::Closed => "CLSD",
-                        };
-
-                        // Truncate the title to fit the available width.
-                        // Layout: "<prefix>#<number> <title>"
-                        let number_prefix = format!("{}#{} ", prefix, issue.number);
-                        let title = match props.available_width {
-                            Some(width) => {
-                                // Account for the prefix+number columns already consumed.
-                                let used = UnicodeWidthStr::width(number_prefix.as_str());
-                                let budget = (width as usize).saturating_sub(used);
-                                truncate_title(&issue.title, budget)
-                            }
-                            None => issue.title.clone(),
-                        };
-
-                        // Primary line: prefix + number + title
-                        let title_line = format!("{number_prefix}{title}");
-
-                        // Secondary line: state, author, updated, comment count
-                        let mut meta_parts = vec![
-                            state_tag.to_string(),
-                            format!("@{}", issue.author_login),
-                            format!("updated:{}", issue.updated_at),
-                        ];
-                        if issue.comment_count > 0 {
-                            meta_parts.push(format!("{} comments", issue.comment_count));
-                        }
-                        if !issue.assignee_summary.is_empty() {
-                            meta_parts.push(format!("assigned:{}", issue.assignee_summary));
-                        }
-                        if !issue.labels_summary.is_empty() {
-                            meta_parts.push(format!("[{}]", issue.labels_summary));
-                        }
-                        let meta_line = format!("     {}", meta_parts.join("  "));
-
-                        if selected {
+                    let projected = issue_list_visible_rows(
+                        &props.issues,
+                        props.selected_index,
+                        props.list_pane_rows,
+                        props.layout,
+                        props.available_width,
+                    );
+                    projected.iter().map(|view| {
+                        let title_line = view.title_line.as_str();
+                        let meta_line = view.meta_line.as_str();
+                        if view.is_selected {
                             if props.layout.is_compact() {
                                 element! {
                                     Box(height: 1u32, background_color: rc.sel_bg) {
@@ -229,8 +307,25 @@ pub fn IssueList(props: &IssueListProps) -> impl Into<AnyElement<'static>> {
 
 #[cfg(test)]
 mod tests {
-    use super::truncate_title;
+    use super::{IssueListLayout, issue_list_visible_rows, truncate_title};
+    use crate::domain::{Issue, IssueState};
     use unicode_width::UnicodeWidthStr;
+
+    fn issue(number: u64) -> Issue {
+        Issue {
+            number,
+            title: format!("Issue {number}"),
+            state: IssueState::Open,
+            author_login: "octocat".to_string(),
+            updated_at: "2026-06-30".to_string(),
+            assignee_summary: String::new(),
+            labels_summary: String::new(),
+            assignees: Vec::new(),
+            labels: Vec::new(),
+            comment_count: 0,
+            body: String::new(),
+        }
+    }
 
     #[test]
     fn short_title_is_returned_unchanged() {
@@ -251,13 +346,10 @@ mod tests {
 
     #[test]
     fn unicode_title_truncates_on_character_boundary() {
-        // Each emoji is one char but multiple bytes; truncation must never
-        // split a multi-byte code point.
         let title = "\u{1F600}\u{1F601}\u{1F602}\u{1F603}\u{1F604}\u{1F605}\u{1F606}\u{1F607}\u{1F608}\u{1F609}";
         let result = truncate_title(title, 5);
         assert!(UnicodeWidthStr::width(result.as_str()) <= 5);
         assert!(result.ends_with('\u{2026}'));
-        // Ensure no panic on multi-byte slicing.
         assert!(result.chars().next().is_some());
     }
 
@@ -275,5 +367,50 @@ mod tests {
         );
         let line = format!("{number_prefix}{title}");
         assert_eq!(UnicodeWidthStr::width(line.as_str()), 8);
+    }
+
+    #[test]
+    fn visible_rows_follow_selection_below_viewport() {
+        let issues: Vec<Issue> = (1..=12).map(issue).collect();
+        let rows = issue_list_visible_rows(&issues, Some(8), 8, IssueListLayout::Compact, Some(40));
+
+        assert_eq!(rows.len(), 5);
+        assert!(rows[0].title_line.contains("#5 "));
+        assert!(rows[4].title_line.contains("> #9 "));
+        assert!(rows[4].is_selected);
+        assert!(rows.iter().all(|row| !row.title_line.contains("#1 ")));
+    }
+
+    #[test]
+    fn visible_rows_follow_selection_to_last_page_without_overscroll() {
+        let issues: Vec<Issue> = (1..=12).map(issue).collect();
+        let rows =
+            issue_list_visible_rows(&issues, Some(11), 8, IssueListLayout::Compact, Some(40));
+
+        assert!(rows[0].title_line.contains("#8 "));
+        assert!(rows[4].title_line.contains("> #12 "));
+        assert!(rows[4].is_selected);
+    }
+
+    #[test]
+    fn visible_rows_subtract_container_chrome_from_pane_height() {
+        let issues: Vec<Issue> = (1..=12).map(issue).collect();
+        let rows = issue_list_visible_rows(&issues, Some(8), 5, IssueListLayout::Compact, Some(40));
+
+        assert_eq!(rows.len(), 2);
+        assert!(rows[0].title_line.contains("#8 "));
+        assert!(rows[1].title_line.contains("> #9 "));
+        assert!(rows[1].is_selected);
+    }
+
+    #[test]
+    fn full_layout_counts_two_terminal_rows_per_issue() {
+        let issues: Vec<Issue> = (1..=12).map(issue).collect();
+        let rows = issue_list_visible_rows(&issues, Some(8), 9, IssueListLayout::Full, Some(40));
+
+        assert_eq!(rows.len(), 3);
+        assert!(rows[0].title_line.contains("#7 "));
+        assert!(rows[2].title_line.contains("> #9 "));
+        assert!(rows[2].is_selected);
     }
 }

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -202,6 +202,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                         IssueList(
                             issues: issues.clone(),
                             selected_index: selected_issue_idx,
+                            list_pane_rows: list_pane_rows,
                             focused: list_focused,
                             loading: list_loading,
                             has_filters: has_filters,


### PR DESCRIPTION
## Summary

- omit issue bodies from list/search fetches so Issues mode can paint list rows faster while details still load full bodies
- make the Issues list render a selected-window projection that follows navigation in compact and full layouts
- add choice-backed assignee/label filter cycling from structured loaded issue metadata without blocking manual text entry
- add a tmux harness scenario for the Issues filter shell

## Verification

- cargo fmt --all
- cargo test --workspace --all-features --locked issue_search_args_omit_body -- --nocapture
- cargo test --workspace --all-features --locked issues_filter::tests -- --nocapture
- cargo test --workspace --all-features --locked issue_list::tests -- --nocapture
- cargo test --workspace --all-features --locked preview_body -- --nocapture
- target/debug/jefe-tmux-harness --scenario dev-docs/tmux-scenarios/issues-filter-open-close.json --jefe-bin target/debug/jefe --config <temp-dir> --out-dir target/tmux-harness/issue95-issues-filter
- make ci-check
- rustreviewer review: approved
- Open Code Review detached with --timeout 20; final substantive findings remediated

Fixes #95
