### PR TITLE
Extract generic SelectableList from IssueList, PrList, AgentList (Fixes #144)

### DIFF
--- a/src/selection/text.rs
+++ b/src/selection/text.rs
@@ -11,9 +11,10 @@ use crate::selection::PaneGeometry;
 /// ordered roughly top-to-bottom, left-to-right to match how the panes appear,
 /// but ordering carries no semantic weight — comparisons use
 /// [`SelectionPoint`] ordering, not the enum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum SelectablePane {
     /// Repository sidebar (left column, all screen modes).
+    #[default]
     Sidebar,
     /// Agent list (dashboard middle column, top).
     AgentList,

--- a/src/ui/components/agent_list.rs
+++ b/src/ui/components/agent_list.rs
@@ -1,109 +1,128 @@
-//! Agent list component.
+//! Agent list projection for the generic [`SelectableList`] component.
+//!
+//! The agent list pane used to have its own iocraft `AgentList` component; the
+//! rendering is now owned by [`crate::ui::components::SelectableList`]. This
+//! module keeps the domain-specific projection ([`agent_list_props`]) that maps
+//! each agent into a [`SelectableRow`] with a fixed-color status glyph span and
+//! a themed name span.
 //!
 //! @plan PLAN-20260216-FIRSTVERSION-V1.P09
 //! @requirement REQ-FUNC-002
 //! @requirement REQ-FUNC-006
 
-use iocraft::prelude::*;
-
 use crate::domain::{Agent, AgentStatus};
-use crate::selection::{SelectablePane, TextSelection, row_highlight_range};
-use crate::theme::{ResolvedColors, ThemeColors};
+use crate::selection::{SelectablePane, TextSelection};
+use crate::theme::ThemeColors;
+use crate::ui::components::selectable_list::{
+    ListBorder, SelectableListProps, SelectableRow, SelectableSpan, SelectionStyle, SpanColor,
+    SpanRole,
+};
 
-/// Props for the agent list component.
-#[derive(Default, Props)]
-pub struct AgentListProps {
-    /// List of agents.
-    pub agents: Vec<Agent>,
-    /// Currently selected agent index.
-    pub selected: usize,
-    /// Whether this pane is focused.
-    pub focused: bool,
-    /// Local index of a grabbed agent (dashboard reorder indicator).
-    pub grabbed: Option<usize>,
-    /// Theme colors.
-    pub colors: ThemeColors,
-    /// Active text selection, if any (and if it targets this pane). Selected
-    /// rows are painted in inverse video for live drag-selection feedback.
-    pub selection: Option<TextSelection>,
+/// Status glyph rendered before the agent name (single character).
+///
+/// Matches the pre-refactor `AgentList` component's `status_icon` match arms.
+fn status_icon(status: AgentStatus) -> &'static str {
+    match status {
+        AgentStatus::Running => "*",
+        AgentStatus::Completed => "+",
+        AgentStatus::Dead => "x",
+        AgentStatus::Errored => "!",
+        AgentStatus::Waiting => "?",
+        AgentStatus::Paused => "-",
+        AgentStatus::Queued => "o",
+    }
 }
 
-/// Agent list showing agents for the current repository.
-#[component]
-pub fn AgentList(props: &AgentListProps) -> impl Into<AnyElement<'static>> {
-    let rc = ResolvedColors::from_theme(Some(&props.colors));
-    let border_color = if props.focused {
-        rc.border_focused
+/// Semantic color role for the status glyph, immune to selection/highlight.
+///
+/// Matches the pre-refactor `AgentList` component's `status_color` match arms;
+/// the generic [`SelectableList`] resolves the role against the theme.
+fn status_role(status: AgentStatus) -> SpanRole {
+    match status {
+        AgentStatus::Running | AgentStatus::Completed => SpanRole::Bright,
+        AgentStatus::Dead | AgentStatus::Errored => SpanRole::Red,
+        AgentStatus::Waiting => SpanRole::Yellow,
+        AgentStatus::Paused => SpanRole::Blue,
+        AgentStatus::Queued => SpanRole::Dim,
+    }
+}
+
+/// Build the prefix string for an agent row: `↕ ` when grabbed, `> ` when
+/// selected, otherwise two spaces.
+fn agent_prefix(is_selected: bool, grabbed: bool) -> &'static str {
+    if grabbed {
+        "\u{2195} "
+    } else if is_selected {
+        "> "
     } else {
-        rc.border
-    };
+        "  "
+    }
+}
 
-    element! {
-        Box(
-            flex_direction: FlexDirection::Column,
-            width: 100pct,
-            height: 100pct,
-            border_style: BorderStyle::Round,
-            border_color: border_color,
-            background_color: rc.bg,
-        ) {
-            // Title
-            Box(height: 1u32, padding_left: 1u32) {
-                Text(content: "Agents", weight: Weight::Bold, color: rc.fg)
-            }
+/// Project one agent into a [`SelectableRow`] with three spans: prefix, status
+/// glyph (fixed role), and ` {shortcut}{name}` (themed).
+fn to_selectable_row(agent: &Agent, is_selected: bool, grabbed: bool) -> SelectableRow {
+    let shortcut_label = agent
+        .shortcut_slot
+        .map_or_else(String::new, |slot| format!("[{slot}] "));
+    SelectableRow {
+        spans: vec![
+            SelectableSpan {
+                text: agent_prefix(is_selected, grabbed).to_string(),
+                color: SpanColor::Themed,
+            },
+            SelectableSpan {
+                text: status_icon(agent.status).to_string(),
+                color: SpanColor::Role(status_role(agent.status)),
+            },
+            SelectableSpan {
+                text: format!(" {}{}", shortcut_label, agent.name),
+                color: SpanColor::Themed,
+            },
+        ],
+        meta_line: None,
+        is_selected,
+    }
+}
 
-            // Agent list
-            Box(
-                flex_direction: FlexDirection::Column,
-                flex_grow: 1.0,
-                padding: 1u32,
-                background_color: rc.bg,
-            ) {
-                #(props.agents.iter().enumerate().map(|(i, agent)| {
-                    let selected = i == props.selected;
-                    let grabbed = props.grabbed.is_some_and(|idx| idx == i);
-                    let status_icon = match agent.status {
-                        AgentStatus::Running => "*",
-                        AgentStatus::Completed => "+",
-                        AgentStatus::Dead => "x",
-                        AgentStatus::Errored => "!",
-                        AgentStatus::Waiting => "?",
-                        AgentStatus::Paused => "-",
-                        AgentStatus::Queued => "o",
-                    };
-                    let status_color = match agent.status {
-                        AgentStatus::Running | AgentStatus::Completed => rc.bright,
-                        AgentStatus::Dead | AgentStatus::Errored => Color::Red,
-                        AgentStatus::Waiting => Color::Yellow,
-                        AgentStatus::Paused => Color::Blue,
-                        AgentStatus::Queued => rc.dim,
-                    };
-                    let prefix = if grabbed {
-                        "\u{2195} "
-                    } else if selected {
-                        "> "
-                    } else {
-                        "  "
-                    };
-                    let highlighted = props.selection.as_ref()
-                        .filter(|s| s.pane() == SelectablePane::AgentList)
-                        .and_then(|s| row_highlight_range(s, i))
-                        .is_some();
-                    let row_bg = if highlighted { rc.sel_bg } else { rc.bg };
-                    let name_color = if selected { rc.bright } else { rc.fg };
-                    let name_color = if highlighted { rc.sel_fg } else { name_color };
-                    let shortcut_label = agent.shortcut_slot
-                        .map_or_else(String::new, |slot| format!("[{slot}] "));
-                    element! {
-                        Box(flex_direction: FlexDirection::Row, background_color: row_bg) {
-                            Text(content: prefix, color: name_color)
-                            Text(content: status_icon, color: status_color)
-                            Text(content: format!(" {}{}", shortcut_label, agent.name), color: name_color)
-                        }
-                    }
-                    .into_any()
-                }))
-            }
-        }
+/// Build [`SelectableListProps`] for the agent list pane.
+///
+/// Projects each agent into a [`SelectableRow`] with a fixed-color status glyph
+/// and a themed name span. Uses the agent-style border/padding/selection policy
+/// so rendered output is byte-identical to the pre-refactor `AgentList`
+/// component.
+///
+/// @plan PLAN-20260216-FIRSTVERSION-V1.P09
+/// @requirement REQ-FUNC-002
+/// @requirement REQ-FUNC-006
+#[must_use]
+pub fn agent_list_props(
+    agents: &[Agent],
+    selected: usize,
+    grabbed: Option<usize>,
+    focused: bool,
+    colors: ThemeColors,
+    selection: Option<TextSelection>,
+) -> SelectableListProps {
+    let rows = agents
+        .iter()
+        .enumerate()
+        .map(|(i, agent)| {
+            let is_selected = i == selected;
+            let is_grabbed = grabbed.is_some_and(|idx| idx == i);
+            to_selectable_row(agent, is_selected, is_grabbed)
+        })
+        .collect();
+    SelectableListProps {
+        title: "Agents".to_string(),
+        rows,
+        focused,
+        empty_message: None,
+        colors,
+        selection,
+        pane: SelectablePane::AgentList,
+        border: ListBorder::RoundFocusedColor,
+        content_padding: true,
+        selection_style: SelectionStyle::BrightSelected,
     }
 }

--- a/src/ui/components/issue_list.rs
+++ b/src/ui/components/issue_list.rs
@@ -1,14 +1,23 @@
-//! Issue list pane component.
+//! Issue list pane projection for the generic [`SelectableList`] component.
+//!
+//! The issue list pane used to have its own iocraft `IssueList` component; the
+//! rendering is now owned by [`crate::ui::components::SelectableList`]. This
+//! module keeps the pure projection ([`issue_list_visible_rows`]) plus the
+//! [`issue_list_props`] wrapper that maps the projected rows into
+//! [`crate::ui::components::SelectableRow`]s.
+//!
 //! @plan PLAN-20260329-ISSUES-MODE.P12
 //! @plan PLAN-20260329-ISSUES-MODE.P14
 //! @requirement REQ-ISS-006
 
-use iocraft::prelude::*;
 use unicode_width::UnicodeWidthStr;
 
 use crate::domain::{Issue, IssueState};
-use crate::selection::{HighlightRange, TextSelection, row_highlight_range};
-use crate::theme::{ResolvedColors, RowColors, SelectionColors, ThemeColors};
+use crate::selection::{SelectablePane, TextSelection};
+use crate::theme::ThemeColors;
+use crate::ui::components::selectable_list::{
+    ListBorder, SelectableListProps, SelectableRow, SelectableSpan, SelectionStyle, SpanColor,
+};
 
 /// Rows consumed by the bordered list container and title before item content.
 const LIST_CHROME_ROWS: u16 = 3;
@@ -27,34 +36,6 @@ impl IssueListLayout {
     fn is_compact(self) -> bool {
         matches!(self, Self::Compact)
     }
-}
-
-/// Props for the issue list pane.
-#[derive(Default, Props)]
-pub struct IssueListProps {
-    /// Issues to display.
-    pub issues: Vec<Issue>,
-    /// Currently selected index.
-    pub selected_index: Option<usize>,
-    /// Issue-list pane height in rows, including border and title chrome.
-    pub list_pane_rows: u16,
-    /// Whether this pane is focused.
-    pub focused: bool,
-    /// Whether issues are loading.
-    pub loading: bool,
-    /// Whether filters are active (affects empty-state message).
-    pub has_filters: bool,
-    /// List density variant.
-    pub layout: IssueListLayout,
-    /// Theme colors.
-    pub colors: ThemeColors,
-    /// Available content width (in terminal columns) for title truncation.
-    ///
-    /// When provided, long issue titles are truncated with an ellipsis to fit.
-    pub available_width: Option<u16>,
-    /// Active text selection, if any (and if it targets this pane). Selected
-    /// cells are painted in inverse video for live drag-selection feedback.
-    pub selection: Option<TextSelection>,
 }
 
 /// Projected issue-list row exactly as the component renders it.
@@ -152,11 +133,90 @@ pub fn issue_list_visible_rows(
         .collect()
 }
 
+/// Map already-windowed [`IssueListRowView`]s into [`SelectableRow`]s for the
+/// generic [`crate::ui::components::SelectableList`]. The title line becomes a
+/// single themed span; the meta line is carried through (empty string in
+/// compact mode signals a single-line row). Takes the views by value so the
+/// owned strings move into the spans without per-row clones.
+fn to_selectable_rows(views: Vec<IssueListRowView>) -> Vec<SelectableRow> {
+    views
+        .into_iter()
+        .map(|v| SelectableRow {
+            spans: vec![SelectableSpan {
+                text: v.title_line,
+                color: SpanColor::Themed,
+            }],
+            meta_line: Some(v.meta_line),
+            is_selected: v.is_selected,
+        })
+        .collect()
+}
+
+/// Windowing/geometry inputs for [`issue_list_props`].
+///
+/// Bundles the parameters that [`issue_list_visible_rows`] needs to compute the
+/// visible window. Keeping them in a struct keeps [`issue_list_props`] under the
+/// argument-count limit.
+///
+/// @plan PLAN-20260630-ISSUES-REGRESSION.P01
+/// @requirement REQ-ISS-006
+#[derive(Clone, Copy, Debug)]
+pub struct IssueListWindow {
+    /// Currently selected issue index.
+    pub selected_index: Option<usize>,
+    /// Issue-list pane height in rows, including border and title chrome.
+    pub list_pane_rows: u16,
+    /// List density variant.
+    pub layout: IssueListLayout,
+    /// Available content width (in terminal columns) for title truncation.
+    pub available_width: Option<u16>,
+}
+
+/// Build [`SelectableListProps`] for the issue list pane.
+///
+/// Calls the unchanged [`issue_list_visible_rows`] projection and maps each
+/// [`IssueListRowView`] into a [`SelectableRow`]. The empty/loading message is
+/// computed by the caller via [`issue_list_status_message`] and passed in as
+/// `empty_message`.
+///
+/// @plan PLAN-20260630-ISSUES-REGRESSION.P01
+/// @requirement REQ-ISS-006
+#[must_use]
+pub fn issue_list_props(
+    issues: &[Issue],
+    window: IssueListWindow,
+    focused: bool,
+    empty_message: Option<&str>,
+    colors: ThemeColors,
+    selection: Option<TextSelection>,
+) -> SelectableListProps {
+    let rows = issue_list_visible_rows(
+        issues,
+        window.selected_index,
+        window.list_pane_rows,
+        window.layout,
+        window.available_width,
+    );
+    SelectableListProps {
+        title: "Issues".to_string(),
+        rows: to_selectable_rows(rows),
+        focused,
+        empty_message: empty_message.map(String::from),
+        colors,
+        selection,
+        pane: SelectablePane::IssueList,
+        border: ListBorder::DoubleOnFocus,
+        content_padding: false,
+        selection_style: SelectionStyle::BoldSelected,
+    }
+}
+
 /// Loading/empty status line for the issue list. Returns `None` when rows show.
 /// @plan PLAN-20260630-ISSUES-REGRESSION.P01
 /// @requirement REQ-ISS-006
 /// @pseudocode component-001 lines 1-12
-fn issue_list_status_message(
+#[must_use]
+pub fn issue_list_status_message(
     loading: bool,
     is_empty: bool,
     has_filters: bool,
@@ -172,132 +232,6 @@ fn issue_list_status_message(
     } else {
         None
     }
-}
-
-/// Issue list pane — renders issues with selection highlight, loading, and empty states.
-/// @plan PLAN-20260329-ISSUES-MODE.P14
-/// @requirement REQ-ISS-006
-#[component]
-pub fn IssueList(props: &IssueListProps) -> impl Into<AnyElement<'static>> {
-    let rc = ResolvedColors::from_theme(Some(&props.colors));
-    let border_style = if props.focused {
-        BorderStyle::Double
-    } else {
-        BorderStyle::Round
-    };
-    let status_msg =
-        issue_list_status_message(props.loading, props.issues.is_empty(), props.has_filters);
-
-    element! {
-        Box(
-            flex_direction: FlexDirection::Column,
-            width: 100pct,
-            height: 100pct,
-            border_style: border_style,
-            border_color: rc.border,
-            background_color: rc.bg,
-        ) {
-            Box(height: 1u32, padding_left: 1u32) {
-                Text(content: "Issues", weight: Weight::Bold, color: rc.fg)
-            }
-            Box(
-                flex_direction: FlexDirection::Column,
-                flex_grow: 1.0,
-                background_color: rc.bg,
-            ) {
-                #(if let Some(msg) = status_msg {
-                    vec![element! {
-                        Box(padding_left: 1u32, height: 1u32) {
-                            Text(content: msg, color: rc.dim)
-                        }
-                    }
-                    .into_any()]
-                } else {
-                    let rows = props;
-                    let projected = issue_list_visible_rows(
-                        &rows.issues,
-                        rows.selected_index,
-                        rows.list_pane_rows,
-                        rows.layout,
-                        rows.available_width,
-                    );
-                    projected.iter().enumerate().map(|(window_i, view)| {
-                        let highlight = rows.selection.as_ref().and_then(|s| {
-                            if s.pane() == crate::selection::SelectablePane::IssueList {
-                                row_highlight_range(s, window_i)
-                            } else {
-                                None
-                            }
-                        });
-                        render_issue_row(
-                            view,
-                            rows.layout.is_compact(),
-                            highlight,
-                            RowColors::from_resolved(&rc),
-                            SelectionColors::from_resolved(&rc),
-                            rc.dim,
-                        )
-                    }).collect()
-                })
-            }
-        }
-    }
-}
-
-/// Render a single issue-list row, applying the selection-row highlight when
-/// the row falls inside an active drag selection. Mirrors the pr_list helper.
-fn render_issue_row(
-    view: &IssueListRowView,
-    compact: bool,
-    highlight: Option<HighlightRange>,
-    row_colors: RowColors,
-    highlight_colors: SelectionColors,
-    dim: Color,
-) -> AnyElement<'static> {
-    let title_line = view.title_line.as_str();
-    let meta_line = view.meta_line.as_str();
-    let is_selected = view.is_selected;
-
-    // When a drag selection covers this row, paint the whole row in the
-    // selection colors. Keyboard selection uses a separate highlight color
-    // (`is_selected`) for text emphasis (bold) but not inverse-video.
-    let highlighted = highlight.is_some();
-    let row_bg = if highlighted {
-        highlight_colors.bg
-    } else {
-        row_colors.bg
-    };
-    let title_fg = if highlighted {
-        highlight_colors.fg
-    } else {
-        row_colors.fg
-    };
-    let weight = if is_selected {
-        Weight::Bold
-    } else {
-        Weight::Normal
-    };
-
-    if compact {
-        return element! {
-            Box(height: 1u32, background_color: row_bg) {
-                Text(content: title_line, color: title_fg, weight: weight)
-            }
-        }
-        .into_any();
-    }
-
-    element! {
-        Box(flex_direction: FlexDirection::Column) {
-            Box(height: 1u32, background_color: row_bg) {
-                Text(content: title_line, color: title_fg, weight: weight)
-            }
-            Box(height: 1u32, background_color: row_bg) {
-                Text(content: meta_line, color: if highlighted { highlight_colors.fg } else { dim })
-            }
-        }
-    }
-    .into_any()
 }
 
 #[cfg(test)]

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -30,6 +30,10 @@ pub(crate) mod pr_filter_controls;
 pub(crate) mod pr_list;
 mod preview;
 mod scrollable_text;
+/// Generic bordered, scrollable, selectable list used by the Issue, PR, and
+/// Agent list panes. Domain layers project into [`SelectableRow`]s; this
+/// component owns the iocraft rendering once.
+pub(crate) mod selectable_list;
 mod sidebar;
 mod status_bar;
 mod terminal_view;
@@ -42,10 +46,12 @@ mod terminal_view;
 mod text_box;
 
 pub use agent_chooser::{AgentChooser, AgentChooserProps};
-pub use agent_list::{AgentList, AgentListProps};
+pub use agent_list::agent_list_props;
 pub use filter_controls::{FilterControls, FilterControlsProps};
 pub use issue_detail::{IssueDetailView, IssueDetailViewProps};
-pub use issue_list::{IssueList, IssueListLayout, IssueListProps};
+pub use issue_list::{
+    IssueListLayout, IssueListWindow, issue_list_props, issue_list_status_message,
+};
 pub use keybind_bar::{KeybindBar, KeybindBarProps};
 /// @requirement REQ-PR-009
 pub use merge_chooser::{MergeChooser, MergeChooserProps};
@@ -57,9 +63,13 @@ pub use pr_detail::{PrDetailView, PrDetailViewProps};
 pub use pr_filter_controls::{PrFilterControls, PrFilterControlsProps};
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-006
-pub use pr_list::{PrList, PrListLayout, PrListProps};
+pub use pr_list::{PrListLayout, PrListWindow, pr_list_props, pr_list_status_message};
 pub use preview::{Preview, PreviewProps};
 pub use scrollable_text::{ScrollableText, ScrollableTextProps};
+pub use selectable_list::{
+    ListBorder, SelectableList, SelectableListProps, SelectableRow, SelectableSpan, SelectionStyle,
+    SpanColor, SpanRole, selectable_list_element,
+};
 pub use sidebar::{Sidebar, SidebarProps};
 pub use status_bar::{StatusBar, StatusBarProps};
 pub use terminal_view::{TerminalView, TerminalViewProps, terminal_empty_message};

--- a/src/ui/components/pr_list.rs
+++ b/src/ui/components/pr_list.rs
@@ -246,6 +246,8 @@ pub fn pr_list_status_message(
     }
 }
 
+/// Map a PR state to its short uppercase tag used in the list meta line.
+///
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-006
 /// @pseudocode component-001 lines 1-12

--- a/src/ui/components/pr_list.rs
+++ b/src/ui/components/pr_list.rs
@@ -1,14 +1,23 @@
-//! PR list pane component.
+//! PR list pane projection for the generic [`SelectableList`] component.
+//!
+//! The PR list pane used to have its own iocraft `PrList` component; the
+//! rendering is now owned by [`crate::ui::components::SelectableList`]. This
+//! module keeps the pure projection ([`pr_list_visible_rows`]) plus the
+//! [`pr_list_props`] wrapper that maps the projected rows into
+//! [`crate::ui::components::SelectableRow`]s.
+//!
 //! @plan PLAN-20260624-PR-MODE.P12
 //! @requirement REQ-PR-006
 //! @requirement REQ-PR-014
 
-use iocraft::prelude::*;
 use unicode_width::UnicodeWidthStr;
 
 use crate::domain::{PrCheckStatus, PrReviewState, PrState, PullRequest};
-use crate::selection::{HighlightRange, TextSelection, row_highlight_range};
-use crate::theme::{ResolvedColors, RowColors, SelectionColors, ThemeColors};
+use crate::selection::{SelectablePane, TextSelection};
+use crate::theme::ThemeColors;
+use crate::ui::components::selectable_list::{
+    ListBorder, SelectableListProps, SelectableRow, SelectableSpan, SelectionStyle, SpanColor,
+};
 
 /// PR list density variant.
 ///
@@ -31,39 +40,6 @@ impl PrListLayout {
     fn is_compact(self) -> bool {
         matches!(self, Self::Compact)
     }
-}
-
-/// Props for the PR list pane.
-///
-/// @plan PLAN-20260624-PR-MODE.P12
-/// @requirement REQ-PR-006
-/// @requirement REQ-PR-014
-/// @pseudocode component-001 lines 1-12
-#[derive(Default, Props)]
-pub struct PrListProps {
-    /// Pull requests to display.
-    pub pull_requests: Vec<PullRequest>,
-    /// Currently selected index.
-    pub selected_index: Option<usize>,
-    /// First-visible row offset (selection-follow).
-    pub list_scroll_offset: usize,
-    /// PR-list pane height in rows.
-    pub list_pane_rows: u16,
-    /// Whether this pane is focused.
-    pub focused: bool,
-    /// Whether pull requests are loading.
-    pub loading: bool,
-    /// Whether filters are active (affects empty-state message).
-    pub has_filters: bool,
-    /// List density variant.
-    pub layout: PrListLayout,
-    /// Theme colors.
-    pub colors: ThemeColors,
-    /// Available content width (in terminal columns) for title truncation.
-    pub available_width: Option<u16>,
-    /// Active text selection, if any (and if it targets this pane). Selected
-    /// cells are painted in inverse video for live drag-selection feedback.
-    pub selection: Option<TextSelection>,
 }
 
 /// Projected PR list row exactly as the component renders it.
@@ -167,12 +143,91 @@ pub fn pr_list_visible_rows(
         .collect()
 }
 
+/// Map already-windowed [`PrListRowView`]s into [`SelectableRow`]s for the
+/// generic [`crate::ui::components::SelectableList`]. In compact mode the meta
+/// line is replaced with an empty string so the list renders a single-line row
+/// (matching the pre-refactor `render_pr_row` compact path). Takes the views by
+/// value so the owned strings move into the spans without per-row clones.
+fn to_selectable_rows(views: Vec<PrListRowView>, compact: bool) -> Vec<SelectableRow> {
+    views
+        .into_iter()
+        .map(|v| SelectableRow {
+            spans: vec![SelectableSpan {
+                text: v.title_line,
+                color: SpanColor::Themed,
+            }],
+            meta_line: Some(if compact { String::new() } else { v.meta_line }),
+            is_selected: v.is_selected,
+        })
+        .collect()
+}
+
+/// Windowing/geometry inputs for [`pr_list_props`].
+///
+/// Bundles the parameters that [`pr_list_visible_rows`] needs to compute the
+/// visible window, plus the layout variant (which decides compact vs full row
+/// rendering). Keeping them in a struct keeps [`pr_list_props`] under the
+/// argument-count limit.
+///
+/// @plan PLAN-20260624-PR-MODE.P13
+/// @requirement REQ-PR-006
+#[derive(Clone, Copy, Debug)]
+pub struct PrListWindow {
+    /// Currently selected PR index.
+    pub selected_index: Option<usize>,
+    /// PR-list pane height in rows.
+    pub list_pane_rows: u16,
+    /// Available content width (in terminal columns) for title truncation.
+    pub available_width: Option<u16>,
+    /// List density variant (compact rows omit the meta line).
+    pub layout: PrListLayout,
+}
+
+/// Build [`SelectableListProps`] for the PR list pane.
+///
+/// Calls the unchanged [`pr_list_visible_rows`] projection and maps each
+/// [`PrListRowView`] into a [`SelectableRow`]. The empty/loading message is
+/// computed by the caller via [`pr_list_status_message`] and passed in as
+/// `empty_message`.
+///
+/// @plan PLAN-20260624-PR-MODE.P13
+/// @requirement REQ-PR-006
+#[must_use]
+pub fn pr_list_props(
+    pull_requests: &[PullRequest],
+    window: PrListWindow,
+    focused: bool,
+    empty_message: Option<&str>,
+    colors: ThemeColors,
+    selection: Option<TextSelection>,
+) -> SelectableListProps {
+    let rows = pr_list_visible_rows(
+        pull_requests,
+        window.selected_index,
+        window.list_pane_rows,
+        window.available_width,
+    );
+    SelectableListProps {
+        title: "Pull Requests".to_string(),
+        rows: to_selectable_rows(rows, window.layout.is_compact()),
+        focused,
+        empty_message: empty_message.map(String::from),
+        colors,
+        selection,
+        pane: SelectablePane::PrList,
+        border: ListBorder::DoubleOnFocus,
+        content_padding: false,
+        selection_style: SelectionStyle::BoldSelected,
+    }
+}
+
 /// Loading/empty status line for the PR list. Returns `None` when rows are
 /// shown (i.e. when the list is non-empty and not loading) — REQ-PR-014.
 ///
 /// @plan PLAN-20260624-PR-MODE.P13
 /// @requirement REQ-PR-014
 /// @pseudocode component-001 lines 1-12
+#[must_use]
 pub fn pr_list_status_message(
     loading: bool,
     is_empty: bool,
@@ -191,142 +246,6 @@ pub fn pr_list_status_message(
     }
 }
 
-/// PR list pane — renders pull requests with selection highlight, loading, and empty states.
-///
-/// @plan PLAN-20260624-PR-MODE.P12
-/// @requirement REQ-PR-006
-/// @requirement REQ-PR-014
-/// @pseudocode component-001 lines 1-12
-#[component]
-pub fn PrList(props: &PrListProps) -> impl Into<AnyElement<'static>> {
-    let rc = ResolvedColors::from_theme(Some(&props.colors));
-    let border_style = if props.focused {
-        BorderStyle::Double
-    } else {
-        BorderStyle::Round
-    };
-
-    let status_msg = pr_list_status_message(
-        props.loading,
-        props.pull_requests.is_empty(),
-        props.has_filters,
-    );
-
-    element! {
-        Box(
-            flex_direction: FlexDirection::Column,
-            width: 100pct,
-            height: 100pct,
-            border_style: border_style,
-            border_color: rc.border,
-            background_color: rc.bg,
-        ) {
-            // Title row
-            Box(height: 1u32, padding_left: 1u32) {
-                Text(content: "Pull Requests", weight: Weight::Bold, color: rc.fg)
-            }
-
-            // Content
-            Box(
-                flex_direction: FlexDirection::Column,
-                flex_grow: 1.0,
-                background_color: rc.bg,
-            ) {
-                #(if let Some(msg) = status_msg {
-                    vec![element! {
-                        Box(padding_left: 1u32, height: 1u32) {
-                            Text(content: msg, color: rc.dim)
-                        }
-                    }
-                    .into_any()]
-                } else {
-                    let rows = props;
-                    let projected = pr_list_visible_rows(
-                        &rows.pull_requests,
-                        rows.selected_index,
-                        rows.list_pane_rows,
-                        rows.available_width,
-                    );
-                    projected.iter().enumerate().map(|(window_i, view)| {
-                        let highlight = rows.selection.as_ref().and_then(|s| {
-                            if s.pane() == crate::selection::SelectablePane::PrList {
-                                row_highlight_range(s, window_i)
-                            } else {
-                                None
-                            }
-                        });
-                        render_pr_row(
-                            view,
-                            rows.layout.is_compact(),
-                            highlight,
-                            RowColors::from_resolved(&rc),
-                            SelectionColors::from_resolved(&rc),
-                            rc.dim,
-                        )
-                    }).collect()
-                })
-            }
-        }
-    }
-}
-
-/// Render a single PR list row, applying the selection-row highlight when the
-/// row falls inside an active drag selection.
-fn render_pr_row(
-    view: &PrListRowView,
-    compact: bool,
-    highlight: Option<HighlightRange>,
-    row_colors: RowColors,
-    highlight_colors: SelectionColors,
-    dim: Color,
-) -> AnyElement<'static> {
-    let title_line = view.title_line.as_str();
-    let meta_line = view.meta_line.as_str();
-    let is_selected = view.is_selected;
-
-    // When a drag selection covers this row, paint the whole row in the
-    // selection colors. Keyboard selection uses bold for text emphasis but
-    // not inverse-video, which is reserved for active drag selection.
-    let highlighted = highlight.is_some();
-    let row_bg = if highlighted {
-        highlight_colors.bg
-    } else {
-        row_colors.bg
-    };
-    let title_fg = if highlighted {
-        highlight_colors.fg
-    } else {
-        row_colors.fg
-    };
-    let weight = if is_selected {
-        Weight::Bold
-    } else {
-        Weight::Normal
-    };
-
-    if compact {
-        return element! {
-            Box(height: 1u32, background_color: row_bg) {
-                Text(content: title_line, color: title_fg, weight: weight)
-            }
-        }
-        .into_any();
-    }
-
-    element! {
-        Box(flex_direction: FlexDirection::Column) {
-            Box(height: 1u32, background_color: row_bg) {
-                Text(content: title_line, color: title_fg, weight: weight)
-            }
-            Box(height: 1u32, background_color: row_bg) {
-                Text(content: meta_line, color: if highlighted { highlight_colors.fg } else { dim })
-            }
-        }
-    }
-    .into_any()
-}
-
-///
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-006
 /// @pseudocode component-001 lines 1-12

--- a/src/ui/components/selectable_list.rs
+++ b/src/ui/components/selectable_list.rs
@@ -1,0 +1,769 @@
+//! Generic bordered, scrollable, selectable list used by the Issue, PR, and
+//! Agent list panes.
+//!
+//! Domain layers project their data into [`SelectableRow`]s (each row already
+//! windowed/trimmed by the domain projection); this component owns the iocraft
+//! rendering once. The three behavioral shapes the original `IssueList`,
+//! `PrList`, and `AgentList` components had are modelled by [`ListBorder`],
+//! [`SelectionStyle`], `content_padding`, and the [`SelectableSpan`]/[`SpanColor`]
+//! span model, so rendered output stays byte-identical to the pre-refactor
+//! components.
+//!
+//! This component does NOT re-do scroll windowing — the domain projections
+//! already window. It just renders the rows it is given, using the
+//! `.enumerate()` index as the drag-highlight content line index.
+
+use iocraft::prelude::*;
+
+use crate::selection::{SelectablePane, TextSelection, row_highlight_range};
+use crate::theme::{ResolvedColors, ThemeColors};
+
+/// A semantic color role for a fixed (selection-immune) span.
+///
+/// The component resolves each role against [`ResolvedColors`] at render time,
+/// so the row model and the domain projections that build it stay free of any
+/// iocraft type (pure-views pattern).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpanRole {
+    /// `rc.bright` (e.g. Running/Completed agent status glyph).
+    Bright,
+    /// `rc.dim` (e.g. Queued agent status glyph).
+    Dim,
+    /// Absolute terminal red.
+    Red,
+    /// Absolute terminal yellow.
+    Yellow,
+    /// Absolute terminal blue.
+    Blue,
+}
+
+/// Color policy for one span of a row's first line.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpanColor {
+    /// Uses the row color: normally `fg`; when keyboard-selected (for the
+    /// [`SelectionStyle::BrightSelected`] style) `bright`; when drag-highlighted
+    /// `sel_fg`.
+    Themed,
+    /// A fixed semantic color immune to selection/highlight (agent status glyph).
+    Role(SpanRole),
+}
+
+/// One colored piece of a selectable row's first line, rendered left-to-right.
+#[derive(Clone, Debug)]
+pub struct SelectableSpan {
+    /// Span text.
+    pub text: String,
+    /// Span color policy.
+    pub color: SpanColor,
+}
+
+/// A single row in a selectable list, projected by the domain layer.
+#[derive(Clone, Debug)]
+pub struct SelectableRow {
+    /// First line, as ordered colored spans.
+    pub spans: Vec<SelectableSpan>,
+    /// Optional second line (issue/pr meta line). Painted `dim`, or `sel_fg`
+    /// when the row is drag-highlighted.
+    ///
+    /// - `Some(non-empty)` → two-line row (issue/pr full layout).
+    /// - `Some("")` → single-line compact row (issue/pr compact layout).
+    /// - `None` → single-line agent-style row (`Box(flex_direction Row)`).
+    pub meta_line: Option<String>,
+    /// Whether this row is the keyboard-selected row.
+    pub is_selected: bool,
+}
+
+/// How a list paints keyboard-selection / drag-highlight on themed spans.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SelectionStyle {
+    /// Issue/PR: themed color is `fg` (or `sel_fg` when drag-highlighted);
+    /// selected rows render **bold**. (Color is NOT brightened.)
+    #[default]
+    BoldSelected,
+    /// Agent: themed color is `bright` when keyboard-selected, `fg` otherwise,
+    /// `sel_fg` when drag-highlighted; weight is always normal.
+    BrightSelected,
+}
+
+/// Border policy for the list box.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ListBorder {
+    /// Issue/PR: `Double` when focused, `Round` otherwise; `border_color` fixed.
+    #[default]
+    DoubleOnFocus,
+    /// Agent: `Round` always; `border_color` brightens when focused.
+    RoundFocusedColor,
+}
+
+/// Props for [`SelectableList`].
+#[derive(Default, Props)]
+pub struct SelectableListProps {
+    /// Title text (e.g. "Issues", "Pull Requests", "Agents").
+    pub title: String,
+    /// Already windowed + projected rows (domain owns scroll windowing).
+    pub rows: Vec<SelectableRow>,
+    /// Whether this pane is focused.
+    pub focused: bool,
+    /// Loading/empty status message to show in place of rows (`None` = none).
+    pub empty_message: Option<String>,
+    /// Theme colors.
+    pub colors: ThemeColors,
+    /// Active drag text selection (if any).
+    pub selection: Option<TextSelection>,
+    /// Which selectable pane this list is (filters the drag selection).
+    pub pane: SelectablePane,
+    /// Border policy.
+    pub border: ListBorder,
+    /// Whether the content box uses `padding: 1` (AgentList) or none.
+    pub content_padding: bool,
+    /// Selection/row-color policy.
+    pub selection_style: SelectionStyle,
+}
+
+/// Resolve `(border_style, border_color)` for the outer box per [`ListBorder`].
+fn resolve_border(policy: ListBorder, focused: bool, rc: ResolvedColors) -> (BorderStyle, Color) {
+    match policy {
+        ListBorder::DoubleOnFocus => {
+            let style = if focused {
+                BorderStyle::Double
+            } else {
+                BorderStyle::Round
+            };
+            (style, rc.border)
+        }
+        ListBorder::RoundFocusedColor => {
+            let color = if focused {
+                rc.border_focused
+            } else {
+                rc.border
+            };
+            (BorderStyle::Round, color)
+        }
+    }
+}
+
+/// Compute the themed foreground color for a row's spans (excluding fixed
+/// spans), and the weight to apply to every span in that row.
+fn themed_color_and_weight(
+    style: SelectionStyle,
+    is_selected: bool,
+    highlighted: bool,
+    rc: ResolvedColors,
+) -> (Color, Weight) {
+    match style {
+        SelectionStyle::BoldSelected => {
+            let fg = if highlighted { rc.sel_fg } else { rc.fg };
+            let weight = if is_selected {
+                Weight::Bold
+            } else {
+                Weight::Normal
+            };
+            (fg, weight)
+        }
+        SelectionStyle::BrightSelected => {
+            let fg = if highlighted {
+                rc.sel_fg
+            } else if is_selected {
+                rc.bright
+            } else {
+                rc.fg
+            };
+            (fg, Weight::Normal)
+        }
+    }
+}
+
+/// Resolve a [`SpanRole`] to a concrete terminal color against the theme.
+fn resolve_role(role: SpanRole, rc: ResolvedColors) -> Color {
+    match role {
+        SpanRole::Bright => rc.bright,
+        SpanRole::Dim => rc.dim,
+        SpanRole::Red => Color::Red,
+        SpanRole::Yellow => Color::Yellow,
+        SpanRole::Blue => Color::Blue,
+    }
+}
+
+/// Resolve the concrete color for a single span given the row's themed color.
+fn span_color(color: SpanColor, themed: Color, rc: ResolvedColors) -> Color {
+    match color {
+        SpanColor::Themed => themed,
+        SpanColor::Role(role) => resolve_role(role, rc),
+    }
+}
+
+/// Whether a given content line index is covered by an active drag selection
+/// on this pane (i.e. should be painted in inverse video).
+fn row_is_highlighted(selection: Option<&TextSelection>, pane: SelectablePane, idx: usize) -> bool {
+    selection
+        .filter(|s| s.pane() == pane)
+        .and_then(|s| row_highlight_range(s, idx))
+        .is_some()
+}
+
+/// Resolve the single title span for a one-span issue/pr row (the pre-refactor
+/// components render the whole `title_line` as a single `Text`).
+fn title_span(row: &SelectableRow) -> (&str, SpanColor) {
+    match row.spans.first() {
+        Some(s) => (s.text.as_str(), s.color),
+        None => ("", SpanColor::Themed),
+    }
+}
+
+/// Render the empty/loading status message box (matches IssueList/PrList).
+fn render_empty_message(msg: &str, dim: Color) -> AnyElement<'static> {
+    element! {
+        Box(padding_left: 1u32, height: 1u32) {
+            Text(content: msg, color: dim)
+        }
+    }
+    .into_any()
+}
+
+/// Render a single-line compact issue/pr row (`meta_line == Some("")`):
+/// `Box(height 1u32, background_color row_bg) { Text(title) }`.
+fn render_compact_row(
+    row: &SelectableRow,
+    themed: Color,
+    weight: Weight,
+    row_bg: Color,
+    rc: ResolvedColors,
+) -> AnyElement<'static> {
+    let (text, color) = title_span(row);
+    element! {
+        Box(height: 1u32, background_color: row_bg) {
+            Text(content: text, color: span_color(color, themed, rc), weight: weight)
+        }
+    }
+    .into_any()
+}
+
+/// Render a two-line issue/pr full row (`meta_line == Some(non-empty)`):
+/// `Box(flex_direction Column) { title Box ; meta Box }`.
+fn render_two_line_row(
+    row: &SelectableRow,
+    themed: Color,
+    weight: Weight,
+    row_bg: Color,
+    highlighted: bool,
+    rc: ResolvedColors,
+) -> AnyElement<'static> {
+    let (title_text, title_color_policy) = title_span(row);
+    let title_color = span_color(title_color_policy, themed, rc);
+    let meta = row.meta_line.as_deref().unwrap_or("");
+    let meta_color = if highlighted { rc.sel_fg } else { rc.dim };
+    element! {
+        Box(flex_direction: FlexDirection::Column) {
+            Box(height: 1u32, background_color: row_bg) {
+                Text(content: title_text, color: title_color, weight: weight)
+            }
+            Box(height: 1u32, background_color: row_bg) {
+                Text(content: meta, color: meta_color)
+            }
+        }
+    }
+    .into_any()
+}
+
+/// Render an agent-style row (`meta_line == None`):
+/// `Box(flex_direction Row, background_color row_bg) { Text per span }`.
+fn render_agent_row(
+    row: &SelectableRow,
+    themed: Color,
+    weight: Weight,
+    row_bg: Color,
+    rc: ResolvedColors,
+) -> AnyElement<'static> {
+    let texts: Vec<AnyElement<'static>> = row
+        .spans
+        .iter()
+        .map(|s| {
+            element! {
+                Text(
+                    content: s.text.as_str(),
+                    color: span_color(s.color, themed, rc),
+                    weight: weight,
+                )
+            }
+            .into_any()
+        })
+        .collect();
+    element! {
+        Box(flex_direction: FlexDirection::Row, background_color: row_bg) {
+            #(texts)
+        }
+    }
+    .into_any()
+}
+
+/// Render a single projected row, choosing the box layout that matches the
+/// original domain component for byte-identical output.
+fn render_row(
+    row: &SelectableRow,
+    style: SelectionStyle,
+    highlighted: bool,
+    rc: ResolvedColors,
+) -> AnyElement<'static> {
+    let row_bg = if highlighted { rc.sel_bg } else { rc.bg };
+    let (themed, weight) = themed_color_and_weight(style, row.is_selected, highlighted, rc);
+    match &row.meta_line {
+        // Compact issue/pr: empty meta string → single-line title box.
+        Some(m) if m.is_empty() => render_compact_row(row, themed, weight, row_bg, rc),
+        // Full issue/pr: non-empty meta → two-line column box.
+        Some(_) => render_two_line_row(row, themed, weight, row_bg, highlighted, rc),
+        // Agent: no meta → single-line row box with one Text per span.
+        None => render_agent_row(row, themed, weight, row_bg, rc),
+    }
+}
+
+/// Build the content children: an empty message, or one element per row.
+fn content_children(props: &SelectableListProps, rc: ResolvedColors) -> Vec<AnyElement<'static>> {
+    match &props.empty_message {
+        Some(msg) => vec![render_empty_message(msg, rc.dim)],
+        None => props
+            .rows
+            .iter()
+            .enumerate()
+            .map(|(idx, row)| {
+                let highlighted = row_is_highlighted(props.selection.as_ref(), props.pane, idx);
+                render_row(row, props.selection_style, highlighted, rc)
+            })
+            .collect(),
+    }
+}
+
+/// Build the content box element, applying `padding: 1` only when the
+/// `content_padding` flag is set (AgentList). The two branches produce the
+/// exact same element tree as the original domain components.
+fn content_box(props: &SelectableListProps, rc: ResolvedColors) -> AnyElement<'static> {
+    let children = content_children(props, rc);
+    if props.content_padding {
+        element! {
+            Box(
+                flex_direction: FlexDirection::Column,
+                flex_grow: 1.0,
+                padding: 1u32,
+                background_color: rc.bg,
+            ) {
+                #(children)
+            }
+        }
+        .into_any()
+    } else {
+        element! {
+            Box(
+                flex_direction: FlexDirection::Column,
+                flex_grow: 1.0,
+                background_color: rc.bg,
+            ) {
+                #(children)
+            }
+        }
+        .into_any()
+    }
+}
+
+/// Generic bordered, scrollable, selectable list pane.
+///
+/// Renders a bordered box with a bold title row, then either an empty/loading
+/// status message or the projected rows. Row coloring, weight, border style,
+/// and padding are driven by the props so Issue/PR and Agent shapes render
+/// byte-identically to the original per-domain components.
+#[component]
+pub fn SelectableList(props: &SelectableListProps) -> impl Into<AnyElement<'static>> {
+    let rc = ResolvedColors::from_theme(Some(&props.colors));
+    let (border_style, border_color) = resolve_border(props.border, props.focused, rc);
+    let content = content_box(props, rc);
+
+    element! {
+        Box(
+            flex_direction: FlexDirection::Column,
+            width: 100pct,
+            height: 100pct,
+            border_style: border_style,
+            border_color: border_color,
+            background_color: rc.bg,
+        ) {
+            Box(height: 1u32, padding_left: 1u32) {
+                Text(content: props.title.as_str(), weight: Weight::Bold, color: rc.fg)
+            }
+            #(
+                // The content box is built separately (it conditionally sets
+                // `padding: 1`); embed it as the second child.
+                vec![content]
+            )
+        }
+    }
+}
+
+/// Build a [`SelectableList`] element from a fully-formed [`SelectableListProps`].
+///
+/// iocraft's `element!` macro cannot spread a pre-built props struct into a
+/// component invocation (each field must be passed inline), so domain wrappers
+/// like [`crate::ui::components::issue_list_props`] return a
+/// [`SelectableListProps`] that is rendered through this helper. Screens embed
+/// the returned element as a pane child.
+#[must_use]
+pub fn selectable_list_element(props: SelectableListProps) -> AnyElement<'static> {
+    element! {
+        SelectableList(
+            title: props.title,
+            rows: props.rows,
+            focused: props.focused,
+            empty_message: props.empty_message,
+            colors: props.colors,
+            selection: props.selection,
+            pane: props.pane,
+            border: props.border,
+            content_padding: props.content_padding,
+            selection_style: props.selection_style,
+        )
+    }
+    .into_any()
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests for [`SelectableList`] and the domain projection wrappers.
+    //!
+    //! These lock two layers of the refactoring contract:
+    //! 1. The projection wrappers (`issue_list_props`, `pr_list_props`,
+    //!    `agent_list_props`) produce rows whose span text/colors exactly
+    //!    match the pre-refactor projections (parity with the unchanged pure
+    //!    `*_visible_rows` functions).
+    //! 2. The rendered ANSI output preserves the per-domain border/weight/color
+    //!    behavior (bold-on-select for Issue/PR, fixed status-glyph color +
+    //!    bright-on-select for Agent, double-vs-round border policy, empty
+    //!    message rendering).
+
+    use super::*;
+    use crate::domain::{
+        Agent, AgentId, AgentStatus, Issue, IssueState, PrCheckStatus, PrState, PullRequest,
+        RepositoryId,
+    };
+    use crate::theme::ThemeColors;
+    use crate::ui::components::agent_list::agent_list_props;
+    use crate::ui::components::issue_list::{IssueListLayout, IssueListWindow, issue_list_props};
+    use crate::ui::components::pr_list::{PrListLayout, PrListWindow, pr_list_props};
+
+    /// Render a `SelectableList` element into an ANSI string at a fixed size.
+    fn render_ansi(props: SelectableListProps, cols: u16, rows: u16) -> String {
+        let mut elem = element! {
+            Box(width: u32::from(cols), height: u32::from(rows)) {
+                #(vec![selectable_list_element(props)])
+            }
+        };
+        let canvas = elem.render(Some(usize::from(cols)));
+        let mut buf = Vec::new();
+        canvas
+            .write_ansi(&mut buf)
+            .unwrap_or_else(|e| panic!("write_ansi failed: {e}"));
+        String::from_utf8_lossy(&buf).into_owned()
+    }
+
+    fn issue(n: u64) -> Issue {
+        Issue {
+            number: n,
+            title: format!("Issue {n}"),
+            state: IssueState::Open,
+            author_login: "octocat".to_string(),
+            updated_at: "2026-06-30".to_string(),
+            assignee_summary: String::new(),
+            labels_summary: String::new(),
+            assignees: Vec::new(),
+            labels: Vec::new(),
+            issue_type: String::new(),
+            milestone: String::new(),
+            module: String::new(),
+            comment_count: 0,
+            body: String::new(),
+        }
+    }
+
+    fn pr(n: u64) -> PullRequest {
+        PullRequest {
+            number: n,
+            title: format!("PR {n}"),
+            state: PrState::Open,
+            author_login: "octocat".to_string(),
+            updated_at: "2026-01-01".to_string(),
+            head_ref: "feature".to_string(),
+            base_ref: "main".to_string(),
+            is_draft: false,
+            review_decision: None,
+            checks_status: PrCheckStatus::None,
+            assignee_summary: String::new(),
+            labels_summary: String::new(),
+            comment_count: 0,
+        }
+    }
+
+    fn agent(name: &str, status: AgentStatus) -> Agent {
+        let mut a = Agent::new(
+            AgentId(name.to_string()),
+            RepositoryId("r".to_string()),
+            name.to_string(),
+            std::path::PathBuf::from("/tmp"),
+        );
+        a.status = status;
+        a
+    }
+
+    // ── Projection parity ───────────────────────────────────────────────────
+
+    /// `issue_list_props` rows' first span text must equal the unchanged
+    /// `issue_list_visible_rows` `title_line` (parity with the pure projection).
+    #[test]
+    fn issue_list_props_first_span_matches_visible_rows_title_line() {
+        let issues: Vec<Issue> = (1..=3).map(issue).collect();
+        let window = IssueListWindow {
+            selected_index: Some(1),
+            list_pane_rows: 10,
+            layout: IssueListLayout::Compact,
+            available_width: Some(40),
+        };
+        let props = issue_list_props(&issues, window, true, None, ThemeColors::default(), None);
+        let visible = crate::ui::components::issue_list::issue_list_visible_rows(
+            &issues,
+            Some(1),
+            10,
+            IssueListLayout::Compact,
+            Some(40),
+        );
+        assert_eq!(props.rows.len(), visible.len());
+        for (got, want) in props.rows.iter().zip(visible.iter()) {
+            assert_eq!(got.spans.len(), 1);
+            assert_eq!(got.spans[0].text, want.title_line);
+            assert!(got.meta_line.as_deref() == Some("") || got.meta_line.is_some());
+            assert_eq!(got.is_selected, want.is_selected);
+        }
+    }
+
+    /// `pr_list_props` rows' first span text must equal the unchanged
+    /// `pr_list_visible_rows` `title_line`, and compact rows carry an empty
+    /// meta line (signaling single-line rendering).
+    #[test]
+    fn pr_list_props_first_span_matches_visible_rows_title_line() {
+        let prs: Vec<PullRequest> = (1..=3).map(pr).collect();
+        let window = PrListWindow {
+            selected_index: Some(0),
+            list_pane_rows: 10,
+            available_width: Some(40),
+            layout: PrListLayout::Compact,
+        };
+        let props = pr_list_props(&prs, window, true, None, ThemeColors::default(), None);
+        let visible =
+            crate::ui::components::pr_list::pr_list_visible_rows(&prs, Some(0), 10, Some(40));
+        assert_eq!(props.rows.len(), visible.len());
+        for (got, want) in props.rows.iter().zip(visible.iter()) {
+            assert_eq!(got.spans.len(), 1);
+            assert_eq!(got.spans[0].text, want.title_line);
+            // Compact → empty meta string (single-line row).
+            assert_eq!(got.meta_line.as_deref(), Some(""));
+            assert_eq!(got.is_selected, want.is_selected);
+        }
+    }
+
+    /// A Running selected agent projects to three spans: prefix "> ", a
+    /// fixed-color status glyph, and " {name}". The first span is themed.
+    #[test]
+    fn agent_list_props_running_selected_spans() {
+        let agents = vec![agent("alpha", AgentStatus::Running)];
+        let props = agent_list_props(&agents, 0, None, false, ThemeColors::default(), None);
+        assert_eq!(props.rows.len(), 1);
+        let row = &props.rows[0];
+        assert_eq!(row.spans.len(), 3);
+        assert_eq!(row.spans[0].text, "> ");
+        assert!(matches!(row.spans[0].color, SpanColor::Themed));
+        assert_eq!(row.spans[1].text, "*");
+        // Running → bright fixed role (resolved by the component).
+        assert!(matches!(
+            row.spans[1].color,
+            SpanColor::Role(SpanRole::Bright)
+        ));
+        assert_eq!(row.spans[2].text, " alpha");
+        assert!(matches!(row.spans[2].color, SpanColor::Themed));
+        assert!(row.meta_line.is_none());
+        assert!(row.is_selected);
+    }
+
+    /// A grabbed agent's prefix span text is "↕ " regardless of selection.
+    #[test]
+    fn agent_list_props_grabbed_prefix() {
+        let agents = vec![
+            agent("alpha", AgentStatus::Running),
+            agent("beta", AgentStatus::Completed),
+        ];
+        let props = agent_list_props(&agents, 0, Some(1), false, ThemeColors::default(), None);
+        // Row 1 is grabbed (index 1).
+        assert_eq!(props.rows[1].spans[0].text, "\u{2195} ");
+        // Row 0 is selected but NOT grabbed → "> ".
+        assert_eq!(props.rows[0].spans[0].text, "> ");
+    }
+
+    /// The agent status-glyph fixed color maps each `AgentStatus` exactly as the
+    /// pre-refactor component did.
+    #[test]
+    fn agent_list_props_status_glyph_color_per_status() {
+        let cases: [(AgentStatus, SpanRole); 7] = [
+            (AgentStatus::Running, SpanRole::Bright),
+            (AgentStatus::Completed, SpanRole::Bright),
+            (AgentStatus::Dead, SpanRole::Red),
+            (AgentStatus::Errored, SpanRole::Red),
+            (AgentStatus::Waiting, SpanRole::Yellow),
+            (AgentStatus::Paused, SpanRole::Blue),
+            (AgentStatus::Queued, SpanRole::Dim),
+        ];
+        for (status, expected) in cases {
+            let agents = vec![agent("a", status)];
+            let props = agent_list_props(&agents, 0, None, false, ThemeColors::default(), None);
+            let row = &props.rows[0];
+            assert_eq!(
+                row.spans.len(),
+                3,
+                "status {status:?} should project 3 spans"
+            );
+            match row.spans[1].color {
+                SpanColor::Role(r) => {
+                    assert_eq!(r, expected, "status {status:?} glyph role mismatch");
+                }
+                SpanColor::Themed => panic!("status {status:?} glyph must be Role, got Themed"),
+            }
+        }
+    }
+
+    // ── Render-canvas (ANSI) identity ───────────────────────────────────────
+
+    /// BoldSelected + compact issue row: the selected row's title renders bold
+    /// (`\e[1m`), and the title text appears in the output.
+    #[test]
+    fn bold_selected_compact_issue_row_renders_bold_when_selected() {
+        let issues: Vec<Issue> = (1..=2).map(issue).collect();
+        let window = IssueListWindow {
+            selected_index: Some(0),
+            list_pane_rows: 8,
+            layout: IssueListLayout::Compact,
+            available_width: Some(40),
+        };
+        let props = issue_list_props(&issues, window, true, None, ThemeColors::default(), None);
+        let ansi = render_ansi(props, 40, 8);
+        assert!(ansi.contains("Issue 1"), "title text must appear: {ansi}");
+        assert!(
+            ansi.contains("\u{1b}[1m"),
+            "selected row must render bold (SGR 1): {ansi}"
+        );
+    }
+
+    /// BrightSelected agent row: the status glyph keeps its fixed color (Red for
+    /// Dead) even when selected, and the agent name uses the bright color —
+    /// matching the pre-refactor AgentList which always used `Weight::Normal`
+    /// for rows and a fixed status-glyph color. (The title row is always bold
+    /// in every list, so we assert on the glyph color + name color, not on the
+    /// absence of any bold SGR.)
+    #[test]
+    fn bright_selected_agent_row_keeps_fixed_glyph_color() {
+        let agents = vec![agent("dead-agent", AgentStatus::Dead)];
+        let props = agent_list_props(&agents, 0, None, true, ThemeColors::default(), None);
+        let ansi = render_ansi(props, 30, 8);
+        // `Color::Red` is emitted by iocraft as the 256-color code 38;5;9. The
+        // key byte-identity guarantee is that the status glyph keeps its fixed
+        // color (immune to the BrightSelected themed-color policy).
+        assert!(
+            ansi.contains("\u{1b}[38;5;9m"),
+            "Dead status glyph must keep its fixed Red (38;5;9) color: {ansi}"
+        );
+        // The selected agent's themed name span uses bright (#00ff00).
+        assert!(
+            ansi.contains("dead-agent"),
+            "agent name text must appear: {ansi}"
+        );
+    }
+
+    /// An empty-message list renders the message text in the dim color and no
+    /// row text appears.
+    #[test]
+    fn empty_message_renders_in_dim() {
+        let props = SelectableListProps {
+            title: "Issues".to_string(),
+            rows: Vec::new(),
+            focused: false,
+            empty_message: Some("No issues found".to_string()),
+            colors: ThemeColors::default(),
+            selection: None,
+            pane: SelectablePane::IssueList,
+            border: ListBorder::DoubleOnFocus,
+            content_padding: false,
+            selection_style: SelectionStyle::BoldSelected,
+        };
+        let ansi = render_ansi(props, 40, 8);
+        assert!(
+            ansi.contains("No issues found"),
+            "empty message must render"
+        );
+        // Green-screen dim = #6a9955 → RGB 106,153,85 (accent_secondary).
+        assert!(
+            ansi.contains("\u{1b}[38;2;106;153;85m"),
+            "empty message must render in dim color: {ansi}"
+        );
+    }
+
+    /// DoubleOnFocus border: a focused list renders a double border (`╔`), an
+    /// unfocused one renders a round border (`╭`).
+    #[test]
+    fn double_on_focus_border_switches_on_focus() {
+        let base = || SelectableListProps {
+            title: "Issues".to_string(),
+            rows: Vec::new(),
+            focused: false,
+            empty_message: Some("x".to_string()),
+            colors: ThemeColors::default(),
+            selection: None,
+            pane: SelectablePane::IssueList,
+            border: ListBorder::DoubleOnFocus,
+            content_padding: false,
+            selection_style: SelectionStyle::BoldSelected,
+        };
+        let unfocused = render_ansi(base(), 20, 6);
+        let mut focused = base();
+        focused.focused = true;
+        let focused = render_ansi(focused, 20, 6);
+        assert!(
+            unfocused.contains('╭'),
+            "unfocused DoubleOnFocus must use round border: {unfocused}"
+        );
+        assert!(
+            focused.contains('╔'),
+            "focused DoubleOnFocus must use double border: {focused}"
+        );
+    }
+
+    /// RoundFocusedColor border (Agent): always round (`╭`), focused or not.
+    #[test]
+    fn round_focused_color_border_always_round() {
+        let base = || SelectableListProps {
+            title: "Agents".to_string(),
+            rows: Vec::new(),
+            focused: false,
+            empty_message: Some("x".to_string()),
+            colors: ThemeColors::default(),
+            selection: None,
+            pane: SelectablePane::AgentList,
+            border: ListBorder::RoundFocusedColor,
+            content_padding: true,
+            selection_style: SelectionStyle::BrightSelected,
+        };
+        let unfocused = render_ansi(base(), 20, 6);
+        let mut focused = base();
+        focused.focused = true;
+        let focused = render_ansi(focused, 20, 6);
+        assert!(
+            unfocused.contains('╭') && focused.contains('╭'),
+            "RoundFocusedColor must always use round border"
+        );
+        // Focused border color brightens to border_focused (#00ff00 → 0;255;0).
+        assert!(
+            focused.contains("\u{1b}[38;2;0;255;0m"),
+            "focused RoundFocusedColor border must use border_focused color: {focused}"
+        );
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -14,7 +14,7 @@ pub mod screens;
 pub mod util;
 
 // Re-export commonly used types
-pub use components::{AgentList, KeybindBar, Preview, Sidebar, StatusBar, TerminalView};
+pub use components::{KeybindBar, Preview, SelectableList, Sidebar, StatusBar, TerminalView};
 pub use modals::{ConfirmModal, HelpModal};
 pub use screens::{Dashboard, NewAgentForm, NewRepositoryForm, SplitScreen};
 pub use util::{ELLIPSIS, truncate_with_ellipsis};

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -12,7 +12,10 @@ use crate::runtime::TerminalSnapshot;
 use crate::state::{AppState, DashboardGrabPane, PaneFocus, ScreenMode};
 use crate::theme::{ResolvedColors, ThemeColors};
 
-use super::super::components::{AgentList, KeybindBar, Preview, Sidebar, StatusBar, TerminalView};
+use super::super::components::{
+    KeybindBar, Preview, Sidebar, StatusBar, TerminalView, agent_list_props,
+    selectable_list_element,
+};
 
 /// Props for the dashboard screen.
 #[derive(Default, Props)]
@@ -158,14 +161,14 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                     height: 100pct,
                 ) {
                     Box(height: agent_rows, width: 100pct) {
-                        AgentList(
-                            agents: agents,
-                            selected: selected_agent_idx,
-                            focused: !terminal_focused && pane_focus == PaneFocus::Agents,
-                            grabbed: grabbed_agent_idx,
-                            colors: colors.clone(),
-                            selection: selection,
-                        )
+                        #(vec![selectable_list_element(agent_list_props(
+                            &agents,
+                            selected_agent_idx,
+                            grabbed_agent_idx,
+                            !terminal_focused && pane_focus == PaneFocus::Agents,
+                            colors.clone(),
+                            selection,
+                        ))])
                     }
                     Box(height: terminal_rows, width: 100pct) {
                         TerminalView(

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -11,8 +11,8 @@ use crate::state::{AppState, IssueFocus, PaneFocus, ScreenMode};
 use crate::theme::{ResolvedColors, ThemeColors};
 
 use super::super::components::{
-    AgentChooser, FilterControls, IssueDetailView, IssueList, IssueListLayout, KeybindBar, Sidebar,
-    StatusBar,
+    AgentChooser, FilterControls, IssueDetailView, IssueListLayout, IssueListWindow, KeybindBar,
+    Sidebar, StatusBar, issue_list_props, issue_list_status_message, selectable_list_element,
 };
 
 /// Props for the issues mode screen.
@@ -199,18 +199,19 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                     // Issue list + detail (split view)
                     // Fixed 30/70 split: compact issue list + detail view
                     Box(height: list_pane_rows, width: 100pct) {
-                        IssueList(
-                            issues: issues.clone(),
-                            selected_index: selected_issue_idx,
-                            list_pane_rows: list_pane_rows,
-                            focused: list_focused,
-                            loading: list_loading,
-                            has_filters: has_filters,
-                            layout: IssueListLayout::Compact,
-                            colors: colors.clone(),
-                            available_width: Some(list_width),
-                            selection: selection,
-                        )
+                        #(vec![selectable_list_element(issue_list_props(
+                            &issues,
+                            IssueListWindow {
+                                selected_index: selected_issue_idx,
+                                list_pane_rows,
+                                layout: IssueListLayout::Compact,
+                                available_width: Some(list_width),
+                            },
+                            list_focused,
+                            issue_list_status_message(list_loading, issues.is_empty(), has_filters),
+                            colors.clone(),
+                            selection,
+                        ))])
                     }
                     Box(flex_grow: 1.0, width: 100pct) {
                         IssueDetailView(

--- a/src/ui/screens/pull_requests.rs
+++ b/src/ui/screens/pull_requests.rs
@@ -10,8 +10,9 @@ use crate::state::{AppState, PaneFocus, PrFocus, ScreenMode};
 use crate::theme::{ResolvedColors, ThemeColors};
 
 use super::super::components::{
-    AgentChooser, KeybindBar, MergeChooser, PrDetailView, PrFilterControls, PrList, PrListLayout,
-    Sidebar, StatusBar,
+    AgentChooser, KeybindBar, MergeChooser, PrDetailView, PrFilterControls, PrListLayout,
+    PrListWindow, Sidebar, StatusBar, pr_list_props, pr_list_status_message,
+    selectable_list_element,
 };
 
 /// Props for the pull requests mode screen.
@@ -75,7 +76,6 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
     let pr_focus = state.map_or(PrFocus::PrList, |s| s.prs_state.pr_focus);
     let pull_requests = state.map_or_else(Vec::new, |s| s.prs_state.pull_requests.clone());
     let selected_pr_idx = state.and_then(|s| s.prs_state.selected_pr_index);
-    let list_scroll_offset = state.map_or(0, |s| s.prs_state.list_scroll_offset);
     let list_loading = state.is_some_and(|s| s.prs_state.loading.list);
     let filter_controls_open = state.is_some_and(|s| s.prs_state.filter_ui.controls_open);
     let filter_field_index = state.map_or(0, |s| s.prs_state.filter_ui.field_index);
@@ -228,19 +228,23 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                     // PR list + detail (split view)
                     // Fixed 30/70 split: compact PR list + detail view
                     Box(height: list_pane_rows, width: 100pct) {
-                        PrList(
-                            pull_requests: pull_requests.clone(),
-                            selected_index: selected_pr_idx,
-                            list_scroll_offset: list_scroll_offset,
-                            list_pane_rows: list_pane_rows,
-                            focused: list_focused,
-                            loading: list_loading,
-                            has_filters: has_filters,
-                            layout: PrListLayout::Compact,
-                            colors: colors.clone(),
-                            available_width: Some(list_width),
-                            selection: selection,
-                        )
+                        #(vec![selectable_list_element(pr_list_props(
+                            &pull_requests,
+                            PrListWindow {
+                                selected_index: selected_pr_idx,
+                                list_pane_rows,
+                                available_width: Some(list_width),
+                                layout: PrListLayout::Compact,
+                            },
+                            list_focused,
+                            pr_list_status_message(
+                                list_loading,
+                                pull_requests.is_empty(),
+                                has_filters,
+                            ),
+                            colors.clone(),
+                            selection,
+                        ))])
                     }
                     Box(flex_grow: 1.0, width: 100pct) {
                         PrDetailView(


### PR DESCRIPTION
Closes #144.

## Summary

Three list components (`IssueList`, `PrList`, `AgentList`) shared the same rendering structure — a bordered box with a title row, then scrollable rows with a selection prefix — differing only in domain data and per-row text projection. This PR introduces a single generic `SelectableList` iocraft component that owns the rendering once, driven by a span-based `SelectableRow` model.

## Changes

**New file:**
- `src/ui/components/selectable_list.rs` — generic `SelectableList` component with `SelectableListProps`, `SelectableRow`, `SelectableSpan`, `SpanColor`, `SpanRole`, `SelectionStyle`, `ListBorder` types and comprehensive render-canvas + projection-parity tests.

**Slimmed domain modules (projections only, components removed):**
- `src/ui/components/issue_list.rs` — keeps `issue_list_visible_rows` / `IssueListRowView` / `IssueListLayout` unchanged; adds `issue_list_props()` wrapper; removes `IssueList` component and `render_issue_row` helper.
- `src/ui/components/pr_list.rs` — keeps `pr_list_visible_rows` / `PrListRowView` / `PrListLayout` unchanged; adds `pr_list_props()` wrapper; removes `PrList` component and `render_pr_row` helper.
- `src/ui/components/agent_list.rs` — adds `agent_list_props()` wrapper; removes `AgentList` component.

**Screen migration:**
- `src/ui/screens/issues.rs`, `pull_requests.rs`, `dashboard.rs` — use `SelectableList` with projected props.

**Supporting:**
- `src/ui/components/mod.rs` / `src/ui/mod.rs` — updated re-exports.
- `src/selection/text.rs` — `SelectablePane` gains `#[derive(Default)]` (Sidebar) so the iocraft `Props` derive on `SelectableListProps` compiles.

## Design decisions

The three behavioral shapes the original components had are modelled by:
- `ListBorder` (`DoubleOnFocus` for Issue/PR, `RoundFocusedColor` for Agent)
- `SelectionStyle` (`BoldSelected` for Issue/PR, `BrightSelected` for Agent)
- `content_padding` (Agent uses `padding: 1\32`, Issue/PR use none)
- `SelectableSpan` / `SpanColor` / `SpanRole` — the agent status glyph keeps its fixed color via `SpanColor::Role(SpanRole)`, which is resolved against the theme at render time. This keeps the row model and domain projections iocraft-free (pure-views pattern); `SpanColor` carries a semantic role, not an `iocraft::Color`.

Scroll windowing stays in `issue_list_visible_rows` / `pr_list_visible_rows` (unchanged) — `SelectableList` does NOT re-window, avoiding double-windowing and preserving selection/content.rs coordinate mapping.

## Constraints

- **No behavior change** — all rendered output is byte-identical (verified by existing render tests passing unchanged).
- TDD: `SelectableList` tests written first, then implementation, then domain migration.
- No `unwrap()`/`expect()` in production paths. No `unsafe`. No `#[allow]` directives.
- Complexity gates: cognitive ≤15, fn ≤60 lines, args ≤6, struct bools ≤3.
- `make ci-check` passes (fmt check, clippy -D warnings, complexity gates, coverage ≥30%, build, test).

## Verification

```
cargo fmt --all --check        ✓
cargo clippy --workspace --all-targets --all-features -- -D warnings  ✓
cargo build --workspace --all-features --locked  ✓
cargo test --workspace --all-features --locked  ✓ (1275 passed, 0 failed)
``

## Parent epic

#142