### PR TITLE
Add mouse text selection and OSC 52 clipboard copy (Fixes #141)

### DIFF
--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -13,8 +13,8 @@ use crate::app_input::{
     persist_state, request_pr_background_refresh, to_persisted_state,
 };
 use crate::pty_encoding::{
-    key_to_bytes, mouse_event_to_bytes, should_arm_paste_enter_suppression,
-    should_disarm_paste_enter_suppression, should_suppress_synthetic_enter,
+    key_to_bytes, should_arm_paste_enter_suppression, should_disarm_paste_enter_suppression,
+    should_suppress_synthetic_enter,
 };
 
 use jefe::domain::{AgentId, AgentStatus};
@@ -367,8 +367,8 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     }
 }
 
-type HookState<T> = iocraft::hooks::State<T>;
-type CtxArc = Arc<std::sync::Mutex<AppContext>>;
+pub type HookState<T> = iocraft::hooks::State<T>;
+pub type CtxArc = Arc<std::sync::Mutex<AppContext>>;
 
 /// Dispatch a terminal event to the appropriate input/runtime handler.
 ///
@@ -383,21 +383,34 @@ fn handle_terminal_event(
     suppress_next_enter: &mut HookState<bool>,
 ) {
     match event {
-        TerminalEvent::Resize(cols, rows) => handle_resize(ctx, cols, rows),
+        TerminalEvent::Resize(cols, rows) => {
+            crate::mouse_routing::clear_selection(app_state);
+            handle_resize(ctx, cols, rows);
+        }
         TerminalEvent::FullscreenMouse(mouse_event) => {
-            handle_fullscreen_mouse(ctx, app_state, mouse_event);
+            crate::mouse_routing::handle_fullscreen_mouse(ctx, app_state, mouse_event);
         }
         TerminalEvent::Paste(pasted_text) => {
+            crate::mouse_routing::clear_selection(app_state);
             handle_paste(ctx, app_state, suppress_next_enter, pasted_text);
         }
-        TerminalEvent::Key(key_event) => handle_key_event(
-            ctx,
-            app_state,
-            should_quit,
-            help_scroll,
-            suppress_next_enter,
-            key_event,
-        ),
+        TerminalEvent::Key(key_event) => {
+            // Clear selection on any keypress except Esc. Esc always clears;
+            // other keys also clear so the selection doesn't linger after the
+            // user transitions to keyboard interaction. (If keyboard copy of
+            // the selection is added later, that key would be excluded here.)
+            if key_event.kind != iocraft::KeyEventKind::Release {
+                crate::mouse_routing::clear_selection(app_state);
+            }
+            handle_key_event(
+                ctx,
+                app_state,
+                should_quit,
+                help_scroll,
+                suppress_next_enter,
+                key_event,
+            );
+        }
         _ => {}
     }
 }
@@ -408,64 +421,6 @@ fn handle_resize(ctx: Option<&CtxArc>, cols: u16, rows: u16) {
     {
         let layout = compute_pty_layout(cols, rows);
         let _ = ctx_guard.runtime.resize(layout.pty_rows, layout.pty_cols);
-    }
-}
-
-fn handle_fullscreen_mouse(
-    ctx: Option<&CtxArc>,
-    app_state: &HookState<AppState>,
-    mouse_event: iocraft::FullscreenMouseEvent,
-) {
-    let terminal_input_enabled = {
-        let state = app_state.read();
-        state.terminal_focused && state.pane_focus == PaneFocus::Terminal
-    };
-    if !terminal_input_enabled {
-        return;
-    }
-
-    let Some(ctx_arc) = ctx else {
-        return;
-    };
-    let Ok(mut ctx_guard) = ctx_arc.lock() else {
-        return;
-    };
-
-    if !ctx_guard.runtime.mouse_reporting_active() {
-        return;
-    }
-
-    let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
-    let layout = compute_pty_layout(cols, rows);
-
-    let row_end = layout
-        .pane_row0
-        .saturating_add(layout.pty_rows.saturating_sub(1));
-    let col_end = layout
-        .pane_col0
-        .saturating_add(layout.pty_cols.saturating_sub(1));
-
-    let screen_row0 = mouse_event.row;
-    let screen_col0 = mouse_event.column;
-
-    let in_terminal_bounds = screen_col0 >= layout.pane_col0
-        && screen_col0 <= col_end
-        && screen_row0 >= layout.pane_row0
-        && screen_row0 <= row_end;
-
-    if !in_terminal_bounds {
-        return;
-    }
-
-    let local_row = screen_row0.saturating_sub(layout.pane_row0);
-    let local_col = screen_col0.saturating_sub(layout.pane_col0);
-
-    let mut local_event =
-        iocraft::FullscreenMouseEvent::new(mouse_event.kind, local_col, local_row);
-    local_event.modifiers = mouse_event.modifiers;
-
-    if let Some(bytes) = mouse_event_to_bytes(&local_event) {
-        let _ = ctx_guard.runtime.write_input(&bytes);
     }
 }
 
@@ -829,7 +784,7 @@ fn clear_all_attachments(app_state: &mut HookState<AppState>) {
 }
 
 /// Capture terminal output for the currently selected agent if available.
-fn capture_terminal_snapshot(
+pub fn capture_terminal_snapshot(
     ctx: Option<&CtxArc>,
     snapshot: &AppState,
     selected_agent_id: Option<&AgentId>,

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -268,13 +268,19 @@ fn build_screen_inner(b64: &str) -> Vec<u8> {
 
 /// Truncate the inner OSC 52 bytes to fit screen's DCS segment limit, on a
 /// 4-char base64 boundary so the truncated payload stays decodable.
+///
+/// The inner buffer layout is `OSC_PREFIX + base64 + BEL`. The OSC prefix
+/// (`\x1b]52;c;`) is 7 bytes, so truncation must align to a base64 4-char
+/// boundary *within the payload*, not within the whole buffer.
+const SCREEN_INNER_PREFIX_LEN: usize = 7;
 fn truncate_for_screen(inner: &[u8]) -> &[u8] {
     if inner.len() <= SCREEN_DCS_CHUNK_BYTES {
         return inner;
     }
-    let limit = SCREEN_DCS_CHUNK_BYTES;
-    let boundary = (limit / 4) * 4;
-    &inner[..boundary.max(4)]
+    let available_for_b64 = SCREEN_DCS_CHUNK_BYTES.saturating_sub(SCREEN_INNER_PREFIX_LEN);
+    let b64_boundary = (available_for_b64 / 4) * 4;
+    let cut = SCREEN_INNER_PREFIX_LEN + b64_boundary.max(4);
+    &inner[..cut.min(inner.len())]
 }
 
 #[cfg(test)]
@@ -385,6 +391,19 @@ mod tests {
             s.ends_with("\x1b\\"),
             "expected DCS terminator at end, got: {s:?}"
         );
+        // The embedded base64 payload must be a multiple of 4 so it decodes.
+        let b64_start = s.find("]52;c;").map(|i| i + 6);
+        if let Some(start) = b64_start {
+            let b64_end = s[start..].find('\x07').map(|i| start + i);
+            if let Some(end) = b64_end {
+                let b64_len = end - start;
+                assert_eq!(
+                    b64_len % 4,
+                    0,
+                    "base64 payload length {b64_len} must be a multiple of 4"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,387 @@
+//! OSC 52 clipboard writer with tmux / GNU screen passthrough.
+//!
+//! Writes an [OSC 52] selection-copy escape sequence so the controlling
+//! terminal emulator copies `text` to the system clipboard. The sequence is
+//! wrapped in a tmux DCS passthrough when `$TMUX` is set, and chunked into GNU
+//! screen DCS segments when `$STY` is set (screen enforces a small per-passthrough
+//! byte limit).
+//!
+//! The core writer ([`write_osc52_to_writer`]) is fully testable with a mock
+//! writer; the public entry point ([`write_osc52`]) opens `/dev/tty` on Unix so
+//! the escape sequence reaches the terminal even when stdout is piped.
+//!
+//! No external `base64` crate: a minimal RFC 4648 standard encoder is provided
+//! here so the dependency surface stays small.
+//!
+//! [OSC 52]: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands
+
+use std::io::{self, Write};
+
+/// Maximum base64 payload size before the copy is truncated.
+///
+/// Keeps escape sequences within terminal buffer limits. ~100 KiB of base64
+/// corresponds to ~75 KiB of source text, far beyond any realistic selection.
+pub const MAX_BASE64_PAYLOAD_BYTES: usize = 100_000;
+
+/// Per-chunk byte cap for GNU screen DCS passthrough.
+///
+/// screen reassembles `ESC P ... ESC \` segments but caps each at a small size;
+/// 240 bytes stays safely under the limit observed in practice.
+pub const SCREEN_DCS_CHUNK_BYTES: usize = 240;
+
+const ESC: u8 = 0x1b;
+const BEL: u8 = 0x07;
+
+const BASE64_ALPHABET: &[u8; 64] =
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/// Which multiplexer passthrough (if any) the OSC 52 sequence must be wrapped in.
+///
+/// Detected from the environment by [`detect_passthrough_mode`] and accepted
+/// explicitly by [`write_osc52_to_writer_with_mode`] so the wrapping logic is
+/// unit-testable without mutating process-global environment variables.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PassthroughMode {
+    /// No multiplexer: emit a plain OSC 52 sequence.
+    None,
+    /// Inside tmux (`$TMUX` set): wrap in a tmux DCS passthrough.
+    Tmux,
+    /// Inside GNU screen (`$STY` set): chunk into screen DCS segments.
+    Screen,
+}
+
+/// Detect the required passthrough mode from the process environment.
+///
+/// tmux takes precedence when both `TMUX` and `STY` are set (the common nesting
+/// is screen-inside-tmux, where tmux's outer passthrough is what matters).
+#[must_use]
+pub fn detect_passthrough_mode() -> PassthroughMode {
+    // SAFETY: `var_os` is safe to call (read-only). It is not marked `unsafe`.
+    if std::env::var_os("TMUX").is_some() {
+        PassthroughMode::Tmux
+    } else if std::env::var_os("STY").is_some() {
+        PassthroughMode::Screen
+    } else {
+        PassthroughMode::None
+    }
+}
+
+/// Write an OSC 52 copy sequence for `text` to `writer`.
+///
+/// The passthrough mode is auto-detected from the environment. Returns the
+/// number of bytes written on success.
+///
+/// # Errors
+///
+/// Propagates any underlying [`io::Write`] error.
+pub fn write_osc52_to_writer(text: &str, writer: &mut impl Write) -> io::Result<usize> {
+    write_osc52_to_writer_with_mode(text, detect_passthrough_mode(), writer)
+}
+
+/// Write an OSC 52 copy sequence using an explicit passthrough mode.
+///
+/// Equivalent to [`write_osc52_to_writer`] but lets tests pass the mode directly
+/// instead of mutating global environment variables. Returns the number of
+/// bytes written.
+///
+/// # Errors
+///
+/// Propagates any underlying [`io::Write`] error.
+pub fn write_osc52_to_writer_with_mode(
+    text: &str,
+    mode: PassthroughMode,
+    writer: &mut impl Write,
+) -> io::Result<usize> {
+    let b64 = base64_encode(text.as_bytes());
+    let truncated = truncate_payload(&b64);
+    write_payload_with_mode(&truncated, mode, writer)
+}
+
+/// Write an OSC 52 copy sequence for `text` to the controlling terminal.
+///
+/// On Unix this opens `/dev/tty` so the sequence is delivered even when stdout
+/// is redirected; on non-Unix targets it falls back to stdout. Errors are
+/// surfaced to the caller (the mouse router logs them via `tracing`).
+///
+/// # Errors
+///
+/// Returns the underlying I/O error if neither `/dev/tty` nor stdout is
+/// writable.
+pub fn write_osc52(text: &str) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        match std::fs::OpenOptions::new().write(true).open("/dev/tty") {
+            Ok(mut tty) => {
+                write_osc52_to_writer(text, &mut tty)?;
+                return Ok(());
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "could not open /dev/tty for OSC 52; falling back to stdout");
+            }
+        }
+    }
+    let stdout = io::stdout();
+    let mut lock = stdout.lock();
+    write_osc52_to_writer(text, &mut lock)?;
+    Ok(())
+}
+
+/// Minimal RFC 4648 standard base64 encoder (with `=` padding).
+#[must_use]
+fn base64_encode(input: &[u8]) -> String {
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let mut buf = [0u8; 3];
+        for (i, byte) in chunk.iter().enumerate() {
+            buf[i] = *byte;
+        }
+        let b0 = usize::from(buf[0]);
+        let b1 = usize::from(buf[1]);
+        let b2 = usize::from(buf[2]);
+        out.push(char::from(BASE64_ALPHABET[b0 >> 2]));
+        out.push(char::from(BASE64_ALPHABET[((b0 & 0x03) << 4) | (b1 >> 4)]));
+        if chunk.len() > 1 {
+            out.push(char::from(BASE64_ALPHABET[((b1 & 0x0f) << 2) | (b2 >> 6)]));
+        } else {
+            out.push('=');
+        }
+        if chunk.len() > 2 {
+            out.push(char::from(BASE64_ALPHABET[b2 & 0x3f]));
+        } else {
+            out.push('=');
+        }
+    }
+    out
+}
+
+/// Truncate the base64 string to the max payload size, keeping it valid base64.
+#[must_use]
+fn truncate_payload(b64: &str) -> String {
+    if b64.len() <= MAX_BASE64_PAYLOAD_BYTES {
+        return b64.to_string();
+    }
+    // Trim back to a multiple-of-4 boundary so the base64 stays decodable.
+    let cut = MAX_BASE64_PAYLOAD_BYTES - (MAX_BASE64_PAYLOAD_BYTES % 4);
+    b64[..cut].to_string()
+}
+
+/// Emit the (optionally wrapped) OSC 52 payload to `writer` for `mode`.
+fn write_payload_with_mode(
+    b64: &str,
+    mode: PassthroughMode,
+    writer: &mut impl Write,
+) -> io::Result<usize> {
+    match mode {
+        PassthroughMode::Tmux => write_tmux_passthrough(b64, writer),
+        PassthroughMode::Screen => write_screen_passthrough(b64, writer),
+        PassthroughMode::None => write_plain_osc52(b64, writer),
+    }
+}
+
+/// Plain OSC 52: `ESC ] 52 ; c ; <base64> BEL`.
+fn write_plain_osc52(b64: &str, writer: &mut impl Write) -> io::Result<usize> {
+    let mut buf: Vec<u8> = Vec::with_capacity(b64.len() + 16);
+    buf.extend_from_slice(&[ESC, b']']);
+    buf.extend_from_slice(b"52;c;");
+    buf.extend_from_slice(b64.as_bytes());
+    buf.push(BEL);
+    writer.write_all(&buf)?;
+    Ok(buf.len())
+}
+
+/// tmux DCS passthrough: each `ESC` byte inside the payload is doubled.
+///
+/// Emits `ESC P tmux ; ESC ESC ] 52 ; c ; <base64, ESC-doubled> ESC ESC \ ESC \`.
+fn write_tmux_passthrough(b64: &str, writer: &mut impl Write) -> io::Result<usize> {
+    let mut buf: Vec<u8> = Vec::new();
+    buf.extend_from_slice(b"\x1bPtmux;");
+    // The inner OSC 52 sequence is `\x1b]52;c;<base64>\x07`. Every ESC byte
+    // inside the DCS payload must be doubled so tmux forwards them literally.
+    buf.extend_from_slice(&escape_for_tmux(b"\x1b]52;c;"));
+    buf.extend_from_slice(&escape_for_tmux(b64.as_bytes()));
+    buf.extend_from_slice(&escape_for_tmux(b"\x07"));
+    buf.extend_from_slice(b"\x1b\\\x1b\\");
+    writer.write_all(&buf)?;
+    Ok(buf.len())
+}
+
+/// Double every `ESC` byte so the sequence survives tmux passthrough embedding.
+fn escape_for_tmux(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(byte);
+        if byte == ESC {
+            out.push(ESC);
+        }
+    }
+    out
+}
+
+/// GNU screen DCS passthrough, chunked to stay under screen's per-segment limit.
+fn write_screen_passthrough(b64: &str, writer: &mut impl Write) -> io::Result<usize> {
+    let mut total = 0usize;
+    for chunk in b64.as_bytes().chunks(SCREEN_DCS_CHUNK_BYTES) {
+        let mut buf: Vec<u8> = Vec::with_capacity(chunk.len() + 16);
+        buf.extend_from_slice(b"\x1bP\x1b]52;c;");
+        buf.extend_from_slice(chunk);
+        buf.push(BEL);
+        buf.extend_from_slice(b"\x1b\\");
+        writer.write_all(&buf)?;
+        total += buf.len();
+    }
+    Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_encodes_known_ascii() {
+        // "hi" -> base64 "aGk=" (RFC 4648 test vector).
+        assert_eq!(base64_encode(b"hi"), "aGk=");
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"abc"), "YWJj");
+    }
+
+    #[test]
+    fn base64_encodes_utf8_bytes() {
+        // "é" is 0xC3 0xA9 in UTF-8 -> base64 "w6k=".
+        assert_eq!(base64_encode("é".as_bytes()), "w6k=");
+    }
+
+    #[test]
+    fn write_osc52_plain_ascii() {
+        let mut out: Vec<u8> = Vec::new();
+        if let Err(e) = write_osc52_to_writer_with_mode("hi", PassthroughMode::None, &mut out) {
+            panic!("write failed: {e}");
+        }
+        let expected: Vec<u8> = vec![
+            ESC, b']', b'5', b'2', b';', b'c', b';', b'a', b'G', b'k', b'=', BEL,
+        ];
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn write_osc52_utf8_text() {
+        let mut out: Vec<u8> = Vec::new();
+        if let Err(e) = write_osc52_to_writer_with_mode("é", PassthroughMode::None, &mut out) {
+            panic!("write failed: {e}");
+        }
+        let Ok(s) = String::from_utf8(out) else {
+            panic!("non-UTF8 output");
+        };
+        assert!(s.ends_with("w6k=\u{7}"), "got {s:?}");
+        assert!(s.starts_with("\x1b]52;c;"), "got {s:?}");
+    }
+
+    #[test]
+    fn write_osc52_empty_string() {
+        let mut out: Vec<u8> = Vec::new();
+        if let Err(e) = write_osc52_to_writer_with_mode("", PassthroughMode::None, &mut out) {
+            panic!("write failed: {e}");
+        }
+        let expected: Vec<u8> = vec![ESC, b']', b'5', b'2', b';', b'c', b';', BEL];
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn write_osc52_tmux_passthrough_exact_bytes() {
+        let mut out: Vec<u8> = Vec::new();
+        if let Err(e) = write_osc52_to_writer_with_mode("hi", PassthroughMode::Tmux, &mut out) {
+            panic!("write failed: {e}");
+        }
+        // Expected: ESC P t m u x ; ESC ESC ] 5 2 ; c ; a G k = BEL ESC \ ESC \
+        // The inner OSC 52 is `\x1b]52;c;aGk=\x07` with every ESC doubled.
+        let expected: Vec<u8> = vec![
+            ESC, b'P', b't', b'm', b'u', b'x', b';', ESC, ESC, b']', b'5', b'2', b';', b'c', b';',
+            b'a', b'G', b'k', b'=', BEL, ESC, b'\\', ESC, b'\\',
+        ];
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn write_osc52_screen_passthrough_emits_chunk() {
+        let mut out: Vec<u8> = Vec::new();
+        if let Err(e) = write_osc52_to_writer_with_mode("hi", PassthroughMode::Screen, &mut out) {
+            panic!("write failed: {e}");
+        }
+        let Ok(s) = String::from_utf8(out) else {
+            panic!("non-UTF8 output");
+        };
+        assert!(
+            s.contains("\x1bP\x1b]52;c;aGk=\u{7}\x1b\\"),
+            "screen chunk missing: {s:?}"
+        );
+    }
+
+    #[test]
+    fn write_osc52_screen_passthrough_splits_large_payload() {
+        // A payload whose base64 exceeds one screen chunk must produce >1 segment.
+        let big = "a".repeat(SCREEN_DCS_CHUNK_BYTES * 4);
+        let mut out: Vec<u8> = Vec::new();
+        if let Err(e) = write_osc52_to_writer_with_mode(&big, PassthroughMode::Screen, &mut out) {
+            panic!("write failed: {e}");
+        }
+        let Ok(s) = String::from_utf8(out) else {
+            panic!("non-UTF8 output");
+        };
+        let segment_count = s.matches("\x1bP\x1b]52;c;").count();
+        assert!(
+            segment_count > 1,
+            "expected multiple chunks, got {segment_count}: {s:?}"
+        );
+    }
+
+    #[test]
+    fn write_osc52_truncates_large_payload() {
+        let big = "a".repeat(MAX_BASE64_PAYLOAD_BYTES * 2);
+        let mut out: Vec<u8> = Vec::new();
+        if let Err(e) = write_osc52_to_writer_with_mode(&big, PassthroughMode::None, &mut out) {
+            panic!("write failed: {e}");
+        }
+        let Ok(s) = String::from_utf8(out) else {
+            panic!("non-UTF8 output");
+        };
+        let payload = s
+            .strip_prefix("\x1b]52;c;")
+            .and_then(|rest| rest.strip_suffix('\u{7}'))
+            .unwrap_or_default();
+        // Truncated payload must be valid base64: length is a multiple of 4.
+        assert_eq!(
+            payload.len() % 4,
+            0,
+            "payload not multiple of 4: {payload:?}"
+        );
+        assert!(payload.len() <= MAX_BASE64_PAYLOAD_BYTES);
+    }
+
+    #[test]
+    fn truncate_keeps_short_payloads_unchanged() {
+        assert_eq!(truncate_payload("aGk="), "aGk=");
+    }
+
+    #[test]
+    fn truncate_lands_on_multiple_of_four() {
+        let overlong = "A".repeat(MAX_BASE64_PAYLOAD_BYTES + 5);
+        let got = truncate_payload(&overlong);
+        // The result must be valid base64: length is a multiple of 4.
+        assert_eq!(got.len() % 4, 0, "truncated payload not multiple of 4");
+        assert!(got.len() <= MAX_BASE64_PAYLOAD_BYTES);
+    }
+
+    #[test]
+    fn escape_for_tmux_doubles_esc_only() {
+        let got = escape_for_tmux(b"\x1b]52");
+        assert_eq!(got, b"\x1b\x1b]52");
+        // Non-ESC bytes pass through unchanged.
+        let got2 = escape_for_tmux(b"abc");
+        assert_eq!(got2, b"abc");
+    }
+
+    #[test]
+    fn passthrough_mode_enum_round_trips() {
+        assert_ne!(PassthroughMode::Tmux, PassthroughMode::Screen);
+        assert_ne!(PassthroughMode::None, PassthroughMode::Tmux);
+    }
+}

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -56,7 +56,7 @@ pub enum PassthroughMode {
 /// is screen-inside-tmux, where tmux's outer passthrough is what matters).
 #[must_use]
 pub fn detect_passthrough_mode() -> PassthroughMode {
-    // SAFETY: `var_os` is safe to call (read-only). It is not marked `unsafe`.
+    // `var_os` performs a read-only environment lookup and is not marked `unsafe`.
     if std::env::var_os("TMUX").is_some() {
         PassthroughMode::Tmux
     } else if std::env::var_os("STY").is_some() {
@@ -238,19 +238,43 @@ fn escape_for_tmux(bytes: &[u8]) -> Vec<u8> {
     out
 }
 
-/// GNU screen DCS passthrough, chunked to stay under screen's per-segment limit.
+/// GNU screen DCS passthrough — wraps the complete OSC 52 sequence in a single
+/// DCS wrapper so the terminal receives one intact clipboard-copy command.
+///
+/// Screen's per-segment byte limit means very large payloads may not fit. When
+/// that happens we truncate the base64 on a 4-char boundary (each 4-char group
+/// decodes to 3 bytes, so truncation stays valid) rather than splitting the OSC
+/// 52 across multiple independent sequences (which would cause only the last
+/// fragment to reach the clipboard).
 fn write_screen_passthrough(b64: &str, writer: &mut impl Write) -> io::Result<usize> {
-    let mut total = 0usize;
-    for chunk in b64.as_bytes().chunks(SCREEN_DCS_CHUNK_BYTES) {
-        let mut buf: Vec<u8> = Vec::with_capacity(chunk.len() + 16);
-        buf.extend_from_slice(b"\x1bP\x1b]52;c;");
-        buf.extend_from_slice(chunk);
-        buf.push(BEL);
-        buf.extend_from_slice(b"\x1b\\");
-        writer.write_all(&buf)?;
-        total += buf.len();
+    let inner = build_screen_inner(b64);
+    let body = truncate_for_screen(&inner);
+    let mut buf: Vec<u8> = Vec::with_capacity(body.len() + 8);
+    buf.extend_from_slice(b"\x1bP");
+    buf.extend_from_slice(body);
+    buf.extend_from_slice(b"\x1b\\");
+    writer.write_all(&buf)?;
+    Ok(buf.len())
+}
+
+/// Build the inner OSC 52 sequence bytes for screen DCS wrapping.
+fn build_screen_inner(b64: &str) -> Vec<u8> {
+    let mut inner: Vec<u8> = Vec::with_capacity(b64.len() + 16);
+    inner.extend_from_slice(b"\x1b]52;c;");
+    inner.extend_from_slice(b64.as_bytes());
+    inner.push(BEL);
+    inner
+}
+
+/// Truncate the inner OSC 52 bytes to fit screen's DCS segment limit, on a
+/// 4-char base64 boundary so the truncated payload stays decodable.
+fn truncate_for_screen(inner: &[u8]) -> &[u8] {
+    if inner.len() <= SCREEN_DCS_CHUNK_BYTES {
+        return inner;
     }
-    Ok(total)
+    let limit = SCREEN_DCS_CHUNK_BYTES;
+    let boundary = (limit / 4) * 4;
+    &inner[..boundary.max(4)]
 }
 
 #[cfg(test)]
@@ -337,8 +361,11 @@ mod tests {
     }
 
     #[test]
-    fn write_osc52_screen_passthrough_splits_large_payload() {
-        // A payload whose base64 exceeds one screen chunk must produce >1 segment.
+    fn write_osc52_screen_passthrough_truncates_large_payload() {
+        // A payload whose base64 exceeds screen's DCS segment limit must be
+        // truncated to fit a single DCS wrapper rather than split across
+        // multiple independent OSC 52 sequences (which would cause only the
+        // last fragment to reach the clipboard).
         let big = "a".repeat(SCREEN_DCS_CHUNK_BYTES * 4);
         let mut out: Vec<u8> = Vec::new();
         if let Err(e) = write_osc52_to_writer_with_mode(&big, PassthroughMode::Screen, &mut out) {
@@ -347,10 +374,16 @@ mod tests {
         let Ok(s) = String::from_utf8(out) else {
             panic!("non-UTF8 output");
         };
+        // Should produce exactly one DCS-wrapped OSC 52 sequence.
         let segment_count = s.matches("\x1bP\x1b]52;c;").count();
+        assert_eq!(
+            segment_count, 1,
+            "expected exactly 1 DCS-wrapped sequence, got {segment_count}: {s:?}"
+        );
+        // The output must end with the DCS terminator.
         assert!(
-            segment_count > 1,
-            "expected multiple chunks, got {segment_count}: {s:?}"
+            s.ends_with("\x1b\\"),
+            "expected DCS terminator at end, got: {s:?}"
         );
     }
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -92,9 +92,10 @@ pub fn write_osc52_to_writer_with_mode(
     mode: PassthroughMode,
     writer: &mut impl Write,
 ) -> io::Result<usize> {
-    let b64 = base64_encode(text.as_bytes());
-    let truncated = truncate_payload(&b64);
-    write_payload_with_mode(&truncated, mode, writer)
+    let truncated_text = truncate_text_on_char_boundary(text);
+    let b64 = base64_encode(truncated_text.as_bytes());
+    let truncated_b64 = truncate_payload(&b64);
+    write_payload_with_mode(&truncated_b64, mode, writer)
 }
 
 /// Write an OSC 52 copy sequence for `text` to the controlling terminal.
@@ -152,6 +153,26 @@ fn base64_encode(input: &[u8]) -> String {
         }
     }
     out
+}
+
+/// Truncate `text` so the base64-encoded form stays within the payload limit.
+///
+/// Truncating on a `char` boundary first guarantees the clipboard text is
+/// always valid UTF-8 even after the base64-level truncation.
+#[must_use]
+fn truncate_text_on_char_boundary(text: &str) -> String {
+    // MAX_BASE64_PAYLOAD_BYTES is the byte limit for the base64 string.
+    // Base64 encodes 3 bytes -> 4 chars, so the max input bytes = limit * 3 / 4.
+    let max_input_bytes = MAX_BASE64_PAYLOAD_BYTES / 4 * 3;
+    if text.len() <= max_input_bytes {
+        return text.to_string();
+    }
+    // Walk backward from the byte limit to a char boundary.
+    let mut cut = max_input_bytes;
+    while cut > 0 && !text.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    text[..cut].to_string()
 }
 
 /// Truncate the base64 string to the max payload size, keeping it valid base64.

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -35,6 +35,47 @@ pub const AGENT_PANE_MIN_ROWS: u16 = 3;
 /// Minimum rows reserved for the terminal pane so it keeps its chrome and a usable viewport.
 pub const TERMINAL_PANE_MIN_ROWS: u16 = TERMINAL_WIDGET_CHROME_ROWS + 2;
 
+// ── Selection chrome offsets ───────────────────────────────────────────────
+//
+// Each bordered pane consumes a fixed number of rows/cols of "chrome" (border,
+// title, padding) before its first content cell. The mouse-selection geometry
+// uses these to translate screen coordinates into content coordinates so a
+// click on the first content line maps to content line 0, not to the border or
+// title row. They mirror exactly what each `#[component]` renders.
+
+/// Bordered-list panes (PrList, IssueList): top border + title row.
+pub const LIST_PANE_CHROME_ROWS: u16 = 2;
+/// Bordered-list panes: left border column.
+pub const LIST_PANE_CHROME_COLS: u16 = 1;
+/// Sidebar: top border + title row.
+pub const SIDEBAR_CHROME_ROWS: u16 = 2;
+/// Sidebar: left border + 1-col content padding.
+pub const SIDEBAR_CHROME_COLS: u16 = 2;
+/// Agent list: top border + title row.
+pub const AGENT_LIST_CHROME_ROWS: u16 = 2;
+/// Agent list: left border + 1-col content padding.
+pub const AGENT_LIST_CHROME_COLS: u16 = 2;
+/// Terminal view: top border + title row.
+pub const TERMINAL_VIEW_CHROME_ROWS: u16 = 2;
+/// Terminal view: left border column.
+pub const TERMINAL_VIEW_CHROME_COLS: u16 = 1;
+/// Detail panes (PrDetail, IssueDetail): top border above the header rows.
+///
+/// The detail pane renders a border, then `DETAIL_HEADER_ROWS` metadata rows
+/// (which includes the trailing separator), so the scrollable content starts
+/// `DETAIL_HEADER_ROWS + 1` rows below the widget-box top.
+pub const DETAIL_PANE_CHROME_ROWS: u16 = 1;
+/// Detail panes: left border + 1-col left padding.
+pub const DETAIL_PANE_CHROME_COLS: u16 = 2;
+/// Status bar: 1-col left padding, no border.
+pub const STATUS_BAR_CHROME_COLS: u16 = 1;
+/// Status bar: no top chrome.
+pub const STATUS_BAR_CHROME_ROWS: u16 = 0;
+/// Keybind bar: 1-col left padding, no border.
+pub const KEYBIND_BAR_CHROME_COLS: u16 = 1;
+/// Keybind bar: no top chrome.
+pub const KEYBIND_BAR_CHROME_ROWS: u16 = 0;
+
 /// Static layout specification: the fixed geometry contract shared across the
 /// dashboard and issues screens.
 ///

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -104,7 +104,7 @@ fn effective_render_size_inner(cols: u16, rows: u16, fullscreen: bool) -> (u16, 
     }
 }
 
-fn dashboard_middle_row_heights_inner(render_rows: u16) -> (u16, u16) {
+pub(crate) fn dashboard_middle_row_heights_inner(render_rows: u16) -> (u16, u16) {
     let content_rows = render_rows.saturating_sub(OUTER_BARS_HEIGHT);
 
     if content_rows <= AGENT_PANE_MIN_ROWS + TERMINAL_PANE_MIN_ROWS {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 //! @requirement REQ-TECH-001
 
 pub mod cli;
+/// OSC 52 clipboard writer with tmux / GNU screen passthrough.
+pub mod clipboard;
 pub mod domain;
 pub mod input;
 pub mod issue_detail_content;
@@ -16,6 +18,8 @@ pub mod persistence;
 /// @requirement REQ-PR-009
 pub mod pr_detail_content;
 pub mod runtime;
+/// Pure, iocraft-free mouse-selection model (pane geometry + text extraction).
+pub mod selection;
 pub mod services;
 pub mod startup;
 pub mod state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 mod app_init;
 mod app_input;
 mod app_shell;
+mod mouse_routing;
 mod pty_encoding;
 
 use std::io::Write;

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -155,18 +155,38 @@ fn resolve_pane(
 /// Begin a new text selection at `(col, row)`.
 fn begin_selection(app_state: &mut HookState<AppState>, col: u16, row: u16) {
     let (cols, rows) = terminal_size();
-    let scroll_offset = read_scroll_offset(app_state, col, row, cols, rows);
-    let point = {
+    let point = resolve_selection_point(app_state, col, row, cols, rows);
+    match point {
+        Some(p) => app_state.write().selection = Some(TextSelection::collapsed(p)),
+        None => app_state.write().selection = None,
+    }
+}
+
+/// Resolve the screen `(col, row)` to a content selection point under the pane
+/// it lands in, applying the detail-header scroll suppression. Returns `None`
+/// when the coordinate is not over any selectable pane.
+fn resolve_selection_point(
+    app_state: &HookState<AppState>,
+    col: u16,
+    row: u16,
+    cols: u16,
+    rows: u16,
+) -> Option<SelectionPoint> {
+    // Resolve the pane + geometry in one short read, then read the scroll
+    // offset in another, so each read guard drops immediately (the guard has a
+    // significant Drop and clippy::significant_drop_tightening requires it not
+    // be held across unrelated statements).
+    let (pane, geometry) = {
         let state = app_state.read();
-        let Some((pane, geometry)) = resolve_pane(&state, col, row, cols, rows) else {
-            drop(state);
-            app_state.write().selection = None;
-            return;
-        };
-        let (line, c) = point_to_content_coords(col, row, scroll_offset, &geometry);
-        SelectionPoint::new(pane, line, c)
+        resolve_pane(&state, col, row, cols, rows)?
     };
-    app_state.write().selection = Some(TextSelection::collapsed(point));
+    let raw_scroll = {
+        let state = app_state.read();
+        scroll_offset_for_pane(&state, pane)
+    };
+    let scroll_offset = effective_scroll_for_detail(pane, row, &geometry, raw_scroll);
+    let (line, c) = point_to_content_coords(col, row, scroll_offset, &geometry);
+    Some(SelectionPoint::new(pane, line, c))
 }
 
 /// Update the focus (drag) point of the active selection.
@@ -178,9 +198,9 @@ fn update_selection(app_state: &mut HookState<AppState>, col: u16, row: u16) {
             return;
         };
         let pane = current.pane();
-        let scroll_offset = scroll_offset_for_pane(&state, pane);
+        let raw_scroll = scroll_offset_for_pane(&state, pane);
         drop(state);
-        (current.anchor, pane, scroll_offset)
+        (current.anchor, pane, raw_scroll)
     };
     let focus_point = {
         let state = app_state.read();
@@ -192,6 +212,7 @@ fn update_selection(app_state: &mut HookState<AppState>, col: u16, row: u16) {
         if resolved_pane != pane {
             return;
         }
+        let scroll_offset = effective_scroll_for_detail(pane, row, &geometry, scroll_offset);
         let (line, c) = point_to_content_coords(col, row, scroll_offset, &geometry);
         SelectionPoint::new(pane, line, c)
     };
@@ -236,19 +257,28 @@ fn finalize_and_copy_selection(ctx: Option<&CtxArc>, app_state: &HookState<AppSt
     }
 }
 
-/// Read the scroll offset of the pane under `(col, row)`, if it is scrollable.
-fn read_scroll_offset(
-    app_state: &HookState<AppState>,
-    col: u16,
+/// For detail panes, headers occupy content lines `0..DETAIL_HEADER_ROWS` and
+/// are not affected by scroll offset. Scrollable content starts at line
+/// `DETAIL_HEADER_ROWS`. Return 0 when the click is in the header area,
+/// otherwise the real scroll offset.
+fn effective_scroll_for_detail(
+    pane: SelectablePane,
     row: u16,
-    cols: u16,
-    rows: u16,
+    geometry: &jefe::selection::PaneGeometry,
+    scroll_offset: usize,
 ) -> usize {
-    let state = app_state.read();
-    let Some((pane, _)) = resolve_pane(&state, col, row, cols, rows) else {
-        return 0;
-    };
-    scroll_offset_for_pane(&state, pane)
+    use jefe::layout::DETAIL_HEADER_ROWS;
+    match pane {
+        SelectablePane::IssueDetail | SelectablePane::PrDetail => {
+            let content_row = usize::from(row.saturating_sub(geometry.content_origin_row));
+            if content_row < DETAIL_HEADER_ROWS {
+                0
+            } else {
+                scroll_offset
+            }
+        }
+        _ => scroll_offset,
+    }
 }
 
 /// Scroll offset for a specific pane from app state.

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -1,0 +1,255 @@
+//! Mouse event routing: selection start/update/finalize and PTY forwarding.
+//!
+//! Extracted from [`crate::app_shell`] to keep that file under the 1000-line
+//! size limit. All functions here operate on the iocraft hook state and the
+//! shared [`crate::app_shell::CtxArc`], translating fullscreen mouse events
+//! into either PTY input (when the terminal pane is focused) or text-selection
+//! state transitions.
+
+use crate::app_shell::{CtxArc, HookState, capture_terminal_snapshot};
+use crate::pty_encoding::mouse_event_to_bytes;
+use jefe::clipboard;
+use jefe::layout::compute_pty_layout;
+use jefe::runtime::RuntimeManager;
+use jefe::selection::{
+    ScreenLayout, SelectablePane, SelectionPoint, TextSelection, pane_at, pane_content_lines,
+    point_to_content_coords, selection_text,
+};
+use jefe::state::{AppState, PaneFocus};
+
+/// Clear any active mouse selection.
+///
+/// Called on every non-mouse terminal event (key, paste, resize) so a
+/// selection doesn't linger after the user moves on to keyboard interaction.
+pub fn clear_selection(app_state: &mut HookState<AppState>) {
+    let needs_clear = app_state.read().selection.is_some();
+    if needs_clear {
+        app_state.write().selection = None;
+    }
+}
+
+/// Route a fullscreen mouse event to PTY forwarding or app-level selection.
+pub fn handle_fullscreen_mouse(
+    ctx: Option<&CtxArc>,
+    app_state: &mut HookState<AppState>,
+    mouse_event: iocraft::FullscreenMouseEvent,
+) {
+    use crossterm::event::{MouseButton, MouseEventKind};
+
+    // Shift bypasses app selection and PTY forwarding: let the host terminal
+    // emulator handle native selection/copy (mirrors mouse_event_to_bytes).
+    if mouse_event.modifiers.contains(iocraft::KeyModifiers::SHIFT) {
+        return;
+    }
+
+    let terminal_input_enabled = {
+        let state = app_state.read();
+        state.terminal_focused && state.pane_focus == PaneFocus::Terminal
+    };
+
+    // When the terminal is focused, mouse events within the terminal pane go to
+    // the managed PTY (current behavior). Everything else is app selection.
+    if terminal_input_enabled && forward_to_pty_if_in_terminal(ctx, &mouse_event) {
+        return;
+    }
+
+    // Route the event to the app-level selection handler.
+    match mouse_event.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            begin_selection(app_state, mouse_event.column, mouse_event.row);
+        }
+        MouseEventKind::Drag(MouseButton::Left) => {
+            update_selection(app_state, mouse_event.column, mouse_event.row);
+        }
+        MouseEventKind::Up(MouseButton::Left) => {
+            finalize_and_copy_selection(ctx, app_state);
+        }
+        _ => {}
+    }
+}
+
+/// Forward `mouse_event` to the managed PTY if the terminal is focused, mouse
+/// reporting is active, and the event lands inside the terminal pane bounds.
+///
+/// Returns `true` when the event was consumed (forwarded or filtered as
+/// out-of-bounds while focused), `false` when the caller should handle it as
+/// an app-level selection.
+fn forward_to_pty_if_in_terminal(
+    ctx: Option<&CtxArc>,
+    mouse_event: &iocraft::FullscreenMouseEvent,
+) -> bool {
+    let Some(ctx_arc) = ctx else {
+        return false;
+    };
+    let Ok(mut ctx_guard) = ctx_arc.lock() else {
+        return false;
+    };
+    if !ctx_guard.runtime.mouse_reporting_active() {
+        return false;
+    }
+
+    let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
+    let layout = compute_pty_layout(cols, rows);
+
+    let row_end = layout
+        .pane_row0
+        .saturating_add(layout.pty_rows.saturating_sub(1));
+    let col_end = layout
+        .pane_col0
+        .saturating_add(layout.pty_cols.saturating_sub(1));
+
+    let screen_row0 = mouse_event.row;
+    let screen_col0 = mouse_event.column;
+
+    let in_terminal_bounds = screen_col0 >= layout.pane_col0
+        && screen_col0 <= col_end
+        && screen_row0 >= layout.pane_row0
+        && screen_row0 <= row_end;
+
+    if !in_terminal_bounds {
+        // Focused but outside the terminal pane: treat as app selection target.
+        return false;
+    }
+
+    let local_row = screen_row0.saturating_sub(layout.pane_row0);
+    let local_col = screen_col0.saturating_sub(layout.pane_col0);
+
+    let mut local_event =
+        iocraft::FullscreenMouseEvent::new(mouse_event.kind, local_col, local_row);
+    local_event.modifiers = mouse_event.modifiers;
+
+    if let Some(bytes) = mouse_event_to_bytes(&local_event) {
+        let _ = ctx_guard.runtime.write_input(&bytes);
+    }
+    true
+}
+
+/// Build the screen-layout descriptor from the current app state + terminal size.
+fn screen_layout_for(state: &AppState, cols: u16, rows: u16) -> ScreenLayout {
+    let error_visible = state.error_message.is_some()
+        || state.issues_state.error.is_some()
+        || state.prs_state.error.is_some();
+    let filter_open =
+        state.issues_state.filter_ui.controls_open || state.prs_state.filter_ui.controls_open;
+    ScreenLayout::new(cols, rows, state.screen_mode, error_visible, filter_open)
+}
+
+/// Resolve which pane + geometry a screen coordinate maps to, given app state.
+fn resolve_pane(
+    state: &AppState,
+    col: u16,
+    row: u16,
+    cols: u16,
+    rows: u16,
+) -> Option<(SelectablePane, jefe::selection::PaneGeometry)> {
+    let layout = screen_layout_for(state, cols, rows);
+    let terminal_input_enabled = state.terminal_focused && state.pane_focus == PaneFocus::Terminal;
+    pane_at(col, row, state.screen_mode, terminal_input_enabled, &layout)
+}
+
+/// Begin a new text selection at `(col, row)`.
+fn begin_selection(app_state: &mut HookState<AppState>, col: u16, row: u16) {
+    let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
+    let scroll_offset = read_scroll_offset(app_state, col, row, cols, rows);
+    let point = {
+        let state = app_state.read();
+        let Some((pane, geometry)) = resolve_pane(&state, col, row, cols, rows) else {
+            drop(state);
+            app_state.write().selection = None;
+            return;
+        };
+        let (line, c) = point_to_content_coords(col, row, scroll_offset, &geometry);
+        SelectionPoint::new(pane, line, c)
+    };
+    app_state.write().selection = Some(TextSelection::collapsed(point));
+}
+
+/// Update the focus (drag) point of the active selection.
+fn update_selection(app_state: &mut HookState<AppState>, col: u16, row: u16) {
+    let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
+    let (anchor, pane, scroll_offset) = {
+        let state = app_state.read();
+        let Some(current) = state.selection else {
+            return;
+        };
+        let pane = current.pane();
+        let scroll_offset = scroll_offset_for_pane(&state, pane);
+        drop(state);
+        (current.anchor, pane, scroll_offset)
+    };
+    let focus_point = {
+        let state = app_state.read();
+        // Clamp drag to the anchor pane: cross-pane drag would mix coordinate
+        // spaces. If the cursor left the anchor pane, keep the last valid focus.
+        let Some((resolved_pane, geometry)) = resolve_pane(&state, col, row, cols, rows) else {
+            return;
+        };
+        if resolved_pane != pane {
+            return;
+        }
+        let (line, c) = point_to_content_coords(col, row, scroll_offset, &geometry);
+        SelectionPoint::new(pane, line, c)
+    };
+    app_state.write().selection = Some(TextSelection {
+        anchor,
+        focus: focus_point,
+    });
+}
+
+/// Finalize the active selection and copy its text to the clipboard via OSC 52.
+fn finalize_and_copy_selection(ctx: Option<&CtxArc>, app_state: &HookState<AppState>) {
+    let selection = {
+        let state = app_state.read();
+        state.selection
+    };
+    let Some(selection) = selection else {
+        return;
+    };
+    if selection.is_empty() {
+        return;
+    }
+    let text = {
+        let state = app_state.read();
+        let snapshot = capture_terminal_snapshot(
+            ctx,
+            &state,
+            state.selected_agent().map(|a| &a.id),
+            state
+                .selected_agent()
+                .filter(|a| a.is_running())
+                .map(|a| &a.id),
+        );
+        let content = pane_content_lines(selection.pane(), &state, snapshot.as_ref());
+        drop(state);
+        selection_text(&selection, &content.lines)
+    };
+    if !text.is_empty() {
+        if let Err(err) = clipboard::write_osc52(&text) {
+            tracing::warn!(error = %err, "OSC 52 clipboard write failed");
+        }
+    }
+}
+
+/// Read the scroll offset of the pane under `(col, row)`, if it is scrollable.
+fn read_scroll_offset(
+    app_state: &HookState<AppState>,
+    col: u16,
+    row: u16,
+    cols: u16,
+    rows: u16,
+) -> usize {
+    let state = app_state.read();
+    let Some((pane, _)) = resolve_pane(&state, col, row, cols, rows) else {
+        return 0;
+    };
+    scroll_offset_for_pane(&state, pane)
+}
+
+/// Scroll offset for a specific pane from app state.
+fn scroll_offset_for_pane(state: &AppState, pane: SelectablePane) -> usize {
+    match pane {
+        SelectablePane::IssueDetail => state.issues_state.detail_scroll_offset,
+        SelectablePane::PrDetail => state.prs_state.detail_scroll_offset,
+        _ => 0,
+    }
+}

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -219,14 +219,15 @@ fn finalize_and_copy_selection(ctx: Option<&CtxArc>, app_state: &HookState<AppSt
                 .filter(|a| a.is_running())
                 .map(|a| &a.id),
         );
-        let content = pane_content_lines(selection.pane(), &state, snapshot.as_ref());
+        let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
+        let content = pane_content_lines(selection.pane(), &state, snapshot.as_ref(), cols, rows);
         drop(state);
         selection_text(&selection, &content.lines)
     };
-    if !text.is_empty() {
-        if let Err(err) = clipboard::write_osc52(&text) {
-            tracing::warn!(error = %err, "OSC 52 clipboard write failed");
-        }
+    if !text.is_empty()
+        && let Err(err) = clipboard::write_osc52(&text)
+    {
+        tracing::warn!(error = %err, "OSC 52 clipboard write failed");
     }
 }
 

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -17,6 +17,11 @@ use jefe::selection::{
 };
 use jefe::state::{AppState, PaneFocus};
 
+/// Terminal size fallback for the default 120x40 geometry.
+fn terminal_size() -> (u16, u16) {
+    crossterm::terminal::size().unwrap_or((120, 40))
+}
+
 /// Clear any active mouse selection.
 ///
 /// Called on every non-mouse terminal event (key, paste, resize) so a
@@ -88,7 +93,7 @@ fn forward_to_pty_if_in_terminal(
         return false;
     }
 
-    let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
+    let (cols, rows) = terminal_size();
     let layout = compute_pty_layout(cols, rows);
 
     let row_end = layout
@@ -149,7 +154,7 @@ fn resolve_pane(
 
 /// Begin a new text selection at `(col, row)`.
 fn begin_selection(app_state: &mut HookState<AppState>, col: u16, row: u16) {
-    let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
+    let (cols, rows) = terminal_size();
     let scroll_offset = read_scroll_offset(app_state, col, row, cols, rows);
     let point = {
         let state = app_state.read();
@@ -166,7 +171,7 @@ fn begin_selection(app_state: &mut HookState<AppState>, col: u16, row: u16) {
 
 /// Update the focus (drag) point of the active selection.
 fn update_selection(app_state: &mut HookState<AppState>, col: u16, row: u16) {
-    let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
+    let (cols, rows) = terminal_size();
     let (anchor, pane, scroll_offset) = {
         let state = app_state.read();
         let Some(current) = state.selection else {
@@ -219,7 +224,7 @@ fn finalize_and_copy_selection(ctx: Option<&CtxArc>, app_state: &HookState<AppSt
                 .filter(|a| a.is_running())
                 .map(|a| &a.id),
         );
-        let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
+        let (cols, rows) = terminal_size();
         let content = pane_content_lines(selection.pane(), &state, snapshot.as_ref(), cols, rows);
         drop(state);
         selection_text(&selection, &content.lines)

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -1,0 +1,326 @@
+//! Pane content providers for mouse selection.
+//!
+//! Each [`crate::selection::SelectablePane`] renders some text; to copy a
+//! selection we need that text as a flat `Vec<String>` of content lines. This
+//! module owns the pure mapping from [`crate::state::AppState`] data to those
+//! lines, reusing the existing pure projection builders
+//! ([`crate::issue_detail_content::build_detail_content`],
+//! [`crate::pr_detail_content::build_pr_detail_content`]) so the copyable text
+//! matches what the user sees.
+//!
+//! All functions are pure and `#[must_use]`. The terminal snapshot is passed in
+//! explicitly (it lives on the runtime, not AppState) so the module stays
+//! iocraft-free and side-effect-free.
+
+use crate::domain::{Agent, AgentStatus, Issue, PullRequest};
+use crate::issue_detail_content::build_detail_content;
+use crate::pr_detail_content::build_pr_detail_content;
+use crate::runtime::TerminalSnapshot;
+use crate::selection::SelectablePane;
+use crate::state::AppState;
+
+/// The copyable text content of a pane, as a flat list of lines.
+///
+/// Built by [`pane_content_lines`] from the active app state. Line order and
+/// contents mirror what the renderer paints so a selection coordinate maps to
+/// the same characters the user sees.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaneContent {
+    /// The pane these lines belong to.
+    pub pane: SelectablePane,
+    /// Content lines (no trailing newlines per line).
+    pub lines: Vec<String>,
+}
+
+impl PaneContent {
+    /// Construct content for `pane` from an iterator of line strings.
+    #[must_use]
+    pub fn new<I: IntoIterator<Item = String>>(pane: SelectablePane, lines: I) -> Self {
+        Self {
+            pane,
+            lines: lines.into_iter().collect(),
+        }
+    }
+
+    /// Empty content for `pane` (no copyable lines).
+    #[must_use]
+    pub fn empty(pane: SelectablePane) -> Self {
+        Self {
+            pane,
+            lines: Vec::new(),
+        }
+    }
+}
+
+/// Build the copyable content lines for `pane` from the app state.
+///
+/// Returns [`PaneContent::empty`] when the pane has no content (e.g. no
+/// selected issue/PR, no agent). The terminal snapshot is passed separately
+/// because it lives on the runtime, not AppState.
+///
+/// # Panics
+///
+/// Never; all indexing is bounds-checked.
+#[must_use]
+pub fn pane_content_lines(
+    pane: SelectablePane,
+    state: &AppState,
+    snapshot: Option<&TerminalSnapshot>,
+) -> PaneContent {
+    match pane {
+        SelectablePane::IssueDetail => issue_detail_lines(state),
+        SelectablePane::PrDetail => pr_detail_lines(state),
+        SelectablePane::IssueList => issue_list_lines(state),
+        SelectablePane::PrList => pr_list_lines(state),
+        SelectablePane::Sidebar => sidebar_lines(state),
+        SelectablePane::AgentList => agent_list_lines(state),
+        SelectablePane::Preview => preview_lines(state),
+        SelectablePane::TerminalView => terminal_lines(snapshot),
+        SelectablePane::HelpModal => help_lines(),
+        SelectablePane::StatusBar => status_bar_lines(state),
+        SelectablePane::KeybindBar => keybind_bar_lines(state),
+    }
+}
+
+fn issue_detail_lines(state: &AppState) -> PaneContent {
+    let Some(detail) = state.issues_state.issue_detail.as_ref() else {
+        return PaneContent::empty(SelectablePane::IssueDetail);
+    };
+    let content = build_detail_content(
+        detail,
+        state.issues_state.detail_subfocus,
+        &state.issues_state.inline_state,
+        state.issues_state.loading.comments,
+    );
+    PaneContent::new(
+        SelectablePane::IssueDetail,
+        content.text.lines().map(String::from),
+    )
+}
+
+fn pr_detail_lines(state: &AppState) -> PaneContent {
+    let Some(detail) = state.prs_state.pr_detail.as_ref() else {
+        return PaneContent::empty(SelectablePane::PrDetail);
+    };
+    let content = build_pr_detail_content(
+        detail,
+        state.prs_state.detail_subfocus,
+        &state.prs_state.inline_state,
+        state.prs_state.loading.detail,
+        state.prs_state.loading.comments,
+    );
+    PaneContent::new(
+        SelectablePane::PrDetail,
+        content.text.lines().map(String::from),
+    )
+}
+
+fn issue_list_lines(state: &AppState) -> PaneContent {
+    let lines: Vec<String> = state
+        .issues_state
+        .issues
+        .iter()
+        .flat_map(issue_to_lines)
+        .collect();
+    PaneContent::new(SelectablePane::IssueList, lines)
+}
+
+fn pr_list_lines(state: &AppState) -> PaneContent {
+    let lines: Vec<String> = state
+        .prs_state
+        .pull_requests
+        .iter()
+        .flat_map(pr_to_lines)
+        .collect();
+    PaneContent::new(SelectablePane::PrList, lines)
+}
+
+fn issue_to_lines(issue: &Issue) -> Vec<String> {
+    vec![
+        format!("#{} {}", issue.number, issue.title),
+        format!(
+            "  @{} updated:{} comments:{}",
+            issue.author_login, issue.updated_at, issue.comment_count
+        ),
+    ]
+}
+
+fn pr_to_lines(pr: &PullRequest) -> Vec<String> {
+    vec![format!("#{} {}", pr.number, pr.title)]
+}
+
+fn sidebar_lines(state: &AppState) -> PaneContent {
+    let lines: Vec<String> = state
+        .repositories
+        .iter()
+        .map(|repo| format!("{} ({})", repo.name, repo.agent_ids.len()))
+        .collect();
+    PaneContent::new(SelectablePane::Sidebar, lines)
+}
+
+fn agent_list_lines(state: &AppState) -> PaneContent {
+    let Some(repo) = state.selected_repository() else {
+        return PaneContent::empty(SelectablePane::AgentList);
+    };
+    let agents = state.visible_agents_for_repository(&repo.id);
+    let lines: Vec<String> = agents.iter().map(agent_to_line).collect();
+    PaneContent::new(SelectablePane::AgentList, lines)
+}
+
+fn agent_to_line(agent: &Agent) -> String {
+    let icon = status_icon(agent.status);
+    let shortcut = agent
+        .shortcut_slot
+        .map_or_else(String::new, |slot| format!("[{slot}] "));
+    format!("{icon} {}{}", shortcut, agent.name)
+}
+
+fn status_icon(status: AgentStatus) -> char {
+    match status {
+        AgentStatus::Running => '*',
+        AgentStatus::Completed => '+',
+        AgentStatus::Dead => 'x',
+        AgentStatus::Errored => '!',
+        AgentStatus::Waiting => '?',
+        AgentStatus::Paused => '-',
+        AgentStatus::Queued => 'o',
+    }
+}
+
+fn preview_lines(state: &AppState) -> PaneContent {
+    let Some(agent) = state.selected_agent() else {
+        return PaneContent::new(
+            SelectablePane::Preview,
+            vec!["No agent selected".to_string()],
+        );
+    };
+    let lines = vec![
+        format!("Name: {}", agent.name),
+        format!("Status: {:?}", agent.status),
+        format!("Dir: {}", agent.work_dir.display()),
+        "Todo:".to_string(),
+        "  (no tasks)".to_string(),
+    ];
+    PaneContent::new(SelectablePane::Preview, lines)
+}
+
+fn terminal_lines(snapshot: Option<&TerminalSnapshot>) -> PaneContent {
+    let Some(snap) = snapshot else {
+        return PaneContent::new(
+            SelectablePane::TerminalView,
+            vec!["No terminal attached".to_string()],
+        );
+    };
+    let lines: Vec<String> = (0..snap.rows)
+        .map(|row| {
+            snap.cells.get(row).map_or_else(String::new, |cells| {
+                cells.iter().take(snap.cols).map(|c| c.ch).collect()
+            })
+        })
+        .collect();
+    PaneContent::new(SelectablePane::TerminalView, lines)
+}
+
+fn help_lines() -> PaneContent {
+    PaneContent::new(SelectablePane::HelpModal, Vec::<String>::new())
+}
+
+fn status_bar_lines(state: &AppState) -> PaneContent {
+    let repo_count = state.repositories.len();
+    let running = state.agents.iter().filter(|a| a.is_running()).count();
+    let line = format!(
+        "jefe {} | repos: {} | running: {}",
+        crate::VERSION,
+        repo_count,
+        running
+    );
+    PaneContent::new(SelectablePane::StatusBar, vec![line])
+}
+
+fn keybind_bar_lines(state: &AppState) -> PaneContent {
+    // The keybind bar content varies by screen mode; expose the mode label so
+    // at least the visible hint text is copyable.
+    let label = match state.screen_mode {
+        crate::state::ScreenMode::Dashboard => "Dashboard",
+        crate::state::ScreenMode::Split => "Split",
+        crate::state::ScreenMode::DashboardIssues => "Issues",
+        crate::state::ScreenMode::DashboardPullRequests => "Pull Requests",
+    };
+    PaneContent::new(SelectablePane::KeybindBar, vec![label.to_string()])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pane_content_empty_has_no_lines() {
+        let c = PaneContent::empty(SelectablePane::Sidebar);
+        assert!(c.lines.is_empty());
+        assert!(matches!(c.pane, SelectablePane::Sidebar));
+    }
+
+    #[test]
+    fn pane_content_new_collects_lines() {
+        let c = PaneContent::new(
+            SelectablePane::IssueList,
+            vec!["a".to_string(), "b".to_string()],
+        );
+        assert_eq!(c.lines, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn terminal_lines_from_snapshot() {
+        use crate::runtime::{TerminalCell, TerminalCellStyle};
+        use iocraft::Color;
+        let style = TerminalCellStyle {
+            fg: Color::White,
+            bg: Color::Black,
+            bold: false,
+            underline: false,
+        };
+        let cells = vec![
+            vec![
+                TerminalCell { ch: 'h', style },
+                TerminalCell { ch: 'i', style },
+            ],
+            vec![TerminalCell { ch: '!', style }],
+        ];
+        let snap = TerminalSnapshot {
+            rows: 2,
+            cols: 2,
+            cells,
+        };
+        let content = pane_content_lines(
+            SelectablePane::TerminalView,
+            &AppState::default(),
+            Some(&snap),
+        );
+        assert_eq!(content.lines, vec!["hi".to_string(), "!".to_string()]);
+    }
+
+    #[test]
+    fn terminal_lines_none_snapshot_shows_placeholder() {
+        let content = pane_content_lines(SelectablePane::TerminalView, &AppState::default(), None);
+        assert_eq!(content.lines, vec!["No terminal attached".to_string()]);
+    }
+
+    #[test]
+    fn sidebar_lines_count_repos() {
+        use crate::domain::{AgentId, Repository, RepositoryId};
+        let mut state = AppState::default();
+        state.repositories.push(Repository {
+            id: RepositoryId("r1".to_string()),
+            name: "repo-one".to_string(),
+            slug: "repo-one".to_string(),
+            base_dir: std::path::PathBuf::new(),
+            default_profile: String::new(),
+            github_repo: String::new(),
+            remote: crate::domain::RemoteRepositorySettings::default(),
+            issue_base_prompt: String::new(),
+            agent_ids: vec![AgentId("a1".to_string()), AgentId("a2".to_string())],
+        });
+        let content = pane_content_lines(SelectablePane::Sidebar, &state, None);
+        assert_eq!(content.lines, vec!["repo-one (2)".to_string()]);
+    }
+}

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -3,21 +3,28 @@
 //! Each [`crate::selection::SelectablePane`] renders some text; to copy a
 //! selection we need that text as a flat `Vec<String>` of content lines. This
 //! module owns the pure mapping from [`crate::state::AppState`] data to those
-//! lines, reusing the existing pure projection builders
-//! ([`crate::issue_detail_content::build_detail_content`],
-//! [`crate::pr_detail_content::build_pr_detail_content`]) so the copyable text
-//! matches what the user sees.
+//! lines, reusing the existing pure projection builders so the copyable text
+//! matches what the user sees:
+//! - [`crate::issue_detail_content::build_detail_content`] /
+//!   [`crate::pr_detail_content::build_pr_detail_content`] for detail panes,
+//! - [`crate::ui::components::pr_list::pr_list_visible_rows`] /
+//!   [`crate::ui::components::issue_list::issue_list_visible_rows`] for list
+//!   panes (these are pure functions even though they live next to iocraft
+//!   components; importing them keeps a single source of truth for the rendered
+//!   row text so selection coordinates map to the exact characters on screen).
 //!
 //! All functions are pure and `#[must_use]`. The terminal snapshot is passed in
 //! explicitly (it lives on the runtime, not AppState) so the module stays
 //! iocraft-free and side-effect-free.
 
-use crate::domain::{Agent, AgentStatus, Issue, PullRequest};
+use crate::domain::AgentStatus;
 use crate::issue_detail_content::build_detail_content;
 use crate::pr_detail_content::build_pr_detail_content;
 use crate::runtime::TerminalSnapshot;
 use crate::selection::SelectablePane;
 use crate::state::AppState;
+use crate::ui::components::issue_list::{IssueListLayout, issue_list_visible_rows};
+use crate::ui::components::pr_list::pr_list_visible_rows;
 
 /// The copyable text content of a pane, as a flat list of lines.
 ///
@@ -56,7 +63,9 @@ impl PaneContent {
 ///
 /// Returns [`PaneContent::empty`] when the pane has no content (e.g. no
 /// selected issue/PR, no agent). The terminal snapshot is passed separately
-/// because it lives on the runtime, not AppState.
+/// because it lives on the runtime, not AppState. `term_cols`/`term_rows` are
+/// the live terminal size, used to compute the same pane widths/heights the
+/// screens render with so list-row truncation matches.
 ///
 /// # Panics
 ///
@@ -66,12 +75,14 @@ pub fn pane_content_lines(
     pane: SelectablePane,
     state: &AppState,
     snapshot: Option<&TerminalSnapshot>,
+    term_cols: u16,
+    term_rows: u16,
 ) -> PaneContent {
     match pane {
         SelectablePane::IssueDetail => issue_detail_lines(state),
         SelectablePane::PrDetail => pr_detail_lines(state),
-        SelectablePane::IssueList => issue_list_lines(state),
-        SelectablePane::PrList => pr_list_lines(state),
+        SelectablePane::IssueList => issue_list_lines(state, term_cols, term_rows),
+        SelectablePane::PrList => pr_list_lines(state, term_cols, term_rows),
         SelectablePane::Sidebar => sidebar_lines(state),
         SelectablePane::AgentList => agent_list_lines(state),
         SelectablePane::Preview => preview_lines(state),
@@ -115,64 +126,94 @@ fn pr_detail_lines(state: &AppState) -> PaneContent {
     )
 }
 
-fn issue_list_lines(state: &AppState) -> PaneContent {
-    let lines: Vec<String> = state
-        .issues_state
-        .issues
-        .iter()
-        .flat_map(issue_to_lines)
-        .collect();
-    PaneContent::new(SelectablePane::IssueList, lines)
+/// Issue list lines that match the rendered Compact-mode projection exactly
+/// (prefix + `#number` + truncated title, one line per issue).
+fn issue_list_lines(state: &AppState, term_cols: u16, term_rows: u16) -> PaneContent {
+    let (list_pane_rows, _) = crate::layout::issues_pane_rows(
+        usize::from(term_rows),
+        state.issues_state.error.is_some(),
+        state.issues_state.filter_ui.controls_open,
+    );
+    let list_pane_rows = u16::try_from(list_pane_rows).unwrap_or(u16::MAX);
+    let available_width = crate::layout::issue_list_content_width(term_cols);
+    let rows = issue_list_visible_rows(
+        &state.issues_state.issues,
+        state.issues_state.selected_issue_index,
+        list_pane_rows,
+        IssueListLayout::Compact,
+        Some(available_width),
+    );
+    PaneContent::new(
+        SelectablePane::IssueList,
+        rows.into_iter().map(|r| r.title_line),
+    )
 }
 
-fn pr_list_lines(state: &AppState) -> PaneContent {
-    let lines: Vec<String> = state
-        .prs_state
-        .pull_requests
-        .iter()
-        .flat_map(pr_to_lines)
-        .collect();
-    PaneContent::new(SelectablePane::PrList, lines)
+/// PR list lines that match the rendered Compact-mode projection exactly
+/// (prefix + `#number` + truncated title, one line per PR).
+fn pr_list_lines(state: &AppState, term_cols: u16, term_rows: u16) -> PaneContent {
+    let (list_pane_rows, _) = crate::layout::prs_pane_rows(
+        usize::from(term_rows),
+        state.prs_state.error.is_some(),
+        state.prs_state.filter_ui.controls_open,
+    );
+    let list_pane_rows = u16::try_from(list_pane_rows).unwrap_or(u16::MAX);
+    let available_width = crate::layout::pr_list_content_width(term_cols);
+    let rows = pr_list_visible_rows(
+        &state.prs_state.pull_requests,
+        state.prs_state.selected_pr_index,
+        list_pane_rows,
+        Some(available_width),
+    );
+    PaneContent::new(
+        SelectablePane::PrList,
+        rows.into_iter().map(|r| r.title_line),
+    )
 }
 
-fn issue_to_lines(issue: &Issue) -> Vec<String> {
-    vec![
-        format!("#{} {}", issue.number, issue.title),
-        format!(
-            "  @{} updated:{} comments:{}",
-            issue.author_login, issue.updated_at, issue.comment_count
-        ),
-    ]
-}
-
-fn pr_to_lines(pr: &PullRequest) -> Vec<String> {
-    vec![format!("#{} {}", pr.number, pr.title)]
-}
-
+/// Sidebar lines that match the rendered repo list, including the `> `/`  `
+/// selection prefix and `(count)` suffix.
 fn sidebar_lines(state: &AppState) -> PaneContent {
-    let lines: Vec<String> = state
-        .repositories
+    let visible_indices = state.visible_repository_indices();
+    let selected_visible = state.selected_repository_visible_index();
+    let lines: Vec<String> = visible_indices
         .iter()
-        .map(|repo| format!("{} ({})", repo.name, repo.agent_ids.len()))
+        .enumerate()
+        .filter_map(|(vis_i, &repo_i)| {
+            let repo = state.repositories.get(repo_i)?;
+            let count = state.visible_agent_count_for_repository(&repo.id);
+            let prefix = if selected_visible == Some(vis_i) {
+                "> "
+            } else {
+                "  "
+            };
+            Some(format!("{prefix}{} ({count})", repo.name))
+        })
         .collect();
     PaneContent::new(SelectablePane::Sidebar, lines)
 }
 
+/// Agent list lines that match the rendered agent list, including the
+/// status icon, `> `/`  ` prefix, optional `[slot]`, and name.
 fn agent_list_lines(state: &AppState) -> PaneContent {
     let Some(repo) = state.selected_repository() else {
         return PaneContent::empty(SelectablePane::AgentList);
     };
     let agents = state.visible_agents_for_repository(&repo.id);
-    let lines: Vec<String> = agents.iter().map(agent_to_line).collect();
+    let selected_local = state.selected_agent_local_index().unwrap_or(0);
+    let lines: Vec<String> = agents
+        .iter()
+        .enumerate()
+        .map(|(i, agent)| {
+            let icon = status_icon(agent.status);
+            let prefix = if i == selected_local { "> " } else { "  " };
+            let shortcut = agent
+                .shortcut_slot
+                .map_or_else(String::new, |slot| format!("[{slot}] "));
+            format!("{prefix}{icon} {shortcut}{}", agent.name)
+        })
+        .collect();
     PaneContent::new(SelectablePane::AgentList, lines)
-}
-
-fn agent_to_line(agent: &Agent) -> String {
-    let icon = status_icon(agent.status);
-    let shortcut = agent
-        .shortcut_slot
-        .map_or_else(String::new, |slot| format!("[{slot}] "));
-    format!("{icon} {}{}", shortcut, agent.name)
 }
 
 fn status_icon(status: AgentStatus) -> char {
@@ -225,28 +266,27 @@ fn help_lines() -> PaneContent {
     PaneContent::new(SelectablePane::HelpModal, Vec::<String>::new())
 }
 
+/// Status bar line that matches the rendered format:
+/// `LLxprt Jefe - {version}   {repos} repos | {running}/{total} running   {theme}`.
+///
+/// The theme name is not in AppState (it is a screen prop), so the right-hand
+/// segment is omitted here; the left/center segments — where selection is most
+/// likely — match exactly.
 fn status_bar_lines(state: &AppState) -> PaneContent {
-    let repo_count = state.repositories.len();
+    let repo_count = state.visible_repository_indices().len();
     let running = state.agents.iter().filter(|a| a.is_running()).count();
-    let line = format!(
-        "jefe {} | repos: {} | running: {}",
-        crate::VERSION,
-        repo_count,
-        running
-    );
+    let agent_count = state.visible_agent_count();
+    let left = format!("LLxprt Jefe - {}", crate::VERSION);
+    let center = format!("{repo_count} repos | {running}/{agent_count} running");
+    let line = format!("{left}   {center}");
     PaneContent::new(SelectablePane::StatusBar, vec![line])
 }
 
+/// Keybind bar line that matches the rendered hint text for the active screen
+/// mode, reusing the pure [`keybind_hints_for`] projection.
 fn keybind_bar_lines(state: &AppState) -> PaneContent {
-    // The keybind bar content varies by screen mode; expose the mode label so
-    // at least the visible hint text is copyable.
-    let label = match state.screen_mode {
-        crate::state::ScreenMode::Dashboard => "Dashboard",
-        crate::state::ScreenMode::Split => "Split",
-        crate::state::ScreenMode::DashboardIssues => "Issues",
-        crate::state::ScreenMode::DashboardPullRequests => "Pull Requests",
-    };
-    PaneContent::new(SelectablePane::KeybindBar, vec![label.to_string()])
+    let hints = crate::ui::components::keybind_bar::keybind_hints_for(state.screen_mode, false);
+    PaneContent::new(SelectablePane::KeybindBar, vec![hints.to_string()])
 }
 
 #[cfg(test)]
@@ -295,18 +335,26 @@ mod tests {
             SelectablePane::TerminalView,
             &AppState::default(),
             Some(&snap),
+            120,
+            40,
         );
         assert_eq!(content.lines, vec!["hi".to_string(), "!".to_string()]);
     }
 
     #[test]
     fn terminal_lines_none_snapshot_shows_placeholder() {
-        let content = pane_content_lines(SelectablePane::TerminalView, &AppState::default(), None);
+        let content = pane_content_lines(
+            SelectablePane::TerminalView,
+            &AppState::default(),
+            None,
+            120,
+            40,
+        );
         assert_eq!(content.lines, vec!["No terminal attached".to_string()]);
     }
 
     #[test]
-    fn sidebar_lines_count_repos() {
+    fn sidebar_lines_include_selection_prefix() {
         use crate::domain::{AgentId, Repository, RepositoryId};
         let mut state = AppState::default();
         state.repositories.push(Repository {
@@ -320,7 +368,85 @@ mod tests {
             issue_base_prompt: String::new(),
             agent_ids: vec![AgentId("a1".to_string()), AgentId("a2".to_string())],
         });
-        let content = pane_content_lines(SelectablePane::Sidebar, &state, None);
-        assert_eq!(content.lines, vec!["repo-one (2)".to_string()]);
+        // Select the first repo so the rendered "> " prefix appears.
+        state.selected_repository_index = Some(0);
+        let content = pane_content_lines(SelectablePane::Sidebar, &state, None, 120, 40);
+        // Selected repo gets "> " prefix; matches the Sidebar renderer.
+        assert_eq!(content.lines, vec!["> repo-one (0)".to_string()]);
+    }
+
+    #[test]
+    fn pr_list_lines_match_rendered_projection_with_prefix() {
+        use crate::domain::{PrCheckStatus, PrState, PullRequest};
+        let mut state = AppState::default();
+        state.prs_state.pull_requests.push(PullRequest {
+            number: 7,
+            title: "A title".to_string(),
+            state: PrState::Open,
+            author_login: "octocat".to_string(),
+            updated_at: String::new(),
+            head_ref: String::new(),
+            base_ref: String::new(),
+            is_draft: false,
+            review_decision: None,
+            checks_status: PrCheckStatus::None,
+            assignee_summary: String::new(),
+            labels_summary: String::new(),
+            comment_count: 0,
+        });
+        state.prs_state.selected_pr_index = Some(0);
+        let content = pane_content_lines(SelectablePane::PrList, &state, None, 120, 40);
+        // Compact mode: one line per PR, with the "> " selected prefix and #N.
+        assert_eq!(content.lines.len(), 1);
+        assert!(content.lines[0].starts_with("> #7 "));
+    }
+
+    #[test]
+    fn issue_list_lines_match_rendered_projection_with_prefix() {
+        use crate::domain::{Issue, IssueState};
+        let mut state = AppState::default();
+        state.issues_state.issues.push(Issue {
+            number: 3,
+            title: "Bug".to_string(),
+            state: IssueState::Open,
+            author_login: "octocat".to_string(),
+            updated_at: String::new(),
+            assignee_summary: String::new(),
+            labels_summary: String::new(),
+            assignees: Vec::new(),
+            labels: Vec::new(),
+            issue_type: String::new(),
+            milestone: String::new(),
+            module: String::new(),
+            comment_count: 0,
+            body: String::new(),
+        });
+        state.issues_state.selected_issue_index = Some(0);
+        let content = pane_content_lines(SelectablePane::IssueList, &state, None, 120, 40);
+        assert_eq!(content.lines.len(), 1);
+        assert!(content.lines[0].starts_with("> #3 "));
+    }
+
+    #[test]
+    fn status_bar_lines_match_rendered_left_and_center() {
+        let content = pane_content_lines(
+            SelectablePane::StatusBar,
+            &AppState::default(),
+            None,
+            120,
+            40,
+        );
+        assert_eq!(content.lines.len(), 1);
+        assert!(content.lines[0].contains("LLxprt Jefe -"));
+        assert!(content.lines[0].contains("repos |"));
+    }
+
+    #[test]
+    fn keybind_bar_lines_match_rendered_hints() {
+        let mut state = AppState::default();
+        state.screen_mode = crate::state::ScreenMode::Dashboard;
+        let content = pane_content_lines(SelectablePane::KeybindBar, &state, None, 120, 40);
+        assert_eq!(content.lines.len(), 1);
+        assert!(content.lines[0].contains("navigate"));
     }
 }

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -24,7 +24,12 @@ use crate::runtime::TerminalSnapshot;
 use crate::selection::SelectablePane;
 use crate::state::AppState;
 use crate::ui::components::issue_list::{IssueListLayout, issue_list_visible_rows};
+use crate::ui::components::pr_detail::pr_detail_header_view;
 use crate::ui::components::pr_list::pr_list_visible_rows;
+
+/// Separator line rendered between the fixed detail header and the scrollable
+/// content, mirroring the components' `"─────…"` row.
+const DETAIL_SEPARATOR_LINE: &str = "─────────────────────────────────────────";
 
 /// The copyable text content of a pane, as a flat list of lines.
 ///
@@ -103,10 +108,9 @@ fn issue_detail_lines(state: &AppState) -> PaneContent {
         &state.issues_state.inline_state,
         state.issues_state.loading.comments,
     );
-    PaneContent::new(
-        SelectablePane::IssueDetail,
-        content.text.lines().map(String::from),
-    )
+    let mut lines = issue_detail_header_lines(detail);
+    lines.extend(content.text.lines().map(String::from));
+    PaneContent::new(SelectablePane::IssueDetail, lines)
 }
 
 fn pr_detail_lines(state: &AppState) -> PaneContent {
@@ -120,10 +124,46 @@ fn pr_detail_lines(state: &AppState) -> PaneContent {
         state.prs_state.loading.detail,
         state.prs_state.loading.comments,
     );
-    PaneContent::new(
-        SelectablePane::PrDetail,
-        content.text.lines().map(String::from),
-    )
+    let header = pr_detail_header_view(detail);
+    let mut lines = vec![
+        header.title,
+        header.state,
+        header.branches,
+        header.url,
+        DETAIL_SEPARATOR_LINE.to_string(),
+    ];
+    lines.extend(content.text.lines().map(String::from));
+    PaneContent::new(SelectablePane::PrDetail, lines)
+}
+
+/// Build the five fixed header lines the `IssueDetailView` renders above its
+/// scrollable viewport, so selection coordinates map to those header rows too.
+fn issue_detail_header_lines(detail: &crate::domain::IssueDetail) -> Vec<String> {
+    let state_tag = match detail.state {
+        crate::domain::IssueState::Open => "OPEN",
+        crate::domain::IssueState::Closed => "CLOSED",
+    };
+    let labels_str = if detail.labels.is_empty() {
+        "-".to_string()
+    } else {
+        detail.labels.join(", ")
+    };
+    let assignees_str = if detail.assignees.is_empty() {
+        "-".to_string()
+    } else {
+        detail.assignees.join(", ")
+    };
+    let milestone_str = detail.milestone.as_deref().unwrap_or("-").to_string();
+    vec![
+        format!("#{} {}", detail.number, detail.title),
+        format!(
+            "{}  by @{}  opened: {}  updated: {}",
+            state_tag, detail.author_login, detail.created_at, detail.updated_at
+        ),
+        format!("labels: {labels_str}  assignees: {assignees_str}  milestone: {milestone_str}"),
+        detail.external_url.clone(),
+        DETAIL_SEPARATOR_LINE.to_string(),
+    ]
 }
 
 /// Issue list lines that match the rendered Compact-mode projection exactly
@@ -448,5 +488,83 @@ mod tests {
         let content = pane_content_lines(SelectablePane::KeybindBar, &state, None, 120, 40);
         assert_eq!(content.lines.len(), 1);
         assert!(content.lines[0].contains("navigate"));
+    }
+
+    #[test]
+    fn issue_detail_lines_start_with_header_rows() {
+        use crate::domain::{IssueDetail, IssueState};
+        let mut state = AppState::default();
+        state.issues_state.issue_detail = Some(IssueDetail {
+            repo_owner_name: "o/r".to_string(),
+            number: 42,
+            title: "My Issue".to_string(),
+            state: IssueState::Open,
+            author_login: "octocat".to_string(),
+            created_at: "2026-01-01".to_string(),
+            updated_at: "2026-02-01".to_string(),
+            labels: vec!["bug".to_string()],
+            assignees: vec!["alice".to_string()],
+            milestone: Some("v1".to_string()),
+            body: "Body text".to_string(),
+            external_url: "https://example.com/42".to_string(),
+            comments: Vec::new(),
+            has_more_comments: false,
+            comments_cursor: None,
+        });
+        let content = pane_content_lines(SelectablePane::IssueDetail, &state, None, 120, 40);
+        // Line 0: title, Line 1: state/author, Line 2: labels/assignees/milestone,
+        // Line 3: url, Line 4: separator, then scrollable content lines.
+        assert!(content.lines.len() > 5);
+        assert_eq!(content.lines[0], "#42 My Issue");
+        assert!(content.lines[1].contains("OPEN"));
+        assert!(content.lines[1].contains("@octocat"));
+        assert!(content.lines[2].contains("labels: bug"));
+        assert!(content.lines[2].contains("assignees: alice"));
+        assert!(content.lines[2].contains("milestone: v1"));
+        assert_eq!(content.lines[3], "https://example.com/42");
+        assert!(content.lines[4].starts_with('─'));
+    }
+
+    #[test]
+    fn pr_detail_lines_start_with_header_rows() {
+        use crate::domain::{PrCheckStatus, PrState, PullRequestDetail};
+        let mut state = AppState::default();
+        state.prs_state.pr_detail = Some(PullRequestDetail {
+            repo_owner_name: "o/r".to_string(),
+            number: 7,
+            title: "My PR".to_string(),
+            state: PrState::Open,
+            is_draft: false,
+            author_login: "octocat".to_string(),
+            created_at: "2026-01-01".to_string(),
+            updated_at: "2026-02-01".to_string(),
+            head_ref: "feature".to_string(),
+            base_ref: "main".to_string(),
+            labels: vec!["enhancement".to_string()],
+            assignees: vec!["bob".to_string()],
+            milestone: None,
+            body: "PR body".to_string(),
+            external_url: "https://example.com/pull/7".to_string(),
+            review_decision: None,
+            checks_status: PrCheckStatus::None,
+            reviews: Vec::new(),
+            checks: Vec::new(),
+            comments: Vec::new(),
+            has_more_comments: false,
+            comments_cursor: None,
+            mergeable: None,
+            merge_state_status: None,
+        });
+        let content = pane_content_lines(SelectablePane::PrDetail, &state, None, 120, 40);
+        // Header rows first, then scrollable content.
+        assert!(content.lines.len() > 5);
+        assert_eq!(content.lines[0], "#7 My PR");
+        assert!(content.lines[1].contains("OPEN"));
+        assert!(content.lines[1].contains("octocat"));
+        assert!(content.lines[2].contains("feature -> main"));
+        assert!(content.lines[2].contains("labels: enhancement"));
+        assert!(content.lines[2].contains("assignees: bob"));
+        assert_eq!(content.lines[3], "https://example.com/pull/7");
+        assert!(content.lines[4].starts_with('─'));
     }
 }

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -17,12 +17,13 @@
 //! explicitly (it lives on the runtime, not AppState) so the module stays
 //! iocraft-free and side-effect-free.
 
-use crate::domain::AgentStatus;
+use crate::domain::{AgentStatus, IssueDetail};
 use crate::issue_detail_content::build_detail_content;
 use crate::pr_detail_content::build_pr_detail_content;
 use crate::runtime::TerminalSnapshot;
 use crate::selection::SelectablePane;
 use crate::state::AppState;
+use crate::ui::components::issue_detail::issue_detail_header_view;
 use crate::ui::components::issue_list::{IssueListLayout, issue_list_visible_rows};
 use crate::ui::components::pr_detail::pr_detail_header_view;
 use crate::ui::components::pr_list::pr_list_visible_rows;
@@ -138,30 +139,16 @@ fn pr_detail_lines(state: &AppState) -> PaneContent {
 
 /// Build the five fixed header lines the `IssueDetailView` renders above its
 /// scrollable viewport, so selection coordinates map to those header rows too.
-fn issue_detail_header_lines(detail: &crate::domain::IssueDetail) -> Vec<String> {
-    let state_tag = match detail.state {
-        crate::domain::IssueState::Open => "OPEN",
-        crate::domain::IssueState::Closed => "CLOSED",
-    };
-    let labels_str = if detail.labels.is_empty() {
-        "-".to_string()
-    } else {
-        detail.labels.join(", ")
-    };
-    let assignees_str = if detail.assignees.is_empty() {
-        "-".to_string()
-    } else {
-        detail.assignees.join(", ")
-    };
-    let milestone_str = detail.milestone.as_deref().unwrap_or("-").to_string();
+///
+/// Reuses [`issue_detail_header_view`] (the same pure projection the renderer
+/// uses) so the copyable header text never drifts from what the user sees.
+fn issue_detail_header_lines(detail: &IssueDetail) -> Vec<String> {
+    let header = issue_detail_header_view(detail);
     vec![
-        format!("#{} {}", detail.number, detail.title),
-        format!(
-            "{}  by @{}  opened: {}  updated: {}",
-            state_tag, detail.author_login, detail.created_at, detail.updated_at
-        ),
-        format!("labels: {labels_str}  assignees: {assignees_str}  milestone: {milestone_str}"),
-        detail.external_url.clone(),
+        header.title,
+        header.state,
+        header.labels,
+        header.url,
         DETAIL_SEPARATOR_LINE.to_string(),
     ]
 }

--- a/src/selection/geometry.rs
+++ b/src/selection/geometry.rs
@@ -7,8 +7,8 @@
 
 use crate::layout::{
     AGENT_LIST_CHROME_COLS, AGENT_LIST_CHROME_ROWS, DETAIL_HEADER_ROWS, DETAIL_PANE_CHROME_COLS,
-    KEYBIND_BAR_CHROME_COLS, LEFT_COL_WIDTH, LIST_PANE_CHROME_COLS, LIST_PANE_CHROME_ROWS,
-    OUTER_BARS_HEIGHT, RIGHT_COL_WIDTH, SIDEBAR_CHROME_COLS, SIDEBAR_CHROME_ROWS,
+    DETAIL_PANE_CHROME_ROWS, KEYBIND_BAR_CHROME_COLS, LEFT_COL_WIDTH, LIST_PANE_CHROME_COLS,
+    LIST_PANE_CHROME_ROWS, RIGHT_COL_WIDTH, SIDEBAR_CHROME_COLS, SIDEBAR_CHROME_ROWS,
     STATUS_BAR_CHROME_COLS, TERMINAL_VIEW_CHROME_COLS, TERMINAL_VIEW_CHROME_ROWS,
     effective_render_size, issues_pane_rows,
 };
@@ -102,19 +102,19 @@ impl PaneGeometry {
 ///
 /// Returns `None` when the point falls outside any known pane (e.g. on a
 /// border line or in the gutter). The layout is computed from `term_cols` /
-/// `term_rows` and the active `screen_mode`, using the exact [`crate::layout`]
-/// constants the screens render with, so geometry can never drift from the
-/// rendered output.
+/// `term_rows` and the active screen mode (read from `layout.screen_mode`),
+/// using the exact [`crate::layout`] constants the screens render with, so
+/// geometry can never drift from the rendered output.
 ///
-/// `terminal_focused` only matters for the dashboard: when the terminal is
-/// focused, mouse events over the terminal pane are forwarded to the PTY and
-/// should not start an app selection, so [`SelectablePane::TerminalView`] is
-/// excluded from the result in that case.
+/// `terminal_input_enabled` only matters for the dashboard: when the terminal
+/// is focused, mouse events over the terminal pane are forwarded to the PTY
+/// and should not start an app selection, so [`SelectablePane::TerminalView`]
+/// is excluded from the result in that case.
 #[must_use]
 pub fn pane_at(
     col: u16,
     row: u16,
-    screen_mode: crate::state::ScreenMode,
+    _screen_mode: crate::state::ScreenMode,
     terminal_input_enabled: bool,
     layout: &ScreenLayout,
 ) -> Option<(SelectablePane, PaneGeometry)> {
@@ -131,7 +131,7 @@ pub fn pane_at(
         return Some(keybind_bar(render_cols, render_rows));
     }
 
-    match screen_mode {
+    match layout.screen_mode {
         crate::state::ScreenMode::Dashboard | crate::state::ScreenMode::Split => {
             dashboard_pane_at(col, row, render_cols, render_rows, terminal_input_enabled)
         }
@@ -229,12 +229,11 @@ fn dashboard_pane_at(
 
 /// Issues/PR-mode layout hit-test (identical geometry, different pane names).
 ///
-/// The caller passes the `SelectablePane` variant set appropriate for the mode
-/// via the [`ScreenLayout`]'s screen mode; here we always return Issue* variants
-/// and rely on the fact that PR mode reuses the same geometry. The pane
-/// *identity* is corrected by the caller when needed — but since this is the
-/// single shared geometry, we return the Issues-named panes and the
-/// mouse-routing layer maps them to PR panes when in PR mode.
+/// The [`ScreenLayout`]'s screen mode determines whether the list and detail
+/// panes are returned as `IssueList`/`IssueDetail` or `PrList`/`PrDetail`
+/// (see [`list_pane`] and [`detail_pane`], which branch on
+/// `layout.is_pr_mode()`). The geometry itself is shared between issues and
+/// PR modes because both use the same `issues_pane_rows` layout math.
 fn issues_pane_at(
     col: u16,
     row: u16,
@@ -356,7 +355,7 @@ fn detail_pane(
     // is shared with the renderer via crate::layout::DETAIL_HEADER_ROWS.
     let detail_chrome_rows = u16::try_from(DETAIL_HEADER_ROWS)
         .unwrap_or(0)
-        .saturating_add(1);
+        .saturating_add(DETAIL_PANE_CHROME_ROWS);
     (
         pane,
         PaneGeometry::with_chrome(
@@ -442,6 +441,5 @@ fn terminal_view(
 /// geometry uses the exact same clamping the renderer applies (single source of
 /// truth). `render_rows` is the post-`effective_render_size` height.
 fn dashboard_middle_row_heights_for_render(render_rows: u16) -> (u16, u16) {
-    let content_rows = render_rows.saturating_sub(OUTER_BARS_HEIGHT);
-    crate::layout::dashboard_middle_row_heights_inner(content_rows)
+    crate::layout::dashboard_middle_row_heights_inner(render_rows)
 }

--- a/src/selection/geometry.rs
+++ b/src/selection/geometry.rs
@@ -6,7 +6,11 @@
 //! the pane under a `(col, row)` along with its screen-space rectangle.
 
 use crate::layout::{
-    LEFT_COL_WIDTH, OUTER_BARS_HEIGHT, RIGHT_COL_WIDTH, effective_render_size, issues_pane_rows,
+    AGENT_LIST_CHROME_COLS, AGENT_LIST_CHROME_ROWS, DETAIL_HEADER_ROWS, DETAIL_PANE_CHROME_COLS,
+    KEYBIND_BAR_CHROME_COLS, LEFT_COL_WIDTH, LIST_PANE_CHROME_COLS, LIST_PANE_CHROME_ROWS,
+    OUTER_BARS_HEIGHT, RIGHT_COL_WIDTH, SIDEBAR_CHROME_COLS, SIDEBAR_CHROME_ROWS,
+    STATUS_BAR_CHROME_COLS, TERMINAL_VIEW_CHROME_COLS, TERMINAL_VIEW_CHROME_ROWS,
+    effective_render_size, issues_pane_rows,
 };
 use crate::selection::ScreenLayout;
 use crate::selection::text::SelectablePane;
@@ -14,33 +18,72 @@ use crate::selection::text::SelectablePane;
 /// Screen-space rectangle of one pane, in render-grid coordinates.
 ///
 /// `origin_col`/`origin_row` is the top-left cell (0-based) of the pane's
-/// content area; `width`/`height` are its size in cells. All fields are
-/// non-negative and clamped to the terminal size.
+/// *widget box* (including borders/title/padding), while
+/// `content_origin_col`/`content_origin_row` is the top-left cell of the
+/// pane's *first content cell* (after borders/title/padding). Selection
+/// coordinate math uses the content origin so a click on the first content
+/// line maps to content line 0. `width`/`height` are the widget-box size in
+/// cells. All fields are non-negative and clamped to the terminal size.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PaneGeometry {
-    /// 0-based column of the pane's left edge.
+    /// 0-based column of the pane's widget-box left edge (border).
     pub origin_col: u16,
-    /// 0-based row of the pane's top edge.
+    /// 0-based row of the pane's widget-box top edge (border).
     pub origin_row: u16,
-    /// Pane width in columns.
+    /// Pane widget-box width in columns.
     pub width: u16,
-    /// Pane height in rows.
+    /// Pane widget-box height in rows.
     pub height: u16,
+    /// 0-based column of the first content cell (after left border/padding).
+    pub content_origin_col: u16,
+    /// 0-based row of the first content cell (after top border/title).
+    pub content_origin_row: u16,
 }
 
 impl PaneGeometry {
-    /// Construct a pane rectangle from its origin and size.
+    /// Construct a pane rectangle from its widget-box origin and size, plus the
+    /// content-cell origin (the first cell inside the border/title/padding).
     #[must_use]
-    pub const fn new(origin_col: u16, origin_row: u16, width: u16, height: u16) -> Self {
+    pub const fn new(
+        origin_col: u16,
+        origin_row: u16,
+        width: u16,
+        height: u16,
+        content_origin_col: u16,
+        content_origin_row: u16,
+    ) -> Self {
         Self {
             origin_col,
             origin_row,
             width,
             height,
+            content_origin_col,
+            content_origin_row,
         }
     }
 
-    /// Whether a screen-space `(col, row)` falls inside this rectangle.
+    /// Construct a pane rectangle from the widget-box origin/size, deriving the
+    /// content origin by adding the given chrome offsets.
+    #[must_use]
+    pub const fn with_chrome(
+        origin_col: u16,
+        origin_row: u16,
+        width: u16,
+        height: u16,
+        chrome_cols: u16,
+        chrome_rows: u16,
+    ) -> Self {
+        Self::new(
+            origin_col,
+            origin_row,
+            width,
+            height,
+            origin_col.saturating_add(chrome_cols),
+            origin_row.saturating_add(chrome_rows),
+        )
+    }
+
+    /// Whether a screen-space `(col, row)` falls inside this widget-box rectangle.
     ///
     /// Points on the bottom/right edge (inclusive of `origin + size - 1`) count
     /// as inside.
@@ -103,7 +146,14 @@ pub fn pane_at(
 fn status_bar(render_cols: u16) -> (SelectablePane, PaneGeometry) {
     (
         SelectablePane::StatusBar,
-        PaneGeometry::new(0, 0, render_cols, 1),
+        PaneGeometry::with_chrome(
+            0,
+            0,
+            render_cols,
+            1,
+            STATUS_BAR_CHROME_COLS,
+            crate::layout::STATUS_BAR_CHROME_ROWS,
+        ),
     )
 }
 
@@ -112,7 +162,14 @@ fn keybind_bar(render_cols: u16, render_rows: u16) -> (SelectablePane, PaneGeome
     let origin_row = render_rows.saturating_sub(1);
     (
         SelectablePane::KeybindBar,
-        PaneGeometry::new(0, origin_row, render_cols, 1),
+        PaneGeometry::with_chrome(
+            0,
+            origin_row,
+            render_cols,
+            1,
+            KEYBIND_BAR_CHROME_COLS,
+            crate::layout::KEYBIND_BAR_CHROME_ROWS,
+        ),
     )
 }
 
@@ -195,29 +252,9 @@ fn issues_pane_at(
 
     // Workspace column: vertical stack of optional bands + list + detail.
     let workspace_col0 = LEFT_COL_WIDTH;
-    let workspace_col_end = render_cols;
-    let workspace_width = workspace_col_end.saturating_sub(workspace_col0);
+    let workspace_width = render_cols.saturating_sub(workspace_col0);
 
-    let mut cursor_row = content_top;
-    if layout.error_visible {
-        // Error banner occupies one row — not selectable (no content provider).
-        if row == cursor_row {
-            return None;
-        }
-        cursor_row = cursor_row.saturating_add(1);
-    }
-    if layout.filter_controls_open {
-        let band_rows = u16::try_from(crate::layout::FILTER_CONTROLS_ROWS).unwrap_or(5);
-        let band_bottom = cursor_row.saturating_add(band_rows);
-        if row < band_bottom {
-            return Some((
-                SelectablePane::IssueList,
-                PaneGeometry::new(workspace_col0, cursor_row, workspace_width, band_rows),
-            ));
-        }
-        cursor_row = band_bottom;
-    }
-
+    let cursor_row = skip_non_list_bands(row, content_top, layout)?;
     let (list_rows, detail_rows) = issues_pane_rows(
         usize::from(render_rows),
         layout.error_visible,
@@ -251,6 +288,30 @@ fn issues_pane_at(
     None
 }
 
+/// Advance `cursor_row` past the error banner and filter band (if present).
+///
+/// Returns `Some(updated_cursor_row)` when the row is not inside a skipped
+/// band, or `None` when the row hits a non-selectable band (error banner) or
+/// the filter-controls band (which is not selectable).
+fn skip_non_list_bands(row: u16, content_top: u16, layout: ScreenLayout) -> Option<u16> {
+    let mut cursor_row = content_top;
+    if layout.error_visible {
+        if row == cursor_row {
+            return None;
+        }
+        cursor_row = cursor_row.saturating_add(1);
+    }
+    if layout.filter_controls_open {
+        let band_rows = u16::try_from(crate::layout::FILTER_CONTROLS_ROWS).unwrap_or(5);
+        let band_bottom = cursor_row.saturating_add(band_rows);
+        if row < band_bottom {
+            return None;
+        }
+        cursor_row = band_bottom;
+    }
+    Some(cursor_row)
+}
+
 /// Choose the IssueList vs PrList variant based on the screen mode in layout.
 fn list_pane(
     col0: u16,
@@ -264,7 +325,17 @@ fn list_pane(
     } else {
         SelectablePane::IssueList
     };
-    (pane, PaneGeometry::new(col0, row0, width, height))
+    (
+        pane,
+        PaneGeometry::with_chrome(
+            col0,
+            row0,
+            width,
+            height,
+            LIST_PANE_CHROME_COLS,
+            LIST_PANE_CHROME_ROWS,
+        ),
+    )
 }
 
 /// Choose the IssueDetail vs PrDetail variant based on the screen mode in layout.
@@ -280,14 +351,37 @@ fn detail_pane(
     } else {
         SelectablePane::IssueDetail
     };
-    (pane, PaneGeometry::new(col0, row0, width, height))
+    // Detail content starts below the border (1 row) + the fixed metadata
+    // header rows (which include the trailing separator). The header row count
+    // is shared with the renderer via crate::layout::DETAIL_HEADER_ROWS.
+    let detail_chrome_rows = u16::try_from(DETAIL_HEADER_ROWS)
+        .unwrap_or(0)
+        .saturating_add(1);
+    (
+        pane,
+        PaneGeometry::with_chrome(
+            col0,
+            row0,
+            width,
+            height,
+            DETAIL_PANE_CHROME_COLS,
+            detail_chrome_rows,
+        ),
+    )
 }
 
 fn sidebar(content_top: u16, content_bottom: u16) -> (SelectablePane, PaneGeometry) {
     let height = content_bottom.saturating_sub(content_top);
     (
         SelectablePane::Sidebar,
-        PaneGeometry::new(0, content_top, LEFT_COL_WIDTH, height),
+        PaneGeometry::with_chrome(
+            0,
+            content_top,
+            LEFT_COL_WIDTH,
+            height,
+            SIDEBAR_CHROME_COLS,
+            SIDEBAR_CHROME_ROWS,
+        ),
     )
 }
 
@@ -295,7 +389,15 @@ fn preview(col0: u16, content_top: u16, content_bottom: u16) -> (SelectablePane,
     let height = content_bottom.saturating_sub(content_top);
     (
         SelectablePane::Preview,
-        PaneGeometry::new(col0, content_top, RIGHT_COL_WIDTH, height),
+        // Preview is a bordered box like the sidebar; reuse sidebar chrome.
+        PaneGeometry::with_chrome(
+            col0,
+            content_top,
+            RIGHT_COL_WIDTH,
+            height,
+            SIDEBAR_CHROME_COLS,
+            SIDEBAR_CHROME_ROWS,
+        ),
     )
 }
 
@@ -303,7 +405,14 @@ fn agent_list(col0: u16, row0: u16, col_end: u16, height: u16) -> (SelectablePan
     let width = col_end.saturating_sub(col0);
     (
         SelectablePane::AgentList,
-        PaneGeometry::new(col0, row0, width, height),
+        PaneGeometry::with_chrome(
+            col0,
+            row0,
+            width,
+            height,
+            AGENT_LIST_CHROME_COLS,
+            AGENT_LIST_CHROME_ROWS,
+        ),
     )
 }
 
@@ -316,7 +425,14 @@ fn terminal_view(
     let width = col_end.saturating_sub(col0);
     (
         SelectablePane::TerminalView,
-        PaneGeometry::new(col0, row0, width, height),
+        PaneGeometry::with_chrome(
+            col0,
+            row0,
+            width,
+            height,
+            TERMINAL_VIEW_CHROME_COLS,
+            TERMINAL_VIEW_CHROME_ROWS,
+        ),
     )
 }
 

--- a/src/selection/geometry.rs
+++ b/src/selection/geometry.rs
@@ -6,7 +6,7 @@
 //! the pane under a `(col, row)` along with its screen-space rectangle.
 
 use crate::layout::{
-    AGENT_LIST_CHROME_COLS, AGENT_LIST_CHROME_ROWS, DETAIL_HEADER_ROWS, DETAIL_PANE_CHROME_COLS,
+    AGENT_LIST_CHROME_COLS, AGENT_LIST_CHROME_ROWS, DETAIL_PANE_CHROME_COLS,
     DETAIL_PANE_CHROME_ROWS, KEYBIND_BAR_CHROME_COLS, LEFT_COL_WIDTH, LIST_PANE_CHROME_COLS,
     LIST_PANE_CHROME_ROWS, RIGHT_COL_WIDTH, SIDEBAR_CHROME_COLS, SIDEBAR_CHROME_ROWS,
     STATUS_BAR_CHROME_COLS, TERMINAL_VIEW_CHROME_COLS, TERMINAL_VIEW_CHROME_ROWS,
@@ -350,12 +350,11 @@ fn detail_pane(
     } else {
         SelectablePane::IssueDetail
     };
-    // Detail content starts below the border (1 row) + the fixed metadata
-    // header rows (which include the trailing separator). The header row count
-    // is shared with the renderer via crate::layout::DETAIL_HEADER_ROWS.
-    let detail_chrome_rows = u16::try_from(DETAIL_HEADER_ROWS)
-        .unwrap_or(0)
-        .saturating_add(DETAIL_PANE_CHROME_ROWS);
+    // Detail content starts directly below the border (1 row). The fixed
+    // metadata header rows (title/state/labels/url/separator) are part of the
+    // selectable content — they are rendered above the scroll viewport but are
+    // NOT scrolled, so `content_origin_row` points at the first header row and
+    // the scroll offset is suppressed for those rows in the mouse router.
     (
         pane,
         PaneGeometry::with_chrome(
@@ -364,7 +363,7 @@ fn detail_pane(
             width,
             height,
             DETAIL_PANE_CHROME_COLS,
-            detail_chrome_rows,
+            DETAIL_PANE_CHROME_ROWS,
         ),
     )
 }

--- a/src/selection/geometry.rs
+++ b/src/selection/geometry.rs
@@ -1,0 +1,331 @@
+//! Pane geometry: maps screen coordinates to a selectable pane using the
+//! same [`crate::layout`] constants the screens render with.
+//!
+//! The single entry point is [`pane_at`], which mirrors the on-screen layout
+//! of each [`crate::state::ScreenMode`] (dashboard, issues, PRs) and returns
+//! the pane under a `(col, row)` along with its screen-space rectangle.
+
+use crate::layout::{
+    LEFT_COL_WIDTH, OUTER_BARS_HEIGHT, RIGHT_COL_WIDTH, effective_render_size, issues_pane_rows,
+};
+use crate::selection::ScreenLayout;
+use crate::selection::text::SelectablePane;
+
+/// Screen-space rectangle of one pane, in render-grid coordinates.
+///
+/// `origin_col`/`origin_row` is the top-left cell (0-based) of the pane's
+/// content area; `width`/`height` are its size in cells. All fields are
+/// non-negative and clamped to the terminal size.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PaneGeometry {
+    /// 0-based column of the pane's left edge.
+    pub origin_col: u16,
+    /// 0-based row of the pane's top edge.
+    pub origin_row: u16,
+    /// Pane width in columns.
+    pub width: u16,
+    /// Pane height in rows.
+    pub height: u16,
+}
+
+impl PaneGeometry {
+    /// Construct a pane rectangle from its origin and size.
+    #[must_use]
+    pub const fn new(origin_col: u16, origin_row: u16, width: u16, height: u16) -> Self {
+        Self {
+            origin_col,
+            origin_row,
+            width,
+            height,
+        }
+    }
+
+    /// Whether a screen-space `(col, row)` falls inside this rectangle.
+    ///
+    /// Points on the bottom/right edge (inclusive of `origin + size - 1`) count
+    /// as inside.
+    #[must_use]
+    pub fn contains(self, col: u16, row: u16) -> bool {
+        let col_end = self.origin_col.saturating_add(self.width).saturating_sub(1);
+        let row_end = self
+            .origin_row
+            .saturating_add(self.height)
+            .saturating_sub(1);
+        col >= self.origin_col && col <= col_end && row >= self.origin_row && row <= row_end
+    }
+}
+
+/// Map a screen-space `(col, row)` to the pane under it.
+///
+/// Returns `None` when the point falls outside any known pane (e.g. on a
+/// border line or in the gutter). The layout is computed from `term_cols` /
+/// `term_rows` and the active `screen_mode`, using the exact [`crate::layout`]
+/// constants the screens render with, so geometry can never drift from the
+/// rendered output.
+///
+/// `terminal_focused` only matters for the dashboard: when the terminal is
+/// focused, mouse events over the terminal pane are forwarded to the PTY and
+/// should not start an app selection, so [`SelectablePane::TerminalView`] is
+/// excluded from the result in that case.
+#[must_use]
+pub fn pane_at(
+    col: u16,
+    row: u16,
+    screen_mode: crate::state::ScreenMode,
+    terminal_input_enabled: bool,
+    layout: &ScreenLayout,
+) -> Option<(SelectablePane, PaneGeometry)> {
+    let (render_cols, render_rows) = effective_render_size(layout.term_cols, layout.term_rows);
+    if col >= render_cols || row >= render_rows {
+        return None;
+    }
+
+    // Outer bars span the full width.
+    if row == 0 {
+        return Some(status_bar(render_cols));
+    }
+    if row == render_rows.saturating_sub(1) {
+        return Some(keybind_bar(render_cols, render_rows));
+    }
+
+    match screen_mode {
+        crate::state::ScreenMode::Dashboard | crate::state::ScreenMode::Split => {
+            dashboard_pane_at(col, row, render_cols, render_rows, terminal_input_enabled)
+        }
+        crate::state::ScreenMode::DashboardIssues
+        | crate::state::ScreenMode::DashboardPullRequests => {
+            issues_pane_at(col, row, render_cols, render_rows, *layout)
+        }
+    }
+}
+
+/// Status bar geometry (row 0, full width).
+fn status_bar(render_cols: u16) -> (SelectablePane, PaneGeometry) {
+    (
+        SelectablePane::StatusBar,
+        PaneGeometry::new(0, 0, render_cols, 1),
+    )
+}
+
+/// Keybind bar geometry (last row, full width).
+fn keybind_bar(render_cols: u16, render_rows: u16) -> (SelectablePane, PaneGeometry) {
+    let origin_row = render_rows.saturating_sub(1);
+    (
+        SelectablePane::KeybindBar,
+        PaneGeometry::new(0, origin_row, render_cols, 1),
+    )
+}
+
+/// Dashboard / split layout hit-test.
+fn dashboard_pane_at(
+    col: u16,
+    row: u16,
+    render_cols: u16,
+    render_rows: u16,
+    terminal_input_enabled: bool,
+) -> Option<(SelectablePane, PaneGeometry)> {
+    let content_top = 1u16;
+    let content_bottom = render_rows.saturating_sub(1);
+
+    // Sidebar: left column, full content height.
+    if col < LEFT_COL_WIDTH {
+        return Some(sidebar(content_top, content_bottom));
+    }
+
+    // Preview: right column, full content height.
+    let preview_col0 = render_cols.saturating_sub(RIGHT_COL_WIDTH);
+    if col >= preview_col0 {
+        return Some(preview(preview_col0, content_top, content_bottom));
+    }
+
+    // Middle column: agent list (top) + terminal widget (bottom).
+    let (agent_rows, terminal_slot_rows) = dashboard_middle_row_heights_for_render(render_rows);
+    let agent_bottom_exclusive = content_top.saturating_add(agent_rows);
+    if row < agent_bottom_exclusive {
+        return Some(agent_list(
+            LEFT_COL_WIDTH,
+            content_top,
+            preview_col0,
+            agent_rows,
+        ));
+    }
+
+    let terminal_top = agent_bottom_exclusive;
+    let terminal_bottom_exclusive = terminal_top.saturating_add(terminal_slot_rows);
+    if row < terminal_bottom_exclusive {
+        // Forward to PTY when terminal input is enabled; otherwise selectable
+        // terminal snapshot.
+        if terminal_input_enabled {
+            return None;
+        }
+        return Some(terminal_view(
+            LEFT_COL_WIDTH,
+            terminal_top,
+            preview_col0,
+            terminal_slot_rows,
+        ));
+    }
+
+    // Below the middle column (shouldn't happen — content_bottom covers it).
+    None
+}
+
+/// Issues/PR-mode layout hit-test (identical geometry, different pane names).
+///
+/// The caller passes the `SelectablePane` variant set appropriate for the mode
+/// via the [`ScreenLayout`]'s screen mode; here we always return Issue* variants
+/// and rely on the fact that PR mode reuses the same geometry. The pane
+/// *identity* is corrected by the caller when needed — but since this is the
+/// single shared geometry, we return the Issues-named panes and the
+/// mouse-routing layer maps them to PR panes when in PR mode.
+fn issues_pane_at(
+    col: u16,
+    row: u16,
+    render_cols: u16,
+    render_rows: u16,
+    layout: ScreenLayout,
+) -> Option<(SelectablePane, PaneGeometry)> {
+    let content_top = 1u16;
+    let content_bottom = render_rows.saturating_sub(1);
+
+    // Sidebar: left column, full content height.
+    if col < LEFT_COL_WIDTH {
+        return Some(sidebar(content_top, content_bottom));
+    }
+
+    // Workspace column: vertical stack of optional bands + list + detail.
+    let workspace_col0 = LEFT_COL_WIDTH;
+    let workspace_col_end = render_cols;
+    let workspace_width = workspace_col_end.saturating_sub(workspace_col0);
+
+    let mut cursor_row = content_top;
+    if layout.error_visible {
+        // Error banner occupies one row — not selectable (no content provider).
+        if row == cursor_row {
+            return None;
+        }
+        cursor_row = cursor_row.saturating_add(1);
+    }
+    if layout.filter_controls_open {
+        let band_rows = u16::try_from(crate::layout::FILTER_CONTROLS_ROWS).unwrap_or(5);
+        let band_bottom = cursor_row.saturating_add(band_rows);
+        if row < band_bottom {
+            return Some((
+                SelectablePane::IssueList,
+                PaneGeometry::new(workspace_col0, cursor_row, workspace_width, band_rows),
+            ));
+        }
+        cursor_row = band_bottom;
+    }
+
+    let (list_rows, detail_rows) = issues_pane_rows(
+        usize::from(render_rows),
+        layout.error_visible,
+        layout.filter_controls_open,
+    );
+    let list_rows_u16 = u16::try_from(list_rows).unwrap_or(0);
+    let detail_rows_u16 = u16::try_from(detail_rows).unwrap_or(0);
+
+    let list_bottom = cursor_row.saturating_add(list_rows_u16);
+    if row < list_bottom {
+        return Some(list_pane(
+            workspace_col0,
+            cursor_row,
+            workspace_width,
+            list_rows_u16,
+            layout,
+        ));
+    }
+
+    let detail_top = list_bottom;
+    if row < detail_top.saturating_add(detail_rows_u16) {
+        return Some(detail_pane(
+            workspace_col0,
+            detail_top,
+            workspace_width,
+            detail_rows_u16,
+            layout,
+        ));
+    }
+
+    None
+}
+
+/// Choose the IssueList vs PrList variant based on the screen mode in layout.
+fn list_pane(
+    col0: u16,
+    row0: u16,
+    width: u16,
+    height: u16,
+    layout: ScreenLayout,
+) -> (SelectablePane, PaneGeometry) {
+    let pane = if layout.is_pr_mode() {
+        SelectablePane::PrList
+    } else {
+        SelectablePane::IssueList
+    };
+    (pane, PaneGeometry::new(col0, row0, width, height))
+}
+
+/// Choose the IssueDetail vs PrDetail variant based on the screen mode in layout.
+fn detail_pane(
+    col0: u16,
+    row0: u16,
+    width: u16,
+    height: u16,
+    layout: ScreenLayout,
+) -> (SelectablePane, PaneGeometry) {
+    let pane = if layout.is_pr_mode() {
+        SelectablePane::PrDetail
+    } else {
+        SelectablePane::IssueDetail
+    };
+    (pane, PaneGeometry::new(col0, row0, width, height))
+}
+
+fn sidebar(content_top: u16, content_bottom: u16) -> (SelectablePane, PaneGeometry) {
+    let height = content_bottom.saturating_sub(content_top);
+    (
+        SelectablePane::Sidebar,
+        PaneGeometry::new(0, content_top, LEFT_COL_WIDTH, height),
+    )
+}
+
+fn preview(col0: u16, content_top: u16, content_bottom: u16) -> (SelectablePane, PaneGeometry) {
+    let height = content_bottom.saturating_sub(content_top);
+    (
+        SelectablePane::Preview,
+        PaneGeometry::new(col0, content_top, RIGHT_COL_WIDTH, height),
+    )
+}
+
+fn agent_list(col0: u16, row0: u16, col_end: u16, height: u16) -> (SelectablePane, PaneGeometry) {
+    let width = col_end.saturating_sub(col0);
+    (
+        SelectablePane::AgentList,
+        PaneGeometry::new(col0, row0, width, height),
+    )
+}
+
+fn terminal_view(
+    col0: u16,
+    row0: u16,
+    col_end: u16,
+    height: u16,
+) -> (SelectablePane, PaneGeometry) {
+    let width = col_end.saturating_sub(col0);
+    (
+        SelectablePane::TerminalView,
+        PaneGeometry::new(col0, row0, width, height),
+    )
+}
+
+/// Dashboard middle-row split for a given *render* row count.
+///
+/// Wraps [`crate::layout::dashboard_middle_row_heights_inner`] so the selection
+/// geometry uses the exact same clamping the renderer applies (single source of
+/// truth). `render_rows` is the post-`effective_render_size` height.
+fn dashboard_middle_row_heights_for_render(render_rows: u16) -> (u16, u16) {
+    let content_rows = render_rows.saturating_sub(OUTER_BARS_HEIGHT);
+    crate::layout::dashboard_middle_row_heights_inner(content_rows)
+}

--- a/src/selection/layout_descriptor.rs
+++ b/src/selection/layout_descriptor.rs
@@ -1,0 +1,53 @@
+//! Layout descriptor passed to [`crate::selection::pane_at`].
+//!
+//! Carries the raw terminal size plus the conditional band flags (error banner,
+//! filter controls) that affect the vertical row split in Issues / PR mode.
+//! Keeping these in a single struct keeps [`crate::selection::pane_at`]'s
+//! signature stable as more conditional bands are added.
+
+use crate::state::ScreenMode;
+
+/// Inputs needed to compute pane geometry for the current screen.
+///
+/// All fields are plain values (no iocraft types) so the descriptor can be
+/// constructed cheaply from [`crate::state::AppState`] snapshots and passed to
+/// the pure [`crate::selection::pane_at`] function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScreenLayout {
+    /// Raw terminal width in columns (as reported by crossterm).
+    pub term_cols: u16,
+    /// Raw terminal height in rows (as reported by crossterm).
+    pub term_rows: u16,
+    /// Active screen mode (drives the layout template).
+    pub screen_mode: ScreenMode,
+    /// Whether an error banner is visible in the workspace (Issues/PR mode).
+    pub error_visible: bool,
+    /// Whether the filter-controls band is open (Issues/PR mode).
+    pub filter_controls_open: bool,
+}
+
+impl ScreenLayout {
+    /// Construct a layout descriptor from its raw fields.
+    #[must_use]
+    pub const fn new(
+        term_cols: u16,
+        term_rows: u16,
+        screen_mode: ScreenMode,
+        error_visible: bool,
+        filter_controls_open: bool,
+    ) -> Self {
+        Self {
+            term_cols,
+            term_rows,
+            screen_mode,
+            error_visible,
+            filter_controls_open,
+        }
+    }
+
+    /// Whether this layout is for PR mode (affects pane identity, not geometry).
+    #[must_use]
+    pub fn is_pr_mode(self) -> bool {
+        matches!(self.screen_mode, ScreenMode::DashboardPullRequests)
+    }
+}

--- a/src/selection/mod.rs
+++ b/src/selection/mod.rs
@@ -33,8 +33,8 @@ pub use content::{PaneContent, pane_content_lines};
 pub use geometry::{PaneGeometry, pane_at};
 pub use layout_descriptor::ScreenLayout;
 pub use text::{
-    SelectablePane, SelectionPoint, TextSelection, normalize_selection, point_to_content_coords,
-    selection_text,
+    HighlightRange, SelectablePane, SelectionPoint, TextSelection, normalize_selection,
+    point_to_content_coords, row_highlight_range, selection_text,
 };
 
 #[cfg(test)]

--- a/src/selection/mod.rs
+++ b/src/selection/mod.rs
@@ -1,0 +1,42 @@
+//! Pure, iocraft-free mouse-selection model.
+//!
+//! This module owns the data model and geometry math for mouse-based text
+//! selection across every jefe pane (issue list/detail, PR list/detail,
+//! sidebar, agent list, preview, and the terminal snapshot when unfocused).
+//!
+//! It is deliberately free of any iocraft types (`Color`, `Props`, element
+//! trees): the geometry here derives from the same [`crate::layout`]
+//! constants the screens use, so a screen `(col, row)` can be mapped to a pane
+//! and content coordinate without hit-testing a component tree.
+//!
+//! # Design
+//!
+//! - [`SelectablePane`] names every region a user can select text in.
+//! - [`SelectionPoint`] is a `(pane, content_line, content_col)` triple —
+//!   content coordinates, already adjusted for the pane's scroll offset.
+//! - [`TextSelection`] pairs an anchor (mouse-down) and focus (current drag)
+//!   point. Both points always live in the *same* pane; selections never cross
+//!   pane boundaries.
+//! - [`PaneGeometry`] is the screen-space rectangle of one pane, computed by
+//!   [`pane_at`] from the active [`crate::state::ScreenMode`] and terminal size.
+//! - [`ScreenLayout`] carries the conditional band flags (error banner,
+//!   filter controls) that affect vertical row splits in Issues/PR mode.
+//!
+//! All functions are pure and `#[must_use]`.
+
+mod content;
+mod geometry;
+mod layout_descriptor;
+mod text;
+
+pub use content::{PaneContent, pane_content_lines};
+pub use geometry::{PaneGeometry, pane_at};
+pub use layout_descriptor::ScreenLayout;
+pub use text::{
+    SelectablePane, SelectionPoint, TextSelection, normalize_selection, point_to_content_coords,
+    selection_text,
+};
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/src/selection/tests.rs
+++ b/src/selection/tests.rs
@@ -1,0 +1,322 @@
+//! Unit tests for the pure selection model (iocraft-free).
+//!
+//! These exercise [`crate::selection::pane_at`], [`normalize_selection`],
+//! [`selection_text`], and [`point_to_content_coords`] without any terminal.
+
+use crate::selection::{
+    PaneGeometry, SelectablePane, SelectionPoint, TextSelection, normalize_selection, pane_at,
+    point_to_content_coords, selection_text,
+};
+use crate::state::ScreenMode;
+
+const DASHBOARD: ScreenMode = ScreenMode::Dashboard;
+const ISSUES: ScreenMode = ScreenMode::DashboardIssues;
+const PRS: ScreenMode = ScreenMode::DashboardPullRequests;
+
+fn layout(
+    cols: u16,
+    rows: u16,
+    mode: ScreenMode,
+    error_visible: bool,
+    filter_open: bool,
+) -> crate::selection::ScreenLayout {
+    crate::selection::ScreenLayout::new(cols, rows, mode, error_visible, filter_open)
+}
+
+// ── PaneGeometry::contains ──────────────────────────────────────────────────
+
+#[test]
+fn geometry_contains_includes_interior_and_edges() {
+    let g = PaneGeometry::new(5, 3, 4, 2);
+    assert!(g.contains(5, 3));
+    assert!(g.contains(8, 4)); // bottom-right inclusive
+    assert!(!g.contains(4, 3)); // left of origin
+    assert!(!g.contains(9, 4)); // right of edge
+    assert!(!g.contains(5, 5)); // below edge
+}
+
+// ── pane_at: dashboard ──────────────────────────────────────────────────────
+
+#[test]
+fn pane_at_dashboard_status_bar() {
+    let lay = layout(120, 40, DASHBOARD, false, false);
+    let Some((pane, geo)) = pane_at(60, 0, DASHBOARD, false, &lay) else {
+        panic!("expected status bar at (60, 0)");
+    };
+    assert!(matches!(pane, SelectablePane::StatusBar));
+    assert_eq!(geo.height, 1);
+}
+
+#[test]
+fn pane_at_dashboard_keybind_bar() {
+    let lay = layout(120, 40, DASHBOARD, false, false);
+    let Some((pane, _)) = pane_at(60, 39, DASHBOARD, false, &lay) else {
+        panic!("expected keybind bar at (60, 39)");
+    };
+    assert!(matches!(pane, SelectablePane::KeybindBar));
+}
+
+#[test]
+fn pane_at_dashboard_sidebar() {
+    let lay = layout(120, 40, DASHBOARD, false, false);
+    let Some((pane, geo)) = pane_at(0, 5, DASHBOARD, false, &lay) else {
+        panic!("expected sidebar at (0, 5)");
+    };
+    assert!(matches!(pane, SelectablePane::Sidebar));
+    assert_eq!(geo.origin_col, 0);
+    assert_eq!(geo.origin_row, 1);
+}
+
+#[test]
+fn pane_at_dashboard_preview() {
+    let lay = layout(120, 40, DASHBOARD, false, false);
+    // Preview starts at col 120-36 = 84.
+    let Some((pane, geo)) = pane_at(100, 5, DASHBOARD, false, &lay) else {
+        panic!("expected preview at (100, 5)");
+    };
+    assert!(matches!(pane, SelectablePane::Preview));
+    assert_eq!(geo.origin_col, 84);
+}
+
+#[test]
+fn pane_at_dashboard_agent_list() {
+    let lay = layout(120, 40, DASHBOARD, false, false);
+    // Agent list sits below the status bar at row 1.
+    let Some((pane, _)) = pane_at(30, 1, DASHBOARD, false, &lay) else {
+        panic!("expected agent list at (30, 1)");
+    };
+    assert!(matches!(pane, SelectablePane::AgentList));
+}
+
+#[test]
+fn pane_at_dashboard_terminal_unfocused() {
+    let lay = layout(120, 40, DASHBOARD, false, false);
+    // Terminal widget is below the agent list. Use a row deep in the middle column.
+    let Some((pane, _)) = pane_at(30, 20, DASHBOARD, false, &lay) else {
+        panic!("expected terminal view at (30, 20)");
+    };
+    assert!(matches!(pane, SelectablePane::TerminalView));
+}
+
+#[test]
+fn pane_at_dashboard_terminal_focused_returns_none_in_terminal_region() {
+    let lay = layout(120, 40, DASHBOARD, false, false);
+    // When the terminal is focused, mouse over the terminal goes to the PTY,
+    // so pane_at yields None for that region (but other panes still resolve).
+    let in_terminal = pane_at(30, 20, DASHBOARD, true, &lay);
+    assert!(in_terminal.is_none());
+    // Sidebar still resolves even when terminal focused.
+    let sidebar = pane_at(0, 5, DASHBOARD, true, &lay);
+    assert!(matches!(
+        sidebar.map(|(p, _)| p),
+        Some(SelectablePane::Sidebar)
+    ));
+}
+
+// ── pane_at: issues mode ────────────────────────────────────────────────────
+
+#[test]
+fn pane_at_issues_sidebar() {
+    let lay = layout(120, 40, ISSUES, false, false);
+    let Some((pane, _)) = pane_at(5, 10, ISSUES, false, &lay) else {
+        panic!("expected issues sidebar at (5, 10)");
+    };
+    assert!(matches!(pane, SelectablePane::Sidebar));
+}
+
+#[test]
+fn pane_at_issues_list() {
+    let lay = layout(120, 40, ISSUES, false, false);
+    // Workspace starts at col 22; list is the top split.
+    let Some((pane, _)) = pane_at(40, 2, ISSUES, false, &lay) else {
+        panic!("expected issue list at (40, 2)");
+    };
+    assert!(matches!(pane, SelectablePane::IssueList));
+}
+
+#[test]
+fn pane_at_issues_detail() {
+    let lay = layout(120, 40, ISSUES, false, false);
+    // Detail sits below the list. Use a row well past the list split (30% of ~38 rows).
+    let Some((pane, _)) = pane_at(40, 25, ISSUES, false, &lay) else {
+        panic!("expected issue detail at (40, 25)");
+    };
+    assert!(matches!(pane, SelectablePane::IssueDetail));
+}
+
+#[test]
+fn pane_at_issues_with_error_banner_shifts_workspace_down() {
+    let lay = layout(120, 40, ISSUES, true, false);
+    // Row 1 is the error banner — not selectable (returns None).
+    assert!(pane_at(40, 1, ISSUES, false, &lay).is_none());
+    // Row 2+ is the workspace, shifted down by one.
+    let Some((pane, geo)) = pane_at(40, 2, ISSUES, false, &lay) else {
+        panic!("expected a pane for workspace at (40, 2)");
+    };
+    assert_eq!(geo.origin_row, 2);
+    let _ = pane;
+}
+
+#[test]
+fn pane_at_issues_with_filter_controls_shifts_workspace_down() {
+    let lay = layout(120, 40, ISSUES, false, true);
+    // Filter band occupies 5 rows starting at row 1.
+    let Some((pane, geo)) = pane_at(40, 2, ISSUES, false, &lay) else {
+        panic!("expected a pane for filter band at (40, 2)");
+    };
+    assert_eq!(geo.origin_row, 1);
+    assert!(geo.height >= 5);
+    let _ = pane;
+}
+
+// ── pane_at: PR mode (mirrors issues geometry, different pane names) ─────────
+
+#[test]
+fn pane_at_pr_list() {
+    let lay = layout(120, 40, PRS, false, false);
+    let Some((pane, _)) = pane_at(40, 2, PRS, false, &lay) else {
+        panic!("expected pr list at (40, 2)");
+    };
+    assert!(matches!(pane, SelectablePane::PrList));
+}
+
+#[test]
+fn pane_at_pr_detail() {
+    let lay = layout(120, 40, PRS, false, false);
+    let Some((pane, _)) = pane_at(40, 25, PRS, false, &lay) else {
+        panic!("expected pr detail at (40, 25)");
+    };
+    assert!(matches!(pane, SelectablePane::PrDetail));
+}
+
+// ── pane_at: out of bounds ──────────────────────────────────────────────────
+
+#[test]
+fn pane_at_out_of_bounds_returns_none() {
+    let lay = layout(120, 40, DASHBOARD, false, false);
+    assert!(pane_at(200, 5, DASHBOARD, false, &lay).is_none());
+    assert!(pane_at(5, 200, DASHBOARD, false, &lay).is_none());
+}
+
+// ── normalize_selection ─────────────────────────────────────────────────────
+
+#[test]
+fn normalize_keeps_order_when_anchor_before_focus() {
+    let early = SelectionPoint::new(SelectablePane::IssueDetail, 0, 2);
+    let late = SelectionPoint::new(SelectablePane::IssueDetail, 1, 0);
+    let (start, end) = normalize_selection(&early, &late);
+    assert_eq!((start.line, start.col), (0, 2));
+    assert_eq!((end.line, end.col), (1, 0));
+}
+
+#[test]
+fn normalize_swaps_when_anchor_after_focus() {
+    let early = SelectionPoint::new(SelectablePane::IssueDetail, 1, 0);
+    let late = SelectionPoint::new(SelectablePane::IssueDetail, 0, 2);
+    let (start, end) = normalize_selection(&late, &early);
+    assert_eq!((start.line, start.col), (0, 2));
+    assert_eq!((end.line, end.col), (1, 0));
+}
+
+#[test]
+fn normalize_same_point_is_equal_pair() {
+    let pt = SelectionPoint::new(SelectablePane::IssueDetail, 3, 4);
+    let (start, end) = normalize_selection(&pt, &pt);
+    assert_eq!(start, pt);
+    assert_eq!(end, pt);
+}
+
+// ── selection_text ──────────────────────────────────────────────────────────
+
+fn lines(input: &[&str]) -> Vec<String> {
+    input.iter().map(|s| (*s).to_string()).collect()
+}
+
+#[test]
+fn selection_text_single_line_substring() {
+    let l = lines(&["hello world", "second"]);
+    let sel = TextSelection {
+        anchor: SelectionPoint::new(SelectablePane::IssueDetail, 0, 6),
+        focus: SelectionPoint::new(SelectablePane::IssueDetail, 0, 11),
+    };
+    assert_eq!(selection_text(&sel, &l), "world");
+}
+
+#[test]
+fn selection_text_single_line_reversed() {
+    let l = lines(&["hello world", "second"]);
+    let sel = TextSelection {
+        anchor: SelectionPoint::new(SelectablePane::IssueDetail, 0, 11),
+        focus: SelectionPoint::new(SelectablePane::IssueDetail, 0, 6),
+    };
+    assert_eq!(selection_text(&sel, &l), "world");
+}
+
+#[test]
+fn selection_text_multi_line() {
+    let l = lines(&["abc", "def", "ghi"]);
+    let sel = TextSelection {
+        anchor: SelectionPoint::new(SelectablePane::IssueDetail, 0, 1),
+        focus: SelectionPoint::new(SelectablePane::IssueDetail, 2, 2),
+    };
+    assert_eq!(selection_text(&sel, &l), "bc\ndef\ngh");
+}
+
+#[test]
+fn selection_text_empty_when_anchor_equals_focus() {
+    let l = lines(&["abc", "def"]);
+    let sel = TextSelection::collapsed(SelectionPoint::new(SelectablePane::IssueDetail, 0, 1));
+    assert_eq!(selection_text(&sel, &l), "");
+}
+
+#[test]
+fn selection_text_clamps_past_end_of_line() {
+    let l = lines(&["ab"]);
+    let sel = TextSelection {
+        anchor: SelectionPoint::new(SelectablePane::IssueDetail, 0, 0),
+        focus: SelectionPoint::new(SelectablePane::IssueDetail, 0, 99),
+    };
+    assert_eq!(selection_text(&sel, &l), "ab");
+}
+
+#[test]
+fn selection_text_clamps_past_last_line() {
+    let l = lines(&["ab", "cd"]);
+    let sel = TextSelection {
+        anchor: SelectionPoint::new(SelectablePane::IssueDetail, 0, 0),
+        focus: SelectionPoint::new(SelectablePane::IssueDetail, 99, 0),
+    };
+    assert_eq!(selection_text(&sel, &l), "ab\ncd");
+}
+
+#[test]
+fn selection_text_empty_lines_input_returns_empty() {
+    let sel = TextSelection::collapsed(SelectionPoint::new(SelectablePane::IssueDetail, 0, 0));
+    assert_eq!(selection_text(&sel, &[]), "");
+}
+
+// ── point_to_content_coords ─────────────────────────────────────────────────
+
+#[test]
+fn point_to_content_coords_adjusts_for_origin_and_scroll() {
+    let geo = PaneGeometry::new(22, 5, 60, 20);
+    let (line, col) = point_to_content_coords(25, 7, 3, &geo);
+    assert_eq!(line, 5); // row 7 - origin 5 + scroll 3
+    assert_eq!(col, 3); // col 25 - origin 22
+}
+
+#[test]
+fn point_to_content_coords_zero_scroll() {
+    let geo = PaneGeometry::new(0, 1, 40, 10);
+    let (line, col) = point_to_content_coords(2, 3, 0, &geo);
+    assert_eq!(line, 2);
+    assert_eq!(col, 2);
+}
+
+#[test]
+fn point_to_content_coords_clamps_before_origin() {
+    let geo = PaneGeometry::new(22, 5, 60, 20);
+    let (line, col) = point_to_content_coords(10, 2, 0, &geo);
+    assert_eq!(line, 0); // row 2 - origin 5 saturates to 0
+    assert_eq!(col, 0); // col 10 - origin 22 saturates to 0
+}

--- a/src/selection/tests.rs
+++ b/src/selection/tests.rs
@@ -371,12 +371,13 @@ fn point_to_content_coords_accounts_for_list_chrome() {
 }
 
 #[test]
-fn point_to_content_coords_detail_pane_skips_header() {
-    // Detail pane: content starts after border + 5 header rows = 6 rows below
-    // widget-box top.
-    let geo = PaneGeometry::with_chrome(22, 20, 60, 18, 2, 6);
-    let (line, _col) = point_to_content_coords(24, 26, 0, &geo);
-    assert_eq!(line, 0); // first content row
+fn point_to_content_coords_detail_pane_header_is_content() {
+    // Detail pane: content (the header rows) starts directly below the border,
+    // 1 row below the widget-box top. A click on the first header row maps to
+    // content line 0.
+    let geo = PaneGeometry::with_chrome(22, 20, 60, 18, 2, 1);
+    let (line, _col) = point_to_content_coords(24, 21, 0, &geo);
+    assert_eq!(line, 0); // first header row (title)
 }
 
 // ── pane_at: content origins account for chrome (#141 follow-up) ────────────
@@ -397,15 +398,14 @@ fn pane_at_pr_list_content_origin_accounts_for_border_and_title() {
 #[test]
 fn pane_at_pr_detail_content_origin_accounts_for_header_rows() {
     let lay = layout(120, 40, PRS, false, false);
-    // Detail pane content starts after border + DETAIL_HEADER_ROWS (5) = 6 rows.
+    // Detail pane content starts directly below the border (1 row). The fixed
+    // header rows are part of the selectable content (rendered above the scroll
+    // viewport but not scrolled), so content_origin_row == origin_row + 1.
     let Some((pane, geo)) = pane_at(40, 25, PRS, false, &lay) else {
         panic!("expected pr detail at (40, 25)");
     };
     assert!(matches!(pane, SelectablePane::PrDetail));
-    assert_eq!(
-        geo.content_origin_row,
-        geo.origin_row + 1 + u16::try_from(crate::layout::DETAIL_HEADER_ROWS).unwrap_or(0)
-    );
+    assert_eq!(geo.content_origin_row, geo.origin_row + 1);
     assert_eq!(geo.content_origin_col, geo.origin_col + 2);
 }
 

--- a/src/selection/tests.rs
+++ b/src/selection/tests.rs
@@ -111,6 +111,27 @@ fn pane_at_dashboard_terminal_unfocused() {
 }
 
 #[test]
+fn pane_at_dashboard_agent_terminal_boundary() {
+    let lay = layout(120, 40, DASHBOARD, false, false);
+    // Find the exact boundary row between AgentList and TerminalView.
+    let Some((_, agent_geo)) = pane_at(30, 1, DASHBOARD, false, &lay) else {
+        panic!("expected agent list at (30, 1)");
+    };
+    let agent_end_row = agent_geo.origin_row + agent_geo.height;
+    // The row at agent_end_row should be the first terminal row.
+    let Some((pane, term_geo)) = pane_at(30, agent_end_row, DASHBOARD, false, &lay) else {
+        panic!("expected terminal view at agent boundary row {agent_end_row}");
+    };
+    assert!(matches!(pane, SelectablePane::TerminalView));
+    assert_eq!(term_geo.origin_row, agent_end_row);
+    // The row just above the boundary should still be AgentList.
+    let Some((above_pane, _)) = pane_at(30, agent_end_row - 1, DASHBOARD, false, &lay) else {
+        panic!("expected agent list at row {}", agent_end_row - 1);
+    };
+    assert!(matches!(above_pane, SelectablePane::AgentList));
+}
+
+#[test]
 fn pane_at_dashboard_terminal_focused_returns_none_in_terminal_region() {
     let lay = layout(120, 40, DASHBOARD, false, false);
     // When the terminal is focused, mouse over the terminal goes to the PTY,

--- a/src/selection/tests.rs
+++ b/src/selection/tests.rs
@@ -4,8 +4,8 @@
 //! [`selection_text`], and [`point_to_content_coords`] without any terminal.
 
 use crate::selection::{
-    PaneGeometry, SelectablePane, SelectionPoint, TextSelection, normalize_selection, pane_at,
-    point_to_content_coords, selection_text,
+    HighlightRange, PaneGeometry, SelectablePane, SelectionPoint, TextSelection,
+    normalize_selection, pane_at, point_to_content_coords, row_highlight_range, selection_text,
 };
 use crate::state::ScreenMode;
 
@@ -27,12 +27,21 @@ fn layout(
 
 #[test]
 fn geometry_contains_includes_interior_and_edges() {
-    let g = PaneGeometry::new(5, 3, 4, 2);
+    let g = PaneGeometry::new(5, 3, 4, 2, 6, 4);
     assert!(g.contains(5, 3));
     assert!(g.contains(8, 4)); // bottom-right inclusive
     assert!(!g.contains(4, 3)); // left of origin
     assert!(!g.contains(9, 4)); // right of edge
     assert!(!g.contains(5, 5)); // below edge
+}
+
+#[test]
+fn geometry_with_chrome_derives_content_origin() {
+    let g = PaneGeometry::with_chrome(10, 5, 40, 20, 2, 3);
+    assert_eq!(g.origin_col, 10);
+    assert_eq!(g.origin_row, 5);
+    assert_eq!(g.content_origin_col, 12);
+    assert_eq!(g.content_origin_row, 8);
 }
 
 // ── pane_at: dashboard ──────────────────────────────────────────────────────
@@ -65,6 +74,9 @@ fn pane_at_dashboard_sidebar() {
     assert!(matches!(pane, SelectablePane::Sidebar));
     assert_eq!(geo.origin_col, 0);
     assert_eq!(geo.origin_row, 1);
+    // Sidebar content starts at col +2 (border + padding), row +2 (border + title).
+    assert_eq!(geo.content_origin_col, 2);
+    assert_eq!(geo.content_origin_row, 3);
 }
 
 #[test]
@@ -160,13 +172,16 @@ fn pane_at_issues_with_error_banner_shifts_workspace_down() {
 #[test]
 fn pane_at_issues_with_filter_controls_shifts_workspace_down() {
     let lay = layout(120, 40, ISSUES, false, true);
-    // Filter band occupies 5 rows starting at row 1.
-    let Some((pane, geo)) = pane_at(40, 2, ISSUES, false, &lay) else {
-        panic!("expected a pane for filter band at (40, 2)");
+    // Filter band occupies 5 rows starting at row 1 — not selectable (it is
+    // a separate UI element with no content provider).
+    assert!(pane_at(40, 2, ISSUES, false, &lay).is_none());
+    // Below the filter band (row 6+) is the issue list.
+    let Some((pane, geo)) = pane_at(40, 6, ISSUES, false, &lay) else {
+        panic!("expected issue list below filter band at (40, 6)");
     };
-    assert_eq!(geo.origin_row, 1);
-    assert!(geo.height >= 5);
-    let _ = pane;
+    assert!(matches!(pane, SelectablePane::IssueList));
+    assert_eq!(geo.origin_row, 6);
+    let _ = geo;
 }
 
 // ── pane_at: PR mode (mirrors issues geometry, different pane names) ─────────
@@ -298,16 +313,18 @@ fn selection_text_empty_lines_input_returns_empty() {
 // ── point_to_content_coords ─────────────────────────────────────────────────
 
 #[test]
-fn point_to_content_coords_adjusts_for_origin_and_scroll() {
-    let geo = PaneGeometry::new(22, 5, 60, 20);
+fn point_to_content_coords_adjusts_for_content_origin_and_scroll() {
+    // Content origin at (22, 5): a click at col 25, row 7 → content (line 2, col 3)
+    // before scroll; with scroll_offset 3 → line 5.
+    let geo = PaneGeometry::new(20, 3, 60, 20, 22, 5);
     let (line, col) = point_to_content_coords(25, 7, 3, &geo);
-    assert_eq!(line, 5); // row 7 - origin 5 + scroll 3
-    assert_eq!(col, 3); // col 25 - origin 22
+    assert_eq!(line, 5); // row 7 - content_origin 5 + scroll 3
+    assert_eq!(col, 3); // col 25 - content_origin 22
 }
 
 #[test]
 fn point_to_content_coords_zero_scroll() {
-    let geo = PaneGeometry::new(0, 1, 40, 10);
+    let geo = PaneGeometry::new(0, 1, 40, 10, 0, 1);
     let (line, col) = point_to_content_coords(2, 3, 0, &geo);
     assert_eq!(line, 2);
     assert_eq!(col, 2);
@@ -315,8 +332,155 @@ fn point_to_content_coords_zero_scroll() {
 
 #[test]
 fn point_to_content_coords_clamps_before_origin() {
-    let geo = PaneGeometry::new(22, 5, 60, 20);
+    let geo = PaneGeometry::new(22, 5, 60, 20, 24, 7);
     let (line, col) = point_to_content_coords(10, 2, 0, &geo);
-    assert_eq!(line, 0); // row 2 - origin 5 saturates to 0
-    assert_eq!(col, 0); // col 10 - origin 22 saturates to 0
+    assert_eq!(line, 0); // row 2 - content_origin 7 saturates to 0
+    assert_eq!(col, 0); // col 10 - content_origin 24 saturates to 0
+}
+
+#[test]
+fn point_to_content_coords_accounts_for_list_chrome() {
+    // Simulate a bordered list pane whose widget box starts at (22, 1) with
+    // content starting at (23, 3) (border + title). A click on the first
+    // content row should map to content line 0.
+    let geo = PaneGeometry::with_chrome(22, 1, 60, 10, 1, 2);
+    let (line, col) = point_to_content_coords(23, 3, 0, &geo);
+    assert_eq!(line, 0);
+    assert_eq!(col, 0);
+}
+
+#[test]
+fn point_to_content_coords_detail_pane_skips_header() {
+    // Detail pane: content starts after border + 5 header rows = 6 rows below
+    // widget-box top.
+    let geo = PaneGeometry::with_chrome(22, 20, 60, 18, 2, 6);
+    let (line, _col) = point_to_content_coords(24, 26, 0, &geo);
+    assert_eq!(line, 0); // first content row
+}
+
+// ── pane_at: content origins account for chrome (#141 follow-up) ────────────
+
+#[test]
+fn pane_at_pr_list_content_origin_accounts_for_border_and_title() {
+    let lay = layout(120, 40, PRS, false, false);
+    // PR list widget box top is at row 1. Content starts at row 3 (border +
+    // title), col 23 (border). Clicking the first content row maps to line 0.
+    let Some((pane, geo)) = pane_at(23, 3, PRS, false, &lay) else {
+        panic!("expected pr list at (23, 3)");
+    };
+    assert!(matches!(pane, SelectablePane::PrList));
+    assert_eq!(geo.content_origin_col, geo.origin_col + 1);
+    assert_eq!(geo.content_origin_row, geo.origin_row + 2);
+}
+
+#[test]
+fn pane_at_pr_detail_content_origin_accounts_for_header_rows() {
+    let lay = layout(120, 40, PRS, false, false);
+    // Detail pane content starts after border + DETAIL_HEADER_ROWS (5) = 6 rows.
+    let Some((pane, geo)) = pane_at(40, 25, PRS, false, &lay) else {
+        panic!("expected pr detail at (40, 25)");
+    };
+    assert!(matches!(pane, SelectablePane::PrDetail));
+    assert_eq!(
+        geo.content_origin_row,
+        geo.origin_row + 1 + u16::try_from(crate::layout::DETAIL_HEADER_ROWS).unwrap_or(0)
+    );
+    assert_eq!(geo.content_origin_col, geo.origin_col + 2);
+}
+
+#[test]
+fn pane_at_status_bar_content_origin_accounts_for_padding() {
+    let lay = layout(120, 40, DASHBOARD, false, false);
+    let Some((pane, geo)) = pane_at(60, 0, DASHBOARD, false, &lay) else {
+        panic!("expected status bar at (60, 0)");
+    };
+    assert!(matches!(pane, SelectablePane::StatusBar));
+    assert_eq!(geo.content_origin_col, 1); // padding_left
+}
+
+#[test]
+fn pane_at_dashboard_agent_list_content_origin_accounts_for_chrome() {
+    let lay = layout(120, 40, DASHBOARD, false, false);
+    let Some((pane, geo)) = pane_at(30, 1, DASHBOARD, false, &lay) else {
+        panic!("expected agent list at (30, 1)");
+    };
+    assert!(matches!(pane, SelectablePane::AgentList));
+    assert_eq!(geo.content_origin_col, geo.origin_col + 2);
+    assert_eq!(geo.content_origin_row, geo.origin_row + 2);
+}
+
+// ── row_highlight_range ─────────────────────────────────────────────────────
+
+fn sel(start_line: usize, start_col: usize, end_line: usize, end_col: usize) -> TextSelection {
+    TextSelection {
+        anchor: SelectionPoint::new(SelectablePane::IssueDetail, start_line, start_col),
+        focus: SelectionPoint::new(SelectablePane::IssueDetail, end_line, end_col),
+    }
+}
+
+#[test]
+fn highlight_range_none_for_empty_selection() {
+    let s = TextSelection::collapsed(SelectionPoint::new(SelectablePane::IssueDetail, 2, 3));
+    assert_eq!(row_highlight_range(&s, 2), None);
+}
+
+#[test]
+fn highlight_range_single_line_substring() {
+    let s = sel(1, 2, 1, 5);
+    assert_eq!(
+        row_highlight_range(&s, 1),
+        Some(HighlightRange { start: 2, end: 5 })
+    );
+}
+
+#[test]
+fn highlight_range_line_outside_selection_is_none() {
+    let s = sel(1, 0, 3, 0);
+    assert_eq!(row_highlight_range(&s, 0), None);
+    assert_eq!(row_highlight_range(&s, 4), None);
+}
+
+#[test]
+fn highlight_range_start_line_tail_to_end() {
+    let s = sel(1, 2, 3, 4);
+    assert_eq!(
+        row_highlight_range(&s, 1),
+        Some(HighlightRange {
+            start: 2,
+            end: usize::MAX
+        })
+    );
+}
+
+#[test]
+fn highlight_range_end_line_head_from_zero() {
+    let s = sel(1, 2, 3, 4);
+    assert_eq!(
+        row_highlight_range(&s, 3),
+        Some(HighlightRange { start: 0, end: 4 })
+    );
+}
+
+#[test]
+fn highlight_range_middle_line_full() {
+    let s = sel(1, 2, 3, 4);
+    assert_eq!(
+        row_highlight_range(&s, 2),
+        Some(HighlightRange {
+            start: 0,
+            end: usize::MAX
+        })
+    );
+}
+
+#[test]
+fn highlight_range_works_with_reversed_anchor_focus() {
+    let s = sel(3, 4, 1, 2);
+    assert_eq!(
+        row_highlight_range(&s, 1),
+        Some(HighlightRange {
+            start: 2,
+            end: usize::MAX
+        })
+    );
 }

--- a/src/selection/text.rs
+++ b/src/selection/text.rs
@@ -1,0 +1,231 @@
+//! Selection data types and pure text-extraction logic.
+//!
+//! These types are iocraft-free and side-effect-free so they can be unit-tested
+//! in isolation and reused by both the mouse-routing layer and the renderers.
+
+use crate::selection::PaneGeometry;
+
+/// Identifies a selectable region of the screen.
+///
+/// One variant per pane the user can drag-select text in. The variants are
+/// ordered roughly top-to-bottom, left-to-right to match how the panes appear,
+/// but ordering carries no semantic weight — comparisons use
+/// [`SelectionPoint`] ordering, not the enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SelectablePane {
+    /// Repository sidebar (left column, all screen modes).
+    Sidebar,
+    /// Agent list (dashboard middle column, top).
+    AgentList,
+    /// Terminal snapshot grid (dashboard, when not focused).
+    TerminalView,
+    /// Preview pane (dashboard right column).
+    Preview,
+    /// Issue list (issues-mode workspace, top split).
+    IssueList,
+    /// Issue detail scrollable document (issues-mode workspace, bottom split).
+    IssueDetail,
+    /// PR list (PR-mode workspace, top split).
+    PrList,
+    /// PR detail scrollable document (PR-mode workspace, bottom split).
+    PrDetail,
+    /// Help modal overlay text.
+    HelpModal,
+    /// Top status bar (low priority, but selectable).
+    StatusBar,
+    /// Bottom keybind hint bar (low priority, but selectable).
+    KeybindBar,
+}
+
+/// A single point within a selection, expressed in *content* coordinates.
+///
+/// `line` is a 0-based index into the pane's content lines (i.e. already
+/// adjusted for the pane's scroll offset), and `col` is a 0-based character
+/// offset within that line. Using content coordinates — not screen rows — keeps
+/// selection stable when the pane scrolls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelectionPoint {
+    /// Which pane this point lives in.
+    pub pane: SelectablePane,
+    /// 0-based content line index.
+    pub line: usize,
+    /// 0-based character column within the line.
+    pub col: usize,
+}
+
+impl SelectionPoint {
+    /// Construct a selection point from its three components.
+    #[must_use]
+    pub const fn new(pane: SelectablePane, line: usize, col: usize) -> Self {
+        Self { pane, line, col }
+    }
+
+    /// Lexicographic ordering key for two points *within the same pane*.
+    ///
+    /// Returns [`std::cmp::Ordering::Equal`] only when both points are
+    /// identical. When the panes differ the result is [`std::cmp::Ordering`]'s
+    /// default — callers should only compare points known to share a pane.
+    #[must_use]
+    fn order_key(self) -> (usize, usize) {
+        (self.line, self.col)
+    }
+}
+
+/// An active text selection: an anchor (mouse-down) and a focus (current/drag).
+///
+/// Both points always share the same [`SelectablePane`]; a selection never
+/// spans panes. Use [`normalize_selection`] to get the ordered (start, end)
+/// pair before extracting text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextSelection {
+    /// Where the selection started (mouse-down position).
+    pub anchor: SelectionPoint,
+    /// Where the selection currently ends (drag or release position).
+    pub focus: SelectionPoint,
+}
+
+impl TextSelection {
+    /// Construct a collapsed selection (anchor == focus) at a single point.
+    #[must_use]
+    pub const fn collapsed(point: SelectionPoint) -> Self {
+        Self {
+            anchor: point,
+            focus: point,
+        }
+    }
+
+    /// The pane this selection lives in (taken from the anchor).
+    #[must_use]
+    pub const fn pane(self) -> SelectablePane {
+        self.anchor.pane
+    }
+
+    /// Whether the selection is empty (anchor == focus).
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        self.anchor == self.focus
+    }
+}
+
+/// Order two points so the result's first element is the earlier one.
+///
+/// "Earlier" is defined lexicographically by `(line, col)`. The two points are
+/// assumed to share a pane (selections never cross panes); if they differ in
+/// pane the comparison falls back to line/col ordering regardless.
+///
+/// # Examples
+///
+/// ```
+/// use jefe::selection::{SelectionPoint, SelectablePane, normalize_selection};
+///
+/// let early = SelectionPoint::new(SelectablePane::IssueDetail, 0, 5);
+/// let late  = SelectionPoint::new(SelectablePane::IssueDetail, 2, 0);
+/// let (start, end) = normalize_selection(&early, &late);
+/// assert_eq!(start.line, 0);
+/// assert_eq!(end.line, 2);
+/// ```
+#[must_use]
+pub fn normalize_selection(
+    anchor: &SelectionPoint,
+    focus: &SelectionPoint,
+) -> (SelectionPoint, SelectionPoint) {
+    if anchor.order_key() <= focus.order_key() {
+        (*anchor, *focus)
+    } else {
+        (*focus, *anchor)
+    }
+}
+
+/// Extract the text covered by a selection from a slice of content lines.
+///
+/// The selection is normalized first; the returned string joins the covered
+/// lines with `\n`. A single-line selection returns the substring between the
+/// two columns; a multi-line selection returns the tail of the first line, all
+/// middle lines in full, and the head of the last line.
+///
+/// Coordinates are clamped to the content bounds, so a selection past the end
+/// of a line or past the last line yields the available text without panicking.
+#[must_use]
+pub fn selection_text(selection: &TextSelection, lines: &[String]) -> String {
+    let (start, end) = normalize_selection(&selection.anchor, &selection.focus);
+    if lines.is_empty() {
+        return String::new();
+    }
+    if start.line == end.line {
+        return single_line_text(lines, &start, &end);
+    }
+    multi_line_text(lines, &start, &end)
+}
+
+/// Extract text from a single content line between two columns (inclusive start, exclusive end).
+fn single_line_text(lines: &[String], start: &SelectionPoint, end: &SelectionPoint) -> String {
+    let line_idx = start.line.min(lines.len() - 1);
+    let chars: Vec<char> = lines[line_idx].chars().collect();
+    let s = start.col.min(chars.len());
+    let e = end.col.min(chars.len());
+    if s >= e {
+        return String::new();
+    }
+    chars[s..e].iter().collect()
+}
+
+/// Extract text spanning multiple lines: tail of start line, full middle lines, head of end line.
+fn multi_line_text(lines: &[String], start: &SelectionPoint, end: &SelectionPoint) -> String {
+    let last = lines.len() - 1;
+    let start_line = start.line.min(last);
+    let end_line = end.line.min(last);
+
+    let mut out = String::new();
+
+    // Tail of the start line (from start.col to end of line).
+    let start_chars: Vec<char> = lines[start_line].chars().collect();
+    let s = start.col.min(start_chars.len());
+    out.extend(&start_chars[s..]);
+    out.push('\n');
+
+    // Full middle lines.
+    for line in lines.iter().take(end_line).skip(start_line + 1) {
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    // Head of the end line (from 0 to end.col). When the focus was past the
+    // last content line, the line was clamped down — include the full last
+    // line rather than truncating at the (now-meaningless) focus column.
+    let end_chars: Vec<char> = lines[end_line].chars().collect();
+    let end_clamped_down = end.line > last;
+    let e = if end_clamped_down {
+        end_chars.len()
+    } else {
+        end.col.min(end_chars.len())
+    };
+    out.extend(&end_chars[..e]);
+
+    out
+}
+
+/// Convert a screen-space `(col, row)` within a pane to content coordinates.
+///
+/// `scroll_offset` is the pane's current scroll position (lines hidden above
+/// the viewport). The result is `(content_line, content_col)` — content line
+/// is the screen row translated by the scroll offset, content col is the
+/// screen column minus the pane's left origin. Both are clamped to be
+/// non-negative via saturating subtraction.
+#[must_use]
+pub fn point_to_content_coords(
+    screen_col: u16,
+    screen_row: u16,
+    scroll_offset: usize,
+    geometry: &PaneGeometry,
+) -> (usize, usize) {
+    let content_line =
+        usize::from(screen_row.saturating_sub(geometry.origin_row)).saturating_add(scroll_offset);
+    let content_col = usize::from(screen_col.saturating_sub(geometry.origin_col));
+    (content_line, content_col)
+}
+
+#[cfg(test)]
+mod text_tests {
+    // The shared, parametrized tests live in the crate-level selection::tests
+    // module so they exercise the public surface exactly as callers do.
+}

--- a/src/selection/text.rs
+++ b/src/selection/text.rs
@@ -208,8 +208,9 @@ fn multi_line_text(lines: &[String], start: &SelectionPoint, end: &SelectionPoin
 ///
 /// `scroll_offset` is the pane's current scroll position (lines hidden above
 /// the viewport). The result is `(content_line, content_col)` — content line
-/// is the screen row translated by the scroll offset, content col is the
-/// screen column minus the pane's left origin. Both are clamped to be
+/// is the screen row translated by the content origin (the first content cell,
+/// after borders/title/padding) plus the scroll offset, and content col is the
+/// screen column minus the content origin column. Both are clamped to be
 /// non-negative via saturating subtraction.
 #[must_use]
 pub fn point_to_content_coords(
@@ -218,9 +219,9 @@ pub fn point_to_content_coords(
     scroll_offset: usize,
     geometry: &PaneGeometry,
 ) -> (usize, usize) {
-    let content_line =
-        usize::from(screen_row.saturating_sub(geometry.origin_row)).saturating_add(scroll_offset);
-    let content_col = usize::from(screen_col.saturating_sub(geometry.origin_col));
+    let content_line = usize::from(screen_row.saturating_sub(geometry.content_origin_row))
+        .saturating_add(scroll_offset);
+    let content_col = usize::from(screen_col.saturating_sub(geometry.content_origin_col));
     (content_line, content_col)
 }
 
@@ -228,4 +229,65 @@ pub fn point_to_content_coords(
 mod text_tests {
     // The shared, parametrized tests live in the crate-level selection::tests
     // module so they exercise the public surface exactly as callers do.
+}
+
+/// A half-open column range `[start, end)` to highlight on a single display row.
+///
+/// Returned by [`row_highlight_range`] when a content line falls within a
+/// selection. `start` is inclusive and `end` is exclusive; both are character
+/// offsets within the line. When the whole line is selected, `start == 0` and
+/// `end == usize::MAX` (callers clamp to the line length).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HighlightRange {
+    /// Inclusive start column.
+    pub start: usize,
+    /// Exclusive end column (`usize::MAX` means "to end of line").
+    pub end: usize,
+}
+
+/// Compute the highlight column range for a single content line within a
+/// selection, or `None` if the line is outside the selection.
+///
+/// The selection is normalized internally. For a line strictly between the
+/// start and end lines the entire line is highlighted (`0..usize::MAX`). For
+/// the start or end line, the column range is clamped to the selection
+/// boundary. A collapsed (empty) selection yields `None`.
+///
+/// This is a pure helper used by the renderers to paint inverse-video
+/// highlights; it owns no iocraft types so it is fully unit-testable.
+#[must_use]
+pub fn row_highlight_range(
+    selection: &TextSelection,
+    content_line: usize,
+) -> Option<HighlightRange> {
+    if selection.is_empty() {
+        return None;
+    }
+    let (start, end) = normalize_selection(&selection.anchor, &selection.focus);
+    if content_line < start.line || content_line > end.line {
+        return None;
+    }
+    if content_line == start.line && content_line == end.line {
+        return Some(HighlightRange {
+            start: start.col,
+            end: end.col.max(start.col),
+        });
+    }
+    if content_line == start.line {
+        return Some(HighlightRange {
+            start: start.col,
+            end: usize::MAX,
+        });
+    }
+    if content_line == end.line {
+        return Some(HighlightRange {
+            start: 0,
+            end: end.col,
+        });
+    }
+    // Strictly between start and end lines: whole line.
+    Some(HighlightRange {
+        start: 0,
+        end: usize::MAX,
+    })
 }

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -180,6 +180,14 @@ pub struct AppState {
 
     /// Rapid `qqq` quit-sequence bookkeeping. Runtime-only — never persisted.
     pub quit_sequence: QuitSequenceState,
+
+    /// Active mouse text-selection, if any. Runtime-only — never persisted.
+    ///
+    /// Set by the app-shell mouse router when the user drag-selects text in any
+    /// pane (or in the terminal snapshot when unfocused). Cleared on Escape or
+    /// when a new selection begins. Used by the renderers to paint an
+    /// inverse-video highlight over the selected cells.
+    pub selection: Option<crate::selection::TextSelection>,
 }
 
 /// @plan PLAN-20260329-ISSUES-MODE.P03

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -110,6 +110,30 @@ pub struct SelectionColors {
     pub bg: Color,
 }
 
+/// Bundled foreground + background colors for a list row's default (non-selected)
+/// styling.
+///
+/// Lets render helpers receive themed values instead of `Color::Reset` (which
+/// leaks the terminal default background and can produce a visible haze).
+#[derive(Debug, Clone, Copy)]
+pub struct RowColors {
+    /// Default text color for a row.
+    pub fg: Color,
+    /// Themed background color for a row (avoids `Color::Reset` haze).
+    pub bg: Color,
+}
+
+impl RowColors {
+    /// Derive row colors from a [`ResolvedColors`] snapshot.
+    #[must_use]
+    pub const fn from_resolved(rc: &ResolvedColors) -> Self {
+        Self {
+            fg: rc.fg,
+            bg: rc.bg,
+        }
+    }
+}
+
 impl SelectionColors {
     /// Derive selection colors from a [`ResolvedColors`] snapshot.
     #[must_use]

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -102,7 +102,7 @@ pub struct ResolvedColors {
 ///
 /// Extracted from [`ResolvedColors`] to keep helper function argument counts
 /// under the clippy `too_many_arguments` threshold (6).
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct SelectionColors {
     /// Inverse-video foreground for selected text.
     pub fg: Color,

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -98,6 +98,29 @@ pub struct ResolvedColors {
     pub sel_bg: Color,
 }
 
+/// Bundled foreground + background colors for selection highlighting.
+///
+/// Extracted from [`ResolvedColors`] to keep helper function argument counts
+/// under the clippy `too_many_arguments` threshold (6).
+#[derive(Clone, Copy)]
+pub struct SelectionColors {
+    /// Inverse-video foreground for selected text.
+    pub fg: Color,
+    /// Inverse-video background for selected text.
+    pub bg: Color,
+}
+
+impl SelectionColors {
+    /// Derive selection colors from a [`ResolvedColors`] snapshot.
+    #[must_use]
+    pub const fn from_resolved(rc: &ResolvedColors) -> Self {
+        Self {
+            fg: rc.sel_fg,
+            bg: rc.sel_bg,
+        }
+    }
+}
+
 impl Default for ResolvedColors {
     fn default() -> Self {
         Self::from_theme(None)

--- a/src/ui/components/agent_list.rs
+++ b/src/ui/components/agent_list.rs
@@ -7,6 +7,7 @@
 use iocraft::prelude::*;
 
 use crate::domain::{Agent, AgentStatus};
+use crate::selection::{SelectablePane, TextSelection, row_highlight_range};
 use crate::theme::{ResolvedColors, ThemeColors};
 
 /// Props for the agent list component.
@@ -22,6 +23,9 @@ pub struct AgentListProps {
     pub grabbed: Option<usize>,
     /// Theme colors.
     pub colors: ThemeColors,
+    /// Active text selection, if any (and if it targets this pane). Selected
+    /// rows are painted in inverse video for live drag-selection feedback.
+    pub selection: Option<TextSelection>,
 }
 
 /// Agent list showing agents for the current repository.
@@ -81,16 +85,23 @@ pub fn AgentList(props: &AgentListProps) -> impl Into<AnyElement<'static>> {
                     } else {
                         "  "
                     };
+                    let highlighted = props.selection.as_ref()
+                        .filter(|s| s.pane() == SelectablePane::AgentList)
+                        .and_then(|s| row_highlight_range(s, i))
+                        .is_some();
+                    let row_bg = if highlighted { rc.sel_bg } else { Color::Reset };
                     let name_color = if selected { rc.bright } else { rc.fg };
+                    let name_color = if highlighted { rc.sel_fg } else { name_color };
                     let shortcut_label = agent.shortcut_slot
                         .map_or_else(String::new, |slot| format!("[{slot}] "));
                     element! {
-                        Box(flex_direction: FlexDirection::Row) {
+                        Box(flex_direction: FlexDirection::Row, background_color: row_bg) {
                             Text(content: prefix, color: name_color)
                             Text(content: status_icon, color: status_color)
                             Text(content: format!(" {}{}", shortcut_label, agent.name), color: name_color)
                         }
                     }
+                    .into_any()
                 }))
             }
         }

--- a/src/ui/components/agent_list.rs
+++ b/src/ui/components/agent_list.rs
@@ -89,7 +89,7 @@ pub fn AgentList(props: &AgentListProps) -> impl Into<AnyElement<'static>> {
                         .filter(|s| s.pane() == SelectablePane::AgentList)
                         .and_then(|s| row_highlight_range(s, i))
                         .is_some();
-                    let row_bg = if highlighted { rc.sel_bg } else { Color::Reset };
+                    let row_bg = if highlighted { rc.sel_bg } else { rc.bg };
                     let name_color = if selected { rc.bright } else { rc.fg };
                     let name_color = if highlighted { rc.sel_fg } else { name_color };
                     let shortcut_label = agent.shortcut_slot

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -8,6 +8,7 @@ use iocraft::prelude::*;
 use crate::domain::{IssueDetail, IssueState};
 use crate::issue_detail_content::{DetailContent, build_detail_content, build_new_issue_content};
 use crate::layout::DETAIL_HEADER_ROWS as HEADER_ROWS;
+use crate::selection::TextSelection;
 use crate::state::{ComposerTarget, DetailSubfocus, InlineState};
 use crate::theme::{ResolvedColors, ThemeColors};
 
@@ -40,6 +41,9 @@ pub struct IssueDetailViewProps {
     pub available_height: Option<u16>,
     /// Actual available width (in terminal columns) for detail/composer text.
     pub available_width: Option<u16>,
+    /// Active text selection, if any (and if it targets this pane). Passed
+    /// through to the `ScrollableText` so selected cells render inverse-video.
+    pub selection: Option<TextSelection>,
 }
 
 fn active_issue_composer(inline_state: &InlineState) -> Option<(String, usize, &'static str)> {
@@ -258,6 +262,9 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
                     cursor_bg: rc.bright,
                     track_color: rc.dim,
                     thumb_color: rc.bright,
+                    selection: props.selection,
+                    selection_bg: Some(rc.sel_bg),
+                    selection_fg: Some(rc.sel_fg),
                 )
             }
 

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -15,6 +15,52 @@ use crate::theme::{ResolvedColors, ThemeColors};
 use super::scrollable_text::ScrollableText;
 use super::text_box::TextBox;
 
+/// Projected issue detail header exactly as the component renders it (the four
+/// fixed metadata rows). The component delegates to this so the selection
+/// content provider (`src/selection/content.rs`) and the renderer share the
+/// same single source of truth, preventing drift.
+pub struct IssueDetailHeaderView {
+    /// "#number title" row.
+    pub title: String,
+    /// State tag + author/created/updated row.
+    pub state: String,
+    /// "labels: ...  assignees: ...  milestone: ..." row.
+    pub labels: String,
+    /// Display-only external URL row.
+    pub url: String,
+}
+
+/// Pure projection of the issue detail's four fixed header rows exactly as the
+/// component renders them.
+pub fn issue_detail_header_view(detail: &IssueDetail) -> IssueDetailHeaderView {
+    let state_tag = match detail.state {
+        IssueState::Open => "OPEN",
+        IssueState::Closed => "CLOSED",
+    };
+    let labels_str = if detail.labels.is_empty() {
+        "-".to_string()
+    } else {
+        detail.labels.join(", ")
+    };
+    let assignees_str = if detail.assignees.is_empty() {
+        "-".to_string()
+    } else {
+        detail.assignees.join(", ")
+    };
+    let milestone_str = detail.milestone.as_deref().unwrap_or("-").to_string();
+    IssueDetailHeaderView {
+        title: format!("#{} {}", detail.number, detail.title),
+        state: format!(
+            "{}  by @{}  opened: {}  updated: {}",
+            state_tag, detail.author_login, detail.created_at, detail.updated_at
+        ),
+        labels: format!(
+            "labels: {labels_str}  assignees: {assignees_str}  milestone: {milestone_str}"
+        ),
+        url: detail.external_url.clone(),
+    }
+}
+
 /// Props for the issue detail view.
 #[derive(Default, Props)]
 pub struct IssueDetailViewProps {
@@ -33,17 +79,59 @@ pub struct IssueDetailViewProps {
     /// Theme colors.
     pub colors: ThemeColors,
     /// Actual available height (in terminal rows) for the detail pane.
-    ///
-    /// When provided, this is used instead of computing the height from
-    /// `crossterm::terminal::size()`, ensuring the viewport matches the real
-    /// flex allocation in the parent layout. Falls back to the terminal-size
-    /// calculation when `None`.
     pub available_height: Option<u16>,
     /// Actual available width (in terminal columns) for detail/composer text.
     pub available_width: Option<u16>,
     /// Active text selection, if any (and if it targets this pane). Passed
     /// through to the `ScrollableText` so selected cells render inverse-video.
     pub selection: Option<TextSelection>,
+}
+
+/// Shared header-row selection highlight + rendering helper used by both
+/// `IssueDetailView` and `PrDetailView`.
+///
+/// `header_highlight` checks whether content line `line` falls inside the
+/// active drag selection for `pane`. `header_row` renders the row with
+/// inverse-video when highlighted, or in the default color otherwise.
+///
+/// Header rows use whole-row highlight (ignoring partial column ranges) for
+/// visual simplicity on short metadata lines.
+pub fn header_highlight(
+    line: usize,
+    selection: Option<&TextSelection>,
+    pane: SelectablePane,
+) -> bool {
+    selection
+        .filter(|s| s.pane() == pane)
+        .and_then(|s| row_highlight_range(s, line))
+        .is_some()
+}
+
+/// Render a single header row, applying whole-row inverse-video when it falls
+/// inside the active drag selection.
+pub fn header_row(
+    content: String,
+    default_fg: Color,
+    line: usize,
+    selection: Option<&TextSelection>,
+    pane: SelectablePane,
+    rc: &ResolvedColors,
+) -> AnyElement<'static> {
+    if header_highlight(line, selection, pane) {
+        element! {
+            Box(height: 1u32, background_color: rc.sel_bg) {
+                Text(content: content, color: rc.sel_fg)
+            }
+        }
+        .into_any()
+    } else {
+        element! {
+            Box(height: 1u32) {
+                Text(content: content, color: default_fg)
+            }
+        }
+        .into_any()
+    }
 }
 
 fn active_issue_composer(inline_state: &InlineState) -> Option<(String, usize, &'static str)> {
@@ -71,48 +159,9 @@ fn active_issue_composer(inline_state: &InlineState) -> Option<(String, usize, &
     }
 }
 
-/// Whether content line `line` (one of the fixed header rows) falls inside the
-/// active selection for the issue detail pane. When true the header row is
-/// painted in inverse-video selection colors.
-///
-/// Header rows use whole-row highlight (ignoring partial column ranges) for
-/// visual simplicity on short metadata lines.
-fn header_highlight(line: usize, selection: Option<&TextSelection>) -> bool {
-    selection
-        .filter(|s| s.pane() == SelectablePane::IssueDetail)
-        .and_then(|s| row_highlight_range(s, line))
-        .is_some()
-}
-
-/// Render a single header row, applying whole-row inverse-video when it falls
-/// inside the active drag selection.
-fn header_row(
-    content: String,
-    default_fg: Color,
-    line: usize,
-    selection: Option<&TextSelection>,
-    rc: &ResolvedColors,
-) -> AnyElement<'static> {
-    if header_highlight(line, selection) {
-        element! {
-            Box(height: 1u32, background_color: rc.sel_bg) {
-                Text(content: content, color: rc.sel_fg)
-            }
-        }
-        .into_any()
-    } else {
-        element! {
-            Box(height: 1u32) {
-                Text(content: content, color: default_fg)
-            }
-        }
-        .into_any()
-    }
-}
-
 /// Issue detail view — fixed structure that NEVER changes layout.
 ///
-/// ALWAYS renders: border box → 5 header rows → fixed-row scrollable viewport.
+/// ALWAYS renders: border box -> 5 header rows -> fixed-row scrollable viewport.
 /// When no issue is selected, header rows are blank and viewport shows a message.
 /// This ensures layout is identical regardless of whether an issue is loaded.
 ///
@@ -172,36 +221,17 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
                 rc.bright,
             )
         } else if let Some(detail) = props.issue_detail.as_ref() {
-            let state_tag = match detail.state {
-                IssueState::Open => "OPEN",
-                IssueState::Closed => "CLOSED",
-            };
+            let header = issue_detail_header_view(detail);
             let sc = match detail.state {
                 IssueState::Open => rc.bright,
                 IssueState::Closed => rc.dim,
             };
-            let labels_str = if detail.labels.is_empty() {
-                "-".to_string()
-            } else {
-                detail.labels.join(", ")
-            };
-            let assignees_str = if detail.assignees.is_empty() {
-                "-".to_string()
-            } else {
-                detail.assignees.join(", ")
-            };
-            let milestone_str = detail.milestone.as_deref().unwrap_or("-").to_string();
 
             (
-                format!("#{} {}", detail.number, detail.title),
-                format!(
-                    "{}  by @{}  opened: {}  updated: {}",
-                    state_tag, detail.author_login, detail.created_at, detail.updated_at
-                ),
-                format!(
-                    "labels: {labels_str}  assignees: {assignees_str}  milestone: {milestone_str}"
-                ),
-                detail.external_url.clone(),
+                header.title,
+                header.state,
+                header.labels,
+                header.url,
                 build_detail_content(
                     detail,
                     props.detail_subfocus,
@@ -267,15 +297,16 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
         ) {
             // ── Metadata header — always exactly HEADER_ROWS rows ─────────
             Box(flex_direction: FlexDirection::Column, padding_left: 1u32, padding_right: 1u32) {
-                #(header_row(h_title, rc.fg, 0, props.selection.as_ref(), &rc))
-                #(header_row(h_state, state_color, 1, props.selection.as_ref(), &rc))
-                #(header_row(h_labels, rc.dim, 2, props.selection.as_ref(), &rc))
-                #(header_row(h_url, rc.dim, 3, props.selection.as_ref(), &rc))
+                #(header_row(h_title, rc.fg, 0, props.selection.as_ref(), SelectablePane::IssueDetail, &rc))
+                #(header_row(h_state, state_color, 1, props.selection.as_ref(), SelectablePane::IssueDetail, &rc))
+                #(header_row(h_labels, rc.dim, 2, props.selection.as_ref(), SelectablePane::IssueDetail, &rc))
+                #(header_row(h_url, rc.dim, 3, props.selection.as_ref(), SelectablePane::IssueDetail, &rc))
                 #(header_row(
                     "─────────────────────────────────────────".to_string(),
                     rc.dim,
                     4,
                     props.selection.as_ref(),
+                    SelectablePane::IssueDetail,
                     &rc,
                 ))
             }

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -74,11 +74,40 @@ fn active_issue_composer(inline_state: &InlineState) -> Option<(String, usize, &
 /// Whether content line `line` (one of the fixed header rows) falls inside the
 /// active selection for the issue detail pane. When true the header row is
 /// painted in inverse-video selection colors.
+///
+/// Header rows use whole-row highlight (ignoring partial column ranges) for
+/// visual simplicity on short metadata lines.
 fn header_highlight(line: usize, selection: Option<&TextSelection>) -> bool {
     selection
         .filter(|s| s.pane() == SelectablePane::IssueDetail)
         .and_then(|s| row_highlight_range(s, line))
         .is_some()
+}
+
+/// Render a single header row, applying whole-row inverse-video when it falls
+/// inside the active drag selection.
+fn header_row(
+    content: String,
+    default_fg: Color,
+    line: usize,
+    selection: Option<&TextSelection>,
+    rc: &ResolvedColors,
+) -> AnyElement<'static> {
+    if header_highlight(line, selection) {
+        element! {
+            Box(height: 1u32, background_color: rc.sel_bg) {
+                Text(content: content, color: rc.sel_fg)
+            }
+        }
+        .into_any()
+    } else {
+        element! {
+            Box(height: 1u32) {
+                Text(content: content, color: default_fg)
+            }
+        }
+        .into_any()
+    }
 }
 
 /// Issue detail view — fixed structure that NEVER changes layout.
@@ -238,77 +267,17 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
         ) {
             // ── Metadata header — always exactly HEADER_ROWS rows ─────────
             Box(flex_direction: FlexDirection::Column, padding_left: 1u32, padding_right: 1u32) {
-                #(if header_highlight(0, props.selection.as_ref()) {
-                    element! {
-                        Box(height: 1u32, background_color: rc.sel_bg) {
-                            Text(content: h_title, color: rc.sel_fg)
-                        }
-                    }.into_any()
-                } else {
-                    element! {
-                        Box(height: 1u32) {
-                            Text(content: h_title, color: rc.fg)
-                        }
-                    }.into_any()
-                })
-                #(if header_highlight(1, props.selection.as_ref()) {
-                    element! {
-                        Box(height: 1u32, background_color: rc.sel_bg) {
-                            Text(content: h_state, color: rc.sel_fg)
-                        }
-                    }.into_any()
-                } else {
-                    element! {
-                        Box(height: 1u32) {
-                            Text(content: h_state, color: state_color)
-                        }
-                    }.into_any()
-                })
-                #(if header_highlight(2, props.selection.as_ref()) {
-                    element! {
-                        Box(height: 1u32, background_color: rc.sel_bg) {
-                            Text(content: h_labels, color: rc.sel_fg)
-                        }
-                    }.into_any()
-                } else {
-                    element! {
-                        Box(height: 1u32) {
-                            Text(content: h_labels, color: rc.dim)
-                        }
-                    }.into_any()
-                })
-                #(if header_highlight(3, props.selection.as_ref()) {
-                    element! {
-                        Box(height: 1u32, background_color: rc.sel_bg) {
-                            Text(content: h_url, color: rc.sel_fg)
-                        }
-                    }.into_any()
-                } else {
-                    element! {
-                        Box(height: 1u32) {
-                            Text(content: h_url, color: rc.dim)
-                        }
-                    }.into_any()
-                })
-                #(if header_highlight(4, props.selection.as_ref()) {
-                    element! {
-                        Box(height: 1u32, background_color: rc.sel_bg) {
-                            Text(
-                                content: "─────────────────────────────────────────",
-                                color: rc.sel_fg,
-                            )
-                        }
-                    }.into_any()
-                } else {
-                    element! {
-                        Box(height: 1u32) {
-                            Text(
-                                content: "─────────────────────────────────────────",
-                                color: rc.dim,
-                            )
-                        }
-                    }.into_any()
-                })
+                #(header_row(h_title, rc.fg, 0, props.selection.as_ref(), &rc))
+                #(header_row(h_state, state_color, 1, props.selection.as_ref(), &rc))
+                #(header_row(h_labels, rc.dim, 2, props.selection.as_ref(), &rc))
+                #(header_row(h_url, rc.dim, 3, props.selection.as_ref(), &rc))
+                #(header_row(
+                    "─────────────────────────────────────────".to_string(),
+                    rc.dim,
+                    4,
+                    props.selection.as_ref(),
+                    &rc,
+                ))
             }
 
             // ── Scrollable viewport — always exactly scroll_rows rows ─────

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -8,7 +8,7 @@ use iocraft::prelude::*;
 use crate::domain::{IssueDetail, IssueState};
 use crate::issue_detail_content::{DetailContent, build_detail_content, build_new_issue_content};
 use crate::layout::DETAIL_HEADER_ROWS as HEADER_ROWS;
-use crate::selection::TextSelection;
+use crate::selection::{SelectablePane, TextSelection, row_highlight_range};
 use crate::state::{ComposerTarget, DetailSubfocus, InlineState};
 use crate::theme::{ResolvedColors, ThemeColors};
 
@@ -69,6 +69,16 @@ fn active_issue_composer(inline_state: &InlineState) -> Option<(String, usize, &
         | InlineState::Editor { .. }
         | InlineState::None => None,
     }
+}
+
+/// Whether content line `line` (one of the fixed header rows) falls inside the
+/// active selection for the issue detail pane. When true the header row is
+/// painted in inverse-video selection colors.
+fn header_highlight(line: usize, selection: Option<&TextSelection>) -> bool {
+    selection
+        .filter(|s| s.pane() == SelectablePane::IssueDetail)
+        .and_then(|s| row_highlight_range(s, line))
+        .is_some()
 }
 
 /// Issue detail view — fixed structure that NEVER changes layout.
@@ -228,24 +238,77 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
         ) {
             // ── Metadata header — always exactly HEADER_ROWS rows ─────────
             Box(flex_direction: FlexDirection::Column, padding_left: 1u32, padding_right: 1u32) {
-                Box(height: 1u32) {
-                    Text(content: h_title, color: rc.fg)
-                }
-                Box(height: 1u32) {
-                    Text(content: h_state, color: state_color)
-                }
-                Box(height: 1u32) {
-                    Text(content: h_labels, color: rc.dim)
-                }
-                Box(height: 1u32) {
-                    Text(content: h_url, color: rc.dim)
-                }
-                Box(height: 1u32) {
-                    Text(
-                        content: "─────────────────────────────────────────",
-                        color: rc.dim,
-                    )
-                }
+                #(if header_highlight(0, props.selection.as_ref()) {
+                    element! {
+                        Box(height: 1u32, background_color: rc.sel_bg) {
+                            Text(content: h_title, color: rc.sel_fg)
+                        }
+                    }.into_any()
+                } else {
+                    element! {
+                        Box(height: 1u32) {
+                            Text(content: h_title, color: rc.fg)
+                        }
+                    }.into_any()
+                })
+                #(if header_highlight(1, props.selection.as_ref()) {
+                    element! {
+                        Box(height: 1u32, background_color: rc.sel_bg) {
+                            Text(content: h_state, color: rc.sel_fg)
+                        }
+                    }.into_any()
+                } else {
+                    element! {
+                        Box(height: 1u32) {
+                            Text(content: h_state, color: state_color)
+                        }
+                    }.into_any()
+                })
+                #(if header_highlight(2, props.selection.as_ref()) {
+                    element! {
+                        Box(height: 1u32, background_color: rc.sel_bg) {
+                            Text(content: h_labels, color: rc.sel_fg)
+                        }
+                    }.into_any()
+                } else {
+                    element! {
+                        Box(height: 1u32) {
+                            Text(content: h_labels, color: rc.dim)
+                        }
+                    }.into_any()
+                })
+                #(if header_highlight(3, props.selection.as_ref()) {
+                    element! {
+                        Box(height: 1u32, background_color: rc.sel_bg) {
+                            Text(content: h_url, color: rc.sel_fg)
+                        }
+                    }.into_any()
+                } else {
+                    element! {
+                        Box(height: 1u32) {
+                            Text(content: h_url, color: rc.dim)
+                        }
+                    }.into_any()
+                })
+                #(if header_highlight(4, props.selection.as_ref()) {
+                    element! {
+                        Box(height: 1u32, background_color: rc.sel_bg) {
+                            Text(
+                                content: "─────────────────────────────────────────",
+                                color: rc.sel_fg,
+                            )
+                        }
+                    }.into_any()
+                } else {
+                    element! {
+                        Box(height: 1u32) {
+                            Text(
+                                content: "─────────────────────────────────────────",
+                                color: rc.dim,
+                            )
+                        }
+                    }.into_any()
+                })
             }
 
             // ── Scrollable viewport — always exactly scroll_rows rows ─────
@@ -264,9 +327,11 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
                     thumb_color: rc.bright,
                     selection: props
                         .selection
-                        .filter(|s| s.pane() == crate::selection::SelectablePane::IssueDetail),
+                        .filter(|s| s.pane() == SelectablePane::IssueDetail),
                     selection_bg: Some(rc.sel_bg),
                     selection_fg: Some(rc.sel_fg),
+                    bg: Some(rc.bg),
+                    content_line_offset: HEADER_ROWS,
                 )
             }
 

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -262,7 +262,9 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
                     cursor_bg: rc.bright,
                     track_color: rc.dim,
                     thumb_color: rc.bright,
-                    selection: props.selection,
+                    selection: props
+                        .selection
+                        .filter(|s| s.pane() == crate::selection::SelectablePane::IssueDetail),
                     selection_bg: Some(rc.sel_bg),
                     selection_fg: Some(rc.sel_fg),
                 )

--- a/src/ui/components/issue_list.rs
+++ b/src/ui/components/issue_list.rs
@@ -256,20 +256,10 @@ pub fn IssueList(props: &IssueListProps) -> impl Into<AnyElement<'static>> {
                         rows.layout,
                         rows.available_width,
                     );
-                    let rows_per_item = if rows.layout.is_compact() { 1 } else { 2 };
-                    let viewport =
-                        (rows.list_pane_rows.saturating_sub(LIST_CHROME_ROWS) / rows_per_item)
-                            .max(1) as usize;
-                    let first_visible = crate::layout::list_first_visible_index(
-                        rows.selected_index.unwrap_or(0),
-                        rows.issues.len(),
-                        viewport,
-                    );
                     projected.iter().enumerate().map(|(window_i, view)| {
-                        let content_line = first_visible + window_i;
                         let highlight = rows.selection.as_ref().and_then(|s| {
                             if s.pane() == crate::selection::SelectablePane::IssueList {
-                                row_highlight_range(s, content_line)
+                                row_highlight_range(s, window_i)
                             } else {
                                 None
                             }
@@ -304,19 +294,15 @@ fn render_issue_row(
     let is_selected = view.is_selected;
 
     // When a drag selection covers this row, paint the whole row in the
-    // selection colors (lists are single-line-per-item in Compact mode, so a
-    // row-level highlight is sufficient and matches the copyable text).
+    // selection colors. Keyboard selection uses a separate highlight color
+    // (`is_selected`) for text emphasis (bold) but not inverse-video.
     let highlighted = highlight.is_some();
-    let row_bg = if highlighted || is_selected {
+    let row_bg = if highlighted {
         highlight_colors.bg
     } else {
         Color::Reset
     };
-    let title_fg = if highlighted || is_selected {
-        highlight_colors.fg
-    } else {
-        fg
-    };
+    let title_fg = if highlighted { highlight_colors.fg } else { fg };
 
     if compact {
         return element! {
@@ -341,7 +327,7 @@ fn render_issue_row(
                 )
             }
             Box(height: 1u32, background_color: row_bg) {
-                Text(content: meta_line.to_string(), color: if is_selected { highlight_colors.fg } else { dim })
+                Text(content: meta_line.to_string(), color: if highlighted { highlight_colors.fg } else { dim })
             }
         }
     }

--- a/src/ui/components/issue_list.rs
+++ b/src/ui/components/issue_list.rs
@@ -7,7 +7,8 @@ use iocraft::prelude::*;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::domain::{Issue, IssueState};
-use crate::theme::{ResolvedColors, ThemeColors};
+use crate::selection::{HighlightRange, TextSelection, row_highlight_range};
+use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
 
 /// Ellipsis character appended when a title is truncated.
 const ELLIPSIS: char = '…';
@@ -86,6 +87,9 @@ pub struct IssueListProps {
     ///
     /// When provided, long issue titles are truncated with an ellipsis to fit.
     pub available_width: Option<u16>,
+    /// Active text selection, if any (and if it targets this pane). Selected
+    /// cells are painted in inverse video for live drag-selection feedback.
+    pub selection: Option<TextSelection>,
 }
 
 /// Projected issue-list row exactly as the component renders it.
@@ -241,68 +245,107 @@ pub fn IssueList(props: &IssueListProps) -> impl Into<AnyElement<'static>> {
                         Box(padding_left: 1u32, height: 1u32) {
                             Text(content: msg, color: rc.dim)
                         }
-                    }]
+                    }
+                    .into_any()]
                 } else {
+                    let rows = props;
                     let projected = issue_list_visible_rows(
-                        &props.issues,
-                        props.selected_index,
-                        props.list_pane_rows,
-                        props.layout,
-                        props.available_width,
+                        &rows.issues,
+                        rows.selected_index,
+                        rows.list_pane_rows,
+                        rows.layout,
+                        rows.available_width,
                     );
-                    projected.iter().map(|view| {
-                        let title_line = view.title_line.as_str();
-                        let meta_line = view.meta_line.as_str();
-                        if view.is_selected {
-                            if props.layout.is_compact() {
-                                element! {
-                                    Box(height: 1u32, background_color: rc.sel_bg) {
-                                        Text(
-                                            content: title_line,
-                                            color: rc.sel_fg,
-                                            weight: Weight::Bold,
-                                        )
-                                    }
-                                }
+                    let rows_per_item = if rows.layout.is_compact() { 1 } else { 2 };
+                    let viewport =
+                        (rows.list_pane_rows.saturating_sub(LIST_CHROME_ROWS) / rows_per_item)
+                            .max(1) as usize;
+                    let first_visible = crate::layout::list_first_visible_index(
+                        rows.selected_index.unwrap_or(0),
+                        rows.issues.len(),
+                        viewport,
+                    );
+                    projected.iter().enumerate().map(|(window_i, view)| {
+                        let content_line = first_visible + window_i;
+                        let highlight = rows.selection.as_ref().and_then(|s| {
+                            if s.pane() == crate::selection::SelectablePane::IssueList {
+                                row_highlight_range(s, content_line)
                             } else {
-                                element! {
-                                    Box(flex_direction: FlexDirection::Column) {
-                                        Box(height: 1u32, background_color: rc.sel_bg) {
-                                            Text(
-                                                content: title_line,
-                                                color: rc.sel_fg,
-                                                weight: Weight::Bold,
-                                            )
-                                        }
-                                        Box(height: 1u32, background_color: rc.sel_bg) {
-                                            Text(content: meta_line, color: rc.sel_fg)
-                                        }
-                                    }
-                                }
+                                None
                             }
-                        } else if props.layout.is_compact() {
-                            element! {
-                                Box(height: 1u32) {
-                                    Text(content: title_line, color: rc.fg)
-                                }
-                            }
-                        } else {
-                            element! {
-                                Box(flex_direction: FlexDirection::Column) {
-                                    Box(height: 1u32) {
-                                        Text(content: title_line, color: rc.fg)
-                                    }
-                                    Box(height: 1u32) {
-                                        Text(content: meta_line, color: rc.dim)
-                                    }
-                                }
-                            }
-                        }
+                        });
+                        render_issue_row(
+                            view,
+                            rows.layout.is_compact(),
+                            highlight,
+                            rc.fg,
+                            SelectionColors::from_resolved(&rc),
+                            rc.dim,
+                        )
                     }).collect()
                 })
             }
         }
     }
+}
+
+/// Render a single issue-list row, applying the selection-row highlight when
+/// the row falls inside an active drag selection. Mirrors the pr_list helper.
+fn render_issue_row(
+    view: &IssueListRowView,
+    compact: bool,
+    highlight: Option<HighlightRange>,
+    fg: Color,
+    highlight_colors: SelectionColors,
+    dim: Color,
+) -> AnyElement<'static> {
+    let title_line = view.title_line.as_str();
+    let meta_line = view.meta_line.as_str();
+    let is_selected = view.is_selected;
+
+    // When a drag selection covers this row, paint the whole row in the
+    // selection colors (lists are single-line-per-item in Compact mode, so a
+    // row-level highlight is sufficient and matches the copyable text).
+    let highlighted = highlight.is_some();
+    let row_bg = if highlighted || is_selected {
+        highlight_colors.bg
+    } else {
+        Color::Reset
+    };
+    let title_fg = if highlighted || is_selected {
+        highlight_colors.fg
+    } else {
+        fg
+    };
+
+    if compact {
+        return element! {
+            Box(height: 1u32, background_color: row_bg) {
+                Text(
+                    content: title_line.to_string(),
+                    color: title_fg,
+                    weight: if is_selected { Weight::Bold } else { Weight::Normal },
+                )
+            }
+        }
+        .into_any();
+    }
+
+    element! {
+        Box(flex_direction: FlexDirection::Column) {
+            Box(height: 1u32, background_color: row_bg) {
+                Text(
+                    content: title_line.to_string(),
+                    color: title_fg,
+                    weight: if is_selected { Weight::Bold } else { Weight::Normal },
+                )
+            }
+            Box(height: 1u32, background_color: row_bg) {
+                Text(content: meta_line.to_string(), color: if is_selected { highlight_colors.fg } else { dim })
+            }
+        }
+    }
+    .into_any()
 }
 
 #[cfg(test)]

--- a/src/ui/components/issue_list.rs
+++ b/src/ui/components/issue_list.rs
@@ -307,15 +307,16 @@ fn render_issue_row(
     } else {
         row_colors.fg
     };
+    let weight = if is_selected {
+        Weight::Bold
+    } else {
+        Weight::Normal
+    };
 
     if compact {
         return element! {
             Box(height: 1u32, background_color: row_bg) {
-                Text(
-                    content: title_line.to_string(),
-                    color: title_fg,
-                    weight: if is_selected { Weight::Bold } else { Weight::Normal },
-                )
+                Text(content: title_line, color: title_fg, weight: weight)
             }
         }
         .into_any();
@@ -324,14 +325,10 @@ fn render_issue_row(
     element! {
         Box(flex_direction: FlexDirection::Column) {
             Box(height: 1u32, background_color: row_bg) {
-                Text(
-                    content: title_line.to_string(),
-                    color: title_fg,
-                    weight: if is_selected { Weight::Bold } else { Weight::Normal },
-                )
+                Text(content: title_line, color: title_fg, weight: weight)
             }
             Box(height: 1u32, background_color: row_bg) {
-                Text(content: meta_line.to_string(), color: if highlighted { highlight_colors.fg } else { dim })
+                Text(content: meta_line, color: if highlighted { highlight_colors.fg } else { dim })
             }
         }
     }

--- a/src/ui/components/issue_list.rs
+++ b/src/ui/components/issue_list.rs
@@ -8,7 +8,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::domain::{Issue, IssueState};
 use crate::selection::{HighlightRange, TextSelection, row_highlight_range};
-use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
+use crate::theme::{ResolvedColors, RowColors, SelectionColors, ThemeColors};
 
 /// Ellipsis character appended when a title is truncated.
 const ELLIPSIS: char = '…';
@@ -268,7 +268,7 @@ pub fn IssueList(props: &IssueListProps) -> impl Into<AnyElement<'static>> {
                             view,
                             rows.layout.is_compact(),
                             highlight,
-                            rc.fg,
+                            RowColors::from_resolved(&rc),
                             SelectionColors::from_resolved(&rc),
                             rc.dim,
                         )
@@ -285,7 +285,7 @@ fn render_issue_row(
     view: &IssueListRowView,
     compact: bool,
     highlight: Option<HighlightRange>,
-    fg: Color,
+    row_colors: RowColors,
     highlight_colors: SelectionColors,
     dim: Color,
 ) -> AnyElement<'static> {
@@ -300,9 +300,13 @@ fn render_issue_row(
     let row_bg = if highlighted {
         highlight_colors.bg
     } else {
-        Color::Reset
+        row_colors.bg
     };
-    let title_fg = if highlighted { highlight_colors.fg } else { fg };
+    let title_fg = if highlighted {
+        highlight_colors.fg
+    } else {
+        row_colors.fg
+    };
 
     if compact {
         return element! {

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -6,7 +6,11 @@
 mod agent_chooser;
 mod agent_list;
 mod filter_controls;
-mod issue_detail;
+/// Issue detail pane projection + component. The projection
+/// (`issue_detail_header_view`, `header_highlight`, `header_row`) is reused by
+/// the PR detail component and the selection content provider so copied text
+/// matches the rendered rows.
+pub(crate) mod issue_detail;
 /// Issue list pane projection + component (projection is reused by the
 /// selection content provider so copied text matches the rendered rows).
 pub(crate) mod issue_list;

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -7,7 +7,9 @@ mod agent_chooser;
 mod agent_list;
 mod filter_controls;
 mod issue_detail;
-mod issue_list;
+/// Issue list pane projection + component (projection is reused by the
+/// selection content provider so copied text matches the rendered rows).
+pub(crate) mod issue_list;
 /// @plan PLAN-20260624-PR-MODE.P13
 /// @requirement REQ-PR-012
 pub(crate) mod keybind_bar;

--- a/src/ui/components/pr_detail.rs
+++ b/src/ui/components/pr_detail.rs
@@ -7,10 +7,11 @@ use iocraft::prelude::*;
 use crate::domain::PullRequestDetail;
 use crate::layout::PR_DETAIL_HEADER_ROWS as HEADER_ROWS;
 use crate::pr_detail_content::{build_pr_detail_content, pr_state_tag};
-use crate::selection::{SelectablePane, TextSelection, row_highlight_range};
+use crate::selection::{SelectablePane, TextSelection};
 use crate::state::{ComposerTarget, InlineState, PrDetailSubfocus};
 use crate::theme::{ResolvedColors, ThemeColors};
 
+use super::issue_detail::header_row;
 use super::scrollable_text::ScrollableText;
 use super::text_box::TextBox;
 
@@ -148,45 +149,6 @@ fn active_pr_composer(inline_state: &InlineState) -> Option<(String, usize, &'st
     }
 }
 
-/// Whether content line `line` (one of the fixed header rows) falls inside the
-/// active selection for `pane`. When true the header row is painted in
-/// inverse-video selection colors.
-///
-/// Header rows use whole-row highlight (ignoring partial column ranges) for
-/// visual simplicity on short metadata lines.
-fn header_highlight(line: usize, selection: Option<&TextSelection>, pane: SelectablePane) -> bool {
-    selection
-        .filter(|s| s.pane() == pane)
-        .and_then(|s| row_highlight_range(s, line))
-        .is_some()
-}
-
-/// Render a single PR header row, applying whole-row inverse-video when it
-/// falls inside the active drag selection.
-fn header_row(
-    content: String,
-    default_fg: Color,
-    line: usize,
-    selection: Option<&TextSelection>,
-    rc: &ResolvedColors,
-) -> AnyElement<'static> {
-    if header_highlight(line, selection, SelectablePane::PrDetail) {
-        element! {
-            Box(height: 1u32, background_color: rc.sel_bg) {
-                Text(content: content, color: rc.sel_fg)
-            }
-        }
-        .into_any()
-    } else {
-        element! {
-            Box(height: 1u32) {
-                Text(content: content, color: default_fg)
-            }
-        }
-        .into_any()
-    }
-}
-
 /// PR detail view — fixed structure that NEVER changes layout.
 ///
 /// ALWAYS renders: border box → `HEADER_ROWS` header rows → fixed-row scrollable viewport.
@@ -297,15 +259,16 @@ pub fn PrDetailView(props: &PrDetailViewProps) -> impl Into<AnyElement<'static>>
         ) {
             // ── Metadata header — always exactly HEADER_ROWS rows ─────────
             Box(flex_direction: FlexDirection::Column, padding_left: 1u32, padding_right: 1u32) {
-                #(header_row(h_title, rc.fg, 0, props.selection.as_ref(), &rc))
-                #(header_row(h_state, state_color, 1, props.selection.as_ref(), &rc))
-                #(header_row(h_branches, rc.dim, 2, props.selection.as_ref(), &rc))
-                #(header_row(h_url, rc.dim, 3, props.selection.as_ref(), &rc))
+                #(header_row(h_title, rc.fg, 0, props.selection.as_ref(), SelectablePane::PrDetail, &rc))
+                #(header_row(h_state, state_color, 1, props.selection.as_ref(), SelectablePane::PrDetail, &rc))
+                #(header_row(h_branches, rc.dim, 2, props.selection.as_ref(), SelectablePane::PrDetail, &rc))
+                #(header_row(h_url, rc.dim, 3, props.selection.as_ref(), SelectablePane::PrDetail, &rc))
                 #(header_row(
                     "─────────────────────────────────────────".to_string(),
                     rc.dim,
                     4,
                     props.selection.as_ref(),
+                    SelectablePane::PrDetail,
                     &rc,
                 ))
             }

--- a/src/ui/components/pr_detail.rs
+++ b/src/ui/components/pr_detail.rs
@@ -292,7 +292,9 @@ pub fn PrDetailView(props: &PrDetailViewProps) -> impl Into<AnyElement<'static>>
                     cursor_bg: rc.bright,
                     track_color: rc.dim,
                     thumb_color: rc.bright,
-                    selection: props.selection,
+                    selection: props
+                        .selection
+                        .filter(|s| s.pane() == crate::selection::SelectablePane::PrDetail),
                     selection_bg: Some(rc.sel_bg),
                     selection_fg: Some(rc.sel_fg),
                 )

--- a/src/ui/components/pr_detail.rs
+++ b/src/ui/components/pr_detail.rs
@@ -7,7 +7,7 @@ use iocraft::prelude::*;
 use crate::domain::PullRequestDetail;
 use crate::layout::PR_DETAIL_HEADER_ROWS as HEADER_ROWS;
 use crate::pr_detail_content::{build_pr_detail_content, pr_state_tag};
-use crate::selection::TextSelection;
+use crate::selection::{SelectablePane, TextSelection, row_highlight_range};
 use crate::state::{ComposerTarget, InlineState, PrDetailSubfocus};
 use crate::theme::{ResolvedColors, ThemeColors};
 
@@ -148,6 +148,16 @@ fn active_pr_composer(inline_state: &InlineState) -> Option<(String, usize, &'st
     }
 }
 
+/// Whether content line `line` (one of the fixed header rows) falls inside the
+/// active selection for `pane`. When true the header row is painted in
+/// inverse-video selection colors.
+fn header_highlight(line: usize, selection: Option<&TextSelection>, pane: SelectablePane) -> bool {
+    selection
+        .filter(|s| s.pane() == pane)
+        .and_then(|s| row_highlight_range(s, line))
+        .is_some()
+}
+
 /// PR detail view — fixed structure that NEVER changes layout.
 ///
 /// ALWAYS renders: border box → `HEADER_ROWS` header rows → fixed-row scrollable viewport.
@@ -258,24 +268,77 @@ pub fn PrDetailView(props: &PrDetailViewProps) -> impl Into<AnyElement<'static>>
         ) {
             // ── Metadata header — always exactly HEADER_ROWS rows ─────────
             Box(flex_direction: FlexDirection::Column, padding_left: 1u32, padding_right: 1u32) {
-                Box(height: 1u32) {
-                    Text(content: h_title, color: rc.fg)
-                }
-                Box(height: 1u32) {
-                    Text(content: h_state, color: state_color)
-                }
-                Box(height: 1u32) {
-                    Text(content: h_branches, color: rc.dim)
-                }
-                Box(height: 1u32) {
-                    Text(content: h_url, color: rc.dim)
-                }
-                Box(height: 1u32) {
-                    Text(
-                        content: "─────────────────────────────────────────",
-                        color: rc.dim,
-                    )
-                }
+                #(if header_highlight(0, props.selection.as_ref(), SelectablePane::PrDetail) {
+                    element! {
+                        Box(height: 1u32, background_color: rc.sel_bg) {
+                            Text(content: h_title, color: rc.sel_fg)
+                        }
+                    }.into_any()
+                } else {
+                    element! {
+                        Box(height: 1u32) {
+                            Text(content: h_title, color: rc.fg)
+                        }
+                    }.into_any()
+                })
+                #(if header_highlight(1, props.selection.as_ref(), SelectablePane::PrDetail) {
+                    element! {
+                        Box(height: 1u32, background_color: rc.sel_bg) {
+                            Text(content: h_state, color: rc.sel_fg)
+                        }
+                    }.into_any()
+                } else {
+                    element! {
+                        Box(height: 1u32) {
+                            Text(content: h_state, color: state_color)
+                        }
+                    }.into_any()
+                })
+                #(if header_highlight(2, props.selection.as_ref(), SelectablePane::PrDetail) {
+                    element! {
+                        Box(height: 1u32, background_color: rc.sel_bg) {
+                            Text(content: h_branches, color: rc.sel_fg)
+                        }
+                    }.into_any()
+                } else {
+                    element! {
+                        Box(height: 1u32) {
+                            Text(content: h_branches, color: rc.dim)
+                        }
+                    }.into_any()
+                })
+                #(if header_highlight(3, props.selection.as_ref(), SelectablePane::PrDetail) {
+                    element! {
+                        Box(height: 1u32, background_color: rc.sel_bg) {
+                            Text(content: h_url, color: rc.sel_fg)
+                        }
+                    }.into_any()
+                } else {
+                    element! {
+                        Box(height: 1u32) {
+                            Text(content: h_url, color: rc.dim)
+                        }
+                    }.into_any()
+                })
+                #(if header_highlight(4, props.selection.as_ref(), SelectablePane::PrDetail) {
+                    element! {
+                        Box(height: 1u32, background_color: rc.sel_bg) {
+                            Text(
+                                content: "─────────────────────────────────────────",
+                                color: rc.sel_fg,
+                            )
+                        }
+                    }.into_any()
+                } else {
+                    element! {
+                        Box(height: 1u32) {
+                            Text(
+                                content: "─────────────────────────────────────────",
+                                color: rc.dim,
+                            )
+                        }
+                    }.into_any()
+                })
             }
 
             // ── Scrollable viewport — always exactly scroll_rows rows ─────
@@ -297,6 +360,8 @@ pub fn PrDetailView(props: &PrDetailViewProps) -> impl Into<AnyElement<'static>>
                         .filter(|s| s.pane() == crate::selection::SelectablePane::PrDetail),
                     selection_bg: Some(rc.sel_bg),
                     selection_fg: Some(rc.sel_fg),
+                    bg: Some(rc.bg),
+                    content_line_offset: HEADER_ROWS,
                 )
             }
 

--- a/src/ui/components/pr_detail.rs
+++ b/src/ui/components/pr_detail.rs
@@ -151,11 +151,40 @@ fn active_pr_composer(inline_state: &InlineState) -> Option<(String, usize, &'st
 /// Whether content line `line` (one of the fixed header rows) falls inside the
 /// active selection for `pane`. When true the header row is painted in
 /// inverse-video selection colors.
+///
+/// Header rows use whole-row highlight (ignoring partial column ranges) for
+/// visual simplicity on short metadata lines.
 fn header_highlight(line: usize, selection: Option<&TextSelection>, pane: SelectablePane) -> bool {
     selection
         .filter(|s| s.pane() == pane)
         .and_then(|s| row_highlight_range(s, line))
         .is_some()
+}
+
+/// Render a single PR header row, applying whole-row inverse-video when it
+/// falls inside the active drag selection.
+fn header_row(
+    content: String,
+    default_fg: Color,
+    line: usize,
+    selection: Option<&TextSelection>,
+    rc: &ResolvedColors,
+) -> AnyElement<'static> {
+    if header_highlight(line, selection, SelectablePane::PrDetail) {
+        element! {
+            Box(height: 1u32, background_color: rc.sel_bg) {
+                Text(content: content, color: rc.sel_fg)
+            }
+        }
+        .into_any()
+    } else {
+        element! {
+            Box(height: 1u32) {
+                Text(content: content, color: default_fg)
+            }
+        }
+        .into_any()
+    }
 }
 
 /// PR detail view — fixed structure that NEVER changes layout.
@@ -268,77 +297,17 @@ pub fn PrDetailView(props: &PrDetailViewProps) -> impl Into<AnyElement<'static>>
         ) {
             // ── Metadata header — always exactly HEADER_ROWS rows ─────────
             Box(flex_direction: FlexDirection::Column, padding_left: 1u32, padding_right: 1u32) {
-                #(if header_highlight(0, props.selection.as_ref(), SelectablePane::PrDetail) {
-                    element! {
-                        Box(height: 1u32, background_color: rc.sel_bg) {
-                            Text(content: h_title, color: rc.sel_fg)
-                        }
-                    }.into_any()
-                } else {
-                    element! {
-                        Box(height: 1u32) {
-                            Text(content: h_title, color: rc.fg)
-                        }
-                    }.into_any()
-                })
-                #(if header_highlight(1, props.selection.as_ref(), SelectablePane::PrDetail) {
-                    element! {
-                        Box(height: 1u32, background_color: rc.sel_bg) {
-                            Text(content: h_state, color: rc.sel_fg)
-                        }
-                    }.into_any()
-                } else {
-                    element! {
-                        Box(height: 1u32) {
-                            Text(content: h_state, color: state_color)
-                        }
-                    }.into_any()
-                })
-                #(if header_highlight(2, props.selection.as_ref(), SelectablePane::PrDetail) {
-                    element! {
-                        Box(height: 1u32, background_color: rc.sel_bg) {
-                            Text(content: h_branches, color: rc.sel_fg)
-                        }
-                    }.into_any()
-                } else {
-                    element! {
-                        Box(height: 1u32) {
-                            Text(content: h_branches, color: rc.dim)
-                        }
-                    }.into_any()
-                })
-                #(if header_highlight(3, props.selection.as_ref(), SelectablePane::PrDetail) {
-                    element! {
-                        Box(height: 1u32, background_color: rc.sel_bg) {
-                            Text(content: h_url, color: rc.sel_fg)
-                        }
-                    }.into_any()
-                } else {
-                    element! {
-                        Box(height: 1u32) {
-                            Text(content: h_url, color: rc.dim)
-                        }
-                    }.into_any()
-                })
-                #(if header_highlight(4, props.selection.as_ref(), SelectablePane::PrDetail) {
-                    element! {
-                        Box(height: 1u32, background_color: rc.sel_bg) {
-                            Text(
-                                content: "─────────────────────────────────────────",
-                                color: rc.sel_fg,
-                            )
-                        }
-                    }.into_any()
-                } else {
-                    element! {
-                        Box(height: 1u32) {
-                            Text(
-                                content: "─────────────────────────────────────────",
-                                color: rc.dim,
-                            )
-                        }
-                    }.into_any()
-                })
+                #(header_row(h_title, rc.fg, 0, props.selection.as_ref(), &rc))
+                #(header_row(h_state, state_color, 1, props.selection.as_ref(), &rc))
+                #(header_row(h_branches, rc.dim, 2, props.selection.as_ref(), &rc))
+                #(header_row(h_url, rc.dim, 3, props.selection.as_ref(), &rc))
+                #(header_row(
+                    "─────────────────────────────────────────".to_string(),
+                    rc.dim,
+                    4,
+                    props.selection.as_ref(),
+                    &rc,
+                ))
             }
 
             // ── Scrollable viewport — always exactly scroll_rows rows ─────

--- a/src/ui/components/pr_detail.rs
+++ b/src/ui/components/pr_detail.rs
@@ -7,6 +7,7 @@ use iocraft::prelude::*;
 use crate::domain::PullRequestDetail;
 use crate::layout::PR_DETAIL_HEADER_ROWS as HEADER_ROWS;
 use crate::pr_detail_content::{build_pr_detail_content, pr_state_tag};
+use crate::selection::TextSelection;
 use crate::state::{ComposerTarget, InlineState, PrDetailSubfocus};
 use crate::theme::{ResolvedColors, ThemeColors};
 
@@ -111,6 +112,9 @@ pub struct PrDetailViewProps {
     pub detail_content_width: usize,
     /// Theme colors.
     pub colors: ThemeColors,
+    /// Active text selection, if any (and if it targets this pane). Passed
+    /// through to the `ScrollableText` so selected cells render inverse-video.
+    pub selection: Option<TextSelection>,
 }
 
 /// Extract the active PR composer `(text, byte_cursor, prefix)`.
@@ -288,6 +292,9 @@ pub fn PrDetailView(props: &PrDetailViewProps) -> impl Into<AnyElement<'static>>
                     cursor_bg: rc.bright,
                     track_color: rc.dim,
                     thumb_color: rc.bright,
+                    selection: props.selection,
+                    selection_bg: Some(rc.sel_bg),
+                    selection_fg: Some(rc.sel_fg),
                 )
             }
 

--- a/src/ui/components/pr_list.rs
+++ b/src/ui/components/pr_list.rs
@@ -7,7 +7,8 @@ use iocraft::prelude::*;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::domain::{PrCheckStatus, PrReviewState, PrState, PullRequest};
-use crate::theme::{ResolvedColors, ThemeColors};
+use crate::selection::{HighlightRange, TextSelection, row_highlight_range};
+use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
 
 /// Ellipsis character appended when a title is truncated.
 const ELLIPSIS: char = '…';
@@ -100,6 +101,9 @@ pub struct PrListProps {
     pub colors: ThemeColors,
     /// Available content width (in terminal columns) for title truncation.
     pub available_width: Option<u16>,
+    /// Active text selection, if any (and if it targets this pane). Selected
+    /// cells are painted in inverse video for live drag-selection feedback.
+    pub selection: Option<TextSelection>,
 }
 
 /// Projected PR list row exactly as the component renders it.
@@ -273,7 +277,8 @@ pub fn PrList(props: &PrListProps) -> impl Into<AnyElement<'static>> {
                         Box(padding_left: 1u32, height: 1u32) {
                             Text(content: msg, color: rc.dim)
                         }
-                    }]
+                    }
+                    .into_any()]
                 } else {
                     let rows = props;
                     let projected = pr_list_visible_rows(
@@ -282,60 +287,84 @@ pub fn PrList(props: &PrListProps) -> impl Into<AnyElement<'static>> {
                         rows.list_pane_rows,
                         rows.available_width,
                     );
-                    projected.iter().map(|view| {
-                        let title_line = view.title_line.as_str();
-                        let meta_line = view.meta_line.as_str();
-                        let is_selected = view.is_selected;
-                        if is_selected {
-                            if rows.layout.is_compact() {
-                                element! {
-                                    Box(height: 1u32, background_color: rc.sel_bg) {
-                                        Text(
-                                            content: title_line,
-                                            color: rc.sel_fg,
-                                            weight: Weight::Bold,
-                                        )
-                                    }
-                                }
+                    let first_visible = crate::layout::list_first_visible_index(
+                        rows.selected_index.unwrap_or(0),
+                        rows.pull_requests.len(),
+                        rows.list_pane_rows as usize,
+                    );
+                    projected.iter().enumerate().map(|(window_i, view)| {
+                        let content_line = first_visible + window_i;
+                        let highlight = rows.selection.as_ref().and_then(|s| {
+                            if s.pane() == crate::selection::SelectablePane::PrList {
+                                row_highlight_range(s, content_line)
                             } else {
-                                element! {
-                                    Box(flex_direction: FlexDirection::Column) {
-                                        Box(height: 1u32, background_color: rc.sel_bg) {
-                                            Text(
-                                                content: title_line,
-                                                color: rc.sel_fg,
-                                                weight: Weight::Bold,
-                                            )
-                                        }
-                                        Box(height: 1u32, background_color: rc.sel_bg) {
-                                            Text(content: meta_line, color: rc.sel_fg)
-                                        }
-                                    }
-                                }
+                                None
                             }
-                        } else if rows.layout.is_compact() {
-                            element! {
-                                Box(height: 1u32) {
-                                    Text(content: title_line, color: rc.fg)
-                                }
-                            }
-                        } else {
-                            element! {
-                                Box(flex_direction: FlexDirection::Column) {
-                                    Box(height: 1u32) {
-                                        Text(content: title_line, color: rc.fg)
-                                    }
-                                    Box(height: 1u32) {
-                                        Text(content: meta_line, color: rc.dim)
-                                    }
-                                }
-                            }
-                        }
+                        });
+                        render_pr_row(
+                            view,
+                            rows.layout.is_compact(),
+                            highlight,
+                            rc.fg,
+                            SelectionColors::from_resolved(&rc),
+                            rc.dim,
+                        )
                     }).collect()
                 })
             }
         }
     }
+}
+
+/// Render a single PR list row, applying the selection-row highlight when the
+/// row falls inside an active drag selection.
+fn render_pr_row(
+    view: &PrListRowView,
+    compact: bool,
+    highlight: Option<HighlightRange>,
+    fg: Color,
+    highlight_colors: SelectionColors,
+    dim: Color,
+) -> AnyElement<'static> {
+    let title_line = view.title_line.as_str();
+    let meta_line = view.meta_line.as_str();
+    let is_selected = view.is_selected;
+
+    // When a drag selection covers this row, paint the whole row in the
+    // selection colors (lists are single-line-per-item in Compact mode, so a
+    // row-level highlight is sufficient and matches the copyable text).
+    let highlighted = highlight.is_some();
+    let row_bg = if highlighted || is_selected {
+        highlight_colors.bg
+    } else {
+        Color::Reset
+    };
+    let title_fg = if highlighted || is_selected {
+        highlight_colors.fg
+    } else {
+        fg
+    };
+
+    if compact {
+        return element! {
+            Box(height: 1u32, background_color: row_bg) {
+                Text(content: title_line.to_string(), color: title_fg, weight: if is_selected { Weight::Bold } else { Weight::Normal })
+            }
+        }
+        .into_any();
+    }
+
+    element! {
+        Box(flex_direction: FlexDirection::Column) {
+            Box(height: 1u32, background_color: row_bg) {
+                Text(content: title_line.to_string(), color: title_fg, weight: if is_selected { Weight::Bold } else { Weight::Normal })
+            }
+            Box(height: 1u32, background_color: row_bg) {
+                Text(content: meta_line.to_string(), color: if is_selected { highlight_colors.fg } else { dim })
+            }
+        }
+    }
+    .into_any()
 }
 
 ///

--- a/src/ui/components/pr_list.rs
+++ b/src/ui/components/pr_list.rs
@@ -287,16 +287,10 @@ pub fn PrList(props: &PrListProps) -> impl Into<AnyElement<'static>> {
                         rows.list_pane_rows,
                         rows.available_width,
                     );
-                    let first_visible = crate::layout::list_first_visible_index(
-                        rows.selected_index.unwrap_or(0),
-                        rows.pull_requests.len(),
-                        rows.list_pane_rows as usize,
-                    );
                     projected.iter().enumerate().map(|(window_i, view)| {
-                        let content_line = first_visible + window_i;
                         let highlight = rows.selection.as_ref().and_then(|s| {
                             if s.pane() == crate::selection::SelectablePane::PrList {
-                                row_highlight_range(s, content_line)
+                                row_highlight_range(s, window_i)
                             } else {
                                 None
                             }
@@ -331,19 +325,15 @@ fn render_pr_row(
     let is_selected = view.is_selected;
 
     // When a drag selection covers this row, paint the whole row in the
-    // selection colors (lists are single-line-per-item in Compact mode, so a
-    // row-level highlight is sufficient and matches the copyable text).
+    // selection colors. Keyboard selection uses bold for text emphasis but
+    // not inverse-video, which is reserved for active drag selection.
     let highlighted = highlight.is_some();
-    let row_bg = if highlighted || is_selected {
+    let row_bg = if highlighted {
         highlight_colors.bg
     } else {
         Color::Reset
     };
-    let title_fg = if highlighted || is_selected {
-        highlight_colors.fg
-    } else {
-        fg
-    };
+    let title_fg = if highlighted { highlight_colors.fg } else { fg };
 
     if compact {
         return element! {
@@ -360,7 +350,7 @@ fn render_pr_row(
                 Text(content: title_line.to_string(), color: title_fg, weight: if is_selected { Weight::Bold } else { Weight::Normal })
             }
             Box(height: 1u32, background_color: row_bg) {
-                Text(content: meta_line.to_string(), color: if is_selected { highlight_colors.fg } else { dim })
+                Text(content: meta_line.to_string(), color: if highlighted { highlight_colors.fg } else { dim })
             }
         }
     }

--- a/src/ui/components/pr_list.rs
+++ b/src/ui/components/pr_list.rs
@@ -8,7 +8,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::domain::{PrCheckStatus, PrReviewState, PrState, PullRequest};
 use crate::selection::{HighlightRange, TextSelection, row_highlight_range};
-use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
+use crate::theme::{ResolvedColors, RowColors, SelectionColors, ThemeColors};
 
 /// Ellipsis character appended when a title is truncated.
 const ELLIPSIS: char = '…';
@@ -299,7 +299,7 @@ pub fn PrList(props: &PrListProps) -> impl Into<AnyElement<'static>> {
                             view,
                             rows.layout.is_compact(),
                             highlight,
-                            rc.fg,
+                            RowColors::from_resolved(&rc),
                             SelectionColors::from_resolved(&rc),
                             rc.dim,
                         )
@@ -316,7 +316,7 @@ fn render_pr_row(
     view: &PrListRowView,
     compact: bool,
     highlight: Option<HighlightRange>,
-    fg: Color,
+    row_colors: RowColors,
     highlight_colors: SelectionColors,
     dim: Color,
 ) -> AnyElement<'static> {
@@ -331,9 +331,13 @@ fn render_pr_row(
     let row_bg = if highlighted {
         highlight_colors.bg
     } else {
-        Color::Reset
+        row_colors.bg
     };
-    let title_fg = if highlighted { highlight_colors.fg } else { fg };
+    let title_fg = if highlighted {
+        highlight_colors.fg
+    } else {
+        row_colors.fg
+    };
 
     if compact {
         return element! {

--- a/src/ui/components/pr_list.rs
+++ b/src/ui/components/pr_list.rs
@@ -338,11 +338,16 @@ fn render_pr_row(
     } else {
         row_colors.fg
     };
+    let weight = if is_selected {
+        Weight::Bold
+    } else {
+        Weight::Normal
+    };
 
     if compact {
         return element! {
             Box(height: 1u32, background_color: row_bg) {
-                Text(content: title_line.to_string(), color: title_fg, weight: if is_selected { Weight::Bold } else { Weight::Normal })
+                Text(content: title_line, color: title_fg, weight: weight)
             }
         }
         .into_any();
@@ -351,10 +356,10 @@ fn render_pr_row(
     element! {
         Box(flex_direction: FlexDirection::Column) {
             Box(height: 1u32, background_color: row_bg) {
-                Text(content: title_line.to_string(), color: title_fg, weight: if is_selected { Weight::Bold } else { Weight::Normal })
+                Text(content: title_line, color: title_fg, weight: weight)
             }
             Box(height: 1u32, background_color: row_bg) {
-                Text(content: meta_line.to_string(), color: if highlighted { highlight_colors.fg } else { dim })
+                Text(content: meta_line, color: if highlighted { highlight_colors.fg } else { dim })
             }
         }
     }

--- a/src/ui/components/scrollable_text.rs
+++ b/src/ui/components/scrollable_text.rs
@@ -3,8 +3,23 @@
 //! Renders a FIXED number of line rows (`viewport_rows`) regardless of content length.
 //! Content is windowed by `scroll_offset`. Empty rows are padded so the component
 //! always occupies the same layout space — preventing layout shifts.
+//!
+//! When a [`TextSelection`] is supplied (and its pane matches), the selected
+//! cells are painted in inverse video so the user sees live drag-selection
+//! feedback. The selection lives in *content* coordinates; this component maps
+//! each display row back to its content line via `scroll_offset`.
 
 use iocraft::prelude::*;
+
+use crate::selection::{HighlightRange, TextSelection, row_highlight_range};
+use crate::theme::SelectionColors;
+
+/// Background color used for the selection highlight when no explicit color is
+/// supplied. Swapped against the foreground for an inverse-video effect.
+const DEFAULT_SEL_BG: Color = Color::White;
+/// Foreground color used for the selection highlight when no explicit color is
+/// supplied.
+const DEFAULT_SEL_FG: Color = Color::Black;
 
 /// Props for the scrollable text viewport.
 #[derive(Default, Props)]
@@ -34,6 +49,14 @@ pub struct ScrollableTextProps {
     pub track_color: Option<Color>,
     /// Scrollbar thumb color (bright).
     pub thumb_color: Option<Color>,
+    /// Active text selection, if any. The selection's content coordinates are
+    /// mapped to display rows via `scroll_offset`; selected cells are painted
+    /// in inverse video.
+    pub selection: Option<TextSelection>,
+    /// Selection highlight background color.
+    pub selection_bg: Option<Color>,
+    /// Selection highlight foreground color.
+    pub selection_fg: Option<Color>,
 }
 
 /// Truncate a string to at most `max_chars` display characters.
@@ -59,15 +82,41 @@ fn scrollbar_geometry(total: usize, visible: usize, offset: usize) -> (usize, us
     (thumb_pos, thumb_size)
 }
 
+/// Split a display line into `(before, selected, after)` segments given a
+/// highlight range. The `end` column is clamped to the line length.
+fn split_for_highlight(line: &str, range: HighlightRange) -> (String, String, String) {
+    let chars: Vec<char> = line.chars().collect();
+    let len = chars.len();
+    let start = range.start.min(len);
+    let end = if range.end == usize::MAX {
+        len
+    } else {
+        range.end.min(len)
+    };
+    let before: String = chars.iter().take(start).collect();
+    let selected: String = if start < end {
+        chars.iter().skip(start).take(end - start).collect()
+    } else {
+        String::new()
+    };
+    let after: String = chars.iter().skip(end).collect();
+    (before, selected, after)
+}
+
 /// Scrollable text viewport — renders exactly `viewport_rows` line boxes.
 ///
 /// Content is windowed from `scroll_offset`. Lines beyond content are blank.
-/// A scrollbar is drawn on the right when content exceeds the viewport.
+/// A scrollbar is drawn on the right when content exceeds the viewport. When a
+/// selection is active, selected cells are painted in inverse video.
 #[component]
 pub fn ScrollableText(props: &ScrollableTextProps) -> impl Into<AnyElement<'static>> {
     let fg = props.color.unwrap_or(Color::Reset);
     let track_color = props.track_color.unwrap_or(Color::DarkGrey);
     let thumb_color = props.thumb_color.unwrap_or(Color::White);
+    let sel_colors = SelectionColors {
+        fg: props.selection_fg.unwrap_or(DEFAULT_SEL_FG),
+        bg: props.selection_bg.unwrap_or(DEFAULT_SEL_BG),
+    };
     let vp = props.viewport_rows.max(1);
 
     // Sidebar (22) + borders/padding (~5) + scrollbar (1) = ~28 chars of chrome
@@ -105,43 +154,31 @@ pub fn ScrollableText(props: &ScrollableTextProps) -> impl Into<AnyElement<'stat
     // Cursor position relative to the viewport (adjusted for scroll offset)
     let cursor_vp_line = props.cursor_line.map(|l| l.saturating_sub(offset));
     let cursor_col = props.cursor_col.unwrap_or(0);
-    let cursor_fg = props.cursor_color.unwrap_or(Color::Black);
-    let cursor_bg_color = props.cursor_bg.unwrap_or(Color::White);
+    let cursor_colors = CursorColors {
+        fg: props.cursor_color.unwrap_or(Color::Black),
+        bg: props.cursor_bg.unwrap_or(Color::White),
+    };
 
     element! {
         Box(flex_direction: FlexDirection::Row, width: 100pct) {
             // Text content column — exactly `vp` rows
             Box(flex_direction: FlexDirection::Column, flex_grow: 1.0) {
                 #(display_lines.iter().enumerate().map(|(row_idx, line)| {
-                    // Check if this row has the cursor
-                    let has_cursor = props.cursor_line.is_some()
-                        && Some(row_idx) == cursor_vp_line
-                        // Only show cursor if the content line is actually within the viewport
-                        && (offset + row_idx) == props.cursor_line.unwrap_or(usize::MAX);
-
-                    if has_cursor {
-                        // Split line into: before_cursor | cursor_char | after_cursor
-                        let chars: Vec<char> = line.chars().collect();
-                        let before: String = chars.iter().take(cursor_col).collect();
-                        let cursor_ch: String = chars.iter().skip(cursor_col).take(1).collect();
-                        let after: String = chars.iter().skip(cursor_col + 1).collect();
-                        let cursor_display = if cursor_ch.is_empty() { " ".to_string() } else { cursor_ch };
-                        element! {
-                            Box(height: 1u32) {
-                                Text(content: before, color: fg, wrap: TextWrap::NoWrap)
-                                Box(background_color: cursor_bg_color) {
-                                    Text(content: cursor_display, color: cursor_fg, wrap: TextWrap::NoWrap)
-                                }
-                                Text(content: after, color: fg, wrap: TextWrap::NoWrap)
-                            }
-                        }
-                    } else {
-                        element! {
-                            Box(height: 1u32) {
-                                Text(content: line.clone(), color: fg, wrap: TextWrap::NoWrap)
-                            }
-                        }
-                    }
+                    render_display_row(
+                        RowContext { row_idx, offset },
+                        line,
+                        fg,
+                        CursorPos {
+                            line: props.cursor_line,
+                            vp_line: cursor_vp_line,
+                            col: cursor_col,
+                        },
+                        cursor_colors,
+                        SelectionState {
+                            selection: props.selection.as_ref(),
+                            colors: sel_colors,
+                        },
+                    )
                 }).collect::<Vec<_>>())
             }
             // Scrollbar column (1 char wide, same `vp` rows)
@@ -167,6 +204,119 @@ pub fn ScrollableText(props: &ScrollableTextProps) -> impl Into<AnyElement<'stat
     }
 }
 
+/// Bundled cursor foreground + background colors.
+///
+/// Extracted to keep [`render_display_row`] under the clippy
+/// `too_many_arguments` threshold (6).
+#[derive(Clone, Copy)]
+struct CursorColors {
+    /// Text color for the character under the cursor.
+    fg: Color,
+    /// Background color for the character under the cursor.
+    bg: Color,
+}
+
+/// Bundled cursor position info for [`render_display_row`].
+#[derive(Clone, Copy)]
+struct CursorPos {
+    /// Content line index of the cursor (0-based), or `None` if no cursor.
+    line: Option<usize>,
+    /// Viewport-relative line index (already adjusted for scroll offset).
+    vp_line: Option<usize>,
+    /// Column index within the display line.
+    col: usize,
+}
+
+/// Bundled row context for [`render_display_row`].
+#[derive(Clone, Copy)]
+struct RowContext {
+    /// Viewport row index (0-based).
+    row_idx: usize,
+    /// Scroll offset of the viewport.
+    offset: usize,
+}
+
+/// Bundled selection state + colors for [`render_display_row`].
+#[derive(Clone, Copy)]
+struct SelectionState<'a> {
+    /// Active text selection, if any.
+    selection: Option<&'a TextSelection>,
+    /// Selection highlight colors.
+    colors: SelectionColors,
+}
+
+/// Returns one `AnyElement` (a `Box(height: 1u32)`).
+fn render_display_row(
+    ctx: RowContext,
+    line: &str,
+    fg: Color,
+    cursor: CursorPos,
+    cursor_colors: CursorColors,
+    selection: SelectionState<'_>,
+) -> AnyElement<'static> {
+    let row_idx = ctx.row_idx;
+    let offset = ctx.offset;
+    let cursor_line = cursor.line;
+    let cursor_vp_line = cursor.vp_line;
+    let cursor_col = cursor.col;
+    let has_cursor = cursor_line.is_some()
+        && Some(row_idx) == cursor_vp_line
+        && (offset + row_idx) == cursor_line.unwrap_or(usize::MAX);
+
+    let content_line = offset + row_idx;
+    let highlight = selection
+        .selection
+        .and_then(|s| row_highlight_range(s, content_line));
+
+    if let Some(range) = highlight {
+        let (before, selected, after) = split_for_highlight(line, range);
+        let sel_text = if selected.is_empty() {
+            " ".to_string()
+        } else {
+            selected
+        };
+        return element! {
+            Box(height: 1u32) {
+                Text(content: before, color: fg, wrap: TextWrap::NoWrap)
+                Box(background_color: selection.colors.bg) {
+                    Text(content: sel_text, color: selection.colors.fg, wrap: TextWrap::NoWrap)
+                }
+                Text(content: after, color: fg, wrap: TextWrap::NoWrap)
+            }
+        }
+        .into_any();
+    }
+
+    if has_cursor {
+        let chars: Vec<char> = line.chars().collect();
+        let before: String = chars.iter().take(cursor_col).collect();
+        let cursor_ch: String = chars.iter().skip(cursor_col).take(1).collect();
+        let after: String = chars.iter().skip(cursor_col + 1).collect();
+        let cursor_display = if cursor_ch.is_empty() {
+            " ".to_string()
+        } else {
+            cursor_ch
+        };
+        return element! {
+            Box(height: 1u32) {
+                Text(content: before, color: fg, wrap: TextWrap::NoWrap)
+                Box(background_color: cursor_colors.bg) {
+                    Text(content: cursor_display, color: cursor_colors.fg, wrap: TextWrap::NoWrap)
+                }
+                Text(content: after, color: fg, wrap: TextWrap::NoWrap)
+            }
+        }
+        .into_any();
+    }
+
+    element! {
+        Box(height: 1u32) {
+            Text(content: line.to_string(), color: fg, wrap: TextWrap::NoWrap)
+        }
+    }
+    .into_any()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,5 +340,37 @@ mod tests {
     fn test_scrollbar_geometry_at_bottom() {
         let (pos, size) = scrollbar_geometry(100, 20, 80);
         assert!(pos + size <= 20);
+    }
+
+    #[test]
+    fn split_for_highlight_middle_substring() {
+        let (before, sel, after) =
+            split_for_highlight("hello world", HighlightRange { start: 2, end: 7 });
+        assert_eq!(before, "he");
+        assert_eq!(sel, "llo w");
+        assert_eq!(after, "orld");
+    }
+
+    #[test]
+    fn split_for_highlight_to_end_of_line() {
+        let (before, sel, after) = split_for_highlight(
+            "hello",
+            HighlightRange {
+                start: 2,
+                end: usize::MAX,
+            },
+        );
+        assert_eq!(before, "he");
+        assert_eq!(sel, "llo");
+        assert!(after.is_empty());
+    }
+
+    #[test]
+    fn split_for_highlight_from_zero() {
+        let (before, sel, after) =
+            split_for_highlight("hello", HighlightRange { start: 0, end: 3 });
+        assert!(before.is_empty());
+        assert_eq!(sel, "hel");
+        assert_eq!(after, "lo");
     }
 }

--- a/src/ui/components/scrollable_text.rs
+++ b/src/ui/components/scrollable_text.rs
@@ -57,6 +57,15 @@ pub struct ScrollableTextProps {
     pub selection_bg: Option<Color>,
     /// Selection highlight foreground color.
     pub selection_fg: Option<Color>,
+    /// Background color painted on plain (non-highlighted, non-cursor) rows.
+    /// When set, avoids `Color::Reset` (terminal default) haze on the themed
+    /// background. Detail panes pass `Some(rc.bg)`.
+    pub bg: Option<Color>,
+    /// Number of content lines preceding the scrollable region (e.g. detail
+    /// header rows rendered above the viewport). The highlight line-mapping
+    /// adds this offset so a content line that lives in the header is detected
+    /// correctly. Defaults to 0 (no preceding header).
+    pub content_line_offset: usize,
 }
 
 /// Truncate a string to at most `max_chars` display characters.
@@ -165,9 +174,16 @@ pub fn ScrollableText(props: &ScrollableTextProps) -> impl Into<AnyElement<'stat
             Box(flex_direction: FlexDirection::Column, flex_grow: 1.0) {
                 #(display_lines.iter().enumerate().map(|(row_idx, line)| {
                     render_display_row(
-                        RowContext { row_idx, offset },
+                        RowContext {
+                            row_idx,
+                            offset,
+                            content_line_offset: props.content_line_offset,
+                        },
                         line,
-                        fg,
+                        PlainRowColors {
+                            fg,
+                            bg: props.bg,
+                        },
                         CursorPos {
                             line: props.cursor_line,
                             vp_line: cursor_vp_line,
@@ -204,6 +220,16 @@ pub fn ScrollableText(props: &ScrollableTextProps) -> impl Into<AnyElement<'stat
     }
 }
 
+/// Bundled default (non-highlighted, non-cursor) foreground + background colors
+/// for [`render_display_row`].
+#[derive(Clone, Copy)]
+struct PlainRowColors {
+    /// Text color for plain rows.
+    fg: Color,
+    /// Background color for plain rows (`None` leaves the cell transparent).
+    bg: Option<Color>,
+}
+
 /// Bundled cursor foreground + background colors.
 ///
 /// Extracted to keep [`render_display_row`] under the clippy
@@ -234,6 +260,8 @@ struct RowContext {
     row_idx: usize,
     /// Scroll offset of the viewport.
     offset: usize,
+    /// Content lines preceding the scrollable region (header rows).
+    content_line_offset: usize,
 }
 
 /// Bundled selection state + colors for [`render_display_row`].
@@ -249,13 +277,14 @@ struct SelectionState<'a> {
 fn render_display_row(
     ctx: RowContext,
     line: &str,
-    fg: Color,
+    plain_colors: PlainRowColors,
     cursor: CursorPos,
     cursor_colors: CursorColors,
     selection: SelectionState<'_>,
 ) -> AnyElement<'static> {
     let row_idx = ctx.row_idx;
     let offset = ctx.offset;
+    let fg = plain_colors.fg;
     let cursor_line = cursor.line;
     let cursor_vp_line = cursor.vp_line;
     let cursor_col = cursor.col;
@@ -263,7 +292,7 @@ fn render_display_row(
         && Some(row_idx) == cursor_vp_line
         && (offset + row_idx) == cursor_line.unwrap_or(usize::MAX);
 
-    let content_line = offset + row_idx;
+    let content_line = ctx.content_line_offset + offset + row_idx;
     let highlight = selection
         .selection
         .and_then(|s| row_highlight_range(s, content_line));
@@ -310,7 +339,7 @@ fn render_display_row(
     }
 
     element! {
-        Box(height: 1u32) {
+        Box(height: 1u32, background_color: plain_colors.bg) {
             Text(content: line.to_string(), color: fg, wrap: TextWrap::NoWrap)
         }
     }

--- a/src/ui/components/sidebar.rs
+++ b/src/ui/components/sidebar.rs
@@ -6,6 +6,7 @@
 use iocraft::prelude::*;
 
 use crate::domain::Repository;
+use crate::selection::{SelectablePane, TextSelection, row_highlight_range};
 use crate::theme::{ResolvedColors, ThemeColors};
 
 /// Props for the sidebar component.
@@ -23,6 +24,9 @@ pub struct SidebarProps {
     pub grabbed: Option<usize>,
     /// Theme colors.
     pub colors: ThemeColors,
+    /// Active text selection, if any (and if it targets this pane). Selected
+    /// rows are painted in inverse video for live drag-selection feedback.
+    pub selection: Option<TextSelection>,
 }
 
 /// Sidebar showing the list of repositories.
@@ -69,19 +73,19 @@ pub fn Sidebar(props: &SidebarProps) -> impl Into<AnyElement<'static>> {
                     let agent_count = props.agent_counts.get(i).copied()
                         .unwrap_or(repo.agent_ids.len());
                     let label = format!("{}{} ({})", prefix, repo.name, agent_count);
-                    if selected {
-                        element! {
-                            Box(height: 1u32, background_color: rc.sel_bg) {
-                                Text(content: label, color: rc.sel_fg, weight: Weight::Bold)
-                            }
-                        }
-                    } else {
-                        element! {
-                            Box(height: 1u32) {
-                                Text(content: label, color: rc.fg)
-                            }
+                    let highlighted = props.selection.as_ref()
+                        .filter(|s| s.pane() == SelectablePane::Sidebar)
+                        .and_then(|s| row_highlight_range(s, i))
+                        .is_some();
+                    let row_bg = if highlighted || selected { rc.sel_bg } else { Color::Reset };
+                    let fg = if highlighted || selected { rc.sel_fg } else { rc.fg };
+                    let weight = if selected { Weight::Bold } else { Weight::Normal };
+                    element! {
+                        Box(height: 1u32, background_color: row_bg) {
+                            Text(content: label, color: fg, weight: weight)
                         }
                     }
+                    .into_any()
                 }))
             }
         }

--- a/src/ui/components/sidebar.rs
+++ b/src/ui/components/sidebar.rs
@@ -77,8 +77,8 @@ pub fn Sidebar(props: &SidebarProps) -> impl Into<AnyElement<'static>> {
                         .filter(|s| s.pane() == SelectablePane::Sidebar)
                         .and_then(|s| row_highlight_range(s, i))
                         .is_some();
-                    let row_bg = if highlighted || selected { rc.sel_bg } else { Color::Reset };
-                    let fg = if highlighted || selected { rc.sel_fg } else { rc.fg };
+                    let row_bg = if highlighted { rc.sel_bg } else { Color::Reset };
+                    let fg = if highlighted { rc.sel_fg } else { rc.fg };
                     let weight = if selected { Weight::Bold } else { Weight::Normal };
                     element! {
                         Box(height: 1u32, background_color: row_bg) {

--- a/src/ui/components/sidebar.rs
+++ b/src/ui/components/sidebar.rs
@@ -77,7 +77,7 @@ pub fn Sidebar(props: &SidebarProps) -> impl Into<AnyElement<'static>> {
                         .filter(|s| s.pane() == SelectablePane::Sidebar)
                         .and_then(|s| row_highlight_range(s, i))
                         .is_some();
-                    let row_bg = if highlighted { rc.sel_bg } else { Color::Reset };
+                    let row_bg = if highlighted { rc.sel_bg } else { rc.bg };
                     let fg = if highlighted { rc.sel_fg } else { rc.fg };
                     let weight = if selected { Weight::Bold } else { Weight::Normal };
                     element! {

--- a/src/ui/components/status_bar.rs
+++ b/src/ui/components/status_bar.rs
@@ -5,6 +5,7 @@
 
 use iocraft::prelude::*;
 
+use crate::selection::{SelectablePane, TextSelection};
 use crate::theme::{ResolvedColors, ThemeColors};
 
 /// Props for the status bar component.
@@ -24,12 +25,25 @@ pub struct StatusBarProps {
     pub warning_message: Option<String>,
     /// Theme colors.
     pub colors: ThemeColors,
+    /// Active text selection, if any. When it targets this pane the whole
+    /// single-line bar is painted in inverse-video.
+    pub selection: Option<TextSelection>,
 }
 
 /// Status bar showing app title and statistics.
 #[component]
 pub fn StatusBar(props: &StatusBarProps) -> impl Into<AnyElement<'static>> {
     let rc = ResolvedColors::from_theme(Some(&props.colors));
+
+    // When a drag selection covers the single-line status bar, paint the whole
+    // line in inverse-video so the user sees live feedback.
+    let highlighted = props
+        .selection
+        .as_ref()
+        .filter(|s| s.pane() == SelectablePane::StatusBar)
+        .is_some();
+    let bar_bg = if highlighted { rc.sel_bg } else { rc.border };
+    let text_color = if highlighted { rc.sel_fg } else { rc.bg };
 
     let stats = props.warning_message.as_ref().map_or_else(
         || {
@@ -46,7 +60,7 @@ pub fn StatusBar(props: &StatusBarProps) -> impl Into<AnyElement<'static>> {
             flex_direction: FlexDirection::Row,
             width: 100pct,
             height: 1u32,
-            background_color: rc.border,
+            background_color: bar_bg,
             justify_content: JustifyContent::SpaceBetween,
             padding_left: 1u32,
             padding_right: 1u32,
@@ -55,14 +69,14 @@ pub fn StatusBar(props: &StatusBarProps) -> impl Into<AnyElement<'static>> {
             Text(
                 content: format!("LLxprt Jefe - {}", props.version),
                 weight: Weight::Bold,
-                color: rc.bg,
+                color: text_color,
             )
 
             // Center: stats
-            Text(content: stats, color: rc.bg)
+            Text(content: stats, color: text_color)
 
             // Right: theme name
-            Text(content: props.theme_name.clone(), color: rc.bg)
+            Text(content: props.theme_name.clone(), color: text_color)
         }
     }
 }

--- a/src/ui/components/status_bar.rs
+++ b/src/ui/components/status_bar.rs
@@ -40,8 +40,7 @@ pub fn StatusBar(props: &StatusBarProps) -> impl Into<AnyElement<'static>> {
     let highlighted = props
         .selection
         .as_ref()
-        .filter(|s| s.pane() == SelectablePane::StatusBar)
-        .is_some();
+        .is_some_and(|s| s.pane() == SelectablePane::StatusBar);
     let bar_bg = if highlighted { rc.sel_bg } else { rc.border };
     let text_color = if highlighted { rc.sel_fg } else { rc.bg };
 

--- a/src/ui/components/terminal_view.rs
+++ b/src/ui/components/terminal_view.rs
@@ -23,7 +23,8 @@
 use iocraft::prelude::*;
 
 use crate::runtime::{TerminalCell, TerminalSnapshot};
-use crate::theme::{ResolvedColors, ThemeColors};
+use crate::selection::{SelectablePane, TextSelection, row_highlight_range};
+use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
 
 /// Props for the terminal view component.
 #[derive(Default, Props)]
@@ -34,6 +35,9 @@ pub struct TerminalViewProps {
     pub focused: bool,
     /// Theme colors for chrome around the terminal content.
     pub colors: ThemeColors,
+    /// Active text selection, if any. Selected cells are painted in
+    /// inverse-video over the terminal grid for live drag-selection feedback.
+    pub selection: Option<TextSelection>,
 }
 
 /// Terminal view showing the PTY output for the attached agent.
@@ -81,7 +85,11 @@ pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>>
             ) {
                 #(if let Some(snapshot) = props.snapshot.clone() {
                     element! {
-                        TerminalGrid(snapshot: snapshot)
+                        TerminalGrid(
+                            snapshot: snapshot,
+                            selection: props.selection,
+                            sel_colors: SelectionColors::from_resolved(&rc),
+                        )
                     }
                     .into_any()
                 } else {
@@ -98,10 +106,28 @@ pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>>
 }
 
 /// Props for the low-level terminal grid renderer.
-#[derive(Default, Props)]
+#[derive(Props)]
 struct TerminalGridProps {
     /// Styled PTY grid to draw.
     snapshot: TerminalSnapshot,
+    /// Active text selection, if any. When it targets the terminal pane,
+    /// selected cells are overpainted in inverse-video in [`TerminalGrid::draw`].
+    selection: Option<TextSelection>,
+    /// Selection foreground + background colors (inverse-video).
+    sel_colors: SelectionColors,
+}
+
+impl Default for TerminalGridProps {
+    fn default() -> Self {
+        Self {
+            snapshot: TerminalSnapshot::default(),
+            selection: None,
+            sel_colors: SelectionColors {
+                fg: Color::Reset,
+                bg: Color::Reset,
+            },
+        }
+    }
 }
 
 /// Low-level component that paints a [`TerminalSnapshot`] directly onto the
@@ -110,9 +136,23 @@ struct TerminalGridProps {
 /// This keeps the taffy node count constant (one leaf) regardless of how many
 /// distinct style-runs the snapshot contains, which is the fix for the render
 /// lockup described in issue #60.
-#[derive(Default)]
 struct TerminalGrid {
     snapshot: TerminalSnapshot,
+    selection: Option<TextSelection>,
+    sel_colors: SelectionColors,
+}
+
+impl Default for TerminalGrid {
+    fn default() -> Self {
+        Self {
+            snapshot: TerminalSnapshot::default(),
+            selection: None,
+            sel_colors: SelectionColors {
+                fg: Color::Reset,
+                bg: Color::Reset,
+            },
+        }
+    }
 }
 
 impl Component for TerminalGrid {
@@ -129,6 +169,8 @@ impl Component for TerminalGrid {
         updater: &mut ComponentUpdater,
     ) {
         self.snapshot = props.snapshot.clone();
+        self.selection = props.selection;
+        self.sel_colors = props.sel_colors;
 
         // Fill the available space; the parent Box constrains us to the pane.
         // Build the taffy style directly so node count stays at one leaf.
@@ -150,36 +192,107 @@ impl Component for TerminalGrid {
         }
 
         let mut canvas = drawer.canvas();
+        paint_terminal_cells(&mut canvas, &self.snapshot, max_rows, max_cols);
+        paint_selection_overlay(
+            &mut canvas,
+            &self.snapshot,
+            self.selection,
+            max_rows,
+            max_cols,
+            self.sel_colors,
+        );
+    }
+}
 
-        for (row_idx, row) in self
-            .snapshot
-            .cells
-            .iter()
-            .take(self.snapshot.rows.min(max_rows))
-            .enumerate()
-        {
-            let Some(y) = canvas_coord(row_idx) else {
+/// Paint the styled terminal cells onto the canvas as style-runs.
+fn paint_terminal_cells(
+    canvas: &mut CanvasSubviewMut<'_>,
+    snapshot: &TerminalSnapshot,
+    max_rows: usize,
+    max_cols: usize,
+) {
+    for (row_idx, row) in snapshot
+        .cells
+        .iter()
+        .take(snapshot.rows.min(max_rows))
+        .enumerate()
+    {
+        let Some(y) = canvas_coord(row_idx) else {
+            continue;
+        };
+        for run in row_to_runs(row, max_cols) {
+            let Some(x) = canvas_coord(run.start_col) else {
                 continue;
             };
-            for run in row_to_runs(row, max_cols) {
-                let Some(x) = canvas_coord(run.start_col) else {
-                    continue;
-                };
-                // CanvasTextStyle is #[non_exhaustive]; build via Default then set fields.
-                let mut style = CanvasTextStyle::default();
-                style.color = Some(run.style.fg);
-                style.weight = if run.style.bold {
-                    Weight::Bold
-                } else {
-                    Weight::Normal
-                };
-                style.underline = run.style.underline;
+            // CanvasTextStyle is #[non_exhaustive]; build via Default then set fields.
+            let mut style = CanvasTextStyle::default();
+            style.color = Some(run.style.fg);
+            style.weight = if run.style.bold {
+                Weight::Bold
+            } else {
+                Weight::Normal
+            };
+            style.underline = run.style.underline;
 
-                // Background is painted as a filled region under the run so that
-                // per-cell background colors are preserved.
-                canvas.set_background_color(x, y, run.width, 1, run.style.bg);
-                canvas.set_text(x, y, &run.text, style);
-            }
+            // Background is painted as a filled region under the run so that
+            // per-cell background colors are preserved.
+            canvas.set_background_color(x, y, run.width, 1, run.style.bg);
+            canvas.set_text(x, y, &run.text, style);
+        }
+    }
+}
+
+/// Paint inverse-video over the selected cells of the terminal grid.
+///
+/// Called after [`paint_terminal_cells`] so the selection highlight overlays the
+/// normal content. Only acts when a selection targets the terminal pane.
+fn paint_selection_overlay(
+    canvas: &mut CanvasSubviewMut<'_>,
+    snapshot: &TerminalSnapshot,
+    selection: Option<TextSelection>,
+    max_rows: usize,
+    max_cols: usize,
+    sel_colors: SelectionColors,
+) {
+    let Some(selection) = selection else {
+        return;
+    };
+    if selection.pane() != SelectablePane::TerminalView || selection.is_empty() {
+        return;
+    }
+    let visible_rows = snapshot.rows.min(max_rows);
+    for row_idx in 0..visible_rows {
+        let Some(range) = row_highlight_range(&selection, row_idx) else {
+            continue;
+        };
+        let Some(y) = canvas_coord(row_idx) else {
+            continue;
+        };
+        let row_len = snapshot
+            .cells
+            .get(row_idx)
+            .map_or(0, |row| row.len().min(max_cols));
+        let start = range.start.min(row_len);
+        let end = if range.end == usize::MAX {
+            row_len
+        } else {
+            range.end.min(row_len)
+        };
+        if start >= end {
+            continue;
+        }
+        let width = end - start;
+        let Some(x) = canvas_coord(start) else {
+            continue;
+        };
+        canvas.set_background_color(x, y, width, 1, sel_colors.bg);
+        // Re-draw the selected cell text in the selection fg so the glyphs stay
+        // legible over the inverse-video background.
+        if let Some(row) = snapshot.cells.get(row_idx) {
+            let chars: String = row.iter().skip(start).take(width).map(|c| c.ch).collect();
+            let mut style = CanvasTextStyle::default();
+            style.color = Some(sel_colors.fg);
+            canvas.set_text(x, y, &chars, style);
         }
     }
 }

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -45,6 +45,7 @@ pub struct DashboardProps {
 #[component]
 pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
     let state = props.state.as_ref();
+    let selection = state.and_then(|s| s.selection);
 
     // Extract state values with defaults
     let visible_repo_indices = state.map_or_else(Vec::new, AppState::visible_repository_indices);
@@ -120,6 +121,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                 version: crate::VERSION.to_owned(),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
                 colors: colors.clone(),
+                selection: selection,
             )
 
             // Main content area
@@ -137,6 +139,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                         focused: !terminal_focused && pane_focus == PaneFocus::Repositories,
                         grabbed: grabbed_repo_idx,
                         colors: colors.clone(),
+                        selection: selection,
                     )
                 }
 
@@ -153,6 +156,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                             focused: !terminal_focused && pane_focus == PaneFocus::Agents,
                             grabbed: grabbed_agent_idx,
                             colors: colors.clone(),
+                            selection: selection,
                         )
                     }
                     Box(height: terminal_rows, width: 100pct) {
@@ -160,6 +164,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                             snapshot: props.terminal_snapshot.clone(),
                             focused: terminal_focused,
                             colors: colors.clone(),
+                            selection: selection,
                         )
                     }
                 }

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -34,6 +34,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
     let state = props.state.as_ref();
     let colors = props.colors.clone().unwrap_or_default();
     let rc = ResolvedColors::from_theme(Some(&colors));
+    let selection = state.and_then(|s| s.selection);
 
     // ── Sidebar data ────────────────────────────────────────────────────────
     let selected_repo_idx = state
@@ -136,6 +137,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                 version: crate::VERSION.to_owned(),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
                 colors: colors.clone(),
+                selection: selection,
             )
 
             // ── Main body: sidebar + issues workspace ───────────────────────
@@ -152,6 +154,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                         selected: selected_repo_idx,
                         focused: sidebar_focused,
                         colors: colors.clone(),
+                        selection: selection,
                     )
                 }
 
@@ -206,6 +209,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                             layout: IssueListLayout::Compact,
                             colors: colors.clone(),
                             available_width: Some(list_width),
+                            selection: selection,
                         )
                     }
                     Box(flex_grow: 1.0, width: 100pct) {
@@ -219,6 +223,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                             colors: colors.clone(),
                             available_height: Some(detail_pane_height),
                             available_width: Some(crate::layout::issues_detail_content_width(term_cols)),
+                            selection: selection,
                         )
                     }
 

--- a/src/ui/screens/pull_requests.rs
+++ b/src/ui/screens/pull_requests.rs
@@ -41,6 +41,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
     let state = props.state.as_ref();
     let colors = props.colors.clone().unwrap_or_default();
     let rc = ResolvedColors::from_theme(Some(&colors));
+    let selection = state.and_then(|s| s.selection);
 
     // ── Sidebar data ────────────────────────────────────────────────────────
     let selected_repo_idx = state
@@ -165,6 +166,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                 version: crate::VERSION.to_owned(),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
                 colors: colors.clone(),
+                selection: selection,
             )
 
             // ── Main body: sidebar + PR workspace ───────────────────────────
@@ -181,6 +183,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                         selected: selected_repo_idx,
                         focused: sidebar_focused,
                         colors: colors.clone(),
+                        selection: selection,
                     )
                 }
 
@@ -236,6 +239,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                             layout: PrListLayout::Compact,
                             colors: colors.clone(),
                             available_width: Some(list_width),
+                            selection: selection,
                         )
                     }
                     Box(flex_grow: 1.0, width: 100pct) {
@@ -250,6 +254,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                             detail_content_width: detail_content_width,
                             colors: colors.clone(),
                             viewport_rows: Some(detail_pane_height),
+                            selection: selection,
                         )
                     }
 

--- a/src/ui/screens/split.rs
+++ b/src/ui/screens/split.rs
@@ -6,6 +6,7 @@
 
 use iocraft::prelude::*;
 
+use crate::selection::{SelectablePane, row_highlight_range};
 use crate::state::{AppState, ScreenMode};
 use crate::theme::{ResolvedColors, ThemeColors};
 
@@ -40,6 +41,7 @@ pub struct SplitScreenProps {
 #[component]
 pub fn SplitScreen(props: &SplitScreenProps) -> impl Into<AnyElement<'static>> {
     let state = props.state.as_ref();
+    let selection = state.and_then(|s| s.selection);
 
     let visible_repo_indices = state.map_or_else(Vec::new, AppState::visible_repository_indices);
     let repo_count = visible_repo_indices.len();
@@ -94,6 +96,7 @@ pub fn SplitScreen(props: &SplitScreenProps) -> impl Into<AnyElement<'static>> {
                 version: crate::VERSION.to_owned(),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
                 colors: colors.clone(),
+                selection: selection,
             )
 
             // Main content - repository list
@@ -124,19 +127,19 @@ pub fn SplitScreen(props: &SplitScreenProps) -> impl Into<AnyElement<'static>> {
                         let visible_count = agent_counts.get(i).copied()
                             .unwrap_or(repo.agent_ids.len());
                         let line = format!("{}{} ({} agents)", prefix, repo.name, visible_count);
-                        if selected {
-                            element! {
-                                Box(height: 1u32, background_color: rc.sel_bg) {
-                                    Text(content: line, color: rc.sel_fg, weight: Weight::Bold)
-                                }
-                            }
-                        } else {
-                            element! {
-                                Box(height: 1u32) {
-                                    Text(content: line, color: rc.fg)
-                                }
+                        let highlighted = selection
+                            .filter(|s| s.pane() == SelectablePane::Sidebar)
+                            .and_then(|s| row_highlight_range(&s, i))
+                            .is_some();
+                        let row_bg = if highlighted || selected { rc.sel_bg } else { Color::Reset };
+                        let fg = if highlighted || selected { rc.sel_fg } else { rc.fg };
+                        let weight = if selected { Weight::Bold } else { Weight::Normal };
+                        element! {
+                            Box(height: 1u32, background_color: row_bg) {
+                                Text(content: line, color: fg, weight: weight)
                             }
                         }
+                        .into_any()
                     }))
                 }
             }

--- a/src/ui/screens/split.rs
+++ b/src/ui/screens/split.rs
@@ -131,7 +131,7 @@ pub fn SplitScreen(props: &SplitScreenProps) -> impl Into<AnyElement<'static>> {
                             .filter(|s| s.pane() == SelectablePane::Sidebar)
                             .and_then(|s| row_highlight_range(&s, i))
                             .is_some();
-                        let row_bg = if highlighted { rc.sel_bg } else { Color::Reset };
+                        let row_bg = if highlighted { rc.sel_bg } else { rc.bg };
                         let fg = if highlighted { rc.sel_fg } else { rc.fg };
                         let weight = if selected { Weight::Bold } else { Weight::Normal };
                         element! {

--- a/src/ui/screens/split.rs
+++ b/src/ui/screens/split.rs
@@ -131,8 +131,8 @@ pub fn SplitScreen(props: &SplitScreenProps) -> impl Into<AnyElement<'static>> {
                             .filter(|s| s.pane() == SelectablePane::Sidebar)
                             .and_then(|s| row_highlight_range(&s, i))
                             .is_some();
-                        let row_bg = if highlighted || selected { rc.sel_bg } else { Color::Reset };
-                        let fg = if highlighted || selected { rc.sel_fg } else { rc.fg };
+                        let row_bg = if highlighted { rc.sel_bg } else { Color::Reset };
+                        let fg = if highlighted { rc.sel_fg } else { rc.fg };
                         let weight = if selected { Weight::Bold } else { Weight::Normal };
                         element! {
                             Box(height: 1u32, background_color: row_bg) {


### PR DESCRIPTION
## Summary

Adds mouse-based text select & copy via OSC 52 across all non-terminal panes in the jefe TUI, plus terminal snapshot selection when the terminal view is unfocused. Previously, mouse events were silently discarded when the terminal was not focused.

Closes #141

## What was implemented

### New modules (iocraft-free, side-effect-free pure projections)

**`src/selection/`** — pure selection model:
- `SelectablePane` enum (Sidebar, AgentList, TerminalView, Preview, IssueList, IssueDetail, PrList, PrDetail, HelpModal, StatusBar, KeybindBar)
- `SelectionPoint` / `TextSelection` (anchor + focus in content coordinates)
- `pane_at()` hit-test using `layout.rs` constants (single source of truth)
- `pane_content_lines()` content provider mapping `AppState` to `Vec<String>`
- `normalize_selection()`, `selection_text()`, `point_to_content_coords()`
- `ScreenLayout` descriptor (term dims, screen mode, error/filter bands)

**`src/clipboard.rs`** — OSC 52 clipboard writer:
- `write_osc52()` / `write_osc52_to_writer()` with mock-writer testable core
- tmux DCS passthrough (ESC-doubling) and GNU screen DCS chunking
- base64 encoder, large-payload truncation to valid base64 boundary
- `/dev/tty` fallback on Unix for piped-stdout safety

**`src/mouse_routing.rs`** — mouse event routing (extracted from `app_shell.rs` for file-size compliance):
- `handle_fullscreen_mouse()`: routes Down/Drag/Up to selection or PTY
- Terminal-focused + in-bounds → PTY forwarding (unchanged behavior)
- Shift modifier → bypass app selection (host terminal native select)
- Cross-pane drag clamped to anchor pane (prevents coordinate corruption)
- `finalize_and_copy_selection()` writes OSC 52 on mouse-up
- `clear_selection()` on key/paste/resize events

### Modified files
- `src/app_shell.rs`: hook into mouse events, delegate routing to `mouse_routing` module; `capture_terminal_snapshot`/`HookState`/`CtxArc` made `pub` for cross-module access
- `src/state/types.rs`: added `selection: Option<TextSelection>` to `AppState`
- `src/layout.rs`: export `dashboard_middle_row_heights_inner` for geometry reuse
- `src/lib.rs`, `src/main.rs`: module declarations

## Testing

238 unit tests + 1 doctest pass. Coverage includes:
- Selection model: `normalize_selection()` ordering, `selection_text()` (single-line, multi-line, reversed, clamping past end-of-line/last-line, empty input)
- OSC 52 encoding: plain ASCII, UTF-8, empty string, tmux exact byte sequence, screen DCS chunking, large-payload truncation (valid base64 boundary)
- Pane geometry hit-testing: dashboard (status bar, keybind bar, sidebar, preview, agent list, terminal unfocused/focused), issues mode (sidebar, list, detail, error banner, filter controls), PR mode (mirrors issues), out-of-bounds
- Content coordinate mapping: scroll-offset adjustment, origin clamping

## Architecture compliance

- Pure-views pattern: all selection model code is iocraft-free and side-effect-free
- Module boundaries: UI renders/emits intent, state owns transitions, mouse routing is an app-shell-level seam (like F12 toggle)
- No `unsafe`, no `unwrap`/`expect`, no `panic!` in production paths
- All files under 1000 lines; all functions under 60 lines
- `#[must_use]` on all pure projection functions; `//!` module docs on every file

## Verification

```
make ci-check  # fmt, clippy -D warnings, build, test, coverage --fail-under-lines 30
```
All gates pass.