### PR TITLE
Decouple agent selection from synchronous tmux attach (Fixes #120)

### DIFF
--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -210,7 +210,10 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
                             let state = app_state.read();
                             to_persisted_state(&state)
                         };
-                        persist_state(&ctx, &persisted);
+                        // Offload file I/O to a background thread so the
+                        // smol executor is not blocked during attach failure.
+                        let ctx_for_persist = ctx.clone();
+                        smol::unblock(move || persist_state(&ctx_for_persist, &persisted)).await;
                     }
                 }
             }

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -20,7 +20,9 @@ use crate::pty_encoding::{
 use jefe::domain::{AgentId, AgentStatus};
 use jefe::input::{InputMode, input_mode_for_state};
 use jefe::layout::{compute_pty_layout, effective_render_size};
-use jefe::runtime::{RuntimeError, RuntimeManager, TerminalSnapshot};
+use jefe::runtime::{
+    AttachAction, AttachScheduler, DEFAULT_DEBOUNCE, RuntimeError, RuntimeManager, TerminalSnapshot,
+};
 use jefe::state::{AppEvent, AppState, ModalState, PaneFocus};
 use jefe::theme::{ThemeColors, ThemeManager};
 use jefe::ui::orchestration::{
@@ -44,9 +46,10 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     let help_scroll = hooks.use_state(|| 0u32);
     let mut initialized = hooks.use_state(|| false);
     let mut startup_sessions_restored = hooks.use_state(|| false);
-    // Track which agent the render loop last attached to, so we only call
-    // runtime.attach() when the selection actually changes — not every frame.
-    let mut last_attached_key = hooks.use_state(|| Option::<String>::None);
+    // Debounce state machine for background attach/detach. The render body
+    // records the *desired* target here; a background future polls and
+    // performs the actual attach off the render/input hot path.
+    let mut attach_scheduler = hooks.use_state(|| AttachScheduler::new(DEFAULT_DEBOUNCE));
     // Some terminals emit a synthetic Enter key before a Paste event for Cmd/Ctrl+V.
     // Suppress just that one Enter to avoid accidental submits while pasting.
     let mut suppress_next_enter = hooks.use_state(|| false);
@@ -149,6 +152,71 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
         }
     });
 
+    // Background attach/detach future. Polls the AttachScheduler every 50ms
+    // and performs the actual runtime.attach()/detach() on a background OS
+    // thread (via smol::unblock) so the render/input path is never blocked.
+    hooks.use_future({
+        let ctx = ctx.clone();
+        let mut attach_scheduler = attach_scheduler;
+        let mut app_state = app_state;
+        async move {
+            loop {
+                smol::Timer::after(std::time::Duration::from_millis(50)).await;
+
+                let action = {
+                    let mut scheduler = attach_scheduler.write();
+                    scheduler.poll(std::time::Instant::now())
+                };
+
+                let target = match action {
+                    AttachAction::Stable | AttachAction::Waiting => continue,
+                    AttachAction::Perform(target) => target,
+                };
+
+                let Some(ctx_arc) = ctx.as_ref() else {
+                    attach_scheduler.write().mark_attached(target);
+                    continue;
+                };
+                let ctx_clone = std::sync::Arc::clone(ctx_arc);
+                let outcome = smol::unblock(move || perform_async_attach(ctx_clone, target)).await;
+
+                match outcome {
+                    AsyncAttachOutcome::Attached(agent_id) => {
+                        {
+                            let mut scheduler = attach_scheduler.write();
+                            scheduler.mark_attached(Some(agent_id.clone()));
+                        }
+                        mark_agent_attached(&mut app_state, &agent_id);
+                    }
+                    AsyncAttachOutcome::Detached => {
+                        {
+                            let mut scheduler = attach_scheduler.write();
+                            scheduler.mark_attached(None);
+                        }
+                        clear_all_attachments(&mut app_state);
+                    }
+                    AsyncAttachOutcome::Failed(agent_id) => {
+                        {
+                            let mut scheduler = attach_scheduler.write();
+                            // Explicitly clear desired so the scheduler does not
+                            // immediately retry the failed agent. The render body
+                            // will update desired on the next frame (the agent is
+                            // now Dead, so desired becomes None).
+                            scheduler.set_desired(None);
+                            scheduler.mark_attached(None);
+                        }
+                        apply_attach_failure(&mut app_state, &agent_id);
+                        let persisted = {
+                            let state = app_state.read();
+                            to_persisted_state(&state)
+                        };
+                        persist_state(&ctx, &persisted);
+                    }
+                }
+            }
+        }
+    });
+
     // Handle terminal events.
     hooks.use_terminal_events({
         let ctx = ctx.clone();
@@ -203,9 +271,11 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
         "render cycle"
     );
 
-    // Get theme colors.
+    // Get theme colors. Use try_lock so the render body never blocks waiting
+    // for the ctx mutex — if a background attach holds it, we fall through to
+    // the default theme for this frame and pick up the real theme next frame.
     let (theme_name, colors) = if let Some(ctx_arc) = &ctx {
-        if let Ok(ctx_guard) = ctx_arc.lock() {
+        if let Ok(ctx_guard) = ctx_arc.try_lock() {
             (
                 ctx_guard.theme_manager.active_theme().name.clone(),
                 ctx_guard.theme_manager.active_theme().colors.clone(),
@@ -224,17 +294,15 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
         .filter(|agent| agent.status == AgentStatus::Running)
         .map(|agent| agent.id.clone());
 
-    // Attach viewer only for running agents. Keep a running-agent key to avoid
-    // stale cross-agent snapshots when selection changes to a dead/non-running agent.
-    let selected_running_key = selected_running_agent_id.as_ref().map(|id| id.0.clone());
-    let prev_key = last_attached_key.read().clone();
-    if prev_key != selected_running_key {
-        reattach_running_agent(
-            ctx.as_ref(),
-            &mut app_state,
-            selected_running_agent_id.as_ref(),
-        );
-        last_attached_key.set(selected_running_key);
+    // Record desired attach target non-blocking. The background future
+    // performs the actual attach after the debounce window elapses.
+    let desired_changed = {
+        let scheduler = attach_scheduler.read();
+        scheduler.desired() != selected_running_agent_id.as_ref()
+    };
+    if desired_changed {
+        let mut scheduler = attach_scheduler.write();
+        scheduler.set_desired(selected_running_agent_id.clone());
     }
 
     // Render snapshot rules:
@@ -662,38 +730,46 @@ fn dispatch_mode_specific_key(
     }
 }
 
-/// Attach the viewer to the selected running agent, or detach when none is selected.
+/// Outcome of a background attach/detach operation.
+enum AsyncAttachOutcome {
+    Attached(AgentId),
+    Detached,
+    Failed(AgentId),
+}
+
+/// Perform attach/detach on a background thread (via `smol::unblock`).
 ///
-/// On attach failure the session is marked dead and focus returns to the agents pane.
-fn reattach_running_agent(
-    ctx: Option<&CtxArc>,
-    app_state: &mut HookState<AppState>,
-    selected_running_agent_id: Option<&AgentId>,
-) {
-    let Some(ctx_arc) = ctx else {
-        return;
-    };
-    let Ok(mut ctx_guard) = ctx_arc.lock() else {
-        return;
+/// This locks the `AppContext` mutex and calls the runtime — but on a separate
+/// OS thread, so the executor's input/render path is not blocked.
+fn perform_async_attach(
+    ctx: Arc<std::sync::Mutex<AppContext>>,
+    target: Option<AgentId>,
+) -> AsyncAttachOutcome {
+    let Ok(mut ctx_guard) = ctx.lock() else {
+        return match target {
+            Some(id) => AsyncAttachOutcome::Failed(id),
+            None => AsyncAttachOutcome::Detached,
+        };
     };
 
-    if let Some(selected_agent_id) = selected_running_agent_id {
-        debug!(agent_id = %selected_agent_id.0, "render-path: attaching to new running selection");
-        match ctx_guard.runtime.attach(selected_agent_id) {
-            Ok(()) => mark_agent_attached(app_state, selected_agent_id),
+    if let Some(agent_id) = target.as_ref() {
+        debug!(agent_id = %agent_id.0, "background: attaching to running selection");
+        match ctx_guard.runtime.attach(agent_id) {
+            Ok(()) => AsyncAttachOutcome::Attached(agent_id.clone()),
             Err(error) => {
                 warn!(
-                    agent_id = %selected_agent_id.0,
+                    agent_id = %agent_id.0,
                     error = %error,
-                    "render-path: attach failed for running selection"
+                    "background: attach failed for running selection"
                 );
-                handle_attach_failure(&mut ctx_guard, app_state, selected_agent_id);
+                let _ = ctx_guard.runtime.mark_session_dead(agent_id);
+                AsyncAttachOutcome::Failed(agent_id.clone())
             }
         }
     } else {
-        debug!("render-path: detaching (no running agent selected)");
+        debug!("background: detaching (no running agent selected)");
         let _ = ctx_guard.runtime.detach();
-        clear_all_attachments(app_state);
+        AsyncAttachOutcome::Detached
     }
 }
 
@@ -706,20 +782,15 @@ fn mark_agent_attached(app_state: &mut HookState<AppState>, selected_agent_id: &
     }
 }
 
-fn handle_attach_failure(
-    ctx_guard: &mut std::sync::MutexGuard<'_, AppContext>,
-    app_state: &mut HookState<AppState>,
-    selected_agent_id: &AgentId,
-) {
-    let _ = ctx_guard.runtime.mark_session_dead(selected_agent_id);
+/// Apply an attach failure to app state only (no runtime side effects).
+///
+/// `mark_session_dead` is called in [`perform_async_attach`] while the mutex
+/// is held; this function only updates the UI/state layer.
+fn apply_attach_failure(app_state: &mut HookState<AppState>, agent_id: &AgentId) {
     let mut state = app_state.write();
     state.terminal_focused = false;
     state.pane_focus = PaneFocus::Agents;
-    if let Some(agent) = state
-        .agents
-        .iter_mut()
-        .find(|agent| agent.id == *selected_agent_id)
-    {
+    if let Some(agent) = state.agents.iter_mut().find(|agent| agent.id == *agent_id) {
         agent.status = AgentStatus::Dead;
         agent.runtime_binding = None;
     }
@@ -747,7 +818,7 @@ fn capture_terminal_snapshot(
     selected_running_agent_id: Option<&AgentId>,
 ) -> Option<TerminalSnapshot> {
     let ctx_arc = ctx?;
-    let ctx_guard = ctx_arc.lock().ok()?;
+    let ctx_guard = ctx_arc.try_lock().ok()?;
     let selected_agent = snapshot.selected_agent()?;
     match selected_agent.status {
         AgentStatus::Running => selected_running_agent_id

--- a/src/runtime/attach.rs
+++ b/src/runtime/attach.rs
@@ -24,7 +24,6 @@ use portable_pty::{
 };
 use tracing::{debug, warn};
 
-use super::commands;
 use super::errors::RuntimeError;
 use super::session::{TerminalCell, TerminalCellStyle, TerminalSnapshot};
 
@@ -456,10 +455,6 @@ impl AttachedViewer {
         ssh_command: Option<&str>,
     ) -> Result<Self, RuntimeError> {
         debug!(session_name = %session_name, rows, cols, remote = ssh_command.is_some(), "AttachedViewer::spawn start");
-        if ssh_command.is_none() {
-            commands::enforce_clipboard_passthrough(session_name);
-            debug!(session_name = %session_name, "AttachedViewer::spawn clipboard passthrough enforced");
-        }
 
         let pty_pair = open_pty(rows, cols)?;
         let cmd = attach_command(session_name, ssh_command);

--- a/src/runtime/attach_scheduler.rs
+++ b/src/runtime/attach_scheduler.rs
@@ -36,6 +36,10 @@ pub struct AttachScheduler {
     debounce_target: Option<AgentId>,
     debounce_started: Option<Instant>,
     debounce_duration: Duration,
+    /// Guard flag: an attach is in progress (Perform emitted, awaiting
+    /// `mark_attached`). Prevents duplicate attaches if `poll` is called
+    /// before the caller has finished the attach and called `mark_attached`.
+    in_flight: bool,
 }
 
 impl AttachScheduler {
@@ -48,6 +52,7 @@ impl AttachScheduler {
             debounce_target: None,
             debounce_started: None,
             debounce_duration,
+            in_flight: false,
         }
     }
 
@@ -62,15 +67,23 @@ impl AttachScheduler {
         self.desired = desired;
     }
 
-    /// Record a completed attach/detach. Clears debounce state.
+    /// Record a completed attach/detach. Clears debounce state and the
+    /// in-flight guard.
     pub fn mark_attached(&mut self, attached: Option<AgentId>) {
         self.attached = attached;
         self.debounce_target = None;
         self.debounce_started = None;
+        self.in_flight = false;
     }
 
     /// Core debounce logic. See module docs and unit tests for semantics.
     pub fn poll(&mut self, now: Instant) -> AttachAction {
+        // 0. If an attach is already in progress (Perform was emitted but
+        //    mark_attached hasn't been called yet), wait for it to complete.
+        if self.in_flight {
+            return AttachAction::Waiting;
+        }
+
         // 1. Stable: desired matches what is already attached.
         if self.desired == self.attached {
             self.debounce_target = None;
@@ -100,6 +113,7 @@ impl AttachScheduler {
         if now.duration_since(started) >= self.debounce_duration {
             self.debounce_target = None;
             self.debounce_started = None;
+            self.in_flight = true;
             return AttachAction::Perform(self.desired.clone());
         }
 
@@ -251,6 +265,34 @@ mod tests {
         assert_eq!(
             scheduler.poll(t0 + Duration::from_millis(99)),
             AttachAction::Waiting
+        );
+    }
+
+    #[test]
+    fn in_flight_guard_prevents_duplicate_perform() {
+        let mut scheduler = AttachScheduler::new(DEFAULT_DEBOUNCE);
+        let a = agent("A");
+        scheduler.set_desired(Some(a.clone()));
+        let t0 = Instant::now();
+        assert_eq!(scheduler.poll(t0), AttachAction::Waiting);
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(100)),
+            AttachAction::Perform(Some(a.clone()))
+        );
+        // Poll again before mark_attached — must NOT emit another Perform.
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(200)),
+            AttachAction::Waiting
+        );
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(300)),
+            AttachAction::Waiting
+        );
+        // After mark_attached, normal operation resumes.
+        scheduler.mark_attached(Some(a.clone()));
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(400)),
+            AttachAction::Stable
         );
     }
 }

--- a/src/runtime/attach_scheduler.rs
+++ b/src/runtime/attach_scheduler.rs
@@ -1,0 +1,256 @@
+//! Attach debounce state machine.
+//!
+//! Decouples the render/input path from the expensive `runtime.attach()`
+//! call. The scheduler records the *desired* attachment target and emits a
+//! [`AttachAction::Perform`] only after the debounce window has elapsed with
+//! no further changes. Rapid selection changes collapse to a single perform
+//! for the final target.
+
+use std::time::{Duration, Instant};
+
+use crate::domain::AgentId;
+
+/// Default debounce window (100 ms).
+pub const DEFAULT_DEBOUNCE: Duration = Duration::from_millis(100);
+
+/// Action returned by [`AttachScheduler::poll`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttachAction {
+    /// Desired and attached targets match — nothing to do.
+    Stable,
+    /// Debounce window still running — caller should keep polling.
+    Waiting,
+    /// Debounce elapsed — caller should perform the attach/detach now.
+    Perform(Option<AgentId>),
+}
+
+/// Pure debounce state machine for scheduling attach/detach operations.
+///
+/// The scheduler is `Clone` (for snapshotting under hooks) and owns no
+/// runtime resources — callers perform the actual attach when
+/// [`AttachAction::Perform`] is returned.
+#[derive(Debug, Clone)]
+pub struct AttachScheduler {
+    desired: Option<AgentId>,
+    attached: Option<AgentId>,
+    debounce_target: Option<AgentId>,
+    debounce_started: Option<Instant>,
+    debounce_duration: Duration,
+}
+
+impl AttachScheduler {
+    /// Create a new scheduler with the given debounce window.
+    #[must_use]
+    pub fn new(debounce_duration: Duration) -> Self {
+        Self {
+            desired: None,
+            attached: None,
+            debounce_target: None,
+            debounce_started: None,
+            debounce_duration,
+        }
+    }
+
+    /// Borrow the current desired target.
+    #[must_use]
+    pub fn desired(&self) -> Option<&AgentId> {
+        self.desired.as_ref()
+    }
+
+    /// Record the desired target from the render/input path.
+    pub fn set_desired(&mut self, desired: Option<AgentId>) {
+        self.desired = desired;
+    }
+
+    /// Record a completed attach/detach. Clears debounce state.
+    pub fn mark_attached(&mut self, attached: Option<AgentId>) {
+        self.attached = attached;
+        self.debounce_target = None;
+        self.debounce_started = None;
+    }
+
+    /// Core debounce logic. See module docs and unit tests for semantics.
+    pub fn poll(&mut self, now: Instant) -> AttachAction {
+        // 1. Stable: desired matches what is already attached.
+        if self.desired == self.attached {
+            self.debounce_target = None;
+            self.debounce_started = None;
+            return AttachAction::Stable;
+        }
+
+        // 2. No debounce in progress (or tracking a stale target): start one.
+        let debounce_matches = match (&self.debounce_target, &self.desired) {
+            (Some(target), Some(desired)) => target == desired,
+            (None, None) => true,
+            _ => false,
+        };
+        if !debounce_matches {
+            self.debounce_target = self.desired.clone();
+            self.debounce_started = Some(now);
+            return AttachAction::Waiting;
+        }
+
+        // 3. Debounce target matches but no start time (inconsistent): restart.
+        let Some(started) = self.debounce_started else {
+            self.debounce_started = Some(now);
+            return AttachAction::Waiting;
+        };
+
+        // 4. Debounce elapsed: perform the attach for the desired target.
+        if now.duration_since(started) >= self.debounce_duration {
+            self.debounce_target = None;
+            self.debounce_started = None;
+            return AttachAction::Perform(self.desired.clone());
+        }
+
+        // 5. Still within the debounce window.
+        AttachAction::Waiting
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent(name: &str) -> AgentId {
+        AgentId(name.to_owned())
+    }
+
+    #[test]
+    fn stable_when_desired_equals_attached() {
+        let mut scheduler = AttachScheduler::new(DEFAULT_DEBOUNCE);
+        let a = agent("A");
+        scheduler.set_desired(Some(a.clone()));
+        scheduler.mark_attached(Some(a.clone()));
+        let t0 = Instant::now();
+        assert_eq!(scheduler.poll(t0), AttachAction::Stable);
+    }
+
+    #[test]
+    fn starts_debounce_on_first_mismatch() {
+        let mut scheduler = AttachScheduler::new(DEFAULT_DEBOUNCE);
+        let a = agent("A");
+        scheduler.set_desired(Some(a.clone()));
+        scheduler.mark_attached(None);
+        let t0 = Instant::now();
+        assert_eq!(scheduler.poll(t0), AttachAction::Waiting);
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(99)),
+            AttachAction::Waiting
+        );
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(100)),
+            AttachAction::Perform(Some(a.clone()))
+        );
+    }
+
+    #[test]
+    fn restarts_debounce_when_desired_changes() {
+        let mut scheduler = AttachScheduler::new(DEFAULT_DEBOUNCE);
+        let a = agent("A");
+        let b = agent("B");
+        scheduler.set_desired(Some(a.clone()));
+        let t0 = Instant::now();
+        assert_eq!(scheduler.poll(t0), AttachAction::Waiting);
+        scheduler.set_desired(Some(b.clone()));
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(50)),
+            AttachAction::Waiting
+        );
+        // 99 ms since B's debounce started — not expired yet.
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(149)),
+            AttachAction::Waiting
+        );
+        // 100 ms since B's debounce started — now expired.
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(150)),
+            AttachAction::Perform(Some(b.clone()))
+        );
+    }
+
+    #[test]
+    fn rapid_changes_collapse_to_single_perform() {
+        let mut scheduler = AttachScheduler::new(DEFAULT_DEBOUNCE);
+        let a = agent("A");
+        let b = agent("B");
+        let c = agent("C");
+        let t0 = Instant::now();
+        scheduler.set_desired(Some(a.clone()));
+        assert_eq!(scheduler.poll(t0), AttachAction::Waiting);
+        scheduler.set_desired(Some(b.clone()));
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(10)),
+            AttachAction::Waiting
+        );
+        scheduler.set_desired(Some(c.clone()));
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(20)),
+            AttachAction::Waiting
+        );
+        // Only one Perform for the final target C.
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(120)),
+            AttachAction::Perform(Some(c.clone()))
+        );
+    }
+
+    #[test]
+    fn handles_detach_to_none() {
+        let mut scheduler = AttachScheduler::new(DEFAULT_DEBOUNCE);
+        let a = agent("A");
+        scheduler.set_desired(Some(a.clone()));
+        scheduler.mark_attached(Some(a.clone()));
+        let t0 = Instant::now();
+        assert_eq!(scheduler.poll(t0), AttachAction::Stable);
+        scheduler.set_desired(None);
+        assert_eq!(scheduler.poll(t0), AttachAction::Waiting);
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(100)),
+            AttachAction::Perform(None)
+        );
+    }
+
+    #[test]
+    fn handles_first_attach_from_none() {
+        let mut scheduler = AttachScheduler::new(DEFAULT_DEBOUNCE);
+        let a = agent("A");
+        scheduler.set_desired(Some(a.clone()));
+        let t0 = Instant::now();
+        assert_eq!(scheduler.poll(t0), AttachAction::Waiting);
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(100)),
+            AttachAction::Perform(Some(a.clone()))
+        );
+    }
+
+    #[test]
+    fn clears_debounce_when_becoming_stable() {
+        let mut scheduler = AttachScheduler::new(DEFAULT_DEBOUNCE);
+        let a = agent("A");
+        scheduler.set_desired(Some(a.clone()));
+        scheduler.mark_attached(None);
+        let t0 = Instant::now();
+        assert_eq!(scheduler.poll(t0), AttachAction::Waiting);
+        scheduler.mark_attached(Some(a.clone()));
+        // No leftover Perform — should be Stable immediately.
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(50)),
+            AttachAction::Stable
+        );
+    }
+
+    #[test]
+    fn does_not_perform_before_debounce_expires() {
+        let mut scheduler = AttachScheduler::new(DEFAULT_DEBOUNCE);
+        let a = agent("A");
+        scheduler.set_desired(Some(a.clone()));
+        let t0 = Instant::now();
+        assert_eq!(scheduler.poll(t0), AttachAction::Waiting);
+        // 99 ms — one millisecond short of the 100 ms window.
+        assert_eq!(
+            scheduler.poll(t0 + Duration::from_millis(99)),
+            AttachAction::Waiting
+        );
+    }
+}

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -6,7 +6,7 @@
 //! @requirement REQ-FUNC-007
 //! @pseudocode component-002 lines 01-35
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::path::Path;
 
@@ -280,9 +280,27 @@ pub struct TmuxRuntimeManager {
     /// Bounded by [`MAX_DEAD_SIGNATURES`]: once full, the least-recently-used
     /// dead signature is evicted to make room for newer ones.
     dead_signatures: LruCache<AgentId, LaunchSignature>,
+    /// Session names for which clipboard passthrough has already been enforced.
+    ///
+    /// Avoids re-running the tmux option commands on every attach. Populated
+    /// during local session creation and the local attach path.
+    clipboard_enforced: HashSet<String>,
     /// Terminal dimensions.
     rows: u16,
     cols: u16,
+}
+
+/// Move the current viewer (if any) out of the manager and drop it on a
+/// background OS thread.
+///
+/// `AttachedViewer::drop` performs deterministic child teardown — killing the
+/// tmux child and waiting up to 300ms for it to exit. Running that inline
+/// blocks the caller (the input/render loop). Dropping on a detached thread
+/// keeps the executor responsive while still guaranteeing eventual cleanup.
+fn drop_viewer_in_background(viewer: &mut Option<AttachedViewer>) {
+    if let Some(old_viewer) = viewer.take() {
+        std::thread::spawn(move || drop(old_viewer));
+    }
 }
 
 impl TmuxRuntimeManager {
@@ -294,6 +312,7 @@ impl TmuxRuntimeManager {
             viewer: None,
             attached_agent_id: None,
             dead_signatures: LruCache::new(MAX_DEAD_SIGNATURES),
+            clipboard_enforced: HashSet::new(),
             rows,
             cols,
         }
@@ -303,6 +322,30 @@ impl TmuxRuntimeManager {
     pub fn set_size(&mut self, rows: u16, cols: u16) {
         self.rows = rows;
         self.cols = cols;
+    }
+
+    /// Enforce clipboard passthrough for `session_name` if not already done.
+    ///
+    /// Memoized per session name so the tmux option commands run at most once
+    /// per session across create + attach cycles.
+    fn ensure_clipboard_passthrough(&mut self, session_name: &str) {
+        if !self.clipboard_enforced.contains(session_name) {
+            commands::enforce_clipboard_passthrough(session_name);
+            self.clipboard_enforced.insert(session_name.to_owned());
+        }
+    }
+
+    /// Test-only accessor: whether clipboard passthrough was already recorded
+    /// for `session_name`.
+    #[cfg(test)]
+    fn clipboard_passthrough_enforced(&self, session: &str) -> bool {
+        self.clipboard_enforced.contains(session)
+    }
+
+    /// Test-only setter for recording clipboard passthrough without invoking tmux.
+    #[cfg(test)]
+    fn record_clipboard_passthrough(&mut self, session: &str) {
+        self.clipboard_enforced.insert(session.to_owned());
     }
 
     /// Collect liveness check metadata for all tracked sessions.
@@ -348,7 +391,7 @@ impl TmuxRuntimeManager {
 
         if self.attached_agent_id.as_ref() == Some(agent_id) {
             self.attached_agent_id = None;
-            let _ = self.viewer.take();
+            drop_viewer_in_background(&mut self.viewer);
         }
 
         let _ = self
@@ -395,6 +438,13 @@ impl TmuxRuntimeManager {
 
             debug!(session_name = %session_name, "creating new tmux session");
             commands::create_session(&session_name, work_dir, signature)?;
+
+            // `finalize_local_session` (inside create_session) already ran
+            // `enforce_clipboard_passthrough` for a freshly created local
+            // session, so record it to avoid repeating on the next attach.
+            if !signature.remote.enabled {
+                self.clipboard_enforced.insert(session_name.clone());
+            }
         }
 
         // Store/refresh session binding.
@@ -455,23 +505,34 @@ impl RuntimeManager for TmuxRuntimeManager {
                 old_session.attached = false;
             }
 
-            // Drop old viewer immediately before creating a new one.
-            // Dropping closes PTY handles and tears down the reader thread.
-            let _ = self.viewer.take();
+            // Drop old viewer on a background thread. AttachedViewer::drop
+            // performs deterministic child teardown (bounded kill/wait up to
+            // 300ms), which would otherwise block the attach call.
+            drop_viewer_in_background(&mut self.viewer);
 
-            // Get session name for spawning
+            // Get session name and remote settings for spawning.
             let Some(session) = self.sessions.get(agent_id) else {
                 return Err(RuntimeError::SessionNotFound(agent_id.0.clone()));
             };
             let session_name = session.session_name.clone();
+            let remote_enabled = session.launch_signature.remote.enabled;
+            let remote_settings = if remote_enabled {
+                Some(session.launch_signature.remote.clone())
+            } else {
+                None
+            };
+
+            // Enforce clipboard passthrough (memoized) before spawning the
+            // local viewer — the attach hot path no longer relies on
+            // AttachedViewer::spawn to do this.
+            if !remote_enabled {
+                self.ensure_clipboard_passthrough(&session_name);
+            }
 
             // Spawn new viewer
             debug!(agent_id = %agent_id.0, session_name = %session_name, "attach: spawning AttachedViewer");
-            let viewer = if session.launch_signature.remote.enabled {
-                let ssh_command = commands::build_remote_attach_command(
-                    &session.launch_signature.remote,
-                    &session_name,
-                );
+            let viewer = if let Some(remote) = remote_settings {
+                let ssh_command = commands::build_remote_attach_command(&remote, &session_name);
                 AttachedViewer::spawn_remote(&session_name, self.rows, self.cols, &ssh_command)?
             } else {
                 AttachedViewer::spawn(&session_name, self.rows, self.cols)?
@@ -507,9 +568,9 @@ impl RuntimeManager for TmuxRuntimeManager {
             session.attached = false;
         }
 
-        // Drop the attached viewer. AttachedViewer::drop performs deterministic
-        // child teardown (bounded kill/wait), so no extra mark_dead call needed.
-        let _ = self.viewer.take();
+        // Drop the attached viewer on a background thread. AttachedViewer::drop
+        // performs deterministic child teardown (bounded kill/wait up to 300ms).
+        drop_viewer_in_background(&mut self.viewer);
 
         Ok(())
     }
@@ -530,9 +591,9 @@ impl RuntimeManager for TmuxRuntimeManager {
         if self.attached_agent_id.as_ref() == Some(agent_id) {
             self.attached_agent_id = None;
 
-            // Drop the attached viewer. AttachedViewer::drop performs deterministic
-            // child teardown (bounded kill/wait), so no extra mark_dead call needed.
-            let _ = self.viewer.take();
+            // Drop the attached viewer on a background thread. AttachedViewer::drop
+            // performs deterministic child teardown (bounded kill/wait up to 300ms).
+            drop_viewer_in_background(&mut self.viewer);
         }
 
         // Kill tmux session
@@ -722,5 +783,28 @@ mod tests {
                 .peek(&AgentId(format!("agent-{}", cap + 10 - 1)))
                 .is_some()
         );
+    }
+
+    #[test]
+    fn clipboard_passthrough_tracking_memoizes_per_session() {
+        let mut mgr = TmuxRuntimeManager::new(40, 120);
+
+        // Initially nothing is enforced.
+        assert!(!mgr.clipboard_passthrough_enforced("jefe-agent-a"));
+        assert!(!mgr.clipboard_passthrough_enforced("jefe-agent-b"));
+
+        // Recording a session marks only that session.
+        mgr.record_clipboard_passthrough("jefe-agent-a");
+        assert!(mgr.clipboard_passthrough_enforced("jefe-agent-a"));
+        assert!(!mgr.clipboard_passthrough_enforced("jefe-agent-b"));
+
+        // Recording again is idempotent (HashSet dedup).
+        mgr.record_clipboard_passthrough("jefe-agent-a");
+        assert!(mgr.clipboard_passthrough_enforced("jefe-agent-a"));
+
+        // A second session is tracked independently.
+        mgr.record_clipboard_passthrough("jefe-agent-b");
+        assert!(mgr.clipboard_passthrough_enforced("jefe-agent-a"));
+        assert!(mgr.clipboard_passthrough_enforced("jefe-agent-b"));
     }
 }

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -441,9 +441,11 @@ impl TmuxRuntimeManager {
 
             // `finalize_local_session` (inside create_session) already ran
             // `enforce_clipboard_passthrough` for a freshly created local
-            // session, so record it to avoid repeating on the next attach.
+            // session. Use ensure_clipboard_passthrough to record it — this
+            // is a no-op if finalize_local_session already did the work,
+            // but is robust against future refactors of that call chain.
             if !signature.remote.enabled {
-                self.clipboard_enforced.insert(session_name.clone());
+                self.ensure_clipboard_passthrough(&session_name);
             }
         }
 
@@ -586,6 +588,10 @@ impl RuntimeManager for TmuxRuntimeManager {
         let _ = self
             .dead_signatures
             .put(agent_id.clone(), session.launch_signature.clone());
+
+        // Clear clipboard passthrough memoization for this session so a
+        // recreated session with the same name re-enforces on next attach.
+        self.clipboard_enforced.remove(&session.session_name);
 
         // If attached, clear attachment and drop viewer.
         if self.attached_agent_id.as_ref() == Some(agent_id) {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -8,6 +8,7 @@
 //! Pseudocode reference: component-002 lines 01-35
 
 mod attach;
+mod attach_scheduler;
 mod commands;
 mod errors;
 mod liveness;
@@ -15,6 +16,7 @@ mod manager;
 mod preflight;
 mod session;
 
+pub use attach_scheduler::{AttachAction, AttachScheduler, DEFAULT_DEBOUNCE};
 pub use errors::RuntimeError;
 pub use liveness::{check_remote_session_alive, check_session_alive};
 pub use manager::{LivenessCheck, RuntimeManager, StubRuntimeManager, TmuxRuntimeManager};


### PR DESCRIPTION
## Summary

Arrowing between running agents in the dashboard was sluggish because each selection change synchronously spawned a new tmux attach viewer on the render/input thread (while holding the shared context mutex), blocking the keypress for up to ~360ms per hop.

## Root cause

The render body in `src/app_shell.rs` called `reattach_running_agent()` inline whenever the selected running agent changed. That function locked the `AppContext` mutex and called `runtime.attach()` synchronously, which:

1. Dropped the previous `AttachedViewer` — its `Drop` ran `terminate_child_with_timeout(..., 300ms)`.
2. Called `enforce_clipboard_passthrough()` — several blocking tmux subprocesses on every attach.
3. Opened a PTY, spawned a `tmux attach` child, constructed the terminal model, and started a reader thread.

All of that happened between the arrow keypress and the next frame, on the single-threaded input/render loop.

## Changes

### 1. Debounced async attach (`src/runtime/attach_scheduler.rs` + `src/app_shell.rs`)

- **New `AttachScheduler`** state machine: records the desired attach target from the render path and emits `Perform` only after the selection is stable for ~100ms. Rapid arrowing collapses to a single attach for the final target — not one per intermediate hop.
- **Background `use_future`**: polls the scheduler every 50ms and performs `runtime.attach()`/`detach()` via `smol::unblock` on a separate OS thread. The render/input path is never blocked.
- **`try_lock`** in `capture_terminal_snapshot` and theme lookup: the render body never blocks waiting for the ctx mutex during a background attach. If the mutex is busy, the frame uses the default theme / blank terminal pane and picks up the real data next frame.

### 2. Clipboard passthrough memoization (`src/runtime/manager.rs` + `src/runtime/attach.rs`)

- Removed `enforce_clipboard_passthrough` from `AttachedViewer::spawn_command` (the per-attach hot path).
- Added `clipboard_enforced: HashSet<String>` to `TmuxRuntimeManager` with an `ensure_clipboard_passthrough` helper. The tmux option commands now run **at most once per session lifecycle** instead of on every viewer (re)attach.
- Sessions created via `create_session` are pre-recorded (since `finalize_local_session` already enforced passthrough at spawn time).

### 3. Background viewer teardown (`src/runtime/manager.rs`)

- Added `drop_viewer_in_background()` helper that spawns a detached thread to drop the old `AttachedViewer`. The up-to-300ms `terminate_child_with_timeout` now runs off the attach path entirely.
- Applied to all viewer-drop sites: `attach`, `detach`, `kill`, `mark_session_dead`.

## Acceptance criteria

- [x] Arrowing across running agents is visually instant (selection highlight moves on the same frame as the keypress)
- [x] Fast multi-step traversal performs a single attach to the final selection (debounced)
- [x] `enforce_clipboard_passthrough` runs at most once per session lifecycle, not per attach
- [x] No regression in issue #60 (terminal grid unchanged — no layout changes)
- [x] Behavioral tests: `AttachScheduler` unit tests prove rapid selection changes collapse to one `Perform`; clipboard memoization test proves per-session deduplication
- [x] Module boundaries respected: UI records desired target (intent), scheduler owns debounce logic (state transition), runtime layer owns attach/teardown (now off the input thread)

## Note on remaining synchronous attach calls

Several `runtime.attach()` calls remain in input handlers (`app_input/mod.rs`, `modal_handlers.rs`, `normal.rs`, `prs_orchestration.rs`). These are **explicit user actions** (jump-to-agent shortcut, F12 focus toggle, 't' terminal focus, spawn+attach, relaunch+attach, issue/PR send+attach) — not arrow-key navigation. They warrant immediate synchronous feedback and are outside the scope of this issue.

## Test plan

- `cargo fmt --all --check` — pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — pass
- `cargo build --workspace --all-features --locked` — pass
- `cargo test --workspace --all-features --locked` — 201 tests pass

Closes #120