### PR TITLE
Migrate Issues composers to TextBox (Fixes #94)

### DIFF
--- a/dev-docs/tmux-scenarios/issues-composer-textbox.json
+++ b/dev-docs/tmux-scenarios/issues-composer-textbox.json
@@ -1,0 +1,27 @@
+{
+  "config": {
+    "cols": 160,
+    "rows": 40,
+    "history_limit": 4000,
+    "initial_wait_ms": 100,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "key": "i" },
+    { "waitFor": "Issues" },
+    { "waitFor": "#" },
+    { "key": "Enter" },
+    { "waitFor": "Body" },
+    { "key": "c" },
+    { "keys": ["f", "i", "r", "s", "t", " ", "l", "i", "n", "e"] },
+    { "key": "Enter" },
+    { "keys": ["s", "e", "c", "o", "n", "d", " ", "l", "i", "n", "e"] },
+    { "key": "Enter" },
+    { "keys": ["c", "u", "r", "r", "e", "n", "t", " ", "l", "i", "n", "e"] },
+    { "waitFor": "current line" },
+    { "key": "Escape" },
+    { "key": "q" },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/src/app_input/issues.rs
+++ b/src/app_input/issues.rs
@@ -50,6 +50,9 @@ pub fn resolve_issues_key_event(state: &AppState, key_event: &KeyEvent) -> Optio
 
 fn resolve_inline_key_event(key_event: &KeyEvent) -> Option<AppEvent> {
     match key_event.code {
+        KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(AppEvent::InlineCancelOrEsc)
+        }
         KeyCode::Esc => Some(AppEvent::InlineCancelOrEsc),
         KeyCode::Enter if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
             Some(AppEvent::InlineSubmit)
@@ -735,6 +738,20 @@ mod tests {
             &key_with_mods(KeyCode::Enter, KeyModifiers::CONTROL),
         );
         assert!(matches!(event, Some(AppEvent::InlineSubmit)));
+    }
+
+    #[test]
+    fn test_ctrl_c_cancels_inline_instead_of_typing_c() {
+        let state = issues_state_with_inline(InlineState::Composer {
+            target: ComposerTarget::NewComment,
+            text: String::from("hello"),
+            cursor: 5,
+        });
+        let event = resolve_issues_key_event(
+            &state,
+            &key_with_mods(KeyCode::Char('c'), KeyModifiers::CONTROL),
+        );
+        assert!(matches!(event, Some(AppEvent::InlineCancelOrEsc)));
     }
 
     /// Esc when inline editor active dispatches InlineCancelOrEsc.

--- a/src/issue_detail_content.rs
+++ b/src/issue_detail_content.rs
@@ -7,6 +7,9 @@
 use crate::domain::{IssueComment, IssueDetail};
 use crate::state::{ComposerTarget, DetailSubfocus, EditorTarget, InlineState};
 
+/// Stable anchor rendered where a reply TextBox is logically attached.
+pub(crate) const ISSUE_REPLY_ANCHOR: &str = "    [Reply]";
+
 /// Scrollable issue-detail content and optional inline cursor position.
 pub struct DetailContent {
     pub text: String,
@@ -253,13 +256,11 @@ fn build_single_comment(
 
     if let InlineState::Composer {
         target: ComposerTarget::Reply { comment_index, .. },
-        text,
-        cursor,
+        ..
     } = inline_state
         && *comment_index == idx
     {
-        builder.lines.push("    [Reply]".to_string());
-        builder.push_editor_lines(text.as_str(), *cursor, true, "    │ ", "    │ ");
+        builder.lines.push(ISSUE_REPLY_ANCHOR.to_string());
         builder
             .lines
             .push("    Ctrl+Enter save | Esc cancel".to_string());
@@ -282,11 +283,9 @@ fn build_new_comment_section(
 
     if let InlineState::Composer {
         target: ComposerTarget::NewComment,
-        text,
-        cursor,
+        ..
     } = inline_state
     {
-        builder.push_editor_lines(text.as_str(), *cursor, true, "  │ ", "  │ ");
         builder
             .lines
             .push("  Ctrl+Enter submit | Esc cancel".to_string());

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -224,7 +224,7 @@ pub const DETAIL_CHROME_ROWS: usize = OUTER_BARS_HEIGHT as usize;
 /// zero rows.
 pub const DETAIL_MIN_VIEWPORT_ROWS: usize = 5;
 
-/// Fixed local viewport height for the embedded PR NewComment text box.
+/// Fixed local viewport height for embedded detail composer text boxes.
 ///
 /// Kept in layout (rather than UI) because state scroll bounds must reserve
 /// the same rows the component renders when it reveals the composer anchor.
@@ -233,7 +233,10 @@ pub const DETAIL_MIN_VIEWPORT_ROWS: usize = 5;
 /// @requirement REQ-PR-009
 /// @requirement REQ-PR-010
 /// @pseudocode component-001 lines 169-176
-pub const PR_COMPOSER_VIEWPORT_ROWS: usize = 5;
+pub const DETAIL_COMPOSER_VIEWPORT_ROWS: usize = 5;
+pub const PR_COMPOSER_VIEWPORT_ROWS: usize = DETAIL_COMPOSER_VIEWPORT_ROWS;
+pub const NEW_COMMENT_COMPOSER_PREFIX: &str = "  │ ";
+pub const REPLY_COMPOSER_PREFIX: &str = "    │ ";
 
 /// Compute rows available to the read-only PR detail document after embedded
 /// local editors reserve rows inside the detail pane.
@@ -246,11 +249,28 @@ pub fn pr_detail_document_viewport_rows(
     detail_viewport_rows: usize,
     pr_composer_text_box_active: bool,
 ) -> usize {
+    detail_document_viewport_rows(detail_viewport_rows, pr_composer_text_box_active)
+}
+
+/// Compute rows available to an Issues detail read-only document after an
+/// embedded composer TextBox reserves rows inside the detail pane.
+#[must_use]
+pub fn issue_detail_document_viewport_rows(
+    detail_viewport_rows: usize,
+    issue_composer_text_box_active: bool,
+) -> usize {
+    detail_document_viewport_rows(detail_viewport_rows, issue_composer_text_box_active)
+}
+
+fn detail_document_viewport_rows(
+    detail_viewport_rows: usize,
+    composer_text_box_active: bool,
+) -> usize {
     if detail_viewport_rows == 0 {
         return 0;
     }
-    let reserved = if pr_composer_text_box_active {
-        PR_COMPOSER_VIEWPORT_ROWS.min(detail_viewport_rows.saturating_sub(1))
+    let reserved = if composer_text_box_active {
+        DETAIL_COMPOSER_VIEWPORT_ROWS.min(detail_viewport_rows.saturating_sub(1))
     } else {
         0
     };
@@ -422,6 +442,19 @@ pub fn prs_detail_pane_rows(
 #[must_use]
 pub fn pr_list_content_width(term_cols: u16) -> u16 {
     term_cols.saturating_sub(PRS_SIDEBAR_WIDTH + PR_LIST_CHROME_COLS)
+}
+
+/// Columns of chrome the Issues detail pane subtracts from the workspace width
+/// before text is rendered: left+right border (2), left padding (1),
+/// scrollbar (1), and a 2-col safety margin matching the PR detail pane.
+const ISSUE_DETAIL_CONTENT_CHROME_COLS: u16 = 6;
+
+/// Compute the inner content width available for Issues-detail text lines.
+#[must_use]
+pub fn issues_detail_content_width(term_cols: u16) -> u16 {
+    term_cols
+        .saturating_sub(ISSUES_SIDEBAR_WIDTH)
+        .saturating_sub(ISSUE_DETAIL_CONTENT_CHROME_COLS)
 }
 
 /// Columns of chrome the PR detail pane subtracts from the workspace width

--- a/src/layout_tests.rs
+++ b/src/layout_tests.rs
@@ -194,9 +194,25 @@ fn pr_detail_document_viewport_reserves_composer_rows_but_preserves_document_row
 }
 
 #[test]
+fn issue_detail_document_viewport_reserves_composer_rows_but_preserves_document_row() {
+    assert_eq!(issue_detail_document_viewport_rows(20, false), 20);
+    assert_eq!(issue_detail_document_viewport_rows(20, true), 15);
+    assert_eq!(issue_detail_document_viewport_rows(5, true), 1);
+    assert_eq!(issue_detail_document_viewport_rows(6, true), 1);
+    assert_eq!(issue_detail_document_viewport_rows(1, true), 1);
+    assert_eq!(issue_detail_document_viewport_rows(0, true), 0);
+}
+
+#[test]
 fn issue_list_content_width_excludes_sidebar_and_border() {
     assert_eq!(issue_list_content_width(120), 96);
     assert_eq!(issue_list_content_width(10), 0);
+}
+
+#[test]
+fn issues_detail_content_width_subtracts_sidebar_and_chrome() {
+    assert_eq!(issues_detail_content_width(120), 92);
+    assert_eq!(issues_detail_content_width(20), 0);
 }
 
 /// @plan PLAN-20260624-PR-MODE.P12

--- a/src/state/issues_inline_ops.rs
+++ b/src/state/issues_inline_ops.rs
@@ -1,5 +1,7 @@
 //! Issues-mode inline composer/editor state operations.
 
+use crate::issue_detail_content::{ISSUE_REPLY_ANCHOR, build_detail_content};
+
 use super::{
     AppEvent, AppState, ComposerTarget, DetailSubfocus, EditorTarget, InlineState, IssueFocus,
     inline_cursor_vertical,
@@ -9,6 +11,34 @@ impl AppState {
     /// Scroll the issue detail viewport so the last content line is visible.
     pub(crate) fn scroll_detail_to_bottom(&mut self) {
         self.issues_state.detail_scroll_offset = self.issues_state.max_detail_scroll_offset();
+    }
+
+    fn scroll_issue_detail_to_reply_anchor(&mut self) {
+        let Some(detail) = self.issues_state.issue_detail.as_ref() else {
+            return;
+        };
+        let content = build_detail_content(
+            detail,
+            self.issues_state.detail_subfocus,
+            &self.issues_state.inline_state,
+            self.issues_state.loading.comments,
+        );
+        let Some(anchor_line) = content
+            .text
+            .lines()
+            .position(|line| line == ISSUE_REPLY_ANCHOR)
+        else {
+            return;
+        };
+        let viewport_rows = if self.issues_state.detail_viewport_rows == 0 {
+            crate::layout::detail_viewport_rows(40)
+        } else {
+            self.issues_state.detail_viewport_rows
+        };
+        let document_rows = crate::layout::issue_detail_document_viewport_rows(viewport_rows, true);
+        let desired = anchor_line.saturating_add(1).saturating_sub(document_rows);
+        self.issues_state.detail_scroll_offset =
+            desired.min(self.issues_state.max_detail_scroll_offset());
     }
 
     fn active_inline_text(inline_state: &mut InlineState) -> Option<(&mut String, &mut usize)> {
@@ -117,25 +147,27 @@ impl AppState {
         true
     }
 
-    fn open_reply_composer(&mut self, comment_index: usize) {
-        if self.issues_state.inline_state == InlineState::None {
-            let author = self
-                .issues_state
-                .issue_detail
-                .as_ref()
-                .and_then(|d| d.comments.get(comment_index))
-                .map(|c| format!("@{} ", c.author_login))
-                .unwrap_or_default();
-            let cursor = author.len();
-            self.issues_state.inline_state = InlineState::Composer {
-                target: ComposerTarget::Reply {
-                    comment_index,
-                    author: author.clone(),
-                },
-                text: author,
-                cursor,
-            };
+    fn open_reply_composer(&mut self, comment_index: usize) -> bool {
+        if self.issues_state.inline_state != InlineState::None {
+            return false;
         }
+        let author = self
+            .issues_state
+            .issue_detail
+            .as_ref()
+            .and_then(|d| d.comments.get(comment_index))
+            .map(|c| format!("@{} ", c.author_login))
+            .unwrap_or_default();
+        let cursor = author.len();
+        self.issues_state.inline_state = InlineState::Composer {
+            target: ComposerTarget::Reply {
+                comment_index,
+                author: author.clone(),
+            },
+            text: author,
+            cursor,
+        };
+        true
     }
 
     fn open_inline_editor(&mut self, target: EditorTarget) {
@@ -197,7 +229,9 @@ impl AppState {
                 }
             }
             AppEvent::OpenReplyComposer { comment_index } => {
-                self.open_reply_composer(comment_index);
+                if self.open_reply_composer(comment_index) {
+                    self.scroll_issue_detail_to_reply_anchor();
+                }
             }
             AppEvent::OpenInlineEditor { target } => self.open_inline_editor(target),
             _ => return false,

--- a/src/state/issues_inline_ops.rs
+++ b/src/state/issues_inline_ops.rs
@@ -41,6 +41,25 @@ impl AppState {
             desired.min(self.issues_state.max_detail_scroll_offset());
     }
 
+    fn apply_inline_event_while_pending(&mut self, event: AppEvent) -> bool {
+        if matches!(event, AppEvent::InlineCancelOrEsc) {
+            self.issues_state.inline_state = InlineState::None;
+            self.issues_state.mutation_pending = None;
+            return true;
+        }
+        matches!(
+            event,
+            AppEvent::InlineChar(_)
+                | AppEvent::InlineNewline
+                | AppEvent::InlineBackspace
+                | AppEvent::InlineDelete
+                | AppEvent::InlineCursorLeft
+                | AppEvent::InlineCursorRight
+                | AppEvent::InlineCursorUp
+                | AppEvent::InlineCursorDown
+        )
+    }
+
     fn active_inline_text(inline_state: &mut InlineState) -> Option<(&mut String, &mut usize)> {
         match inline_state {
             InlineState::Composer { text, cursor, .. }
@@ -95,18 +114,7 @@ impl AppState {
 
     pub(super) fn apply_inline_event(&mut self, event: AppEvent) -> bool {
         if self.issues_state.mutation_pending.is_some() {
-            return matches!(
-                event,
-                AppEvent::InlineChar(_)
-                    | AppEvent::InlineNewline
-                    | AppEvent::InlineBackspace
-                    | AppEvent::InlineDelete
-                    | AppEvent::InlineCursorLeft
-                    | AppEvent::InlineCursorRight
-                    | AppEvent::InlineCursorUp
-                    | AppEvent::InlineCursorDown
-                    | AppEvent::InlineCancelOrEsc
-            );
+            return self.apply_inline_event_while_pending(event);
         }
         match event {
             AppEvent::InlineChar(c) => {

--- a/src/state/issues_tests_composer_focus.rs
+++ b/src/state/issues_tests_composer_focus.rs
@@ -7,7 +7,9 @@
 
 use crate::domain::{IssueComment, IssueDetail, IssueState, Repository, RepositoryId};
 use crate::state::AppState;
-use crate::state::types::{AppEvent, ComposerTarget, DetailSubfocus, EditorTarget, InlineState};
+use crate::state::types::{
+    AppEvent, ComposerTarget, DetailSubfocus, EditorTarget, InlineState, IssueMutationPending,
+};
 
 fn issues_mode_state_with_repo(repo_id: &str) -> AppState {
     let mut state = AppState::default();
@@ -227,6 +229,24 @@ fn test_backspacing_in_issue_composer_does_not_mutate_detail_scroll_offset() {
     ));
 
     assert_eq!(state.issues_state.detail_scroll_offset, offset_after_open);
+}
+
+/// Esc/Ctrl-C cancel intent must remain responsive while comment submission is pending.
+#[test]
+fn test_inline_cancel_clears_pending_issue_comment_mutation() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let mut state = state_with_long_detail(&repo_id, 42).apply(AppEvent::OpenNewCommentComposer);
+    let pending_target = state.issues_state.inline_state.clone();
+    state.issues_state.mutation_pending = Some(IssueMutationPending {
+        scope_repo_id: repo_id,
+        id: 7,
+        target: pending_target,
+    });
+
+    let state = state.apply(AppEvent::InlineCancelOrEsc);
+
+    assert_eq!(state.issues_state.inline_state, InlineState::None);
+    assert!(state.issues_state.mutation_pending.is_none());
 }
 
 /// Opening a reply composer reveals the stable reply anchor above the TextBox.

--- a/src/state/issues_tests_composer_focus.rs
+++ b/src/state/issues_tests_composer_focus.rs
@@ -150,6 +150,157 @@ fn test_open_new_comment_composer_blocked_does_not_change_subfocus_or_scroll() {
     ));
 }
 
+fn type_into_composer(mut state: AppState, text: &str) -> AppState {
+    for ch in text.chars() {
+        state = if ch == '\n' {
+            state.apply(AppEvent::InlineNewline)
+        } else {
+            state.apply(AppEvent::InlineChar(ch))
+        };
+    }
+    state
+}
+
+/// Typing into the Issues NewComment composer must not mutate parent document scroll.
+#[test]
+fn test_typing_in_issue_composer_does_not_mutate_detail_scroll_offset() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let mut state = state_with_long_detail(&repo_id, 42);
+    state.issues_state.detail_viewport_rows = 5;
+    let state = state.apply(AppEvent::OpenNewCommentComposer);
+    let offset_after_open = state.issues_state.detail_scroll_offset;
+
+    let state = type_into_composer(state, "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8");
+
+    assert!(matches!(
+        &state.issues_state.inline_state,
+        InlineState::Composer { text, .. } if text == "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8"
+    ));
+    assert_eq!(state.issues_state.detail_scroll_offset, offset_after_open);
+}
+
+/// Arrowing inside the Issues composer must not mutate parent document scroll.
+#[test]
+fn test_arrowing_in_issue_composer_does_not_mutate_detail_scroll_offset() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let mut state = state_with_long_detail(&repo_id, 42);
+    state.issues_state.detail_viewport_rows = 5;
+    let state = state.apply(AppEvent::OpenNewCommentComposer);
+    let offset_after_open = state.issues_state.detail_scroll_offset;
+    let typed = "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8";
+    let mut state = type_into_composer(state, typed);
+
+    for event in [
+        AppEvent::InlineCursorLeft,
+        AppEvent::InlineCursorRight,
+        AppEvent::InlineCursorUp,
+        AppEvent::InlineCursorDown,
+    ] {
+        for _ in 0..typed.chars().count() {
+            state = state.apply(event.clone());
+        }
+        assert_eq!(state.issues_state.detail_scroll_offset, offset_after_open);
+        assert!(matches!(
+            &state.issues_state.inline_state,
+            InlineState::Composer { .. }
+        ));
+    }
+}
+
+/// Backspacing inside the Issues composer must not mutate parent document scroll.
+#[test]
+fn test_backspacing_in_issue_composer_does_not_mutate_detail_scroll_offset() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let mut state = state_with_long_detail(&repo_id, 42);
+    state.issues_state.detail_viewport_rows = 5;
+    let state = state.apply(AppEvent::OpenNewCommentComposer);
+    let offset_after_open = state.issues_state.detail_scroll_offset;
+    let typed = "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8";
+    let mut state = type_into_composer(state, typed);
+
+    for _ in 0..typed.chars().count() {
+        state = state.apply(AppEvent::InlineBackspace);
+    }
+    assert!(matches!(
+        &state.issues_state.inline_state,
+        InlineState::Composer { text, .. } if text.is_empty()
+    ));
+
+    assert_eq!(state.issues_state.detail_scroll_offset, offset_after_open);
+}
+
+/// Opening a reply composer reveals the stable reply anchor above the TextBox.
+#[test]
+fn test_open_reply_composer_reveals_reply_anchor() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let mut state = state_with_long_detail(&repo_id, 42);
+    state.issues_state.detail_viewport_rows = 8;
+    state.issues_state.detail_scroll_offset = 0;
+    state
+        .issues_state
+        .issue_detail
+        .as_mut()
+        .unwrap_or_else(|| panic!("expected detail"))
+        .comments
+        .push(p15_comment(
+            1,
+            "alice",
+            "2026-07-01T00:00:00Z",
+            "comment body",
+        ));
+
+    let state = state.apply(AppEvent::OpenReplyComposer { comment_index: 0 });
+    let detail = state
+        .issues_state
+        .issue_detail
+        .as_ref()
+        .unwrap_or_else(|| panic!("expected detail"));
+    let content = crate::issue_detail_content::build_detail_content(
+        detail,
+        state.issues_state.detail_subfocus,
+        &state.issues_state.inline_state,
+        state.issues_state.loading.comments,
+    );
+    let anchor_line = content
+        .text
+        .lines()
+        .position(|line| line == crate::issue_detail_content::ISSUE_REPLY_ANCHOR)
+        .unwrap_or_else(|| panic!("reply anchor should render"));
+    let document_rows = crate::layout::issue_detail_document_viewport_rows(
+        state.issues_state.detail_viewport_rows,
+        true,
+    );
+
+    assert!(state.issues_state.detail_scroll_offset > 0);
+    assert!(anchor_line >= state.issues_state.detail_scroll_offset);
+    assert!(anchor_line < state.issues_state.detail_scroll_offset + document_rows);
+}
+/// A blocked reply-open attempt must not perform another parent scroll reveal.
+#[test]
+fn test_blocked_reply_composer_open_does_not_mutate_scroll() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let mut state = state_with_long_detail(&repo_id, 42);
+    state.issues_state.detail_viewport_rows = 8;
+    state
+        .issues_state
+        .issue_detail
+        .as_mut()
+        .unwrap_or_else(|| panic!("expected detail"))
+        .comments
+        .push(p15_comment(
+            1,
+            "alice",
+            "2026-07-01T00:00:00Z",
+            "comment body",
+        ));
+    let mut state = state.apply(AppEvent::OpenReplyComposer { comment_index: 0 });
+    state.issues_state.detail_scroll_offset = 0;
+
+    let state = state.apply(AppEvent::OpenReplyComposer { comment_index: 0 });
+
+    assert_eq!(state.issues_state.detail_scroll_offset, 0);
+}
+
 /// Issue #56: After a comment is successfully created, the detail viewport
 /// scrolls to the bottom so the new comment is visible.
 #[test]

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -502,8 +502,16 @@ impl IssuesState {
         if self.issue_detail.is_none() {
             return 0;
         }
-        self.detail_content_line_count()
-            .saturating_sub(viewport_rows)
+        let composer_active = matches!(
+            self.inline_state,
+            InlineState::Composer {
+                target: ComposerTarget::NewComment | ComposerTarget::Reply { .. },
+                ..
+            }
+        );
+        self.detail_content_line_count().saturating_sub(
+            crate::layout::issue_detail_document_viewport_rows(viewport_rows, composer_active),
+        )
     }
 
     /// Maximum detail scroll offset for the Issues-mode layout bands currently

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -12,6 +12,7 @@ use crate::state::{ComposerTarget, DetailSubfocus, InlineState};
 use crate::theme::{ResolvedColors, ThemeColors};
 
 use super::scrollable_text::ScrollableText;
+use super::text_box::TextBox;
 
 /// Props for the issue detail view.
 #[derive(Default, Props)]
@@ -37,6 +38,33 @@ pub struct IssueDetailViewProps {
     /// flex allocation in the parent layout. Falls back to the terminal-size
     /// calculation when `None`.
     pub available_height: Option<u16>,
+    /// Actual available width (in terminal columns) for detail/composer text.
+    pub available_width: Option<u16>,
+}
+
+fn active_issue_composer(inline_state: &InlineState) -> Option<(String, usize, &'static str)> {
+    match inline_state {
+        InlineState::Composer {
+            target: ComposerTarget::NewComment,
+            text,
+            cursor,
+        } => Some((
+            text.clone(),
+            *cursor,
+            crate::layout::NEW_COMMENT_COMPOSER_PREFIX,
+        )),
+        InlineState::Composer {
+            target: ComposerTarget::Reply { .. },
+            text,
+            cursor,
+        } => Some((text.clone(), *cursor, crate::layout::REPLY_COMPOSER_PREFIX)),
+        InlineState::Composer {
+            target: ComposerTarget::NewIssue,
+            ..
+        }
+        | InlineState::Editor { .. }
+        | InlineState::None => None,
+    }
 }
 
 /// Issue detail view — fixed structure that NEVER changes layout.
@@ -59,7 +87,7 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
     // Compute viewport rows. Prefer the actual available height passed from the
     // parent layout; fall back to deriving it from the terminal size when the
     // parent did not supply one.
-    let scroll_rows = if let Some(height) = props.available_height {
+    let detail_viewport_rows = if let Some(height) = props.available_height {
         // The available height is the real flex allocation for the detail pane,
         // including its borders and header. Subtract header + border (2) to get
         // the scrollable viewport. Do NOT force the minimum-viewport floor here:
@@ -71,6 +99,17 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
         let term_rows = crossterm::terminal::size().map_or(40, |(_, h)| h as usize);
         crate::layout::detail_viewport_rows(term_rows)
     };
+    let composer = active_issue_composer(&props.inline_state);
+    let scroll_rows = crate::layout::issue_detail_document_viewport_rows(
+        detail_viewport_rows,
+        composer.is_some(),
+    );
+    let composer_rows = detail_viewport_rows.saturating_sub(scroll_rows);
+    let detail_content_width = usize::from(props.available_width.unwrap_or_else(|| {
+        crate::layout::issues_detail_content_width(
+            crossterm::terminal::size().map_or(120, |(w, _)| w),
+        )
+    }));
 
     // Build header and content.
     let showing_new_issue_composer = matches!(
@@ -144,6 +183,25 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
             )
         };
 
+    let composer_element: Option<AnyElement<'static>> =
+        composer.map(|(text, byte_cursor, prefix)| {
+            element! {
+                Box(width: 100pct, padding_left: 1u32) {
+                    TextBox(
+                        text: text,
+                        byte_cursor: byte_cursor,
+                        viewport_rows: composer_rows,
+                        content_width: detail_content_width,
+                        prefix: prefix.to_string(),
+                        color: rc.fg,
+                        caret_color: rc.bg,
+                        caret_bg: rc.bright,
+                    )
+                }
+            }
+            .into()
+        });
+
     element! {
         Box(
             flex_direction: FlexDirection::Column,
@@ -181,6 +239,7 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
                     content: detail_content.text,
                     scroll_offset: props.scroll_offset,
                     viewport_rows: scroll_rows,
+                    max_line_width: detail_content_width,
                     cursor_line: detail_content.cursor.map(|(l, _)| l),
                     cursor_col: detail_content.cursor.map(|(_, c)| c),
                     color: rc.fg,
@@ -190,6 +249,8 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
                     thumb_color: rc.bright,
                 )
             }
+
+            #(composer_element)
         }
     }
 }

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -100,11 +100,9 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
         crate::layout::detail_viewport_rows(term_rows)
     };
     let composer = active_issue_composer(&props.inline_state);
-    let scroll_rows = crate::layout::issue_detail_document_viewport_rows(
-        detail_viewport_rows,
-        composer.is_some(),
-    );
-    let composer_rows = detail_viewport_rows.saturating_sub(scroll_rows);
+    let composer_active = composer.is_some();
+    let reserved_document_rows =
+        crate::layout::issue_detail_document_viewport_rows(detail_viewport_rows, composer_active);
     let detail_content_width = usize::from(props.available_width.unwrap_or_else(|| {
         crate::layout::issues_detail_content_width(
             crossterm::terminal::size().map_or(120, |(w, _)| w),
@@ -182,6 +180,19 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
                 rc.dim,
             )
         };
+
+    let document_line_count = detail_content.text.lines().count().max(1);
+    let scroll_rows = if composer_active {
+        reserved_document_rows.min(document_line_count)
+    } else {
+        reserved_document_rows
+    };
+    let composer_rows = if composer_active {
+        crate::layout::DETAIL_COMPOSER_VIEWPORT_ROWS
+            .min(detail_viewport_rows.saturating_sub(scroll_rows))
+    } else {
+        0
+    };
 
     let composer_element: Option<AnyElement<'static>> =
         composer.map(|(text, byte_cursor, prefix)| {

--- a/src/ui/components/issue_detail_render_tests.rs
+++ b/src/ui/components/issue_detail_render_tests.rs
@@ -143,6 +143,50 @@ fn active_issue_new_comment_renders_text_box_text_and_caret_with_stale_offset() 
     assert!(with_caret > baseline);
 }
 
+/// For short issue details, the embedded composer should appear immediately after
+/// the read-only document content instead of being pushed to the pane bottom.
+#[test]
+fn active_issue_new_comment_on_short_detail_starts_after_comments() {
+    let detail = issue_detail_with_comment();
+    let inline = InlineState::Composer {
+        target: ComposerTarget::NewComment,
+        text: "short draft".to_string(),
+        cursor: "short draft".len(),
+    };
+
+    let rendered = render_detail(RenderParams {
+        detail: &detail,
+        subfocus: DetailSubfocus::NewComment,
+        inline_state: &inline,
+        scroll_offset: 0,
+        pane_height: 36,
+        cols: 80,
+    });
+    let lines: Vec<&str> = rendered.lines().collect();
+    let comment_line = lines
+        .iter()
+        .position(|line| line.contains("A comment to reply to"))
+        .unwrap_or_else(|| panic!("missing final comment line in: {rendered}"));
+    let help_line = lines
+        .iter()
+        .position(|line| line.contains("Ctrl+Enter submit | Esc cancel"))
+        .unwrap_or_else(|| panic!("missing composer help line in: {rendered}"));
+    let draft_line = lines
+        .iter()
+        .position(|line| line.contains("short draft"))
+        .unwrap_or_else(|| panic!("missing TextBox draft line in: {rendered}"));
+
+    assert!(
+        draft_line <= comment_line + 5,
+        "composer should stay near the final comment instead of the pane bottom: {rendered}"
+    );
+    assert_eq!(
+        draft_line,
+        help_line + 1,
+        "composer should follow the new-comment help line without blank gap: {rendered}"
+    );
+}
+
 /// Long single-line Issues composer drafts must keep the caret-owned tail visible
 /// through TextBox even when the parent detail scroll offset is stale.
 #[test]

--- a/src/ui/components/issue_detail_render_tests.rs
+++ b/src/ui/components/issue_detail_render_tests.rs
@@ -1,0 +1,236 @@
+//! Render-path tests for IssueDetailView composer ownership.
+//!
+//! @requirement REQ-ISS-009
+
+use crate::domain::{IssueComment, IssueDetail, IssueState};
+use crate::state::{ComposerTarget, DetailSubfocus, InlineState};
+use crate::theme::ThemeColors;
+use crate::ui::components::IssueDetailView;
+
+use iocraft::prelude::*;
+
+fn issue_detail_with_comment() -> IssueDetail {
+    IssueDetail {
+        repo_owner_name: "owner/repo".to_string(),
+        number: 94,
+        title: "Migrate issue composers".to_string(),
+        state: IssueState::Open,
+        author_login: "octocat".to_string(),
+        created_at: "2026-07-01T00:00:00Z".to_string(),
+        updated_at: "2026-07-01T01:00:00Z".to_string(),
+        labels: vec![],
+        assignees: vec![],
+        milestone: None,
+        body: "Body line".to_string(),
+        external_url: "https://github.com/owner/repo/issues/94".to_string(),
+        comments: vec![IssueComment {
+            comment_id: 1,
+            author_login: "alice".to_string(),
+            created_at: "2026-07-01T02:00:00Z".to_string(),
+            edited_at: None,
+            body: "A comment to reply to".to_string(),
+        }],
+        has_more_comments: false,
+        comments_cursor: None,
+    }
+}
+
+struct RenderParams<'a> {
+    detail: &'a IssueDetail,
+    subfocus: DetailSubfocus,
+    inline_state: &'a InlineState,
+    scroll_offset: usize,
+    pane_height: u16,
+    cols: u16,
+}
+
+fn render_detail_canvas(p: RenderParams) -> iocraft::Canvas {
+    let rows: u16 = p.pane_height + 10;
+    let mut elem = element! {
+        Box(width: u32::from(p.cols), height: u32::from(rows)) {
+            IssueDetailView(
+                issue_detail: Some(p.detail.clone()),
+                detail_subfocus: p.subfocus,
+                inline_state: p.inline_state.clone(),
+                comments_loading: false,
+                focused: true,
+                scroll_offset: p.scroll_offset,
+                colors: ThemeColors::default(),
+                available_height: Some(p.pane_height),
+                available_width: Some(p.cols),
+            )
+        }
+    };
+    elem.render(Some(usize::from(p.cols)))
+}
+
+fn render_detail(p: RenderParams) -> String {
+    render_detail_canvas(p).to_string()
+}
+
+fn background_sgr_count(p: RenderParams) -> usize {
+    let canvas = render_detail_canvas(p);
+    let mut buf = Vec::new();
+    canvas
+        .write_ansi(&mut buf)
+        .unwrap_or_else(|e| panic!("write_ansi failed: {e}"));
+    let ansi = String::from_utf8_lossy(&buf);
+    ansi.matches("\u{1b}[48;2;").count() + ansi.matches("\u{1b}[48;5;").count()
+}
+
+/// Active Issues NewComment draft text must be rendered by the embedded TextBox,
+/// not flattened into the read-only detail document.
+#[test]
+fn build_issue_detail_content_cursor_none_for_new_comment_composer() {
+    let detail = issue_detail_with_comment();
+    let inline = InlineState::Composer {
+        target: ComposerTarget::NewComment,
+        text: "draft issue comment".to_string(),
+        cursor: "draft issue comment".len(),
+    };
+
+    let content = crate::issue_detail_content::build_detail_content(
+        &detail,
+        DetailSubfocus::NewComment,
+        &inline,
+        false,
+    );
+
+    assert!(content.cursor.is_none());
+    assert!(!content.text.contains("draft issue comment"));
+}
+
+/// Active Issues NewComment composer text and caret must remain visible even
+/// when the parent document scroll offset is stale.
+#[test]
+fn active_issue_new_comment_renders_text_box_text_and_caret_with_stale_offset() {
+    let detail = issue_detail_with_comment();
+    let inline = InlineState::Composer {
+        target: ComposerTarget::NewComment,
+        text: "first line\nsecond line\ncurrent line".to_string(),
+        cursor: "first line\nsecond line\ncurrent line".len(),
+    };
+
+    let rendered = render_detail(RenderParams {
+        detail: &detail,
+        subfocus: DetailSubfocus::NewComment,
+        inline_state: &inline,
+        scroll_offset: 999,
+        pane_height: 28,
+        cols: 80,
+    });
+    assert!(
+        rendered.contains("current line"),
+        "rendered output: {rendered}"
+    );
+
+    let baseline = background_sgr_count(RenderParams {
+        detail: &detail,
+        subfocus: DetailSubfocus::NewComment,
+        inline_state: &InlineState::None,
+        scroll_offset: 0,
+        pane_height: 28,
+        cols: 80,
+    });
+    let with_caret = background_sgr_count(RenderParams {
+        detail: &detail,
+        subfocus: DetailSubfocus::NewComment,
+        inline_state: &inline,
+        scroll_offset: 0,
+        pane_height: 28,
+        cols: 80,
+    });
+    assert!(with_caret > baseline);
+}
+
+/// Long single-line Issues composer drafts must keep the caret-owned tail visible
+/// through TextBox even when the parent detail scroll offset is stale.
+#[test]
+fn active_issue_new_comment_long_line_keeps_tail_visible_with_stale_offset() {
+    let detail = issue_detail_with_comment();
+    let text = "abcdefghijklmnopqrstuvwxyz0123456789-tail".to_string();
+    let inline = InlineState::Composer {
+        target: ComposerTarget::NewComment,
+        cursor: text.len(),
+        text,
+    };
+
+    let rendered = render_detail(RenderParams {
+        detail: &detail,
+        subfocus: DetailSubfocus::NewComment,
+        inline_state: &inline,
+        scroll_offset: 999,
+        pane_height: 28,
+        cols: 32,
+    });
+
+    assert!(rendered.contains("6789-tai"), "rendered output: {rendered}");
+}
+
+#[test]
+fn build_issue_detail_content_cursor_none_for_reply_composer() {
+    let detail = issue_detail_with_comment();
+    let inline = InlineState::Composer {
+        target: ComposerTarget::Reply {
+            comment_index: 0,
+            author: "@alice ".to_string(),
+        },
+        text: "@alice draft reply".to_string(),
+        cursor: "@alice draft reply".len(),
+    };
+
+    let content = crate::issue_detail_content::build_detail_content(
+        &detail,
+        DetailSubfocus::Comment(0),
+        &inline,
+        false,
+    );
+
+    assert!(content.cursor.is_none());
+    assert!(!content.text.contains("draft reply"));
+}
+
+/// Active Issues Reply composer text and caret must be rendered by TextBox.
+#[test]
+fn active_issue_reply_renders_text_box_text_and_caret() {
+    let detail = issue_detail_with_comment();
+    let inline = InlineState::Composer {
+        target: ComposerTarget::Reply {
+            comment_index: 0,
+            author: "@alice ".to_string(),
+        },
+        text: "@alice first\nreply current".to_string(),
+        cursor: "@alice first\nreply current".len(),
+    };
+
+    let rendered = render_detail(RenderParams {
+        detail: &detail,
+        subfocus: DetailSubfocus::Comment(0),
+        inline_state: &inline,
+        scroll_offset: 999,
+        pane_height: 28,
+        cols: 80,
+    });
+    assert!(
+        rendered.contains("reply current"),
+        "rendered output: {rendered}"
+    );
+
+    let baseline = background_sgr_count(RenderParams {
+        detail: &detail,
+        subfocus: DetailSubfocus::Comment(0),
+        inline_state: &InlineState::None,
+        scroll_offset: 0,
+        pane_height: 28,
+        cols: 80,
+    });
+    let with_caret = background_sgr_count(RenderParams {
+        detail: &detail,
+        subfocus: DetailSubfocus::Comment(0),
+        inline_state: &inline,
+        scroll_offset: 0,
+        pane_height: 28,
+        cols: 80,
+    });
+    assert!(with_caret > baseline);
+}

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -64,6 +64,10 @@ pub use text_box::{TextBox, TextBoxProps};
 mod pr_render_tests;
 
 /// @plan PLAN-20260624-PR-MODE.P14
+#[cfg(test)]
+#[path = "issue_detail_render_tests.rs"]
+mod issue_detail_render_tests;
+
 /// @requirement REQ-PR-009
 /// @requirement REQ-PR-010
 /// @pseudocode component-001 lines 1-12

--- a/src/ui/components/pr_detail.rs
+++ b/src/ui/components/pr_detail.rs
@@ -125,12 +125,16 @@ fn active_pr_composer(inline_state: &InlineState) -> Option<(String, usize, &'st
             target: ComposerTarget::NewComment,
             text,
             cursor,
-        } => Some((text.clone(), *cursor, "  │ ")),
+        } => Some((
+            text.clone(),
+            *cursor,
+            crate::layout::NEW_COMMENT_COMPOSER_PREFIX,
+        )),
         InlineState::Composer {
             target: ComposerTarget::Reply { .. },
             text,
             cursor,
-        } => Some((text.clone(), *cursor, "    │ ")),
+        } => Some((text.clone(), *cursor, crate::layout::REPLY_COMPOSER_PREFIX)),
         InlineState::Composer {
             target: ComposerTarget::NewIssue,
             ..

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -218,6 +218,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                             scroll_offset: detail_scroll_offset,
                             colors: colors.clone(),
                             available_height: Some(detail_pane_height),
+                            available_width: Some(crate::layout::issues_detail_content_width(term_cols)),
                         )
                     }
 


### PR DESCRIPTION
## Summary

Fixes #94

- Migrates Issues mode NewComment and Reply composers to the shared TextBox component.
- Keeps active composer drafts and carets out of the read-only issue detail document.
- Reserves detail viewport rows while composer TextBox is active and preserves one-shot reveal behavior for NewComment and Reply.
- Adds render/unit coverage plus a shipped TUI harness scenario for the Issues composer TextBox path.

## Verification

- RED proof: focused content/render contract failed before implementation because active NewComment returned a read-only document cursor.
- TUI harness scenario: dev-docs/tmux-scenarios/issues-composer-textbox.json passed with seeded repository config.
- cargo fmt --all --check
- scripts/check-clippy-allows.sh
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- complexity clippy gate with project clippy config
- cargo llvm-cov workspace all-features summary-only fail-under-lines 30; TOTAL 63.25 percent
- cargo build --workspace --all-features --locked
- cargo test --workspace --all-features --locked
- rustreviewer: blocking false
- Open Code Review: 12 files reviewed, 0 comments
