### PR TITLE
Keep killed agents visible in active-only mode until navigation (Fixes #116)

### DIFF
--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -451,3 +451,170 @@ fn unique_session(label: &str) -> String {
         .map_or(0, |duration| duration.as_nanos());
     format!("jefe-runner-{label}-{pid}-{nanos}")
 }
+
+/// Issue #116: When active-only mode is ON and the user kills an agent, the
+/// dead agent should remain visible (sticky) until the user navigates away.
+///
+/// This scenario pre-creates a tmux session running `sleep 300` so jefe's
+/// runtime kill can actually succeed, seeds a state.json with a Running agent
+/// bound to that session, then drives the real jefe binary through the
+/// kill → still-visible → navigate → filtered → quit flow.
+#[test]
+fn guarded_real_jefe_sticky_kill_scenario() {
+    let tmux = TmuxDriver::new();
+    if !tmux.is_available() {
+        let _ = std::io::Write::write_all(
+            &mut std::io::stderr(),
+            b"skipping sticky kill test: tmux unavailable\n",
+        );
+        return;
+    }
+    let Some(jefe_binary) = jefe_binary_path() else {
+        let _ = std::io::Write::write_all(
+            &mut std::io::stderr(),
+            b"skipping sticky kill test: jefe binary unavailable\n",
+        );
+        return;
+    };
+
+    let unique = unique_session("stickyagent");
+    let agent_session = format!("jefe-stickyagent-{unique}");
+
+    // Pre-create a tmux session running sleep so jefe's kill can target it.
+    let session_ok = std::process::Command::new("tmux")
+        .args([
+            "new-session",
+            "-d",
+            "-s",
+            &agent_session,
+            "--",
+            "sleep",
+            "300",
+        ])
+        .output()
+        .is_ok_and(|output| output.status.success());
+
+    if !session_ok {
+        let _ = std::io::Write::write_all(
+            &mut std::io::stderr(),
+            b"skipping sticky kill test: could not pre-create agent tmux session\n",
+        );
+        return;
+    }
+
+    // Guard ensures the pre-created session is cleaned up even on panic.
+    let _cleanup = TmuxSessionCleanup {
+        session_name: agent_session.clone(),
+    };
+
+    let config_dir = tempfile::tempdir().value_or_panic("isolated config tempdir");
+    seed_sticky_agent_state(config_dir.path(), &agent_session);
+
+    let summary = run_sticky_scenario(&jefe_binary, config_dir.path());
+    assert_eq!(summary.steps_run, 13);
+}
+
+/// Seed a config directory with a state.json containing a single Running agent
+/// bound to the given tmux session name (issue #116 scenario fixture).
+fn seed_sticky_agent_state(config_dir: &std::path::Path, agent_session: &str) {
+    use crate::domain::{
+        Agent, AgentId, AgentStatus, DEFAULT_SANDBOX_FLAGS, LaunchSignature,
+        RemoteRepositorySettings, Repository, RepositoryId, RuntimeBinding, SandboxEngine,
+    };
+    use crate::persistence::{FilePersistenceManager, PersistenceManager, PersistencePaths, State};
+
+    let mut agent = Agent::new(
+        AgentId("stickyagent".into()),
+        RepositoryId("testrepo".into()),
+        "StickyAgent".into(),
+        std::path::PathBuf::from("/tmp"),
+    );
+    agent.status = AgentStatus::Running;
+    agent.shortcut_slot = Some(1);
+    agent.runtime_binding = Some(RuntimeBinding {
+        session_name: agent_session.to_string(),
+        launch_signature: LaunchSignature {
+            work_dir: std::path::PathBuf::from("/tmp"),
+            profile: String::new(),
+            mode_flags: vec![],
+            llxprt_debug: String::new(),
+            pass_continue: true,
+            sandbox_enabled: false,
+            sandbox_engine: SandboxEngine::Podman,
+            sandbox_flags: DEFAULT_SANDBOX_FLAGS.to_owned(),
+            remote: RemoteRepositorySettings::default(),
+        },
+        attached: false,
+        last_seen: None,
+    });
+
+    let persisted_state = State {
+        schema_version: crate::persistence::STATE_SCHEMA_VERSION,
+        repositories: vec![Repository::new(
+            RepositoryId("testrepo".into()),
+            "TestRepo".into(),
+            "testrepo".into(),
+            std::path::PathBuf::from("/tmp"),
+        )],
+        agents: vec![agent],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        hide_idle_repositories: false,
+        last_selected_agent_by_repo: vec![],
+    };
+
+    let paths = PersistencePaths {
+        settings_path: config_dir.join("settings.toml"),
+        state_path: config_dir.join("state.json"),
+    };
+    let persistence = FilePersistenceManager::with_paths(paths);
+    persistence
+        .save_state(&persisted_state)
+        .unwrap_or_else(|e| panic!("save state: {e:?}"));
+}
+
+/// Run the issue #116 sticky-kill TUI scenario against the real jefe binary.
+fn run_sticky_scenario(jefe_binary: &std::path::Path, config_dir: &std::path::Path) -> RunSummary {
+    let scenario = scenario(
+        r#"[
+            { "waitFor": "LLxprt Jefe" },
+            { "key": "v" },
+            { "wait": 300 },
+            { "key": "Tab" },
+            { "wait": 200 },
+            { "key": "C-k" },
+            { "wait": 1000 },
+            { "expect": "StickyAgent" },
+            { "key": "Down" },
+            { "wait": 500 },
+            { "waitForNot": "StickyAgent" },
+            { "key": "q" },
+            { "waitForExit": 3000 }
+        ]"#,
+    );
+    let session_name = unique_session("sticky-jefe");
+    let request = TmuxStartRequest::jefe(
+        session_name,
+        jefe_binary.to_path_buf(),
+        config_dir,
+        std::env::current_dir().value_or_panic("current dir"),
+        TmuxPaneSize::new(100, 30, 2_000),
+    )
+    .value_or_panic("jefe request");
+
+    run_tmux_scenario(&scenario, &request, None).value_or_panic("run sticky scenario")
+}
+
+/// RAII guard that kills a pre-created tmux session on drop, ensuring cleanup
+/// even if the test panics mid-scenario.
+struct TmuxSessionCleanup {
+    session_name: String,
+}
+
+impl Drop for TmuxSessionCleanup {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("tmux")
+            .args(["kill-session", "-t", &self.session_name])
+            .output();
+    }
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -12,6 +12,7 @@ mod issues_inline_ops;
 mod issues_load_ops;
 mod issues_mutation_ops;
 mod issues_ops;
+mod modal_ops;
 // @plan PLAN-20260624-PR-MODE.P03
 // @requirement REQ-PR-001
 mod prs_inline_ops;
@@ -29,11 +30,11 @@ pub use types::*;
 
 use tracing::{debug, trace};
 
-use crate::domain::{Agent, AgentId, AgentStatus, DEFAULT_SANDBOX_FLAGS, SandboxEngine};
+use crate::domain::{Agent, AgentId, AgentStatus};
 use crate::domain::{Repository, RepositoryId};
 use crate::messages::{
-    AppMessage, MessageRoute, ModalMessage, PersistenceMessage, RepositoryAgentMessage,
-    RuntimeMessage, SystemMessage, ThemeMessage, UiNavigationMessage,
+    AppMessage, MessageRoute, PersistenceMessage, RuntimeMessage, SystemMessage, ThemeMessage,
+    UiNavigationMessage,
 };
 
 /// Move the inline editor cursor up or down by `direction` lines (-1 = up, 1 = down).
@@ -118,7 +119,7 @@ impl AppState {
         self.repository_by_id(&agent.repository_id)
     }
 
-    fn first_unused_shortcut_slot(&self, ignore_agent: Option<&AgentId>) -> Option<u8> {
+    pub(super) fn first_unused_shortcut_slot(&self, ignore_agent: Option<&AgentId>) -> Option<u8> {
         (1u8..=9u8).find(|slot| {
             self.agents.iter().all(|agent| {
                 if ignore_agent.is_some_and(|id| &agent.id == id) {
@@ -194,14 +195,17 @@ impl AppState {
         self.selected_agent_index = visible_indices.first().copied();
     }
 
-    fn has_running_agent_in_repository(&self, repository_id: &RepositoryId) -> bool {
-        self.agents
-            .iter()
-            .any(|agent| &agent.repository_id == repository_id && agent.is_running())
+    fn has_visible_agent_in_repository(&self, repository_id: &RepositoryId) -> bool {
+        self.agents.iter().any(|agent| {
+            &agent.repository_id == repository_id
+                && (agent.is_running() || self.sticky_dead_agent_ids.contains(&agent.id))
+        })
     }
 
     fn is_agent_visible_with_idle_filter(&self, agent: &Agent) -> bool {
-        !self.hide_idle_repositories || agent.is_running()
+        !self.hide_idle_repositories
+            || agent.is_running()
+            || self.sticky_dead_agent_ids.contains(&agent.id)
     }
 
     pub fn rebuild_repository_agent_ids(&mut self) {
@@ -376,6 +380,25 @@ impl AppState {
     }
 
     fn apply_ui_navigation(&mut self, message: UiNavigationMessage) {
+        // Clear sticky-dead agent visibility on selection-changing navigation.
+        // Once the user moves away, the normal active-only filter applies and
+        // dead agents drop out of the visible set (issue #116).
+        //
+        // Display-only toggles (filter, focus, mode switches) do NOT clear
+        // sticky visibility — only actual selection changes do.
+        match message {
+            UiNavigationMessage::NavigateUp
+            | UiNavigationMessage::NavigateDown
+            | UiNavigationMessage::NavigateLeft
+            | UiNavigationMessage::NavigateRight
+            | UiNavigationMessage::SelectRepository(_)
+            | UiNavigationMessage::SelectAgent(_)
+            | UiNavigationMessage::JumpToAgentByShortcut(_) => {
+                self.sticky_dead_agent_ids.clear();
+            }
+            _ => {}
+        }
+
         match message {
             UiNavigationMessage::NavigateUp => self.handle_navigate_up(),
             UiNavigationMessage::NavigateDown => self.handle_navigate_down(),
@@ -582,191 +605,21 @@ impl AppState {
         }
     }
 
-    fn apply_modal_message(&mut self, message: ModalMessage) {
-        match message {
-            ModalMessage::OpenHelp => self.modal = ModalState::Help,
-            ModalMessage::OpenSearch => {
-                self.modal = ModalState::Search {
-                    query: String::new(),
-                };
-            }
-            ModalMessage::CloseModal => self.modal = ModalState::None,
-            ModalMessage::SubmitForm => self.handle_submit_form(),
-            ModalMessage::FormChar(c) => self.handle_form_char(c),
-            ModalMessage::FormBackspace => self.handle_form_backspace(),
-            ModalMessage::FormDelete => self.handle_form_delete(),
-            ModalMessage::FormMoveCursorLeft => self.handle_form_move_cursor_left(),
-            ModalMessage::FormMoveCursorRight => self.handle_form_move_cursor_right(),
-            ModalMessage::FormNextField => self.handle_form_next_field(),
-            ModalMessage::FormPrevField => self.handle_form_prev_field(),
-            ModalMessage::FormToggleCheckbox => self.handle_form_toggle_checkbox(),
-        }
-    }
-
-    fn apply_repository_agent_message(&mut self, message: RepositoryAgentMessage) {
-        match message {
-            RepositoryAgentMessage::OpenNewRepository => self.open_new_repository_modal(),
-            RepositoryAgentMessage::OpenEditRepository(id) => self.open_edit_repository_modal(id),
-            RepositoryAgentMessage::OpenDeleteRepository(id) => {
-                self.modal = ModalState::ConfirmDeleteRepository { id };
-            }
-            RepositoryAgentMessage::OpenNewAgent(repository_id) => {
-                self.open_new_agent_modal(repository_id);
-            }
-            RepositoryAgentMessage::OpenEditAgent(id) => self.open_edit_agent_modal(id),
-            RepositoryAgentMessage::OpenDeleteAgent(id) => {
-                self.modal = ModalState::ConfirmDeleteAgent {
-                    id,
-                    delete_work_dir: false,
-                };
-            }
-            RepositoryAgentMessage::ToggleDeleteWorkDir => self.toggle_delete_work_dir(),
-        }
-    }
-
-    fn open_new_repository_modal(&mut self) {
-        self.modal = ModalState::NewRepository {
-            fields: RepositoryFormFields::default(),
-            focus: RepositoryFormFocus::default(),
-            cursor: RepositoryFormCursor::default(),
-        };
-    }
-
-    fn open_edit_repository_modal(&mut self, id: RepositoryId) {
-        let fields = self
-            .repositories
-            .iter()
-            .find(|r| r.id == id)
-            .map(|r| RepositoryFormFields {
-                name: r.name.clone(),
-                base_dir: r.base_dir.to_string_lossy().into_owned(),
-                default_profile: r.default_profile.clone(),
-                github_repo: r.github_repo.clone(),
-                remote_enabled: r.remote.enabled,
-                login_user: r.remote.login_user.clone(),
-                host: r.remote.host.clone(),
-                run_as_user: r.remote.run_as_user.clone(),
-                setup_env_default: r.remote.setup_env_default,
-            })
-            .unwrap_or_default();
-        self.modal = ModalState::EditRepository {
-            id,
-            cursor: RepositoryFormCursor {
-                name: fields.name.chars().count(),
-                base_dir: fields.base_dir.chars().count(),
-                default_profile: fields.default_profile.chars().count(),
-                github_repo: fields.github_repo.chars().count(),
-                login_user: fields.login_user.chars().count(),
-                host: fields.host.chars().count(),
-                run_as_user: fields.run_as_user.chars().count(),
-            },
-            fields,
-            focus: RepositoryFormFocus::default(),
-        };
-    }
-
-    fn open_new_agent_modal(&mut self, repository_id: RepositoryId) {
-        let (base_dir, default_profile) = self
-            .repositories
-            .iter()
-            .find(|r| r.id == repository_id)
-            .map(|r| {
-                (
-                    r.base_dir.to_string_lossy().into_owned(),
-                    r.default_profile.clone(),
-                )
-            })
-            .unwrap_or_default();
-
-        let work_dir_len = base_dir.chars().count();
-        let profile_len = default_profile.chars().count();
-
-        self.modal = ModalState::NewAgent {
-            repository_id,
-            fields: AgentFormFields {
-                shortcut_slot: self.first_unused_shortcut_slot(None),
-                name: String::new(),
-                description: String::new(),
-                work_dir: base_dir,
-                profile: default_profile,
-                mode: "--yolo".to_owned(),
-                llxprt_debug: String::new(),
-                pass_continue: true,
-                sandbox_enabled: false,
-                sandbox_engine: SandboxEngine::Podman.label().to_owned(),
-                sandbox_flags: DEFAULT_SANDBOX_FLAGS.to_owned(),
-            },
-            cursor: AgentFormCursor {
-                work_dir: work_dir_len,
-                profile: profile_len,
-                mode: "--yolo".chars().count(),
-                sandbox_flags: DEFAULT_SANDBOX_FLAGS.chars().count(),
-                ..AgentFormCursor::default()
-            },
-            focus: AgentFormFocus::default(),
-            work_dir_manual: false,
-        };
-    }
-
-    fn open_edit_agent_modal(&mut self, id: AgentId) {
-        let fields = self
-            .agents
-            .iter()
-            .find(|a| a.id == id)
-            .map(|a| AgentFormFields {
-                shortcut_slot: a.shortcut_slot,
-                name: a.name.clone(),
-                description: a.description.clone(),
-                work_dir: a.work_dir.to_string_lossy().into_owned(),
-                profile: a.profile.clone(),
-                mode: a.mode_flags.join(" "),
-                llxprt_debug: a.llxprt_debug.clone(),
-                pass_continue: a.pass_continue,
-                sandbox_enabled: a.sandbox_enabled,
-                sandbox_engine: a.sandbox_engine.label().to_owned(),
-                sandbox_flags: a.sandbox_flags.clone(),
-            })
-            .unwrap_or_default();
-        self.modal = ModalState::EditAgent {
-            id,
-            cursor: AgentFormCursor {
-                name: fields.name.chars().count(),
-                description: fields.description.chars().count(),
-                work_dir: fields.work_dir.chars().count(),
-                profile: fields.profile.chars().count(),
-                mode: fields.mode.chars().count(),
-                llxprt_debug: fields.llxprt_debug.chars().count(),
-                sandbox_flags: fields.sandbox_flags.chars().count(),
-            },
-            fields,
-            focus: AgentFormFocus::default(),
-        };
-    }
-
-    fn toggle_delete_work_dir(&mut self) {
-        if let ModalState::ConfirmDeleteAgent {
-            id,
-            delete_work_dir,
-        } = self.modal.clone()
-        {
-            self.modal = ModalState::ConfirmDeleteAgent {
-                id,
-                delete_work_dir: !delete_work_dir,
-            };
-        }
-    }
-
     fn apply_runtime_message(&mut self, message: RuntimeMessage) {
         match message {
             RuntimeMessage::KillAgent(agent_id) => {
                 if let Some(agent) = self.agents.iter_mut().find(|a| a.id == agent_id) {
                     agent.status = AgentStatus::Dead;
                     agent.runtime_binding = None;
+                    self.sticky_dead_agent_ids.insert(agent_id);
                 }
             }
             RuntimeMessage::AgentStatusChanged(agent_id, status) => {
                 if let Some(agent) = self.agents.iter_mut().find(|a| a.id == agent_id) {
                     agent.status = status;
+                    if status == AgentStatus::Running {
+                        self.sticky_dead_agent_ids.remove(&agent_id);
+                    }
                 }
             }
             RuntimeMessage::RelaunchAgent(agent_id) => {
@@ -774,6 +627,7 @@ impl AppState {
                     && agent.runtime_binding.is_some()
                 {
                     agent.status = AgentStatus::Running;
+                    self.sticky_dead_agent_ids.remove(&agent_id);
                 }
             }
         }

--- a/src/state/modal_ops.rs
+++ b/src/state/modal_ops.rs
@@ -1,0 +1,190 @@
+//! Modal and repository-agent message dispatch.
+//!
+//! Extracted from the main reducer to keep `mod.rs` within the source-file
+//! length limit. These methods open/close/edit modal forms and handle
+//! repository/agent-related UI messages.
+
+use crate::domain::{AgentId, DEFAULT_SANDBOX_FLAGS, RepositoryId, SandboxEngine};
+use crate::messages::{ModalMessage, RepositoryAgentMessage};
+
+use super::AppState;
+use super::types::{
+    AgentFormCursor, AgentFormFields, AgentFormFocus, ModalState, RepositoryFormCursor,
+    RepositoryFormFields, RepositoryFormFocus,
+};
+
+impl AppState {
+    pub(super) fn apply_modal_message(&mut self, message: ModalMessage) {
+        match message {
+            ModalMessage::OpenHelp => self.modal = ModalState::Help,
+            ModalMessage::OpenSearch => {
+                self.modal = ModalState::Search {
+                    query: String::new(),
+                };
+            }
+            ModalMessage::CloseModal => self.modal = ModalState::None,
+            ModalMessage::SubmitForm => self.handle_submit_form(),
+            ModalMessage::FormChar(c) => self.handle_form_char(c),
+            ModalMessage::FormBackspace => self.handle_form_backspace(),
+            ModalMessage::FormDelete => self.handle_form_delete(),
+            ModalMessage::FormMoveCursorLeft => self.handle_form_move_cursor_left(),
+            ModalMessage::FormMoveCursorRight => self.handle_form_move_cursor_right(),
+            ModalMessage::FormNextField => self.handle_form_next_field(),
+            ModalMessage::FormPrevField => self.handle_form_prev_field(),
+            ModalMessage::FormToggleCheckbox => self.handle_form_toggle_checkbox(),
+        }
+    }
+
+    pub(super) fn apply_repository_agent_message(&mut self, message: RepositoryAgentMessage) {
+        match message {
+            RepositoryAgentMessage::OpenNewRepository => self.open_new_repository_modal(),
+            RepositoryAgentMessage::OpenEditRepository(id) => self.open_edit_repository_modal(id),
+            RepositoryAgentMessage::OpenDeleteRepository(id) => {
+                self.modal = ModalState::ConfirmDeleteRepository { id };
+            }
+            RepositoryAgentMessage::OpenNewAgent(repository_id) => {
+                self.open_new_agent_modal(repository_id);
+            }
+            RepositoryAgentMessage::OpenEditAgent(id) => self.open_edit_agent_modal(id),
+            RepositoryAgentMessage::OpenDeleteAgent(id) => {
+                self.modal = ModalState::ConfirmDeleteAgent {
+                    id,
+                    delete_work_dir: false,
+                };
+            }
+            RepositoryAgentMessage::ToggleDeleteWorkDir => self.toggle_delete_work_dir(),
+        }
+    }
+
+    fn open_new_repository_modal(&mut self) {
+        self.modal = ModalState::NewRepository {
+            fields: RepositoryFormFields::default(),
+            focus: RepositoryFormFocus::default(),
+            cursor: RepositoryFormCursor::default(),
+        };
+    }
+
+    fn open_edit_repository_modal(&mut self, id: RepositoryId) {
+        let fields = self
+            .repositories
+            .iter()
+            .find(|r| r.id == id)
+            .map(|r| RepositoryFormFields {
+                name: r.name.clone(),
+                base_dir: r.base_dir.to_string_lossy().into_owned(),
+                default_profile: r.default_profile.clone(),
+                github_repo: r.github_repo.clone(),
+                remote_enabled: r.remote.enabled,
+                login_user: r.remote.login_user.clone(),
+                host: r.remote.host.clone(),
+                run_as_user: r.remote.run_as_user.clone(),
+                setup_env_default: r.remote.setup_env_default,
+            })
+            .unwrap_or_default();
+        self.modal = ModalState::EditRepository {
+            id,
+            cursor: RepositoryFormCursor {
+                name: fields.name.chars().count(),
+                base_dir: fields.base_dir.chars().count(),
+                default_profile: fields.default_profile.chars().count(),
+                github_repo: fields.github_repo.chars().count(),
+                login_user: fields.login_user.chars().count(),
+                host: fields.host.chars().count(),
+                run_as_user: fields.run_as_user.chars().count(),
+            },
+            fields,
+            focus: RepositoryFormFocus::default(),
+        };
+    }
+
+    fn open_new_agent_modal(&mut self, repository_id: RepositoryId) {
+        let (base_dir, default_profile) = self
+            .repositories
+            .iter()
+            .find(|r| r.id == repository_id)
+            .map(|r| {
+                (
+                    r.base_dir.to_string_lossy().into_owned(),
+                    r.default_profile.clone(),
+                )
+            })
+            .unwrap_or_default();
+
+        let work_dir_len = base_dir.chars().count();
+        let profile_len = default_profile.chars().count();
+
+        self.modal = ModalState::NewAgent {
+            repository_id,
+            fields: AgentFormFields {
+                shortcut_slot: self.first_unused_shortcut_slot(None),
+                name: String::new(),
+                description: String::new(),
+                work_dir: base_dir,
+                profile: default_profile,
+                mode: "--yolo".to_owned(),
+                llxprt_debug: String::new(),
+                pass_continue: true,
+                sandbox_enabled: false,
+                sandbox_engine: SandboxEngine::Podman.label().to_owned(),
+                sandbox_flags: DEFAULT_SANDBOX_FLAGS.to_owned(),
+            },
+            cursor: AgentFormCursor {
+                work_dir: work_dir_len,
+                profile: profile_len,
+                mode: "--yolo".chars().count(),
+                sandbox_flags: DEFAULT_SANDBOX_FLAGS.chars().count(),
+                ..AgentFormCursor::default()
+            },
+            focus: AgentFormFocus::default(),
+            work_dir_manual: false,
+        };
+    }
+
+    fn open_edit_agent_modal(&mut self, id: AgentId) {
+        let fields = self
+            .agents
+            .iter()
+            .find(|a| a.id == id)
+            .map(|a| AgentFormFields {
+                shortcut_slot: a.shortcut_slot,
+                name: a.name.clone(),
+                description: a.description.clone(),
+                work_dir: a.work_dir.to_string_lossy().into_owned(),
+                profile: a.profile.clone(),
+                mode: a.mode_flags.join(" "),
+                llxprt_debug: a.llxprt_debug.clone(),
+                pass_continue: a.pass_continue,
+                sandbox_enabled: a.sandbox_enabled,
+                sandbox_engine: a.sandbox_engine.label().to_owned(),
+                sandbox_flags: a.sandbox_flags.clone(),
+            })
+            .unwrap_or_default();
+        self.modal = ModalState::EditAgent {
+            id,
+            cursor: AgentFormCursor {
+                name: fields.name.chars().count(),
+                description: fields.description.chars().count(),
+                work_dir: fields.work_dir.chars().count(),
+                profile: fields.profile.chars().count(),
+                mode: fields.mode.chars().count(),
+                llxprt_debug: fields.llxprt_debug.chars().count(),
+                sandbox_flags: fields.sandbox_flags.chars().count(),
+            },
+            fields,
+            focus: AgentFormFocus::default(),
+        };
+    }
+
+    fn toggle_delete_work_dir(&mut self) {
+        if let ModalState::ConfirmDeleteAgent {
+            id,
+            delete_work_dir,
+        } = self.modal.clone()
+        {
+            self.modal = ModalState::ConfirmDeleteAgent {
+                id,
+                delete_work_dir: !delete_work_dir,
+            };
+        }
+    }
+}

--- a/src/state/selectors.rs
+++ b/src/state/selectors.rs
@@ -13,7 +13,7 @@ impl AppState {
             .enumerate()
             .filter_map(|(idx, repository)| {
                 (!self.hide_idle_repositories
-                    || self.has_running_agent_in_repository(&repository.id))
+                    || self.has_visible_agent_in_repository(&repository.id))
                 .then_some(idx)
             })
             .collect()

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -269,6 +269,10 @@ pub struct AppState {
     pub terminal_focused: bool,
     pub hide_idle_repositories: bool,
 
+    /// Agent IDs that were just killed and should remain visible in active-only
+    /// mode until the user navigates away. Runtime-only — not persisted.
+    pub sticky_dead_agent_ids: std::collections::HashSet<crate::domain::AgentId>,
+
     // Modal/form state
     pub modal: ModalState,
 

--- a/tests/core/visibility_filter_contracts.rs
+++ b/tests/core/visibility_filter_contracts.rs
@@ -371,3 +371,274 @@ fn visible_repo_count_matches_visible_repository_indices() {
     assert_eq!(hidden.visible_repository_indices().len(), 1);
     assert_eq!(hidden.visible_repository_indices()[0], 0);
 }
+
+// =============================================================================
+// Sticky dead-agent visibility (issue #116)
+//
+// When hide_idle_repositories is ON and the user kills an agent, the dead
+// agent should remain visible until ANY UI navigation occurs. This prevents
+// the user from losing their place when the agent they were viewing dies.
+// =============================================================================
+
+fn running_agent(id: &str, name: &str, repo_id: &str) -> Agent {
+    let mut a = Agent::new(
+        AgentId(id.into()),
+        RepositoryId(repo_id.into()),
+        name.into(),
+        PathBuf::from(format!("/{repo_id}/{id}")),
+    );
+    a.status = AgentStatus::Running;
+    a
+}
+
+/// Test 1: With hide_idle_repositories=true, kill the selected running agent.
+/// The agent should still be visible and selected, and the repo should still
+/// be in visible_repository_indices.
+#[test]
+fn kill_agent_in_active_only_mode_stays_visible() {
+    let mut state = AppState {
+        repositories: vec![repository("r1")],
+        agents: vec![running_agent("a1", "Agent One", "r1")],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Agents,
+        hide_idle_repositories: true,
+        ..AppState::default()
+    };
+    state.normalize_selection_indices();
+
+    let killed = state.apply(AppEvent::KillAgent(AgentId("a1".into())));
+
+    // The agent is Dead but should still be in the visible set (sticky).
+    let repo_id = RepositoryId("r1".into());
+    let visible_agents = killed.visible_agents_for_repository(&repo_id);
+    assert!(
+        visible_agents.iter().any(|a| a.id == AgentId("a1".into())),
+        "killed agent should remain visible via sticky until navigation"
+    );
+
+    // The agent should still be selected.
+    let selected = killed.selected_agent();
+    assert!(
+        selected.is_some_and(|a| a.id == AgentId("a1".into())),
+        "killed agent should still be selected (sticky keeps it visible)"
+    );
+
+    // The repo should still be visible.
+    let visible_repos = killed.visible_repository_indices();
+    assert!(
+        visible_repos.contains(&0),
+        "repo r1 should still be visible (sticky dead agent keeps it alive)"
+    );
+}
+
+/// Test 2: After killing (sticky), navigating away should clear the sticky
+/// list and the dead agent should be filtered out.
+#[test]
+fn navigate_after_kill_filters_dead_agent() {
+    let mut state = AppState {
+        repositories: vec![repository("r1"), repository("r2")],
+        agents: vec![
+            running_agent("a1", "Agent One", "r1"),
+            running_agent("a2", "Agent Two", "r2"),
+        ],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Agents,
+        hide_idle_repositories: true,
+        ..AppState::default()
+    };
+    state.normalize_selection_indices();
+
+    let killed = state.apply(AppEvent::KillAgent(AgentId("a1".into())));
+
+    // Navigate down — this should clear the sticky list.
+    let after_nav = killed.apply(AppEvent::NavigateDown);
+
+    let repo_id = RepositoryId("r1".into());
+    let visible_agents = after_nav.visible_agents_for_repository(&repo_id);
+    assert!(
+        !visible_agents.iter().any(|a| a.id == AgentId("a1".into())),
+        "after navigation, the dead agent should be filtered out"
+    );
+}
+
+/// Test 3: Kill the last running agent in a repo. The repo should stay visible
+/// (sticky). After navigating away, the repo should be filtered out.
+#[test]
+fn kill_last_running_agent_keeps_repo_visible() {
+    let mut state = AppState {
+        repositories: vec![repository("r1"), repository("r2")],
+        agents: vec![
+            running_agent("a1", "Agent One", "r1"),
+            running_agent("a2", "Agent Two", "r2"),
+        ],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Repositories,
+        hide_idle_repositories: true,
+        ..AppState::default()
+    };
+    state.normalize_selection_indices();
+
+    // Kill the only running agent in r1.
+    let killed = state.apply(AppEvent::KillAgent(AgentId("a1".into())));
+
+    // r1 should still be visible because of the sticky dead agent.
+    let visible_repos = killed.visible_repository_indices();
+    assert!(
+        visible_repos.contains(&0),
+        "repo r1 should still be visible after killing its last running agent (sticky)"
+    );
+
+    // Navigate down — clears sticky, r1 should now be filtered out.
+    let after_nav = killed.apply(AppEvent::NavigateDown);
+    let visible_repos_after = after_nav.visible_repository_indices();
+    assert!(
+        !visible_repos_after.contains(&0),
+        "after navigation, repo r1 should be filtered out (no running agents)"
+    );
+}
+
+/// Test 4: AgentStatusChanged(Dead) should NOT trigger sticky behavior.
+/// Only an explicit KillAgent action should be sticky.
+#[test]
+fn agent_status_changed_does_not_trigger_sticky() {
+    let mut state = AppState {
+        repositories: vec![repository("r1")],
+        agents: vec![running_agent("a1", "Agent One", "r1")],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Agents,
+        hide_idle_repositories: true,
+        ..AppState::default()
+    };
+    state.normalize_selection_indices();
+
+    // Use AgentStatusChanged (external status update) instead of KillAgent.
+    let after = state.apply(AppEvent::AgentStatusChanged(
+        AgentId("a1".into()),
+        AgentStatus::Dead,
+    ));
+
+    let repo_id = RepositoryId("r1".into());
+    let visible_agents = after.visible_agents_for_repository(&repo_id);
+    assert!(
+        !visible_agents.iter().any(|a| a.id == AgentId("a1".into())),
+        "AgentStatusChanged(Dead) should NOT be sticky — agent should be filtered immediately"
+    );
+}
+
+/// Test 5: Kill with filter OFF (sticky is set), then toggle filter ON.
+/// Toggling the filter is a display setting, not a navigation, so it should
+/// NOT clear the sticky list. The dead agent remains visible until the user
+/// actually navigates away.
+#[test]
+fn kill_with_filter_off_then_toggle_on_keeps_sticky() {
+    let mut state = AppState {
+        repositories: vec![repository("r1")],
+        agents: vec![running_agent("a1", "Agent One", "r1")],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Agents,
+        hide_idle_repositories: false,
+        ..AppState::default()
+    };
+    state.normalize_selection_indices();
+
+    // Kill while filter is OFF — sticky list should still be populated.
+    let killed = state.apply(AppEvent::KillAgent(AgentId("a1".into())));
+
+    // Toggle filter ON — this is a display toggle, NOT navigation; sticky persists.
+    let toggled = killed.apply(AppEvent::ToggleHideIdleRepositories);
+    assert!(toggled.hide_idle_repositories);
+
+    let repo_id = RepositoryId("r1".into());
+    let visible_agents = toggled.visible_agents_for_repository(&repo_id);
+    assert!(
+        visible_agents.iter().any(|a| a.id == AgentId("a1".into())),
+        "toggling filter ON should NOT clear sticky — dead agent stays visible"
+    );
+
+    // Now navigate down — this clears sticky, and the dead agent is filtered out.
+    let navigated = toggled.apply(AppEvent::NavigateDown);
+    let visible_after_nav = navigated.visible_agents_for_repository(&repo_id);
+    assert!(
+        !visible_after_nav
+            .iter()
+            .any(|a| a.id == AgentId("a1".into())),
+        "after navigation, sticky is cleared and dead agent is filtered out"
+    );
+}
+
+/// Test 6: Kill multiple agents in the same repo. All should be sticky until
+/// navigation clears them.
+#[test]
+fn multiple_kills_all_sticky() {
+    let mut state = AppState {
+        repositories: vec![repository("r1")],
+        agents: vec![
+            running_agent("a1", "Agent One", "r1"),
+            running_agent("a2", "Agent Two", "r1"),
+        ],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Agents,
+        hide_idle_repositories: true,
+        ..AppState::default()
+    };
+    state.normalize_selection_indices();
+
+    let killed_a = state.apply(AppEvent::KillAgent(AgentId("a1".into())));
+    let killed_b = killed_a.apply(AppEvent::KillAgent(AgentId("a2".into())));
+
+    let repo_id = RepositoryId("r1".into());
+    let visible_agents = killed_b.visible_agents_for_repository(&repo_id);
+    assert!(
+        visible_agents.iter().any(|a| a.id == AgentId("a1".into())),
+        "agent a1 should be sticky-visible"
+    );
+    assert!(
+        visible_agents.iter().any(|a| a.id == AgentId("a2".into())),
+        "agent a2 should be sticky-visible"
+    );
+
+    // Navigate away — both should be filtered.
+    let after_nav = killed_b.apply(AppEvent::NavigateDown);
+    let visible_after = after_nav.visible_agents_for_repository(&repo_id);
+    assert!(
+        visible_after.is_empty(),
+        "after navigation, both dead agents should be filtered out"
+    );
+}
+
+/// Test 7: Kill agent, then SelectRepository (even to the same repo) should
+/// clear the sticky list.
+#[test]
+fn sticky_cleared_on_select_repository() {
+    let mut state = AppState {
+        repositories: vec![repository("r1"), repository("r2")],
+        agents: vec![
+            running_agent("a1", "Agent One", "r1"),
+            running_agent("a2", "Agent Two", "r2"),
+        ],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Repositories,
+        hide_idle_repositories: true,
+        ..AppState::default()
+    };
+    state.normalize_selection_indices();
+
+    let killed = state.apply(AppEvent::KillAgent(AgentId("a1".into())));
+
+    // SelectRepository is a navigation message — clears sticky.
+    let after_select = killed.apply(AppEvent::SelectRepository(0));
+
+    let repo_id = RepositoryId("r1".into());
+    let visible_agents = after_select.visible_agents_for_repository(&repo_id);
+    assert!(
+        !visible_agents.iter().any(|a| a.id == AgentId("a1".into())),
+        "SelectRepository should clear sticky and filter out the dead agent"
+    );
+}


### PR DESCRIPTION
## Summary

When "active-only" mode (hide_idle_repositories) is ON and the user kills an agent with Ctrl-k, the dead agent and its repository now remain visible until the user navigates away. Previously, the dead agent immediately disappeared from the view, which was jarring and made it hard to see what just happened.

## Changes

### State layer (`src/state/`)

- **`types.rs`**: Added `sticky_dead_agent_ids: HashSet<AgentId>` to `AppState`. This is runtime-only — it is NOT persisted to `state.json`.
- **`mod.rs`**:
  - `KillAgent` pushes the agent_id to `sticky_dead_agent_ids` (only if the agent actually exists)
  - `AgentStatusChanged(Running)` and `RelaunchAgent` clear stale sticky IDs for the affected agent
  - Selection-changing navigation (`NavigateUp/Down/Left/Right`, `SelectRepository`, `SelectAgent`, `JumpToAgentByShortcut`) clears the entire sticky list
  - Display-only toggles (`ToggleHideIdleRepositories`, `ToggleTerminalFocus`, `CyclePaneFocus`, split/grab mode) do NOT clear sticky
  - `has_visible_agent_in_repository` (renamed from `has_running_agent_in_repository`) returns true for sticky-dead agents
  - `is_agent_visible_with_idle_filter` returns true for sticky-dead agents

### Tests

- **7 state-layer behavioral tests** (`tests/core/visibility_filter_contracts.rs`): kill keeps visible, navigation filters, last-agent repo stays visible, AgentStatusChanged is NOT sticky, toggle filter does NOT clear sticky (navigation does), multiple kills all sticky, navigation clears
- **1 TUI harness scenario test** (`src/harness/runner_tests.rs`): pre-creates a tmux session running `sleep 300`, seeds state.json with Running agent bound to that session, drives the real jefe binary through: toggle active-only -> select agent -> Ctrl-k -> verify agent still visible -> navigate away -> verify agent filtered -> quit

## Design notes

- `HashSet<AgentId>` used for O(1) membership checks in hot-path iterators
- `TmuxSessionCleanup` RAII guard ensures the pre-created test session is cleaned up even on panic
- `STATE_SCHEMA_VERSION` constant used instead of hardcoded value
- Sticky list is cleared on relaunch/running-status to avoid stale state

Fixes #116