### PR TITLE
Add OCR PR review workflow for Rust project (Fixes #153)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1,0 +1,1297 @@
+name: OCR Review
+
+# Runs OpenCodeReview (OCR) on pull requests alongside the existing review
+# bot. OCR is an observational, non-required review signal while it is being
+# proven out. The existing CI pipeline (ci.yml) remains the gating workflow and
+# is untouched.
+#
+# Fork-safety model: this workflow uses `pull_request_target` so repository
+# secrets are available for fork PRs, but it NEVER checks out or executes
+# PR-supplied code/config while secrets are in scope. The trusted base
+# branch is checked out first; the PR head is fetched into an explicit local
+# ref and read for diff computation only. No make/cargo/npm-repo-scripts are
+# invoked. OCR rules/config are configured from variables+secret only; no
+# PR-supplied OCR rules are loaded.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to review'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  # Keep CI reviews deterministic by disabling OCR self-update checks.
+  OCR_NO_UPDATE: '1'
+  # Disable colorized CLI output so text parsers (e.g. the changed-test
+  # scope guard) always see plain text.
+  NO_COLOR: '1'
+
+jobs:
+  code-review:
+    name: OpenCodeReview
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Infrastructure failures are intentionally non-blocking for PR checks, but
+    # this output lets downstream jobs distinguish a completed OCR review from a
+    # review that could not run because of provider, install, or script issues.
+    outputs:
+      infrastructure_failure: ${{ steps.ocr-classification.outputs.infrastructure_failure }}
+      policy_failure: ${{ steps.ocr-classification.outputs.policy_failure }}
+    # For issue_comment, only run on PR comments requesting a review.
+    # The toJSON checks intentionally support LF, CRLF, and tab after the
+    # command; other whitespace is not matched to keep triggers predictable.
+    if: |
+      github.event_name == 'pull_request_target' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
+       (github.event.comment.body == '/ocr' ||
+        startsWith(github.event.comment.body, '/ocr ') ||
+        startsWith(toJSON(github.event.comment.body), '"/ocr\n') ||
+        startsWith(toJSON(github.event.comment.body), '"/ocr\r\n') ||
+        startsWith(toJSON(github.event.comment.body), '"/ocr\t') ||
+        github.event.comment.body == '/open-code-review' ||
+        startsWith(github.event.comment.body, '/open-code-review ') ||
+        startsWith(toJSON(github.event.comment.body), '"/open-code-review\n') ||
+        startsWith(toJSON(github.event.comment.body), '"/open-code-review\r\n') ||
+        startsWith(toJSON(github.event.comment.body), '"/open-code-review\t')))
+    # Job-level concurrency is evaluated only for runs that pass this job if filter,
+    # so ordinary, unauthorized, and non-PR issue comments cannot cancel OCR.
+    # All authorized OCR triggers for the same PR share one group so the latest
+    # run owns the sticky summary and inline-comment posting.
+    concurrency:
+      group: >-
+        ocr-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+      cancel-in-progress: true
+    steps:
+      - name: Resolve PR context
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
+        id: pr-context
+        with:
+          script: |
+            const number = (context.payload.pull_request && context.payload.pull_request.number)
+              || (context.issue && context.issue.number)
+              || Number(context.payload.inputs && context.payload.inputs.pr_number);
+            if (!number) {
+              core.setFailed('Could not resolve a pull request number from the event.');
+              return;
+            }
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: number,
+            });
+            core.setOutput('number', String(number));
+            core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('base_sha', pr.base.sha);
+            core.setOutput('head_sha', pr.head.sha);
+
+      - name: Checkout trusted base
+        # Fork-safety keystone: check out the trusted base branch (never the
+        # PR head) so the working tree never reflects PR-supplied files.
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
+        with:
+          ref: ${{ steps.pr-context.outputs.base_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch PR head and compute merge-base
+        shell: bash
+        env:
+          PR_NUMBER: ${{ steps.pr-context.outputs.number }}
+          HEAD_SHA: ${{ steps.pr-context.outputs.head_sha }}
+          BASE_SHA: ${{ steps.pr-context.outputs.base_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          { set +x; } 2>/dev/null
+          cleanup_git_auth() {
+            set +e
+            git config --global --unset-all safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
+            unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+            unset AUTH_B64
+          }
+          trap cleanup_git_auth EXIT
+          trap 'cleanup_git_auth; exit 130' INT TERM
+          trap 'cleanup_git_auth; exit 129' HUP
+          umask 077
+          GH_SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+          GH_SERVER_URL="${GH_SERVER_URL%/}/"
+          # Scope safe.directory to this trusted workspace only (never '*').
+          # Persist one entry for later steps, then also add it to the global
+          # config while the fetch-step auth header is passed only to git fetch.
+          git config --file "${HOME}/.gitconfig" --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+          # Fetch the PR head into an explicit local ref WITHOUT making it the
+          # working copy, so no PR-supplied scripts become executable.
+          # The one-command env config makes auth explicit for this fetch even
+          # when the runner's Git ignores the temp global config for HTTP auth.
+          # Use basic auth with the x-access-token username, matching the
+          # header format actions/checkout persists. GitHub's smart HTTP
+          # endpoint rejects "bearer" for this token type, and git then
+          # falls back to an interactive username prompt, which fails.
+          AUTH_B64="$(printf '%s' "x-access-token:${GH_TOKEN}" | base64 | tr -d '\n')"
+          export GIT_CONFIG_COUNT=1
+          export GIT_CONFIG_KEY_0="http.${GH_SERVER_URL}.extraheader"
+          export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${AUTH_B64}"
+          if ! git fetch origin "pull/${PR_NUMBER}/head:pr-head"; then
+            unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0 AUTH_B64
+            echo "::error::Failed to fetch PR head ref."
+            exit 1
+          fi
+          unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0 AUTH_B64
+          if ! git cat-file -e "${BASE_SHA}^{commit}"; then
+            echo "::error::Base SHA ${BASE_SHA} is missing after trusted checkout. It may no longer be reachable from origin."
+            exit 1
+          fi
+
+          BASE_SHA="$(git merge-base "${BASE_SHA}" pr-head)"
+          FETCHED_HEAD="$(git rev-parse pr-head)"
+          if [ "${FETCHED_HEAD}" != "${HEAD_SHA}" ]; then
+            echo "::error::PR head changed between API resolution and fetch (expected ${HEAD_SHA}, got ${FETCHED_HEAD}). Re-run to review the latest push."
+            exit 1
+          fi
+          cleanup_git_auth
+          trap - EXIT INT TERM HUP
+          {
+            echo "BASE_SHA=${BASE_SHA}"
+            echo "HEAD_SHA=${HEAD_SHA}"
+          } >> "$GITHUB_ENV"
+
+      - name: Initialize OCR artifact files
+        shell: bash
+        run: |
+          set -euo pipefail
+          : > ocr-result.json
+          : > ocr-stdout.raw
+          : > ocr-stderr.log
+          : > ocr-version.txt
+          : > ocr-preview.txt
+          : > ocr-preview-stderr.log
+          : > ocr-exit-code.txt
+          : > ocr-phase.txt
+          : > ocr-infrastructure-failure.txt
+          : > ocr-policy-failure.txt
+          cat > ocr-workflow-helpers.sh <<'EOF'
+          mark_infrastructure_failure() {
+            echo "phase=$1; reason=$2" > ocr-infrastructure-failure.txt
+          }
+          mark_policy_failure() {
+            echo "$1" > ocr-policy-failure.txt
+          }
+          EOF
+
+      - name: Install OpenCodeReview
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "install" > ocr-phase.txt
+          if ! . ./ocr-workflow-helpers.sh; then
+            echo "::warning::Could not load OCR workflow helper script."
+            echo "127" > ocr-exit-code.txt
+            echo "phase=install; reason=OCR workflow helper script could not be loaded" > ocr-infrastructure-failure.txt
+            exit 0
+          fi
+          OCR_PREFIX="${RUNNER_TEMP}/ocr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          if ! npm install --prefix "$OCR_PREFIX" --ignore-scripts @alibaba-group/open-code-review@1.7.5 2>> ocr-stderr.log; then
+            echo "::warning::OpenCodeReview installation failed."
+            echo "70" > ocr-exit-code.txt
+            mark_infrastructure_failure "install" "OpenCodeReview installation failed"
+            exit 0
+          fi
+          OCR_BIN="${OCR_PREFIX}/node_modules/.bin"
+          echo "$OCR_BIN" >> "$GITHUB_PATH"
+          export PATH="${OCR_BIN}:${PATH}"
+          if ! command -v ocr >/dev/null 2>&1; then
+            echo "::warning::OpenCodeReview command was not found after install."
+            echo "127" > ocr-exit-code.txt
+            mark_infrastructure_failure "install" "OpenCodeReview command was not found after install"
+            exit 0
+          fi
+          if ! ocr version > ocr-version.txt 2>> ocr-stderr.log; then
+            echo "::warning::OpenCodeReview version check failed."
+            echo "70" > ocr-exit-code.txt
+            mark_infrastructure_failure "install" "OpenCodeReview version check failed"
+            exit 0
+          fi
+          cat ocr-version.txt
+
+      - name: Configure OCR review rules
+        shell: bash
+        # Project policy: changed test files must be reviewed. OCR's default
+        # rules exclude test/spec files, so re-include them here. This config
+        # is written from this trusted workflow only (env-provided JSON); no
+        # PR-supplied OCR rules are ever loaded.
+        #
+        # Include patterns cover this Rust project's test layout:
+        # *_test.rs, *_tests.rs, tests/**, test/**.
+        env:
+          OCR_RULES_JSON: |
+            {
+              "include": [
+                "**/*_test.rs",
+                "**/*_tests.rs",
+                "**/tests/**",
+                "**/test/**"
+              ],
+              "exclude": [
+                "**/target/**",
+                "**/vendor/**",
+                "**/generated/**"
+              ]
+            }
+        run: |
+          mkdir -p "${HOME}/.opencodereview"
+          printf '%s' "$OCR_RULES_JSON" > "${HOME}/.opencodereview/rule.json"
+
+      - name: Validate OCR configuration
+        shell: bash
+        env:
+          OCR_LLM_URL: ${{ vars.OCR_LLM_URL }}
+          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          OCR_LLM_MODEL: ${{ vars.OCR_LLM_MODEL }}
+          OCR_USE_ANTHROPIC: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+        run: |
+          set -euo pipefail
+          if [ -s ocr-exit-code.txt ]; then
+            echo "::warning::Skipping OCR configuration validation because an earlier OCR setup failure was recorded."
+            exit 0
+          fi
+          echo "validate" > ocr-phase.txt
+          if ! . ./ocr-workflow-helpers.sh; then
+            echo "::warning::Could not load OCR workflow helper script."
+            echo "127" > ocr-exit-code.txt
+            echo "phase=validate; reason=OCR workflow helper script could not be loaded" > ocr-infrastructure-failure.txt
+            exit 0
+          fi
+          missing=0
+          if [ -z "${OCR_LLM_URL:-}" ]; then
+            echo "::warning::Required variable OCR_LLM_URL is not set"
+            echo "Required variable OCR_LLM_URL is not set" >> ocr-stderr.log
+            missing=1
+          fi
+          if [ -z "${OCR_LLM_TOKEN:-}" ]; then
+            echo "::warning::Required secret OCR_LLM_AUTH_TOKEN is not set"
+            echo "Required secret OCR_LLM_AUTH_TOKEN is not set" >> ocr-stderr.log
+            missing=1
+          fi
+          if [ -z "${OCR_LLM_MODEL:-}" ]; then
+            echo "::warning::Required variable OCR_LLM_MODEL is not set"
+            echo "Required variable OCR_LLM_MODEL is not set" >> ocr-stderr.log
+            missing=1
+          fi
+          if [ "$missing" -ne 0 ]; then
+            echo "78" > ocr-exit-code.txt
+            mark_infrastructure_failure "validate" "OCR configuration is missing required variables or secrets"
+            exit 0
+          fi
+
+      - name: Verify review scope includes changed tests
+        shell: bash
+        env:
+          BASE_SHA: ${{ env.BASE_SHA }}
+          HEAD_SHA: ${{ env.HEAD_SHA }}
+          OCR_LLM_URL: ${{ vars.OCR_LLM_URL }}
+          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          OCR_LLM_MODEL: ${{ vars.OCR_LLM_MODEL }}
+          OCR_USE_ANTHROPIC: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+        run: |
+          set -euo pipefail
+          if [ -s ocr-exit-code.txt ]; then
+            echo "::warning::Skipping OCR preview because an earlier OCR setup/configuration failure was recorded."
+            exit 0
+          fi
+          echo "preview" > ocr-phase.txt
+          : > ocr-preview.txt
+          : > ocr-preview-stderr.log
+          if ! . ./ocr-workflow-helpers.sh; then
+            echo "::warning::Could not load OCR workflow helper script."
+            echo "127" > ocr-exit-code.txt
+            echo "phase=preview; reason=OCR workflow helper script could not be loaded" > ocr-infrastructure-failure.txt
+            exit 0
+          fi
+          changed_tests="$(
+            git diff --name-only --diff-filter=d "${BASE_SHA}..${HEAD_SHA}" \
+              | grep -v '^target/' \
+              | grep -Ei '(^|/)(tests?)/.*\.rs$|(_test|_tests)\.rs$' \
+              || true
+          )"
+          if [ -n "$changed_tests" ]; then
+            echo "Changed test/spec files detected that must be reviewed:"
+            echo "$changed_tests"
+            if ! command -v ocr >/dev/null 2>&1; then
+              echo "::warning::OpenCodeReview command is unavailable before preview."
+              echo "OpenCodeReview command is unavailable before preview." >> ocr-preview-stderr.log
+              echo "127" > ocr-exit-code.txt
+              mark_infrastructure_failure "preview" "OpenCodeReview command is unavailable before preview"
+              exit 0
+            fi
+            set +e
+            ocr review --preview --from "$BASE_SHA" --to "$HEAD_SHA" \
+              > ocr-preview.txt 2> ocr-preview-stderr.log
+            status=$?
+            set -e
+            if [ "$status" -ne 0 ]; then
+              echo "::warning::Could not verify OCR preview scope for changed test files."
+              echo "$status" > ocr-exit-code.txt
+              mark_infrastructure_failure "preview" "OCR preview command failed"
+              exit 0
+            fi
+            if ! sed -i 's/\x1b\[[0-9;?<>=]*[A-Za-z]//g; s/\x1b\][^\x07\x1b]*\(\x07\|\x1b\\\)//g' ocr-preview.txt; then
+              echo "::warning::Could not normalize OCR preview output."
+              echo "1" > ocr-exit-code.txt
+              mark_infrastructure_failure "preview" "OCR preview normalization failed"
+              exit 0
+            fi
+            reviewed="$(awk '
+              BEGIN { IGNORECASE = 1; in_section = 0 }
+              /^Will review[[:space:]]*\(/ { in_section = 1; next }
+              /^[[:alpha:] ]+[[:space:]]*\([0-9]+\):/ { in_section = 0 }
+              in_section { print }
+            ' ocr-preview.txt || true)"
+            excluded="$(awk '
+              BEGIN { IGNORECASE = 1; in_section = 0 }
+              /^Excluded[[:space:]]*\(/ { in_section = 1; next }
+              /^[[:alpha:] ]+[[:space:]]*\([0-9]+\):/ { if (in_section) in_section = 0 }
+              in_section { print }
+            ' ocr-preview.txt || true)"
+            # Sanity check: if the 'Will review' section was not detected, the
+            # preview output format may have changed in a future OCR version.
+            # Bail out rather than risk false policy failures from empty parsing.
+            if [ -z "$reviewed" ]; then
+              echo "::warning::OCR preview 'Will review' section was not detected; output format may have changed."
+              echo "1" > ocr-exit-code.txt
+              mark_infrastructure_failure "preview" "OCR preview output format was unexpected (no 'Will review' section found)"
+              exit 0
+            fi
+            missing=""
+            excluded_tests=""
+            path_in_section() {
+              awk -v target="$1" '
+                {
+                  line = $0
+                  sub(/^[[:space:]]*/, "", line)
+                  sub(/^[-*][[:space:]]*/, "", line)
+                  sub(/^\[[^]]+\][[:space:]]*/, "", line)
+                  sub(/^[[:space:]]*/, "", line)
+                  split(line, fields, /[[:space:]]+/)
+                  candidate = fields[1]
+                  quote = sprintf("%c", 39)
+                  if ((substr(candidate, 1, 1) == "\"" && substr(candidate, length(candidate), 1) == "\"") ||
+                      (substr(candidate, 1, 1) == quote && substr(candidate, length(candidate), 1) == quote)) {
+                    candidate = substr(candidate, 2, length(candidate) - 2)
+                  }
+                  if (candidate == target) found = 1
+                }
+                END { exit found ? 0 : 1 }
+              '
+            }
+            while IFS= read -r t; do
+              [ -z "$t" ] && continue
+              if ! echo "$reviewed" | path_in_section "$t"; then
+                missing="${missing}${t}"$'\n'
+              fi
+              if echo "$excluded" | path_in_section "$t"; then
+                excluded_tests="${excluded_tests}${t}"$'\n'
+              fi
+            done <<< "$changed_tests"
+            if [ -n "$missing" ]; then
+              echo "::error::OCR preview did not list changed test files in the reviewed set:"
+              echo "$missing"
+              echo "changed-test-missing" > ocr-phase.txt
+              echo "1" > ocr-exit-code.txt
+              mark_policy_failure "changed test files were missing from OCR reviewed set"
+              exit 1
+            fi
+            if [ -n "$excluded_tests" ]; then
+              echo "::error::OCR would exclude changed test files that must be reviewed:"
+              echo "$excluded_tests"
+              echo "changed-test-excluded" > ocr-phase.txt
+              echo "1" > ocr-exit-code.txt
+              mark_policy_failure "changed test files were excluded from OCR reviewed set"
+              exit 1
+            fi
+          fi
+
+      - name: Run OpenCodeReview
+        shell: bash
+        # Full merge-base..head diff. Parse failures are handled distinctly
+        # in the posting step (OCR failed vs. no findings).
+        env:
+          BASE_SHA: ${{ env.BASE_SHA }}
+          HEAD_SHA: ${{ env.HEAD_SHA }}
+          OCR_LLM_URL: ${{ vars.OCR_LLM_URL }}
+          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          OCR_LLM_MODEL: ${{ vars.OCR_LLM_MODEL }}
+          OCR_USE_ANTHROPIC: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+        run: |
+          set +e
+          if [ -s ocr-exit-code.txt ]; then
+            echo "::warning::Skipping OCR review because an earlier OCR setup/configuration/preview failure was recorded."
+            exit 0
+          fi
+          echo "review" > ocr-phase.txt
+          if ! . ./ocr-workflow-helpers.sh; then
+            echo "::warning::Could not load OCR workflow helper script."
+            echo "127" > ocr-exit-code.txt
+            echo "phase=review; reason=OCR workflow helper script could not be loaded" > ocr-infrastructure-failure.txt
+            exit 0
+          fi
+          if ! command -v ocr >/dev/null 2>&1; then
+            echo "::warning::OpenCodeReview command is unavailable before review."
+            echo "OpenCodeReview command is unavailable before review." >> ocr-stderr.log
+            echo "127" > ocr-exit-code.txt
+            mark_infrastructure_failure "review" "OpenCodeReview command is unavailable before review"
+            exit 0
+          fi
+          ocr review \
+            --from "$BASE_SHA" \
+            --to "$HEAD_SHA" \
+            --format json \
+            --audience agent \
+            --timeout 30 \
+            > ocr-stdout.raw 2> ocr-stderr.log
+          status=$?
+          if ! cp ocr-stdout.raw ocr-result.json; then
+            : > ocr-result.json
+          fi
+          echo "$status" > ocr-exit-code.txt
+          if [ "$status" -ne 0 ]; then
+            mark_infrastructure_failure "review" "OCR review command failed"
+          fi
+          exit 0
+
+      - name: Post OCR results
+        if: always()
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
+        env:
+          BASE_SHA: ${{ env.BASE_SHA }}
+          HEAD_SHA: ${{ env.HEAD_SHA }}
+          PR_NUMBER: ${{ steps.pr-context.outputs.number }}
+          # Exact OCR endpoint/credential values are provided only for redaction;
+          # do not log process.env from this step.
+          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          OCR_LLM_URL: ${{ vars.OCR_LLM_URL }}
+        with:
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- jefe-ocr-review -->';
+            const INLINE_MARKER = '<!-- jefe-ocr-inline -->';
+            const INFRA_FAILURE_FILE = 'ocr-infrastructure-failure.txt';
+            const POLICY_FAILURE_FILE = 'ocr-policy-failure.txt';
+            const REDACTION = '[REDACTED]';
+            const ocrTokenForRedaction = process.env.OCR_LLM_TOKEN;
+            const ocrUrlForRedaction = process.env.OCR_LLM_URL;
+            delete process.env.OCR_LLM_TOKEN;
+            delete process.env.OCR_LLM_URL;
+            const number = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(number) || number <= 0) {
+              core.setFailed('No valid PR number resolved from pr-context step.');
+              return;
+            }
+            const headSha = process.env.HEAD_SHA;
+            if (!headSha) {
+              core.setFailed('No valid HEAD_SHA resolved from environment.');
+              return;
+            }
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            function readTrimmed(fileName, fallback = '') {
+              try {
+                return fs.readFileSync(fileName, 'utf8').trim();
+              } catch (_) {
+                return fallback;
+              }
+            }
+
+            function escapeRegExp(value) {
+              return String(value).replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+            }
+
+            function redactSecretDiagnostics(value) {
+              let sanitized = String(value ?? '');
+              const exactSecrets = [ocrTokenForRedaction, ocrUrlForRedaction]
+                .filter((secret) => typeof secret === 'string' && secret.length > 0);
+              for (const secret of exactSecrets) {
+                try {
+                  sanitized = sanitized.replace(new RegExp(escapeRegExp(secret), 'g'), REDACTION);
+                } catch (_) {
+                  sanitized = sanitized.split(secret).join(REDACTION);
+                }
+              }
+              sanitized = sanitized
+                .replace(/\b(Authorization\s*:\s*(?:(?:Bearer|Basic|token|ApiKey)\s+)?)([^\s,;]+)/gi, '$1[REDACTED]')
+                .replace(/\b(x-api-key\s*:\s*)([^\s,;]+)/gi, '$1[REDACTED]')
+                .replace(/\b(api[_-]?key\s*[=:]\s*)([^\s,;&]+)/gi, '$1[REDACTED]')
+                .replace(/([?&](?:key|api[_-]?key|token)=)([^\s,;&]+)/gi, '$1[REDACTED]')
+                .replace(/\b(access[_-]?token\s*[=:]\s*)([^\s,;&]+)/gi, '$1[REDACTED]')
+                .replace(/\b(refresh[_-]?token\s*[=:]\s*)([^\s,;&]+)/gi, '$1[REDACTED]')
+                .replace(/\b(id[_-]?token\s*[=:]\s*)([^\s,;&]+)/gi, '$1[REDACTED]')
+                .replace(/\b(token\s*[=:]\s*)([A-Za-z0-9_./+=:@-]{16,})/gi, '$1[REDACTED]')
+                .replace(/\b(secret\s*[=:]\s*)([A-Za-z0-9_./+=:@-]{16,})/gi, '$1[REDACTED]');
+              return sanitized;
+            }
+
+            function sanitizeExcerpt(value) {
+              return redactSecretDiagnostics(value)
+                .split('\n')
+                .slice(0, 40)
+                .join('\n') || '(empty)';
+            }
+
+            let ocrVersion = readTrimmed('ocr-version.txt', 'unknown');
+            if (!ocrVersion) {
+              ocrVersion = 'unknown';
+            }
+            const phase = readTrimmed('ocr-phase.txt', 'unknown') || 'unknown';
+            let diagnosticPhase = phase;
+
+            function markInfrastructureFailure(markerPhase, reason) {
+              const message = redactSecretDiagnostics(`phase=${markerPhase}; reason=${reason}`);
+              fs.writeFileSync(INFRA_FAILURE_FILE, `${message}\n`);
+              diagnosticPhase = markerPhase;
+              fs.writeFileSync('ocr-phase.txt', `${markerPhase}\n`);
+              core.warning(`OCR infrastructure diagnostic recorded: ${message}`);
+            }
+
+            function stderrSection(title, fileName) {
+              const excerpt = sanitizeExcerpt(readTrimmed(fileName, ''));
+              return [
+                `### ${title}`,
+                '',
+                '```text',
+                excerpt.slice(0, 4000),
+                '```',
+              ];
+            }
+
+            function readExitCode(fileName) {
+              const raw = readTrimmed(fileName, '');
+              if (!raw) {
+                return 1;
+              }
+              const parsed = Number(raw);
+              return Number.isInteger(parsed) ? parsed : 1;
+            }
+
+            let ran = true;
+            let findings = [];
+            const policyFailure = readTrimmed(POLICY_FAILURE_FILE, '');
+            const exitCode = readExitCode('ocr-exit-code.txt');
+            if (exitCode !== 0) {
+              ran = false;
+            }
+            function findingsFromParsed(parsed) {
+              if (Array.isArray(parsed)) return parsed;
+              // ocr --format json emits an object envelope with a comments
+              // array (e.g. { "status": "success", "comments": [...] }).
+              if (parsed && typeof parsed === 'object' && Array.isArray(parsed.comments)) {
+                return parsed.comments;
+              }
+              return null;
+            }
+
+            function parseFindings(raw) {
+              const trimmed = raw.trim();
+              if (!trimmed) {
+                markInfrastructureFailure('parse', 'OCR output was empty or unusable');
+                return null;
+              }
+              try {
+                const parsed = findingsFromParsed(JSON.parse(trimmed));
+                if (!parsed) {
+                  markInfrastructureFailure('parse', 'OCR output did not contain a supported findings array');
+                }
+                return parsed;
+              } catch (parseErr) {
+                const start = trimmed.indexOf('[');
+                const end = trimmed.lastIndexOf(']');
+                if (start < 0 || end <= start) {
+                  markInfrastructureFailure('parse', `OCR output could not be parsed: ${parseErr.message || parseErr}`);
+                  core.warning(redactSecretDiagnostics(`OCR result was not valid JSON and no JSON array could be extracted: ${parseErr.message || parseErr}`));
+                  return null;
+                }
+                try {
+                  const parsed = findingsFromParsed(JSON.parse(trimmed.slice(start, end + 1)));
+                  if (!parsed) {
+                    markInfrastructureFailure('parse', 'OCR output did not contain a supported findings array');
+                  }
+                  return parsed;
+                } catch (innerErr) {
+                  markInfrastructureFailure('parse', `OCR output could not be parsed: ${innerErr.message || innerErr}`);
+                  core.warning(redactSecretDiagnostics(`OCR result was not valid JSON and extracted array substring could not be parsed: ${innerErr.message || innerErr}`));
+                  return null;
+                }
+              }
+            }
+
+            function escapeMarkdownHtml(value) {
+              return value
+                .replace(new RegExp('&', 'g'), '&amp;')
+                .replace(new RegExp('<', 'g'), '&lt;')
+                .replace(new RegExp('>', 'g'), '&gt;');
+            }
+
+            function renderFindingText(value) {
+              const sanitized = redactSecretDiagnostics(typeof value === 'string' && value ? value : 'OCR finding');
+              const text = escapeMarkdownHtml(sanitized
+                .replace(/<!--[\s\S]*?-->/g, '')
+                .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+                .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1'))
+                .replace(/@/g, '@\u200b')
+                .replace(/^(\s*[-*]\s*)\[[ xX]\]/gm, '$1\\[ \\]');
+              return `> ${text.replace(/\n/g, '\n> ')}`;
+            }
+
+            function unrenderFindingText(value) {
+              return redactSecretDiagnostics(String(value || 'OCR finding')
+                .replace(/<!--[\s\S]*?-->/g, '')
+                .replace(/^> ?/gm, '')
+                .trim());
+            }
+
+            function inlineCommentKey(comment) {
+              const startLine = comment.start_line || '';
+              return `${comment.path}\u0000${comment.line}\u0000${startLine}\u0000${unrenderFindingText(comment.body)}`;
+            }
+
+            async function existingInlineCommentKeys() {
+              const comments = await github.paginate(github.rest.pulls.listReviewComments, {
+                owner, repo, pull_number: number, per_page: 100,
+              });
+              return new Set(comments
+                .filter((comment) => comment.commit_id === headSha
+                  && typeof comment.body === 'string'
+                  && comment.body.includes(INLINE_MARKER))
+                .map((comment) => inlineCommentKey({
+                  path: comment.path,
+                  line: comment.line || comment.original_line,
+                  start_line: comment.start_line || comment.original_start_line,
+                  body: comment.body,
+                })));
+            }
+            if (policyFailure) {
+              ran = false;
+              core.warning('Skipping OCR output parsing because OCR policy failure was recorded.');
+            } else if (exitCode === 0) {
+              try {
+                const raw = fs.readFileSync('ocr-result.json', 'utf8');
+                const parsed = parseFindings(raw);
+                if (parsed) {
+                  findings = parsed;
+                } else {
+                  ran = false;
+                }
+              } catch (parseErr) {
+                markInfrastructureFailure('parse', `OCR output could not be parsed: ${parseErr.message || parseErr}`);
+                core.warning(redactSecretDiagnostics(`Failed to parse OCR JSON output: ${parseErr.message || parseErr}`));
+                ran = false;
+              }
+            } else {
+              core.warning(`Skipping OCR output parsing because phase ${phase} already recorded exit code ${exitCode}.`);
+            }
+
+            // Split findings into inline (resolvable file/line) vs. lineless.
+            const inline = [];
+            const lineless = [];
+            for (const f of findings) {
+              if (f && f.path && Number.isInteger(f.start_line) &&
+                  Number.isInteger(f.end_line) && f.start_line > 0 && f.end_line > 0) {
+                let startLine = Number(f.start_line);
+                let endLine = Number(f.end_line);
+                if (startLine > endLine) {
+                  [startLine, endLine] = [endLine, startLine];
+                }
+                const rawText = f.content || f.comment || f.message || f.body;
+                const text = renderFindingText(typeof rawText === 'string' ? rawText : 'OCR finding');
+                const comment = {
+                  path: String(f.path),
+                  line: endLine,
+                  side: 'RIGHT',
+                  body: `${INLINE_MARKER}\n${text}`,
+                };
+                if (startLine < endLine) {
+                  comment.start_line = startLine;
+                  comment.start_side = 'RIGHT';
+                }
+                inline.push(comment);
+              } else {
+                lineless.push(f && typeof f === 'object' ? f : { body: f || 'Malformed OCR finding' });
+              }
+            }
+
+            // Post inline comments via a COMMENT review on the head SHA.
+            // Capture the original lineless count so the summary can distinguish
+            // findings that were always positionless from inline comments that
+            // overflowed/fell back into the summary section.
+            const linelessOriginalCount = lineless.length;
+            let postedInline = 0;
+            if (ran && inline.length > 0) {
+              let existingInlineKeys = new Set();
+              try {
+                existingInlineKeys = await existingInlineCommentKeys();
+              } catch (listErr) {
+                core.warning(redactSecretDiagnostics(`Could not list existing OCR inline comments before posting: ${listErr.message || listErr}`));
+              }
+              const inlineToPost = inline.filter((c) => !existingInlineKeys.has(inlineCommentKey(c)));
+              if (inlineToPost.length === 0) {
+                core.info('All OCR inline comments already exist on this head SHA; skipping inline posting.');
+              } else {
+              try {
+                await github.rest.pulls.createReview({
+                  owner, repo, pull_number: number,
+                  event: 'COMMENT', commit_id: headSha, comments: inlineToPost,
+                });
+                postedInline = inlineToPost.length;
+              } catch (batchErr) {
+                core.warning(redactSecretDiagnostics(`Batch review post failed (${inlineToPost.length} comments), falling back to individual posting: ${batchErr.message || batchErr}`));
+                // Fallback: post each inline comment individually, with a cap to avoid secondary rate limits.
+                try {
+                  existingInlineKeys = await existingInlineCommentKeys();
+                } catch (listErr) {
+                  core.warning(redactSecretDiagnostics(`Could not list existing OCR inline comments before fallback posting: ${listErr.message || listErr}`));
+                }
+                const MAX_INLINE_FALLBACK = 50;
+                for (const [index, c] of inlineToPost.entries()) {
+                  if (index >= MAX_INLINE_FALLBACK) {
+                    const lineRange = c.start_line && c.start_line !== c.line
+                      ? `${c.start_line}-${c.line}`
+                      : String(c.line);
+                    const overflowBody = `${unrenderFindingText(c.body)} (line ${lineRange})`;
+                    lineless.push({
+                      path: c.path,
+                      comment: overflowBody,
+                      message: overflowBody,
+                      body: overflowBody,
+                    });
+                    continue;
+                  }
+                  if (existingInlineKeys.has(inlineCommentKey(c))) {
+                    core.warning(`Skipping duplicate OCR inline comment on ${c.path}:${c.line} after batch post uncertainty.`);
+                    postedInline += 1;
+                    continue;
+                  }
+                  try {
+                    await github.rest.pulls.createReviewComment({
+                      owner,
+                      repo,
+                      pull_number: number,
+                      commit_id: headSha,
+                      path: c.path,
+                      line: c.line,
+                      side: c.side,
+                      body: c.body,
+                      ...(c.start_line ? { start_line: c.start_line, start_side: c.start_side } : {}),
+                    });
+                    postedInline += 1;
+                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                  } catch (commentErr) {
+                    core.warning(redactSecretDiagnostics(`Failed to post inline comment on ${c.path}:${c.line}: ${commentErr.message || commentErr}`));
+                    const lineRange = c.start_line && c.start_line !== c.line
+                      ? `${c.start_line}-${c.line}`
+                      : String(c.line);
+                    const fallbackBody = `${unrenderFindingText(c.body)} (line ${lineRange})`;
+                    lineless.push({
+                      path: c.path,
+                      comment: fallbackBody,
+                      message: fallbackBody,
+                      body: fallbackBody,
+                    });
+                  }
+                }
+              }
+              }
+            }
+
+            // Build the sticky summary, including lineless findings.
+            const artifactLine =
+              'Artifacts: `ocr-review-output` contains raw JSON, stdout, stderr, preview, phase, and exit-code diagnostics.';
+            let statusLine;
+            if (!ran) {
+              statusLine = policyFailure
+                ? `OCR policy failure: ${policyFailure}`
+                : 'OCR failed to run or parse output.';
+            } else if (findings.length === 0) {
+              statusLine = 'No findings.';
+            } else {
+              const overflow = lineless.length - linelessOriginalCount;
+              statusLine = overflow > 0
+                ? `${findings.length} finding(s) (${postedInline} posted inline, ${overflow} moved to summary).`
+                : `${findings.length} finding(s) (${postedInline} posted inline).`;
+            }
+            const infrastructureFailure = readTrimmed(INFRA_FAILURE_FILE, '');
+            let body = [
+              MARKER,
+              `## OpenCodeReview — PR #${number}`,
+              '',
+              `- Reviewed head SHA: \`${headSha}\``,
+              `- Merge base: \`${process.env.BASE_SHA}\``,
+              `- OCR version: \`${ocrVersion}\``,
+              `- Phase: \`${diagnosticPhase}\``,
+              `- Exit code: \`${exitCode}\``,
+              `- Run: ${runUrl}`,
+              `- ${statusLine}`,
+              `- ${artifactLine}`,
+            ];
+            if (!ran || infrastructureFailure) {
+              body.push(
+                '',
+                ...stderrSection('OCR stderr excerpt', 'ocr-stderr.log'),
+                '',
+                ...stderrSection('OCR preview stderr excerpt', 'ocr-preview-stderr.log'),
+              );
+            }
+            if (infrastructureFailure) {
+              const sanitizedInfrastructureFailure = redactSecretDiagnostics(infrastructureFailure);
+              const infrastructureDiagnosticLine = `- Infrastructure diagnostic: \`${sanitizedInfrastructureFailure.replace(/`/g, "\\`")}\``;
+              const artifactLineIndex = body.indexOf(`- ${artifactLine}`);
+              if (artifactLineIndex >= 0) {
+                body.splice(artifactLineIndex + 1, 0, infrastructureDiagnosticLine);
+              } else {
+                body.push(infrastructureDiagnosticLine);
+              }
+            }
+            if (lineless.length > 0) {
+              body.push('', '### Findings without a resolvable position', '');
+              for (const f of lineless) {
+                const item = f && typeof f === 'object' ? f : {};
+                const where = item.path ? `\`${item.path}\`: ` : '';
+                const rawText = item.content || item.comment || item.message || item.body;
+                const text = renderFindingText(typeof rawText === 'string' ? rawText : 'OCR finding');
+                body.push(`- ${where}${text}`);
+              }
+            }
+            const summary = body.join('\n');
+
+            // Sticky summary: update in place if the marker exists, else create.
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: number, per_page: 100,
+              });
+              const markerComments = comments.filter((c) =>
+                c.body && c.body.includes(MARKER));
+              const existing = markerComments[0];
+              for (const duplicate of markerComments.slice(1)) {
+                try {
+                  await github.rest.issues.deleteComment({
+                    owner, repo, comment_id: duplicate.id,
+                  });
+                  await new Promise((resolve) => setTimeout(resolve, 1000));
+                } catch (duplicateError) {
+                  core.warning(redactSecretDiagnostics(`Failed to delete duplicate OCR marker comment ${duplicate.id}: ${duplicateError.message || duplicateError}`));
+                }
+              }
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: existing.id, body: summary,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: number, body: summary,
+                });
+              }
+            } catch (summaryError) {
+              core.warning(redactSecretDiagnostics(`Failed to post OCR sticky summary; continuing without failing the workflow: ${summaryError.message || summaryError}`));
+            }
+
+            if (!ran) {
+              if (policyFailure) {
+                core.setFailed(`OCR policy failure: ${policyFailure}`);
+              } else {
+                core.warning(`OpenCodeReview failed or produced unparsable output (exit code ${exitCode}).`);
+              }
+            }
+
+      - name: Resolve OCR failure classification
+        shell: bash
+        id: ocr-classification
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -s ocr-policy-failure.txt ]; then
+            echo "policy_failure=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "policy_failure=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -s ocr-infrastructure-failure.txt ]; then
+            echo "infrastructure_failure=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "infrastructure_failure=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Redact OCR diagnostic artifacts
+        shell: bash
+        if: always()
+        env:
+          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          OCR_LLM_URL: ${{ vars.OCR_LLM_URL }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const REDACTION = '[REDACTED]';
+          const escapeRegExp = (value) => String(value).replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+          const redact = (value) => {
+            let sanitized = String(value ?? '');
+            for (const secret of [process.env.OCR_LLM_TOKEN, process.env.OCR_LLM_URL]) {
+              if (typeof secret === 'string' && secret.length > 0) {
+                sanitized = sanitized.replace(new RegExp(escapeRegExp(secret), 'g'), REDACTION);
+              }
+            }
+            return sanitized
+              .replace(/\b(Authorization\s*:\s*(?:(?:Bearer|Basic|token|ApiKey)\s+)?)([^\s,;]+)/gi, `$1${REDACTION}`)
+              .replace(/\b(x-api-key\s*:\s*)([^\s,;]+)/gi, `$1${REDACTION}`)
+              .replace(/\b(api[_-]?key\s*[=:]\s*)([^\s,;&]+)/gi, `$1${REDACTION}`)
+              .replace(/([?&](?:key|api[_-]?key|token)=)([^\s,;&]+)/gi, `$1${REDACTION}`)
+              .replace(/\b(access[_-]?token\s*[=:]\s*)([^\s,;&]+)/gi, `$1${REDACTION}`)
+              .replace(/\b(refresh[_-]?token\s*[=:]\s*)([^\s,;&]+)/gi, `$1${REDACTION}`)
+              .replace(/\b(id[_-]?token\s*[=:]\s*)([^\s,;&]+)/gi, `$1${REDACTION}`)
+              .replace(/\b(token\s*[=:]\s*)([A-Za-z0-9_./+=:@-]{16,})/gi, `$1${REDACTION}`)
+              .replace(/\b(secret\s*[=:]\s*)([A-Za-z0-9_./+=:@-]{16,})/gi, `$1${REDACTION}`);
+          };
+          const diagnosticArtifacts = [
+            'ocr-result.json',
+            'ocr-stdout.raw',
+            'ocr-stderr.log',
+            'ocr-version.txt',
+            'ocr-preview.txt',
+            'ocr-preview-stderr.log',
+            'ocr-exit-code.txt',
+            'ocr-phase.txt',
+            'ocr-infrastructure-failure.txt',
+            'ocr-policy-failure.txt',
+          ];
+          const replaceWithRedactionFailure = (fileName, error) => {
+            const code = error && error.code ? error.code : 'unknown';
+            const diagnostic = `redaction failed for ${fileName}: ${code}\n`;
+            try {
+              fs.writeFileSync(fileName, diagnostic);
+            } catch (_) {
+              try {
+                fs.rmSync(fileName, { force: true });
+              } catch (_) {
+                process.exitCode = 1;
+              }
+            }
+          };
+          for (const fileName of diagnosticArtifacts) {
+            try {
+              fs.writeFileSync(fileName, redact(fs.readFileSync(fileName, 'utf8')));
+            } catch (error) {
+              if (error && error.code !== 'ENOENT') {
+                replaceWithRedactionFailure(fileName, error);
+              }
+            }
+          }
+          NODE
+      - name: Ensure OCR artifact placeholders exist
+        shell: bash
+        if: always()
+        run: |
+          set -euo pipefail
+          missing=""
+          for file_name in \
+            ocr-result.json \
+            ocr-stdout.raw \
+            ocr-stderr.log \
+            ocr-version.txt \
+            ocr-preview.txt \
+            ocr-preview-stderr.log \
+            ocr-exit-code.txt \
+            ocr-phase.txt \
+            ocr-infrastructure-failure.txt \
+            ocr-policy-failure.txt; do
+            if [ ! -e "$file_name" ]; then
+              : > "$file_name"
+              missing="${missing}${file_name}"$'\n'
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::warning::OCR artifact placeholders were missing before upload:"
+            echo "$missing"
+            if [ ! -s ocr-exit-code.txt ]; then
+              echo "127" > ocr-exit-code.txt
+            fi
+            if [ ! -s ocr-phase.txt ]; then
+              echo "artifact" > ocr-phase.txt
+            fi
+            if [ ! -s ocr-infrastructure-failure.txt ]; then
+              echo "phase=artifact; reason=OCR artifact placeholders were missing before upload" > ocr-infrastructure-failure.txt
+            fi
+          fi
+          for critical_artifact in ocr-exit-code.txt ocr-phase.txt; do
+            if [ ! -s "$critical_artifact" ]; then
+              echo "::warning::Critical OCR artifact $critical_artifact is empty before upload."
+            fi
+          done
+
+      - name: Upload OCR artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
+        with:
+          name: ocr-review-output
+          path: |
+            ocr-result.json
+            ocr-stdout.raw
+            ocr-stderr.log
+            ocr-version.txt
+            ocr-preview.txt
+            ocr-preview-stderr.log
+            ocr-exit-code.txt
+            ocr-phase.txt
+            ocr-infrastructure-failure.txt
+            ocr-policy-failure.txt
+          if-no-files-found: warn
+
+      - name: Clean up scoped safe.directory
+        shell: bash
+        if: always()
+        run: |
+          set +e
+          git config --file "${HOME}/.gitconfig" --unset-all safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
+
+  notify-ocr-infrastructure-failure:
+    name: Notify OCR infrastructure failure
+    runs-on: ubuntu-latest
+    needs: code-review
+    # Skipped/cancelled superseded OCR runs should not create infrastructure issues;
+    # successful runs check artifacts because OCR runtime failures are non-blocking,
+    # and failed runs may still have artifacts from an unexpected later failure.
+    if: ${{ !cancelled() && (needs.code-review.result == 'success' || needs.code-review.result == 'failure') }}
+    timeout-minutes: 5
+    concurrency:
+      group: ocr-review-infrastructure-issue
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      issues: write
+    steps:
+      - name: Download OCR artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: ocr-review-output
+          path: ocr-review-output
+
+      - name: Notify OCR infrastructure failure issue
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CODE_REVIEW_RESULT: ${{ needs.code-review.result }}
+          CODE_REVIEW_POLICY_FAILURE: ${{ needs.code-review.outputs.policy_failure }}
+          CODE_REVIEW_INFRASTRUCTURE_FAILURE: ${{ needs.code-review.outputs.infrastructure_failure }}
+          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          OCR_LLM_URL: ${{ vars.OCR_LLM_URL }}
+        run: |
+          set -uo pipefail
+          sanitize_diagnostics() {
+            local diagnostic
+            local exact_secret
+            local exact_url
+            diagnostic="$1"
+            exact_secret="${OCR_LLM_TOKEN:-}"
+            exact_url="${OCR_LLM_URL:-}"
+            OCR_EXACT_SECRET="$exact_secret" OCR_EXACT_URL="$exact_url" perl -0pe '
+              BEGIN {
+                $redaction = "[REDACTED]";
+                $secret = $ENV{"OCR_EXACT_SECRET"} // "";
+                $url = $ENV{"OCR_EXACT_URL"} // "";
+              }
+              if (length($secret) > 0) {
+                my $quoted_secret = quotemeta($secret);
+                s/$quoted_secret/$redaction/g;
+              }
+              if (length($url) > 0) {
+                my $quoted_url = quotemeta($url);
+                s/$quoted_url/$redaction/g;
+              }
+              s/\b(Authorization\s*:\s*(?:(?:Bearer|Basic|token|ApiKey)\s+)?)([^\s,;]+)/$1$redaction/gi;
+              s/\b(x-api-key\s*:\s*)([^\s,;]+)/$1$redaction/gi;
+              s/\b(api[_-]?key\s*[=:]\s*)([^\s,;&]+)/$1$redaction/gi;
+              s/([?&](?:key|api[_-]?key|token)=)([^\s,;&]+)/$1$redaction/gi;
+              s/\b(access[_-]?token\s*[=:]\s*)([^\s,;&]+)/$1$redaction/gi;
+              s/\b(refresh[_-]?token\s*[=:]\s*)([^\s,;&]+)/$1$redaction/gi;
+              s/\b(id[_-]?token\s*[=:]\s*)([^\s,;&]+)/$1$redaction/gi;
+              s/\b(token\s*[=:]\s*)([A-Za-z0-9_.\/+=:\@-]{16,})/$1$redaction/gi;
+              s/\b(secret\s*[=:]\s*)([A-Za-z0-9_.\/+=:\@-]{16,})/$1$redaction/gi;
+            ' <<< "$diagnostic" || return 1
+          }
+          notify_ocr_infrastructure_failure() {
+            if ! command -v gh >/dev/null 2>&1; then
+              echo "::warning::GitHub CLI is unavailable; skipping OCR infrastructure issue notification."
+              printf '%s\n' '### OCR infrastructure notification skipped' '' 'GitHub CLI was unavailable; see workflow warnings and artifacts for diagnostics.' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+              return 0
+            fi
+            if ! gh auth status >/dev/null 2>&1; then
+              echo "::warning::GitHub CLI is not authenticated; skipping OCR infrastructure issue notification."
+              printf '%s\n' '### OCR infrastructure notification skipped' '' 'GitHub CLI was not authenticated; see workflow warnings and artifacts for diagnostics.' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+              return 0
+            fi
+            exit_code="unknown"
+            phase="unknown"
+            infra_failure=""
+            policy_failure=""
+            if [ -d ocr-review-output ]; then
+              cd ocr-review-output || return 1
+              missing_diagnostics=""
+              for diagnostic_file in ocr-exit-code.txt ocr-phase.txt ocr-infrastructure-failure.txt ocr-policy-failure.txt; do
+                if [ ! -f "$diagnostic_file" ]; then
+                  missing_diagnostics="${missing_diagnostics}${diagnostic_file} "
+                fi
+              done
+              if [ -f ocr-exit-code.txt ] && [ -s ocr-exit-code.txt ]; then
+                raw_exit_code="$(cat ocr-exit-code.txt)"
+                case "$raw_exit_code" in
+                  ''|*[!0-9]*) exit_code="unknown" ;;
+                  *) exit_code="$raw_exit_code" ;;
+                esac
+              fi
+              if [ -f ocr-phase.txt ] && [ -s ocr-phase.txt ]; then
+                phase="$(cat ocr-phase.txt)"
+              fi
+              if [ -f ocr-infrastructure-failure.txt ]; then
+                infra_failure="$(cat ocr-infrastructure-failure.txt)"
+              fi
+              if [ -f ocr-policy-failure.txt ]; then
+                policy_failure="$(cat ocr-policy-failure.txt)"
+              fi
+              if [ -z "$policy_failure" ] && [ "${CODE_REVIEW_POLICY_FAILURE:-}" = "true" ]; then
+                policy_failure="policy failure recorded by code-review job output"
+              fi
+              if [ -z "$infra_failure" ] && [ -n "$missing_diagnostics" ] && [ "${CODE_REVIEW_RESULT:-}" = "failure" ]; then
+                phase="artifact"
+                infra_failure="phase=artifact; reason=OCR diagnostic artifact was incomplete: ${missing_diagnostics}"
+              fi
+              if [ -z "$infra_failure" ] && [ "$exit_code" = "0" ] && [ ! -s ocr-result.json ]; then
+                phase="artifact"
+                infra_failure="phase=artifact; reason=OCR result artifact was missing after a zero-exit review"
+              fi
+            elif [ "${CODE_REVIEW_RESULT:-}" = "failure" ] || [ "${CODE_REVIEW_INFRASTRUCTURE_FAILURE:-}" = "true" ]; then
+              if [ "${CODE_REVIEW_POLICY_FAILURE:-}" = "true" ]; then
+                echo "::notice::OCR policy failure output was set; skipping missing-artifact infrastructure notification."
+                return 0
+              fi
+              phase="artifact"
+              infra_failure="phase=artifact; reason=OCR artifacts were unavailable after code-review completed with failure or infrastructure diagnostics"
+              echo "::warning::OCR artifacts were unavailable after code-review completed with failure or infrastructure diagnostics; creating infrastructure notification."
+            else
+              echo "::warning::OCR artifacts were unavailable; cannot determine whether an infrastructure failure occurred."
+              printf '%s\n' '### OCR artifact diagnostics unavailable' '' 'The OCR artifact download failed, and the code-review job did not report a policy or infrastructure failure output. See workflow logs for details.' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+              return 0
+            fi
+            if [ -n "$policy_failure" ]; then
+              echo "::notice::OCR policy failure detected; skipping infrastructure issue notification."
+              return 0
+            fi
+            if [ -z "$infra_failure" ]; then
+              return 0
+            fi
+            if ! command -v perl >/dev/null 2>&1; then
+              echo "::warning::Perl is unavailable; skipping OCR infrastructure issue notification."
+              printf '%s\n' '### OCR infrastructure notification skipped' '' 'Perl was unavailable, so the final issue-notification sanitizer could not run. See the redacted OCR artifacts and workflow warnings for diagnostics.' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+              return 0
+            fi
+            # Keep ISSUE_TITLE as a simple repository-owned literal; it is used inside gh search strings below.
+            ISSUE_TITLE="OCR review infrastructure failure"
+            if ! sanitized_infra_failure="$(sanitize_diagnostics "$infra_failure")"; then
+              echo "::warning::Failed to sanitize OCR infrastructure diagnostic; skipping notification."
+              return 1
+            fi
+            retry_gh() {
+              local attempt
+              for attempt in 1 2 3 4; do
+                if "$@"; then
+                  return 0
+                fi
+                if [ "$attempt" -lt 4 ]; then
+                  sleep $(( attempt * 5 ))
+                fi
+              done
+              echo "All retries exhausted for: $*" >&2
+              return 1
+            }
+            create_infrastructure_issue() {
+              local issue_body_file
+              issue_body_file="$1"
+              shift
+              if retry_gh gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd"; then
+                return 0
+              fi
+              echo "::warning::Failed to create OCR infrastructure issue with ci/cd label; retrying without labels."
+              if retry_gh gh issue create "$@" --body-file "$issue_body_file"; then
+                return 0
+              fi
+              echo "::warning::Failed to create OCR infrastructure issue."
+              return 1
+            }
+            if ! EXISTING_ISSUE="$(
+              retry_gh gh issue list \
+                --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-desc" \
+                --limit 30 \
+                --json number,title \
+                --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty"
+            )"; then
+              echo "::warning::Failed to search for existing OCR infrastructure issue."
+              return 0
+            fi
+            diagnostic_block="$(printf '%s\n' "$sanitized_infra_failure" | sed 's/^/    /')"
+            body="$(printf 'OCR review infrastructure failure on %s. Phase: %s. Exit code: %s. Artifact: ocr-review-output. Infrastructure diagnostic:\n\n%s\n\nRun: %s. Raw stderr remains available only in the workflow artifact.' "$(TZ=UTC date +'%Y-%m-%d')" "$phase" "$exit_code" "$diagnostic_block" "$RUN_URL")"
+            if ! body_file="$(mktemp)"; then
+              echo "::warning::Failed to create OCR infrastructure issue body file."
+              return 1
+            fi
+            trap 'rm -f "$body_file"' EXIT
+            if ! printf '%s\n' "$body" > "$body_file"; then
+              echo "::warning::Failed to write OCR infrastructure issue body file."
+              rm -f "$body_file"
+              return 1
+            fi
+            if [ -n "$EXISTING_ISSUE" ]; then
+              retry_gh gh issue comment "${EXISTING_ISSUE}" --body-file "$body_file" || echo "::warning::Failed to comment on OCR infrastructure issue."
+              return 0
+            fi
+            if ! EXISTING_ISSUE="$(
+              retry_gh gh issue list \
+                --search "\"${ISSUE_TITLE}\" in:title is:issue state:open sort:created-desc" \
+                --limit 30 \
+                --json number,title \
+                --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty"
+            )"; then
+              echo "::warning::Failed to recheck for existing OCR infrastructure issue before create."
+              return 0
+            fi
+            if [ -n "$EXISTING_ISSUE" ]; then
+              retry_gh gh issue comment "${EXISTING_ISSUE}" --body-file "$body_file" || echo "::warning::Failed to comment on OCR infrastructure issue after recheck."
+              return 0
+            fi
+            create_infrastructure_issue "$body_file" \
+              --title "${ISSUE_TITLE}"
+            return 0
+          }
+          notify_ocr_infrastructure_failure || echo "::warning::OCR infrastructure issue notification failed; continuing."
+          exit 0


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ocr-review.yml` to bring OpenCodeReview (OCR) — an AI-powered code review tool — to the jefe repository, matching the capability already present in the sister repos llxprt-code and llxprt-luther.

Closes #153.

## Approach

Used the **llxprt-code** workflow as the base (the more robust version) because it includes:
- **Infrastructure failure tracking** — classifies failures as infrastructure vs. policy, with a secondary job that auto-creates/tracks a GitHub issue when OCR itself breaks
- **Secret redaction** — redacts LLM tokens/URLs from all artifact files and PR comments before upload/posting
- **Policy failure detection** — distinguishes "OCR broke" from "OCR found a policy violation"
- **Phase tracking** — records which phase failed (install, validate, preview, review, parse)
- **`OCR_NO_UPDATE: 1`** — disables OCR self-update for deterministic CI
- **`timeout-minutes: 45`** — prevents stuck runs
- **Pinned action SHAs** with ratchet comments (security best practice for `pull_request_target`)
- **Local prefix install** (not global) — cleaner isolation per run

## Adaptations for jefe (Rust project)

1. **OCR version pinned to 1.7.5** (both sister repos use 1.6.1, which is outdated)
2. **Rust test file patterns** in the OCR rules JSON:
   ```json
   {
     "include": ["**/*_test.rs", "**/*_tests.rs", "**/tests/**", "**/test/**"],
     "exclude": ["**/target/**", "**/vendor/**", "**/generated/**"]
   }
   ```
3. **Changed-test detection grep** updated for Rust conventions (`_test.rs`, `_tests.rs`, files under `tests/`), with a `grep -v ^target/` guard
4. **Project-specific comment markers**: `jefe-ocr-review` / `jefe-ocr-inline`
5. **`target/` excluded** from OCR review scope

## OCR review findings addressed

Ran `ocr` on the diff before pushing. Addressed 2 of 4 findings:
- **[high] Status line overflow tracking** — added `linelessOriginalCount` to distinguish always-lineless findings from inline comments that overflowed/fell back into the summary
- **[medium] awk parsing sanity check** — added a guard that bails out with an infrastructure failure if the OCR preview "Will review" section is not detected (prevents false policy failures from format changes)

Two findings dismissed as established reference design choices (variable naming for `BASE_SHA`/merge-base, and the self-acknowledged "fine" actions pinning note).

## Required repo configuration

Before the workflow will function, these must be configured:

**Variables** (Settings > Secrets and variables > Actions > Variables):
- `OCR_LLM_URL` — the LLM API endpoint URL
- `OCR_LLM_MODEL` — the model name to use for review
- `OCR_LLM_USE_ANTHROPIC` — (optional) set to `true` if using an Anthropic-compatible endpoint

**Secrets** (Settings > Secrets and variables > Actions > Secrets):
- `OCR_LLM_AUTH_TOKEN` — the API key/token for the LLM provider

## Fork-safety model

Uses `pull_request_target` (not `pull_request`) so secrets are available without being exposed to fork PRs. The trusted base branch is checked out first; the PR head is fetched into an explicit local ref and read for diff computation only. No PR-supplied scripts or OCR rules are executed.

## Non-blocking

OCR is an observational, non-required review signal. The existing CI workflow (`ci.yml`) remains the gating pipeline.

## Test plan

- [x] YAML validated as well-formed
- [x] OCR review run on the diff — findings addressed
- [ ] Workflow runs successfully on a test PR (manual trigger via `workflow_dispatch` with a PR number) — requires repo variables/secrets to be configured first