### PR TITLE
Add Ctrl-r restart-agent hotkey: kill, wait, relaunch in one action (Fixes #117)

### DIFF
--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -447,6 +447,9 @@ pub fn dispatch_app_message(
         AppMessage::Runtime(RuntimeMessage::RelaunchAgent(agent_id)) => {
             dispatch_relaunch_agent(app_state, ctx, agent_id);
         }
+        AppMessage::Runtime(RuntimeMessage::RestartAgent(agent_id)) => {
+            dispatch_restart_agent(app_state, ctx, agent_id);
+        }
         AppMessage::Issues(
             message @ (IssuesMessage::NavigateUp
             | IssuesMessage::NavigateDown
@@ -546,6 +549,43 @@ fn persist_error_message(app_state: &mut AppStateHandle, ctx: &SharedContext, er
     let persisted = to_persisted_state(&state);
     drop(state);
     persist_state(ctx, &persisted);
+}
+
+/// Restart an agent: kill, wait for session teardown, then relaunch with fresh
+/// config/env (issue #117). Surfaces an error if any step fails.
+fn dispatch_restart_agent(app_state: &mut AppStateHandle, ctx: &SharedContext, agent_id: AgentId) {
+    // Only kill if the agent is currently running; dead agents skip straight
+    // to relaunch (tolerating Ctrl-r on already-dead agents).
+    let agent_is_running = app_state
+        .read()
+        .agents
+        .iter()
+        .find(|a| a.id == agent_id)
+        .is_some_and(jefe::domain::Agent::is_running);
+
+    if agent_is_running {
+        if let Err(error) = kill_runtime_agent(ctx, &agent_id) {
+            warn!(agent_id = %agent_id.0, error = %error, "restart: kill failed");
+            persist_error_message(app_state, ctx, error);
+            return;
+        }
+
+        // Apply kill state transition so the UI reflects the kill immediately.
+        {
+            let mut state = app_state.write();
+            *state = std::mem::take(&mut *state).apply(AppEvent::KillAgent(agent_id.clone()));
+            state.terminal_focused = false;
+            let persisted = to_persisted_state(&state);
+            drop(state);
+            persist_state(ctx, &persisted);
+        }
+
+        // Wait for session teardown before relaunching (issue says 1-2s).
+        std::thread::sleep(Duration::from_millis(1500));
+    }
+
+    // Relaunch with fresh config (reuses existing relaunch plumbing).
+    dispatch_relaunch_agent(app_state, ctx, agent_id);
 }
 
 fn dispatch_relaunch_agent(app_state: &mut AppStateHandle, ctx: &SharedContext, agent_id: AgentId) {

--- a/src/app_input/normal.rs
+++ b/src/app_input/normal.rs
@@ -22,6 +22,7 @@ struct NormalKeySnapshot {
     selected_agent_id: Option<AgentId>,
 }
 
+#[derive(Debug)]
 pub(super) enum KeyHandling {
     Unhandled,
     Handled(Option<AppEvent>),
@@ -331,6 +332,17 @@ fn resolve_agent_lifecycle_key(key_event: &KeyEvent, snapshot: &NormalKeySnapsho
         KeyCode::Char('k' | 'K') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
             KeyHandling::Handled(snapshot.selected_agent_id.clone().map(AppEvent::KillAgent))
         }
+        // Ctrl-r: kill + relaunch in one action (issue #117). Placed BEFORE
+        // the plain `l`/`L` arm so the CONTROL modifier is checked first, and
+        // before `handle_direct_pane_focus_key` (which handles plain `r`).
+        KeyCode::Char('r' | 'R') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyHandling::Handled(
+                snapshot
+                    .selected_agent_id
+                    .clone()
+                    .map(AppEvent::RestartAgent),
+            )
+        }
         KeyCode::Char('l' | 'L') => KeyHandling::Handled(relaunch_event_for_selected_agent(
             snapshot.selected_agent_id.clone(),
             snapshot.selected_agent_is_running,
@@ -507,13 +519,17 @@ fn handle_theme_key(ctx: &SharedContext, key_event: &KeyEvent) -> KeyHandling {
 
 #[cfg(test)]
 mod tests {
-    use super::{issues_quit_shortcut_active, relaunch_event_for_selected_agent};
+    use super::{
+        KeyHandling, NormalKeySnapshot, issues_quit_shortcut_active,
+        relaunch_event_for_selected_agent, resolve_agent_lifecycle_key,
+    };
+    use iocraft::prelude::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
     use jefe::domain::AgentId;
     use jefe::input::InputMode;
     use jefe::input::input_mode_for_state;
     use jefe::state::{
         AgentChooserState, AppEvent, AppState, ComposerTarget, InlineState, IssueFocus,
-        IssuesState, ScreenMode,
+        IssuesState, PaneFocus, ScreenMode,
     };
 
     #[test]
@@ -628,5 +644,98 @@ mod tests {
         };
         assert!(matches!(input_mode_for_state(&state), InputMode::Normal));
         assert!(!issues_quit_shortcut_active(&state));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Ctrl-r restart-agent key handler (RED → GREEN)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    fn key_press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(KeyEventKind::Press, code)
+    }
+
+    fn key_with_mods(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        let mut evt = KeyEvent::new(KeyEventKind::Press, code);
+        evt.modifiers = modifiers;
+        evt
+    }
+
+    fn snapshot_with_agent(agent_id: &str, running: bool) -> NormalKeySnapshot {
+        NormalKeySnapshot {
+            pane_focus: PaneFocus::Agents,
+            selected_agent_is_running: running,
+            selected_repo_id: None,
+            selected_agent_id: Some(AgentId(agent_id.to_string())),
+        }
+    }
+
+    /// Ctrl-r on a running agent should emit `RestartAgent` (issue #117).
+    #[test]
+    fn restart_event_is_emitted_for_running_agent() {
+        let snapshot = snapshot_with_agent("a1", true);
+        let key_event = key_with_mods(KeyCode::Char('r'), KeyModifiers::CONTROL);
+        let handling = resolve_agent_lifecycle_key(&key_event, &snapshot);
+        match handling {
+            KeyHandling::Handled(Some(AppEvent::RestartAgent(AgentId(id)))) => {
+                assert_eq!(id, "a1");
+            }
+            other => panic!("expected Handled(RestartAgent), got {other:?}"),
+        }
+    }
+
+    /// Ctrl-r on a dead agent should also emit `RestartAgent` — restart works
+    /// regardless of status (unlike `l` which only relaunches dead agents).
+    #[test]
+    fn restart_event_is_emitted_for_dead_agent() {
+        let snapshot = snapshot_with_agent("a2", false);
+        let key_event = key_with_mods(KeyCode::Char('r'), KeyModifiers::CONTROL);
+        let handling = resolve_agent_lifecycle_key(&key_event, &snapshot);
+        match handling {
+            KeyHandling::Handled(Some(AppEvent::RestartAgent(AgentId(id)))) => {
+                assert_eq!(id, "a2");
+            }
+            other => panic!("expected Handled(RestartAgent), got {other:?}"),
+        }
+    }
+
+    /// Plain `r` without CONTROL must NOT produce a restart event — it should
+    /// be unhandled by `resolve_agent_lifecycle_key` so it falls through to
+    /// `handle_direct_pane_focus_key` (focus repositories pane).
+    #[test]
+    fn plain_r_does_not_restart() {
+        let snapshot = snapshot_with_agent("a1", true);
+        let key_event = key_press(KeyCode::Char('r'));
+        let handling = resolve_agent_lifecycle_key(&key_event, &snapshot);
+        assert!(
+            matches!(handling, KeyHandling::Unhandled),
+            "plain r should not be handled by lifecycle resolver"
+        );
+    }
+
+    /// Ctrl-R (uppercase / shift) should also restart — be lenient with case.
+    #[test]
+    fn ctrl_shift_r_also_restarts() {
+        let snapshot = snapshot_with_agent("a3", true);
+        let key_event = key_with_mods(KeyCode::Char('R'), KeyModifiers::CONTROL);
+        let handling = resolve_agent_lifecycle_key(&key_event, &snapshot);
+        assert!(matches!(
+            handling,
+            KeyHandling::Handled(Some(AppEvent::RestartAgent(_)))
+        ));
+    }
+
+    /// Ctrl-r with no selected agent should produce `Handled(None)` — the key
+    /// is consumed (handled) but there's nothing to restart.
+    #[test]
+    fn ctrl_r_with_no_selection_is_handled_without_event() {
+        let snapshot = NormalKeySnapshot {
+            pane_focus: PaneFocus::Agents,
+            selected_agent_is_running: false,
+            selected_repo_id: None,
+            selected_agent_id: None,
+        };
+        let key_event = key_with_mods(KeyCode::Char('r'), KeyModifiers::CONTROL);
+        let handling = resolve_agent_lifecycle_key(&key_event, &snapshot);
+        assert!(matches!(handling, KeyHandling::Handled(None)));
     }
 }

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -618,3 +618,164 @@ impl Drop for TmuxSessionCleanup {
             .output();
     }
 }
+
+/// Issue #117: Ctrl-r should restart (kill + relaunch) a running agent in one
+/// action. This scenario pre-creates a tmux session running `sleep 300`, seeds
+/// a state.json with a Running agent bound to that session, then drives the
+/// real jefe binary through the restart flow: active-only → Tab to Agents →
+/// Ctrl-r → expect agent still visible and running → quit.
+#[test]
+fn guarded_real_jefe_restart_scenario() {
+    let tmux = TmuxDriver::new();
+    if !tmux.is_available() {
+        let _ = std::io::Write::write_all(
+            &mut std::io::stderr(),
+            b"skipping restart test: tmux unavailable
+",
+        );
+        return;
+    }
+    let Some(jefe_binary) = jefe_binary_path() else {
+        let _ = std::io::Write::write_all(
+            &mut std::io::stderr(),
+            b"skipping restart test: jefe binary unavailable
+",
+        );
+        return;
+    };
+
+    let unique = unique_session("restartagent");
+    let agent_session = format!("jefe-restartagent-{unique}");
+
+    // Pre-create a tmux session running sleep so jefe's kill can target it.
+    let session_ok = std::process::Command::new("tmux")
+        .args([
+            "new-session",
+            "-d",
+            "-s",
+            &agent_session,
+            "--",
+            "sleep",
+            "300",
+        ])
+        .output()
+        .is_ok_and(|output| output.status.success());
+
+    if !session_ok {
+        let _ = std::io::Write::write_all(
+            &mut std::io::stderr(),
+            b"skipping restart test: could not pre-create agent tmux session
+",
+        );
+        return;
+    }
+
+    // Guard ensures the pre-created session is cleaned up even on panic.
+    let _cleanup = TmuxSessionCleanup {
+        session_name: agent_session.clone(),
+    };
+
+    let config_dir = tempfile::tempdir().value_or_panic("isolated config tempdir");
+    seed_restart_agent_state(config_dir.path(), &agent_session);
+
+    let summary = run_restart_scenario(&jefe_binary, config_dir.path());
+    assert_eq!(summary.steps_run, 8);
+
+    // Verify the restart actually killed the original `sleep 300` process.
+    // After restart, the session should no longer contain the sleep process
+    // (it was killed and replaced with the agent command).
+    let sleep_still_running = std::process::Command::new("tmux")
+        .args(["capture-pane", "-t", &agent_session, "-p", "-S", "-"])
+        .output()
+        .is_ok_and(|o| String::from_utf8_lossy(&o.stdout).contains("sleep 300"));
+    assert!(
+        !sleep_still_running,
+        "restart should have killed the original sleep process"
+    );
+}
+
+/// Seed a config directory with a state.json containing a single Running agent
+/// bound to the given tmux session name (issue #117 scenario fixture).
+fn seed_restart_agent_state(config_dir: &std::path::Path, agent_session: &str) {
+    use crate::domain::{
+        Agent, AgentId, AgentStatus, DEFAULT_SANDBOX_FLAGS, LaunchSignature,
+        RemoteRepositorySettings, Repository, RepositoryId, RuntimeBinding, SandboxEngine,
+    };
+    use crate::persistence::{FilePersistenceManager, PersistenceManager, PersistencePaths, State};
+
+    let mut agent = Agent::new(
+        AgentId("restartagent".into()),
+        RepositoryId("testrepo".into()),
+        "RestartAgent".into(),
+        std::path::PathBuf::from("/tmp"),
+    );
+    agent.status = AgentStatus::Running;
+    agent.shortcut_slot = Some(1);
+    agent.runtime_binding = Some(RuntimeBinding {
+        session_name: agent_session.to_string(),
+        launch_signature: LaunchSignature {
+            work_dir: std::path::PathBuf::from("/tmp"),
+            profile: String::new(),
+            mode_flags: vec![],
+            llxprt_debug: String::new(),
+            pass_continue: true,
+            sandbox_enabled: false,
+            sandbox_engine: SandboxEngine::Podman,
+            sandbox_flags: DEFAULT_SANDBOX_FLAGS.to_owned(),
+            remote: RemoteRepositorySettings::default(),
+        },
+        attached: false,
+        last_seen: None,
+    });
+
+    let persisted_state = State {
+        schema_version: crate::persistence::STATE_SCHEMA_VERSION,
+        repositories: vec![Repository::new(
+            RepositoryId("testrepo".into()),
+            "TestRepo".into(),
+            "testrepo".into(),
+            std::path::PathBuf::from("/tmp"),
+        )],
+        agents: vec![agent],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        hide_idle_repositories: false,
+        last_selected_agent_by_repo: vec![],
+    };
+
+    let paths = PersistencePaths {
+        settings_path: config_dir.join("settings.toml"),
+        state_path: config_dir.join("state.json"),
+    };
+    let persistence = FilePersistenceManager::with_paths(paths);
+    persistence
+        .save_state(&persisted_state)
+        .unwrap_or_else(|e| panic!("save state: {e:?}"));
+}
+
+/// Run the issue #117 restart TUI scenario against the real jefe binary.
+fn run_restart_scenario(jefe_binary: &std::path::Path, config_dir: &std::path::Path) -> RunSummary {
+    let scenario = scenario(
+        r#"[
+            { "waitFor": "LLxprt Jefe" },
+            { "key": "Tab" },
+            { "wait": 200 },
+            { "key": "C-r" },
+            { "wait": 3000 },
+            { "expect": "RestartAgent" },
+            { "key": "q" },
+            { "waitForExit": 5000 }
+        ]"#,
+    );
+    let session_name = unique_session("restart-jefe");
+    let request = TmuxStartRequest::jefe(
+        session_name,
+        jefe_binary.to_path_buf(),
+        config_dir,
+        std::env::current_dir().value_or_panic("current dir"),
+        TmuxPaneSize::new(100, 30, 2_000),
+    )
+    .value_or_panic("jefe request");
+
+    run_tmux_scenario(&scenario, &request, None).value_or_panic("run restart scenario")
+}

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -100,6 +100,8 @@ pub enum RepositoryAgentMessage {
 pub enum RuntimeMessage {
     KillAgent(AgentId),
     RelaunchAgent(AgentId),
+    /// Kill then relaunch an agent in one action (issue #117).
+    RestartAgent(AgentId),
     AgentStatusChanged(AgentId, AgentStatus),
 }
 
@@ -638,6 +640,7 @@ message_names!(RepositoryAgentMessage {
 message_names!(RuntimeMessage {
     Self::KillAgent(_) => "KillAgent",
     Self::RelaunchAgent(_) => "RelaunchAgent",
+    Self::RestartAgent(_) => "RestartAgent",
     Self::AgentStatusChanged(_, _) => "AgentStatusChanged",
 });
 

--- a/src/messages/event_conversion.rs
+++ b/src/messages/event_conversion.rs
@@ -90,6 +90,7 @@ impl AppMessage {
             }
             AppEvent::KillAgent(id) => Self::Runtime(RuntimeMessage::KillAgent(id)),
             AppEvent::RelaunchAgent(id) => Self::Runtime(RuntimeMessage::RelaunchAgent(id)),
+            AppEvent::RestartAgent(id) => Self::Runtime(RuntimeMessage::RestartAgent(id)),
             AppEvent::AgentStatusChanged(id, status) => {
                 Self::Runtime(RuntimeMessage::AgentStatusChanged(id, status))
             }
@@ -295,6 +296,7 @@ impl From<RuntimeMessage> for AppEvent {
         match message {
             RuntimeMessage::KillAgent(id) => Self::KillAgent(id),
             RuntimeMessage::RelaunchAgent(id) => Self::RelaunchAgent(id),
+            RuntimeMessage::RestartAgent(id) => Self::RestartAgent(id),
             RuntimeMessage::AgentStatusChanged(id, status) => Self::AgentStatusChanged(id, status),
         }
     }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -630,6 +630,18 @@ impl AppState {
                     self.sticky_dead_agent_ids.remove(&agent_id);
                 }
             }
+            // RestartAgent handles the edge case where apply_and_persist is
+            // called with RestartAgent directly (not via dispatch). The normal
+            // path goes through dispatch_restart_agent which applies Kill then
+            // Relaunch separately. Here we clear sticky and set Running.
+            RuntimeMessage::RestartAgent(agent_id) => {
+                self.sticky_dead_agent_ids.remove(&agent_id);
+                if let Some(agent) = self.agents.iter_mut().find(|a| a.id == agent_id)
+                    && agent.runtime_binding.is_some()
+                {
+                    agent.status = AgentStatus::Running;
+                }
+            }
         }
     }
 

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -590,6 +590,9 @@ pub enum AppEvent {
     // Lifecycle
     KillAgent(AgentId),
     RelaunchAgent(AgentId),
+    /// Kill and relaunch an agent in one action (Ctrl-r). Surfaces an error
+    /// if any step fails rather than silently dropping the agent (issue #117).
+    RestartAgent(AgentId),
     AgentStatusChanged(AgentId, AgentStatus),
 
     // Persistence results

--- a/src/ui/components/keybind_bar.rs
+++ b/src/ui/components/keybind_bar.rs
@@ -32,7 +32,7 @@ pub fn keybind_hints_for(screen_mode: ScreenMode, terminal_focused: bool) -> &'s
     }
     match screen_mode {
         ScreenMode::Dashboard => {
-            "^/v navigate | </> pane | t/f12 terminal focus | v active-only (repos+agents) | \u{2325}1-9 jump agent | n new-agent | N new-repo | ctrl-d delete | ctrl-k kill | l relaunch-dead | s split | ? help | q quit"
+            "^/v navigate | </> pane | t/f12 terminal focus | v active-only (repos+agents) | \u{2325}1-9 jump agent | n new-agent | N new-repo | ctrl-d delete | ctrl-k kill | ctrl-r restart | l relaunch-dead | s split | ? help | q quit"
         }
         ScreenMode::Split => "^/v select | g grab | m move | Esc back | ? help",
         ScreenMode::DashboardIssues => {

--- a/src/ui/modals/help.rs
+++ b/src/ui/modals/help.rs
@@ -23,7 +23,7 @@ pub fn HelpModal(props: &HelpModalProps) -> impl Into<AnyElement<'static>> {
         Box(
             flex_direction: FlexDirection::Column,
             width: 60u32,
-            height: 20u32,
+            height: 22u32,
             border_style: BorderStyle::Round,
             border_color: rc.border_focused,
             background_color: rc.bg,
@@ -50,6 +50,7 @@ pub fn HelpModal(props: &HelpModalProps) -> impl Into<AnyElement<'static>> {
                 Text(content: "  N           New repository", color: rc.fg)
                 Text(content: "  Ctrl-d      Delete selected", color: rc.fg)
                 Text(content: "  Ctrl-k      Kill agent", color: rc.fg)
+                Text(content: "  Ctrl-r      Restart agent", color: rc.fg)
                 Text(content: "  l           Relaunch dead agent", color: rc.fg)
                 Text(content: "  s           Split mode", color: rc.fg)
                 Text(content: "  v           Toggle active-only (repos + agents)", color: rc.fg)


### PR DESCRIPTION
## Summary

Adds a **Ctrl-r** hotkey that restarts the selected agent in one action: kill, wait for teardown (~1.5s), relaunch with fresh config/env. Works on both running and dead agents (dead agents skip the kill step). Surfaces a visible error if any step fails.

## Changes

| File | Change |
|------|--------|
| `src/state/types.rs` | Added `RestartAgent(AgentId)` to `AppEvent` |
| `src/messages.rs` | Added `RestartAgent(AgentId)` to `RuntimeMessage` |
| `src/messages/event_conversion.rs` | Event conversion both directions |
| `src/state/mod.rs` | RestartAgent reducer arm (clears sticky, sets Running when binding exists) |
| `src/app_input/normal.rs` | Ctrl-r key handler in `resolve_agent_lifecycle_key` (CONTROL modifier required) + 5 unit tests |
| `src/app_input/mod.rs` | `dispatch_restart_agent`: kills session, applies kill state, waits, delegates to existing relaunch plumbing |
| `src/ui/components/keybind_bar.rs` | Added `ctrl-r restart` to Dashboard hints |
| `src/ui/modals/help.rs` | Added `Ctrl-r Restart agent` entry |
| `src/harness/runner_tests.rs` | TUI scenario test that verifies kill actually occurred |

## Key design decisions

- **Ctrl-r only with CONTROL modifier**: plain r/R still focuses the Repositories pane. resolve_agent_lifecycle_key runs before handle_direct_pane_focus_key, so Ctrl-r is intercepted first.
- **Tolerates dead agents**: if the agent is already dead, the kill step is skipped and restart goes straight to relaunch.
- **Reuses existing plumbing**: dispatch_restart_agent calls kill_runtime_agent then dispatch_relaunch_agent -- no duplicated tmux/PTY code.
- **Sticky interaction**: RestartAgent clears the agent from sticky_dead_agent_ids (issue #116), since the agent is being brought back to Running.

## Tests

- 5 unit tests for key routing (Ctrl-r on running/dead agents, plain-r does not restart, works with no selection)
- 1 TUI harness scenario that pre-creates a sleep 300 tmux session, seeds state, drives the restart flow, and verifies the original sleep process was killed
- All 999 existing tests still pass

Fixes #117
