### PR TITLE
Add periodic auto-refresh and post-mutation reload for PR view (Fixes #128)

### DIFF
--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -35,6 +35,10 @@ pub use modal_handlers::{handle_f12_toggle, handle_mode_confirm_key, handle_mode
 
 pub use normal::{handle_global_shortcut_key, handle_normal_key_event};
 
+// Re-export the background-refresh orchestration helper so `app_shell` can
+// import it from `app_input` (issue #128).
+pub use prs_orchestration::request_pr_background_refresh;
+
 use iocraft::hooks::State as HookState;
 use iocraft::prelude::*;
 use tracing::{debug, warn};

--- a/src/app_input/prs_dispatch.rs
+++ b/src/app_input/prs_dispatch.rs
@@ -17,7 +17,9 @@ use jefe::domain::RepositoryId;
 use jefe::github::PrSendPayload;
 use jefe::state::AppEvent;
 
-use super::{AppStateHandle, SharedContext, apply_and_persist, gh_async, github_client};
+use super::{
+    AppStateHandle, SharedContext, apply_and_persist, dispatch_app_event, gh_async, github_client,
+};
 
 /// Typed unavailable-context result for PR open-in-browser (REQ-PR-013).
 ///
@@ -124,23 +126,30 @@ pub(super) fn load_pr_detail_for_selection(app_state: &mut AppStateHandle, ctx: 
     );
 }
 
+/// Silently refresh PR detail for the currently selected PR (issue #128).
+/// Lives in `prs_orchestration.rs` (re-exported here for the dispatch chain) to
+/// keep this file under the architecture boundary line limit.
+///
+/// @requirement issue #128
+pub(super) use super::prs_orchestration::load_pr_detail_silent_refresh;
+
 /// @plan PLAN-20260624-PR-MODE.P11
 /// @requirement REQ-PR-009
 /// @pseudocode component-004 lines 139-145
 #[derive(Clone)]
-struct PrDetailLoadParams {
-    scope_repo_id: RepositoryId,
-    pr_number: u64,
-    owner: String,
-    repo: String,
-    request_id: u64,
+pub(super) struct PrDetailLoadParams {
+    pub(super) scope_repo_id: RepositoryId,
+    pub(super) pr_number: u64,
+    pub(super) owner: String,
+    pub(super) repo: String,
+    pub(super) request_id: u64,
 }
 
 /// Gather detail-load params from state (returns None if no PR selected).
 /// @plan PLAN-20260624-PR-MODE.P11
 /// @requirement REQ-PR-009
 /// @pseudocode component-004 lines 139-145
-fn pr_detail_load_params(app_state: &AppStateHandle) -> Option<PrDetailLoadParams> {
+pub(super) fn pr_detail_load_params(app_state: &AppStateHandle) -> Option<PrDetailLoadParams> {
     let state = app_state.read();
     let pr_number = state
         .prs_state
@@ -711,7 +720,12 @@ fn spawn_pr_merge(app_state: &AppStateHandle, ctx: &SharedContext, info: PrMerge
         ctx,
         move |mut app_state, ctx| {
             let event = pr_merge_event(&ctx, &info);
-            apply_and_persist(&mut app_state, &ctx, event);
+            // Route the merge result through the full dispatch chain so that a
+            // successful `PrMerged` hits the `PullRequestsMessage::Merged` arm
+            // and triggers the post-mutation list + detail reload (issue #128).
+            // A `PrMergeFailed` outcome is converted to a message but does NOT
+            // trigger a reload (it lacks the `Merged`/`CommentCreated` markers).
+            dispatch_app_event(&mut app_state, &ctx, event);
         },
         move |mut app_state, ctx, message| {
             apply_and_persist(

--- a/src/app_input/prs_integration_tests.rs
+++ b/src/app_input/prs_integration_tests.rs
@@ -842,8 +842,125 @@ fn it_no_blocking_gh_call_on_ui_thread() {
     );
 
     // ── Async dispatch arms exist BY NAME (compile-time wiring proof) ──
-    let _: fn(&mut AppStateHandle, &SharedContext, bool) =
+    let _: fn(&mut AppStateHandle, &SharedContext, bool, bool) =
         prs_list_dispatch::dispatch_pr_list_fetch;
     let _: fn(&mut AppStateHandle, &SharedContext) = prs_dispatch::load_pr_detail_for_selection;
     let _: fn(&mut AppStateHandle, &SharedContext) = prs_comments_dispatch::load_more_pr_comments;
+}
+
+// ═════════════════════════════════════════════════════════════════════════
+// Issue #128: PR view auto-refresh — post-mutation reload + background refresh
+// ═════════════════════════════════════════════════════════════════════════
+
+/// A successful in-app merge (`PrMerged`) must clear the merge-mutation pending
+/// marker, mark the PR as Merged in both the detail and list, and surface a
+/// visible notice. The post-mutation list+detail reload is dispatched by the
+/// orchestration layer (proven by the function-existence test below), so at
+/// the reducer level we assert the merge lifecycle effects.
+///
+/// @requirement issue #128
+#[test]
+fn test_pr_merged_clears_pending_and_marks_merged() {
+    use jefe::domain::{MergeMethod, PrState};
+
+    let mut state = active_prs_state();
+    state.prs_state.pr_focus = PrFocus::PrDetail;
+    state.prs_state.pull_requests = vec![make_test_pr(7)];
+    state.prs_state.selected_pr_index = Some(0);
+    state.prs_state.pr_detail = Some(make_test_pr_detail(7));
+    state.prs_state.merge_mutation_pending = Some(jefe::state::PrMergeMutationPending {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        mutation_id: 1,
+        pr_number: 7,
+        method: MergeMethod::Merge,
+    });
+
+    state.apply_in_place(AppEvent::PrMerged {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        pr_number: 7,
+        method: MergeMethod::Merge,
+    });
+
+    assert!(
+        state.prs_state.merge_mutation_pending.is_none(),
+        "PrMerged must clear the merge-mutation pending marker"
+    );
+    let detail = state
+        .prs_state
+        .pr_detail
+        .as_ref()
+        .unwrap_or_else(|| panic!("pr_detail must still be present after PrMerged"));
+    assert_eq!(
+        detail.state,
+        PrState::Merged,
+        "PrMerged must mark the detail PR as Merged"
+    );
+    let pr = state
+        .prs_state
+        .pull_requests
+        .first()
+        .unwrap_or_else(|| panic!("list must still have the PR after PrMerged"));
+    assert_eq!(
+        pr.state,
+        PrState::Merged,
+        "PrMerged must mark the list-row PR as Merged"
+    );
+    assert!(
+        state.prs_state.draft_notice.is_some(),
+        "PrMerged must surface a visible notice"
+    );
+}
+
+/// The background-refresh public API exists and has the expected type (compile-
+/// time proof that the orchestration layer wires `request_pr_background_refresh`).
+/// This proves the background loop can call into the dispatch layer to silently
+/// refresh the PR list + detail while the PR view is open.
+///
+/// @requirement issue #128
+#[test]
+fn test_background_refresh_function_exists_and_checks_screen_mode() {
+    let _: fn(&mut AppStateHandle, &SharedContext) =
+        crate::app_input::request_pr_background_refresh;
+}
+
+/// The background-refresh guard must skip when a detail load is in flight
+/// (issue #128 remediation). Exercises the pure `should_background_refresh`
+/// predicate directly so the guard logic is covered without an
+/// `AppStateHandle`.
+///
+/// @requirement issue #128
+#[test]
+fn test_background_refresh_skips_when_detail_load_in_flight() {
+    use super::prs_orchestration::should_background_refresh;
+    use jefe::state::ScreenMode;
+
+    // No in-flight loads → should refresh.
+    assert!(
+        should_background_refresh(ScreenMode::DashboardPullRequests, false, false, false),
+        "should refresh when PR view is open and nothing is in flight"
+    );
+
+    // Detail load in flight → must NOT refresh (clobber guard).
+    assert!(
+        !should_background_refresh(ScreenMode::DashboardPullRequests, false, false, true),
+        "must NOT refresh when a detail load is in flight"
+    );
+
+    // List reload pending → must NOT refresh.
+    assert!(
+        !should_background_refresh(ScreenMode::DashboardPullRequests, true, false, false),
+        "must NOT refresh when a list reload is pending"
+    );
+
+    // List page pending → must NOT refresh.
+    assert!(
+        !should_background_refresh(ScreenMode::DashboardPullRequests, false, true, false),
+        "must NOT refresh when a list page load is pending"
+    );
+
+    // Not on the PR view → must NOT refresh.
+    assert!(
+        !should_background_refresh(ScreenMode::Dashboard, false, false, false),
+        "must NOT refresh when not on the PR view"
+    );
 }

--- a/src/app_input/prs_list_dispatch.rs
+++ b/src/app_input/prs_list_dispatch.rs
@@ -30,7 +30,7 @@ pub fn dispatch_pr_list_reload(
 ) {
     let fresh_reload = is_fresh_pr_list_reload(&message);
     apply_and_persist(app_state, ctx, AppEvent::from(message));
-    dispatch_pr_list_fetch(app_state, ctx, fresh_reload);
+    dispatch_pr_list_fetch(app_state, ctx, fresh_reload, false);
 }
 
 /// Whether the message triggers a fresh (cursor-resetting) list reload.
@@ -63,10 +63,16 @@ pub(super) fn dispatch_pr_list_fetch(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
     fresh_reload: bool,
+    silent: bool,
 ) {
-    let mut params = pr_fetch_params(app_state, fresh_reload);
+    let mut params = pr_fetch_params(app_state, fresh_reload, silent);
 
     if params.owner.is_empty() || params.repo.is_empty() {
+        if params.silent {
+            // Silent refresh of a repo with no GitHub slug: silently no-op
+            // (do NOT surface a visible error — issue #128).
+            return;
+        }
         persist_missing_github_repo(app_state, ctx);
         return;
     }
@@ -98,7 +104,16 @@ pub(super) fn dispatch_pr_list_fetch(
 /// @requirement REQ-PR-007
 /// @pseudocode component-004 lines 127-137
 pub(super) fn request_pr_list_reload(app_state: &mut AppStateHandle, ctx: &SharedContext) {
-    dispatch_pr_list_fetch(app_state, ctx, true);
+    dispatch_pr_list_fetch(app_state, ctx, true, false);
+}
+
+/// Request a silent background refresh of the PR list (issue #128). This is a
+/// fresh reload that does NOT flash the loading spinner, preserves selection,
+/// and is dispatched only when the PR view is open with no in-flight load.
+///
+/// @requirement issue #128
+pub(super) fn request_pr_list_silent_refresh(app_state: &mut AppStateHandle, ctx: &SharedContext) {
+    dispatch_pr_list_fetch(app_state, ctx, true, true);
 }
 
 /// @plan PLAN-20260624-PR-MODE.P11
@@ -113,6 +128,10 @@ struct PrFetchParams {
     request_id: u64,
     cursor: Option<String>,
     fresh_reload: bool,
+    /// When true, the result is delivered as a silent background refresh
+    /// (`PrListSilentRefreshed`/`PrListSilentRefreshFailed`) that preserves
+    /// selection/scroll and does NOT flash the loading spinner (issue #128).
+    silent: bool,
 }
 
 /// Mark the PR list fetch as loading and return the monotonic request id.
@@ -124,7 +143,13 @@ fn mark_pr_list_fetch_loading(app_state: &mut AppStateHandle, params: &PrFetchPa
     let mut state = app_state.write();
     let request_id = state.prs_state.next_pr_list_request_id.saturating_add(1);
     state.prs_state.next_pr_list_request_id = request_id;
-    if params.fresh_reload {
+    if params.silent && params.fresh_reload {
+        state.mark_pr_list_silent_refresh_loading(
+            params.scope_repo_id.clone(),
+            params.filter.clone(),
+            request_id,
+        );
+    } else if params.fresh_reload {
         state.mark_pr_list_reload_loading(
             params.scope_repo_id.clone(),
             params.filter.clone(),
@@ -146,7 +171,7 @@ fn mark_pr_list_fetch_loading(app_state: &mut AppStateHandle, params: &PrFetchPa
 /// @plan PLAN-20260624-PR-MODE.P11
 /// @requirement REQ-PR-006
 /// @pseudocode component-004 lines 127-137
-fn pr_fetch_params(app_state: &AppStateHandle, fresh_reload: bool) -> PrFetchParams {
+fn pr_fetch_params(app_state: &AppStateHandle, fresh_reload: bool, silent: bool) -> PrFetchParams {
     let state = app_state.read();
     let gh_repo = prs_dispatch::resolve_pr_gh_repo(&state);
     PrFetchParams {
@@ -159,6 +184,7 @@ fn pr_fetch_params(app_state: &AppStateHandle, fresh_reload: bool) -> PrFetchPar
             .then(|| state.prs_state.list_cursor.clone())
             .flatten(),
         fresh_reload,
+        silent,
     }
 }
 
@@ -233,7 +259,9 @@ fn persist_pr_list_loaded(
 ) {
     let has_prs = !response.pull_requests.is_empty();
     let mut state = app_state.write();
-    let should_preview = params.fresh_reload
+    // Silent refresh skips the preview logic (it must not disrupt selection).
+    let should_preview = !params.silent
+        && params.fresh_reload
         && has_prs
         && state
             .selected_repository_index
@@ -248,7 +276,16 @@ fn persist_pr_list_loaded(
                     && pending.filter == params.filter
                     && pending.request_id == params.request_id
             });
-    let event = if params.fresh_reload {
+    let event = if params.silent {
+        AppEvent::PrListSilentRefreshed {
+            scope_repo_id: params.scope_repo_id.clone(),
+            filter: std::boxed::Box::new(params.filter.clone()),
+            request_id: params.request_id,
+            pull_requests: response.pull_requests,
+            cursor: response.cursor,
+            has_more: response.has_more,
+        }
+    } else if params.fresh_reload {
         AppEvent::PrListLoaded {
             scope_repo_id: params.scope_repo_id.clone(),
             filter: std::boxed::Box::new(params.filter.clone()),
@@ -288,15 +325,19 @@ fn persist_pr_list_failed(
     params: &PrFetchParams,
     error: String,
 ) {
-    apply_and_persist(
-        app_state,
-        ctx,
+    let event = if params.silent {
+        AppEvent::PrListSilentRefreshFailed {
+            scope_repo_id: params.scope_repo_id.clone(),
+            request_id: params.request_id,
+        }
+    } else {
         AppEvent::PrListLoadFailed {
             scope_repo_id: params.scope_repo_id.clone(),
             request_id: params.request_id,
             error,
-        },
-    );
+        }
+    };
+    apply_and_persist(app_state, ctx, event);
 }
 
 /// Load more PRs if the selection is at the end of the list.
@@ -311,9 +352,15 @@ pub(super) fn load_more_prs_if_at_end(app_state: &mut AppStateHandle, ctx: &Shar
             .prs_state
             .selected_pr_index
             .is_some_and(|idx| idx + 1 >= state.prs_state.pull_requests.len());
-        at_end && state.prs_state.has_more_prs && !state.prs_state.loading.list
+        // Guard against a pending silent refresh (`loading.list` is false but
+        // `list_reload_pending` is `Some`) so pagination does not clobber an
+        // in-flight background refresh (issue #128).
+        at_end
+            && state.prs_state.has_more_prs
+            && !state.prs_state.loading.list
+            && state.prs_state.list_reload_pending.is_none()
     };
     if should_load {
-        dispatch_pr_list_fetch(app_state, ctx, false);
+        dispatch_pr_list_fetch(app_state, ctx, false, false);
     }
 }

--- a/src/app_input/prs_mutation.rs
+++ b/src/app_input/prs_mutation.rs
@@ -11,7 +11,8 @@
 use jefe::state::{AppEvent, ComposerTarget, InlineState};
 
 use super::{
-    AppStateHandle, SharedContext, apply_and_persist, gh_async, github_client, prs_dispatch,
+    AppStateHandle, SharedContext, apply_and_persist, dispatch_app_event, gh_async, github_client,
+    prs_dispatch,
 };
 
 /// Handle an inline submit for PR Mode.
@@ -153,7 +154,10 @@ fn dispatch_pr_comment_create(
         ctx,
         move |mut app_state, ctx| {
             let event = pr_comment_create_event(&ctx, &repo, &action);
-            apply_and_persist(&mut app_state, &ctx, event);
+            // Route through the full dispatch chain so a successful
+            // `PrCommentCreated` triggers the post-mutation detail reload
+            // (issue #128). A `PrCommentCreateFailed` does not trigger a reload.
+            dispatch_app_event(&mut app_state, &ctx, event);
         },
         move |mut app_state, ctx, message| {
             apply_and_persist(
@@ -221,7 +225,10 @@ fn dispatch_pr_thread_reply(
         ctx,
         move |mut app_state, ctx| {
             let event = pr_thread_reply_event(&ctx, &action, &thread_id);
-            apply_and_persist(&mut app_state, &ctx, event);
+            // Route through the full dispatch chain so a successful
+            // `PrCommentCreated` triggers the post-mutation detail reload
+            // (issue #128). A `PrCommentCreateFailed` does not trigger a reload.
+            dispatch_app_event(&mut app_state, &ctx, event);
         },
         move |mut app_state, ctx, message| {
             apply_and_persist(

--- a/src/app_input/prs_orchestration.rs
+++ b/src/app_input/prs_orchestration.rs
@@ -17,9 +17,10 @@ use tracing::warn;
 
 use super::{
     AppStateHandle, REMOTE_ATTACH_SETTLE_DELAY, SharedContext, apply_and_persist,
-    clear_agent_runtime_attachment, dispatch_app_event, launch_signature_for_agent,
-    mark_agent_runtime_attached, persist_state, pid_on_success, preflight_or_prompt,
-    prs_comments_dispatch, prs_dispatch, prs_list_dispatch, prs_mutation, to_persisted_state,
+    clear_agent_runtime_attachment, dispatch_app_event, gh_async, github_client,
+    launch_signature_for_agent, mark_agent_runtime_attached, persist_state, pid_on_success,
+    preflight_or_prompt, prs_comments_dispatch, prs_dispatch, prs_list_dispatch, prs_mutation,
+    to_persisted_state,
 };
 
 // ── PR-mode dispatch routing + loader helpers ──────────────────────────────
@@ -51,14 +52,19 @@ pub(super) fn dispatch_prs_message(
     ctx: &SharedContext,
     message: PullRequestsMessage,
 ) {
-    use jefe::messages::{PrInlineMsg, ScrollDir};
-
-    // Refresh detail_viewport_rows ONCE at the dispatch boundary (before any
-    // reducer runs a scroll clamp or detail line-count) so every clamp path
-    // uses the current terminal dimensions, not a stale height from a
-    // previous ScrollDetail(Down|PageDown). Reducers stay crossterm-free;
-    // this is the only crossterm read here.
     update_pr_detail_viewport_rows(app_state);
+    route_prs_message(app_state, ctx, message);
+}
+
+/// Route a `PullRequestsMessage` to the appropriate dispatch helper.
+/// Extracted from `dispatch_prs_message` to stay under the per-function line
+/// limit (issue #128).
+fn route_prs_message(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    message: PullRequestsMessage,
+) {
+    use jefe::messages::{PrInlineMsg, ScrollDir};
 
     match message {
         m @ (PullRequestsMessage::Navigate(_)
@@ -111,9 +117,155 @@ pub(super) fn dispatch_prs_message(
             apply_and_persist(app_state, ctx, AppEvent::from(message));
             prs_mutation::handle_pr_thread_resolve(app_state, ctx);
         }
+        PullRequestsMessage::Merged { .. } | PullRequestsMessage::CommentCreated { .. } => {
+            let is_merged = matches!(message, PullRequestsMessage::Merged { .. });
+            dispatch_prs_post_mutation(app_state, ctx, message, is_merged);
+        }
         // All other PullRequests variants (data-load results, notices, etc.)
         // route through the reducer only.
         message => apply_and_persist(app_state, ctx, AppEvent::from(message)),
+    }
+}
+
+/// Post-mutation refresh: after a merge or comment, reload the list/detail to
+/// reflect server state (issue #128).
+fn dispatch_prs_post_mutation(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    message: PullRequestsMessage,
+    is_merged: bool,
+) {
+    apply_and_persist(app_state, ctx, AppEvent::from(message));
+    // Merged reloads BOTH list + detail; CommentCreated reloads detail only.
+    if is_merged {
+        prs_list_dispatch::request_pr_list_reload(app_state, ctx);
+    }
+    prs_dispatch::load_pr_detail_for_selection(app_state, ctx);
+}
+
+/// Request a silent background refresh of the PR list + detail (issue #128).
+///
+/// Fires ONLY when the PR view is open (`DashboardPullRequests`) and no list
+/// or detail load is already in flight. The refresh is silent: it preserves
+/// selection, scroll offset, filter, and search query, and does NOT flash the
+/// loading spinner.
+///
+/// @requirement issue #128
+pub fn request_pr_background_refresh(app_state: &mut AppStateHandle, ctx: &SharedContext) {
+    let should_refresh = {
+        let state = app_state.read();
+        should_background_refresh(
+            state.screen_mode,
+            state.prs_state.list_reload_pending.is_some(),
+            state.prs_state.list_page_pending.is_some(),
+            state.prs_state.detail_pending.is_some(),
+        )
+    };
+    if should_refresh {
+        prs_list_dispatch::request_pr_list_silent_refresh(app_state, ctx);
+        prs_dispatch::load_pr_detail_silent_refresh(app_state, ctx);
+    }
+}
+
+/// Pure guard predicate for `request_pr_background_refresh` (issue #128).
+/// Returns `true` when the PR view is open AND no list/detail load is in
+/// flight. Extracted so the guard logic is unit-testable without an
+/// `AppStateHandle`.
+///
+/// @requirement issue #128
+pub(super) fn should_background_refresh(
+    screen_mode: jefe::state::ScreenMode,
+    list_reload_pending: bool,
+    list_page_pending: bool,
+    detail_pending: bool,
+) -> bool {
+    screen_mode == jefe::state::ScreenMode::DashboardPullRequests
+        && !list_reload_pending
+        && !list_page_pending
+        && !detail_pending
+}
+
+/// Silently refresh PR detail for the currently selected PR (issue #128).
+/// Mirrors `prs_dispatch::load_pr_detail_for_selection` but does NOT set
+/// `loading.detail` (no spinner flash), preserves `detail_subfocus` and
+/// `detail_scroll_offset` on success, and does NOT surface errors visibly on
+/// failure. Lives here (not in `prs_dispatch.rs`) to keep that file under the
+/// architecture boundary line limit.
+///
+/// @requirement issue #128
+pub(super) fn load_pr_detail_silent_refresh(app_state: &mut AppStateHandle, ctx: &SharedContext) {
+    let Some(mut params) = prs_dispatch::pr_detail_load_params(app_state) else {
+        return;
+    };
+    mark_pr_detail_silent_loading(app_state, &mut params);
+    if params.owner.is_empty() || params.repo.is_empty() {
+        // Missing repo: silently clear the pending marker (no visible error).
+        apply_and_persist(app_state, ctx, silent_refresh_failed_event(&params));
+        return;
+    }
+
+    let panic_params = params.clone();
+    gh_async::spawn_gh_task_with_panic(
+        app_state,
+        ctx,
+        move |mut app_state, ctx| {
+            let event = silent_refresh_event(&ctx, &params);
+            apply_and_persist(&mut app_state, &ctx, event);
+        },
+        move |mut app_state, ctx, _message| {
+            // On panic: silently clear the pending marker (no visible error).
+            apply_and_persist(
+                &mut app_state,
+                &ctx,
+                silent_refresh_failed_event(&panic_params),
+            );
+        },
+    );
+}
+
+/// Mark the PR detail as silently loading (does NOT set `loading.detail`).
+/// @requirement issue #128
+fn mark_pr_detail_silent_loading(
+    app_state: &mut AppStateHandle,
+    params: &mut prs_dispatch::PrDetailLoadParams,
+) {
+    let mut state = app_state.write();
+    let request_id = state.next_pr_detail_request_id();
+    state.mark_pr_detail_silent_loading(params.scope_repo_id.clone(), params.pr_number, request_id);
+    drop(state);
+    params.request_id = request_id;
+}
+
+/// Build the silent-refresh detail-loaded/failed event from the gh result.
+/// Unlike the loud variant, failures are delivered as
+/// `PrDetailSilentRefreshFailed` (no visible error) and success as
+/// `PrDetailSilentRefreshed` (no `loading.detail` flag).
+/// @requirement issue #128
+fn silent_refresh_event(
+    ctx: &SharedContext,
+    params: &prs_dispatch::PrDetailLoadParams,
+) -> AppEvent {
+    let result = github_client(ctx).map(|client| {
+        client.get_pull_request_detail(&params.owner, &params.repo, params.pr_number)
+    });
+    match result {
+        Some(Ok(detail)) => AppEvent::PrDetailSilentRefreshed {
+            scope_repo_id: params.scope_repo_id.clone(),
+            pr_number: params.pr_number,
+            request_id: params.request_id,
+            detail: std::boxed::Box::new(detail),
+        },
+        _ => silent_refresh_failed_event(params),
+    }
+}
+
+/// Build the silent-refresh failure event (clears pending, no visible error).
+/// @requirement issue #128
+fn silent_refresh_failed_event(params: &prs_dispatch::PrDetailLoadParams) -> AppEvent {
+    AppEvent::PrDetailSilentRefreshFailed {
+        scope_repo_id: params.scope_repo_id.clone(),
+        pr_number: params.pr_number,
+        request_id: params.request_id,
     }
 }
 

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -10,7 +10,7 @@ use crate::AppContext;
 use crate::app_input::{
     dispatch_app_event, handle_f12_toggle, handle_global_shortcut_key, handle_mode_confirm_key,
     handle_mode_form_key, handle_mode_help_key, handle_mode_search_key, handle_normal_key_event,
-    persist_state, to_persisted_state,
+    persist_state, request_pr_background_refresh, to_persisted_state,
 };
 use crate::pty_encoding::{
     key_to_bytes, mouse_event_to_bytes, should_arm_paste_enter_suppression,
@@ -216,6 +216,21 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
                         smol::unblock(move || persist_state(&ctx_for_persist, &persisted)).await;
                     }
                 }
+            }
+        }
+    });
+
+    // Periodic PR-mode background refresh (~every 60s). Mirrors the liveness
+    // poll pattern: a background loop that fires while the PR view is open and
+    // silently refreshes the PR list + detail without flashing the loading
+    // spinner or disrupting the user's selection/scroll position.
+    hooks.use_future({
+        let ctx = ctx.clone();
+        let mut app_state = app_state;
+        async move {
+            loop {
+                smol::Timer::after(std::time::Duration::from_secs(60)).await;
+                request_pr_background_refresh(&mut app_state, &ctx);
             }
         }
     });

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -330,6 +330,20 @@ pub enum PullRequestsMessage {
         cursor: Option<String>,
         has_more: bool,
     },
+    /// Silent background refresh succeeded (issue #128).
+    ListSilentRefreshed {
+        scope_repo_id: RepositoryId,
+        filter: Box<PrFilter>,
+        request_id: u64,
+        pull_requests: Vec<PullRequest>,
+        cursor: Option<String>,
+        has_more: bool,
+    },
+    /// Silent background refresh failed (issue #128).
+    ListSilentRefreshFailed {
+        scope_repo_id: RepositoryId,
+        request_id: u64,
+    },
     DetailLoaded {
         scope_repo_id: RepositoryId,
         pr_number: u64,
@@ -341,6 +355,19 @@ pub enum PullRequestsMessage {
         pr_number: u64,
         request_id: u64,
         error: String,
+    },
+    /// Silent background detail refresh succeeded (issue #128).
+    DetailSilentRefreshed {
+        scope_repo_id: RepositoryId,
+        pr_number: u64,
+        request_id: u64,
+        detail: Box<PullRequestDetail>,
+    },
+    /// Silent background detail refresh failed (issue #128).
+    DetailSilentRefreshFailed {
+        scope_repo_id: RepositoryId,
+        pr_number: u64,
+        request_id: u64,
     },
     CommentsPageLoaded {
         scope_repo_id: RepositoryId,
@@ -803,8 +830,12 @@ message_names!(PullRequestsMessage {
     Self::ListLoaded { .. } => "PrListLoaded",
     Self::ListLoadFailed { .. } => "PrListLoadFailed",
     Self::ListPageLoaded { .. } => "PrListPageLoaded",
+    Self::ListSilentRefreshed { .. } => "PrListSilentRefreshed",
+    Self::ListSilentRefreshFailed { .. } => "PrListSilentRefreshFailed",
     Self::DetailLoaded { .. } => "PrDetailLoaded",
     Self::DetailLoadFailed { .. } => "PrDetailLoadFailed",
+    Self::DetailSilentRefreshed { .. } => "PrDetailSilentRefreshed",
+    Self::DetailSilentRefreshFailed { .. } => "PrDetailSilentRefreshFailed",
     Self::CommentsPageLoaded { .. } => "PrCommentsPageLoaded",
     Self::CommentsPageFailed { .. } => "PrCommentsPageFailed",
     Self::OpenFilterControls => "PrOpenFilterControls",

--- a/src/messages/prs_conversion.rs
+++ b/src/messages/prs_conversion.rs
@@ -87,10 +87,13 @@ impl PullRequestsMessage {
         match event {
             AppEvent::PrListLoaded { .. }
             | AppEvent::PrListLoadFailed { .. }
-            | AppEvent::PrListPageLoaded { .. } => Self::from_app_event_list(event),
-            AppEvent::PrDetailLoaded { .. } | AppEvent::PrDetailLoadFailed { .. } => {
-                Self::from_app_event_detail(event)
-            }
+            | AppEvent::PrListPageLoaded { .. }
+            | AppEvent::PrListSilentRefreshed { .. }
+            | AppEvent::PrListSilentRefreshFailed { .. } => Self::from_app_event_list(event),
+            AppEvent::PrDetailLoaded { .. }
+            | AppEvent::PrDetailLoadFailed { .. }
+            | AppEvent::PrDetailSilentRefreshed { .. }
+            | AppEvent::PrDetailSilentRefreshFailed { .. } => Self::from_app_event_detail(event),
             AppEvent::PrCommentsPageLoaded { .. } | AppEvent::PrCommentsPageFailed { .. } => {
                 Self::from_app_event_comments(event)
             }
@@ -104,6 +107,9 @@ impl PullRequestsMessage {
     /// @requirement REQ-PR-NFR-001
     /// @pseudocode component-004 lines 51-67
     fn from_app_event_list(event: AppEvent) -> Self {
+        if let Some(msg) = Self::from_app_event_silent_refresh(&event) {
+            return msg;
+        }
         match event {
             AppEvent::PrListLoaded {
                 scope_repo_id,
@@ -146,6 +152,35 @@ impl PullRequestsMessage {
         }
     }
 
+    /// Silent-refresh list events (issue #128).
+    fn from_app_event_silent_refresh(event: &AppEvent) -> Option<Self> {
+        match event {
+            AppEvent::PrListSilentRefreshed {
+                scope_repo_id,
+                filter,
+                request_id,
+                pull_requests,
+                cursor,
+                has_more,
+            } => Some(Self::ListSilentRefreshed {
+                scope_repo_id: scope_repo_id.clone(),
+                filter: filter.clone(),
+                request_id: *request_id,
+                pull_requests: pull_requests.clone(),
+                cursor: cursor.clone(),
+                has_more: *has_more,
+            }),
+            AppEvent::PrListSilentRefreshFailed {
+                scope_repo_id,
+                request_id,
+            } => Some(Self::ListSilentRefreshFailed {
+                scope_repo_id: scope_repo_id.clone(),
+                request_id: *request_id,
+            }),
+            _ => None,
+        }
+    }
+
     /// Detail loaded/error payload events.
     ///
     /// @plan PLAN-20260624-PR-MODE.P05
@@ -174,6 +209,26 @@ impl PullRequestsMessage {
                 pr_number,
                 request_id,
                 error,
+            },
+            AppEvent::PrDetailSilentRefreshed {
+                scope_repo_id,
+                pr_number,
+                request_id,
+                detail,
+            } => Self::DetailSilentRefreshed {
+                scope_repo_id,
+                pr_number,
+                request_id,
+                detail,
+            },
+            AppEvent::PrDetailSilentRefreshFailed {
+                scope_repo_id,
+                pr_number,
+                request_id,
+            } => Self::DetailSilentRefreshFailed {
+                scope_repo_id,
+                pr_number,
+                request_id,
             },
             _ => unreachable!("non-detail AppEvent routed to detail converter"),
         }
@@ -499,12 +554,15 @@ impl PullRequestsMessage {
     /// @pseudocode component-004 lines 68-85
     fn into_app_event_data(self) -> AppEvent {
         match self {
-            Self::ListLoaded { .. } | Self::ListLoadFailed { .. } | Self::ListPageLoaded { .. } => {
-                self.into_app_event_list()
-            }
-            Self::DetailLoaded { .. } | Self::DetailLoadFailed { .. } => {
-                self.into_app_event_detail()
-            }
+            Self::ListLoaded { .. }
+            | Self::ListLoadFailed { .. }
+            | Self::ListPageLoaded { .. }
+            | Self::ListSilentRefreshed { .. }
+            | Self::ListSilentRefreshFailed { .. } => self.into_app_event_list(),
+            Self::DetailLoaded { .. }
+            | Self::DetailLoadFailed { .. }
+            | Self::DetailSilentRefreshed { .. }
+            | Self::DetailSilentRefreshFailed { .. } => self.into_app_event_detail(),
             Self::CommentsPageLoaded { .. } | Self::CommentsPageFailed { .. } => {
                 self.into_app_event_comments()
             }
@@ -518,6 +576,9 @@ impl PullRequestsMessage {
     /// @requirement REQ-PR-NFR-001
     /// @pseudocode component-004 lines 68-85
     fn into_app_event_list(self) -> AppEvent {
+        if let Some(event) = self.silent_refresh_to_app_event() {
+            return event;
+        }
         match self {
             Self::ListLoaded {
                 scope_repo_id,
@@ -560,6 +621,35 @@ impl PullRequestsMessage {
         }
     }
 
+    /// Convert silent-refresh PR messages back into `AppEvent` (issue #128).
+    fn silent_refresh_to_app_event(&self) -> Option<AppEvent> {
+        match self {
+            Self::ListSilentRefreshed {
+                scope_repo_id,
+                filter,
+                request_id,
+                pull_requests,
+                cursor,
+                has_more,
+            } => Some(AppEvent::PrListSilentRefreshed {
+                scope_repo_id: scope_repo_id.clone(),
+                filter: filter.clone(),
+                request_id: *request_id,
+                pull_requests: pull_requests.clone(),
+                cursor: cursor.clone(),
+                has_more: *has_more,
+            }),
+            Self::ListSilentRefreshFailed {
+                scope_repo_id,
+                request_id,
+            } => Some(AppEvent::PrListSilentRefreshFailed {
+                scope_repo_id: scope_repo_id.clone(),
+                request_id: *request_id,
+            }),
+            _ => None,
+        }
+    }
+
     /// Detail loaded/error payload messages.
     ///
     /// @plan PLAN-20260624-PR-MODE.P05
@@ -588,6 +678,26 @@ impl PullRequestsMessage {
                 pr_number,
                 request_id,
                 error,
+            },
+            Self::DetailSilentRefreshed {
+                scope_repo_id,
+                pr_number,
+                request_id,
+                detail,
+            } => AppEvent::PrDetailSilentRefreshed {
+                scope_repo_id,
+                pr_number,
+                request_id,
+                detail,
+            },
+            Self::DetailSilentRefreshFailed {
+                scope_repo_id,
+                pr_number,
+                request_id,
+            } => AppEvent::PrDetailSilentRefreshFailed {
+                scope_repo_id,
+                pr_number,
+                request_id,
             },
             _ => unreachable!("non-detail PullRequestsMessage routed to detail"),
         }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -859,6 +859,11 @@ mod prs_tests_components;
 ///
 /// @plan PLAN-20260624-PR-MODE.P05
 /// @requirement REQ-PR-009
+/// Silent background refresh state-transition tests (issue #128).
+#[cfg(test)]
+#[path = "prs_tests_silent_refresh.rs"]
+mod prs_tests_silent_refresh;
+
 #[cfg(test)]
 #[path = "prs_tests_review_threads.rs"]
 mod prs_tests_review_threads;

--- a/src/state/prs_load_ops.rs
+++ b/src/state/prs_load_ops.rs
@@ -22,6 +22,17 @@ pub(super) struct PrListLoadedData {
     has_more: bool,
 }
 
+/// Payload for a silent background refresh (issue #128). Mirrors
+/// `PrListLoadedData` but the reducer preserves selection/scroll/detail.
+pub(super) struct PrListSilentRefreshedData {
+    pub(super) scope_repo_id: RepositoryId,
+    pub(super) filter: PrFilter,
+    pub(super) request_id: u64,
+    pub(super) pull_requests: Vec<PullRequest>,
+    pub(super) cursor: Option<String>,
+    pub(super) has_more: bool,
+}
+
 pub(super) struct PrListPageLoadedData {
     scope_repo_id: RepositoryId,
     request_id: u64,
@@ -58,7 +69,10 @@ impl AppState {
         self.prs_state.loading.list = false;
         self.prs_state.list_reload_pending = None;
         self.prs_state.list_page_pending = None;
-        self.prs_state.detail_pending = None;
+        // Do NOT clear detail_pending here — clearing it cancels any in-flight
+        // detail load (e.g. the post-merge detail reload). The detail staleness
+        // guard (pr_detail_pending_matches) already discards stale results when
+        // the scope or selected PR number changes (issue #128).
         if self.prs_state.pull_requests.is_empty() {
             self.prs_state.selected_pr_index = None;
             self.prs_state.pr_detail = None;
@@ -73,6 +87,76 @@ impl AppState {
             self.prs_state.detail_scroll_offset = 0;
         }
         self.prs_state.list_scroll_offset = 0;
+    }
+
+    /// Apply a silent background refresh (issue #128). Mirrors
+    /// `apply_pr_list_loaded` but preserves selection, scroll offset, and
+    /// `pr_detail`, and does NOT set `loading.list` (no spinner flash).
+    ///
+    /// @requirement issue #128
+    pub(super) fn apply_pr_list_silent_refreshed(&mut self, data: PrListSilentRefreshedData) {
+        if !self.pr_list_reload_pending_matches(&data.scope_repo_id, &data.filter, data.request_id)
+        {
+            return;
+        }
+        // Remember the selected PR by number so we can follow it across a
+        // reorder or list replacement.
+        let selected_pr_number = self
+            .prs_state
+            .selected_pr_index
+            .and_then(|idx| self.prs_state.pull_requests.get(idx))
+            .map(|pr| pr.number);
+        self.prs_state.error = None;
+        self.prs_state.pull_requests = data.pull_requests;
+        self.prs_state.list_cursor = data.cursor;
+        self.prs_state.has_more_prs = data.has_more;
+        // Do NOT set loading.list — this is a silent background refresh.
+        self.prs_state.list_reload_pending = None;
+        self.prs_state.list_page_pending = None;
+        // Do NOT clear detail_pending or pr_detail — the detail reload is a
+        // separate operation; preserve the current detail until it arrives.
+        self.preserve_silent_refresh_selection(selected_pr_number);
+    }
+
+    /// Re-derive selection + scroll after a silent refresh (issue #128 helper).
+    fn preserve_silent_refresh_selection(&mut self, selected_pr_number: Option<u64>) {
+        if self.prs_state.pull_requests.is_empty() {
+            self.prs_state.selected_pr_index = None;
+            // Do NOT clear pr_detail on an empty silent refresh (issue #128):
+            // the detail pane keeps showing the last-loaded detail until the
+            // next manual reload, avoiding an empty flash.
+            return;
+        }
+        // Follow the previously-selected PR by number; fall back to first.
+        let new_index = selected_pr_number
+            .and_then(|num| {
+                self.prs_state
+                    .pull_requests
+                    .iter()
+                    .position(|pr| pr.number == num)
+            })
+            .unwrap_or(0);
+        self.prs_state.selected_pr_index = Some(new_index);
+        // Clamp the scroll offset so it never exceeds the new list bounds.
+        let max_scroll = self.prs_state.pull_requests.len().saturating_sub(1);
+        if self.prs_state.list_scroll_offset > max_scroll {
+            self.prs_state.list_scroll_offset = max_scroll;
+        }
+    }
+
+    /// Apply a silent background refresh failure (issue #128). Clears the
+    /// pending marker WITHOUT surfacing an error (silent, non-disruptive).
+    ///
+    /// @requirement issue #128
+    pub(super) fn apply_pr_list_silent_refresh_failed(
+        &mut self,
+        scope_repo_id: &RepositoryId,
+        request_id: u64,
+    ) {
+        if self.pr_list_reload_pending_matches_id(scope_repo_id, request_id) {
+            self.prs_state.list_reload_pending = None;
+            // Do NOT set error — background failures are silent.
+        }
     }
 
     /// Apply a PR list page (append) with staleness guards.
@@ -112,6 +196,43 @@ impl AppState {
         self.prs_state.detail_pending = None;
         self.prs_state.detail_subfocus = PrDetailSubfocus::Body;
         self.prs_state.detail_scroll_offset = 0;
+    }
+
+    /// Apply a silent background detail refresh (issue #128). Mirrors
+    /// `apply_pr_detail_loaded` but does NOT set `loading.detail`, does NOT
+    /// reset `detail_subfocus` or `detail_scroll_offset`, and does NOT set an
+    /// error. Preserves the user's scroll/focus position.
+    ///
+    /// @requirement issue #128
+    pub(super) fn apply_pr_detail_silent_refreshed(
+        &mut self,
+        scope_repo_id: RepositoryId,
+        pr_number: u64,
+        request_id: u64,
+        detail: crate::domain::PullRequestDetail,
+    ) {
+        if !self.pr_detail_pending_matches(&scope_repo_id, pr_number, request_id) {
+            return;
+        }
+        // Do NOT set loading.detail (silent), do NOT reset detail_subfocus or
+        // detail_scroll_offset, do NOT set error.
+        self.prs_state.pr_detail = Some(detail);
+        self.prs_state.detail_pending = None;
+    }
+
+    /// Apply a silent background detail refresh failure (issue #128). Clears
+    /// `detail_pending` silently WITHOUT setting `loading.detail` or an error.
+    ///
+    /// @requirement issue #128
+    pub(super) fn apply_pr_detail_silent_refresh_failed(
+        &mut self,
+        scope_repo_id: &RepositoryId,
+        pr_number: u64,
+        request_id: u64,
+    ) {
+        if self.pr_detail_pending_matches(scope_repo_id, pr_number, request_id) {
+            self.prs_state.detail_pending = None;
+        }
     }
 
     /// Apply a PR comments page (append) with staleness guards.
@@ -347,6 +468,22 @@ impl AppState {
         });
     }
 
+    /// Mark a silent background refresh as pending (issue #128). Does NOT set
+    /// `loading.list` (no spinner flash) and does NOT clear `detail_pending`.
+    pub fn mark_pr_list_silent_refresh_loading(
+        &mut self,
+        scope_repo_id: RepositoryId,
+        filter: PrFilter,
+        request_id: u64,
+    ) {
+        self.prs_state.list_page_pending = None;
+        self.prs_state.list_reload_pending = Some(PrListReloadPending {
+            scope_repo_id,
+            filter,
+            request_id,
+        });
+    }
+
     /// Mark a PR list page as loading (staleness tracking).
     ///
     /// @plan PLAN-20260624-PR-MODE.P05
@@ -388,6 +525,24 @@ impl AppState {
         });
     }
 
+    /// Mark a PR detail silent refresh as pending (issue #128). Sets
+    /// `detail_pending` for staleness tracking but does NOT set
+    /// `loading.detail` (no spinner flash).
+    ///
+    /// @requirement issue #128
+    pub fn mark_pr_detail_silent_loading(
+        &mut self,
+        scope_repo_id: RepositoryId,
+        pr_number: u64,
+        request_id: u64,
+    ) {
+        self.prs_state.detail_pending = Some(PrDetailPending {
+            scope_repo_id,
+            pr_number,
+            request_id,
+        });
+    }
+
     /// Next PR detail request ID (staleness counter).
     ///
     /// @plan PLAN-20260624-PR-MODE.P05
@@ -417,56 +572,134 @@ impl AppState {
     /// @requirement REQ-PR-009
     /// @pseudocode component-001 lines 21-27,209-241
     pub(crate) fn apply_prs_data(&mut self, event: AppEvent) {
+        if let AppEvent::PrListSilentRefreshed { .. } = event {
+            self.apply_prs_silent_list_data(event);
+            return;
+        }
         match event {
-            AppEvent::PrListLoaded {
-                scope_repo_id,
-                filter,
-                request_id,
-                pull_requests,
-                cursor,
-                has_more,
-            } => self.apply_pr_list_loaded(PrListLoadedData {
+            AppEvent::PrListLoaded { .. } => self.apply_prs_list_loaded_data(event),
+            AppEvent::PrListPageLoaded { .. } => self.apply_prs_list_page_data(event),
+            detail_event @ (AppEvent::PrDetailLoaded { .. }
+            | AppEvent::PrDetailSilentRefreshed { .. }) => {
+                self.apply_prs_detail_data(detail_event);
+            }
+            AppEvent::PrCommentsPageLoaded { .. } => self.apply_prs_comments_data(event),
+            _ => {}
+        }
+    }
+
+    /// Apply a silent list refresh event (issue #128). Extracted from
+    /// `apply_prs_data` to keep it under the per-function line limit.
+    fn apply_prs_silent_list_data(&mut self, event: AppEvent) {
+        if let AppEvent::PrListSilentRefreshed {
+            scope_repo_id,
+            filter,
+            request_id,
+            pull_requests,
+            cursor,
+            has_more,
+        } = event
+        {
+            self.apply_pr_list_silent_refreshed(PrListSilentRefreshedData {
                 scope_repo_id,
                 filter: *filter,
                 request_id,
                 pull_requests,
                 cursor,
                 has_more,
-            }),
-            AppEvent::PrListPageLoaded {
+            });
+        }
+    }
+
+    /// Apply a `PrListLoaded` event. Extracted from `apply_prs_data`.
+    fn apply_prs_list_loaded_data(&mut self, event: AppEvent) {
+        if let AppEvent::PrListLoaded {
+            scope_repo_id,
+            filter,
+            request_id,
+            pull_requests,
+            cursor,
+            has_more,
+        } = event
+        {
+            self.apply_pr_list_loaded(PrListLoadedData {
+                scope_repo_id,
+                filter: *filter,
+                request_id,
+                pull_requests,
+                cursor,
+                has_more,
+            });
+        }
+    }
+
+    /// Apply a `PrListPageLoaded` event. Extracted from `apply_prs_data`.
+    fn apply_prs_list_page_data(&mut self, event: AppEvent) {
+        if let AppEvent::PrListPageLoaded {
+            scope_repo_id,
+            request_id,
+            pull_requests,
+            cursor,
+            has_more,
+        } = event
+        {
+            self.apply_pr_list_page_loaded(PrListPageLoadedData {
                 scope_repo_id,
                 request_id,
                 pull_requests,
                 cursor,
                 has_more,
-            } => self.apply_pr_list_page_loaded(PrListPageLoadedData {
+            });
+        }
+    }
+
+    /// Apply a `PrCommentsPageLoaded` event. Extracted from `apply_prs_data`.
+    fn apply_prs_comments_data(&mut self, event: AppEvent) {
+        if let AppEvent::PrCommentsPageLoaded {
+            scope_repo_id,
+            pr_number,
+            request_id,
+            comments,
+            cursor,
+            has_more,
+        } = event
+        {
+            self.apply_pr_comments_page_loaded(PrCommentsPageLoadedData {
                 scope_repo_id,
+                pr_number,
                 request_id,
-                pull_requests,
+                comments,
                 cursor,
                 has_more,
-            }),
+            });
+        }
+    }
+
+    /// Apply a detail data event (loud or silent). Extracted from
+    /// `apply_prs_data` to keep it under the per-function line limit.
+    ///
+    /// @requirement issue #128
+    fn apply_prs_detail_data(&mut self, event: AppEvent) {
+        match event {
             AppEvent::PrDetailLoaded {
                 scope_repo_id,
                 pr_number,
                 request_id,
                 detail,
             } => self.apply_pr_detail_loaded(scope_repo_id, pr_number, request_id, *detail),
-            AppEvent::PrCommentsPageLoaded {
+            AppEvent::PrDetailSilentRefreshed {
                 scope_repo_id,
                 pr_number,
                 request_id,
-                comments,
-                cursor,
-                has_more,
-            } => self.apply_pr_comments_page_loaded(PrCommentsPageLoadedData {
-                scope_repo_id,
-                pr_number,
-                request_id,
-                comments,
-                cursor,
-                has_more,
-            }),
+                detail,
+            } => {
+                self.apply_pr_detail_silent_refreshed(
+                    scope_repo_id,
+                    pr_number,
+                    request_id,
+                    *detail,
+                );
+            }
             _ => {}
         }
     }
@@ -483,12 +716,21 @@ impl AppState {
                 request_id,
                 error,
             } => self.apply_pr_list_load_failed(&scope_repo_id, request_id, error),
+            AppEvent::PrListSilentRefreshFailed {
+                scope_repo_id,
+                request_id,
+            } => self.apply_pr_list_silent_refresh_failed(&scope_repo_id, request_id),
             AppEvent::PrDetailLoadFailed {
                 scope_repo_id,
                 pr_number,
                 request_id,
                 error,
             } => self.apply_pr_detail_load_failed(&scope_repo_id, pr_number, request_id, error),
+            AppEvent::PrDetailSilentRefreshFailed {
+                scope_repo_id,
+                pr_number,
+                request_id,
+            } => self.apply_pr_detail_silent_refresh_failed(&scope_repo_id, pr_number, request_id),
             AppEvent::PrCommentsPageFailed {
                 scope_repo_id,
                 pr_number,

--- a/src/state/prs_ops.rs
+++ b/src/state/prs_ops.rs
@@ -597,7 +597,9 @@ impl AppState {
             event,
             AppEvent::PrListLoaded { .. }
                 | AppEvent::PrListPageLoaded { .. }
+                | AppEvent::PrListSilentRefreshed { .. }
                 | AppEvent::PrDetailLoaded { .. }
+                | AppEvent::PrDetailSilentRefreshed { .. }
                 | AppEvent::PrCommentsPageLoaded { .. }
         );
         if handled {
@@ -615,7 +617,9 @@ impl AppState {
         let handled = matches!(
             event,
             AppEvent::PrListLoadFailed { .. }
+                | AppEvent::PrListSilentRefreshFailed { .. }
                 | AppEvent::PrDetailLoadFailed { .. }
+                | AppEvent::PrDetailSilentRefreshFailed { .. }
                 | AppEvent::PrCommentsPageFailed { .. }
         );
         if handled {

--- a/src/state/prs_tests_detail_flow.rs
+++ b/src/state/prs_tests_detail_flow.rs
@@ -491,3 +491,5 @@ fn test_list_loaded_non_empty_clears_stale_pr_detail() {
         "detail_subfocus MUST reset to Body"
     );
 }
+
+// Silent background refresh tests moved to prs_tests_silent_refresh.rs (issue #128).

--- a/src/state/prs_tests_silent_refresh.rs
+++ b/src/state/prs_tests_silent_refresh.rs
@@ -1,0 +1,571 @@
+//! Silent background refresh state-transition tests (issue #128).
+//!
+//! These tests verify the reducer semantics for `PrListSilentRefreshed`,
+//! `PrListSilentRefreshFailed`, `PrDetailSilentRefreshed`, and
+//! `PrDetailSilentRefreshFailed`:
+//! - Selection is preserved by PR number across list replacement/reorder.
+//! - Scroll offset is preserved (clamped to new list bounds).
+//! - Filter, search query, and `pr_detail` are NOT clobbered.
+//! - `loading.list` / `loading.detail` are NOT set (no spinner flash).
+//! - Errors are NOT surfaced on silent failure.
+//! - Stale scope/request_id results are discarded.
+//! - Loud `PrListLoaded` does NOT cancel an in-flight detail load.
+
+use crate::domain::{
+    IssueComment, PrCheckStatus, PrFilter, PrState, PullRequest, PullRequestDetail, Repository,
+    RepositoryId,
+};
+use crate::state::AppState;
+use crate::state::types::{AppEvent, ScreenMode};
+
+// ── Test fixtures ──────────────────────────────────────────────────────────
+
+/// Build a PR-mode AppState with the given repo scope.
+fn prs_mode_state(repo_id: &str) -> AppState {
+    let mut state = AppState {
+        screen_mode: ScreenMode::DashboardPullRequests,
+        ..AppState::default()
+    };
+    state.repositories.push(Repository::new(
+        RepositoryId(repo_id.to_string()),
+        "Test Repo".to_string(),
+        repo_id.to_string(),
+        std::path::PathBuf::from("/tmp/test"),
+    ));
+    state.selected_repository_index = Some(0);
+    state.prs_state.active = true;
+    state.prs_state.pr_focus = crate::state::PrFocus::PrList;
+    state
+}
+
+/// Build a minimal test `PullRequest` with the given number.
+fn make_test_pr(number: u64) -> PullRequest {
+    PullRequest {
+        number,
+        title: format!("PR #{number}"),
+        state: PrState::Open,
+        author_login: "testuser".to_string(),
+        updated_at: "2024-01-01T00:00:00Z".to_string(),
+        head_ref: "feature".to_string(),
+        base_ref: "main".to_string(),
+        is_draft: false,
+        review_decision: None,
+        checks_status: PrCheckStatus::None,
+        assignee_summary: String::new(),
+        labels_summary: String::new(),
+        comment_count: 0,
+    }
+}
+
+/// Build a minimal test `PullRequestDetail` with the given comments list.
+fn make_test_pr_detail(number: u64, comments: Vec<IssueComment>) -> PullRequestDetail {
+    PullRequestDetail {
+        repo_owner_name: "owner/repo".to_string(),
+        number,
+        title: format!("PR #{number}"),
+        state: PrState::Open,
+        is_draft: false,
+        author_login: "octocat".to_string(),
+        created_at: "2024-01-01T00:00:00Z".to_string(),
+        updated_at: "2024-01-02T00:00:00Z".to_string(),
+        head_ref: "feature".to_string(),
+        base_ref: "main".to_string(),
+        labels: vec![],
+        assignees: vec![],
+        milestone: None,
+        body: "PR body".to_string(),
+        external_url: format!("https://github.com/owner/repo/pull/{number}"),
+        review_decision: None,
+        checks_status: PrCheckStatus::None,
+        reviews: vec![],
+        checks: vec![],
+        comments,
+        has_more_comments: true,
+        comments_cursor: Some("cursor-1".to_string()),
+        mergeable: None,
+        merge_state_status: None,
+    }
+}
+
+/// Seed a `list_reload_pending` for the given scope + filter + request_id so
+/// the silent-refresh staleness guard passes.
+fn seed_silent_refresh_pending(state: &mut AppState, scope: &str, request_id: u64) {
+    state.prs_state.committed_filter = PrFilter::default();
+    state.prs_state.list_reload_pending = Some(crate::state::types::PrListReloadPending {
+        scope_repo_id: RepositoryId(scope.to_string()),
+        filter: PrFilter::default(),
+        request_id,
+    });
+}
+
+// ── Loud PrListLoaded: detail_pending preservation ─────────────────────────
+
+/// A loud (non-silent) `PrListLoaded` must NOT clear `detail_pending` (issue
+/// #128). This prevents a concurrent loud list reload (e.g. the post-merge
+/// refresh) from cancelling an in-flight detail load. The detail staleness
+/// guard already discards stale detail results when scope/PR changes.
+///
+/// @requirement issue #128
+#[test]
+fn test_list_loaded_does_not_clear_detail_pending() {
+    let mut state = prs_mode_state("repo-1");
+    state.prs_state.pull_requests = vec![make_test_pr(1), make_test_pr(2)];
+    state.prs_state.selected_pr_index = Some(1);
+    state.prs_state.committed_filter = PrFilter::default();
+    state.prs_state.list_reload_pending = Some(crate::state::types::PrListReloadPending {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        filter: PrFilter::default(),
+        request_id: 100,
+    });
+    // Simulate an in-flight detail load.
+    state.prs_state.detail_pending = Some(crate::state::types::PrDetailPending {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        pr_number: 2,
+        request_id: 42,
+    });
+
+    let new_state = state.apply(AppEvent::PrListLoaded {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        filter: Box::new(PrFilter::default()),
+        request_id: 100,
+        pull_requests: vec![make_test_pr(1), make_test_pr(2)],
+        cursor: None,
+        has_more: false,
+    });
+
+    assert!(
+        new_state.prs_state.detail_pending.is_some(),
+        "loud PrListLoaded must NOT clear detail_pending (issue #128)"
+    );
+}
+
+// ── Silent list refresh: selection + scroll preservation ───────────────────
+
+/// Silent refresh preserves selection + scroll when the PR list is unchanged
+/// in membership (same PR numbers, updated data) and does NOT flash the
+/// loading spinner or clear pr_detail.
+///
+/// @requirement issue #128
+#[test]
+fn test_silent_refresh_preserves_selection_and_scroll() {
+    let mut state = prs_mode_state("repo-1");
+    state.prs_state.pull_requests = (1u64..=5).map(make_test_pr).collect();
+    state.prs_state.selected_pr_index = Some(2);
+    state.prs_state.list_scroll_offset = 2;
+    state.prs_state.pr_detail = Some(make_test_pr_detail(3, vec![]));
+    seed_silent_refresh_pending(&mut state, "repo-1", 100);
+
+    let new_state = state.apply(AppEvent::PrListSilentRefreshed {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        filter: Box::new(PrFilter::default()),
+        request_id: 100,
+        pull_requests: (1u64..=5).map(make_test_pr).collect(),
+        cursor: None,
+        has_more: false,
+    });
+
+    assert_eq!(
+        new_state.prs_state.selected_pr_index,
+        Some(2),
+        "selection must be preserved"
+    );
+    assert_eq!(
+        new_state.prs_state.list_scroll_offset, 2,
+        "scroll offset must be preserved"
+    );
+    assert!(
+        !new_state.prs_state.loading.list,
+        "silent refresh must NOT set loading.list"
+    );
+    assert!(
+        new_state.prs_state.list_reload_pending.is_none(),
+        "silent refresh must clear list_reload_pending"
+    );
+    assert!(
+        new_state.prs_state.pr_detail.is_some(),
+        "silent refresh must NOT clear pr_detail"
+    );
+}
+
+/// Silent refresh preserves selection when PRs are reordered — the selected
+/// PR is tracked by number, not by index.
+///
+/// @requirement issue #128
+#[test]
+fn test_silent_refresh_preserves_selection_when_pr_reordered() {
+    let mut state = prs_mode_state("repo-1");
+    state.prs_state.pull_requests = vec![make_test_pr(1), make_test_pr(2), make_test_pr(3)];
+    state.prs_state.selected_pr_index = Some(1); // PR #2
+    seed_silent_refresh_pending(&mut state, "repo-1", 100);
+
+    let new_state = state.apply(AppEvent::PrListSilentRefreshed {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        filter: Box::new(PrFilter::default()),
+        request_id: 100,
+        pull_requests: vec![make_test_pr(3), make_test_pr(2), make_test_pr(1)],
+        cursor: None,
+        has_more: false,
+    });
+
+    assert_eq!(
+        new_state.prs_state.selected_pr_index,
+        Some(1),
+        "selection must track PR #2 by number (now at index 1)"
+    );
+    assert_eq!(
+        new_state.prs_state.pull_requests.get(1).map(|pr| pr.number),
+        Some(2),
+        "index 1 must be PR #2"
+    );
+}
+
+/// Silent refresh falls back to first PR when the selected PR is no longer in
+/// the list (merged/closed elsewhere), and clamps scroll offset.
+///
+/// @requirement issue #128
+#[test]
+fn test_silent_refresh_handles_selected_pr_removed() {
+    let mut state = prs_mode_state("repo-1");
+    state.prs_state.pull_requests = vec![make_test_pr(1), make_test_pr(2), make_test_pr(3)];
+    state.prs_state.selected_pr_index = Some(1); // PR #2
+    state.prs_state.list_scroll_offset = 2;
+    seed_silent_refresh_pending(&mut state, "repo-1", 100);
+
+    let new_state = state.apply(AppEvent::PrListSilentRefreshed {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        filter: Box::new(PrFilter::default()),
+        request_id: 100,
+        pull_requests: vec![make_test_pr(1), make_test_pr(3)],
+        cursor: None,
+        has_more: false,
+    });
+
+    assert_eq!(
+        new_state.prs_state.selected_pr_index,
+        Some(0),
+        "removed PR: selection falls back to first"
+    );
+    assert!(
+        new_state.prs_state.list_scroll_offset <= 1,
+        "scroll offset must be clamped to new list bounds"
+    );
+}
+
+// ── Silent list refresh: staleness guards ──────────────────────────────────
+
+/// Silent refresh discards results with a mismatched scope_repo_id.
+///
+/// @requirement issue #128
+#[test]
+fn test_silent_refresh_discards_stale_scope() {
+    let mut state = prs_mode_state("repo-1");
+    state.prs_state.pull_requests = vec![make_test_pr(1), make_test_pr(2)];
+    state.prs_state.selected_pr_index = Some(0);
+    seed_silent_refresh_pending(&mut state, "repo-1", 100);
+
+    let new_state = state.apply(AppEvent::PrListSilentRefreshed {
+        scope_repo_id: RepositoryId("repo-WRONG".to_string()),
+        filter: Box::new(PrFilter::default()),
+        request_id: 100,
+        pull_requests: vec![make_test_pr(99)],
+        cursor: None,
+        has_more: false,
+    });
+
+    assert_eq!(
+        new_state.prs_state.pull_requests.len(),
+        2,
+        "stale scope result must be discarded"
+    );
+    assert!(
+        new_state.prs_state.list_reload_pending.is_some(),
+        "stale scope: list_reload_pending must remain"
+    );
+}
+
+// ── Silent list refresh: no loading/error flags ────────────────────────────
+
+/// Silent refresh does NOT set loading.list or error.
+///
+/// @requirement issue #128
+#[test]
+fn test_silent_refresh_does_not_set_loading_or_error() {
+    let mut state = prs_mode_state("repo-1");
+    state.prs_state.pull_requests = vec![make_test_pr(1), make_test_pr(2)];
+    state.prs_state.selected_pr_index = Some(0);
+    state.prs_state.loading.list = false;
+    state.prs_state.error = None;
+    seed_silent_refresh_pending(&mut state, "repo-1", 100);
+
+    let new_state = state.apply(AppEvent::PrListSilentRefreshed {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        filter: Box::new(PrFilter::default()),
+        request_id: 100,
+        pull_requests: vec![make_test_pr(1), make_test_pr(2)],
+        cursor: None,
+        has_more: false,
+    });
+
+    assert!(
+        !new_state.prs_state.loading.list,
+        "silent refresh must NOT set loading.list"
+    );
+    assert!(
+        new_state.prs_state.error.is_none(),
+        "silent refresh must NOT set error"
+    );
+}
+
+// ── Silent list refresh failure ────────────────────────────────────────────
+
+/// Silent refresh failure clears pending WITHOUT setting an error.
+///
+/// @requirement issue #128
+#[test]
+fn test_silent_refresh_failed_clears_pending_without_error() {
+    let mut state = prs_mode_state("repo-1");
+    state.prs_state.pull_requests = vec![make_test_pr(1)];
+    state.prs_state.error = None;
+    seed_silent_refresh_pending(&mut state, "repo-1", 100);
+
+    let new_state = state.apply(AppEvent::PrListSilentRefreshFailed {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        request_id: 100,
+    });
+
+    assert!(
+        new_state.prs_state.list_reload_pending.is_none(),
+        "silent refresh failure must clear list_reload_pending"
+    );
+    assert!(
+        new_state.prs_state.error.is_none(),
+        "silent refresh failure must NOT set error"
+    );
+}
+
+/// Silent list refresh failure with a STALE request_id must be discarded
+/// (the pending marker for the CURRENT request_id remains).
+///
+/// @requirement issue #128
+#[test]
+fn test_silent_refresh_failed_discards_stale_request_id() {
+    let mut state = prs_mode_state("repo-1");
+    state.prs_state.pull_requests = vec![make_test_pr(1)];
+    state.prs_state.committed_filter = PrFilter::default();
+    state.prs_state.list_reload_pending = Some(crate::state::types::PrListReloadPending {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        filter: PrFilter::default(),
+        request_id: 100,
+    });
+
+    let new_state = state.apply(AppEvent::PrListSilentRefreshFailed {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        request_id: 999,
+    });
+
+    assert!(
+        new_state.prs_state.list_reload_pending.is_some(),
+        "stale silent-refresh failure must be discarded (pending remains)"
+    );
+    let pending = new_state
+        .prs_state
+        .list_reload_pending
+        .as_ref()
+        .unwrap_or_else(|| panic!("pending must remain"));
+    assert_eq!(
+        pending.request_id, 100,
+        "the CURRENT request_id (100) must still be pending"
+    );
+}
+
+// ── Silent list refresh: pr_detail preservation ───────────────────────────
+
+/// Silent refresh must NOT clear `pr_detail` (unlike loud `PrListLoaded`).
+///
+/// @requirement issue #128
+#[test]
+fn test_silent_refresh_does_not_clear_pr_detail() {
+    let mut state = prs_mode_state("repo-1");
+    let detail = make_test_pr_detail(2, vec![]);
+    state.prs_state.pr_detail = Some(detail);
+    state.prs_state.pull_requests = vec![make_test_pr(1), make_test_pr(2)];
+    state.prs_state.selected_pr_index = Some(1);
+    state.prs_state.detail_scroll_offset = 3;
+    seed_silent_refresh_pending(&mut state, "repo-1", 100);
+
+    let new_state = state.apply(AppEvent::PrListSilentRefreshed {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        filter: Box::new(PrFilter::default()),
+        request_id: 100,
+        pull_requests: vec![make_test_pr(1), make_test_pr(2)],
+        cursor: None,
+        has_more: false,
+    });
+
+    assert!(
+        new_state.prs_state.pr_detail.is_some(),
+        "silent refresh must NOT clear pr_detail"
+    );
+    assert_eq!(
+        new_state.prs_state.detail_scroll_offset, 3,
+        "silent refresh must NOT reset detail_scroll_offset"
+    );
+}
+
+/// Silent list refresh with an empty list must NOT clear `pr_detail` (issue
+/// #128 remediation). The detail pane keeps showing the last-loaded detail
+/// until the next manual reload, avoiding an empty flash.
+///
+/// @requirement issue #128
+#[test]
+fn test_silent_refresh_empty_list_preserves_pr_detail() {
+    let mut state = prs_mode_state("repo-1");
+    state.prs_state.pr_detail = Some(make_test_pr_detail(2, vec![]));
+    state.prs_state.pull_requests = vec![make_test_pr(1), make_test_pr(2)];
+    state.prs_state.selected_pr_index = Some(1);
+    seed_silent_refresh_pending(&mut state, "repo-1", 100);
+
+    let new_state = state.apply(AppEvent::PrListSilentRefreshed {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        filter: Box::new(PrFilter::default()),
+        request_id: 100,
+        pull_requests: vec![],
+        cursor: None,
+        has_more: false,
+    });
+
+    assert!(
+        new_state.prs_state.pr_detail.is_some(),
+        "silent refresh with empty list must NOT clear pr_detail"
+    );
+    assert!(
+        new_state.prs_state.selected_pr_index.is_none(),
+        "empty list must clear selected_pr_index"
+    );
+}
+
+// ── Silent list refresh: search query + filter preservation ───────────────
+
+/// Silent list refresh must preserve the search query and committed filter.
+///
+/// @requirement issue #128
+#[test]
+fn test_silent_refresh_preserves_search_query_and_filter() {
+    let mut state = prs_mode_state("repo-1");
+    state.prs_state.pull_requests = vec![make_test_pr(1), make_test_pr(2)];
+    state.prs_state.selected_pr_index = Some(0);
+    state.prs_state.search_query = "foo".to_string();
+    let filter = PrFilter {
+        state: Some(crate::domain::PrFilterState::Open),
+        ..PrFilter::default()
+    };
+    state.prs_state.committed_filter = filter.clone();
+    // Seed pending with the SAME filter so the staleness guard passes.
+    state.prs_state.list_reload_pending = Some(crate::state::types::PrListReloadPending {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        filter: filter.clone(),
+        request_id: 100,
+    });
+
+    let new_state = state.apply(AppEvent::PrListSilentRefreshed {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        filter: Box::new(filter),
+        request_id: 100,
+        pull_requests: vec![make_test_pr(1), make_test_pr(2)],
+        cursor: None,
+        has_more: false,
+    });
+
+    assert_eq!(
+        new_state.prs_state.search_query, "foo",
+        "silent refresh must preserve search_query"
+    );
+    assert_eq!(
+        new_state.prs_state.committed_filter.state,
+        Some(crate::domain::PrFilterState::Open),
+        "silent refresh must preserve committed_filter"
+    );
+}
+
+// ── Silent detail refresh ──────────────────────────────────────────────────
+
+/// Silent detail refresh must preserve `detail_subfocus` and
+/// `detail_scroll_offset` (NOT reset them to Body/0 like the loud load).
+///
+/// @requirement issue #128
+#[test]
+fn test_silent_detail_refresh_preserves_subfocus_and_scroll() {
+    let mut state = prs_mode_state("repo-1");
+    state.prs_state.pull_requests = vec![make_test_pr(5)];
+    state.prs_state.selected_pr_index = Some(0);
+    state.prs_state.pr_detail = Some(make_test_pr_detail(5, vec![]));
+    state.prs_state.detail_subfocus = crate::state::types::PrDetailSubfocus::Comment(1);
+    state.prs_state.detail_scroll_offset = 5;
+    state.prs_state.detail_pending = Some(crate::state::types::PrDetailPending {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        pr_number: 5,
+        request_id: 42,
+    });
+
+    let new_state = state.apply(AppEvent::PrDetailSilentRefreshed {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        pr_number: 5,
+        request_id: 42,
+        detail: std::boxed::Box::new(make_test_pr_detail(5, vec![])),
+    });
+
+    assert_eq!(
+        new_state.prs_state.detail_subfocus,
+        crate::state::types::PrDetailSubfocus::Comment(1),
+        "silent detail refresh must preserve detail_subfocus"
+    );
+    assert_eq!(
+        new_state.prs_state.detail_scroll_offset, 5,
+        "silent detail refresh must preserve detail_scroll_offset"
+    );
+    assert!(
+        new_state.prs_state.detail_pending.is_none(),
+        "silent detail refresh must clear detail_pending"
+    );
+    assert!(
+        !new_state.prs_state.loading.detail,
+        "silent detail refresh must NOT set loading.detail"
+    );
+}
+
+/// Silent detail refresh failure must clear `detail_pending` WITHOUT setting an
+/// error or `loading.detail`.
+///
+/// @requirement issue #128
+#[test]
+fn test_silent_detail_refresh_failed_does_not_set_error() {
+    let mut state = prs_mode_state("repo-1");
+    state.prs_state.pull_requests = vec![make_test_pr(5)];
+    state.prs_state.selected_pr_index = Some(0);
+    state.prs_state.error = None;
+    state.prs_state.loading.detail = false;
+    state.prs_state.detail_pending = Some(crate::state::types::PrDetailPending {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        pr_number: 5,
+        request_id: 42,
+    });
+
+    let new_state = state.apply(AppEvent::PrDetailSilentRefreshFailed {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        pr_number: 5,
+        request_id: 42,
+    });
+
+    assert!(
+        new_state.prs_state.error.is_none(),
+        "silent detail refresh failure must NOT set an error"
+    );
+    assert!(
+        new_state.prs_state.detail_pending.is_none(),
+        "silent detail refresh failure must clear detail_pending"
+    );
+    assert!(
+        !new_state.prs_state.loading.detail,
+        "silent detail refresh failure must NOT set loading.detail"
+    );
+}

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -731,6 +731,22 @@ pub enum AppEvent {
         cursor: Option<String>,
         has_more: bool,
     },
+    /// Silent background refresh succeeded (issue #128). Like `PrListLoaded`
+    /// but preserves selection/scroll and does NOT flash the loading spinner.
+    PrListSilentRefreshed {
+        scope_repo_id: RepositoryId,
+        filter: Box<crate::domain::PrFilter>,
+        request_id: u64,
+        pull_requests: Vec<crate::domain::PullRequest>,
+        cursor: Option<String>,
+        has_more: bool,
+    },
+    /// Silent background refresh failed (issue #128). Clears the pending marker
+    /// WITHOUT surfacing an error (background failures are non-disruptive).
+    PrListSilentRefreshFailed {
+        scope_repo_id: RepositoryId,
+        request_id: u64,
+    },
     PrDetailLoaded {
         scope_repo_id: RepositoryId,
         pr_number: u64,
@@ -742,6 +758,22 @@ pub enum AppEvent {
         pr_number: u64,
         request_id: u64,
         error: String,
+    },
+    /// Silent background detail refresh succeeded (issue #128). Like
+    /// `PrDetailLoaded` but does NOT set `loading.detail` and preserves
+    /// `detail_subfocus` and `detail_scroll_offset`.
+    PrDetailSilentRefreshed {
+        scope_repo_id: RepositoryId,
+        pr_number: u64,
+        request_id: u64,
+        detail: Box<crate::domain::PullRequestDetail>,
+    },
+    /// Silent background detail refresh failed (issue #128). Clears
+    /// `detail_pending` silently WITHOUT setting `loading.detail` or an error.
+    PrDetailSilentRefreshFailed {
+        scope_repo_id: RepositoryId,
+        pr_number: u64,
+        request_id: u64,
     },
     PrCommentsPageLoaded {
         scope_repo_id: RepositoryId,


### PR DESCRIPTION
## Summary

The PR view never refreshed on its own. Once the PR list and detail were loaded, the data was frozen until the user manually re-entered the mode, refocused (p), changed the filter/search, or switched repositories. This PR implements GitHub issue #128.

## Changes

### 1. Periodic silent background refresh (~60s)

A fourth background `use_future` loop in `src/app_shell.rs` fires every 60 seconds. When `screen_mode == DashboardPullRequests` and no list/detail load is in flight, it triggers a **silent** refresh of both the PR list and the selected PR detail.

The silent refresh:
- Does **NOT** flash the "Loading pull requests..." spinner (uses `mark_pr_list_silent_refresh_loading` / `mark_pr_detail_silent_loading` which skip the `loading.list` / `loading.detail` flags)
- **Preserves selection** by tracking the selected PR by number across list replacement/reorder
- **Preserves scroll offset** (clamped to new list bounds)
- **Preserves filter, search query, and pr_detail** (the detail pane keeps showing the last-loaded detail until the silent detail refresh updates it)
- Does **NOT** surface errors visibly on failure (background failures are silent)

### 2. Post-mutation refresh

After a successful in-app merge (`PrMerged`), the orchestration layer triggers a loud list reload + detail reload so the merged PR leaves an open-filtered view and the detail reflects post-merge state. After a comment creation (`PrCommentCreated`), a detail reload is triggered.

Merge and comment results are now routed through `dispatch_app_event` (instead of `apply_and_persist`) so they hit the `PullRequestsMessage::Merged` / `CommentCreated` arms in the dispatch chain, which trigger the reloads.

### 3. Staleness / clobber guards

- Background refresh is skipped when any list or detail load is already in flight (`should_background_refresh` predicate checks `list_reload_pending`, `list_page_pending`, and `detail_pending`)
- Pagination (`load_more_prs_if_at_end`) is blocked when a silent refresh is pending
- Loud `PrListLoaded` no longer clears `detail_pending` — this prevents a concurrent loud list reload (e.g. post-merge) from cancelling an in-flight detail load. The detail staleness guard (`pr_detail_pending_matches`) already discards stale results when scope or selected PR changes.
- Silent refresh of a repo with no GitHub slug: silently no-ops (does NOT surface a visible error)

## New event/message variants

- `AppEvent::PrListSilentRefreshed` / `PrListSilentRefreshFailed`
- `AppEvent::PrDetailSilentRefreshed` / `PrDetailSilentRefreshFailed`
- Corresponding `PullRequestsMessage` variants with bidirectional conversion in `prs_conversion.rs`

## Tests

13 new behavioral tests:

**Reducer tests** (`src/state/prs_tests_detail_flow.rs`):
- `test_silent_refresh_preserves_selection_and_scroll` — same PRs, updated data: selection/scroll preserved
- `test_silent_refresh_preserves_selection_when_pr_reordered` — selection tracks PR by number across reorder
- `test_silent_refresh_handles_selected_pr_removed` — removed PR falls back to first, scroll clamped
- `test_silent_refresh_discards_stale_scope` — mismatched scope_repo_id discarded
- `test_silent_refresh_does_not_set_loading_or_error` — no spinner, no error
- `test_silent_refresh_failed_clears_pending_without_error` — failure is silent
- `test_silent_refresh_does_not_clear_pr_detail` — detail preserved (unlike loud PrListLoaded)
- `test_silent_refresh_empty_list_preserves_pr_detail` — empty list does NOT clear detail
- `test_silent_refresh_failed_discards_stale_request_id` — stale failure discarded
- `test_silent_refresh_preserves_search_query_and_filter` — search/filter untouched
- `test_silent_detail_refresh_preserves_subfocus_and_scroll` — detail subfocus/scroll preserved
- `test_silent_detail_refresh_failed_does_not_set_error` — detail failure silent
- `test_list_loaded_does_not_clear_detail_pending` — loud list load does NOT cancel in-flight detail

**Integration tests** (`src/app_input/prs_integration_tests.rs`):
- `test_pr_merged_clears_pending_and_marks_merged` — merge lifecycle effects
- `test_background_refresh_function_exists_and_checks_screen_mode` — API existence
- `test_background_refresh_skips_when_detail_load_in_flight` — clobber guard

## Verification

All gates pass:
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo build --workspace --all-features --locked` ✅
- `cargo test --workspace --all-features --locked` ✅ (717 + 199 + 6 + 238 = 1160 tests)
- All files under 1000-line hard limit
- No `#[allow(clippy::...)]` directives, no unwrap/expect in production paths

Closes #128