### PR TITLE
Show live terminal preview for running agents without pane-focus gate (Fixes #160)

### DIFF
--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -99,7 +99,14 @@ pub fn init_app_state(app_state: &mut HookState<AppState>, ctx: &SharedContext) 
     state.selected_agent_index = persisted.selected_agent_index;
     state.hide_idle_repositories = persisted.hide_idle_repositories;
     state.last_selected_agent_by_repo = persisted.last_selected_agent_by_repo;
-    state.terminal_focused = false;
+    // Restore the persisted pane focus and terminal-focus so an explicitly
+    // focused view survives restart (issue #160). `terminal_focused` is only
+    // meaningful when the terminal pane is active, so clamp an inconsistent
+    // persisted pair (terminal_focused=true but pane != Terminal) back to false;
+    // the per-keypress defensive guard in app_shell would clear it anyway.
+    state.pane_focus = crate::app_input::pane_focus_from_persisted(&persisted.pane_focus);
+    state.terminal_focused =
+        persisted.terminal_focused && state.pane_focus == jefe::state::PaneFocus::Terminal;
     state.rebuild_repository_agent_ids();
     state.normalize_selection_indices();
 

--- a/src/app_input/app_input_tests.rs
+++ b/src/app_input/app_input_tests.rs
@@ -46,6 +46,7 @@ fn sample_agent(agent_id: &AgentId) -> Agent {
 #[test]
 fn filter_and_search_messages_are_fresh_issue_list_reloads() {
     use super::issues_list_dispatch::is_fresh_issue_list_reload;
+
     assert!(is_fresh_issue_list_reload(&IssuesMessage::EnterMode));
     assert!(is_fresh_issue_list_reload(&IssuesMessage::RefocusList));
     assert!(is_fresh_issue_list_reload(&IssuesMessage::ApplyFilter));
@@ -223,6 +224,43 @@ fn to_persisted_state_carries_hide_idle_toggle() {
 
     let persisted = to_persisted_state(&state);
     assert!(persisted.hide_idle_repositories);
+}
+
+#[test]
+fn to_persisted_state_carries_pane_focus_and_terminal_focused() {
+    let state = AppState {
+        pane_focus: PaneFocus::Terminal,
+        terminal_focused: true,
+        ..AppState::default()
+    };
+
+    let persisted = to_persisted_state(&state);
+    assert_eq!(persisted.pane_focus, "terminal");
+    assert!(persisted.terminal_focused);
+}
+
+#[test]
+fn pane_focus_round_trip_all_variants() {
+    for focus in [
+        PaneFocus::Repositories,
+        PaneFocus::Agents,
+        PaneFocus::Terminal,
+    ] {
+        let s = pane_focus_to_persisted(focus);
+        assert_eq!(
+            pane_focus_from_persisted(&s),
+            focus,
+            "round-trip for {focus:?}"
+        );
+    }
+}
+
+#[test]
+fn pane_focus_from_persisted_unknown_defaults_to_repositories() {
+    // Older state files written before this field existed have "" or an
+    // unrecognized value; both must fall back to Repositories.
+    assert_eq!(pane_focus_from_persisted(""), PaneFocus::Repositories);
+    assert_eq!(pane_focus_from_persisted("bogus"), PaneFocus::Repositories);
 }
 
 /// to_persisted_state must EXCLUDE all prs_state data — no PR key appears in

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -7,6 +7,7 @@ mod issues_list_dispatch;
 mod issues_mutation;
 mod modal_handlers;
 mod normal;
+mod persist_focus;
 mod preflight;
 
 // PR-mode key-routing + dispatch surface.
@@ -60,7 +61,7 @@ const MAC_ALT_DIGIT_SHORTCUTS: &[(char, u8)] = &[
 ];
 use jefe::input::{SearchKeyRoute, route_search_key};
 use jefe::messages::{AppMessage, IssuesMessage, RuntimeMessage, UiNavigationMessage};
-use jefe::persistence::{PersistenceManager, State as PersistedState};
+use jefe::persistence::State as PersistedState;
 const REMOTE_ATTACH_SETTLE_DELAY: Duration = Duration::from_millis(150);
 
 use jefe::runtime::{RuntimeError, RuntimeManager, sandbox_preflight, sandbox_ssh_agent_warning};
@@ -145,17 +146,12 @@ pub fn to_persisted_state(state: &AppState) -> PersistedState {
         selected_agent_index: state.selected_agent_index,
         hide_idle_repositories: state.hide_idle_repositories,
         last_selected_agent_by_repo: state.last_selected_agent_by_repo.clone(),
+        pane_focus: pane_focus_to_persisted(state.pane_focus),
+        terminal_focused: state.terminal_focused,
     }
 }
 
-pub fn persist_state(ctx: &SharedContext, persisted: &PersistedState) {
-    if let Some(ctx_arc) = &ctx
-        && let Ok(ctx_guard) = ctx_arc.lock()
-        && let Err(e) = ctx_guard.persistence.save_state(persisted)
-    {
-        warn!(error = %e, "could not save state");
-    }
-}
+pub use persist_focus::{pane_focus_from_persisted, pane_focus_to_persisted, persist_state};
 
 fn launch_signature_for_agent(
     agent: &jefe::domain::Agent,

--- a/src/app_input/persist_focus.rs
+++ b/src/app_input/persist_focus.rs
@@ -1,0 +1,49 @@
+//! Persistence helpers: state serialization and pane-focus conversion.
+//!
+//! `pane_focus_to_persisted` / `pane_focus_from_persisted` bridge the state-layer
+//! `PaneFocus` enum and the string form stored in the persisted `State` DTO. They
+//! live in the app-shell layer (not in `persistence/`) because the persistence
+//! module is restricted to `domain/` dependencies and cannot reference
+//! `state::PaneFocus`. See issue #160.
+
+use tracing::warn;
+
+use jefe::persistence::{PersistenceManager, State as PersistedState};
+use jefe::state::PaneFocus;
+
+use super::SharedContext;
+
+/// Serialize a `PaneFocus` to its persisted string form.
+#[must_use]
+pub fn pane_focus_to_persisted(focus: PaneFocus) -> String {
+    match focus {
+        PaneFocus::Repositories => "repositories",
+        PaneFocus::Agents => "agents",
+        PaneFocus::Terminal => "terminal",
+    }
+    .to_owned()
+}
+
+/// Parse a persisted pane-focus string back into `PaneFocus`.
+///
+/// Unknown or empty strings (e.g. older state files written before this field
+/// existed) fall back to `Repositories`, matching the pre-existing default.
+#[must_use]
+pub fn pane_focus_from_persisted(value: &str) -> PaneFocus {
+    match value {
+        "agents" => PaneFocus::Agents,
+        "terminal" => PaneFocus::Terminal,
+        _ => PaneFocus::Repositories,
+    }
+}
+
+/// Persist the current state to disk via the shared context's persistence
+/// manager. Failures are logged but never crash the app.
+pub fn persist_state(ctx: &SharedContext, persisted: &PersistedState) {
+    if let Some(ctx_arc) = ctx
+        && let Ok(ctx_guard) = ctx_arc.lock()
+        && let Err(e) = ctx_guard.persistence.save_state(persisted)
+    {
+        warn!(error = %e, "could not save state");
+    }
+}

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -92,13 +92,12 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
                     let state = app_state.read();
                     state.pane_focus == PaneFocus::Terminal
                 };
-                let running_preview = !terminal_focused
-                    && {
-                        let state = app_state.read();
-                        state
-                            .selected_agent()
-                            .is_some_and(|agent| agent.status == AgentStatus::Running)
-                    };
+                let running_preview = !terminal_focused && {
+                    let state = app_state.read();
+                    state
+                        .selected_agent()
+                        .is_some_and(|agent| agent.status == AgentStatus::Running)
+                };
 
                 let dirty = is_pty_dirty(ctx.as_ref());
                 let should_render = elapsed_ms >= SAFETY_NET_MS

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -71,9 +71,10 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     // Event-driven render: only trigger a re-render when the PTY has new data
     // (dirty flag) or a safety-net interval (~1s) has elapsed. This avoids
     // wasteful ~30fps renders that block keyboard input on smol's single
-    // executor thread. PTY dirtiness is only consumed as a render trigger when
-    // the terminal pane is the active focus target — when the user is
-    // navigating agents/repos lists, the safety-net interval is sufficient.
+    // executor thread. PTY dirtiness triggers fast renders when the terminal
+    // pane has input focus; for a read-only preview (Running agent selected but
+    // terminal not focused), dirty renders are throttled to avoid starving the
+    // input loop while navigating lists (issue #160).
     hooks.use_future({
         let ctx = ctx.clone();
         let app_state = app_state;
@@ -81,18 +82,28 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
         async move {
             const POLL_MS: u64 = 16;
             const SAFETY_NET_MS: u64 = 1000;
+            const PREVIEW_THROTTLE_MS: u64 = 250;
             let mut elapsed_ms: u64 = 0;
             loop {
                 smol::Timer::after(std::time::Duration::from_millis(POLL_MS)).await;
                 elapsed_ms = elapsed_ms.saturating_add(POLL_MS);
 
-                let terminal_active = {
+                let terminal_focused = {
                     let state = app_state.read();
                     state.pane_focus == PaneFocus::Terminal
                 };
+                let running_preview = !terminal_focused
+                    && {
+                        let state = app_state.read();
+                        state
+                            .selected_agent()
+                            .is_some_and(|agent| agent.status == AgentStatus::Running)
+                    };
 
-                let should_render =
-                    elapsed_ms >= SAFETY_NET_MS || (terminal_active && is_pty_dirty(ctx.as_ref()));
+                let dirty = is_pty_dirty(ctx.as_ref());
+                let should_render = elapsed_ms >= SAFETY_NET_MS
+                    || (terminal_focused && dirty)
+                    || (running_preview && elapsed_ms >= PREVIEW_THROTTLE_MS && dirty);
 
                 if should_render {
                     elapsed_ms = 0;
@@ -813,16 +824,15 @@ fn clear_all_attachments(app_state: &mut HookState<AppState>) {
     }
 }
 
-/// Whether the live PTY snapshot should be skipped because the terminal pane
-/// is not the active focus target.
+/// Whether the live PTY snapshot should be attempted for the selected agent.
 ///
-/// Only the live PTY snapshot for a running agent is gated — it is the
-/// expensive hot-path operation (cell-by-cell terminal grid iteration under
-/// mutex lock). Dead-agent output capture is a one-shot read and is always
-/// allowed regardless of pane focus.
+/// Previously gated on `pane_focus == Terminal` for Running agents via
+/// `should_skip_live_snapshot(status, pane_focus)` (issue #160); now always
+/// attempts for Running agents so the terminal renders as a read-only preview
+/// regardless of which pane has focus. Dead agents also get a one-shot capture.
 #[must_use]
-fn should_skip_live_snapshot(status: AgentStatus, pane_focus: PaneFocus) -> bool {
-    status == AgentStatus::Running && pane_focus != PaneFocus::Terminal
+fn wants_live_snapshot(status: AgentStatus) -> bool {
+    matches!(status, AgentStatus::Running | AgentStatus::Dead)
 }
 
 /// Capture terminal output for the currently selected agent if available.
@@ -834,13 +844,22 @@ pub fn capture_terminal_snapshot(
 ) -> Option<TerminalSnapshot> {
     let selected_agent = snapshot.selected_agent()?;
 
-    // Skip the expensive live PTY snapshot when the terminal pane is not the
-    // active focus target. This check runs before locking the ctx mutex so
-    // the render cycle stays cheap while the user navigates agents/repos lists.
-    if should_skip_live_snapshot(selected_agent.status, snapshot.pane_focus) {
+    // The live PTY snapshot is attempted for any Running agent whose viewer is
+    // attached, regardless of pane focus. Decoupling the snapshot from
+    // `pane_focus` lets the terminal render as a read-only *preview* while the
+    // user navigates the agents/repos lists (and after restart), so a healthy
+    // live session is never mistaken for a lost one (issue #160). Keystroke
+    // forwarding is controlled separately by `terminal_focused`.
+    //
+    // Early-return for statuses that never produce a snapshot, before locking
+    // the ctx mutex.
+    if !wants_live_snapshot(selected_agent.status) {
         return None;
     }
 
+    // `try_lock` keeps the render cycle non-blocking: when a background attach
+    // holds the ctx mutex, this frame simply returns None and the next frame
+    // picks up the snapshot.
     let ctx_arc = ctx?;
     let ctx_guard = ctx_arc.try_lock().ok()?;
     match selected_agent.status {
@@ -879,59 +898,47 @@ mod tests {
     use jefe::domain::AgentStatus;
     use jefe::state::PaneFocus;
 
-    // --- should_skip_live_snapshot ---
+    // --- wants_live_snapshot (issue #160 gate removal) ---
+    //
+    // The old `should_skip_live_snapshot(status, pane_focus)` gate suppressed
+    // Running-agent snapshots when `pane_focus != Terminal`. That gate was
+    // removed; `wants_live_snapshot` is the replacement decision function that
+    // depends ONLY on agent status, never on pane focus. These tests pin that
+    // contract: a Running agent's snapshot is always eligible, so the terminal
+    // renders as a read-only preview after restart and during list navigation.
 
     #[test]
-    fn should_skip_live_snapshot_for_running_when_pane_is_agents() {
-        assert!(
-            should_skip_live_snapshot(AgentStatus::Running, PaneFocus::Agents),
-            "running agent with Agents pane should be skipped"
-        );
-    }
-
-    #[test]
-    fn should_skip_live_snapshot_for_running_when_pane_is_repositories() {
-        assert!(
-            should_skip_live_snapshot(AgentStatus::Running, PaneFocus::Repositories),
-            "running agent with Repositories pane should be skipped"
-        );
-    }
-
-    #[test]
-    fn should_not_skip_live_snapshot_for_running_when_pane_is_terminal() {
-        assert!(
-            !should_skip_live_snapshot(AgentStatus::Running, PaneFocus::Terminal),
-            "running agent with Terminal pane should NOT be skipped"
-        );
-    }
-
-    #[test]
-    fn should_not_skip_live_snapshot_for_dead_regardless_of_pane() {
+    fn wants_live_snapshot_for_running_regardless_of_pane() {
+        // Running agents always get a snapshot attempt. `wants_live_snapshot`
+        // does NOT take pane_focus — proving the old focus gate is gone.
         for focus in [
             PaneFocus::Agents,
             PaneFocus::Repositories,
             PaneFocus::Terminal,
         ] {
+            let _ = focus; // pane focus is intentionally irrelevant
             assert!(
-                !should_skip_live_snapshot(AgentStatus::Dead, focus),
-                "dead agent with {focus:?} pane should NOT be skipped"
+                wants_live_snapshot(AgentStatus::Running),
+                "Running status must always want a live snapshot (pane_focus={focus:?})"
             );
         }
     }
 
-    /// The live-snapshot gate only applies to Running agents. Other statuses
-    /// (Queued, Completed, etc.) are handled by the match arms in
-    /// `capture_terminal_snapshot`, not by this gate.
     #[test]
-    fn gate_only_affects_running_status() {
-        for focus in [PaneFocus::Agents, PaneFocus::Terminal] {
+    fn wants_live_snapshot_for_dead() {
+        // Dead agents get a one-shot pane capture.
+        assert!(
+            wants_live_snapshot(AgentStatus::Dead),
+            "Dead status must want a snapshot capture"
+        );
+    }
+
+    #[test]
+    fn does_not_want_live_snapshot_for_idle_statuses() {
+        for status in [AgentStatus::Queued, AgentStatus::Completed] {
             assert!(
-                !should_skip_live_snapshot(AgentStatus::Queued, focus),
-                "queued agent should not be skipped by live-snapshot gate"
-            );
-            assert!(
-                !should_skip_live_snapshot(AgentStatus::Completed, focus),
-                "completed agent should not be skipped by live-snapshot gate"
+                !wants_live_snapshot(status),
+                "{status:?} should not produce a terminal snapshot"
             );
         }
     }

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -586,8 +586,9 @@ fn seed_sticky_agent_state(config_dir: &std::path::Path, agent_session: &str) {
         selected_agent_index: Some(0),
         hide_idle_repositories: false,
         last_selected_agent_by_repo: vec![],
+        pane_focus: String::new(),
+        terminal_focused: false,
     };
-
     let paths = PersistencePaths {
         settings_path: config_dir.join("settings.toml"),
         state_path: config_dir.join("state.json"),
@@ -828,8 +829,9 @@ fn seed_restart_agent_state(config_dir: &std::path::Path, agent_session: &str) {
         selected_agent_index: Some(0),
         hide_idle_repositories: false,
         last_selected_agent_by_repo: vec![],
+        pane_focus: String::new(),
+        terminal_focused: false,
     };
-
     let paths = PersistencePaths {
         settings_path: config_dir.join("settings.toml"),
         state_path: config_dir.join("state.json"),

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -97,6 +97,17 @@ pub struct State {
     pub hide_idle_repositories: bool,
     #[serde(default)]
     pub last_selected_agent_by_repo: Vec<(RepositoryId, AgentId)>,
+    /// Persisted pane focus ("repositories" | "agents" | "terminal"). Stored
+    /// as a string rather than the state-layer `PaneFocus` enum so this module
+    /// stays within its `domain/`-only dependency budget. Conversion lives in
+    /// the app-shell layer (`app_input`/`app_init`).
+    #[serde(default)]
+    pub pane_focus: String,
+    /// Whether the terminal pane had input focus at last save. Restored on
+    /// startup so a focused terminal survives restart (issue #160), clamped to
+    /// consistency with `pane_focus` during restore.
+    #[serde(default)]
+    pub terminal_focused: bool,
 }
 
 impl State {
@@ -110,6 +121,8 @@ impl State {
             selected_agent_index: None,
             hide_idle_repositories: false,
             last_selected_agent_by_repo: Vec::new(),
+            pane_focus: String::new(),
+            terminal_focused: false,
         }
     }
 }

--- a/src/persistence/tests.rs
+++ b/src/persistence/tests.rs
@@ -159,8 +159,9 @@ fn file_persistence_roundtrip_state() {
         selected_agent_index: None,
         hide_idle_repositories: true,
         last_selected_agent_by_repo: vec![],
+        pane_focus: String::new(),
+        terminal_focused: false,
     };
-
     mgr.save_state(&state).value_or_panic("should save");
     let loaded = mgr.load_state().value_or_panic("should load");
 
@@ -168,6 +169,37 @@ fn file_persistence_roundtrip_state() {
     assert!(loaded.hide_idle_repositories);
 
     // Cleanup
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+/// Pane focus and terminal focus must survive a save/load round-trip (issue #160).
+#[test]
+fn file_persistence_roundtrip_pane_focus_and_terminal_focused() {
+    let temp = std::env::temp_dir().join("jefe_test_roundtrip_focus");
+    let _ = std::fs::remove_dir_all(&temp);
+    let paths = PersistencePaths {
+        settings_path: temp.join("settings.toml"),
+        state_path: temp.join("state.json"),
+    };
+    let mgr = FilePersistenceManager::with_paths(paths);
+
+    let state = State {
+        schema_version: STATE_SCHEMA_VERSION,
+        repositories: vec![],
+        agents: vec![],
+        selected_repository_index: None,
+        selected_agent_index: None,
+        hide_idle_repositories: false,
+        last_selected_agent_by_repo: vec![],
+        pane_focus: "terminal".to_string(),
+        terminal_focused: true,
+    };
+    mgr.save_state(&state).value_or_panic("should save");
+    let loaded = mgr.load_state().value_or_panic("should load");
+
+    assert_eq!(loaded.pane_focus, "terminal");
+    assert!(loaded.terminal_focused);
+
     let _ = std::fs::remove_dir_all(&temp);
 }
 
@@ -225,8 +257,9 @@ fn test_issue_base_prompt_state_round_trip() {
         selected_agent_index: None,
         hide_idle_repositories: false,
         last_selected_agent_by_repo: vec![],
+        pane_focus: String::new(),
+        terminal_focused: false,
     };
-
     let temp = std::env::temp_dir().join("jefe_test_p13_issue_base_prompt_roundtrip");
     let _ = std::fs::remove_dir_all(&temp);
     let paths = PersistencePaths {

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -27,6 +27,7 @@ use crate::ui::components::issue_detail::issue_detail_header_view;
 use crate::ui::components::issue_list::{IssueListLayout, issue_list_visible_rows};
 use crate::ui::components::pr_detail::pr_detail_header_view;
 use crate::ui::components::pr_list::pr_list_visible_rows;
+use crate::ui::components::terminal_empty_message;
 
 /// Separator line rendered between the fixed detail header and the scrollable
 /// content, mirroring the components' `"─────…"` row.
@@ -92,7 +93,7 @@ pub fn pane_content_lines(
         SelectablePane::Sidebar => sidebar_lines(state),
         SelectablePane::AgentList => agent_list_lines(state),
         SelectablePane::Preview => preview_lines(state),
-        SelectablePane::TerminalView => terminal_lines(snapshot),
+        SelectablePane::TerminalView => terminal_lines(snapshot, state),
         SelectablePane::HelpModal => help_lines(),
         SelectablePane::StatusBar => status_bar_lines(state),
         SelectablePane::KeybindBar => keybind_bar_lines(state),
@@ -272,11 +273,17 @@ fn preview_lines(state: &AppState) -> PaneContent {
     PaneContent::new(SelectablePane::Preview, lines)
 }
 
-fn terminal_lines(snapshot: Option<&TerminalSnapshot>) -> PaneContent {
+fn terminal_lines(snapshot: Option<&TerminalSnapshot>, state: &AppState) -> PaneContent {
     let Some(snap) = snapshot else {
+        // A Running selected agent has a live session even before the viewer
+        // finishes attaching; mirror the TerminalView empty-state copy so a
+        // healthy session is not mistaken for a lost one (issue #160).
+        let session_live = state
+            .selected_agent()
+            .is_some_and(|agent| agent.status == AgentStatus::Running);
         return PaneContent::new(
             SelectablePane::TerminalView,
-            vec!["No terminal attached".to_string()],
+            vec![terminal_empty_message(session_live).to_string()],
         );
     };
     let lines: Vec<String> = (0..snap.rows)
@@ -378,6 +385,39 @@ mod tests {
             40,
         );
         assert_eq!(content.lines, vec!["No terminal attached".to_string()]);
+    }
+
+    /// A Running selected agent with no snapshot yet shows the reassuring
+    /// "session live" hint rather than the misleading "No terminal attached"
+    /// (issue #160).
+    #[test]
+    fn terminal_lines_none_snapshot_running_agent_shows_session_live() {
+        use crate::domain::{Agent, AgentId, Repository, RepositoryId};
+        let repo_id = RepositoryId("r1".to_string());
+        let mut state = AppState::default();
+        state.repositories.push(Repository::new(
+            repo_id.clone(),
+            "repo".to_string(),
+            "repo".to_string(),
+            std::path::PathBuf::from("/tmp/repo"),
+        ));
+        let agent_id = AgentId("a1".to_string());
+        let mut agent = Agent::new(
+            agent_id,
+            repo_id,
+            "agent".to_string(),
+            std::path::PathBuf::from("/tmp/agent"),
+        );
+        agent.status = AgentStatus::Running;
+        state.agents.push(agent);
+        state.selected_repository_index = Some(0);
+        state.selected_agent_index = Some(0);
+
+        let content = pane_content_lines(SelectablePane::TerminalView, &state, None, 120, 40);
+        assert_eq!(
+            content.lines,
+            vec!["Session live - press t to focus terminal".to_string()]
+        );
     }
 
     #[test]

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -62,7 +62,7 @@ pub use preview::{Preview, PreviewProps};
 pub use scrollable_text::{ScrollableText, ScrollableTextProps};
 pub use sidebar::{Sidebar, SidebarProps};
 pub use status_bar::{StatusBar, StatusBarProps};
-pub use terminal_view::{TerminalView, TerminalViewProps};
+pub use terminal_view::{TerminalView, TerminalViewProps, terminal_empty_message};
 /// @plan PLAN-20260624-PR-MODE.P14
 /// @requirement REQ-PR-009
 /// @requirement REQ-PR-010

--- a/src/ui/components/terminal_view.rs
+++ b/src/ui/components/terminal_view.rs
@@ -38,6 +38,25 @@ pub struct TerminalViewProps {
     /// Active text selection, if any. Selected cells are painted in
     /// inverse-video over the terminal grid for live drag-selection feedback.
     pub selection: Option<TextSelection>,
+    /// Whether the selected agent has a live session (Running) even though no
+    /// snapshot is currently available (e.g. the viewer has not finished
+    /// attaching). When true the empty-state copy distinguishes a healthy live
+    /// session from a genuinely unattached terminal (issue #160).
+    pub session_live: bool,
+}
+
+/// Empty-state message for the terminal pane when no snapshot is available.
+///
+/// Pure (iocraft-free) so it is unit-testable. A Running agent with no snapshot
+/// yet gets a reassuring "session live" hint; everything else reports no
+/// terminal attached.
+#[must_use]
+pub fn terminal_empty_message(session_live: bool) -> &'static str {
+    if session_live {
+        "Session live - press t to focus terminal"
+    } else {
+        "No terminal attached"
+    }
 }
 
 /// Terminal view showing the PTY output for the attached agent.
@@ -95,7 +114,7 @@ pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>>
                 } else {
                     element! {
                         Box {
-                            Text(content: "No terminal attached", color: rc.dim)
+                            Text(content: terminal_empty_message(props.session_live), color: rc.dim)
                         }
                     }
                     .into_any()
@@ -473,5 +492,20 @@ mod tests {
         let total: usize = runs.iter().map(|r| r.width).sum();
         assert_eq!(total, 3);
         assert_eq!(runs[0].text, "abc");
+    }
+
+    // --- terminal_empty_message (issue #160) ---
+
+    #[test]
+    fn empty_message_live_session_when_session_live() {
+        assert_eq!(
+            terminal_empty_message(true),
+            "Session live - press t to focus terminal"
+        );
+    }
+
+    #[test]
+    fn empty_message_no_terminal_when_not_live() {
+        assert_eq!(terminal_empty_message(false), "No terminal attached");
     }
 }

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -93,6 +93,14 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
     });
     let selected_agent_data = state.and_then(|s| s.selected_agent().cloned());
 
+    // Whether the selected agent is Running with a live session. Threading this
+    // to TerminalView lets the empty-state copy distinguish a healthy live
+    // session (viewer not yet attached) from a genuinely unattached terminal
+    // (issue #160).
+    let session_live = selected_agent_data
+        .as_ref()
+        .is_some_and(crate::domain::Agent::is_running);
+
     // Resolve colors with green screen fallback
     let colors = props.colors.clone().unwrap_or_default();
     let rc = ResolvedColors::from_theme(Some(&colors));
@@ -165,6 +173,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                             focused: terminal_focused,
                             colors: colors.clone(),
                             selection: selection,
+                            session_live: session_live,
                         )
                     }
                 }

--- a/tests/e2e/end_to_end.rs
+++ b/tests/e2e/end_to_end.rs
@@ -182,6 +182,8 @@ fn persistence_roundtrip_preserves_state() {
         selected_agent_index: Some(0),
         hide_idle_repositories: false,
         last_selected_agent_by_repo: vec![],
+        pane_focus: String::new(),
+        terminal_focused: false,
     };
 
     // Save and reload

--- a/tests/e2e/recovery_paths.rs
+++ b/tests/e2e/recovery_paths.rs
@@ -236,6 +236,8 @@ fn startup_recovery_corrupt_settings_valid_state() {
         selected_agent_index: None,
         hide_idle_repositories: false,
         last_selected_agent_by_repo: vec![],
+        pane_focus: String::new(),
+        terminal_focused: false,
     };
     let state_json = serde_json::to_string(&valid_state).test_unwrap("test unwrap");
     fs::write(&state_path, state_json).test_unwrap("test unwrap");

--- a/tests/ui/dashboard_reorder.rs
+++ b/tests/ui/dashboard_reorder.rs
@@ -511,6 +511,8 @@ fn reordered_repository_vec_order_matches_persisted_order() {
         selected_agent_index: state.selected_agent_index,
         hide_idle_repositories: state.hide_idle_repositories,
         last_selected_agent_by_repo: state.last_selected_agent_by_repo.clone(),
+        pane_focus: String::new(),
+        terminal_focused: false,
     };
 
     assert_eq!(persisted.repositories[0].name, "bravo");

--- a/tests/ui/dashboard_reorder_tui.rs
+++ b/tests/ui/dashboard_reorder_tui.rs
@@ -52,6 +52,8 @@ fn seed_reorder_state(config_dir: &Path) {
         selected_agent_index: Some(0),
         hide_idle_repositories: false,
         last_selected_agent_by_repo: vec![],
+        pane_focus: String::new(),
+        terminal_focused: false,
     };
 
     let paths = PersistencePaths {


### PR DESCRIPTION
## Summary

Fixes #160 — Running agents showed "No terminal attached" after restart and during agent-list navigation, even though the underlying tmux sessions were alive and attached. The root cause was a render gate (`should_skip_live_snapshot`) that suppressed the terminal snapshot for Running agents whenever `pane_focus != Terminal`, conflating input routing with preview rendering.

## Changes

### 1. Core fix: Decouple snapshot from pane focus
- Removed `should_skip_live_snapshot(status, pane_focus)` in `src/app_shell.rs`
- Extracted pure `wants_live_snapshot(status)` decision function that depends only on agent status (Running/Dead), never on pane focus — so the terminal renders as a read-only preview regardless of which pane has focus
- Changed the render-tick future to throttle preview dirty-renders at 250ms (`PREVIEW_THROTTLE_MS`) when a Running agent is selected but the terminal pane is not focused. Full-rate dirty renders still apply when the terminal pane has focus. Safety-net interval (1s) unchanged.
- `capture_terminal_snapshot` now uses `wants_live_snapshot` as an early-return guard for non-Running/Dead statuses (before locking the ctx mutex), then proceeds to attempt the snapshot for any Running agent via `try_lock`

### 2. Persist pane_focus + terminal_focused across restarts
- Added `pane_focus: String` and `terminal_focused: bool` (both `#[serde(default)]`) to persisted `State` in `src/persistence/mod.rs`
- Stored as String/bool to respect the persistence layer domain-only dependency budget (cannot import `state::PaneFocus`)
- Conversion functions `pane_focus_to_persisted`/`pane_focus_from_persisted` live in new `src/app_input/persist_focus.rs` (also houses the moved `persist_state`)
- `init_app_state` now restores pane_focus/terminal_focused with a consistency clamp (`terminal_focused && pane_focus == Terminal`) instead of force-resetting `terminal_focused = false`

### 3. Better empty-state copy
- Added pure `terminal_empty_message(session_live)` function in `src/ui/components/terminal_view.rs` returning "Session live - press t to focus terminal" for live-but-unattached agents vs "No terminal attached" for genuinely unattached
- Added `session_live: bool` to `TerminalViewProps`; Dashboard computes it from `selected_agent.is_running()`
- Text-selection content (`src/selection/content.rs`) mirrors the same copy

## Symptoms fixed

- **Restart symptom**: After restarting jefe, a selected Running agent now shows its live terminal as a read-only preview (or the restored focused state) instead of "No terminal attached"
- **Navigation symptom**: The terminal preview stays visible when navigating between agents — no need to press t per agent
- **Misleading copy**: A healthy live session shows "Session live - press t to focus terminal" instead of implying the connection was lost

## Architecture

Respects the module boundary DAG: persistence layer stays domain-only (String/bool representation), conversion at the app-shell layer, runtime owns PTY, UI receives `session_live` as render data.

## Test coverage

- `wants_live_snapshot` pure decision tests (Running always eligible regardless of pane focus)
- `terminal_empty_message` pure function tests
- `pane_focus_to_persisted`/`pane_focus_from_persisted` round-trip + unknown-value fallback
- `to_persisted_state` includes pane_focus + terminal_focused assertions
- Persistence round-trip with non-default focus values
- Selection content mirror test for Running agent empty-state copy
- All 238 existing tests pass