### PR TITLE
Add threaded PR review rendering with reply and resolve (Fixes #119)

### DIFF
--- a/src/app_input/prs.rs
+++ b/src/app_input/prs.rs
@@ -209,6 +209,7 @@ fn handle_pr_detail_key(state: &AppState, key_event: &KeyEvent) -> Option<AppEve
         KeyCode::Char('k') => Some(AppEvent::PrDetailSubfocusPrev),
         KeyCode::Char('c') => Some(comment_event_for_subfocus(state.prs_state.detail_subfocus)),
         KeyCode::Char('r') => Some(reply_event_for_subfocus(state.prs_state.detail_subfocus)),
+        KeyCode::Char('R') => Some(resolve_event_for_subfocus(state.prs_state.detail_subfocus)),
         KeyCode::Char('e') => Some(AppEvent::PrShowNotice(
             ReadOnlyHintKind::ReadOnlyNotEditable,
         )),
@@ -232,9 +233,9 @@ fn comment_event_for_subfocus(subfocus: PrDetailSubfocus) -> AppEvent {
         PrDetailSubfocus::Body | PrDetailSubfocus::Comment(_) | PrDetailSubfocus::NewComment => {
             AppEvent::PrOpenNewCommentComposer
         }
-        PrDetailSubfocus::Review(_) | PrDetailSubfocus::Check(_) => {
-            AppEvent::PrShowNotice(ReadOnlyHintKind::ReadOnlyNoComment)
-        }
+        PrDetailSubfocus::Review(_)
+        | PrDetailSubfocus::ReviewThread(_)
+        | PrDetailSubfocus::Check(_) => AppEvent::PrShowNotice(ReadOnlyHintKind::ReadOnlyNoComment),
     }
 }
 
@@ -248,7 +249,23 @@ fn comment_event_for_subfocus(subfocus: PrDetailSubfocus) -> AppEvent {
 fn reply_event_for_subfocus(subfocus: PrDetailSubfocus) -> AppEvent {
     match subfocus {
         PrDetailSubfocus::Comment(idx) => AppEvent::PrOpenReplyComposer { comment_index: idx },
+        PrDetailSubfocus::ReviewThread(idx) => {
+            AppEvent::PrOpenThreadReplyComposer { thread_index: idx }
+        }
         _ => AppEvent::PrShowNotice(ReadOnlyHintKind::ReadOnlyReplyOnComment),
+    }
+}
+
+/// Map `R` to the resolve/unresolve thread event on ReviewThread subfocus, or
+/// to a read-only notice elsewhere (resolve is only valid on a review thread).
+///
+/// @requirement REQ-PR-009
+fn resolve_event_for_subfocus(subfocus: PrDetailSubfocus) -> AppEvent {
+    match subfocus {
+        PrDetailSubfocus::ReviewThread(idx) => {
+            AppEvent::PrToggleThreadResolve { thread_index: idx }
+        }
+        _ => AppEvent::PrShowNotice(ReadOnlyHintKind::ReadOnlyResolveOnThread),
     }
 }
 

--- a/src/app_input/prs_key_tests.rs
+++ b/src/app_input/prs_key_tests.rs
@@ -835,3 +835,42 @@ fn test_pr_detail() -> jefe::domain::PullRequestDetail {
         merge_state_status: None,
     }
 }
+
+// =============================================================================
+// Review-thread key dispatch tests (issue #119)
+// =============================================================================
+
+/// `r` on ReviewThread subfocus opens the thread-reply composer.
+#[test]
+fn test_r_on_review_thread_opens_thread_reply_composer() {
+    let thread = prs_state_with_detail_subfocus(PrDetailSubfocus::ReviewThread(0));
+    let event = resolve_prs_key_event(&thread, &key(KeyCode::Char('r')));
+    assert!(matches!(
+        event,
+        Some(AppEvent::PrOpenThreadReplyComposer { thread_index: 0 })
+    ));
+}
+
+/// `R` on ReviewThread subfocus toggles resolve.
+#[test]
+fn test_big_r_on_review_thread_toggles_resolve() {
+    let thread = prs_state_with_detail_subfocus(PrDetailSubfocus::ReviewThread(1));
+    let event = resolve_prs_key_event(&thread, &key(KeyCode::Char('R')));
+    assert!(matches!(
+        event,
+        Some(AppEvent::PrToggleThreadResolve { thread_index: 1 })
+    ));
+}
+
+/// `R` on non-thread subfocus emits a notice (NOT None).
+#[test]
+fn test_big_r_on_body_emits_show_notice_not_none() {
+    let body = prs_state_with_detail_subfocus(PrDetailSubfocus::Body);
+    let event = resolve_prs_key_event(&body, &key(KeyCode::Char('R')));
+    assert!(matches!(
+        event,
+        Some(AppEvent::PrShowNotice(
+            ReadOnlyHintKind::ReadOnlyResolveOnThread
+        ))
+    ));
+}

--- a/src/app_input/prs_mutation.rs
+++ b/src/app_input/prs_mutation.rs
@@ -8,7 +8,7 @@
 //! @requirement REQ-PR-011
 //! @pseudocode component-003 lines 109-119
 
-use jefe::state::{AppEvent, InlineState};
+use jefe::state::{AppEvent, ComposerTarget, InlineState};
 
 use super::{
     AppStateHandle, SharedContext, apply_and_persist, gh_async, github_client, prs_dispatch,
@@ -17,7 +17,7 @@ use super::{
 /// Handle an inline submit for PR Mode.
 ///
 /// Reads the mutation-pending target + composer text, validates the repo, and
-/// spawns `GhClient::create_pr_comment` via `spawn_gh_task_with_panic`,
+/// spawns the gh comment/reply task via `spawn_gh_task_with_panic`,
 /// delivering `PrCommentCreated` on success or `PrCommentCreateFailed` on
 /// Err/panic.
 ///
@@ -34,7 +34,24 @@ pub fn handle_pr_inline_submit(app_state: &mut AppStateHandle, ctx: &SharedConte
         report_missing_github_repo(app_state, ctx, &action);
         return;
     };
-    dispatch_pr_comment_create(app_state, ctx, repo, action);
+    if let ComposerTarget::ReplyToReviewThread { thread_index, .. } = &action.target {
+        let Some(thread_id) = resolve_thread_id(app_state, *thread_index) else {
+            apply_and_persist(
+                app_state,
+                ctx,
+                AppEvent::PrCommentCreateFailed {
+                    scope_repo_id: action.scope_repo_id.clone(),
+                    pr_number: action.pr_number,
+                    mutation_id: action.mutation_id,
+                    error: "Review thread not found (it may have been removed).".to_string(),
+                },
+            );
+            return;
+        };
+        dispatch_pr_thread_reply(app_state, ctx, repo, action, thread_id);
+    } else {
+        dispatch_pr_comment_create(app_state, ctx, repo, action);
+    }
 }
 
 /// @plan PLAN-20260624-PR-MODE.P11
@@ -46,6 +63,7 @@ struct PrInlineSubmitAction {
     pr_number: u64,
     mutation_id: u64,
     text: String,
+    target: ComposerTarget,
 }
 
 /// Resolve the inline-submit action from state (mutation_pending + composer text).
@@ -57,8 +75,9 @@ fn resolve_pr_inline_submit(app_state: &AppStateHandle) -> Option<PrInlineSubmit
     let state = app_state.read();
     let pending = state.prs_state.mutation_pending.as_ref()?;
     let pr_number = state.prs_state.pr_detail.as_ref()?.number;
-    let text = match &state.prs_state.inline_state {
-        InlineState::Composer { text, .. } | InlineState::Editor { text, .. } => text.clone(),
+    let (text, target) = match &state.prs_state.inline_state {
+        InlineState::Composer { text, target, .. } => (text.clone(), target.clone()),
+        InlineState::Editor { text, .. } => (text.clone(), ComposerTarget::NewComment),
         InlineState::None => return None,
     };
     if text.trim().is_empty() {
@@ -69,6 +88,7 @@ fn resolve_pr_inline_submit(app_state: &AppStateHandle) -> Option<PrInlineSubmit
         pr_number,
         mutation_id: pending.mutation_id,
         text,
+        target,
     };
     drop(state);
     Some(action)
@@ -180,6 +200,189 @@ fn pr_comment_create_event(
             scope_repo_id: action.scope_repo_id.clone(),
             pr_number: action.pr_number,
             mutation_id: action.mutation_id,
+            error: "Application context unavailable".to_string(),
+        },
+    }
+}
+
+/// Spawn the gh review-thread-reply task off the UI thread.
+///
+/// @requirement REQ-PR-009
+fn dispatch_pr_thread_reply(
+    app_state: &AppStateHandle,
+    ctx: &SharedContext,
+    _repo: PrRepoTarget,
+    action: PrInlineSubmitAction,
+    thread_id: String,
+) {
+    let panic_action = action.clone();
+    gh_async::spawn_gh_task_with_panic(
+        app_state,
+        ctx,
+        move |mut app_state, ctx| {
+            let event = pr_thread_reply_event(&ctx, &action, &thread_id);
+            apply_and_persist(&mut app_state, &ctx, event);
+        },
+        move |mut app_state, ctx, message| {
+            apply_and_persist(
+                &mut app_state,
+                &ctx,
+                AppEvent::PrCommentCreateFailed {
+                    scope_repo_id: panic_action.scope_repo_id,
+                    pr_number: panic_action.pr_number,
+                    mutation_id: panic_action.mutation_id,
+                    error: format!("GitHub thread reply task panicked: {message}"),
+                },
+            );
+        },
+    );
+}
+
+/// Build the thread-reply-created/failed event from the gh result.
+///
+/// @requirement REQ-PR-009
+fn pr_thread_reply_event(
+    ctx: &SharedContext,
+    action: &PrInlineSubmitAction,
+    thread_id: &str,
+) -> AppEvent {
+    let result = github_client(ctx)
+        .map(|client| client.create_pr_review_thread_reply(thread_id, &action.text));
+    match result {
+        Some(Ok(comment)) => AppEvent::PrCommentCreated {
+            scope_repo_id: action.scope_repo_id.clone(),
+            pr_number: action.pr_number,
+            mutation_id: action.mutation_id,
+            comment,
+        },
+        Some(Err(error)) => AppEvent::PrCommentCreateFailed {
+            scope_repo_id: action.scope_repo_id.clone(),
+            pr_number: action.pr_number,
+            mutation_id: action.mutation_id,
+            error: error.to_string(),
+        },
+        None => AppEvent::PrCommentCreateFailed {
+            scope_repo_id: action.scope_repo_id.clone(),
+            pr_number: action.pr_number,
+            mutation_id: action.mutation_id,
+            error: "Application context unavailable".to_string(),
+        },
+    }
+}
+
+/// Handle a review-thread resolve/unresolve action by spawning the gh task.
+///
+/// Reads the `thread_resolve_pending` state, resolves the thread_id and current
+/// resolve state, and spawns the gh resolve/unresolve mutation.
+///
+/// @requirement REQ-PR-009
+pub fn handle_pr_thread_resolve(app_state: &AppStateHandle, ctx: &SharedContext) {
+    let Some(pending) = pr_thread_resolve_action(app_state) else {
+        tracing::debug!("ignoring PR thread resolve: no pending resolve or detail");
+        return;
+    };
+    dispatch_pr_thread_resolve(app_state, ctx, pending);
+}
+
+/// Resolve the GitHub thread node ID from a flat thread index.
+fn resolve_thread_id(app_state: &AppStateHandle, thread_index: usize) -> Option<String> {
+    let state = app_state.read();
+    let detail = state.prs_state.pr_detail.as_ref()?;
+    let thread_id = detail
+        .reviews
+        .iter()
+        .flat_map(|r| &r.review_threads)
+        .nth(thread_index)
+        .map(|t| t.thread_id.clone());
+    drop(state);
+    thread_id
+}
+
+/// Resolve the thread resolve action from state.
+fn pr_thread_resolve_action(app_state: &AppStateHandle) -> Option<ThreadResolveAction> {
+    let state = app_state.read();
+    let pending = state.prs_state.thread_resolve_pending.as_ref()?;
+    let detail = state.prs_state.pr_detail.as_ref()?;
+    let thread = detail
+        .reviews
+        .iter()
+        .flat_map(|r| &r.review_threads)
+        .nth(pending.thread_index)?;
+    let action = ThreadResolveAction {
+        scope_repo_id: pending.scope_repo_id.clone(),
+        thread_index: pending.thread_index,
+        resolve: pending.resolve,
+        request_id: pending.request_id,
+        thread_id: thread.thread_id.clone(),
+    };
+    drop(state);
+    Some(action)
+}
+
+#[derive(Clone)]
+struct ThreadResolveAction {
+    scope_repo_id: jefe::domain::RepositoryId,
+    thread_index: usize,
+    resolve: bool,
+    request_id: u64,
+    thread_id: String,
+}
+
+/// Spawn the gh thread resolve/unresolve task off the UI thread.
+fn dispatch_pr_thread_resolve(
+    app_state: &AppStateHandle,
+    ctx: &SharedContext,
+    action: ThreadResolveAction,
+) {
+    let panic_action = action.clone();
+    gh_async::spawn_gh_task_with_panic(
+        app_state,
+        ctx,
+        move |mut app_state, ctx| {
+            let event = pr_thread_resolve_result_event(&ctx, &action);
+            apply_and_persist(&mut app_state, &ctx, event);
+        },
+        move |mut app_state, ctx, message| {
+            apply_and_persist(
+                &mut app_state,
+                &ctx,
+                AppEvent::PrThreadResolveFailed {
+                    scope_repo_id: panic_action.scope_repo_id,
+                    thread_index: panic_action.thread_index,
+                    request_id: panic_action.request_id,
+                    error: format!("GitHub thread resolve task panicked: {message}"),
+                },
+            );
+        },
+    );
+}
+
+/// Build the thread-resolve result event from the gh result.
+fn pr_thread_resolve_result_event(ctx: &SharedContext, action: &ThreadResolveAction) -> AppEvent {
+    let result = github_client(ctx).map(|client| {
+        if action.resolve {
+            client.resolve_review_thread(&action.thread_id)
+        } else {
+            client.unresolve_review_thread(&action.thread_id)
+        }
+    });
+    match result {
+        Some(Ok(is_resolved)) => AppEvent::PrThreadResolveSucceeded {
+            scope_repo_id: action.scope_repo_id.clone(),
+            thread_index: action.thread_index,
+            is_resolved,
+            request_id: action.request_id,
+        },
+        Some(Err(error)) => AppEvent::PrThreadResolveFailed {
+            scope_repo_id: action.scope_repo_id.clone(),
+            thread_index: action.thread_index,
+            request_id: action.request_id,
+            error: error.to_string(),
+        },
+        None => AppEvent::PrThreadResolveFailed {
+            scope_repo_id: action.scope_repo_id.clone(),
+            thread_index: action.thread_index,
+            request_id: action.request_id,
             error: "Application context unavailable".to_string(),
         },
     }

--- a/src/app_input/prs_orchestration.rs
+++ b/src/app_input/prs_orchestration.rs
@@ -107,6 +107,10 @@ pub(super) fn dispatch_prs_message(
             apply_and_persist(app_state, ctx, AppEvent::PrMergeConfirm);
             prs_dispatch::dispatch_pr_merge(app_state, ctx);
         }
+        PullRequestsMessage::ToggleThreadResolve { .. } => {
+            apply_and_persist(app_state, ctx, AppEvent::from(message));
+            prs_mutation::handle_pr_thread_resolve(app_state, ctx);
+        }
         // All other PullRequests variants (data-load results, notices, etc.)
         // route through the reducer only.
         message => apply_and_persist(app_state, ctx, AppEvent::from(message)),

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -469,6 +469,32 @@ pub struct PrReview {
     pub state: PrReviewState,
     pub submitted_at: String,
     pub body: Option<String>,
+    /// Line-level review threads attached to this review (issue #119).
+    /// Empty when no threads were fetched (graceful degradation).
+    pub review_threads: Vec<PrReviewThread>,
+}
+
+/// A review-thread conversation group with its line-level comments.
+///
+/// Each thread carries the GraphQL node id (for resolve/unresolve mutations),
+/// its resolved state, the file location it is attached to, and the nested
+/// reply comments. Reuses [`IssueComment`] for thread replies so the rendering
+/// and message-bus layers share one comment type across the app.
+///
+/// @plan PLAN-20260624-PR-MODE.P03
+/// @requirement REQ-PR-009
+#[derive(Debug, Clone)]
+pub struct PrReviewThread {
+    /// GraphQL node id used for resolve/unresolve mutations.
+    pub thread_id: String,
+    /// Whether the thread is currently resolved.
+    pub is_resolved: bool,
+    /// File path the thread is attached to (`None` for PR-level threads).
+    pub path: Option<String>,
+    /// Line number the thread is attached to (`None` for PR-level threads).
+    pub line: Option<u32>,
+    /// Nested thread reply comments (oldest first).
+    pub comments: Vec<IssueComment>,
 }
 
 /// @plan PLAN-20260624-PR-MODE.P03

--- a/src/domain/tests.rs
+++ b/src/domain/tests.rs
@@ -374,3 +374,91 @@ fn runtime_binding_roundtrips_pid_when_present() {
         serde_json::from_value(json).value_or_panic("should deserialize");
     assert_eq!(binding2.pid, Some(42_000));
 }
+
+// =============================================================================
+// PR review threads (issue #119)
+// =============================================================================
+
+/// @plan PLAN-20260624-PR-MODE.P03
+/// @requirement REQ-PR-009
+#[test]
+fn pr_review_thread_constructs_with_thread_id_and_resolved_flag() {
+    let thread = PrReviewThread {
+        thread_id: "PRRT_kwAAA".to_string(),
+        is_resolved: false,
+        path: Some("src/lib.rs".to_string()),
+        line: Some(42),
+        comments: vec![IssueComment {
+            comment_id: 1,
+            author_login: "reviewer1".to_string(),
+            created_at: "2026-07-01T10:00:00Z".to_string(),
+            edited_at: None,
+            body: "Please fix this".to_string(),
+        }],
+    };
+    assert_eq!(thread.thread_id, "PRRT_kwAAA");
+    assert!(!thread.is_resolved);
+    assert_eq!(thread.path.as_deref(), Some("src/lib.rs"));
+    assert_eq!(thread.line, Some(42));
+    assert_eq!(thread.comments.len(), 1);
+}
+
+/// @plan PLAN-PR-REVIEW-THREADS
+/// @requirement REQ-PR-009
+#[test]
+fn pr_review_carries_review_threads_field() {
+    let review = PrReview {
+        author_login: "reviewer1".to_string(),
+        state: PrReviewState::Commented,
+        submitted_at: "2026-07-01T10:00:00Z".to_string(),
+        body: Some("Please review".to_string()),
+        review_threads: vec![PrReviewThread {
+            thread_id: "PRRT_kwBBB".to_string(),
+            is_resolved: true,
+            path: None,
+            line: None,
+            comments: vec![],
+        }],
+    };
+    assert_eq!(review.review_threads.len(), 1);
+    let thread = &review.review_threads[0];
+    assert!(thread.is_resolved);
+    assert!(thread.path.is_none());
+    assert!(thread.line.is_none());
+    assert!(thread.comments.is_empty());
+}
+
+/// @plan PLAN-20260624-PR-MODE.P03
+/// @requirement REQ-PR-009
+#[test]
+fn pr_review_thread_supports_unresolved_with_location() {
+    let thread = PrReviewThread {
+        thread_id: "PRRT_kwCCC".to_string(),
+        is_resolved: false,
+        path: Some("src/main.rs".to_string()),
+        line: Some(10),
+        comments: vec![
+            IssueComment {
+                comment_id: 100,
+                author_login: "alice".to_string(),
+                created_at: "2026-07-01T10:00:00Z".to_string(),
+                edited_at: None,
+                body: "First reply".to_string(),
+            },
+            IssueComment {
+                comment_id: 101,
+                author_login: "bob".to_string(),
+                created_at: "2026-07-01T11:00:00Z".to_string(),
+                edited_at: Some("2026-07-01T11:30:00Z".to_string()),
+                body: "Second reply".to_string(),
+            },
+        ],
+    };
+    assert_eq!(thread.comments.len(), 2);
+    assert_eq!(thread.comments[0].author_login, "alice");
+    assert_eq!(thread.comments[1].author_login, "bob");
+    assert_eq!(
+        thread.comments[1].edited_at.as_deref(),
+        Some("2026-07-01T11:30:00Z")
+    );
+}

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -11,11 +11,12 @@
 
 use crate::domain::{
     Issue, IssueComment, IssueDetail, IssueFilter, IssueState, PrCheck, PrFilter, PrReview,
-    PrReviewState, PrState, PullRequestDetail,
+    PrReviewState, PrReviewThread, PrState, PullRequestDetail,
 };
 use std::process::Command;
 
 mod create_issue;
+mod pr_threads;
 pub use create_issue::{CreatedIssue, parse_created_issue_json};
 
 mod parse;
@@ -28,9 +29,10 @@ pub use parse::{
 
 mod parse_pr;
 pub use parse_pr::{
-    build_pr_comments_query, build_pr_search_args, build_pr_search_query, parse_check_status,
-    parse_checks_rollup, parse_pr_check, parse_pr_review, parse_pr_state,
-    parse_pull_request_detail_json, parse_pull_requests_json, parse_review_decision, rollup_nodes,
+    build_pr_comments_query, build_pr_review_threads_query, build_pr_search_args,
+    build_pr_search_query, parse_check_status, parse_checks_rollup, parse_pr_check,
+    parse_pr_review, parse_pr_review_threads, parse_pr_state, parse_pull_request_detail_json,
+    parse_pull_requests_json, parse_review_decision, parse_thread_reply_json, rollup_nodes,
     sort_pull_requests,
 };
 
@@ -550,6 +552,8 @@ impl GhClient {
         detail.comments = comments_response.comments;
         detail.comments_cursor = comments_response.cursor;
         detail.has_more_comments = comments_response.has_more;
+        let threads = self.list_pr_review_threads(owner, name, number);
+        assign_threads_to_reviews(&mut detail.reviews, threads);
         Ok(detail)
     }
 
@@ -727,7 +731,7 @@ impl GhClient {
     /// Run `gh` with the given args, returning stdout on success. Encapsulates
     /// the established error idiom: `NotFound→NotInstalled` else
     /// `NetworkError`; non-zero exit → `categorize_error`.
-    fn run_gh(args: &[String]) -> Result<String, GhError> {
+    pub(super) fn run_gh(args: &[String]) -> Result<String, GhError> {
         let output = Command::new("gh").args(args).output().map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 GhError::NotInstalled
@@ -747,6 +751,25 @@ impl Default for GhClient {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Distribute fetched review threads onto the review structs.
+///
+/// GitHub's `reviewThreads` connection is on `PullRequest`, not on each
+/// `Review`. Since the domain model stores threads under `PrReview`, all
+/// fetched threads are assigned to the first review (if any). When there are
+/// no reviews but threads exist, the threads are silently dropped (there is
+/// no review slot to hold them). The renderer flattens
+/// `reviews.iter().flat_map(|r| &r.review_threads)` so this preserves all
+/// threads for display.
+fn assign_threads_to_reviews(reviews: &mut [PrReview], threads: Vec<PrReviewThread>) {
+    if threads.is_empty() {
+        return;
+    }
+    let Some(first_review) = reviews.first_mut() else {
+        return;
+    };
+    first_review.review_threads = threads;
 }
 
 /// Map a [`PrState`] to its lowercase send-payload string.

--- a/src/github/parse_pr.rs
+++ b/src/github/parse_pr.rs
@@ -10,8 +10,8 @@
 //! NOT import `crate::ui`, `crate::state`, or `crate::app_input`.
 
 use crate::domain::{
-    ChecksFilter, PrCheck, PrCheckStatus, PrFilter, PrFilterState, PrReview, PrReviewState,
-    PrState, PullRequest, PullRequestDetail, ReviewDecisionFilter,
+    ChecksFilter, IssueComment, PrCheck, PrCheckStatus, PrFilter, PrFilterState, PrReview,
+    PrReviewState, PrReviewThread, PrState, PullRequest, PullRequestDetail, ReviewDecisionFilter,
 };
 use serde_json::Value;
 
@@ -417,6 +417,7 @@ pub fn parse_pr_review(node: &Value) -> PrReview {
         state,
         submitted_at,
         body,
+        review_threads: Vec::new(),
     }
 }
 
@@ -585,4 +586,194 @@ pub fn sort_pull_requests(items: &mut [PullRequest]) {
             .cmp(&a.updated_at)
             .then(a.number.cmp(&b.number))
     });
+}
+
+// =============================================================================
+// PR review threads (issue #119)
+// =============================================================================
+
+/// Build the GraphQL query string for the PR review-threads fetch.
+///
+/// Selects `repository.pullRequest(number:).reviewThreads(first: N) { nodes
+/// { id isResolved path line comments(first: 50) { nodes { databaseId author
+/// { login } createdAt lastEditedAt body } } } }`. Threads are a direct
+/// connection on `PullRequest` (not nested under each `Review`).
+///
+/// `with_cursor=true` includes the `$after` variable declaration and the
+/// `after: $after` argument on the reviewThreads connection;
+/// `with_cursor=false` omits both.
+///
+/// @plan PLAN-20260624-PR-MODE.P08
+/// @requirement REQ-PR-009
+#[must_use]
+pub fn build_pr_review_threads_query(with_cursor: bool) -> String {
+    if with_cursor {
+        "query($owner: String!, $repo: String!, $number: Int!, $first: Int!, $after: String) { repository(owner: $owner, name: $repo) { pullRequest(number: $number) { reviewThreads(first: $first, after: $after) { nodes { id isResolved path line comments(first: 50) { nodes { databaseId author { login } createdAt lastEditedAt body } } } } } } }"
+    } else {
+        "query($owner: String!, $repo: String!, $number: Int!, $first: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $number) { reviewThreads(first: $first) { nodes { id isResolved path line comments(first: 50) { nodes { databaseId author { login } createdAt lastEditedAt body } } } } } } }"
+    }
+    .to_owned()
+}
+
+/// Parse review threads from a GraphQL response JSON value.
+///
+/// Navigates `data.repository.pullRequest.reviewThreads.nodes` and maps each
+/// thread node to a [`PrReviewThread`]. Also accepts the legacy nested shape
+/// `reviews.nodes[*].reviewThreads.nodes` for backward compatibility.
+/// Malformed threads yield degraded entries (never dropped — REQ-PR-013).
+/// Missing data yields an empty vec (graceful degradation).
+///
+/// @plan PLAN-20260624-PR-MODE.P08
+/// @requirement REQ-PR-009
+/// @requirement REQ-PR-013
+#[must_use]
+pub fn parse_pr_review_threads(json: &Value) -> Vec<PrReviewThread> {
+    let pull_request = json
+        .get("data")
+        .and_then(|d| d.get("repository"))
+        .and_then(|r| r.get("pullRequest"));
+
+    let Some(pull_request) = pull_request else {
+        return Vec::new();
+    };
+
+    // Primary path: pullRequest.reviewThreads.nodes (correct GitHub API).
+    if let Some(thread_nodes) = pull_request
+        .get("reviewThreads")
+        .and_then(|rt| rt.get("nodes"))
+        .and_then(Value::as_array)
+    {
+        return thread_nodes
+            .iter()
+            .map(parse_single_review_thread)
+            .collect();
+    }
+
+    // Legacy/fallback path: pullRequest.reviews.nodes[*].reviewThreads.nodes.
+    parse_nested_review_threads(pull_request)
+}
+
+/// Parse threads nested under `reviews.nodes[*].reviewThreads` (fallback).
+fn parse_nested_review_threads(pull_request: &Value) -> Vec<PrReviewThread> {
+    let Some(review_nodes) = pull_request
+        .get("reviews")
+        .and_then(|r| r.get("nodes"))
+        .and_then(Value::as_array)
+    else {
+        return Vec::new();
+    };
+
+    let mut threads = Vec::new();
+    for review_node in review_nodes {
+        let Some(thread_nodes) = review_node
+            .get("reviewThreads")
+            .and_then(|rt| rt.get("nodes"))
+            .and_then(Value::as_array)
+        else {
+            continue;
+        };
+        for thread_node in thread_nodes {
+            threads.push(parse_single_review_thread(thread_node));
+        }
+    }
+    threads
+}
+
+/// Parse a single review-thread node into a [`PrReviewThread`].
+///
+/// TOTAL function — a malformed thread node still yields a degraded
+/// [`PrReviewThread`] with a placeholder id so it is not dropped.
+fn parse_single_review_thread(node: &Value) -> PrReviewThread {
+    let thread_id = node
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("(unknown thread)")
+        .to_string();
+    let is_resolved = node
+        .get("isResolved")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let path = node
+        .get("path")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+    let line = node
+        .get("line")
+        .and_then(Value::as_u64)
+        .and_then(|n| u32::try_from(n).ok());
+    let comments = parse_thread_comments(node);
+    PrReviewThread {
+        thread_id,
+        is_resolved,
+        path,
+        line,
+        comments,
+    }
+}
+
+/// Parse the `comments.nodes` array of a thread node into [`IssueComment`]s.
+fn parse_thread_comments(thread_node: &Value) -> Vec<IssueComment> {
+    let Some(nodes) = thread_node
+        .get("comments")
+        .and_then(|c| c.get("nodes"))
+        .and_then(Value::as_array)
+    else {
+        return Vec::new();
+    };
+    nodes.iter().map(parse_thread_comment_node).collect()
+}
+
+/// Parse a single thread comment node into an [`IssueComment`].
+///
+/// Mirrors the GraphQL comment node shape: `databaseId`, `author { login }`,
+/// `createdAt`, `lastEditedAt`, `body`.
+fn parse_thread_comment_node(node: &Value) -> IssueComment {
+    let comment_id = node.get("databaseId").and_then(Value::as_u64).unwrap_or(0);
+    let author_login = node
+        .get("author")
+        .and_then(|a| a.get("login"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("(unknown)")
+        .to_string();
+    let created_at = node
+        .get("createdAt")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let edited_at = node
+        .get("lastEditedAt")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+    let body = node
+        .get("body")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    IssueComment {
+        comment_id,
+        author_login,
+        created_at,
+        edited_at,
+        body,
+    }
+}
+
+/// Parse the `addPullRequestReviewThreadReply` mutation response into an
+/// [`IssueComment`]. The GraphQL path is
+/// `data.addPullRequestReviewThreadReply.comment`.
+///
+/// @requirement REQ-PR-009
+pub fn parse_thread_reply_json(stdout: &str) -> Result<IssueComment, GhError> {
+    let json: Value = serde_json::from_str(stdout)
+        .map_err(|e| GhError::ParseError(format!("thread reply JSON: {e}")))?;
+    let comment_node = json
+        .get("data")
+        .and_then(|d| d.get("addPullRequestReviewThreadReply"))
+        .and_then(|r| r.get("comment"))
+        .ok_or_else(|| GhError::ParseError("missing thread reply comment node".to_string()))?;
+    Ok(parse_thread_comment_node(comment_node))
 }

--- a/src/github/pr_threads.rs
+++ b/src/github/pr_threads.rs
@@ -1,0 +1,110 @@
+//! Review-thread gh API methods for pull requests (issue #119).
+//!
+//! Extracted from `mod.rs` to keep the main client file under the 1000-line
+//! limit. These methods are on `impl super::GhClient` and use `Self::run_gh`
+//! plus the parse helpers from `parse_pr`.
+
+use crate::domain::{IssueComment, PrReviewThread};
+
+use super::parse_pr::{
+    build_pr_review_threads_query, parse_pr_review_threads, parse_thread_reply_json,
+};
+use super::{GhClient, GhError};
+
+impl GhClient {
+    /// List review threads for a pull request.
+    ///
+    /// Runs the `build_pr_review_threads_query` GraphQL query targeting
+    /// `repository.pullRequest(number:).reviewThreads` and parses the
+    /// result via `parse_pr_review_threads`. On parse/network error returns an
+    /// empty vec (graceful degradation — the detail load must not fail because
+    /// the threads fetch failed).
+    ///
+    /// @requirement REQ-PR-009
+    #[must_use]
+    pub fn list_pr_review_threads(
+        &self,
+        owner: &str,
+        name: &str,
+        number: u64,
+    ) -> Vec<PrReviewThread> {
+        let args = vec![
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            format!("query={}", build_pr_review_threads_query(false)),
+            "-F".to_string(),
+            format!("owner={owner}"),
+            "-F".to_string(),
+            format!("repo={name}"),
+            "-F".to_string(),
+            format!("number={number}"),
+            "-F".to_string(),
+            "first=20".to_string(),
+        ];
+        let Ok(stdout) = Self::run_gh(&args) else {
+            return Vec::new();
+        };
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&stdout) else {
+            return Vec::new();
+        };
+        parse_pr_review_threads(&json)
+    }
+    /// Resolve a review thread via the GraphQL `resolveReviewThread` mutation.
+    ///
+    /// @requirement REQ-PR-009
+    pub fn resolve_review_thread(&self, thread_id: &str) -> Result<bool, GhError> {
+        let query = "mutation($thread: ID!) { resolveReviewThread(input: {threadId: $thread}) { thread { isResolved } } }";
+        let args = vec![
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            format!("query={query}"),
+            "-F".to_string(),
+            format!("thread={thread_id}"),
+        ];
+        Self::run_gh(&args)?;
+        Ok(true)
+    }
+
+    /// Unresolve a review thread via the GraphQL `unresolveReviewThread` mutation.
+    ///
+    /// @requirement REQ-PR-009
+    pub fn unresolve_review_thread(&self, thread_id: &str) -> Result<bool, GhError> {
+        let query = "mutation($thread: ID!) { unresolveReviewThread(input: {threadId: $thread}) { thread { isResolved } } }";
+        let args = vec![
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            format!("query={query}"),
+            "-F".to_string(),
+            format!("thread={thread_id}"),
+        ];
+        Self::run_gh(&args)?;
+        Ok(false)
+    }
+
+    /// Reply to a review thread via the GraphQL `addPullRequestReviewThreadReply`
+    /// mutation. Returns the created comment on success.
+    ///
+    /// @requirement REQ-PR-009
+    pub fn create_pr_review_thread_reply(
+        &self,
+        thread_id: &str,
+        body: &str,
+    ) -> Result<IssueComment, GhError> {
+        let query = "mutation($thread: ID!, $body: String!) { addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $thread, body: $body}) { comment { databaseId author { login } createdAt body } } }";
+        let args = vec![
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            format!("query={query}"),
+            "-F".to_string(),
+            format!("thread={thread_id}"),
+            "-f".to_string(),
+            format!("body={body}"),
+        ];
+        let stdout = Self::run_gh(&args)?;
+        parse_thread_reply_json(&stdout)
+    }
+}

--- a/src/github/tests_pr_detail.rs
+++ b/src/github/tests_pr_detail.rs
@@ -174,6 +174,7 @@ fn sample_pr_detail() -> PullRequestDetail {
             state: PrReviewState::Approved,
             submitted_at: "2026-06-14T10:00:00Z".to_string(),
             body: Some("LGTM".to_string()),
+            review_threads: vec![],
         }],
         checks: vec![PrCheck {
             name: "build".to_string(),

--- a/src/github/tests_pr_threads.rs
+++ b/src/github/tests_pr_threads.rs
@@ -1,0 +1,291 @@
+//!
+//! Review-thread parser/query tests for issue #119.
+//!
+//! Split out of `github/tests_pr_detail.rs` to keep each test module under the
+//! source-file length policy. Covers the `reviewThreads` GraphQL query builder
+//! and the `parse_pr_review_threads` parser.
+//!
+//! @requirement REQ-PR-009
+
+use crate::github::{build_pr_review_threads_query, parse_pr_review_threads};
+
+/// Test helper for unwrapping Results with a descriptive panic message.
+trait TestResultExt<T> {
+    fn value_or_panic(self, context: &str) -> T;
+}
+
+impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
+    fn value_or_panic(self, context: &str) -> T {
+        match self {
+            Ok(value) => value,
+            Err(error) => panic!("{context}: {error:?}"),
+        }
+    }
+}
+
+/// @plan PLAN-20260624-PR-MODE.P08
+/// @requirement REQ-PR-009
+#[test]
+fn test_build_pr_review_threads_query_targets_pull_request_reviews() {
+    let query = build_pr_review_threads_query(false);
+    assert!(
+        query.contains("pullRequest(number:"),
+        "thread query must target pullRequest(number:)"
+    );
+    assert!(
+        query.contains("reviewThreads(first:"),
+        "thread query must select the reviewThreads connection"
+    );
+    assert!(
+        query.contains("isResolved"),
+        "thread query must select isResolved"
+    );
+    assert!(
+        query.contains("id"),
+        "thread query must select the thread node id"
+    );
+    assert!(
+        query.contains("databaseId"),
+        "thread query must select comment databaseId"
+    );
+    assert!(
+        !query.contains("$after"),
+        "no-cursor variant must NOT include $after variable"
+    );
+}
+
+/// @plan PLAN-20260624-PR-MODE.P08
+/// @requirement REQ-PR-009
+#[test]
+fn test_build_pr_review_threads_query_with_cursor_includes_after() {
+    let query = build_pr_review_threads_query(true);
+    assert!(
+        query.contains("$after") && query.contains("after:"),
+        "with-cursor variant must include the $after/after: clauses"
+    );
+    assert!(
+        query.contains("reviewThreads(first:"),
+        "with-cursor variant must still select reviewThreads"
+    );
+}
+
+/// @plan PLAN-20260624-PR-MODE.P08
+/// @requirement REQ-PR-009
+/// @pseudocode component-002 lines 174-193
+#[test]
+fn test_parse_pr_review_threads_extracts_threads_and_comments() {
+    let json = r#"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "id": "PRRT_kwAAAA",
+                                "isResolved": false,
+                                "path": "src/lib.rs",
+                                "line": 42,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "databaseId": 501,
+                                            "author": {"login": "reviewer1"},
+                                            "createdAt": "2026-07-01T10:00:00Z",
+                                            "lastEditedAt": null,
+                                            "body": "Please fix this line"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }"#;
+    let value: serde_json::Value =
+        serde_json::from_str(json).value_or_panic("valid review-threads JSON");
+    let threads = parse_pr_review_threads(&value);
+    assert_eq!(threads.len(), 1, "one thread expected");
+    let thread = &threads[0];
+    assert_eq!(thread.thread_id, "PRRT_kwAAAA");
+    assert!(!thread.is_resolved);
+    assert_eq!(thread.path.as_deref(), Some("src/lib.rs"));
+    assert_eq!(thread.line, Some(42));
+    assert_eq!(thread.comments.len(), 1);
+    assert_eq!(thread.comments[0].comment_id, 501);
+    assert_eq!(thread.comments[0].author_login, "reviewer1");
+    assert_eq!(thread.comments[0].body, "Please fix this line");
+    assert!(thread.comments[0].edited_at.is_none());
+}
+
+/// @plan PLAN-20260624-PR-MODE.P08
+/// @requirement REQ-PR-009
+#[test]
+fn test_parse_pr_review_threads_resolved_thread_with_multiple_replies() {
+    let json = r#"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "id": "PRRT_kwBBBB",
+                                "isResolved": true,
+                                "path": "src/main.rs",
+                                "line": 10,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "databaseId": 600,
+                                            "author": {"login": "alice"},
+                                            "createdAt": "2026-07-01T10:00:00Z",
+                                            "lastEditedAt": null,
+                                            "body": "nit: spacing"
+                                        },
+                                        {
+                                            "databaseId": 601,
+                                            "author": {"login": "bob"},
+                                            "createdAt": "2026-07-01T11:00:00Z",
+                                            "lastEditedAt": "2026-07-01T11:30:00Z",
+                                            "body": "fixed"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }"#;
+    let value: serde_json::Value =
+        serde_json::from_str(json).value_or_panic("valid review-threads JSON");
+    let threads = parse_pr_review_threads(&value);
+    assert_eq!(threads.len(), 1);
+    let thread = &threads[0];
+    assert_eq!(thread.thread_id, "PRRT_kwBBBB");
+    assert!(thread.is_resolved);
+    assert_eq!(thread.comments.len(), 2);
+    assert_eq!(thread.comments[0].author_login, "alice");
+    assert_eq!(thread.comments[1].author_login, "bob");
+    assert_eq!(
+        thread.comments[1].edited_at.as_deref(),
+        Some("2026-07-01T11:30:00Z")
+    );
+}
+
+/// @plan PLAN-20260624-PR-MODE.P08
+/// @requirement REQ-PR-009
+/// @requirement REQ-PR-013
+#[test]
+fn test_parse_pr_review_threads_missing_data_yields_empty_not_panic() {
+    let json = r#"{"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}}"#;
+    let value: serde_json::Value = serde_json::from_str(json).value_or_panic("valid empty JSON");
+    let threads = parse_pr_review_threads(&value);
+    assert!(
+        threads.is_empty(),
+        "empty reviewThreads nodes yields empty threads"
+    );
+}
+
+/// @plan PLAN-20260624-PR-MODE.P08
+/// @requirement REQ-PR-009
+/// @requirement REQ-PR-013
+#[test]
+fn test_parse_pr_review_threads_malformed_thread_is_degraded_not_dropped() {
+    // A thread node missing all fields must still yield a degraded entry.
+    let json = r#"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {}
+                        ]
+                    }
+                }
+            }
+        }
+    }"#;
+    let value: serde_json::Value =
+        serde_json::from_str(json).value_or_panic("valid JSON with malformed thread");
+    let threads = parse_pr_review_threads(&value);
+    assert_eq!(threads.len(), 1, "malformed thread must not be dropped");
+    assert!(
+        !threads[0].thread_id.is_empty(),
+        "degraded thread must have a placeholder id"
+    );
+    assert!(
+        threads[0].comments.is_empty(),
+        "degraded thread has no comments"
+    );
+}
+
+/// @plan PLAN-20260624-PR-MODE.P08
+/// @requirement REQ-PR-009
+/// @requirement REQ-PR-013
+#[test]
+fn test_parse_pr_review_threads_missing_pullrequest_yields_empty() {
+    let json = r#"{"data": {"repository": {}}}"#;
+    let value: serde_json::Value =
+        serde_json::from_str(json).value_or_panic("valid JSON missing pullRequest");
+    let threads = parse_pr_review_threads(&value);
+    assert!(
+        threads.is_empty(),
+        "missing pullRequest yields empty threads"
+    );
+}
+
+/// @plan PLAN-20260624-PR-MODE.P08
+/// @requirement REQ-PR-009
+/// @requirement REQ-PR-013
+#[test]
+fn test_parse_pr_review_threads_legacy_nested_fallback() {
+    let json = r#"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviews": {
+                        "nodes": [
+                            {
+                                "reviewThreads": {
+                                    "nodes": [
+                                        {
+                                            "id": "PRRT_legacy",
+                                            "isResolved": false,
+                                            "path": "src/lib.rs",
+                                            "line": 10,
+                                            "comments": {
+                                                "nodes": [
+                                                    {
+                                                        "databaseId": 99,
+                                                        "author": {"login": "ghost"},
+                                                        "createdAt": "2026-07-01T00:00:00Z",
+                                                        "body": "legacy thread comment"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }"#;
+    let value: serde_json::Value =
+        serde_json::from_str(json).value_or_panic("valid legacy nested JSON");
+    let threads = parse_pr_review_threads(&value);
+    assert_eq!(
+        threads.len(),
+        1,
+        "legacy nested path should still parse threads"
+    );
+    assert_eq!(threads[0].thread_id, "PRRT_legacy");
+    assert!(!threads[0].is_resolved);
+    assert_eq!(threads[0].comments.len(), 1);
+    assert_eq!(threads[0].comments[0].author_login, "ghost");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,10 @@ mod github_tests_pr;
 #[path = "github/tests_pr_detail.rs"]
 mod github_tests_pr_detail;
 
+#[cfg(test)]
+#[path = "github/tests_pr_threads.rs"]
+mod github_tests_pr_threads;
+
 /// Current application version.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub mod harness;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -441,6 +441,29 @@ pub enum PullRequestsMessage {
         pr_number: u64,
         allowed_methods: Vec<MergeMethod>,
     },
+    // PR Review Threads (issue #119)
+    /// Open the inline reply composer for a review thread.
+    OpenThreadReply {
+        thread_index: usize,
+    },
+    /// Toggle resolve/unresolve on a focused review thread.
+    ToggleThreadResolve {
+        thread_index: usize,
+    },
+    /// A review-thread resolve/unresolve mutation succeeded.
+    ThreadResolveSucceeded {
+        scope_repo_id: RepositoryId,
+        thread_index: usize,
+        is_resolved: bool,
+        request_id: u64,
+    },
+    /// A review-thread resolve/unresolve mutation failed.
+    ThreadResolveFailed {
+        scope_repo_id: RepositoryId,
+        thread_index: usize,
+        request_id: u64,
+        error: String,
+    },
 }
 
 /// Navigation direction for PR list and filter controls.
@@ -822,4 +845,8 @@ message_names!(PullRequestsMessage {
     Self::Merged { .. } => "PrMerged",
     Self::MergeFailed { .. } => "PrMergeFailed",
     Self::MergeMethodsLoaded { .. } => "PrMergeMethodsLoaded",
+    Self::OpenThreadReply { .. } => "PrOpenThreadReply",
+    Self::ToggleThreadResolve { .. } => "PrToggleThreadResolve",
+    Self::ThreadResolveSucceeded { .. } => "PrThreadResolveSucceeded",
+    Self::ThreadResolveFailed { .. } => "PrThreadResolveFailed",
 });

--- a/src/messages/prs_conversion.rs
+++ b/src/messages/prs_conversion.rs
@@ -356,6 +356,9 @@ impl PullRequestsMessage {
     /// @plan PLAN-20260624-PR-MODE.P05
     /// @requirement REQ-PR-009
     fn from_app_event_merge(event: AppEvent) -> Self {
+        if let Some(msg) = Self::from_app_event_thread(&event) {
+            return msg;
+        }
         match event {
             AppEvent::PrOpenMergeChooser => Self::OpenMergeChooser,
             AppEvent::PrMergeNavigateUp => Self::MergeNavigate(NavDir::Up),
@@ -392,6 +395,43 @@ impl PullRequestsMessage {
                 allowed_methods,
             },
             _ => unreachable!("non-PR AppEvent routed to PR converter"),
+        }
+    }
+
+    /// Convert thread-related `AppEvent` variants into PR messages.
+    ///
+    /// @requirement REQ-PR-009
+    fn from_app_event_thread(event: &AppEvent) -> Option<Self> {
+        match event {
+            AppEvent::PrOpenThreadReplyComposer { thread_index } => Some(Self::OpenThreadReply {
+                thread_index: *thread_index,
+            }),
+            AppEvent::PrToggleThreadResolve { thread_index } => Some(Self::ToggleThreadResolve {
+                thread_index: *thread_index,
+            }),
+            AppEvent::PrThreadResolveSucceeded {
+                scope_repo_id,
+                thread_index,
+                is_resolved,
+                request_id,
+            } => Some(Self::ThreadResolveSucceeded {
+                scope_repo_id: scope_repo_id.clone(),
+                thread_index: *thread_index,
+                is_resolved: *is_resolved,
+                request_id: *request_id,
+            }),
+            AppEvent::PrThreadResolveFailed {
+                scope_repo_id,
+                thread_index,
+                request_id,
+                error,
+            } => Some(Self::ThreadResolveFailed {
+                scope_repo_id: scope_repo_id.clone(),
+                thread_index: *thread_index,
+                request_id: *request_id,
+                error: error.clone(),
+            }),
+            _ => None,
         }
     }
 
@@ -730,6 +770,9 @@ impl PullRequestsMessage {
     /// @plan PLAN-20260624-PR-MODE.P05
     /// @requirement REQ-PR-009
     fn into_app_event_merge(self) -> AppEvent {
+        if let Some(event) = self.thread_to_app_event() {
+            return event;
+        }
         match self {
             Self::OpenMergeChooser => AppEvent::PrOpenMergeChooser,
             Self::MergeNavigate(NavDir::Up | NavDir::Prev) => AppEvent::PrMergeNavigateUp,
@@ -766,6 +809,43 @@ impl PullRequestsMessage {
                 allowed_methods,
             },
             _ => unreachable!("unrouted PullRequestsMessage variant reached merge converter"),
+        }
+    }
+
+    /// Convert thread-related PR messages back into `AppEvent`.
+    ///
+    /// @requirement REQ-PR-009
+    fn thread_to_app_event(&self) -> Option<AppEvent> {
+        match self {
+            Self::OpenThreadReply { thread_index } => Some(AppEvent::PrOpenThreadReplyComposer {
+                thread_index: *thread_index,
+            }),
+            Self::ToggleThreadResolve { thread_index } => Some(AppEvent::PrToggleThreadResolve {
+                thread_index: *thread_index,
+            }),
+            Self::ThreadResolveSucceeded {
+                scope_repo_id,
+                thread_index,
+                is_resolved,
+                request_id,
+            } => Some(AppEvent::PrThreadResolveSucceeded {
+                scope_repo_id: scope_repo_id.clone(),
+                thread_index: *thread_index,
+                is_resolved: *is_resolved,
+                request_id: *request_id,
+            }),
+            Self::ThreadResolveFailed {
+                scope_repo_id,
+                thread_index,
+                request_id,
+                error,
+            } => Some(AppEvent::PrThreadResolveFailed {
+                scope_repo_id: scope_repo_id.clone(),
+                thread_index: *thread_index,
+                request_id: *request_id,
+                error: error.clone(),
+            }),
+            _ => None,
         }
     }
 }

--- a/src/pr_detail_content.rs
+++ b/src/pr_detail_content.rs
@@ -166,24 +166,84 @@ fn build_reviews_section(
     if detail.reviews.is_empty() {
         builder.lines.push("  No reviews yet.".to_string());
     } else {
+        let mut flat_thread_idx = 0usize;
         for (idx, review) in detail.reviews.iter().enumerate() {
-            let prefix = if subfocus == PrDetailSubfocus::Review(idx) {
-                "> "
-            } else {
-                "- "
-            };
-            let state_label = review_state_label(review.state);
-            let body_excerpt = review
-                .body
-                .as_deref()
-                .filter(|b| !b.is_empty())
-                .map_or_else(String::new, |b| format!("  \"{b}\""));
-            builder.lines.push(format!(
-                "{prefix}{:<8} {:<18} {}{}",
-                review.author_login, state_label, review.submitted_at, body_excerpt
-            ));
+            build_single_review(idx, review, subfocus, builder);
+            for thread in &review.review_threads {
+                build_review_thread(flat_thread_idx, thread, subfocus, builder);
+                flat_thread_idx += 1;
+            }
         }
     }
+}
+
+/// Render a single review header line (author, state, submitted_at, body).
+///
+/// @plan PLAN-20260624-PR-MODE.P12
+/// @requirement REQ-PR-009
+fn build_single_review(
+    idx: usize,
+    review: &crate::domain::PrReview,
+    subfocus: PrDetailSubfocus,
+    builder: &mut ContentBuilder,
+) {
+    let prefix = if subfocus == PrDetailSubfocus::Review(idx) {
+        "> "
+    } else {
+        "- "
+    };
+    let state_label = review_state_label(review.state);
+    let body_excerpt = review
+        .body
+        .as_deref()
+        .filter(|b| !b.is_empty())
+        .map_or_else(String::new, |b| format!("  \"{b}\""));
+    builder.lines.push(format!(
+        "{prefix}{:<8} {:<18} {}{}",
+        review.author_login, state_label, review.submitted_at, body_excerpt
+    ));
+}
+
+/// Render a review thread with its comments (indented under the review).
+///
+/// @plan PLAN-20260624-PR-MODE.P12
+/// @requirement REQ-PR-009
+fn build_review_thread(
+    flat_idx: usize,
+    thread: &crate::domain::PrReviewThread,
+    subfocus: PrDetailSubfocus,
+    builder: &mut ContentBuilder,
+) {
+    let focused = subfocus == PrDetailSubfocus::ReviewThread(flat_idx);
+    let marker = if focused { "> " } else { "  " };
+    let resolve_tag = if thread.is_resolved {
+        "[RESOLVED]"
+    } else {
+        "[UNRESOLVED]"
+    };
+    let location = match (&thread.path, thread.line) {
+        (Some(path), Some(line)) => format!("{path}:{line}"),
+        (Some(path), None) => path.clone(),
+        (None, _) => "(no file)".to_string(),
+    };
+    builder
+        .lines
+        .push(format!("{marker}    {location}  {resolve_tag}"));
+    for comment in &thread.comments {
+        builder.lines.push(format!(
+            "      {}  {}",
+            comment.author_login, comment.created_at
+        ));
+        for body_line in comment.body.lines() {
+            builder.lines.push(format!("        {body_line}"));
+        }
+    }
+    if focused {
+        builder
+            .lines
+            .push("      [ r reply ]  [ R resolve ]".to_string());
+    }
+    builder.lines.push(String::new());
 }
 
 /// @plan PLAN-20260624-PR-MODE.P12

--- a/src/pr_detail_content_tests.rs
+++ b/src/pr_detail_content_tests.rs
@@ -30,6 +30,7 @@ fn sample_detail() -> PullRequestDetail {
             state: PrReviewState::ChangesRequested,
             submitted_at: "2026-06-23".to_string(),
             body: Some("please split handler".to_string()),
+            review_threads: vec![],
         }],
         checks: vec![PrCheck {
             name: "ci/fmt".to_string(),
@@ -311,5 +312,173 @@ fn empty_reply_composer_emits_only_anchor_no_flattened_row() {
     assert!(
         !content.text.lines().any(|l| l == "    │ " || l == "    │"),
         "document must NOT contain a flattened reply composer prefix row"
+    );
+}
+
+// =============================================================================
+// Review-thread rendering tests (issue #119)
+// =============================================================================
+
+use crate::domain::PrReviewThread;
+
+fn detail_with_threads() -> PullRequestDetail {
+    let mut detail = sample_detail();
+    detail.reviews[0].review_threads = vec![
+        PrReviewThread {
+            thread_id: "PRRT_kw1".to_string(),
+            is_resolved: false,
+            path: Some("src/parser.rs".to_string()),
+            line: Some(42),
+            comments: vec![
+                IssueComment {
+                    comment_id: 10,
+                    author_login: "bob".to_string(),
+                    created_at: "2026-06-23T11:00:00Z".to_string(),
+                    edited_at: None,
+                    body: "This unwrap can panic.".to_string(),
+                },
+                IssueComment {
+                    comment_id: 11,
+                    author_login: "ada".to_string(),
+                    created_at: "2026-06-23T12:00:00Z".to_string(),
+                    edited_at: None,
+                    body: "Good catch.".to_string(),
+                },
+            ],
+        },
+        PrReviewThread {
+            thread_id: "PRRT_kw2".to_string(),
+            is_resolved: true,
+            path: Some("src/main.rs".to_string()),
+            line: Some(5),
+            comments: vec![IssueComment {
+                comment_id: 20,
+                author_login: "carol".to_string(),
+                created_at: "2026-06-23T10:00:00Z".to_string(),
+                edited_at: None,
+                body: "Looks good.".to_string(),
+            }],
+        },
+    ];
+    detail
+}
+
+#[test]
+fn reviews_section_renders_nested_thread_comments() {
+    let detail = detail_with_threads();
+    let content = build_pr_detail_content(
+        &detail,
+        PrDetailSubfocus::Body,
+        &InlineState::None,
+        false,
+        false,
+    );
+    assert!(
+        content.text.contains("src/parser.rs:42"),
+        "thread path:line"
+    );
+    assert!(content.text.contains("[UNRESOLVED]"), "unresolved tag");
+    assert!(content.text.contains("bob"), "thread comment author");
+    assert!(
+        content.text.contains("This unwrap can panic."),
+        "thread body"
+    );
+    assert!(content.text.contains("ada"), "second comment author");
+}
+
+#[test]
+fn reviews_section_renders_resolution_state() {
+    let detail = detail_with_threads();
+    let content = build_pr_detail_content(
+        &detail,
+        PrDetailSubfocus::Body,
+        &InlineState::None,
+        false,
+        false,
+    );
+    assert!(
+        content.text.contains("[RESOLVED]"),
+        "resolved tag for second thread"
+    );
+    assert!(
+        content.text.contains("[UNRESOLVED]"),
+        "unresolved tag for first thread"
+    );
+}
+
+#[test]
+fn focused_review_thread_shows_reply_and_resolve_hints() {
+    let detail = detail_with_threads();
+    let content = build_pr_detail_content(
+        &detail,
+        PrDetailSubfocus::ReviewThread(0),
+        &InlineState::None,
+        false,
+        false,
+    );
+    assert!(
+        content.text.contains("[ r reply ]"),
+        "focused thread must show reply hint"
+    );
+    assert!(
+        content.text.contains("[ R resolve ]"),
+        "focused thread must show resolve hint"
+    );
+}
+
+#[test]
+fn unfocused_review_thread_hides_reply_resolve_hints() {
+    let detail = detail_with_threads();
+    let content = build_pr_detail_content(
+        &detail,
+        PrDetailSubfocus::Body,
+        &InlineState::None,
+        false,
+        false,
+    );
+    assert!(
+        !content.text.contains("[ r reply ]"),
+        "unfocused threads must NOT show hints"
+    );
+}
+
+#[test]
+fn review_thread_focused_shows_focus_marker() {
+    let detail = detail_with_threads();
+    let content = build_pr_detail_content(
+        &detail,
+        PrDetailSubfocus::ReviewThread(0),
+        &InlineState::None,
+        false,
+        false,
+    );
+    assert!(
+        content.text.contains(">     src/parser.rs:42"),
+        "focused thread must have > marker"
+    );
+}
+
+#[test]
+fn pr_detail_line_count_with_threads_exceeds_base() {
+    let detail_no_threads = sample_detail();
+    let base_count = pr_detail_content_line_count(
+        &detail_no_threads,
+        PrDetailSubfocus::Body,
+        &InlineState::None,
+        false,
+        false,
+    );
+
+    let detail_with_threads = detail_with_threads();
+    let thread_count = pr_detail_content_line_count(
+        &detail_with_threads,
+        PrDetailSubfocus::ReviewThread(0),
+        &InlineState::None,
+        false,
+        false,
+    );
+    assert!(
+        thread_count > base_count,
+        "threads must add rendered lines: {thread_count} vs base {base_count}"
     );
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -22,6 +22,7 @@ mod prs_merge_ops;
 mod prs_mutation_ops;
 mod prs_nav_ops;
 mod prs_ops;
+mod prs_thread_ops;
 mod selectors;
 pub mod state_ops;
 mod types;
@@ -853,6 +854,14 @@ mod prs_tests_detail_flow;
 #[cfg(test)]
 #[path = "prs_tests_components.rs"]
 mod prs_tests_components;
+
+/// Review-thread state tests (issue #119): open reply composer, toggle resolve.
+///
+/// @plan PLAN-20260624-PR-MODE.P05
+/// @requirement REQ-PR-009
+#[cfg(test)]
+#[path = "prs_tests_review_threads.rs"]
+mod prs_tests_review_threads;
 
 // @plan PLAN-20260624-PR-MODE.P15
 // @requirement REQ-PR-001

--- a/src/state/pr_types.rs
+++ b/src/state/pr_types.rs
@@ -48,6 +48,8 @@ pub enum PrDetailSubfocus {
     #[default]
     Body,
     Review(usize),
+    /// Focus on a review thread (flat index across all reviews' threads).
+    ReviewThread(usize),
     Check(usize),
     Comment(usize),
     NewComment,
@@ -76,6 +78,8 @@ pub enum ReadOnlyHintKind {
     NoPrToMerge,
     /// `m` pressed on a PR that is not in an open+mergeable state.
     PrNotMergeable,
+    /// `R` pressed outside a review thread (resolve only valid on a review thread).
+    ReadOnlyResolveOnThread,
 }
 
 /// @plan PLAN-20260624-PR-MODE.P03
@@ -124,6 +128,10 @@ pub struct PullRequestsState {
     pub next_pr_detail_request_id: u64,
     pub comments_page_pending: Option<PrCommentsPagePending>,
     pub next_comments_page_request_id: u64,
+    /// Pending review-thread resolve/unresolve mutation (issue #119).
+    pub thread_resolve_pending: Option<PrThreadResolvePending>,
+    /// Monotonic request id for thread-resolve mutations (issue #119).
+    pub next_thread_resolve_request_id: u64,
 }
 
 /// @plan PLAN-20260624-PR-MODE.P03
@@ -169,6 +177,20 @@ pub struct PrCommentsPagePending {
     pub scope_repo_id: RepositoryId,
     pub pr_number: u64,
     pub cursor: Option<String>,
+    pub request_id: u64,
+}
+
+/// Pending review-thread resolve/unresolve mutation staleness guard
+/// (issue #119). Tracks the in-flight thread resolve toggle so the UI can
+/// show a pending state and ignore stale responses.
+///
+/// @plan PLAN-20260624-PR-MODE.P03
+/// @requirement REQ-PR-009
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrThreadResolvePending {
+    pub scope_repo_id: RepositoryId,
+    pub thread_index: usize,
+    pub resolve: bool,
     pub request_id: u64,
 }
 

--- a/src/state/prs_integration_tests.rs
+++ b/src/state/prs_integration_tests.rs
@@ -82,6 +82,7 @@ fn make_test_pr_detail(number: u64) -> PullRequestDetail {
             state: PrReviewState::Approved,
             submitted_at: "2024-01-01T12:00:00Z".to_string(),
             body: Some("LGTM".to_string()),
+            review_threads: vec![],
         }],
         checks: vec![PrCheck {
             name: "CI".to_string(),

--- a/src/state/prs_nav_ops.rs
+++ b/src/state/prs_nav_ops.rs
@@ -197,14 +197,18 @@ impl AppState {
             return;
         };
         let review_count = detail.reviews.len();
+        let thread_count = count_review_threads(detail);
         let check_count = detail.checks.len();
         let comment_count = detail.comments.len();
         self.prs_state.detail_subfocus = match self.prs_state.detail_subfocus {
             PrDetailSubfocus::Body => {
-                Self::next_after_body(review_count, check_count, comment_count)
+                Self::next_after_body(review_count, thread_count, check_count, comment_count)
             }
             PrDetailSubfocus::Review(i) => {
-                Self::next_after_review(i, review_count, check_count, comment_count)
+                Self::next_after_review(i, review_count, thread_count, check_count, comment_count)
+            }
+            PrDetailSubfocus::ReviewThread(i) => {
+                Self::next_after_thread(i, thread_count, check_count, comment_count)
             }
             PrDetailSubfocus::Check(i) => Self::next_after_check(i, check_count, comment_count),
             PrDetailSubfocus::Comment(i) => Self::next_after_comment(i, comment_count),
@@ -223,25 +227,22 @@ impl AppState {
             return;
         };
         let review_count = detail.reviews.len();
+        let thread_count = count_review_threads(detail);
         let check_count = detail.checks.len();
         let comment_count = detail.comments.len();
         self.prs_state.detail_subfocus = match self.prs_state.detail_subfocus {
             PrDetailSubfocus::Body => {
-                if comment_count > 0 {
-                    PrDetailSubfocus::Comment(comment_count - 1)
-                } else if check_count > 0 {
-                    PrDetailSubfocus::Check(check_count - 1)
-                } else if review_count > 0 {
-                    PrDetailSubfocus::Review(review_count - 1)
-                } else {
-                    PrDetailSubfocus::NewComment
-                }
+                Self::prev_from_body(comment_count, check_count, thread_count, review_count)
             }
             PrDetailSubfocus::Review(0) => PrDetailSubfocus::Body,
             PrDetailSubfocus::Review(i) => PrDetailSubfocus::Review(i - 1),
-            PrDetailSubfocus::Check(0) => Self::prev_from_check_zero(review_count),
+            PrDetailSubfocus::ReviewThread(0) => Self::prev_from_thread_zero(review_count),
+            PrDetailSubfocus::ReviewThread(i) => PrDetailSubfocus::ReviewThread(i - 1),
+            PrDetailSubfocus::Check(0) => Self::prev_from_check_zero(thread_count, review_count),
             PrDetailSubfocus::Check(i) => PrDetailSubfocus::Check(i - 1),
-            PrDetailSubfocus::Comment(0) => Self::prev_from_comment_zero(review_count, check_count),
+            PrDetailSubfocus::Comment(0) => {
+                Self::prev_from_comment_zero(review_count, check_count, thread_count)
+            }
             PrDetailSubfocus::Comment(i) => PrDetailSubfocus::Comment(i - 1),
             PrDetailSubfocus::NewComment => {
                 if comment_count > 0 {
@@ -254,14 +255,22 @@ impl AppState {
     }
 
     /// Compute the next subfocus from Body (skip empty sections).
+    /// Cycle: Body -> Review -> ReviewThread -> Check -> Comment -> NewComment.
     ///
     /// @plan PLAN-20260624-PR-MODE.P05
     /// @requirement REQ-PR-003
     /// @pseudocode component-001 lines 201-208
-    fn next_after_body(reviews: usize, checks: usize, comments: usize) -> super::PrDetailSubfocus {
+    fn next_after_body(
+        reviews: usize,
+        threads: usize,
+        checks: usize,
+        comments: usize,
+    ) -> super::PrDetailSubfocus {
         use super::PrDetailSubfocus;
         if reviews > 0 {
             PrDetailSubfocus::Review(0)
+        } else if threads > 0 {
+            PrDetailSubfocus::ReviewThread(0)
         } else if checks > 0 {
             PrDetailSubfocus::Check(0)
         } else if comments > 0 {
@@ -271,7 +280,7 @@ impl AppState {
         }
     }
 
-    /// Compute the next subfocus from Review(i) (advance or fall through).
+    /// Compute the next subfocus from Review(i) (advance, threads, or fall through).
     ///
     /// @plan PLAN-20260624-PR-MODE.P05
     /// @requirement REQ-PR-003
@@ -279,12 +288,37 @@ impl AppState {
     fn next_after_review(
         i: usize,
         reviews: usize,
+        threads: usize,
         checks: usize,
         comments: usize,
     ) -> super::PrDetailSubfocus {
         use super::PrDetailSubfocus;
         if i + 1 < reviews {
             PrDetailSubfocus::Review(i + 1)
+        } else if threads > 0 {
+            PrDetailSubfocus::ReviewThread(0)
+        } else if checks > 0 {
+            PrDetailSubfocus::Check(0)
+        } else if comments > 0 {
+            PrDetailSubfocus::Comment(0)
+        } else {
+            PrDetailSubfocus::NewComment
+        }
+    }
+
+    /// Compute the next subfocus from ReviewThread(i) (advance or fall through).
+    ///
+    /// @plan PLAN-20260624-PR-MODE.P05
+    /// @requirement REQ-PR-003
+    fn next_after_thread(
+        i: usize,
+        threads: usize,
+        checks: usize,
+        comments: usize,
+    ) -> super::PrDetailSubfocus {
+        use super::PrDetailSubfocus;
+        if i + 1 < threads {
+            PrDetailSubfocus::ReviewThread(i + 1)
         } else if checks > 0 {
             PrDetailSubfocus::Check(0)
         } else if comments > 0 {
@@ -324,14 +358,47 @@ impl AppState {
         }
     }
 
-    /// Compute the previous subfocus from Check(0) (reverse traversal).
+    /// Compute the previous subfocus from Body (reverse: Comment, Check,
+    /// ReviewThread, Review, NewComment).
+    fn prev_from_body(
+        comments: usize,
+        checks: usize,
+        threads: usize,
+        reviews: usize,
+    ) -> super::PrDetailSubfocus {
+        use super::PrDetailSubfocus;
+        if comments > 0 {
+            PrDetailSubfocus::Comment(comments - 1)
+        } else if checks > 0 {
+            PrDetailSubfocus::Check(checks - 1)
+        } else if threads > 0 {
+            PrDetailSubfocus::ReviewThread(threads - 1)
+        } else if reviews > 0 {
+            PrDetailSubfocus::Review(reviews - 1)
+        } else {
+            PrDetailSubfocus::NewComment
+        }
+    }
+
+    /// Compute the previous subfocus from ReviewThread(0) (go to last Review).
+    fn prev_from_thread_zero(reviews: usize) -> super::PrDetailSubfocus {
+        use super::PrDetailSubfocus;
+        if reviews > 0 {
+            PrDetailSubfocus::Review(reviews - 1)
+        } else {
+            PrDetailSubfocus::Body
+        }
+    }
+
+    /// Compute the previous subfocus from Check(0) (reverse to ReviewThread/Review).
     ///
     /// @plan PLAN-20260624-PR-MODE.P05
     /// @requirement REQ-PR-003
-    /// @pseudocode component-001 lines 201-208
-    fn prev_from_check_zero(reviews: usize) -> super::PrDetailSubfocus {
+    fn prev_from_check_zero(threads: usize, reviews: usize) -> super::PrDetailSubfocus {
         use super::PrDetailSubfocus;
-        if reviews > 0 {
+        if threads > 0 {
+            PrDetailSubfocus::ReviewThread(threads - 1)
+        } else if reviews > 0 {
             PrDetailSubfocus::Review(reviews - 1)
         } else {
             PrDetailSubfocus::Body
@@ -342,11 +409,16 @@ impl AppState {
     ///
     /// @plan PLAN-20260624-PR-MODE.P05
     /// @requirement REQ-PR-003
-    /// @pseudocode component-001 lines 201-208
-    fn prev_from_comment_zero(reviews: usize, checks: usize) -> super::PrDetailSubfocus {
+    fn prev_from_comment_zero(
+        reviews: usize,
+        checks: usize,
+        threads: usize,
+    ) -> super::PrDetailSubfocus {
         use super::PrDetailSubfocus;
         if checks > 0 {
             PrDetailSubfocus::Check(checks - 1)
+        } else if threads > 0 {
+            PrDetailSubfocus::ReviewThread(threads - 1)
         } else if reviews > 0 {
             PrDetailSubfocus::Review(reviews - 1)
         } else {
@@ -371,7 +443,9 @@ impl AppState {
         let text_box_active = matches!(
             &self.prs_state.inline_state,
             InlineState::Composer {
-                target: ComposerTarget::NewComment | ComposerTarget::Reply { .. },
+                target: ComposerTarget::NewComment
+                    | ComposerTarget::Reply { .. }
+                    | ComposerTarget::ReplyToReviewThread { .. },
                 ..
             }
         );
@@ -583,4 +657,20 @@ impl AppState {
         self.apply_pr_scroll_event(dir);
         true
     }
+}
+
+/// Count all review threads across all reviews in a PR detail.
+///
+/// Threads are stored under each `PrReview.review_threads`; this flattens and
+/// counts them to support the flat `PrDetailSubfocus::ReviewThread(usize)`
+/// index used for navigation and rendering.
+///
+/// @plan PLAN-20260624-PR-MODE.P05
+/// @requirement REQ-PR-009
+pub(super) fn count_review_threads(detail: &crate::domain::PullRequestDetail) -> usize {
+    detail
+        .reviews
+        .iter()
+        .flat_map(|r| &r.review_threads)
+        .count()
 }

--- a/src/state/prs_ops.rs
+++ b/src/state/prs_ops.rs
@@ -437,6 +437,9 @@ impl AppState {
             ReadOnlyHintKind::PrNotMergeable => {
                 "Pull request is not mergeable (closed/merged)".to_string()
             }
+            ReadOnlyHintKind::ReadOnlyResolveOnThread => {
+                "Select a review thread to resolve (read-only context)".to_string()
+            }
         };
         self.prs_state.draft_notice = Some(text);
     }
@@ -555,6 +558,7 @@ impl AppState {
             || self.apply_pr_merge_event(&event)
             || self.apply_prs_data_wrapper(&event)
             || self.apply_prs_load_error_wrapper(&event)
+            || self.apply_pr_thread_event(&event)
             || self.apply_pr_notice_event(&event)
             || self.apply_pr_open_browser_event(&event)
             || self.apply_pr_error_event(event)

--- a/src/state/prs_tests_composer_focus.rs
+++ b/src/state/prs_tests_composer_focus.rs
@@ -272,12 +272,14 @@ Line C"
             state: PrReviewState::Approved,
             submitted_at: "2024-01-02T00:00:00Z".to_string(),
             body: Some("looks good".to_string()),
+            review_threads: vec![],
         },
         PrReview {
             author_login: "rev2".to_string(),
             state: PrReviewState::ChangesRequested,
             submitted_at: "2024-01-02T01:00:00Z".to_string(),
             body: None,
+            review_threads: vec![],
         },
     ];
     detail.checks = vec![

--- a/src/state/prs_tests_review_threads.rs
+++ b/src/state/prs_tests_review_threads.rs
@@ -1,0 +1,363 @@
+//! Pull Requests Mode review-thread state tests (issue #119) — open thread
+//! reply composer, toggle resolve pending, resolve succeeded/failed.
+//!
+//! @plan PLAN-20260624-PR-MODE.P05
+//! @requirement REQ-PR-009
+
+use super::prs_test_fixtures::prs_state_with_detail;
+use crate::domain::{IssueComment, PrReview, PrReviewState, PrReviewThread, RepositoryId};
+use crate::state::AppState;
+use crate::state::types::{
+    AppEvent, ComposerTarget, InlineState, PrDetailSubfocus, PrThreadResolvePending,
+};
+
+/// Helper: build a review thread with the given resolved state + path/line.
+fn make_thread(
+    thread_id: &str,
+    is_resolved: bool,
+    path: Option<&str>,
+    line: Option<u32>,
+) -> PrReviewThread {
+    PrReviewThread {
+        thread_id: thread_id.to_string(),
+        is_resolved,
+        path: path.map(String::from),
+        line,
+        comments: vec![IssueComment {
+            comment_id: 1,
+            author_login: "reviewer".to_string(),
+            created_at: "2024-01-03T00:00:00Z".to_string(),
+            edited_at: None,
+            body: "needs work".to_string(),
+        }],
+    }
+}
+
+/// Helper: state with a single review that has two threads.
+fn state_with_two_threads() -> AppState {
+    let mut state = prs_state_with_detail("repo-1", 1);
+    let Some(detail) = state.prs_state.pr_detail.as_mut() else {
+        panic!("test fixture must have pr_detail");
+    };
+    detail.reviews = vec![PrReview {
+        author_login: "ada".to_string(),
+        state: PrReviewState::ChangesRequested,
+        submitted_at: "2024-01-02T00:00:00Z".to_string(),
+        body: Some("please fix".to_string()),
+        review_threads: vec![
+            make_thread("T1", false, Some("src/main.rs"), Some(10)),
+            make_thread("T2", true, Some("src/lib.rs"), Some(20)),
+        ],
+    }];
+    state
+}
+
+// ── OpenThreadReplyComposer ───────────────────────────────────────────────
+
+/// PrOpenThreadReplyComposer opens a Composer targeting ReplyToReviewThread
+/// with the flat thread_index, prefilled author, and sets subfocus.
+#[test]
+fn open_thread_reply_composer_sets_composer_target() {
+    let state = state_with_two_threads();
+
+    let new_state = state.apply(AppEvent::PrOpenThreadReplyComposer { thread_index: 0 });
+
+    let InlineState::Composer {
+        target,
+        text,
+        cursor,
+    } = &new_state.prs_state.inline_state
+    else {
+        panic!(
+            "inline_state must be Composer, got {:?}",
+            new_state.prs_state.inline_state
+        );
+    };
+    assert!(
+        matches!(
+            target,
+            ComposerTarget::ReplyToReviewThread {
+                thread_index: 0,
+                ..
+            }
+        ),
+        "target must be ReplyToReviewThread(0), got {target:?}"
+    );
+    assert!(
+        text.starts_with("@reviewer "),
+        "text must prefill @reviewer, got {text:?}"
+    );
+    assert_eq!(*cursor, text.len(), "cursor must be at end of prefill");
+    assert_eq!(
+        new_state.prs_state.detail_subfocus,
+        PrDetailSubfocus::ReviewThread(0),
+        "subfocus must be ReviewThread(0)"
+    );
+}
+
+/// PrOpenThreadReplyComposer for thread_index 1 still works and maps subfocus.
+#[test]
+fn open_thread_reply_composer_for_second_thread() {
+    let state = state_with_two_threads();
+
+    let new_state = state.apply(AppEvent::PrOpenThreadReplyComposer { thread_index: 1 });
+
+    assert!(
+        matches!(
+            &new_state.prs_state.inline_state,
+            InlineState::Composer {
+                target: ComposerTarget::ReplyToReviewThread {
+                    thread_index: 1,
+                    ..
+                },
+                ..
+            }
+        ),
+        "target must be ReplyToReviewThread(1)"
+    );
+    assert_eq!(
+        new_state.prs_state.detail_subfocus,
+        PrDetailSubfocus::ReviewThread(1)
+    );
+}
+
+/// PrOpenThreadReplyComposer is a no-op when inline_state is already active.
+#[test]
+fn open_thread_reply_composer_noop_when_inline_active() {
+    let mut state = state_with_two_threads();
+    state.prs_state.inline_state = InlineState::Composer {
+        target: ComposerTarget::NewComment,
+        text: "draft".to_string(),
+        cursor: 5,
+    };
+
+    let new_state = state.apply(AppEvent::PrOpenThreadReplyComposer { thread_index: 0 });
+
+    // The existing composer must be preserved (not overwritten).
+    assert!(
+        matches!(
+            &new_state.prs_state.inline_state,
+            InlineState::Composer {
+                target: ComposerTarget::NewComment,
+                ..
+            }
+        ),
+        "existing composer must not be overwritten"
+    );
+}
+
+/// PrOpenThreadReplyComposer on an out-of-range thread_index is a no-op
+/// (graceful degradation — never panic).
+#[test]
+fn open_thread_reply_composer_out_of_range_is_noop() {
+    let state = state_with_two_threads();
+
+    let new_state = state.apply(AppEvent::PrOpenThreadReplyComposer { thread_index: 99 });
+
+    assert_eq!(
+        new_state.prs_state.inline_state,
+        InlineState::None,
+        "out-of-range thread_index must not open a composer"
+    );
+}
+
+// ── ToggleThreadResolve ───────────────────────────────────────────────────
+
+/// PrToggleThreadResolve on an unresolved thread sets pending to resolve=true.
+#[test]
+fn toggle_thread_resolve_sets_pending_for_unresolved() {
+    let state = state_with_two_threads();
+
+    let new_state = state.apply(AppEvent::PrToggleThreadResolve { thread_index: 0 });
+
+    let Some(pending) = &new_state.prs_state.thread_resolve_pending else {
+        panic!("thread_resolve_pending must be set");
+    };
+    assert_eq!(pending.thread_index, 0, "pending thread_index must be 0");
+    assert!(
+        pending.resolve,
+        "pending resolve must be true for unresolved thread"
+    );
+    assert_eq!(
+        pending.scope_repo_id,
+        RepositoryId("repo-1".to_string()),
+        "scope must match selected repo"
+    );
+    assert_eq!(
+        pending.request_id, 1,
+        "request_id must be incremented from 0 to 1"
+    );
+}
+#[test]
+fn toggle_thread_resolve_sets_pending_for_resolved() {
+    let state = state_with_two_threads();
+
+    let new_state = state.apply(AppEvent::PrToggleThreadResolve { thread_index: 1 });
+
+    let Some(pending) = &new_state.prs_state.thread_resolve_pending else {
+        panic!("thread_resolve_pending must be set");
+    };
+    assert_eq!(pending.thread_index, 1, "pending thread_index must be 1");
+    assert!(
+        !pending.resolve,
+        "pending resolve must be false for resolved thread"
+    );
+}
+
+/// PrToggleThreadResolve on an out-of-range thread_index is a no-op.
+#[test]
+fn toggle_thread_resolve_out_of_range_is_noop() {
+    let state = state_with_two_threads();
+
+    let new_state = state.apply(AppEvent::PrToggleThreadResolve { thread_index: 99 });
+
+    assert!(
+        new_state.prs_state.thread_resolve_pending.is_none(),
+        "out-of-range thread_index must not set pending"
+    );
+}
+
+// ── ThreadResolveSucceeded ────────────────────────────────────────────────
+
+/// PrThreadResolveSucceeded flips the thread is_resolved and clears pending.
+#[test]
+fn thread_resolve_succeeded_flips_is_resolved_and_clears_pending() {
+    let mut state = state_with_two_threads();
+    // Set pending for thread 0 (currently unresolved -> resolve=true).
+    state.prs_state.thread_resolve_pending = Some(PrThreadResolvePending {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        thread_index: 0,
+        resolve: true,
+        request_id: 1,
+    });
+
+    let new_state = state.apply(AppEvent::PrThreadResolveSucceeded {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        thread_index: 0,
+        is_resolved: true,
+        request_id: 1,
+    });
+
+    assert!(
+        new_state.prs_state.thread_resolve_pending.is_none(),
+        "pending must be cleared on success"
+    );
+    let Some(detail) = new_state.prs_state.pr_detail.as_ref() else {
+        panic!("detail must remain");
+    };
+    let thread = &detail.reviews[0].review_threads[0];
+    assert!(
+        thread.is_resolved,
+        "thread 0 is_resolved must be true after resolve succeeded"
+    );
+}
+
+/// PrThreadResolveSucceeded for an out-of-range thread clears pending without
+/// panic (graceful).
+#[test]
+fn thread_resolve_succeeded_out_of_range_clears_pending() {
+    let mut state = state_with_two_threads();
+    state.prs_state.thread_resolve_pending = Some(PrThreadResolvePending {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        thread_index: 99,
+        resolve: true,
+        request_id: 1,
+    });
+
+    let new_state = state.apply(AppEvent::PrThreadResolveSucceeded {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        thread_index: 99,
+        is_resolved: true,
+        request_id: 1,
+    });
+
+    assert!(
+        new_state.prs_state.thread_resolve_pending.is_none(),
+        "pending must clear even for out-of-range thread"
+    );
+}
+
+/// PrThreadResolveSucceeded with a mismatched request_id is ignored (stale).
+#[test]
+fn thread_resolve_succeeded_stale_request_id_ignored() {
+    let mut state = state_with_two_threads();
+    state.prs_state.thread_resolve_pending = Some(PrThreadResolvePending {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        thread_index: 0,
+        resolve: true,
+        request_id: 5,
+    });
+
+    let new_state = state.apply(AppEvent::PrThreadResolveSucceeded {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        thread_index: 0,
+        is_resolved: true,
+        request_id: 99,
+    });
+
+    assert!(
+        new_state.prs_state.thread_resolve_pending.is_some(),
+        "stale request_id must not clear pending"
+    );
+}
+
+// ── ThreadResolveFailed ───────────────────────────────────────────────────
+
+/// PrThreadResolveFailed clears pending and sets an error message.
+#[test]
+fn thread_resolve_failed_clears_pending_and_sets_error() {
+    let mut state = state_with_two_threads();
+    state.prs_state.thread_resolve_pending = Some(PrThreadResolvePending {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        thread_index: 0,
+        resolve: true,
+        request_id: 1,
+    });
+
+    let new_state = state.apply(AppEvent::PrThreadResolveFailed {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        thread_index: 0,
+        request_id: 1,
+        error: "network error".to_string(),
+    });
+
+    assert!(
+        new_state.prs_state.thread_resolve_pending.is_none(),
+        "pending must be cleared on failure"
+    );
+    let Some(error) = new_state.prs_state.error.as_ref() else {
+        panic!("error must be set on failure");
+    };
+    assert!(
+        error.contains("network error"),
+        "error must contain the failure message, got {error}"
+    );
+}
+
+/// PrThreadResolveFailed with a stale request_id is ignored.
+#[test]
+fn thread_resolve_failed_stale_request_id_ignored() {
+    let mut state = state_with_two_threads();
+    state.prs_state.thread_resolve_pending = Some(PrThreadResolvePending {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        thread_index: 0,
+        resolve: true,
+        request_id: 5,
+    });
+
+    let new_state = state.apply(AppEvent::PrThreadResolveFailed {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        thread_index: 0,
+        request_id: 99,
+        error: "network error".to_string(),
+    });
+
+    assert!(
+        new_state.prs_state.thread_resolve_pending.is_some(),
+        "stale request_id must not clear pending"
+    );
+    assert!(
+        new_state.prs_state.error.is_none(),
+        "stale failure must not set error"
+    );
+}

--- a/src/state/prs_thread_ops.rs
+++ b/src/state/prs_thread_ops.rs
@@ -1,0 +1,230 @@
+//! Pull Requests mode review-thread state operations (issue #119).
+//!
+//! Handles opening the thread-reply composer, toggling resolve/unresolve
+//! pending state, and applying resolve succeeded/failed results. Thread
+//! navigation uses a flat index across all reviews' `review_threads` (matching
+//! `PrDetailSubfocus::ReviewThread(usize)` and the renderer's flattening).
+//!
+//! @plan PLAN-20260624-PR-MODE.P05
+//! @requirement REQ-PR-009
+
+use super::{
+    AppEvent, AppState, ComposerTarget, InlineState, PrDetailSubfocus, PrFocus,
+    PrThreadResolvePending,
+};
+use crate::domain::{PrReviewThread, RepositoryId};
+
+impl AppState {
+    /// Apply review-thread events (open reply, toggle resolve, succeeded/failed).
+    ///
+    /// Returns `true` when the event was handled. Added to the dispatch chain
+    /// in `apply_prs_event`.
+    ///
+    /// @plan PLAN-20260624-PR-MODE.P05
+    /// @requirement REQ-PR-009
+    pub(super) fn apply_pr_thread_event(&mut self, event: &AppEvent) -> bool {
+        match event {
+            AppEvent::PrOpenThreadReplyComposer { thread_index } => {
+                self.pr_open_thread_reply_composer(*thread_index);
+                true
+            }
+            AppEvent::PrToggleThreadResolve { thread_index } => {
+                self.pr_toggle_thread_resolve(*thread_index);
+                true
+            }
+            AppEvent::PrThreadResolveSucceeded {
+                scope_repo_id,
+                thread_index,
+                is_resolved,
+                request_id,
+            } => {
+                self.pr_thread_resolve_succeeded(
+                    scope_repo_id,
+                    *thread_index,
+                    *is_resolved,
+                    *request_id,
+                );
+                true
+            }
+            AppEvent::PrThreadResolveFailed {
+                scope_repo_id,
+                thread_index,
+                request_id,
+                error,
+            } => {
+                self.pr_thread_resolve_failed(scope_repo_id, *thread_index, *request_id, error);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Open the thread-reply composer for the given flat thread index.
+    ///
+    /// Prefills with `@author ` from the thread's last comment author. Sets
+    /// subfocus to `ReviewThread(thread_index)`. No-op when an inline composer
+    /// is already active or when the thread index is out of range.
+    ///
+    /// @plan PLAN-20260624-PR-MODE.P05
+    /// @requirement REQ-PR-009
+    fn pr_open_thread_reply_composer(&mut self, thread_index: usize) {
+        if self.prs_state.pr_focus != PrFocus::PrDetail {
+            return;
+        }
+        if self.prs_state.inline_state != InlineState::None {
+            return;
+        }
+        let thread = self.pr_find_thread(thread_index);
+        let Some(thread) = thread else {
+            return;
+        };
+        let author = thread
+            .comments
+            .last()
+            .map(|c| format!("@{} ", c.author_login))
+            .unwrap_or_default();
+        let cursor = author.len();
+        self.prs_state.inline_state = InlineState::Composer {
+            target: ComposerTarget::ReplyToReviewThread {
+                thread_index,
+                author: author.clone(),
+            },
+            text: author,
+            cursor,
+        };
+        self.prs_state.detail_subfocus = PrDetailSubfocus::ReviewThread(thread_index);
+    }
+
+    /// Toggle resolve/unresolve on a review thread.
+    ///
+    /// Sets `thread_resolve_pending` with the target state (resolve=true for an
+    /// unresolved thread, resolve=false for a resolved one). The dispatch layer
+    /// spawns the actual GraphQL mutation and emits succeeded/failed.
+    ///
+    /// @plan PLAN-20260624-PR-MODE.P05
+    /// @requirement REQ-PR-009
+    fn pr_toggle_thread_resolve(&mut self, thread_index: usize) {
+        let Some(thread) = self.pr_find_thread(thread_index) else {
+            return;
+        };
+        let resolve = !thread.is_resolved;
+        let Some(scope) = self.selected_repository_id().cloned() else {
+            self.prs_state.error = Some("No repository selected".to_string());
+            return;
+        };
+        let request_id = self
+            .prs_state
+            .next_thread_resolve_request_id
+            .saturating_add(1);
+        self.prs_state.next_thread_resolve_request_id = request_id;
+        self.prs_state.thread_resolve_pending = Some(PrThreadResolvePending {
+            scope_repo_id: scope,
+            thread_index,
+            resolve,
+            request_id,
+        });
+    }
+
+    /// Apply a successful resolve/unresolve mutation.
+    ///
+    /// Flips the thread's `is_resolved` to the returned value and clears
+    /// pending — but only when the request_id matches (staleness guard).
+    /// Out-of-range thread indices clear pending without panic.
+    ///
+    /// @plan PLAN-20260624-PR-MODE.P05
+    /// @requirement REQ-PR-009
+    fn pr_thread_resolve_succeeded(
+        &mut self,
+        scope_repo_id: &RepositoryId,
+        thread_index: usize,
+        is_resolved: bool,
+        request_id: u64,
+    ) {
+        if !self.scope_repo_id_matches_pr(scope_repo_id) {
+            return;
+        }
+        if !self.pr_thread_resolve_request_matches(request_id) {
+            return;
+        }
+        self.prs_state.thread_resolve_pending = None;
+        if let Some(thread) =
+            Self::pr_find_thread_mut(self.prs_state.pr_detail.as_mut(), thread_index)
+        {
+            thread.is_resolved = is_resolved;
+        }
+    }
+
+    /// Apply a failed resolve/unresolve mutation.
+    ///
+    /// Clears pending and sets a visible error — but only when the request_id
+    /// matches (staleness guard).
+    ///
+    /// @plan PLAN-20260624-PR-MODE.P05
+    /// @requirement REQ-PR-009
+    fn pr_thread_resolve_failed(
+        &mut self,
+        scope_repo_id: &RepositoryId,
+        _thread_index: usize,
+        request_id: u64,
+        error: &str,
+    ) {
+        if !self.scope_repo_id_matches_pr(scope_repo_id) {
+            return;
+        }
+        if !self.pr_thread_resolve_request_matches(request_id) {
+            return;
+        }
+        self.prs_state.thread_resolve_pending = None;
+        self.prs_state.error = Some(error.to_string());
+    }
+
+    /// Check whether a request_id matches the current pending resolve.
+    fn pr_thread_resolve_request_matches(&self, request_id: u64) -> bool {
+        self.prs_state
+            .thread_resolve_pending
+            .as_ref()
+            .is_some_and(|p| p.request_id == request_id)
+    }
+
+    /// Borrow a review thread by flat index (immutable).
+    fn pr_find_thread(&self, thread_index: usize) -> Option<&PrReviewThread> {
+        let detail = self.prs_state.pr_detail.as_ref()?;
+        detail
+            .reviews
+            .iter()
+            .flat_map(|r| &r.review_threads)
+            .nth(thread_index)
+    }
+
+    /// Borrow a review thread by flat index (mutable).
+    ///
+    /// Walks `reviews → review_threads` in order, counting the flat index.
+    /// This is the single source of truth for the flat-index → thread mapping,
+    /// shared by the navigation cycle and the rendering projection.
+    fn pr_find_thread_mut(
+        detail: Option<&mut crate::domain::PullRequestDetail>,
+        thread_index: usize,
+    ) -> Option<&mut PrReviewThread> {
+        let detail = detail?;
+        let mut idx = 0usize;
+        for review in &mut detail.reviews {
+            for thread in &mut review.review_threads {
+                if idx == thread_index {
+                    return Some(thread);
+                }
+                idx += 1;
+            }
+        }
+        None
+    }
+
+    /// Check if a scope_repo_id matches the currently-selected repository.
+    ///
+    /// Mirrors `scope_repo_id_matches` in `prs_ops.rs` but is scoped to this
+    /// module to keep thread operations self-contained.
+    fn scope_repo_id_matches_pr(&self, scope_repo_id: &RepositoryId) -> bool {
+        self.selected_repository_index
+            .and_then(|idx| self.repositories.get(idx))
+            .is_some_and(|repo| &repo.id == scope_repo_id)
+    }
+}

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -235,6 +235,12 @@ pub enum ComposerTarget {
         comment_index: usize,
         author: String,
     },
+    /// Reply to a PR review thread (issue #119). `thread_index` is the flat
+    /// index across all reviews' threads, matching `PrDetailSubfocus::ReviewThread`.
+    ReplyToReviewThread {
+        thread_index: usize,
+        author: String,
+    },
 }
 
 /// @plan PLAN-20260329-ISSUES-MODE.P03
@@ -862,6 +868,30 @@ pub enum AppEvent {
     PrAgentChooserCancel,
     PrSendToAgentCompleted,
     PrSendToAgentFailed {
+        error: String,
+    },
+
+    // PR Review Threads (issue #119)
+    /// Open the inline reply composer for a review thread.
+    PrOpenThreadReplyComposer {
+        thread_index: usize,
+    },
+    /// Toggle resolve/unresolve on a focused review thread.
+    PrToggleThreadResolve {
+        thread_index: usize,
+    },
+    /// A review-thread resolve/unresolve mutation succeeded.
+    PrThreadResolveSucceeded {
+        scope_repo_id: RepositoryId,
+        thread_index: usize,
+        is_resolved: bool,
+        request_id: u64,
+    },
+    /// A review-thread resolve/unresolve mutation failed.
+    PrThreadResolveFailed {
+        scope_repo_id: RepositoryId,
+        thread_index: usize,
+        request_id: u64,
         error: String,
     },
 }

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -54,7 +54,7 @@ fn active_issue_composer(inline_state: &InlineState) -> Option<(String, usize, &
             crate::layout::NEW_COMMENT_COMPOSER_PREFIX,
         )),
         InlineState::Composer {
-            target: ComposerTarget::Reply { .. },
+            target: ComposerTarget::Reply { .. } | ComposerTarget::ReplyToReviewThread { .. },
             text,
             cursor,
         } => Some((text.clone(), *cursor, crate::layout::REPLY_COMPOSER_PREFIX)),

--- a/src/ui/components/keybind_bar.rs
+++ b/src/ui/components/keybind_bar.rs
@@ -41,7 +41,7 @@ pub fn keybind_hints_for(screen_mode: ScreenMode, terminal_focused: bool) -> &'s
         // @plan PLAN-20260624-PR-MODE.P12
         // @requirement REQ-PR-001
         ScreenMode::DashboardPullRequests => {
-            "^/v navigate | Enter open detail | f filter | / search | Tab cycle focus | p PR list | r reply | S send-to-agent | e edit | c comment | o open in browser | m merge | a exit | Esc back/exit"
+            "^/v navigate | Enter open detail | f filter | / search | Tab cycle focus | p PR list | r reply | R resolve | S send-to-agent | e edit | c comment | o open in browser | m merge | a exit | Esc back/exit"
         }
     }
 }

--- a/src/ui/components/pr_detail.rs
+++ b/src/ui/components/pr_detail.rs
@@ -131,7 +131,7 @@ fn active_pr_composer(inline_state: &InlineState) -> Option<(String, usize, &'st
             crate::layout::NEW_COMMENT_COMPOSER_PREFIX,
         )),
         InlineState::Composer {
-            target: ComposerTarget::Reply { .. },
+            target: ComposerTarget::Reply { .. } | ComposerTarget::ReplyToReviewThread { .. },
             text,
             cursor,
         } => Some((text.clone(), *cursor, crate::layout::REPLY_COMPOSER_PREFIX)),

--- a/src/ui/components/pr_render_tests.rs
+++ b/src/ui/components/pr_render_tests.rs
@@ -123,12 +123,14 @@ fn detail_with_reviews_and_checks(number: u64) -> PullRequestDetail {
             state: PrReviewState::Approved,
             submitted_at: "2024-01-03".to_string(),
             body: Some("LGTM".to_string()),
+            review_threads: vec![],
         },
         PrReview {
             author_login: "bob".to_string(),
             state: PrReviewState::Commented,
             submitted_at: "2024-01-04".to_string(),
             body: None,
+            review_threads: vec![],
         },
     ];
     detail.checks = vec![
@@ -170,18 +172,21 @@ fn rich_reviews() -> Vec<PrReview> {
             state: PrReviewState::Approved,
             submitted_at: "2024-01-03".to_string(),
             body: Some("Looks good".to_string()),
+            review_threads: vec![],
         },
         PrReview {
             author_login: "reviewer2".to_string(),
             state: PrReviewState::Commented,
             submitted_at: "2024-01-04".to_string(),
             body: Some("nit: spacing".to_string()),
+            review_threads: vec![],
         },
         PrReview {
             author_login: "reviewer3".to_string(),
             state: PrReviewState::Approved,
             submitted_at: "2024-01-05".to_string(),
             body: None,
+            review_threads: vec![],
         },
     ]
 }


### PR DESCRIPTION
## Summary

Renders PR reviews like the GitHub PR conversation UI, replacing the flat one-line-per-review summary with nested review-thread display, threaded reply, and resolve/unresolve capabilities.

## Changes

### Domain model (`src/domain/mod.rs`)
- Added `PrReviewThread` struct: `thread_id`, `is_resolved`, `path`, `line`, `comments: Vec<IssueComment>`
- Added `review_threads: Vec<PrReviewThread>` field to `PrReview`

### GitHub layer (`src/github/`)
- New `pr_threads.rs` module with GhClient methods: `list_pr_review_threads`, `resolve_review_thread`, `unresolve_review_thread`, `create_pr_review_thread_reply`
- GraphQL queries for `reviewThreads` connection on `pullRequest.reviews`, with legacy nested fallback path
- Parsing in `parse_pr.rs`: `parse_pr_review_threads`, `parse_single_review_thread`, `parse_thread_comments`
- Thread reply parsing via `parse_thread_reply_json`
- `get_pull_request_detail` now fetches review threads

### State layer (`src/state/`)
- `PrDetailSubfocus::ReviewThread(usize)` — flat index across all reviews' threads
- `ComposerTarget::ReplyToReviewThread { thread_index, author }` — posts into specific thread
- `PrThreadResolvePending` with request-id staleness guard
- New `prs_thread_ops.rs`: open thread reply composer, toggle resolve, apply succeeded/failed
- Navigation cycle (`prs_nav_ops.rs`) extended: Body → Review → ReviewThread → Check → Comment → NewComment
- Inline ops (`prs_inline_ops.rs`) handle thread reply composer
- `AppEvent` variants: `PrOpenThreadReplyComposer`, `PrToggleThreadResolve`, `PrThreadResolveSucceeded`, `PrThreadResolveFailed`

### Messages layer (`src/messages/`)
- `PullRequestsMessage` variants for thread events with full scope_repo_id/request_id propagation
- Conversion arms in `prs_conversion.rs`

### Rendering (`src/pr_detail_content.rs`)
- `build_reviews_section` rewritten to render nested threads: review header → indented thread comments → [RESOLVED]/[UNRESOLVED] tags → file path:line
- Focus markers (`>`) and reply/resolve hints on focused threads
- `pr_detail_content_line_count` remains the single source of truth for scroll bounds

### Key dispatch (`src/app_input/prs.rs`)
- `r` on a focused `ReviewThread(idx)` opens thread reply composer
- `R` toggles resolve/unresolve on focused thread
- Keybind hint updated to include `R resolve`

### Mutation dispatch (`src/app_input/prs_mutation.rs`, `prs_orchestration.rs`)
- Thread reply submit spawns `create_pr_review_thread_reply` GraphQL mutation
- Resolve toggle spawns `resolveReviewThread`/`unresolveReviewThread` mutations
- Errors surfaced visibly (no silent drop)

### Tests
- 12 state tests (`prs_tests_review_threads.rs`): open reply, toggle resolve, succeeded/failed with staleness guards
- 6 rendering tests (`pr_detail_content_tests.rs`): nested threads, resolution tags, focus markers, line count
- 3 key dispatch tests (`prs_key_tests.rs`): r/R dispatch on ReviewThread
- 8 parser/query tests (`tests_pr_threads.rs`): thread parsing, legacy fallback, malformed degradation, missing data
- Domain serialization round-trip for PrReviewThread

## Verification
- `make ci-check` passes completely (fmt, clippy, source-size, complexity, coverage 30%+, build, 1144 tests)
- Open Code Review (ocr) findings remediated: fixed tautological test, added request_id assertion, added legacy fallback + missing pullRequest parser tests, fixed import consistency

Closes #119