### PR TITLE
Fix sluggish key input when agent produces output (Fixes #156)

### DIFF
--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -68,14 +68,37 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
         crate::app_init::restore_runtime_sessions(&mut app_state, &ctx);
     }
 
-    // Poll for PTY output updates (~30fps).
+    // Event-driven render: only trigger a re-render when the PTY has new data
+    // (dirty flag) or a safety-net interval (~1s) has elapsed. This avoids
+    // wasteful ~30fps renders that block keyboard input on smol's single
+    // executor thread. PTY dirtiness is only consumed as a render trigger when
+    // the terminal pane is the active focus target — when the user is
+    // navigating agents/repos lists, the safety-net interval is sufficient.
     hooks.use_future({
+        let ctx = ctx.clone();
+        let app_state = app_state;
         let mut render_tick = render_tick;
         async move {
+            const POLL_MS: u64 = 16;
+            const SAFETY_NET_MS: u64 = 1000;
+            let mut elapsed_ms: u64 = 0;
             loop {
-                smol::Timer::after(std::time::Duration::from_millis(33)).await;
-                let tick = render_tick.get();
-                render_tick.set(tick.wrapping_add(1));
+                smol::Timer::after(std::time::Duration::from_millis(POLL_MS)).await;
+                elapsed_ms = elapsed_ms.saturating_add(POLL_MS);
+
+                let terminal_active = {
+                    let state = app_state.read();
+                    state.pane_focus == PaneFocus::Terminal
+                };
+
+                let should_render =
+                    elapsed_ms >= SAFETY_NET_MS || (terminal_active && is_pty_dirty(ctx.as_ref()));
+
+                if should_render {
+                    elapsed_ms = 0;
+                    let tick = render_tick.get();
+                    render_tick.set(tick.wrapping_add(1));
+                }
             }
         }
     });
@@ -783,6 +806,18 @@ fn clear_all_attachments(app_state: &mut HookState<AppState>) {
     }
 }
 
+/// Whether the live PTY snapshot should be skipped because the terminal pane
+/// is not the active focus target.
+///
+/// Only the live PTY snapshot for a running agent is gated — it is the
+/// expensive hot-path operation (cell-by-cell terminal grid iteration under
+/// mutex lock). Dead-agent output capture is a one-shot read and is always
+/// allowed regardless of pane focus.
+#[must_use]
+fn should_skip_live_snapshot(status: AgentStatus, pane_focus: PaneFocus) -> bool {
+    status == AgentStatus::Running && pane_focus != PaneFocus::Terminal
+}
+
 /// Capture terminal output for the currently selected agent if available.
 pub fn capture_terminal_snapshot(
     ctx: Option<&CtxArc>,
@@ -790,9 +825,17 @@ pub fn capture_terminal_snapshot(
     selected_agent_id: Option<&AgentId>,
     selected_running_agent_id: Option<&AgentId>,
 ) -> Option<TerminalSnapshot> {
+    let selected_agent = snapshot.selected_agent()?;
+
+    // Skip the expensive live PTY snapshot when the terminal pane is not the
+    // active focus target. This check runs before locking the ctx mutex so
+    // the render cycle stays cheap while the user navigates agents/repos lists.
+    if should_skip_live_snapshot(selected_agent.status, snapshot.pane_focus) {
+        return None;
+    }
+
     let ctx_arc = ctx?;
     let ctx_guard = ctx_arc.try_lock().ok()?;
-    let selected_agent = snapshot.selected_agent()?;
     match selected_agent.status {
         AgentStatus::Running => selected_running_agent_id
             .as_ref()
@@ -805,5 +848,94 @@ pub fn capture_terminal_snapshot(
                 .and_then(|_| ctx_guard.runtime.capture_session_output(agent_id))
         }),
         _ => None,
+    }
+}
+
+/// Check whether the attached PTY has new data since the last render.
+///
+/// Uses `try_lock` so the timer future never blocks on the `ctx` mutex. When
+/// the lock is contended (e.g. a background attach is running), this returns
+/// `false` — the next poll iteration will try again.
+fn is_pty_dirty(ctx: Option<&CtxArc>) -> bool {
+    let Some(ctx_arc) = ctx else {
+        return false;
+    };
+    let Ok(ctx_guard) = ctx_arc.try_lock() else {
+        return false;
+    };
+    ctx_guard.runtime.take_dirty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jefe::domain::AgentStatus;
+    use jefe::state::PaneFocus;
+
+    // --- should_skip_live_snapshot ---
+
+    #[test]
+    fn should_skip_live_snapshot_for_running_when_pane_is_agents() {
+        assert!(
+            should_skip_live_snapshot(AgentStatus::Running, PaneFocus::Agents),
+            "running agent with Agents pane should be skipped"
+        );
+    }
+
+    #[test]
+    fn should_skip_live_snapshot_for_running_when_pane_is_repositories() {
+        assert!(
+            should_skip_live_snapshot(AgentStatus::Running, PaneFocus::Repositories),
+            "running agent with Repositories pane should be skipped"
+        );
+    }
+
+    #[test]
+    fn should_not_skip_live_snapshot_for_running_when_pane_is_terminal() {
+        assert!(
+            !should_skip_live_snapshot(AgentStatus::Running, PaneFocus::Terminal),
+            "running agent with Terminal pane should NOT be skipped"
+        );
+    }
+
+    #[test]
+    fn should_not_skip_live_snapshot_for_dead_regardless_of_pane() {
+        for focus in [
+            PaneFocus::Agents,
+            PaneFocus::Repositories,
+            PaneFocus::Terminal,
+        ] {
+            assert!(
+                !should_skip_live_snapshot(AgentStatus::Dead, focus),
+                "dead agent with {focus:?} pane should NOT be skipped"
+            );
+        }
+    }
+
+    /// The live-snapshot gate only applies to Running agents. Other statuses
+    /// (Queued, Completed, etc.) are handled by the match arms in
+    /// `capture_terminal_snapshot`, not by this gate.
+    #[test]
+    fn gate_only_affects_running_status() {
+        for focus in [PaneFocus::Agents, PaneFocus::Terminal] {
+            assert!(
+                !should_skip_live_snapshot(AgentStatus::Queued, focus),
+                "queued agent should not be skipped by live-snapshot gate"
+            );
+            assert!(
+                !should_skip_live_snapshot(AgentStatus::Completed, focus),
+                "completed agent should not be skipped by live-snapshot gate"
+            );
+        }
+    }
+
+    // --- is_pty_dirty ---
+
+    #[test]
+    fn is_pty_dirty_returns_false_without_ctx() {
+        assert!(
+            !is_pty_dirty(None),
+            "is_pty_dirty should be false with no ctx"
+        );
     }
 }

--- a/src/runtime/attach.rs
+++ b/src/runtime/attach.rs
@@ -794,7 +794,10 @@ mod tests {
         };
         let snapshot = snapshot_from_term(&guard);
         assert!(
-            snapshot.cells.iter().any(|row| row.iter().any(|c| c.ch == 'X')),
+            snapshot
+                .cells
+                .iter()
+                .any(|row| row.iter().any(|c| c.ch == 'X')),
             "terminal model should contain processed data after read"
         );
     }

--- a/src/runtime/attach.rs
+++ b/src/runtime/attach.rs
@@ -131,6 +131,12 @@ pub struct AttachedViewer {
     term: Arc<Mutex<Term<RuntimeListener>>>,
     /// Liveness flag.
     alive: Arc<AtomicBool>,
+    /// Dirty flag set by the reader thread on every successful PTY read.
+    ///
+    /// The render loop polls this flag to decide whether to re-render. Using
+    /// `Relaxed` ordering is safe because the flag is only a hint — the actual
+    /// terminal state is protected by the `term` mutex.
+    dirty: Arc<AtomicBool>,
     /// Child process handle for deterministic teardown.
     child: Arc<Mutex<Box<dyn PtyChild + Send + Sync>>>,
     /// Reader thread handle.
@@ -495,12 +501,14 @@ impl AttachedViewer {
         let term = Arc::new(Mutex::new(term));
 
         let alive = Arc::new(AtomicBool::new(true));
+        let dirty = Arc::new(AtomicBool::new(false));
 
         // Spawn reader thread
         let term_clone = Arc::clone(&term);
         let alive_clone = Arc::clone(&alive);
+        let dirty_clone = Arc::clone(&dirty);
         let reader_thread = thread::spawn(move || {
-            reader_loop(reader, term_clone, alive_clone);
+            reader_loop(reader, term_clone, alive_clone, dirty_clone);
         });
 
         debug!(session_name = %session_name, "AttachedViewer::spawn ready");
@@ -509,6 +517,7 @@ impl AttachedViewer {
             writer,
             term,
             alive,
+            dirty,
             child,
             _reader_thread: reader_thread,
         })
@@ -517,6 +526,15 @@ impl AttachedViewer {
     /// Check if the viewer is still alive.
     pub fn is_alive(&self) -> bool {
         self.alive.load(Ordering::Relaxed)
+    }
+
+    /// Atomically read and clear the dirty flag.
+    ///
+    /// Returns `true` when new PTY data has arrived since the last call,
+    /// `false` otherwise. The flag is cleared regardless of the return value.
+    #[must_use]
+    pub fn take_dirty(&self) -> bool {
+        self.dirty.swap(false, Ordering::Relaxed)
     }
 
     /// Write input bytes to the PTY.
@@ -648,10 +666,14 @@ impl Drop for AttachedViewer {
 }
 
 /// Reader loop that feeds PTY output into the terminal model.
+///
+/// On every successful read, the `dirty` flag is set so the render loop knows
+/// new terminal data is available and should trigger a re-render.
 fn reader_loop(
     mut reader: Box<dyn Read + Send>,
     term: Arc<Mutex<Term<RuntimeListener>>>,
     alive: Arc<AtomicBool>,
+    dirty: Arc<AtomicBool>,
 ) {
     let mut buf = [0u8; 4096];
     let mut parser: Processor<StdSyncHandler> = Processor::new();
@@ -664,11 +686,7 @@ fn reader_loop(
                 break;
             }
             Ok(n) => {
-                if let Ok(mut term) = term.lock() {
-                    for byte in &buf[..n] {
-                        parser.advance(&mut *term, *byte);
-                    }
-                }
+                process_pty_read(&buf[..n], &mut parser, &term, &dirty);
             }
             Err(_) => {
                 // Reader error - mark viewer as dead
@@ -676,5 +694,108 @@ fn reader_loop(
                 break;
             }
         }
+    }
+}
+
+/// Process a batch of bytes from a PTY read: advance the terminal parser and
+/// mark the viewer dirty so the render loop knows new data arrived.
+///
+/// Extracted from `reader_loop` so the "data arrives → dirty is set" behavior
+/// can be unit-tested without a live PTY.
+fn process_pty_read(
+    bytes: &[u8],
+    parser: &mut Processor<StdSyncHandler>,
+    term: &Mutex<Term<RuntimeListener>>,
+    dirty: &AtomicBool,
+) {
+    if let Ok(mut term) = term.lock() {
+        for byte in bytes {
+            parser.advance(&mut *term, *byte);
+        }
+    }
+    dirty.store(true, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal terminal model for testing `process_pty_read`.
+    fn test_term() -> Arc<Mutex<Term<RuntimeListener>>> {
+        let size = TermDimensions { cols: 80, rows: 24 };
+        Arc::new(Mutex::new(Term::new(
+            TermConfig::default(),
+            &size,
+            RuntimeListener,
+        )))
+    }
+
+    /// Processing a batch of PTY bytes must set the dirty flag — this is the
+    /// core wiring between the reader thread and the event-driven render loop.
+    #[test]
+    fn process_pty_read_marks_viewer_dirty() {
+        let term = test_term();
+        let dirty = Arc::new(AtomicBool::new(false));
+        let mut parser: Processor<StdSyncHandler> = Processor::new();
+
+        assert!(
+            !dirty.load(Ordering::Relaxed),
+            "dirty should be false before any data arrives"
+        );
+
+        process_pty_read(b"hello world", &mut parser, &term, &dirty);
+
+        assert!(
+            dirty.load(Ordering::Relaxed),
+            "dirty must be set after PTY data arrives"
+        );
+
+        // take_dirty() pattern: swap clears and returns the previous value.
+        assert!(
+            dirty.swap(false, Ordering::Relaxed),
+            "take_dirty must return true after data arrived"
+        );
+        assert!(
+            !dirty.load(Ordering::Relaxed),
+            "take_dirty must clear the flag"
+        );
+
+        // A second take_dirty() returns false (no new data since last clear).
+        assert!(
+            !dirty.swap(false, Ordering::Relaxed),
+            "take_dirty must return false when no new data"
+        );
+    }
+
+    /// Processing a PTY batch advances the terminal parser model (not just
+    /// the dirty flag), proving the wiring feeds real bytes into the `Term`.
+    #[test]
+    fn process_pty_read_advances_terminal_model() {
+        let term = test_term();
+        let dirty = Arc::new(AtomicBool::new(false));
+        let mut parser: Processor<StdSyncHandler> = Processor::new();
+
+        // A blank terminal has no content in the first cell.
+        {
+            let Ok(guard) = term.lock() else {
+                panic!("term lock should succeed");
+            };
+            let snapshot = snapshot_from_term(&guard);
+            assert_eq!(
+                snapshot.cells[0][0].ch, ' ',
+                "terminal should be blank before processing"
+            );
+        }
+
+        process_pty_read(b"X", &mut parser, &term, &dirty);
+
+        let Ok(guard) = term.lock() else {
+            panic!("term lock should succeed");
+        };
+        let snapshot = snapshot_from_term(&guard);
+        assert!(
+            snapshot.cells.iter().any(|row| row.iter().any(|c| c.ch == 'X')),
+            "terminal model should contain processed data after read"
+        );
     }
 }

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -118,6 +118,15 @@ pub trait RuntimeManager: Send {
     /// Whether the attached application currently has bracketed paste enabled.
     fn bracketed_paste_active(&self) -> bool;
 
+    /// Atomically read and clear the dirty flag on the attached viewer.
+    ///
+    /// Returns `true` when new PTY data has arrived since the last call,
+    /// `false` otherwise. This enables event-driven rendering: the render loop
+    /// only triggers a re-render when the terminal content has actually changed,
+    /// avoiding wasteful ~30fps renders that block keyboard input processing.
+    #[must_use]
+    fn take_dirty(&self) -> bool;
+
     /// Get a reference to a session by agent ID.
     fn get_session(&self, agent_id: &AgentId) -> Option<&RuntimeSession>;
 
@@ -251,6 +260,10 @@ impl RuntimeManager for StubRuntimeManager {
     }
 
     fn bracketed_paste_active(&self) -> bool {
+        false
+    }
+
+    fn take_dirty(&self) -> bool {
         false
     }
 
@@ -728,6 +741,10 @@ impl RuntimeManager for TmuxRuntimeManager {
             .is_some_and(AttachedViewer::bracketed_paste_active)
     }
 
+    fn take_dirty(&self) -> bool {
+        self.viewer.as_ref().is_some_and(AttachedViewer::take_dirty)
+    }
+
     fn get_session(&self, agent_id: &AgentId) -> Option<&RuntimeSession> {
         self.sessions.get(agent_id)
     }
@@ -842,5 +859,25 @@ mod tests {
         mgr.record_clipboard_passthrough("jefe-agent-b");
         assert!(mgr.clipboard_passthrough_enforced("jefe-agent-a"));
         assert!(mgr.clipboard_passthrough_enforced("jefe-agent-b"));
+    }
+
+    #[test]
+    fn stub_take_dirty_always_returns_false() {
+        let mgr = StubRuntimeManager::default();
+        // The stub has no real PTY, so the dirty flag is always false.
+        assert!(
+            !mgr.take_dirty(),
+            "StubRuntimeManager should never be dirty"
+        );
+    }
+
+    #[test]
+    fn tmux_take_dirty_returns_false_without_viewer() {
+        let mgr = TmuxRuntimeManager::new(40, 120);
+        // No viewer attached → take_dirty must return false (not panic).
+        assert!(
+            !mgr.take_dirty(),
+            "take_dirty should return false when no viewer is attached"
+        );
     }
 }


### PR DESCRIPTION
## Summary

When jefe hosts an agent actively producing output (spinner, cursor blink, log tail), switching between agents or repos was extremely sluggish — key presses were visibly delayed. This PR replaces the unconditional 33ms render tick with event-driven rendering and gates the expensive PTY snapshot on terminal pane focus.

Closes #156

## Root Cause

The blanket 33ms render tick forced a full synchronous render ~30x/sec on iocraft's single-threaded smol executor. Keyboard events can't be processed while a render is in progress. When a hosted agent is active, each render cycle:

1. Locks the vte `Term` mutex (contending with the reader thread)
2. Iterates every cell (~8,000 cells for a 48x170 terminal), resolving ANSI colors
3. Builds iocraft elements, lays them out, diffs the canvas
4. Writes the full canvas to the terminal

All of this blocks the executor, delaying keyboard input.

Additionally, `capture_terminal_snapshot()` fired unconditionally — even when the user was navigating the agents/repos list with the terminal pane not focused.

## Changes

### Option A: Event-driven rendering (eliminates unnecessary renders)

- **`src/runtime/attach.rs`**: Added an `AtomicBool` dirty flag to `AttachedViewer`. The reader thread (`reader_loop`) sets it on every successful PTY read via the extracted `process_pty_read()` helper. Added `take_dirty()` method that atomically reads and clears the flag.
- **`src/runtime/manager.rs`**: Exposed `take_dirty()` through the `RuntimeManager` trait. `TmuxRuntimeManager` delegates to the viewer; `StubRuntimeManager` returns `false`.
- **`src/app_shell.rs`**: Replaced the unconditional 33ms timer with a 16ms poll that only triggers a re-render when the PTY is dirty (or a 1s safety-net interval elapses). PTY dirtiness is only consumed as a render trigger when the terminal pane is the active focus target — background agent output does not drive renders while the user navigates lists.

### Option B: Pane-focus snapshot gating (makes each render cheaper)

- **`src/app_shell.rs`**: Added pure helper `should_skip_live_snapshot(status, pane_focus)` that gates the expensive live PTY snapshot on `pane_focus == Terminal`. The gate runs before locking the ctx mutex. Dead-agent output capture is not gated (one-shot read, not a hot-path operation).

## Performance Impact

| Scenario | Before | After |
|---|---|---|
| No agent running | ~30fps renders (cheap, canvas unchanged) | ~1fps safety-net renders |
| Terminal focused + agent active | ~30fps renders (expensive snapshot each) | ~62fps max (dirty-triggered, snapshot taken) |
| Navigating lists + agent active | ~30fps renders (expensive snapshot wasted) | ~1fps safety-net (no snapshot, no dirty consumption) |

## Testing

- Unit tests for `should_skip_live_snapshot()` covering all agent-status x pane-focus combinations
- Behavioral tests for `process_pty_read()` proving data arrival marks the viewer dirty and advances the terminal model
- Tests for `RuntimeManager::take_dirty()` on both TmuxRuntimeManager (no viewer → false) and StubRuntimeManager (always false)
- Test for `is_pty_dirty()` returning false without ctx

## Verification

All CI gates pass locally:
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- Complexity clippy pass (cognitive_complexity, too_many_lines, etc.)
- `scripts/check-clippy-allows.sh`
- `scripts/check-source-file-size.sh`
- `cargo build --workspace --all-features --locked`
- `cargo test --workspace --all-features --locked` (238 tests, 0 failures)
- `cargo llvm-cov --fail-under-lines 30` (64.35% coverage)