### PR TITLE
Add mousewheel scroll for PR/Issue detail panes (Fixes #148)

### DIFF
--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -69,6 +69,22 @@ pub fn handle_fullscreen_mouse(
         MouseEventKind::Up(MouseButton::Left) => {
             finalize_and_copy_selection(ctx, app_state);
         }
+        MouseEventKind::ScrollUp => {
+            scroll_detail_pane(
+                app_state,
+                mouse_event.column,
+                mouse_event.row,
+                WheelDirection::Up,
+            );
+        }
+        MouseEventKind::ScrollDown => {
+            scroll_detail_pane(
+                app_state,
+                mouse_event.column,
+                mouse_event.row,
+                WheelDirection::Down,
+            );
+        }
         _ => {}
     }
 }
@@ -287,5 +303,149 @@ fn scroll_offset_for_pane(state: &AppState, pane: SelectablePane) -> usize {
         SelectablePane::IssueDetail => state.issues_state.detail_scroll_offset,
         SelectablePane::PrDetail => state.prs_state.detail_scroll_offset,
         _ => 0,
+    }
+}
+
+/// Direction of a single mousewheel tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WheelDirection {
+    Up,
+    Down,
+}
+
+/// Next detail scroll offset after one mousewheel tick, clamped to `[0, max]`.
+///
+/// Pure and side-effect-free so the clamp invariant is unit-testable without
+/// the iocraft runtime: scrolling up never drops below 0 and scrolling down
+/// never exceeds the pane's maximum offset. `max` is the detail pane's
+/// `max_detail_scroll_offset()` (0 when there is no content to scroll).
+#[must_use]
+fn next_wheel_scroll_offset(current: usize, max: usize, direction: WheelDirection) -> usize {
+    match direction {
+        WheelDirection::Up => current.saturating_sub(1),
+        WheelDirection::Down => (current + 1).min(max),
+    }
+}
+
+/// Maximum scroll offset for a detail pane from app state.
+///
+/// Returns 0 for non-scrollable panes (they are never advanced by the wheel).
+fn max_scroll_offset_for_pane(state: &AppState, pane: SelectablePane) -> usize {
+    match pane {
+        SelectablePane::IssueDetail => state.issues_state.max_detail_scroll_offset(),
+        SelectablePane::PrDetail => state.pr_detail_max_scroll_offset(),
+        _ => 0,
+    }
+}
+
+/// Scroll the detail pane under `(col, row)` by one wheel tick.
+///
+/// Resolves the pane under the cursor via [`resolve_pane`] and, when it is a
+/// scrollable detail pane (`IssueDetail` / `PrDetail`), advances its scroll
+/// offset by one line in the given direction, clamped to the pane's valid
+/// bounds via [`next_wheel_scroll_offset`]. Non-detail panes are ignored —
+/// mousewheel scrolling in list/terminal panes is out of scope (issue #148).
+fn scroll_detail_pane(
+    app_state: &mut HookState<AppState>,
+    col: u16,
+    row: u16,
+    direction: WheelDirection,
+) {
+    let (cols, rows) = terminal_size();
+    // Resolve the pane in one short read guard, then read current/max offsets
+    // in another, so each read guard drops immediately (the guard has a
+    // significant Drop and clippy::significant_drop_tightening requires it not
+    // be held across unrelated statements).
+    let pane = {
+        let state = app_state.read();
+        let Some((pane, _geometry)) = resolve_pane(&state, col, row, cols, rows) else {
+            return;
+        };
+        pane
+    };
+    if !matches!(pane, SelectablePane::IssueDetail | SelectablePane::PrDetail) {
+        return;
+    }
+    let (current, max) = {
+        let state = app_state.read();
+        let current = scroll_offset_for_pane(&state, pane);
+        let max = max_scroll_offset_for_pane(&state, pane);
+        drop(state);
+        (current, max)
+    };
+    let next = next_wheel_scroll_offset(current, max, direction);
+    let mut state = app_state.write();
+    match pane {
+        SelectablePane::IssueDetail => state.issues_state.detail_scroll_offset = next,
+        SelectablePane::PrDetail => state.prs_state.detail_scroll_offset = next,
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WheelDirection, next_wheel_scroll_offset};
+
+    #[test]
+    fn scroll_down_advances_within_bounds() {
+        assert_eq!(
+            next_wheel_scroll_offset(2, 5, WheelDirection::Down),
+            3,
+            "scrolling down from 2 with max 5 should advance to 3"
+        );
+    }
+
+    #[test]
+    fn scroll_up_decrements_within_bounds() {
+        assert_eq!(
+            next_wheel_scroll_offset(2, 5, WheelDirection::Up),
+            1,
+            "scrolling up from 2 with max 5 should decrement to 1"
+        );
+    }
+
+    #[test]
+    fn scroll_down_clamps_at_max_offset() {
+        assert_eq!(
+            next_wheel_scroll_offset(5, 5, WheelDirection::Down),
+            5,
+            "scrolling down at max offset must not overscroll"
+        );
+    }
+
+    #[test]
+    fn scroll_up_clamps_at_zero() {
+        assert_eq!(
+            next_wheel_scroll_offset(0, 5, WheelDirection::Up),
+            0,
+            "scrolling up at offset 0 must not underscroll"
+        );
+    }
+
+    #[test]
+    fn scroll_down_with_zero_max_stays_zero() {
+        assert_eq!(
+            next_wheel_scroll_offset(0, 0, WheelDirection::Down),
+            0,
+            "empty detail pane (max 0) cannot scroll down"
+        );
+    }
+
+    #[test]
+    fn scroll_up_with_zero_max_stays_zero() {
+        assert_eq!(
+            next_wheel_scroll_offset(0, 0, WheelDirection::Up),
+            0,
+            "empty detail pane (max 0) cannot scroll up"
+        );
+    }
+
+    #[test]
+    fn scroll_down_in_middle_of_large_content() {
+        assert_eq!(
+            next_wheel_scroll_offset(10, 100, WheelDirection::Down),
+            11,
+            "scrolling down from 10 within a large pane should advance to 11"
+        );
     }
 }

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -306,6 +306,36 @@ fn scroll_offset_for_pane(state: &AppState, pane: SelectablePane) -> usize {
     }
 }
 
+/// Refresh the cached `detail_viewport_rows` for `pane` from the current
+/// terminal size and conditional bands.
+///
+/// Mirrors `update_detail_viewport_rows` / `update_pr_detail_viewport_rows` in
+/// the keyboard dispatch path so the scroll-offset clamp bound
+/// (`max_detail_scroll_offset` / `pr_detail_max_scroll_offset`) agrees with the
+/// viewport the renderer actually uses. Without this, a stale cache (e.g. left
+/// over from before entering the mode, since it is only refreshed on keyboard
+/// scroll-down) lets the stored offset drift past the renderer's clamp bound.
+fn refresh_detail_viewport_rows(state: &mut AppState, pane: SelectablePane, term_rows: u16) {
+    let term_rows = usize::from(term_rows);
+    match pane {
+        SelectablePane::IssueDetail => {
+            state.issues_state.detail_viewport_rows = jefe::layout::issues_detail_viewport_rows(
+                term_rows,
+                state.issues_state.error.is_some(),
+                state.issues_state.filter_ui.controls_open,
+            );
+        }
+        SelectablePane::PrDetail => {
+            state.prs_state.detail_viewport_rows = jefe::layout::prs_detail_viewport_rows(
+                term_rows,
+                state.prs_state.error.is_some(),
+                state.prs_state.filter_ui.controls_open,
+            );
+        }
+        _ => {}
+    }
+}
+
 /// Direction of a single mousewheel tick.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum WheelDirection {
@@ -319,11 +349,17 @@ enum WheelDirection {
 /// the iocraft runtime: scrolling up never drops below 0 and scrolling down
 /// never exceeds the pane's maximum offset. `max` is the detail pane's
 /// `max_detail_scroll_offset()` (0 when there is no content to scroll).
+///
+/// `current` is clamped to `max` *before* the tick is applied, so a stale
+/// offset that drifted past `max` (e.g. the cached viewport shrank) snaps back
+/// into the valid range on the very next tick instead of stranding the view in
+/// a phantom region the renderer clamps but the stored value does not.
 #[must_use]
 fn next_wheel_scroll_offset(current: usize, max: usize, direction: WheelDirection) -> usize {
+    let clamped = current.min(max);
     match direction {
-        WheelDirection::Up => current.saturating_sub(1),
-        WheelDirection::Down => (current + 1).min(max),
+        WheelDirection::Up => clamped.saturating_sub(1),
+        WheelDirection::Down => (clamped + 1).min(max),
     }
 }
 
@@ -343,8 +379,10 @@ fn max_scroll_offset_for_pane(state: &AppState, pane: SelectablePane) -> usize {
 /// Resolves the pane under the cursor via [`resolve_pane`] and, when it is a
 /// scrollable detail pane (`IssueDetail` / `PrDetail`), advances its scroll
 /// offset by one line in the given direction, clamped to the pane's valid
-/// bounds via [`next_wheel_scroll_offset`]. Non-detail panes are ignored —
-/// mousewheel scrolling in list/terminal panes is out of scope (issue #148).
+/// bounds via [`next_wheel_scroll_offset`]. The cached viewport row count is
+/// refreshed first ([`refresh_detail_viewport_rows`]) so the clamp bound
+/// matches the renderer. Non-detail panes are ignored — mousewheel scrolling
+/// in list/terminal panes is out of scope (issue #148).
 fn scroll_detail_pane(
     app_state: &mut HookState<AppState>,
     col: u16,
@@ -365,6 +403,18 @@ fn scroll_detail_pane(
     };
     if !matches!(pane, SelectablePane::IssueDetail | SelectablePane::PrDetail) {
         return;
+    }
+    // Refresh the cached detail-viewport row count from the current terminal
+    // layout before computing the clamp bound. The renderer windows content
+    // with a *fresh* viewport (derived from the actual layout), but
+    // `max_detail_scroll_offset` / `pr_detail_max_scroll_offset` read the cached
+    // `detail_viewport_rows` field. The keyboard dispatch path refreshes that
+    // cache (`update_*_detail_viewport_rows`) before every scroll; the mouse
+    // path must too, otherwise a stale (smaller) cache lets the offset run past
+    // the renderer's clamp bound and the wheel appears to overscroll / stick.
+    {
+        let mut state = app_state.write();
+        refresh_detail_viewport_rows(&mut state, pane, rows);
     }
     let (current, max) = {
         let state = app_state.read();
@@ -446,6 +496,43 @@ mod tests {
             next_wheel_scroll_offset(10, 100, WheelDirection::Down),
             11,
             "scrolling down from 10 within a large pane should advance to 11"
+        );
+    }
+
+    // ── stale / inflated offset recovery ───────────────────────────────────
+    //
+    // The stored detail scroll offset can lag behind the renderer's clamp
+    // bound when the cached `detail_viewport_rows` is smaller than the
+    // renderer's fresh viewport (the keyboard dispatch path refreshes that
+    // cache before scrolling; the mouse path now does too). If the offset is
+    // ever inflated past `max`, a single wheel tick must snap it back into the
+    // valid range instead of leaving it stranded in a phantom region where the
+    // renderer clamps the display but the stored value keeps climbing.
+
+    #[test]
+    fn scroll_up_from_inflated_offset_snaps_below_max() {
+        assert_eq!(
+            next_wheel_scroll_offset(8, 5, WheelDirection::Up),
+            4,
+            "scrolling up from an inflated offset (8) with max 5 must snap to 4, not walk back one-at-a-time through the phantom region"
+        );
+    }
+
+    #[test]
+    fn scroll_down_from_inflated_offset_snaps_to_max() {
+        assert_eq!(
+            next_wheel_scroll_offset(8, 5, WheelDirection::Down),
+            5,
+            "scrolling down from an inflated offset (8) with max 5 must snap to 5"
+        );
+    }
+
+    #[test]
+    fn scroll_up_from_inflated_offset_near_zero_snaps_to_zero() {
+        assert_eq!(
+            next_wheel_scroll_offset(8, 1, WheelDirection::Up),
+            0,
+            "scrolling up from an inflated offset (8) with max 1 must snap to 0"
         );
     }
 }

--- a/src/state/prs_nav_ops.rs
+++ b/src/state/prs_nav_ops.rs
@@ -484,7 +484,8 @@ impl AppState {
     /// @plan PLAN-20260624-PR-MODE.P14
     /// @requirement REQ-PR-009
     /// @pseudocode component-001 lines 169-176
-    fn pr_detail_max_scroll_offset(&self) -> usize {
+    #[must_use]
+    pub fn pr_detail_max_scroll_offset(&self) -> usize {
         let Some(detail) = &self.prs_state.pr_detail else {
             return 0;
         };


### PR DESCRIPTION
## Summary

Fixes #148

When the PR detail or Issue detail pane is under the mouse cursor, scrolling the mousewheel now scrolls that detail pane's content up/down — mirroring how keyboard scrolling works today. Previously `MouseEventKind::ScrollUp` / `ScrollDown` were ignored in `handle_fullscreen_mouse`.

## Changes

**`src/mouse_routing.rs`**
- `handle_fullscreen_mouse` gains `ScrollUp` / `ScrollDown` match arms that route to a new `scroll_detail_pane` helper.
- `scroll_detail_pane` resolves the pane under the cursor via the existing `pane_at()` hit-test (position-based, not keyboard-focus-based, per the issue) and advances the `IssueDetail` / `PrDetail` scroll offset by one line. Non-detail panes are ignored (list-pane and terminal-pane wheel scroll are explicit non-goals).
- `next_wheel_scroll_offset` — a pure, side-effect-free, `#[must_use]` clamp function: scroll-up saturating-subs to `0`, scroll-down is capped at the pane's max offset. This is the unit-testable invariant, since iocraft's `HookState` cannot be constructed in a plain unit test (it requires the iocraft runtime owner).
- `max_scroll_offset_for_pane` reads the clamp bound per pane: `IssuesState::max_detail_scroll_offset()` (already public) and `AppState::pr_detail_max_scroll_offset()`.

**`src/state/prs_nav_ops.rs`**
- `pr_detail_max_scroll_offset` is now `pub` + `#[must_use]` so the mouse router can clamp PR detail scrolling without duplicating the PR detail line-count logic (mirrors the already-public `IssuesState::max_detail_scroll_offset`).

## Design notes

- **Position-based, not focus-based:** the pane is resolved from `(column, row)`, so scrolling works whenever the cursor is over the detail pane regardless of keyboard focus — matching the issue requirement.
- **Scope:** deliberately does NOT add wheel scroll to the terminal pane (goes to the PTY already when focused) or list panes (separate enhancement). Auto-scroll-during-drag (#141 Phase 6) is also out of scope (mentioned only as a related enhancement).
- **Unaffected behavior:** the PTY-forwarding early return and the Shift-scroll bypass run before the new arms, so terminal-pane mouse reporting and host-native Shift-scroll are unchanged. Empty detail panes (max offset 0) cannot scroll past 0.
- **Guard discipline:** `scroll_detail_pane` splits the iocraft read/write guards into separate short scopes (matching the existing `update_selection` / `resolve_selection_point` pattern in the same file) to satisfy `significant_drop_tightening`.

## Testing

TDD (RED → GREEN → REFACTOR). 7 unit tests on the pure `next_wheel_scroll_offset` clamp invariant:
- advance within bounds (down 2→3)
- decrement within bounds (up 2→1)
- clamp at max offset (down 5→5, no overscroll)
- clamp at zero (up 0→0, no underscroll)
- empty pane, max 0, cannot scroll up or down
- middle of large content (down 10→11)

The full verification suite is green:
- `cargo fmt --all --check`
- `clippy --workspace --all-targets --all-features -- -D warnings`
- complexity-only clippy pass
- `cargo build --workspace --all-features --locked`
- `cargo test --workspace --all-features --locked` (0 failures)
- `cargo llvm-cov --fail-under-lines 30` (64.4% line coverage)

Closes #148
