### PR TITLE
Extract generic DetailPane and FilterBar from duplicated domain components (Fixes #145, Fixes #146)

### DIFF
--- a/src/ui/components/detail_pane.rs
+++ b/src/ui/components/detail_pane.rs
@@ -1,0 +1,339 @@
+//! Generic bordered, header + scrollable + optional-composer detail pane.
+//!
+//! Both the Issue and PR detail panes render the identical structure: a bordered
+//! box → N fixed metadata header rows (rendered through the shared
+//! [`header_row`] helper) → a [`ScrollableText`] viewport → an optional
+//! [`TextBox`] composer. This module owns that iocraft structure once; the
+//! per-domain projection modules (`issue_detail`, `pr_detail`) build a
+//! [`DetailPaneProps`] carrying all layout math + semantic colors and delegate
+//! rendering through [`detail_pane_element`].
+//!
+//! The header-row selection-highlight helpers ([`header_highlight`],
+//! [`header_row`]) live here because both detail components share them; the
+//! per-domain pure header projections (`issue_detail_header_view`,
+//! `pr_detail_header_view`) stay iocraft-free in their own modules.
+
+use iocraft::prelude::*;
+
+use crate::selection::{SelectablePane, TextSelection, row_highlight_range};
+use crate::state::InlineState;
+use crate::theme::{ResolvedColors, ThemeColors};
+
+use super::scrollable_text::ScrollableText;
+use super::text_box::TextBox;
+
+/// Semantic color role for a single header row.
+///
+/// Resolved against [`ResolvedColors`] by the component. Keeping the role (not
+/// a concrete `Color`) in the projection keeps the projection modules
+/// iocraft-free (pure-views pattern).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DetailHeaderColor {
+    /// `rc.fg`.
+    #[default]
+    Fg,
+    /// `rc.bright` (e.g. OPEN state).
+    Bright,
+    /// `rc.dim` (e.g. CLOSED state, labels, url, separator).
+    Dim,
+}
+
+/// One fixed metadata header row projected by the domain layer.
+#[derive(Clone, Debug, Default)]
+pub struct DetailHeaderRow {
+    /// Row text.
+    pub content: String,
+    /// Semantic color role resolved by the component.
+    pub color: DetailHeaderColor,
+    /// Content-line index used for drag-selection whole-row highlighting.
+    pub line: usize,
+}
+
+/// Composer props for the embedded `TextBox`, when present.
+#[derive(Clone, Debug, Default)]
+pub struct DetailComposerProps {
+    /// Raw composer text.
+    pub text: String,
+    /// Byte cursor within `text`.
+    pub byte_cursor: usize,
+    /// Max display width (terminal cols) for prefix + row text.
+    pub content_width: usize,
+    /// Gutter prefix string (e.g. `"  │ "`).
+    pub prefix: String,
+}
+
+/// Props for the generic [`DetailPane`] component.
+///
+/// The projection owns ALL layout math (viewport rows, composer rows,
+/// content-line offset) and supplies already-final values; the component is a
+/// pure renderer.
+#[derive(Default, Props)]
+pub struct DetailPaneProps {
+    /// Fixed metadata header rows (rendered top-to-bottom).
+    pub header_rows: Vec<DetailHeaderRow>,
+    /// Scrollable viewport text.
+    pub content: String,
+    /// Cursor `(line, col)` within the content (for the caret), if any.
+    pub content_cursor: Option<(usize, usize)>,
+    /// Scroll offset (lines) for the viewport.
+    pub scroll_offset: usize,
+    /// Rows the `ScrollableText` viewport occupies (already-final layout).
+    pub viewport_rows: usize,
+    /// Header-row count; passed as `ScrollableText::content_line_offset` so
+    /// selection content coordinates line up with the header rows above.
+    pub content_line_offset: usize,
+    /// `ScrollableText::max_line_width` (content width in cols).
+    pub max_line_width: usize,
+    /// Whether this pane is focused (drives double-vs-round border).
+    pub focused: bool,
+    /// Which selectable pane this is (filters the drag selection).
+    pub pane: SelectablePane,
+    /// Theme colors.
+    pub colors: ThemeColors,
+    /// Active drag text selection, if any.
+    pub selection: Option<TextSelection>,
+    /// Embedded composer props; when present a `TextBox` renders below the
+    /// viewport.
+    pub composer: Option<DetailComposerProps>,
+    /// Rows the `TextBox` composer occupies (0 when no composer).
+    pub composer_rows: usize,
+}
+
+/// Resolve a [`DetailHeaderColor`] role to a concrete terminal color.
+fn resolve_header_color(role: DetailHeaderColor, rc: ResolvedColors) -> Color {
+    match role {
+        DetailHeaderColor::Fg => rc.fg,
+        DetailHeaderColor::Bright => rc.bright,
+        DetailHeaderColor::Dim => rc.dim,
+    }
+}
+
+/// Whether content line `line` falls inside the active drag selection for
+/// `pane`. Shared by both detail components for whole-row header highlighting.
+///
+/// Header rows use whole-row highlight (ignoring partial column ranges) for
+/// visual simplicity on short metadata lines.
+#[must_use]
+pub fn header_highlight(
+    line: usize,
+    selection: Option<&TextSelection>,
+    pane: SelectablePane,
+) -> bool {
+    selection
+        .filter(|s| s.pane() == pane)
+        .and_then(|s| row_highlight_range(s, line))
+        .is_some()
+}
+
+/// Render a single header row, applying whole-row inverse-video when it falls
+/// inside the active drag selection. Shared by both detail components.
+#[must_use]
+pub fn header_row(
+    content: String,
+    default_fg: Color,
+    line: usize,
+    selection: Option<&TextSelection>,
+    pane: SelectablePane,
+    rc: &ResolvedColors,
+) -> AnyElement<'static> {
+    if header_highlight(line, selection, pane) {
+        element! {
+            Box(height: 1u32, background_color: rc.sel_bg) {
+                Text(content: content, color: rc.sel_fg)
+            }
+        }
+        .into_any()
+    } else {
+        element! {
+            Box(height: 1u32) {
+                Text(content: content, color: default_fg)
+            }
+        }
+        .into_any()
+    }
+}
+
+/// Extract the active detail composer `(text, byte_cursor, prefix)`.
+///
+/// Both Issues and PRs detail panes use the same match arms and the same
+/// composer prefixes, so this single helper replaces the duplicated
+/// `active_issue_composer` / `active_pr_composer`.
+#[must_use]
+pub fn composer_from_inline_state(
+    inline_state: &InlineState,
+) -> Option<(String, usize, &'static str)> {
+    use crate::state::ComposerTarget;
+    match inline_state {
+        InlineState::Composer {
+            target: ComposerTarget::NewComment,
+            text,
+            cursor,
+        } => Some((
+            text.clone(),
+            *cursor,
+            crate::layout::NEW_COMMENT_COMPOSER_PREFIX,
+        )),
+        InlineState::Composer {
+            target: ComposerTarget::Reply { .. } | ComposerTarget::ReplyToReviewThread { .. },
+            text,
+            cursor,
+        } => Some((text.clone(), *cursor, crate::layout::REPLY_COMPOSER_PREFIX)),
+        InlineState::Composer {
+            target: ComposerTarget::NewIssue,
+            ..
+        }
+        | InlineState::Editor { .. }
+        | InlineState::None => None,
+    }
+}
+
+/// Build the header-column box children (one [`header_row`] per projected row).
+fn header_children(props: &DetailPaneProps, rc: &ResolvedColors) -> Vec<AnyElement<'static>> {
+    props
+        .header_rows
+        .iter()
+        .map(|row| {
+            header_row(
+                row.content.clone(),
+                resolve_header_color(row.color, *rc),
+                row.line,
+                props.selection.as_ref(),
+                props.pane,
+                rc,
+            )
+        })
+        .collect()
+}
+
+/// Build the header-column box (always present, contains the projected rows).
+fn header_box(props: &DetailPaneProps, rc: &ResolvedColors) -> AnyElement<'static> {
+    let children = header_children(props, rc);
+    element! {
+        Box(flex_direction: FlexDirection::Column, padding_left: 1u32, padding_right: 1u32) {
+            #(children)
+        }
+    }
+    .into_any()
+}
+
+/// Build the scrollable viewport box (always present).
+fn viewport_box(props: &DetailPaneProps, rc: ResolvedColors) -> AnyElement<'static> {
+    let (cursor_line, cursor_col) = (
+        props.content_cursor.map(|(l, _)| l),
+        props.content_cursor.map(|(_, c)| c),
+    );
+    element! {
+        Box(width: 100pct, padding_left: 1u32) {
+            ScrollableText(
+                content: props.content.clone(),
+                scroll_offset: props.scroll_offset,
+                viewport_rows: props.viewport_rows,
+                max_line_width: props.max_line_width,
+                cursor_line: cursor_line,
+                cursor_col: cursor_col,
+                color: rc.fg,
+                cursor_color: rc.bg,
+                cursor_bg: rc.bright,
+                track_color: rc.dim,
+                thumb_color: rc.bright,
+                selection: props
+                    .selection
+                    .filter(|s| s.pane() == props.pane),
+                selection_bg: Some(rc.sel_bg),
+                selection_fg: Some(rc.sel_fg),
+                bg: Some(rc.bg),
+                content_line_offset: props.content_line_offset,
+            )
+        }
+    }
+    .into_any()
+}
+
+/// Build the embedded composer `TextBox` box; `None` when no composer.
+fn composer_box(
+    composer: &DetailComposerProps,
+    composer_rows: usize,
+    rc: ResolvedColors,
+) -> AnyElement<'static> {
+    element! {
+        Box(width: 100pct, padding_left: 1u32) {
+            TextBox(
+                text: composer.text.clone(),
+                byte_cursor: composer.byte_cursor,
+                viewport_rows: composer_rows,
+                content_width: composer.content_width,
+                prefix: composer.prefix.clone(),
+                color: rc.fg,
+                caret_color: rc.bg,
+                caret_bg: rc.bright,
+            )
+        }
+    }
+    .into_any()
+}
+
+/// Generic bordered, header + scrollable + optional-composer detail pane.
+///
+/// Renders byte-identically to the pre-refactor `IssueDetailView` /
+/// `PrDetailView`: a bordered box → header-column box → scrollable viewport →
+/// optional composer box. All layout math + color roles are supplied by the
+/// per-domain projection so this component stays a pure renderer.
+#[component]
+pub fn DetailPane(props: &DetailPaneProps) -> impl Into<AnyElement<'static>> {
+    let rc = ResolvedColors::from_theme(Some(&props.colors));
+    let border_style = if props.focused {
+        BorderStyle::Double
+    } else {
+        BorderStyle::Round
+    };
+    let header = header_box(props, &rc);
+    let viewport = viewport_box(props, rc);
+    let composer: Option<AnyElement<'static>> = props
+        .composer
+        .as_ref()
+        .map(|c| composer_box(c, props.composer_rows, rc));
+
+    element! {
+        Box(
+            flex_direction: FlexDirection::Column,
+            width: 100pct,
+            height: 100pct,
+            border_style: border_style,
+            border_color: rc.border,
+            background_color: rc.bg,
+        ) {
+            #(vec![header])
+            #(vec![viewport])
+            #(composer.map(|e| vec![e]).unwrap_or_default())
+        }
+    }
+}
+
+/// Build a [`DetailPane`] element from a fully-formed [`DetailPaneProps`].
+///
+/// iocraft's `element!` macro cannot spread a pre-built props struct into a
+/// component invocation (each field must be passed inline), so domain wrappers
+/// like [`crate::ui::components::issue_detail_props`] return a
+/// [`DetailPaneProps`] that is rendered through this helper. Screens embed the
+/// returned element as a pane child.
+#[must_use]
+pub fn detail_pane_element(props: DetailPaneProps) -> AnyElement<'static> {
+    element! {
+        DetailPane(
+            header_rows: props.header_rows,
+            content: props.content,
+            content_cursor: props.content_cursor,
+            scroll_offset: props.scroll_offset,
+            viewport_rows: props.viewport_rows,
+            content_line_offset: props.content_line_offset,
+            max_line_width: props.max_line_width,
+            focused: props.focused,
+            pane: props.pane,
+            colors: props.colors,
+            selection: props.selection,
+            composer: props.composer,
+            composer_rows: props.composer_rows,
+        )
+    }
+    .into_any()
+}

--- a/src/ui/components/detail_pane.rs
+++ b/src/ui/components/detail_pane.rs
@@ -58,8 +58,9 @@ pub struct DetailComposerProps {
     pub byte_cursor: usize,
     /// Max display width (terminal cols) for prefix + row text.
     pub content_width: usize,
-    /// Gutter prefix string (e.g. `"  │ "`).
-    pub prefix: String,
+    /// Gutter prefix (e.g. `"  │ "`). Always a `&'static str` derived from
+    /// [`composer_from_inline_state`], avoiding per-render allocation.
+    pub prefix: &'static str,
 }
 
 /// Props for the generic [`DetailPane`] component.
@@ -217,7 +218,7 @@ fn header_box(props: &DetailPaneProps, rc: &ResolvedColors) -> AnyElement<'stati
 }
 
 /// Build the scrollable viewport box (always present).
-fn viewport_box(props: &DetailPaneProps, rc: ResolvedColors) -> AnyElement<'static> {
+fn viewport_box(props: &DetailPaneProps, rc: &ResolvedColors) -> AnyElement<'static> {
     let (cursor_line, cursor_col) = (
         props.content_cursor.map(|(l, _)| l),
         props.content_cursor.map(|(_, c)| c),
@@ -253,7 +254,7 @@ fn viewport_box(props: &DetailPaneProps, rc: ResolvedColors) -> AnyElement<'stat
 fn composer_box(
     composer: &DetailComposerProps,
     composer_rows: usize,
-    rc: ResolvedColors,
+    rc: &ResolvedColors,
 ) -> AnyElement<'static> {
     element! {
         Box(width: 100pct, padding_left: 1u32) {
@@ -262,7 +263,7 @@ fn composer_box(
                 byte_cursor: composer.byte_cursor,
                 viewport_rows: composer_rows,
                 content_width: composer.content_width,
-                prefix: composer.prefix.clone(),
+                prefix: composer.prefix.to_string(),
                 color: rc.fg,
                 caret_color: rc.bg,
                 caret_bg: rc.bright,
@@ -287,11 +288,11 @@ pub fn DetailPane(props: &DetailPaneProps) -> impl Into<AnyElement<'static>> {
         BorderStyle::Round
     };
     let header = header_box(props, &rc);
-    let viewport = viewport_box(props, rc);
+    let viewport = viewport_box(props, &rc);
     let composer: Option<AnyElement<'static>> = props
         .composer
         .as_ref()
-        .map(|c| composer_box(c, props.composer_rows, rc));
+        .map(|c| composer_box(c, props.composer_rows, &rc));
 
     element! {
         Box(

--- a/src/ui/components/detail_pane_render_tests.rs
+++ b/src/ui/components/detail_pane_render_tests.rs
@@ -1,0 +1,215 @@
+//! Render-path tests for the generic `DetailPane` component.
+//!
+//! These lock the shared structure that `IssueDetailView` and `PrDetailView`
+//! delegate to after the refactoring: a bordered box → N header rows →
+//! `ScrollableText` viewport → optional `TextBox` composer. The assertions are
+//! structural (border style on focus, header-row rendering, composer presence)
+//! so they validate the generic renderer independently of the per-domain
+//! projections (which keep their own regression-guard render tests).
+
+use crate::selection::SelectablePane;
+use crate::theme::ThemeColors;
+use crate::ui::components::{
+    DetailComposerProps, DetailHeaderColor, DetailHeaderRow, DetailPaneProps, detail_pane_element,
+};
+
+use iocraft::prelude::*;
+
+/// Render a `DetailPane` element into an ANSI string at a fixed size.
+fn render_ansi(props: DetailPaneProps, cols: u16, rows: u16) -> String {
+    let mut elem = element! {
+        Box(width: u32::from(cols), height: u32::from(rows)) {
+            #(vec![detail_pane_element(props)])
+        }
+    };
+    let canvas = elem.render(Some(usize::from(cols)));
+    let mut buf = Vec::new();
+    canvas
+        .write_ansi(&mut buf)
+        .unwrap_or_else(|e| panic!("write_ansi failed: {e}"));
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// Helper: a 5-row header mirroring the real detail components.
+fn sample_header_rows() -> Vec<DetailHeaderRow> {
+    vec![
+        DetailHeaderRow {
+            content: "#1 Title".to_string(),
+            color: DetailHeaderColor::Fg,
+            line: 0,
+        },
+        DetailHeaderRow {
+            content: "OPEN  by @x".to_string(),
+            color: DetailHeaderColor::Bright,
+            line: 1,
+        },
+        DetailHeaderRow {
+            content: "labels: -".to_string(),
+            color: DetailHeaderColor::Dim,
+            line: 2,
+        },
+        DetailHeaderRow {
+            content: "https://example.com".to_string(),
+            color: DetailHeaderColor::Dim,
+            line: 3,
+        },
+        DetailHeaderRow {
+            content: "─────────────────────────────────────────".to_string(),
+            color: DetailHeaderColor::Dim,
+            line: 4,
+        },
+    ]
+}
+
+/// A focused `DetailPane` must render a double border (`╔`); unfocused renders
+/// a round border (`╭`). This mirrors the original `DoubleOnFocus` behavior of
+/// both `IssueDetailView` and `PrDetailView`.
+#[test]
+fn detail_pane_border_switches_on_focus() {
+    let base = || DetailPaneProps {
+        header_rows: sample_header_rows(),
+        content: "body".to_string(),
+        content_cursor: None,
+        scroll_offset: 0,
+        viewport_rows: 5,
+        content_line_offset: 5,
+        max_line_width: 40,
+        focused: false,
+        pane: SelectablePane::IssueDetail,
+        colors: ThemeColors::default(),
+        selection: None,
+        composer: None,
+        composer_rows: 0,
+    };
+    let unfocused = render_ansi(base(), 40, 14);
+    let mut focused = base();
+    focused.focused = true;
+    let focused = render_ansi(focused, 40, 14);
+    assert!(
+        unfocused.contains('╭'),
+        "unfocused detail must use round border: {unfocused}"
+    );
+    assert!(
+        focused.contains('╔'),
+        "focused detail must use double border: {focused}"
+    );
+}
+
+/// The header rows' text must all appear in the rendered output.
+#[test]
+fn detail_pane_renders_all_header_rows() {
+    let props = DetailPaneProps {
+        header_rows: sample_header_rows(),
+        content: "the body line".to_string(),
+        content_cursor: None,
+        scroll_offset: 0,
+        viewport_rows: 5,
+        content_line_offset: 5,
+        max_line_width: 40,
+        focused: true,
+        pane: SelectablePane::IssueDetail,
+        colors: ThemeColors::default(),
+        selection: None,
+        composer: None,
+        composer_rows: 0,
+    };
+    let ansi = render_ansi(props, 50, 16);
+    assert!(ansi.contains("#1 Title"), "title row missing: {ansi}");
+    assert!(ansi.contains("OPEN  by @x"), "state row missing: {ansi}");
+    assert!(ansi.contains("labels: -"), "labels row missing: {ansi}");
+    assert!(
+        ansi.contains("https://example.com"),
+        "url row missing: {ansi}"
+    );
+    assert!(
+        ansi.contains("─────────────────────────────────────────"),
+        "separator row missing: {ansi}"
+    );
+}
+
+/// The scrollable content text must appear below the header rows.
+#[test]
+fn detail_pane_renders_scrollable_content() {
+    let props = DetailPaneProps {
+        header_rows: sample_header_rows(),
+        content: "unique body marker".to_string(),
+        content_cursor: None,
+        scroll_offset: 0,
+        viewport_rows: 5,
+        content_line_offset: 5,
+        max_line_width: 40,
+        focused: true,
+        pane: SelectablePane::IssueDetail,
+        colors: ThemeColors::default(),
+        selection: None,
+        composer: None,
+        composer_rows: 0,
+    };
+    let ansi = render_ansi(props, 50, 16);
+    assert!(
+        ansi.contains("unique body marker"),
+        "content text must render: {ansi}"
+    );
+}
+
+/// When a composer is supplied, the TextBox draft text must render below the
+/// viewport, and the composer prefix must appear.
+#[test]
+fn detail_pane_renders_composer_when_present() {
+    let props = DetailPaneProps {
+        header_rows: sample_header_rows(),
+        content: "body".to_string(),
+        content_cursor: None,
+        scroll_offset: 0,
+        viewport_rows: 3,
+        content_line_offset: 5,
+        max_line_width: 40,
+        focused: true,
+        pane: SelectablePane::IssueDetail,
+        colors: ThemeColors::default(),
+        selection: None,
+        composer: Some(DetailComposerProps {
+            text: "draft composer text".to_string(),
+            byte_cursor: "draft composer text".len(),
+            content_width: 40,
+            prefix: "  │ ".to_string(),
+        }),
+        composer_rows: 3,
+    };
+    let ansi = render_ansi(props, 50, 16);
+    assert!(
+        ansi.contains("draft composer text"),
+        "composer draft text must render: {ansi}"
+    );
+    assert!(
+        ansi.contains("  │ "),
+        "composer prefix must render when composer is present: {ansi}"
+    );
+}
+
+/// The composer must NOT render when `composer` is `None` (the draft text must
+/// be absent from the output).
+#[test]
+fn detail_pane_omits_composer_when_absent() {
+    let props = DetailPaneProps {
+        header_rows: sample_header_rows(),
+        content: "body".to_string(),
+        content_cursor: None,
+        scroll_offset: 0,
+        viewport_rows: 5,
+        content_line_offset: 5,
+        max_line_width: 40,
+        focused: true,
+        pane: SelectablePane::IssueDetail,
+        colors: ThemeColors::default(),
+        selection: None,
+        composer: None,
+        composer_rows: 0,
+    };
+    let ansi = render_ansi(props, 50, 16);
+    // No TextBox gutter/prefix should appear when no composer is active.
+    assert!(
+        !ansi.contains("  │ "),
+        "no composer prefix should render when composer is None: {ansi}"
+    );
+}

--- a/src/ui/components/detail_pane_render_tests.rs
+++ b/src/ui/components/detail_pane_render_tests.rs
@@ -61,12 +61,11 @@ fn sample_header_rows() -> Vec<DetailHeaderRow> {
     ]
 }
 
-/// A focused `DetailPane` must render a double border (`╔`); unfocused renders
-/// a round border (`╭`). This mirrors the original `DoubleOnFocus` behavior of
-/// both `IssueDetailView` and `PrDetailView`.
-#[test]
-fn detail_pane_border_switches_on_focus() {
-    let base = || DetailPaneProps {
+/// Base props shared by every test: the full default field set so individual
+/// tests only override the values they care about (avoids error-prone manual
+/// updates whenever a new field is added).
+fn base_props() -> DetailPaneProps {
+    DetailPaneProps {
         header_rows: sample_header_rows(),
         content: "body".to_string(),
         content_cursor: None,
@@ -80,11 +79,24 @@ fn detail_pane_border_switches_on_focus() {
         selection: None,
         composer: None,
         composer_rows: 0,
+    }
+}
+
+/// A focused `DetailPane` must render a double border (`╔`); unfocused renders
+/// a round border (`╭`). This mirrors the original `DoubleOnFocus` behavior of
+/// both `IssueDetailView` and `PrDetailView`.
+#[test]
+fn detail_pane_border_switches_on_focus() {
+    let unfocused = {
+        let mut p = base_props();
+        p.focused = false;
+        render_ansi(p, 40, 14)
     };
-    let unfocused = render_ansi(base(), 40, 14);
-    let mut focused = base();
-    focused.focused = true;
-    let focused = render_ansi(focused, 40, 14);
+    let focused = {
+        let mut p = base_props();
+        p.focused = true;
+        render_ansi(p, 40, 14)
+    };
     assert!(
         unfocused.contains('╭'),
         "unfocused detail must use round border: {unfocused}"
@@ -98,21 +110,8 @@ fn detail_pane_border_switches_on_focus() {
 /// The header rows' text must all appear in the rendered output.
 #[test]
 fn detail_pane_renders_all_header_rows() {
-    let props = DetailPaneProps {
-        header_rows: sample_header_rows(),
-        content: "the body line".to_string(),
-        content_cursor: None,
-        scroll_offset: 0,
-        viewport_rows: 5,
-        content_line_offset: 5,
-        max_line_width: 40,
-        focused: true,
-        pane: SelectablePane::IssueDetail,
-        colors: ThemeColors::default(),
-        selection: None,
-        composer: None,
-        composer_rows: 0,
-    };
+    let mut props = base_props();
+    props.focused = true;
     let ansi = render_ansi(props, 50, 16);
     assert!(ansi.contains("#1 Title"), "title row missing: {ansi}");
     assert!(ansi.contains("OPEN  by @x"), "state row missing: {ansi}");
@@ -130,21 +129,9 @@ fn detail_pane_renders_all_header_rows() {
 /// The scrollable content text must appear below the header rows.
 #[test]
 fn detail_pane_renders_scrollable_content() {
-    let props = DetailPaneProps {
-        header_rows: sample_header_rows(),
-        content: "unique body marker".to_string(),
-        content_cursor: None,
-        scroll_offset: 0,
-        viewport_rows: 5,
-        content_line_offset: 5,
-        max_line_width: 40,
-        focused: true,
-        pane: SelectablePane::IssueDetail,
-        colors: ThemeColors::default(),
-        selection: None,
-        composer: None,
-        composer_rows: 0,
-    };
+    let mut props = base_props();
+    props.focused = true;
+    props.content = "unique body marker".to_string();
     let ansi = render_ansi(props, 50, 16);
     assert!(
         ansi.contains("unique body marker"),
@@ -156,26 +143,16 @@ fn detail_pane_renders_scrollable_content() {
 /// viewport, and the composer prefix must appear.
 #[test]
 fn detail_pane_renders_composer_when_present() {
-    let props = DetailPaneProps {
-        header_rows: sample_header_rows(),
-        content: "body".to_string(),
-        content_cursor: None,
-        scroll_offset: 0,
-        viewport_rows: 3,
-        content_line_offset: 5,
-        max_line_width: 40,
-        focused: true,
-        pane: SelectablePane::IssueDetail,
-        colors: ThemeColors::default(),
-        selection: None,
-        composer: Some(DetailComposerProps {
-            text: "draft composer text".to_string(),
-            byte_cursor: "draft composer text".len(),
-            content_width: 40,
-            prefix: "  │ ".to_string(),
-        }),
-        composer_rows: 3,
-    };
+    let mut props = base_props();
+    props.focused = true;
+    props.viewport_rows = 3;
+    props.composer = Some(DetailComposerProps {
+        text: "draft composer text".to_string(),
+        byte_cursor: "draft composer text".len(),
+        content_width: 40,
+        prefix: "  │ ",
+    });
+    props.composer_rows = 3;
     let ansi = render_ansi(props, 50, 16);
     assert!(
         ansi.contains("draft composer text"),
@@ -191,21 +168,8 @@ fn detail_pane_renders_composer_when_present() {
 /// be absent from the output).
 #[test]
 fn detail_pane_omits_composer_when_absent() {
-    let props = DetailPaneProps {
-        header_rows: sample_header_rows(),
-        content: "body".to_string(),
-        content_cursor: None,
-        scroll_offset: 0,
-        viewport_rows: 5,
-        content_line_offset: 5,
-        max_line_width: 40,
-        focused: true,
-        pane: SelectablePane::IssueDetail,
-        colors: ThemeColors::default(),
-        selection: None,
-        composer: None,
-        composer_rows: 0,
-    };
+    let mut props = base_props();
+    props.focused = true;
     let ansi = render_ansi(props, 50, 16);
     // No TextBox gutter/prefix should appear when no composer is active.
     assert!(

--- a/src/ui/components/filter_bar.rs
+++ b/src/ui/components/filter_bar.rs
@@ -1,0 +1,225 @@
+//! Generic bordered filter bar with labeled `[value]` fields and action hints.
+//!
+//! Both the Issue (`FilterControls`) and PR (`PrFilterControls`) filter
+//! controls render the identical structure: a bordered column box → rows of
+//! labeled `[value]` fields (N per row) with active-field inverted-color
+//! highlighting → an action-hints row. This module owns that iocraft structure
+//! once; the per-domain projection modules (`filter_controls`, `pr_filter_controls`)
+//! build a [`FilterBarProps`] carrying the field views, row prefixes,
+//! fields-per-row count, action hints, and theme colors, then delegate
+//! rendering through [`filter_bar_element`].
+//!
+//! The active-field color logic (inverted colors on the active field) lives
+//! here because it needs iocraft `Color`/`ResolvedColors`; the per-domain
+//! projections stay iocraft-free (pure-views pattern).
+//!
+//! @plan PLAN-20260329-ISSUES-MODE.P14
+//! @plan PLAN-20260624-PR-MODE.P12
+//! @requirement REQ-ISS-008
+//! @requirement REQ-PR-008
+
+use iocraft::prelude::*;
+
+use crate::theme::{ResolvedColors, ThemeColors};
+
+/// A single filter field for display, projected by the domain layer.
+///
+/// Carries the label, the display value (without brackets), and the
+/// active-highlight flag. Owned `String` labels let the same type serve both
+/// the Issue (inline string literals) and PR (`&'static str` label table)
+/// domains. The component resolves the active/inactive colors against
+/// [`ResolvedColors`], so this struct stays free of iocraft types (pure-views
+/// pattern).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FilterFieldView {
+    /// Field label (e.g. "state", "author").
+    pub label: String,
+    /// Display value WITHOUT brackets (e.g. "open", "any", "alice").
+    pub value: String,
+    /// Whether this field is the active (highlighted) field.
+    pub active: bool,
+}
+
+/// Props for the generic [`FilterBar`] component.
+///
+/// The projection owns the field computation, the row-prefix text, the
+/// fields-per-row count, and the action-hint list; the component is a pure
+/// renderer that applies the shared color logic and box structure.
+#[derive(Default, Props)]
+pub struct FilterBarProps {
+    /// Projected field views, in render order (row-major).
+    pub fields: Vec<FilterFieldView>,
+    /// Whether the controls are visible (false → 0×0 box).
+    pub visible: bool,
+    /// Text before the first field on row 1 (e.g. "Filter: ").
+    pub row_prefix: String,
+    /// Alignment padding for row 2+ (matches row_prefix width per domain).
+    pub continuation_prefix: String,
+    /// Number of fields per row (both domains use 4).
+    pub fields_per_row: usize,
+    /// Action hint segments rendered in the final row.
+    pub action_hints: Vec<String>,
+    /// Theme colors.
+    pub colors: ThemeColors,
+}
+
+/// Build the two-element group (label `Text` + value `Box`) for a single
+/// field with active/inactive colors.
+///
+/// The label text carries its own leading padding (the first field in a row
+/// has no leading spaces; subsequent fields have `"  "` prepended by the
+/// caller building the row). The value renders inside a `Box` whose background
+/// flips to `rc.bright` when the field is active. Returns a two-element vec so
+/// the row `Box` can flatten label + value as direct children (matching the
+/// pre-refactor element tree for byte-identical output).
+fn field_group(field: &FilterFieldView, rc: ResolvedColors) -> Vec<AnyElement<'static>> {
+    let val_color = if field.active { rc.bg } else { rc.fg };
+    let val_bg = if field.active { rc.bright } else { rc.bg };
+    let label_color = if field.active { rc.bright } else { rc.dim };
+    let label = element! {
+        Text(content: format!("{}:", field.label), color: label_color)
+    }
+    .into_any();
+    let value = element! {
+        Box(background_color: val_bg) {
+            Text(content: format!("[{}]", field.value), color: val_color)
+        }
+    }
+    .into_any();
+    vec![label, value]
+}
+
+/// Build the children for one field row: the row-prefix `Text`, then the
+/// [`field_group`] elements for each field. The first field in the row
+/// renders its label as `"{label}:"`; subsequent fields render
+/// `"  {label}:"` (two-space prefix).
+fn field_row_children(
+    prefix: &str,
+    row_fields: &[FilterFieldView],
+    rc: ResolvedColors,
+) -> Vec<AnyElement<'static>> {
+    let mut children: Vec<AnyElement<'static>> = Vec::new();
+    children.push(
+        element! {
+            Text(content: prefix, color: rc.dim)
+        }
+        .into_any(),
+    );
+    for (i, field) in row_fields.iter().enumerate() {
+        let mut view = field.clone();
+        if i > 0 {
+            view.label = format!("  {}", field.label);
+        }
+        children.extend(field_group(&view, rc));
+    }
+    children
+}
+
+/// Build a single field-row `Box(height: 1u32)` from the projected fields.
+fn field_row_box(
+    prefix: &str,
+    row_fields: &[FilterFieldView],
+    rc: ResolvedColors,
+) -> AnyElement<'static> {
+    let children = field_row_children(prefix, row_fields, rc);
+    element! {
+        Box(height: 1u32) {
+            #(children)
+        }
+    }
+    .into_any()
+}
+
+/// Build the action-hints row: one `Text` per hint segment, all in `rc.dim`.
+fn action_hints_row(hints: &[String], rc: ResolvedColors) -> AnyElement<'static> {
+    let texts: Vec<AnyElement<'static>> = hints
+        .iter()
+        .map(|h| {
+            element! {
+                Text(content: h.as_str(), color: rc.dim)
+            }
+            .into_any()
+        })
+        .collect();
+    element! {
+        Box(height: 1u32) {
+            #(texts)
+        }
+    }
+    .into_any()
+}
+
+/// Build all children for the outer bordered column box: the field rows
+/// (chunked into `fields_per_row`), then the action-hints row.
+fn outer_children(props: &FilterBarProps, rc: ResolvedColors) -> Vec<AnyElement<'static>> {
+    let chunk = props.fields_per_row.max(1);
+    let mut children: Vec<AnyElement<'static>> = Vec::new();
+    for (row_idx, row_fields) in props.fields.chunks(chunk).enumerate() {
+        // Row 0 uses row_prefix; every subsequent row uses continuation_prefix.
+        let prefix = if row_idx == 0 {
+            props.row_prefix.as_str()
+        } else {
+            props.continuation_prefix.as_str()
+        };
+        children.push(field_row_box(prefix, row_fields, rc));
+    }
+    children.push(action_hints_row(&props.action_hints, rc));
+    children
+}
+
+/// Generic bordered filter bar with labeled `[value]` fields and action hints.
+///
+/// Renders byte-identically to the pre-refactor `FilterControls` (Issues) and
+/// `PrFilterControls` (PRs): a bordered column box → rows of labeled
+/// `[value]` fields with active-field inverted-color highlighting → an
+/// action-hints row. All field computation, row-prefix text, and action-hint
+/// list are supplied by the per-domain projection so this component stays a
+/// pure renderer.
+#[component]
+pub fn FilterBar(props: &FilterBarProps) -> impl Into<AnyElement<'static>> {
+    if !props.visible {
+        return element! {
+            Box(width: 0u32, height: 0u32) {}
+        };
+    }
+
+    let rc = ResolvedColors::from_theme(Some(&props.colors));
+    let children = outer_children(props, rc);
+
+    element! {
+        Box(
+            flex_direction: FlexDirection::Column,
+            width: 100pct,
+            border_style: BorderStyle::Round,
+            border_color: rc.bright,
+            background_color: rc.bg,
+            padding_left: 1u32,
+            padding_right: 1u32,
+        ) {
+            #(children)
+        }
+    }
+}
+
+/// Build a [`FilterBar`] element from a fully-formed [`FilterBarProps`].
+///
+/// iocraft's `element!` macro cannot spread a pre-built props struct into a
+/// component invocation (each field must be passed inline), so domain wrappers
+/// like [`crate::ui::components::issue_filter_props`] return a
+/// [`FilterBarProps`] that is rendered through this helper. Screens embed the
+/// returned element as a pane child.
+#[must_use]
+pub fn filter_bar_element(props: FilterBarProps) -> AnyElement<'static> {
+    element! {
+        FilterBar(
+            fields: props.fields,
+            visible: props.visible,
+            row_prefix: props.row_prefix,
+            continuation_prefix: props.continuation_prefix,
+            fields_per_row: props.fields_per_row,
+            action_hints: props.action_hints,
+            colors: props.colors,
+        )
+    }
+    .into_any()
+}

--- a/src/ui/components/filter_bar.rs
+++ b/src/ui/components/filter_bar.rs
@@ -45,20 +45,24 @@ pub struct FilterFieldView {
 /// The projection owns the field computation, the row-prefix text, the
 /// fields-per-row count, and the action-hint list; the component is a pure
 /// renderer that applies the shared color logic and box structure.
+///
+/// `row_prefix`, `continuation_prefix`, and `action_hints` use `&'static str`
+/// because both domains (Issues and PRs) supply compile-time constant strings
+/// — this avoids per-render heap allocations.
 #[derive(Default, Props)]
 pub struct FilterBarProps {
     /// Projected field views, in render order (row-major).
     pub fields: Vec<FilterFieldView>,
     /// Whether the controls are visible (false → 0×0 box).
     pub visible: bool,
-    /// Text before the first field on row 1 (e.g. "Filter: ").
-    pub row_prefix: String,
+    /// Text before the first field on row 1 (e.g. `"Filter: "`).
+    pub row_prefix: &'static str,
     /// Alignment padding for row 2+ (matches row_prefix width per domain).
-    pub continuation_prefix: String,
+    pub continuation_prefix: &'static str,
     /// Number of fields per row (both domains use 4).
     pub fields_per_row: usize,
     /// Action hint segments rendered in the final row.
-    pub action_hints: Vec<String>,
+    pub action_hints: Vec<&'static str>,
     /// Theme colors.
     pub colors: ThemeColors,
 }
@@ -131,12 +135,12 @@ fn field_row_box(
 }
 
 /// Build the action-hints row: one `Text` per hint segment, all in `rc.dim`.
-fn action_hints_row(hints: &[String], rc: ResolvedColors) -> AnyElement<'static> {
+fn action_hints_row(hints: &[&'static str], rc: ResolvedColors) -> AnyElement<'static> {
     let texts: Vec<AnyElement<'static>> = hints
         .iter()
-        .map(|h| {
+        .map(|&h| {
             element! {
-                Text(content: h.as_str(), color: rc.dim)
+                Text(content: h, color: rc.dim)
             }
             .into_any()
         })
@@ -152,14 +156,18 @@ fn action_hints_row(hints: &[String], rc: ResolvedColors) -> AnyElement<'static>
 /// Build all children for the outer bordered column box: the field rows
 /// (chunked into `fields_per_row`), then the action-hints row.
 fn outer_children(props: &FilterBarProps, rc: ResolvedColors) -> Vec<AnyElement<'static>> {
+    debug_assert!(
+        props.fields_per_row > 0,
+        "fields_per_row must be > 0 — domain projections must always set it"
+    );
     let chunk = props.fields_per_row.max(1);
     let mut children: Vec<AnyElement<'static>> = Vec::new();
     for (row_idx, row_fields) in props.fields.chunks(chunk).enumerate() {
         // Row 0 uses row_prefix; every subsequent row uses continuation_prefix.
         let prefix = if row_idx == 0 {
-            props.row_prefix.as_str()
+            props.row_prefix
         } else {
-            props.continuation_prefix.as_str()
+            props.continuation_prefix
         };
         children.push(field_row_box(prefix, row_fields, rc));
     }

--- a/src/ui/components/filter_bar.rs
+++ b/src/ui/components/filter_bar.rs
@@ -62,7 +62,7 @@ pub struct FilterBarProps {
     /// Number of fields per row (both domains use 4).
     pub fields_per_row: usize,
     /// Action hint segments rendered in the final row.
-    pub action_hints: Vec<&'static str>,
+    pub action_hints: &'static [&'static str],
     /// Theme colors.
     pub colors: ThemeColors,
 }
@@ -77,7 +77,7 @@ impl Default for FilterBarProps {
             row_prefix: "",
             continuation_prefix: "",
             fields_per_row: 1,
-            action_hints: Vec::new(),
+            action_hints: &[],
             colors: ThemeColors::default(),
         }
     }
@@ -187,7 +187,7 @@ fn outer_children(props: &FilterBarProps, rc: ResolvedColors) -> Vec<AnyElement<
         };
         children.push(field_row_box(prefix, row_fields, rc));
     }
-    children.push(action_hints_row(&props.action_hints, rc));
+    children.push(action_hints_row(props.action_hints, rc));
     children
 }
 

--- a/src/ui/components/filter_bar.rs
+++ b/src/ui/components/filter_bar.rs
@@ -49,7 +49,7 @@ pub struct FilterFieldView {
 /// `row_prefix`, `continuation_prefix`, and `action_hints` use `&'static str`
 /// because both domains (Issues and PRs) supply compile-time constant strings
 /// — this avoids per-render heap allocations.
-#[derive(Default, Props)]
+#[derive(Props)]
 pub struct FilterBarProps {
     /// Projected field views, in render order (row-major).
     pub fields: Vec<FilterFieldView>,
@@ -65,6 +65,22 @@ pub struct FilterBarProps {
     pub action_hints: Vec<&'static str>,
     /// Theme colors.
     pub colors: ThemeColors,
+}
+
+impl Default for FilterBarProps {
+    /// Manual default so `fields_per_row` is `1` (a safe non-zero value)
+    /// instead of the derived `0`, preventing silent single-row collapse.
+    fn default() -> Self {
+        Self {
+            fields: Vec::new(),
+            visible: false,
+            row_prefix: "",
+            continuation_prefix: "",
+            fields_per_row: 1,
+            action_hints: Vec::new(),
+            colors: ThemeColors::default(),
+        }
+    }
 }
 
 /// Build the two-element group (label `Text` + value `Box`) for a single

--- a/src/ui/components/filter_bar_render_tests.rs
+++ b/src/ui/components/filter_bar_render_tests.rs
@@ -82,7 +82,7 @@ fn base_props(row_prefix: &'static str, continuation_prefix: &'static str) -> Fi
         row_prefix,
         continuation_prefix,
         fields_per_row: 4,
-        action_hints: vec!["Tab next  ", "Esc cancel"],
+        action_hints: &["Tab next  ", "Esc cancel"],
         colors: ThemeColors::default(),
     }
 }
@@ -165,7 +165,7 @@ fn filter_bar_renders_continuation_prefix_on_second_row() {
         row_prefix: "Filter: ",
         continuation_prefix: "       ",
         fields_per_row: 4,
-        action_hints: vec![],
+        action_hints: &[],
         colors: ThemeColors::default(),
     };
     let ansi = render_ansi(props, 80, 6);
@@ -275,7 +275,7 @@ fn filter_bar_issues_continuation_prefix_is_eight_spaces() {
         row_prefix: "Filter: ",
         continuation_prefix: "        ",
         fields_per_row: 4,
-        action_hints: vec![],
+        action_hints: &[],
         colors: ThemeColors::default(),
     };
     let plain = render_plain(props, 80, 6);
@@ -310,7 +310,7 @@ fn filter_bar_pr_continuation_prefix_is_seven_spaces() {
         row_prefix: "Filter: ",
         continuation_prefix: "       ",
         fields_per_row: 4,
-        action_hints: vec![],
+        action_hints: &[],
         colors: ThemeColors::default(),
     };
     let plain = render_plain(props, 80, 6);
@@ -348,7 +348,7 @@ fn forwarding_test_props() -> FilterBarProps {
         row_prefix: "ROWMARKER ",
         continuation_prefix: "CONTMARKER ",
         fields_per_row: 1,
-        action_hints: vec!["HINTMARKER"],
+        action_hints: &["HINTMARKER"],
         colors: ThemeColors::default(),
     }
 }
@@ -384,7 +384,7 @@ fn filter_bar_element_forwards_all_props_fields() {
         row_prefix: "",
         continuation_prefix: "",
         fields_per_row: 4,
-        action_hints: vec![],
+        action_hints: &[],
         colors: ThemeColors::default(),
     };
     let ansi = render_ansi(highlight_props, 60, 4);

--- a/src/ui/components/filter_bar_render_tests.rs
+++ b/src/ui/components/filter_bar_render_tests.rs
@@ -18,6 +18,8 @@ use crate::ui::components::{FilterBarProps, FilterFieldView, filter_bar_element}
 
 use iocraft::prelude::*;
 
+// ── Render helpers (kept together at the top) ──────────────────────────────
+
 /// Render a `FilterBar` element into an ANSI string at a fixed size.
 fn render_ansi(props: FilterBarProps, cols: u16, rows: u16) -> String {
     let mut elem = element! {
@@ -33,8 +35,36 @@ fn render_ansi(props: FilterBarProps, cols: u16, rows: u16) -> String {
     String::from_utf8_lossy(&buf).into_owned()
 }
 
+/// Strip ANSI SGR/cursor escape sequences so spacing assertions see plain text.
+fn strip_ansi(ansi: &str) -> String {
+    let mut out = String::with_capacity(ansi.len());
+    let mut chars = ansi.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' && chars.peek() == Some(&'[') {
+            // Consume the CSI sequence: ESC '[' ... letter.
+            chars.next();
+            for inner in chars.by_ref() {
+                if inner.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Render a `FilterBar` element into a plain-text canvas (ANSI-stripped) at a
+/// fixed size. Used for exact-substring checks on rendered row text.
+fn render_plain(props: FilterBarProps, cols: u16, rows: u16) -> String {
+    strip_ansi(&render_ansi(props, cols, rows))
+}
+
+// ── Test props ─────────────────────────────────────────────────────────────
+
 /// Build a minimal props with two fields (one row) for the basic tests.
-fn base_props(row_prefix: &str, continuation_prefix: &str) -> FilterBarProps {
+fn base_props(row_prefix: &'static str, continuation_prefix: &'static str) -> FilterBarProps {
     FilterBarProps {
         fields: vec![
             FilterFieldView {
@@ -49,10 +79,10 @@ fn base_props(row_prefix: &str, continuation_prefix: &str) -> FilterBarProps {
             },
         ],
         visible: true,
-        row_prefix: row_prefix.to_string(),
-        continuation_prefix: continuation_prefix.to_string(),
+        row_prefix,
+        continuation_prefix,
         fields_per_row: 4,
-        action_hints: vec!["Tab next  ".to_string(), "Esc cancel".to_string()],
+        action_hints: vec!["Tab next  ", "Esc cancel"],
         colors: ThemeColors::default(),
     }
 }
@@ -78,12 +108,6 @@ fn filter_bar_renders_empty_box_when_not_visible() {
         !ansi.contains('╭'),
         "invisible filter bar must not render a border: {ansi}"
     );
-}
-
-/// Render a `FilterBar` element into a plain-text canvas (ANSI-stripped) at a
-/// fixed size. Used for exact-substring checks on rendered row text.
-fn render_plain(props: FilterBarProps, cols: u16, rows: u16) -> String {
-    strip_ansi(&render_ansi(props, cols, rows))
 }
 
 // ── Field rendering ───────────────────────────────────────────────────────
@@ -138,8 +162,8 @@ fn filter_bar_renders_continuation_prefix_on_second_row() {
     let props = FilterBarProps {
         fields,
         visible: true,
-        row_prefix: "Filter: ".to_string(),
-        continuation_prefix: "       ".to_string(),
+        row_prefix: "Filter: ",
+        continuation_prefix: "       ",
         fields_per_row: 4,
         action_hints: vec![],
         colors: ThemeColors::default(),
@@ -156,6 +180,14 @@ fn filter_bar_renders_continuation_prefix_on_second_row() {
 
 // ── Active-field highlight color ───────────────────────────────────────────
 
+/// The SGR RGB values below are tightly coupled to `ThemeColors::default()`
+/// (the green-screen theme: bright=#00ff00, bg=#000000, dim=#6a9955). If the
+/// default theme changes, these assertions will fail — that is intentional:
+/// it forces a conscious update of the expected colors.
+const BRIGHT_BG_SGR: &str = "\u{1b}[48;2;0;255;0m";
+const BG_FG_SGR: &str = "\u{1b}[38;2;0;0;0m";
+const DIM_FG_SGR: &str = "\u{1b}[38;2;106;153;85m";
+
 /// The active field's value renders with the inverted-color background
 /// (`rc.bright` = #00ff00 → RGB 0;255;0). The inactive field's value does not
 /// carry that background SGR.
@@ -165,15 +197,14 @@ fn filter_bar_highlights_active_field_with_bright_background() {
     // Make field 0 active, field 1 inactive.
     props.fields[0].active = true;
     let ansi = render_ansi(props, 60, 6);
-    // Green-screen bright = #00ff00 → RGB 0;255;0. The active value's Box
-    // paints its background with the bright color (SGR 48;2;0;255;0).
+    // Coupled to ThemeColors::default() green-screen bright (#00ff00).
     assert!(
-        ansi.contains("\u{1b}[48;2;0;255;0m"),
+        ansi.contains(BRIGHT_BG_SGR),
         "active field value must render with bright (0;255;0) background: {ansi}"
     );
-    // The active value text itself uses rc.bg (#000000 → 0;0;0).
+    // Coupled to ThemeColors::default() green-screen bg (#000000).
     assert!(
-        ansi.contains("\u{1b}[38;2;0;0;0m"),
+        ansi.contains(BG_FG_SGR),
         "active field value text must render with bg (0;0;0) foreground: {ansi}"
     );
 }
@@ -184,7 +215,7 @@ fn filter_bar_renders_no_highlight_when_no_field_active() {
     let props = base_props("Filter: ", "        ");
     let ansi = render_ansi(props, 60, 6);
     assert!(
-        !ansi.contains("\u{1b}[48;2;0;255;0m"),
+        !ansi.contains(BRIGHT_BG_SGR),
         "no active field → no bright background highlight: {ansi}"
     );
 }
@@ -198,9 +229,9 @@ fn filter_bar_renders_no_highlight_when_no_field_active() {
 fn filter_bar_renders_action_hints_in_dim_color() {
     let props = base_props("Filter: ", "        ");
     let ansi = render_ansi(props, 60, 6);
-    // Green-screen dim = accent_secondary = #6a9955 → RGB 106;153;85.
+    // Coupled to ThemeColors::default() green-screen dim (#6a9955).
     assert!(
-        ansi.contains("\u{1b}[38;2;106;153;85m"),
+        ansi.contains(DIM_FG_SGR),
         "action hints must render in dim (106;153;85) color: {ansi}"
     );
     assert!(ansi.contains("Esc cancel"), "last hint text: {ansi}");
@@ -208,33 +239,21 @@ fn filter_bar_renders_action_hints_in_dim_color() {
 
 // ── Alignment parity (Issues vs PR) ────────────────────────────────────────
 
-/// Strip ANSI SGR/cursor escape sequences so spacing assertions see plain text.
-fn strip_ansi(ansi: &str) -> String {
-    let mut out = String::with_capacity(ansi.len());
-    let mut chars = ansi.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '\u{1b}' && chars.peek() == Some(&'[') {
-            // Consume the CSI sequence: ESC '[' ... letter.
-            chars.next();
-            for inner in chars.by_ref() {
-                if inner.is_ascii_alphabetic() {
-                    break;
-                }
-            }
-        } else {
-            out.push(c);
-        }
-    }
-    out
-}
-
 /// Count the leading spaces on a rendered row line, skipping the iocraft box
 /// border glyph (`│`). Both domains use `padding_left: 1u32`, so the count
 /// includes that single padding space plus the continuation-prefix spaces.
+///
+/// Asserts the border glyph is present before stripping so a rendering change
+/// (different border style, border removed) produces a clear test failure
+/// rather than a misleading space-count mismatch.
 fn leading_continuation_spaces(row: &str) -> usize {
-    // Drop the leading border glyph (`│`) if present, then count the run of
-    // spaces (padding_left + continuation prefix) before the first label.
-    let after_border = row.trim_start_matches('│');
+    assert!(
+        row.starts_with('│'),
+        "rendered row must start with the iocraft border glyph │: {row:?}"
+    );
+    // Drop the leading border glyph, then count the run of spaces
+    // (padding_left + continuation prefix) before the first label.
+    let after_border = &row['│'.len_utf8()..];
     after_border.chars().take_while(|&c| c == ' ').count()
 }
 
@@ -253,14 +272,13 @@ fn filter_bar_issues_continuation_prefix_is_eight_spaces() {
     let props = FilterBarProps {
         fields,
         visible: true,
-        row_prefix: "Filter: ".to_string(),
-        continuation_prefix: "        ".to_string(),
+        row_prefix: "Filter: ",
+        continuation_prefix: "        ",
         fields_per_row: 4,
         action_hints: vec![],
         colors: ThemeColors::default(),
     };
-    let ansi = render_ansi(props, 80, 6);
-    let plain = strip_ansi(&ansi);
+    let plain = render_plain(props, 80, 6);
     // Row 2 (the line containing f4) must start with 8 continuation-prefix
     // spaces before f4. The count includes the box padding-left (1 space), so
     // the rendered run is 1 (padding) + 8 (continuation) = 9 spaces.
@@ -289,14 +307,13 @@ fn filter_bar_pr_continuation_prefix_is_seven_spaces() {
     let props = FilterBarProps {
         fields,
         visible: true,
-        row_prefix: "Filter: ".to_string(),
-        continuation_prefix: "       ".to_string(),
+        row_prefix: "Filter: ",
+        continuation_prefix: "       ",
         fields_per_row: 4,
         action_hints: vec![],
         colors: ThemeColors::default(),
     };
-    let ansi = render_ansi(props, 80, 6);
-    let plain = strip_ansi(&ansi);
+    let plain = render_plain(props, 80, 6);
     // Row 2: 1 (padding) + 7 (continuation) = 8 rendered spaces before f4.
     let row2 = plain
         .lines()
@@ -306,5 +323,77 @@ fn filter_bar_pr_continuation_prefix_is_seven_spaces() {
     assert_eq!(
         leading, 8,
         "PR row-2 must have 8 rendered spaces (1 padding + 7 continuation) before f4: {row2:?}"
+    );
+}
+
+// ── filter_bar_element field-forwarding guard ──────────────────────────────
+
+/// Build props where every field contributes a unique marker so that
+/// `filter_bar_element` field-forwarding omissions are detectable.
+fn forwarding_test_props() -> FilterBarProps {
+    FilterBarProps {
+        fields: vec![
+            FilterFieldView {
+                label: "alphafield".to_string(),
+                value: "alphaval".to_string(),
+                active: true,
+            },
+            FilterFieldView {
+                label: "betafield".to_string(),
+                value: "betaval".to_string(),
+                active: false,
+            },
+        ],
+        visible: true,
+        row_prefix: "ROWMARKER ",
+        continuation_prefix: "CONTMARKER ",
+        fields_per_row: 1,
+        action_hints: vec!["HINTMARKER"],
+        colors: ThemeColors::default(),
+    }
+}
+
+/// Verify that `filter_bar_element` forwards every `FilterBarProps` field
+/// into the `FilterBar` component. If a field is dropped from the helper, its
+/// distinctive value will not appear in the rendered output.
+#[test]
+fn filter_bar_element_forwards_all_props_fields() {
+    let plain = render_plain(forwarding_test_props(), 80, 6);
+
+    // row_prefix forwarded → appears on row 1.
+    assert!(plain.contains("ROWMARKER"), "row_prefix: {plain}");
+    // continuation_prefix forwarded → appears on row 2 (fields_per_row=1).
+    assert!(plain.contains("CONTMARKER"), "continuation_prefix: {plain}");
+    // fields forwarded → labels and values appear.
+    assert!(
+        plain.contains("alphafield:[alphaval]"),
+        "fields[0]: {plain}"
+    );
+    assert!(plain.contains("betafield:[betaval]"), "fields[1]: {plain}");
+    // action_hints forwarded → hint text appears.
+    assert!(plain.contains("HINTMARKER"), "action_hints: {plain}");
+
+    // colors + visible forwarded → active highlight SGR + border glyph appear.
+    let highlight_props = FilterBarProps {
+        fields: vec![FilterFieldView {
+            label: "x".to_string(),
+            value: "y".to_string(),
+            active: true,
+        }],
+        visible: true,
+        row_prefix: "",
+        continuation_prefix: "",
+        fields_per_row: 4,
+        action_hints: vec![],
+        colors: ThemeColors::default(),
+    };
+    let ansi = render_ansi(highlight_props, 60, 4);
+    assert!(
+        ansi.contains(BRIGHT_BG_SGR),
+        "colors forwarded (active highlight visible): {ansi}"
+    );
+    assert!(
+        ansi.contains('│'),
+        "visible=true must produce a bordered box: {ansi}"
     );
 }

--- a/src/ui/components/filter_bar_render_tests.rs
+++ b/src/ui/components/filter_bar_render_tests.rs
@@ -1,0 +1,310 @@
+//! Render-path tests for the generic `FilterBar` component.
+//!
+//! These lock the shared structure that `FilterControls` (Issues) and
+//! `PrFilterControls` (PRs) delegate to after the refactoring: a bordered
+//! column box → rows of labeled `[value]` fields with active-field
+//! inverted-color highlighting → an action-hints row. The assertions are
+//! structural (visibility toggle, field/value text, active highlight color,
+//! action-hint text, row-prefix/continuation-prefix alignment) so they
+//! validate the generic renderer independently of the per-domain projections.
+//!
+//! @plan PLAN-20260329-ISSUES-MODE.P14
+//! @plan PLAN-20260624-PR-MODE.P12
+//! @requirement REQ-ISS-008
+//! @requirement REQ-PR-008
+
+use crate::theme::ThemeColors;
+use crate::ui::components::{FilterBarProps, FilterFieldView, filter_bar_element};
+
+use iocraft::prelude::*;
+
+/// Render a `FilterBar` element into an ANSI string at a fixed size.
+fn render_ansi(props: FilterBarProps, cols: u16, rows: u16) -> String {
+    let mut elem = element! {
+        Box(width: u32::from(cols), height: u32::from(rows)) {
+            #(vec![filter_bar_element(props)])
+        }
+    };
+    let canvas = elem.render(Some(usize::from(cols)));
+    let mut buf = Vec::new();
+    canvas
+        .write_ansi(&mut buf)
+        .unwrap_or_else(|e| panic!("write_ansi failed: {e}"));
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// Build a minimal props with two fields (one row) for the basic tests.
+fn base_props(row_prefix: &str, continuation_prefix: &str) -> FilterBarProps {
+    FilterBarProps {
+        fields: vec![
+            FilterFieldView {
+                label: "state".to_string(),
+                value: "open".to_string(),
+                active: false,
+            },
+            FilterFieldView {
+                label: "author".to_string(),
+                value: "alice".to_string(),
+                active: false,
+            },
+        ],
+        visible: true,
+        row_prefix: row_prefix.to_string(),
+        continuation_prefix: continuation_prefix.to_string(),
+        fields_per_row: 4,
+        action_hints: vec!["Tab next  ".to_string(), "Esc cancel".to_string()],
+        colors: ThemeColors::default(),
+    }
+}
+
+// ── Visibility toggle ─────────────────────────────────────────────────────
+
+/// When `visible` is false, the component renders a 0×0 box: no border, no
+/// field text, no hint text appears in the output.
+#[test]
+fn filter_bar_renders_empty_box_when_not_visible() {
+    let mut props = base_props("Filter: ", "        ");
+    props.visible = false;
+    let ansi = render_ansi(props, 60, 6);
+    assert!(
+        !ansi.contains("Filter:"),
+        "invisible filter bar must not render field text: {ansi}"
+    );
+    assert!(
+        !ansi.contains("Tab next"),
+        "invisible filter bar must not render hints: {ansi}"
+    );
+    assert!(
+        !ansi.contains('╭'),
+        "invisible filter bar must not render a border: {ansi}"
+    );
+}
+
+/// Render a `FilterBar` element into a plain-text canvas (ANSI-stripped) at a
+/// fixed size. Used for exact-substring checks on rendered row text.
+fn render_plain(props: FilterBarProps, cols: u16, rows: u16) -> String {
+    strip_ansi(&render_ansi(props, cols, rows))
+}
+
+// ── Field rendering ───────────────────────────────────────────────────────
+
+/// A visible filter bar renders the row prefix, every field label + bracketed
+/// value, and every action hint.
+#[test]
+fn filter_bar_renders_all_fields_and_hints_when_visible() {
+    let props = base_props("Filter: ", "        ");
+    let ansi = render_ansi(props, 60, 6);
+    assert!(ansi.contains("Filter:"), "row prefix must render: {ansi}");
+    assert!(ansi.contains("state:"), "first label must render: {ansi}");
+    assert!(ansi.contains("[open]"), "first value must render: {ansi}");
+    assert!(
+        ansi.contains("author:"),
+        "second label must render (note: two-space prefix is part of label): {ansi}"
+    );
+    assert!(ansi.contains("[alice]"), "second value must render: {ansi}");
+    assert!(ansi.contains("Tab next"), "first hint must render: {ansi}");
+    assert!(ansi.contains("Esc cancel"), "last hint must render: {ansi}");
+}
+
+/// The two-space separator between fields in the same row must be part of the
+/// second label's Text content (matching the pre-refactor components), not
+/// separate spacing. Verified by inspecting the plain-text rendered row:
+/// `state:[open]  author:[alice]`.
+#[test]
+fn filter_bar_two_space_prefix_is_part_of_subsequent_label_text() {
+    let props = base_props("Filter: ", "        ");
+    let plain = render_plain(props, 60, 6);
+    let row = plain
+        .lines()
+        .find(|line| line.contains("state:[open]"))
+        .unwrap_or_else(|| panic!("row with state field must render: {plain}"));
+    assert!(
+        row.contains("state:[open]  author:[alice]"),
+        "two-space prefix must be part of the subsequent label text: {row}"
+    );
+}
+
+/// When fields exceed one row, the continuation prefix renders on row 2 and
+/// row-2 field labels/values appear.
+#[test]
+fn filter_bar_renders_continuation_prefix_on_second_row() {
+    let fields: Vec<FilterFieldView> = (0..8)
+        .map(|i| FilterFieldView {
+            label: format!("f{i}"),
+            value: format!("v{i}"),
+            active: false,
+        })
+        .collect();
+    let props = FilterBarProps {
+        fields,
+        visible: true,
+        row_prefix: "Filter: ".to_string(),
+        continuation_prefix: "       ".to_string(),
+        fields_per_row: 4,
+        action_hints: vec![],
+        colors: ThemeColors::default(),
+    };
+    let ansi = render_ansi(props, 80, 6);
+    // Row 1 carries the row prefix and fields 0-3; row 2 carries fields 4-7.
+    assert!(ansi.contains("f0:"), "row-1 first label: {ansi}");
+    assert!(ansi.contains("[v0]"), "row-1 first value: {ansi}");
+    assert!(ansi.contains("f4:"), "row-2 first label: {ansi}");
+    assert!(ansi.contains("[v4]"), "row-2 first value: {ansi}");
+    assert!(ansi.contains("f7:"), "row-2 last label: {ansi}");
+    assert!(ansi.contains("[v7]"), "row-2 last value: {ansi}");
+}
+
+// ── Active-field highlight color ───────────────────────────────────────────
+
+/// The active field's value renders with the inverted-color background
+/// (`rc.bright` = #00ff00 → RGB 0;255;0). The inactive field's value does not
+/// carry that background SGR.
+#[test]
+fn filter_bar_highlights_active_field_with_bright_background() {
+    let mut props = base_props("Filter: ", "        ");
+    // Make field 0 active, field 1 inactive.
+    props.fields[0].active = true;
+    let ansi = render_ansi(props, 60, 6);
+    // Green-screen bright = #00ff00 → RGB 0;255;0. The active value's Box
+    // paints its background with the bright color (SGR 48;2;0;255;0).
+    assert!(
+        ansi.contains("\u{1b}[48;2;0;255;0m"),
+        "active field value must render with bright (0;255;0) background: {ansi}"
+    );
+    // The active value text itself uses rc.bg (#000000 → 0;0;0).
+    assert!(
+        ansi.contains("\u{1b}[38;2;0;0;0m"),
+        "active field value text must render with bg (0;0;0) foreground: {ansi}"
+    );
+}
+
+/// When no field is active, no inverted-color background SGR appears.
+#[test]
+fn filter_bar_renders_no_highlight_when_no_field_active() {
+    let props = base_props("Filter: ", "        ");
+    let ansi = render_ansi(props, 60, 6);
+    assert!(
+        !ansi.contains("\u{1b}[48;2;0;255;0m"),
+        "no active field → no bright background highlight: {ansi}"
+    );
+}
+
+// ── Action hints ──────────────────────────────────────────────────────────
+
+/// The action-hints row renders every hint segment in the dim color
+/// (`rc.dim` = #6a9955 → RGB 106;153;85) — same as both pre-refactor
+/// components which painted all hints `rc.dim`.
+#[test]
+fn filter_bar_renders_action_hints_in_dim_color() {
+    let props = base_props("Filter: ", "        ");
+    let ansi = render_ansi(props, 60, 6);
+    // Green-screen dim = accent_secondary = #6a9955 → RGB 106;153;85.
+    assert!(
+        ansi.contains("\u{1b}[38;2;106;153;85m"),
+        "action hints must render in dim (106;153;85) color: {ansi}"
+    );
+    assert!(ansi.contains("Esc cancel"), "last hint text: {ansi}");
+}
+
+// ── Alignment parity (Issues vs PR) ────────────────────────────────────────
+
+/// Strip ANSI SGR/cursor escape sequences so spacing assertions see plain text.
+fn strip_ansi(ansi: &str) -> String {
+    let mut out = String::with_capacity(ansi.len());
+    let mut chars = ansi.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' && chars.peek() == Some(&'[') {
+            // Consume the CSI sequence: ESC '[' ... letter.
+            chars.next();
+            for inner in chars.by_ref() {
+                if inner.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Count the leading spaces on a rendered row line, skipping the iocraft box
+/// border glyph (`│`). Both domains use `padding_left: 1u32`, so the count
+/// includes that single padding space plus the continuation-prefix spaces.
+fn leading_continuation_spaces(row: &str) -> usize {
+    // Drop the leading border glyph (`│`) if present, then count the run of
+    // spaces (padding_left + continuation prefix) before the first label.
+    let after_border = row.trim_start_matches('│');
+    after_border.chars().take_while(|&c| c == ' ').count()
+}
+
+/// Issues-style props (8-space continuation prefix) reproduce the exact row-2
+/// alignment: 8 leading spaces before the first row-2 label. The rendered
+/// output for row 2 starts with the continuation prefix text.
+#[test]
+fn filter_bar_issues_continuation_prefix_is_eight_spaces() {
+    let fields: Vec<FilterFieldView> = (0..8)
+        .map(|i| FilterFieldView {
+            label: format!("f{i}"),
+            value: format!("v{i}"),
+            active: false,
+        })
+        .collect();
+    let props = FilterBarProps {
+        fields,
+        visible: true,
+        row_prefix: "Filter: ".to_string(),
+        continuation_prefix: "        ".to_string(),
+        fields_per_row: 4,
+        action_hints: vec![],
+        colors: ThemeColors::default(),
+    };
+    let ansi = render_ansi(props, 80, 6);
+    let plain = strip_ansi(&ansi);
+    // Row 2 (the line containing f4) must start with 8 continuation-prefix
+    // spaces before f4. The count includes the box padding-left (1 space), so
+    // the rendered run is 1 (padding) + 8 (continuation) = 9 spaces.
+    let row2 = plain
+        .lines()
+        .find(|line| line.contains("f4"))
+        .unwrap_or_else(|| panic!("row containing f4 not found: {plain}"));
+    let leading = leading_continuation_spaces(row2);
+    assert_eq!(
+        leading, 9,
+        "Issues row-2 must have 9 rendered spaces (1 padding + 8 continuation) before f4: {row2:?}"
+    );
+}
+
+/// PR-style props (7-space continuation prefix) reproduce the exact row-2
+/// alignment: 7 leading spaces before the first row-2 label.
+#[test]
+fn filter_bar_pr_continuation_prefix_is_seven_spaces() {
+    let fields: Vec<FilterFieldView> = (0..8)
+        .map(|i| FilterFieldView {
+            label: format!("f{i}"),
+            value: format!("v{i}"),
+            active: false,
+        })
+        .collect();
+    let props = FilterBarProps {
+        fields,
+        visible: true,
+        row_prefix: "Filter: ".to_string(),
+        continuation_prefix: "       ".to_string(),
+        fields_per_row: 4,
+        action_hints: vec![],
+        colors: ThemeColors::default(),
+    };
+    let ansi = render_ansi(props, 80, 6);
+    let plain = strip_ansi(&ansi);
+    // Row 2: 1 (padding) + 7 (continuation) = 8 rendered spaces before f4.
+    let row2 = plain
+        .lines()
+        .find(|line| line.contains("f4"))
+        .unwrap_or_else(|| panic!("row containing f4 not found: {plain}"));
+    let leading = leading_continuation_spaces(row2);
+    assert_eq!(
+        leading, 8,
+        "PR row-2 must have 8 rendered spaces (1 padding + 7 continuation) before f4: {row2:?}"
+    );
+}

--- a/src/ui/components/filter_controls.rs
+++ b/src/ui/components/filter_controls.rs
@@ -1,28 +1,34 @@
-//! Filter controls component.
+//! Issue filter bar projection (pure, iocraft-free).
+//!
+//! Extracts the Issue filter field views, action hints, and full
+//! [`FilterBarProps`] for the generic [`super::filter_bar::FilterBar`] to
+//! render. This module owns NO iocraft types (`Color`, `Props`,
+//! `AnyElement`) — it is a pure projection per the pure-views pattern
+//! (see `dev-docs/standards/architecture.md`). The screen calls
+//! `filter_bar_element(issue_filter_props(...))`.
+//!
 //! @plan PLAN-20260329-ISSUES-MODE.P12
 //! @plan PLAN-20260329-ISSUES-MODE.P14
 //! @requirement REQ-ISS-008
 
-use iocraft::prelude::*;
-
 use crate::domain::{FILTER_CHOICE_ANY, IssueFilter, IssueFilterState};
-use crate::theme::{ResolvedColors, ThemeColors};
+use crate::theme::ThemeColors;
 
-/// Props for the filter controls pane.
-#[derive(Default, Props)]
-pub struct FilterControlsProps {
-    /// Current draft filter values.
-    pub draft_filter: IssueFilter,
-    /// Whether the controls are visible.
-    pub visible: bool,
-    /// Theme colors.
-    pub colors: ThemeColors,
-    /// Index of the currently focused filter field.
-    pub active_field_index: usize,
-    /// Raw labels text for display during editing.
-    pub draft_labels_text: String,
-}
+use super::filter_bar::{FilterBarProps, FilterFieldView};
 
+/// Row-1 prefix text before the first field (matches the pre-refactor
+/// `FilterControls` component exactly).
+const ROW_PREFIX: &str = "Filter: ";
+
+/// Row-2+ continuation prefix: 8 spaces (matches the pre-refactor Issues
+/// `FilterControls` component exactly — `"        "`).
+const CONTINUATION_PREFIX: &str = "        ";
+
+/// Number of fields per row (matches the pre-refactor two-row layout).
+const FIELDS_PER_ROW: usize = 4;
+
+/// Render `value` if non-empty, otherwise the "any" sentinel (used for the
+/// text fields: author, assignee, labels, type, milestone, module, search).
 fn display_any(value: &str) -> String {
     if value.is_empty() {
         FILTER_CHOICE_ANY.to_string()
@@ -31,97 +37,112 @@ fn display_any(value: &str) -> String {
     }
 }
 
-/// Filter controls — compact horizontal band showing current filter values and action hints.
-/// @plan PLAN-20260329-ISSUES-MODE.P14
-/// @requirement REQ-ISS-008
-#[component]
-pub fn FilterControls(props: &FilterControlsProps) -> impl Into<AnyElement<'static>> {
-    if !props.visible {
-        return element! {
-            Box(width: 0u32, height: 0u32) {}
-        };
-    }
-
-    let rc = ResolvedColors::from_theme(Some(&props.colors));
-    let idx = props.active_field_index;
-
-    let state_label = match props.draft_filter.state {
+/// The display value for the state filter field (without brackets), matching
+/// the pre-refactor `state_label` match.
+fn state_label(state: Option<IssueFilterState>) -> &'static str {
+    match state {
         Some(IssueFilterState::Open) | None => "open",
         Some(IssueFilterState::Closed) => "closed",
         Some(IssueFilterState::All) => "all",
-    };
+    }
+}
 
-    let author_val = display_any(&props.draft_filter.author);
-    let assignee_val = display_any(&props.draft_filter.assignee);
-    let labels_val = display_any(&props.draft_labels_text);
-    let type_val = display_any(&props.draft_filter.issue_type);
-    let milestone_val = display_any(&props.draft_filter.milestone);
-    let module_val = display_any(&props.draft_filter.module);
-    let search_val = display_any(&props.draft_filter.query_text);
+/// Pure projection of the eight Issue filter fields (state, author, assignee,
+/// labels, type, milestone, module, search) with display values + active
+/// highlighting.
+///
+/// @plan PLAN-20260329-ISSUES-MODE.P14
+/// @requirement REQ-ISS-008
+#[must_use]
+pub fn issue_filter_fields(
+    filter: &IssueFilter,
+    draft_labels_text: &str,
+    active_index: usize,
+) -> Vec<FilterFieldView> {
+    vec![
+        FilterFieldView {
+            label: "state".to_string(),
+            value: state_label(filter.state).to_string(),
+            active: active_index == 0,
+        },
+        FilterFieldView {
+            label: "author".to_string(),
+            value: display_any(&filter.author),
+            active: active_index == 1,
+        },
+        FilterFieldView {
+            label: "assignee".to_string(),
+            value: display_any(&filter.assignee),
+            active: active_index == 2,
+        },
+        FilterFieldView {
+            label: "labels".to_string(),
+            value: display_any(draft_labels_text),
+            active: active_index == 3,
+        },
+        FilterFieldView {
+            label: "type".to_string(),
+            value: display_any(&filter.issue_type),
+            active: active_index == 4,
+        },
+        FilterFieldView {
+            label: "milestone".to_string(),
+            value: display_any(&filter.milestone),
+            active: active_index == 5,
+        },
+        FilterFieldView {
+            label: "module".to_string(),
+            value: display_any(&filter.module),
+            active: active_index == 6,
+        },
+        FilterFieldView {
+            label: "search".to_string(),
+            value: display_any(&filter.query_text),
+            active: active_index == 7,
+        },
+    ]
+}
 
-    // Active field: inverted colors (bright bg, dark fg). Inactive: normal.
-    let val_color = |active: bool| if active { rc.bg } else { rc.fg };
-    let val_bg = |active: bool| if active { rc.bright } else { rc.bg };
-    let label_color = |active: bool| if active { rc.bright } else { rc.dim };
+/// Action-hint segments for the Issues filter bar (matches the pre-refactor
+/// `FilterControls` action-hints row exactly).
+///
+/// @plan PLAN-20260329-ISSUES-MODE.P14
+/// @requirement REQ-ISS-008
+#[must_use]
+pub fn issue_filter_action_hints() -> Vec<String> {
+    vec![
+        "Tab next  ".to_string(),
+        "←/→ choices  ".to_string(),
+        "Enter apply  ".to_string(),
+        "Delete field  ".to_string(),
+        "Ctrl-L clear all  ".to_string(),
+        "Esc cancel".to_string(),
+    ]
+}
 
-    element! {
-        Box(
-            flex_direction: FlexDirection::Column,
-            width: 100pct,
-            border_style: BorderStyle::Round,
-            border_color: rc.bright,
-            background_color: rc.bg,
-            padding_left: 1u32,
-            padding_right: 1u32,
-        ) {
-            // Filter values rows
-            Box(height: 1u32) {
-                Text(content: "Filter: ", color: rc.dim)
-                Text(content: "state:", color: label_color(idx == 0))
-                Box(background_color: val_bg(idx == 0)) {
-                    Text(content: format!("[{state_label}]"), color: val_color(idx == 0))
-                }
-                Text(content: "  author:", color: label_color(idx == 1))
-                Box(background_color: val_bg(idx == 1)) {
-                    Text(content: format!("[{author_val}]"), color: val_color(idx == 1))
-                }
-                Text(content: "  assignee:", color: label_color(idx == 2))
-                Box(background_color: val_bg(idx == 2)) {
-                    Text(content: format!("[{assignee_val}]"), color: val_color(idx == 2))
-                }
-                Text(content: "  labels:", color: label_color(idx == 3))
-                Box(background_color: val_bg(idx == 3)) {
-                    Text(content: format!("[{labels_val}]"), color: val_color(idx == 3))
-                }
-            }
-            Box(height: 1u32) {
-                Text(content: "        ", color: rc.dim)
-                Text(content: "type:", color: label_color(idx == 4))
-                Box(background_color: val_bg(idx == 4)) {
-                    Text(content: format!("[{type_val}]"), color: val_color(idx == 4))
-                }
-                Text(content: "  milestone:", color: label_color(idx == 5))
-                Box(background_color: val_bg(idx == 5)) {
-                    Text(content: format!("[{milestone_val}]"), color: val_color(idx == 5))
-                }
-                Text(content: "  module:", color: label_color(idx == 6))
-                Box(background_color: val_bg(idx == 6)) {
-                    Text(content: format!("[{module_val}]"), color: val_color(idx == 6))
-                }
-                Text(content: "  search:", color: label_color(idx == 7))
-                Box(background_color: val_bg(idx == 7)) {
-                    Text(content: format!("[{search_val}]"), color: val_color(idx == 7))
-                }
-            }
-            // Actions hint row
-            Box(height: 1u32) {
-                Text(content: "Tab next  ", color: rc.dim)
-                Text(content: "←/→ choices  ", color: rc.dim)
-                Text(content: "Enter apply  ", color: rc.dim)
-                Text(content: "Delete field  ", color: rc.dim)
-                Text(content: "Ctrl-L clear all  ", color: rc.dim)
-                Text(content: "Esc cancel", color: rc.dim)
-            }
-        }
+/// Build the full [`FilterBarProps`] for the Issues filter bar.
+///
+/// The screen calls `filter_bar_element(issue_filter_props(...))` to render
+/// the generic component. This projection owns the field computation, the
+/// row-prefix text, the continuation-prefix alignment, and the action hints.
+///
+/// @plan PLAN-20260329-ISSUES-MODE.P14
+/// @requirement REQ-ISS-008
+#[must_use]
+pub fn issue_filter_props(
+    filter: &IssueFilter,
+    draft_labels_text: &str,
+    active_index: usize,
+    visible: bool,
+    colors: ThemeColors,
+) -> FilterBarProps {
+    FilterBarProps {
+        fields: issue_filter_fields(filter, draft_labels_text, active_index),
+        visible,
+        row_prefix: ROW_PREFIX.to_string(),
+        continuation_prefix: CONTINUATION_PREFIX.to_string(),
+        fields_per_row: FIELDS_PER_ROW,
+        action_hints: issue_filter_action_hints(),
+        colors,
     }
 }

--- a/src/ui/components/filter_controls.rs
+++ b/src/ui/components/filter_controls.rs
@@ -106,13 +106,14 @@ pub fn issue_filter_fields(
 /// Action-hint segments for the Issues filter bar (matches the pre-refactor
 /// `FilterControls` action-hints row exactly).
 ///
-/// Returns `&'static str` slices to avoid per-render heap allocation.
+/// Returns a `&'static [&'static str]` slice to avoid per-render heap
+/// allocation — the hints are compile-time constants.
 ///
 /// @plan PLAN-20260329-ISSUES-MODE.P14
 /// @requirement REQ-ISS-008
 #[must_use]
-pub fn issue_filter_action_hints() -> Vec<&'static str> {
-    vec![
+pub fn issue_filter_action_hints() -> &'static [&'static str] {
+    &[
         "Tab next  ",
         "←/→ choices  ",
         "Enter apply  ",

--- a/src/ui/components/filter_controls.rs
+++ b/src/ui/components/filter_controls.rs
@@ -106,17 +106,19 @@ pub fn issue_filter_fields(
 /// Action-hint segments for the Issues filter bar (matches the pre-refactor
 /// `FilterControls` action-hints row exactly).
 ///
+/// Returns `&'static str` slices to avoid per-render heap allocation.
+///
 /// @plan PLAN-20260329-ISSUES-MODE.P14
 /// @requirement REQ-ISS-008
 #[must_use]
-pub fn issue_filter_action_hints() -> Vec<String> {
+pub fn issue_filter_action_hints() -> Vec<&'static str> {
     vec![
-        "Tab next  ".to_string(),
-        "←/→ choices  ".to_string(),
-        "Enter apply  ".to_string(),
-        "Delete field  ".to_string(),
-        "Ctrl-L clear all  ".to_string(),
-        "Esc cancel".to_string(),
+        "Tab next  ",
+        "←/→ choices  ",
+        "Enter apply  ",
+        "Delete field  ",
+        "Ctrl-L clear all  ",
+        "Esc cancel",
     ]
 }
 
@@ -139,8 +141,8 @@ pub fn issue_filter_props(
     FilterBarProps {
         fields: issue_filter_fields(filter, draft_labels_text, active_index),
         visible,
-        row_prefix: ROW_PREFIX.to_string(),
-        continuation_prefix: CONTINUATION_PREFIX.to_string(),
+        row_prefix: ROW_PREFIX,
+        continuation_prefix: CONTINUATION_PREFIX,
         fields_per_row: FIELDS_PER_ROW,
         action_hints: issue_filter_action_hints(),
         colors,

--- a/src/ui/components/filter_controls.rs
+++ b/src/ui/components/filter_controls.rs
@@ -27,6 +27,10 @@ const CONTINUATION_PREFIX: &str = "        ";
 /// Number of fields per row (matches the pre-refactor two-row layout).
 const FIELDS_PER_ROW: usize = 4;
 
+// Compile-time invariant: the continuation prefix must align with the row
+// prefix so row-2+ fields line up under row-1 fields. Both are 8 chars.
+const _: () = assert!(ROW_PREFIX.len() == CONTINUATION_PREFIX.len());
+
 /// Render `value` if non-empty, otherwise the "any" sentinel (used for the
 /// text fields: author, assignee, labels, type, milestone, module, search).
 fn display_any(value: &str) -> String {

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -287,7 +287,7 @@ pub fn issue_detail_props(inputs: IssueDetailProjectionInputs<'_>) -> DetailPane
         text,
         byte_cursor,
         content_width,
-        prefix: prefix.to_string(),
+        prefix,
     });
 
     DetailPaneProps {

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -70,7 +70,6 @@ pub fn issue_detail_header_view(detail: &IssueDetail) -> IssueDetailHeaderView {
 
 /// Inputs the Issues screen passes to [`issue_detail_props`], bundled to stay
 /// under the clippy::too_many-arguments threshold (max 6).
-#[derive(Clone)]
 pub struct IssueDetailProjectionInputs<'a> {
     /// Full issue detail (metadata, body, comments).
     pub issue_detail: Option<&'a IssueDetail>,

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -1,19 +1,25 @@
-//! Unified issue detail + comments view.
-//! @plan PLAN-20260329-ISSUES-MODE.P12
-//! @plan PLAN-20260329-ISSUES-MODE.P14
-//! @requirement REQ-ISS-009
-
-use iocraft::prelude::*;
+//! Issue detail pane projection.
+//!
+//! The pure header projection ([`IssueDetailHeaderView`] /
+//! [`issue_detail_header_view`]) is shared with the selection content provider
+//! so copied text matches the rendered rows. The full-pane projection
+//! ([`issue_detail_props`]) computes all layout math + semantic colors and
+//! builds a [`DetailPaneProps`] that the generic [`DetailPane`] renders via
+//! [`detail_pane_element`]. This module stays iocraft-free (pure-views
+//! pattern): it never touches `Color` — only semantic [`DetailHeaderColor`]
+//! roles resolved by the component.
 
 use crate::domain::{IssueDetail, IssueState};
 use crate::issue_detail_content::{DetailContent, build_detail_content, build_new_issue_content};
 use crate::layout::DETAIL_HEADER_ROWS as HEADER_ROWS;
-use crate::selection::{SelectablePane, TextSelection, row_highlight_range};
+use crate::selection::{SelectablePane, TextSelection};
 use crate::state::{ComposerTarget, DetailSubfocus, InlineState};
-use crate::theme::{ResolvedColors, ThemeColors};
+use crate::theme::ThemeColors;
 
-use super::scrollable_text::ScrollableText;
-use super::text_box::TextBox;
+use super::detail_pane::{
+    DetailComposerProps, DetailHeaderColor, DetailHeaderRow, DetailPaneProps,
+    composer_from_inline_state,
+};
 
 /// Projected issue detail header exactly as the component renders it (the four
 /// fixed metadata rows). The component delegates to this so the selection
@@ -32,6 +38,7 @@ pub struct IssueDetailHeaderView {
 
 /// Pure projection of the issue detail's four fixed header rows exactly as the
 /// component renders them.
+#[must_use]
 pub fn issue_detail_header_view(detail: &IssueDetail) -> IssueDetailHeaderView {
     let state_tag = match detail.state {
         IssueState::Open => "OPEN",
@@ -61,15 +68,16 @@ pub fn issue_detail_header_view(detail: &IssueDetail) -> IssueDetailHeaderView {
     }
 }
 
-/// Props for the issue detail view.
-#[derive(Default, Props)]
-pub struct IssueDetailViewProps {
+/// Inputs the Issues screen passes to [`issue_detail_props`], bundled to stay
+/// under the clippy::too_many-arguments threshold (max 6).
+#[derive(Clone)]
+pub struct IssueDetailProjectionInputs<'a> {
     /// Full issue detail (metadata, body, comments).
-    pub issue_detail: Option<IssueDetail>,
+    pub issue_detail: Option<&'a IssueDetail>,
     /// Which sub-element is focused within the detail view.
     pub detail_subfocus: DetailSubfocus,
     /// Active inline editor/composer state.
-    pub inline_state: InlineState,
+    pub inline_state: &'a InlineState,
     /// Whether comments are loading.
     pub comments_loading: bool,
     /// Whether this pane is focused.
@@ -82,179 +90,139 @@ pub struct IssueDetailViewProps {
     pub available_height: Option<u16>,
     /// Actual available width (in terminal columns) for detail/composer text.
     pub available_width: Option<u16>,
-    /// Active text selection, if any (and if it targets this pane). Passed
-    /// through to the `ScrollableText` so selected cells render inverse-video.
+    /// Active text selection, if any (and if it targets this pane).
     pub selection: Option<TextSelection>,
 }
 
-/// Shared header-row selection highlight + rendering helper used by both
-/// `IssueDetailView` and `PrDetailView`.
-///
-/// `header_highlight` checks whether content line `line` falls inside the
-/// active drag selection for `pane`. `header_row` renders the row with
-/// inverse-video when highlighted, or in the default color otherwise.
-///
-/// Header rows use whole-row highlight (ignoring partial column ranges) for
-/// visual simplicity on short metadata lines.
-pub fn header_highlight(
-    line: usize,
-    selection: Option<&TextSelection>,
-    pane: SelectablePane,
-) -> bool {
-    selection
-        .filter(|s| s.pane() == pane)
-        .and_then(|s| row_highlight_range(s, line))
-        .is_some()
-}
-
-/// Render a single header row, applying whole-row inverse-video when it falls
-/// inside the active drag selection.
-pub fn header_row(
-    content: String,
-    default_fg: Color,
-    line: usize,
-    selection: Option<&TextSelection>,
-    pane: SelectablePane,
-    rc: &ResolvedColors,
-) -> AnyElement<'static> {
-    if header_highlight(line, selection, pane) {
-        element! {
-            Box(height: 1u32, background_color: rc.sel_bg) {
-                Text(content: content, color: rc.sel_fg)
-            }
-        }
-        .into_any()
-    } else {
-        element! {
-            Box(height: 1u32) {
-                Text(content: content, color: default_fg)
-            }
-        }
-        .into_any()
+/// Semantic state-row color for an issue: `Bright` when Open, `Dim` when Closed.
+/// Matches the pre-refactor component (`rc.bright` / `rc.dim`).
+fn issue_state_color(state: IssueState) -> DetailHeaderColor {
+    match state {
+        IssueState::Open => DetailHeaderColor::Bright,
+        IssueState::Closed => DetailHeaderColor::Dim,
     }
 }
 
-fn active_issue_composer(inline_state: &InlineState) -> Option<(String, usize, &'static str)> {
-    match inline_state {
-        InlineState::Composer {
-            target: ComposerTarget::NewComment,
-            text,
-            cursor,
-        } => Some((
-            text.clone(),
-            *cursor,
-            crate::layout::NEW_COMMENT_COMPOSER_PREFIX,
-        )),
-        InlineState::Composer {
-            target: ComposerTarget::Reply { .. } | ComposerTarget::ReplyToReviewThread { .. },
-            text,
-            cursor,
-        } => Some((text.clone(), *cursor, crate::layout::REPLY_COMPOSER_PREFIX)),
-        InlineState::Composer {
-            target: ComposerTarget::NewIssue,
-            ..
-        }
-        | InlineState::Editor { .. }
-        | InlineState::None => None,
-    }
-}
-
-/// Issue detail view — fixed structure that NEVER changes layout.
-///
-/// ALWAYS renders: border box -> 5 header rows -> fixed-row scrollable viewport.
-/// When no issue is selected, header rows are blank and viewport shows a message.
-/// This ensures layout is identical regardless of whether an issue is loaded.
-///
-/// @plan PLAN-20260329-ISSUES-MODE.P14
-/// @requirement REQ-ISS-009
-#[component]
-pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'static>> {
-    let rc = ResolvedColors::from_theme(Some(&props.colors));
-    let border_style = if props.focused {
-        BorderStyle::Double
-    } else {
-        BorderStyle::Round
-    };
-
-    // Compute viewport rows. Prefer the actual available height passed from the
-    // parent layout; fall back to deriving it from the terminal size when the
-    // parent did not supply one.
-    let detail_viewport_rows = if let Some(height) = props.available_height {
-        // The available height is the real flex allocation for the detail pane,
-        // including its borders and header. Subtract header + border (2) to get
-        // the scrollable viewport. Do NOT force the minimum-viewport floor here:
-        // on a very short terminal that floor would exceed the parent allocation
-        // and overflow the layout. The floor is only a fallback heuristic used
-        // when the parent does not report an actual height.
+/// Compute the detail viewport rows (scrollable area) from the available pane
+/// height. Mirrors the pre-refactor component's height-derived viewport math.
+fn detail_viewport_rows(available_height: Option<u16>) -> usize {
+    if let Some(height) = available_height {
         (height as usize).saturating_sub(HEADER_ROWS + 2)
     } else {
         let term_rows = crossterm::terminal::size().map_or(40, |(_, h)| h as usize);
         crate::layout::detail_viewport_rows(term_rows)
-    };
-    let composer = active_issue_composer(&props.inline_state);
-    let composer_active = composer.is_some();
-    let reserved_document_rows =
-        crate::layout::issue_detail_document_viewport_rows(detail_viewport_rows, composer_active);
-    let detail_content_width = usize::from(props.available_width.unwrap_or_else(|| {
+    }
+}
+
+/// Build the five fixed header rows (title, state, labels, url, separator) with
+/// their semantic colors and selection-line indices.
+fn build_header_rows(
+    h_title: String,
+    h_state: String,
+    h_labels: String,
+    h_url: String,
+    state_color: DetailHeaderColor,
+) -> Vec<DetailHeaderRow> {
+    vec![
+        DetailHeaderRow {
+            content: h_title,
+            color: DetailHeaderColor::Fg,
+            line: 0,
+        },
+        DetailHeaderRow {
+            content: h_state,
+            color: state_color,
+            line: 1,
+        },
+        DetailHeaderRow {
+            content: h_labels,
+            color: DetailHeaderColor::Dim,
+            line: 2,
+        },
+        DetailHeaderRow {
+            content: h_url,
+            color: DetailHeaderColor::Dim,
+            line: 3,
+        },
+        DetailHeaderRow {
+            content: "─────────────────────────────────────────".to_string(),
+            color: DetailHeaderColor::Dim,
+            line: 4,
+        },
+    ]
+}
+
+/// Resolve the content + header for the "new issue composer" branch (title
+/// "New Issue", state "Draft", bright state color).
+fn new_issue_composer_content(inline_state: &InlineState) -> (Vec<DetailHeaderRow>, DetailContent) {
+    let rows = build_header_rows(
+        "New Issue".to_string(),
+        "Draft".to_string(),
+        String::new(),
+        String::new(),
+        DetailHeaderColor::Bright,
+    );
+    (rows, build_new_issue_content(inline_state))
+}
+
+/// Resolve the content + header for a loaded issue detail.
+fn loaded_issue_content(
+    detail: &IssueDetail,
+    detail_subfocus: DetailSubfocus,
+    inline_state: &InlineState,
+    comments_loading: bool,
+) -> (Vec<DetailHeaderRow>, DetailContent) {
+    let header = issue_detail_header_view(detail);
+    let rows = build_header_rows(
+        header.title,
+        header.state,
+        header.labels,
+        header.url,
+        issue_state_color(detail.state),
+    );
+    (
+        rows,
+        build_detail_content(detail, detail_subfocus, inline_state, comments_loading),
+    )
+}
+
+/// Resolve the content + header for the "no issue selected" placeholder branch.
+fn empty_issue_content() -> (Vec<DetailHeaderRow>, DetailContent) {
+    let rows = build_header_rows(
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        DetailHeaderColor::Dim,
+    );
+    (
+        rows,
+        DetailContent {
+            text: "No issue selected".to_string(),
+            cursor: None,
+        },
+    )
+}
+
+/// Resolve the issue detail content width (terminal cols) from the supplied
+/// width, falling back to the terminal size when the parent did not supply one.
+fn detail_content_width(available_width: Option<u16>) -> usize {
+    usize::from(available_width.unwrap_or_else(|| {
         crate::layout::issues_detail_content_width(
             crossterm::terminal::size().map_or(120, |(w, _)| w),
         )
-    }));
+    }))
+}
 
-    // Build header and content.
-    let showing_new_issue_composer = matches!(
-        &props.inline_state,
-        InlineState::Composer {
-            target: ComposerTarget::NewIssue,
-            ..
-        }
-    );
-
-    let (h_title, h_state, h_labels, h_url, detail_content, state_color) =
-        if showing_new_issue_composer {
-            (
-                "New Issue".to_string(),
-                "Draft".to_string(),
-                String::new(),
-                String::new(),
-                build_new_issue_content(&props.inline_state),
-                rc.bright,
-            )
-        } else if let Some(detail) = props.issue_detail.as_ref() {
-            let header = issue_detail_header_view(detail);
-            let sc = match detail.state {
-                IssueState::Open => rc.bright,
-                IssueState::Closed => rc.dim,
-            };
-
-            (
-                header.title,
-                header.state,
-                header.labels,
-                header.url,
-                build_detail_content(
-                    detail,
-                    props.detail_subfocus,
-                    &props.inline_state,
-                    props.comments_loading,
-                ),
-                sc,
-            )
-        } else {
-            (
-                String::new(),
-                String::new(),
-                String::new(),
-                String::new(),
-                DetailContent {
-                    text: "No issue selected".to_string(),
-                    cursor: None,
-                },
-                rc.dim,
-            )
-        };
-
-    let document_line_count = detail_content.text.lines().count().max(1);
+/// Compute the `(scroll_rows, composer_rows)` split for the issue detail pane
+/// given the total detail viewport rows, the reserved document rows, the
+/// document line count, and whether a composer is active.
+fn issue_scroll_composer_rows(
+    detail_viewport_rows: usize,
+    reserved_document_rows: usize,
+    document_line_count: usize,
+    composer_active: bool,
+) -> (usize, usize) {
     let scroll_rows = if composer_active {
         reserved_document_rows.min(document_line_count)
     } else {
@@ -266,77 +234,77 @@ pub fn IssueDetailView(props: &IssueDetailViewProps) -> impl Into<AnyElement<'st
     } else {
         0
     };
+    (scroll_rows, composer_rows)
+}
 
-    let composer_element: Option<AnyElement<'static>> =
-        composer.map(|(text, byte_cursor, prefix)| {
-            element! {
-                Box(width: 100pct, padding_left: 1u32) {
-                    TextBox(
-                        text: text,
-                        byte_cursor: byte_cursor,
-                        viewport_rows: composer_rows,
-                        content_width: detail_content_width,
-                        prefix: prefix.to_string(),
-                        color: rc.fg,
-                        caret_color: rc.bg,
-                        caret_bg: rc.bright,
-                    )
-                }
-            }
-            .into()
-        });
+/// Pure projection of the issue detail pane into a [`DetailPaneProps`].
+///
+/// Encapsulates ALL the logic the pre-refactor `IssueDetailView` component body
+/// owned: the new-issue-composer / loaded-detail / empty branching, the
+/// viewport/composer row math, the semantic state color, and the composer
+/// extraction. The result is rendered byte-identically by the generic
+/// [`DetailPane`] via [`detail_pane_element`].
+///
+/// This function is iocraft-free: it emits semantic [`DetailHeaderColor`] roles
+/// (never concrete `Color`), keeping the pure-views invariant.
+#[must_use]
+pub fn issue_detail_props(inputs: IssueDetailProjectionInputs<'_>) -> DetailPaneProps {
+    let detail_vp_rows = detail_viewport_rows(inputs.available_height);
+    let composer = composer_from_inline_state(inputs.inline_state);
+    let composer_active = composer.is_some();
+    let reserved_document_rows =
+        crate::layout::issue_detail_document_viewport_rows(detail_vp_rows, composer_active);
+    let content_width = detail_content_width(inputs.available_width);
 
-    element! {
-        Box(
-            flex_direction: FlexDirection::Column,
-            width: 100pct,
-            height: 100pct,
-            border_style: border_style,
-            border_color: rc.border,
-            background_color: rc.bg,
-        ) {
-            // ── Metadata header — always exactly HEADER_ROWS rows ─────────
-            Box(flex_direction: FlexDirection::Column, padding_left: 1u32, padding_right: 1u32) {
-                #(header_row(h_title, rc.fg, 0, props.selection.as_ref(), SelectablePane::IssueDetail, &rc))
-                #(header_row(h_state, state_color, 1, props.selection.as_ref(), SelectablePane::IssueDetail, &rc))
-                #(header_row(h_labels, rc.dim, 2, props.selection.as_ref(), SelectablePane::IssueDetail, &rc))
-                #(header_row(h_url, rc.dim, 3, props.selection.as_ref(), SelectablePane::IssueDetail, &rc))
-                #(header_row(
-                    "─────────────────────────────────────────".to_string(),
-                    rc.dim,
-                    4,
-                    props.selection.as_ref(),
-                    SelectablePane::IssueDetail,
-                    &rc,
-                ))
-            }
-
-            // ── Scrollable viewport — always exactly scroll_rows rows ─────
-            Box(width: 100pct, padding_left: 1u32) {
-                ScrollableText(
-                    content: detail_content.text,
-                    scroll_offset: props.scroll_offset,
-                    viewport_rows: scroll_rows,
-                    max_line_width: detail_content_width,
-                    cursor_line: detail_content.cursor.map(|(l, _)| l),
-                    cursor_col: detail_content.cursor.map(|(_, c)| c),
-                    color: rc.fg,
-                    cursor_color: rc.bg,
-                    cursor_bg: rc.bright,
-                    track_color: rc.dim,
-                    thumb_color: rc.bright,
-                    selection: props
-                        .selection
-                        .filter(|s| s.pane() == SelectablePane::IssueDetail),
-                    selection_bg: Some(rc.sel_bg),
-                    selection_fg: Some(rc.sel_fg),
-                    bg: Some(rc.bg),
-                    content_line_offset: HEADER_ROWS,
-                )
-            }
-
-            #(composer_element)
+    let showing_new_issue_composer = matches!(
+        inputs.inline_state,
+        InlineState::Composer {
+            target: ComposerTarget::NewIssue,
+            ..
         }
+    );
+
+    let (header_rows, detail_content) = if showing_new_issue_composer {
+        new_issue_composer_content(inputs.inline_state)
+    } else if let Some(detail) = inputs.issue_detail {
+        loaded_issue_content(
+            detail,
+            inputs.detail_subfocus,
+            inputs.inline_state,
+            inputs.comments_loading,
+        )
+    } else {
+        empty_issue_content()
+    };
+
+    let document_line_count = detail_content.text.lines().count().max(1);
+    let (scroll_rows, composer_rows) = issue_scroll_composer_rows(
+        detail_vp_rows,
+        reserved_document_rows,
+        document_line_count,
+        composer_active,
+    );
+    let composer_props = composer.map(|(text, byte_cursor, prefix)| DetailComposerProps {
+        text,
+        byte_cursor,
+        content_width,
+        prefix: prefix.to_string(),
+    });
+
+    DetailPaneProps {
+        header_rows,
+        content: detail_content.text,
+        content_cursor: detail_content.cursor,
+        scroll_offset: inputs.scroll_offset,
+        viewport_rows: scroll_rows,
+        content_line_offset: HEADER_ROWS,
+        max_line_width: content_width,
+        focused: inputs.focused,
+        pane: SelectablePane::IssueDetail,
+        colors: inputs.colors,
+        selection: inputs.selection,
+        composer: composer_props,
+        composer_rows,
     }
 }
 
@@ -358,10 +326,8 @@ mod tests {
         assert!(text.contains("New Issue"));
         assert!(text.contains("Title: first line | Body: remaining lines"));
         assert!(text.contains("Ctrl+Enter submit | Esc cancel"));
-        // Cursor should be positioned at the end of the text
         assert!(cursor.is_some());
         if let Some((line, col)) = cursor {
-            // Cursor on second line (after the newline), at end of body
             assert!(line > 0, "cursor should be on a text line");
             assert!(col > 0, "cursor column should be non-zero at end of text");
         }

--- a/src/ui/components/issue_detail_render_tests.rs
+++ b/src/ui/components/issue_detail_render_tests.rs
@@ -5,7 +5,7 @@
 use crate::domain::{IssueComment, IssueDetail, IssueState};
 use crate::state::{ComposerTarget, DetailSubfocus, InlineState};
 use crate::theme::ThemeColors;
-use crate::ui::components::IssueDetailView;
+use crate::ui::components::{IssueDetailProjectionInputs, detail_pane_element, issue_detail_props};
 
 use iocraft::prelude::*;
 
@@ -48,17 +48,20 @@ fn render_detail_canvas(p: RenderParams) -> iocraft::Canvas {
     let rows: u16 = p.pane_height + 10;
     let mut elem = element! {
         Box(width: u32::from(p.cols), height: u32::from(rows)) {
-            IssueDetailView(
-                issue_detail: Some(p.detail.clone()),
-                detail_subfocus: p.subfocus,
-                inline_state: p.inline_state.clone(),
-                comments_loading: false,
-                focused: true,
-                scroll_offset: p.scroll_offset,
-                colors: ThemeColors::default(),
-                available_height: Some(p.pane_height),
-                available_width: Some(p.cols),
-            )
+            #(vec![detail_pane_element(issue_detail_props(
+                IssueDetailProjectionInputs {
+                    issue_detail: Some(p.detail),
+                    detail_subfocus: p.subfocus,
+                    inline_state: p.inline_state,
+                    comments_loading: false,
+                    focused: true,
+                    scroll_offset: p.scroll_offset,
+                    colors: ThemeColors::default(),
+                    available_height: Some(p.pane_height),
+                    available_width: Some(p.cols),
+                    selection: None,
+                },
+            ))])
         }
     };
     elem.render(Some(usize::from(p.cols)))

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -21,6 +21,9 @@ pub(crate) mod filter_bar;
 /// Issue filter bar projection. The pure field projection
 /// (`issue_filter_fields`) and props builder (`issue_filter_props`) feed the
 /// generic [`filter_bar::FilterBar`] via `filter_bar_element`.
+///
+/// @plan PLAN-20260329-ISSUES-MODE.P14
+/// @requirement REQ-ISS-008
 mod filter_controls;
 /// Issue detail pane projection. The pure header projection
 /// (`issue_detail_header_view`) is reused by the selection content provider so
@@ -40,7 +43,14 @@ mod merge_chooser;
 /// (`pr_detail_header_view`) is reused by the selection content provider;
 /// rendering is delegated to the generic [`super::detail_pane::DetailPane`] via
 /// `pr_detail_props` + `detail_pane_element`.
+///
+/// @plan PLAN-20260624-PR-MODE.P12
+/// @requirement REQ-PR-006
 pub(crate) mod pr_detail;
+/// PR filter bar projection. The pure field projection
+/// (`pr_filter_field_views`) and props builder (`pr_filter_props`) feed the
+/// generic [`filter_bar::FilterBar`] via `filter_bar_element`.
+///
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-008
 pub(crate) mod pr_filter_controls;

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -5,11 +5,28 @@
 
 mod agent_chooser;
 mod agent_list;
+/// Generic bordered, header + scrollable + optional-composer detail pane.
+/// Domain layers (`issue_detail`, `pr_detail`) project into [`DetailPaneProps`]
+/// and delegate rendering through [`detail_pane_element`]. The shared header-row
+/// helpers (`header_highlight`, `header_row`) live here so both detail panes
+/// share one source of truth.
+pub(crate) mod detail_pane;
+/// Generic bordered filter bar with labeled `[value]` fields and action hints.
+/// Domain layers (`filter_controls` for Issues, `pr_filter_controls` for PRs)
+/// project into [`FilterBarProps`] and delegate rendering through
+/// [`filter_bar_element`]. The active-field inverted-color logic lives here
+/// because it needs iocraft `Color`/`ResolvedColors`; the projections stay
+/// iocraft-free.
+pub(crate) mod filter_bar;
+/// Issue filter bar projection. The pure field projection
+/// (`issue_filter_fields`) and props builder (`issue_filter_props`) feed the
+/// generic [`filter_bar::FilterBar`] via `filter_bar_element`.
 mod filter_controls;
-/// Issue detail pane projection + component. The projection
-/// (`issue_detail_header_view`, `header_highlight`, `header_row`) is reused by
-/// the PR detail component and the selection content provider so copied text
-/// matches the rendered rows.
+/// Issue detail pane projection. The pure header projection
+/// (`issue_detail_header_view`) is reused by the selection content provider so
+/// copied text matches the rendered rows; rendering is delegated to the generic
+/// [`super::detail_pane::DetailPane`] via `issue_detail_props` +
+/// `detail_pane_element`.
 pub(crate) mod issue_detail;
 /// Issue list pane projection + component (projection is reused by the
 /// selection content provider so copied text matches the rendered rows).
@@ -19,8 +36,10 @@ pub(crate) mod issue_list;
 pub(crate) mod keybind_bar;
 /// @requirement REQ-PR-009
 mod merge_chooser;
-/// @plan PLAN-20260624-PR-MODE.P12
-/// @requirement REQ-PR-006
+/// PR detail pane projection. The pure header projection
+/// (`pr_detail_header_view`) is reused by the selection content provider;
+/// rendering is delegated to the generic [`super::detail_pane::DetailPane`] via
+/// `pr_detail_props` + `detail_pane_element`.
 pub(crate) mod pr_detail;
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-008
@@ -47,8 +66,13 @@ mod text_box;
 
 pub use agent_chooser::{AgentChooser, AgentChooserProps};
 pub use agent_list::agent_list_props;
-pub use filter_controls::{FilterControls, FilterControlsProps};
-pub use issue_detail::{IssueDetailView, IssueDetailViewProps};
+pub use detail_pane::{
+    DetailComposerProps, DetailHeaderColor, DetailHeaderRow, DetailPane, DetailPaneProps,
+    composer_from_inline_state, detail_pane_element, header_highlight, header_row,
+};
+pub use filter_bar::{FilterBar, FilterBarProps, FilterFieldView, filter_bar_element};
+pub use filter_controls::{issue_filter_action_hints, issue_filter_fields, issue_filter_props};
+pub use issue_detail::{IssueDetailProjectionInputs, issue_detail_props};
 pub use issue_list::{
     IssueListLayout, IssueListWindow, issue_list_props, issue_list_status_message,
 };
@@ -57,10 +81,10 @@ pub use keybind_bar::{KeybindBar, KeybindBarProps};
 pub use merge_chooser::{MergeChooser, MergeChooserProps};
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-009
-pub use pr_detail::{PrDetailView, PrDetailViewProps};
+pub use pr_detail::{PrDetailProjectionInputs, pr_detail_props};
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-008
-pub use pr_filter_controls::{PrFilterControls, PrFilterControlsProps};
+pub use pr_filter_controls::{pr_filter_action_hints, pr_filter_field_views, pr_filter_props};
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-006
 pub use pr_list::{PrListLayout, PrListWindow, pr_list_props, pr_list_status_message};
@@ -98,3 +122,11 @@ mod pr_detail_render_tests;
 #[cfg(test)]
 #[path = "pr_render_screen_tests.rs"]
 mod pr_render_screen_tests;
+
+#[cfg(test)]
+#[path = "detail_pane_render_tests.rs"]
+mod detail_pane_render_tests;
+
+#[cfg(test)]
+#[path = "filter_bar_render_tests.rs"]
+mod filter_bar_render_tests;

--- a/src/ui/components/pr_detail.rs
+++ b/src/ui/components/pr_detail.rs
@@ -267,7 +267,7 @@ pub fn pr_detail_props(inputs: PrDetailProjectionInputs<'_>) -> DetailPaneProps 
         text,
         byte_cursor,
         content_width: inputs.detail_content_width,
-        prefix: prefix.to_string(),
+        prefix,
     });
 
     DetailPaneProps {

--- a/src/ui/components/pr_detail.rs
+++ b/src/ui/components/pr_detail.rs
@@ -1,19 +1,24 @@
-//! Unified PR detail + reviews + checks + comments view.
-//! @plan PLAN-20260624-PR-MODE.P12
-//! @requirement REQ-PR-009
+//! PR detail pane projection.
+//!
+//! The pure header projection ([`PrDetailHeaderView`] /
+//! [`pr_detail_header_view`]) is shared with the selection content provider.
+//! The full-pane projection ([`pr_detail_props`]) computes all layout math +
+//! semantic colors and builds a [`DetailPaneProps`] that the generic
+//! [`DetailPane`] renders via [`detail_pane_element`]. This module stays
+//! iocraft-free (pure-views pattern): it emits semantic [`DetailHeaderColor`]
+//! roles, never concrete `Color`.
 
-use iocraft::prelude::*;
-
-use crate::domain::PullRequestDetail;
+use crate::domain::{PrState, PullRequestDetail};
 use crate::layout::PR_DETAIL_HEADER_ROWS as HEADER_ROWS;
 use crate::pr_detail_content::{build_pr_detail_content, pr_state_tag};
 use crate::selection::{SelectablePane, TextSelection};
-use crate::state::{ComposerTarget, InlineState, PrDetailSubfocus};
-use crate::theme::{ResolvedColors, ThemeColors};
+use crate::state::{InlineState, PrDetailSubfocus};
+use crate::theme::ThemeColors;
 
-use super::issue_detail::header_row;
-use super::scrollable_text::ScrollableText;
-use super::text_box::TextBox;
+use super::detail_pane::{
+    DetailComposerProps, DetailHeaderColor, DetailHeaderRow, DetailPaneProps,
+    composer_from_inline_state,
+};
 
 /// Pure fallback term-rows constant used when no viewport height is supplied
 /// by the screen (the component never reads the terminal itself). Mirrors the
@@ -21,8 +26,7 @@ use super::text_box::TextBox;
 const DEFAULT_PR_DETAIL_TERM_ROWS: usize = 40;
 
 /// Projected PR detail header exactly as the component renders it (the four
-/// fixed metadata rows). The `#[component]` delegates to this so tests assert
-/// the SAME header the component renders (REQ-PR-009 / REQ-PR-012).
+/// fixed metadata rows). Tests assert the SAME header the renderer renders.
 ///
 /// @plan PLAN-20260624-PR-MODE.P13
 /// @requirement REQ-PR-009
@@ -46,6 +50,7 @@ pub struct PrDetailHeaderView {
 /// @requirement REQ-PR-009
 /// @requirement REQ-PR-012
 /// @pseudocode component-001 lines 1-12
+#[must_use]
 pub fn pr_detail_header_view(detail: &PullRequestDetail) -> PrDetailHeaderView {
     let state_tag = pr_state_tag(detail.state);
     let draft_marker = if detail.is_draft { " [DRAFT]" } else { "" };
@@ -74,15 +79,16 @@ pub fn pr_detail_header_view(detail: &PullRequestDetail) -> PrDetailHeaderView {
     }
 }
 
-/// Props for the PR detail view.
+/// Inputs the PRs screen passes to [`pr_detail_props`], bundled to stay under
+/// the clippy::too_many-arguments threshold (max 6).
 ///
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-009
 /// @pseudocode component-001 lines 1-12
-#[derive(Default, Props)]
-pub struct PrDetailViewProps {
+#[derive(Clone)]
+pub struct PrDetailProjectionInputs<'a> {
     /// Full PR detail (metadata, body, reviews, checks, comments).
-    pub detail: Option<PullRequestDetail>,
+    pub detail: Option<&'a PullRequestDetail>,
     /// Which sub-element is focused within the detail view.
     pub subfocus: PrDetailSubfocus,
     /// Scroll offset for the content viewport.
@@ -91,7 +97,6 @@ pub struct PrDetailViewProps {
     ///
     /// @plan PLAN-20260624-PR-MODE.P12
     /// @requirement REQ-PR-009
-    /// @pseudocode component-001 lines 1-12
     pub viewport_rows: Option<u16>,
     /// Whether the full PR detail is loading (after instant list preview).
     pub detail_loading: bool,
@@ -100,205 +105,185 @@ pub struct PrDetailViewProps {
     /// Whether this pane is focused.
     pub focused: bool,
     /// Active inline editor/composer state.
-    pub inline_state: InlineState,
-    /// Content width (terminal cols) for truncating PR-detail text via the
-    /// ScrollableText `max_line_width`, supplied by the screen from the same
-    /// `crossterm::terminal::size()` read the screen already performs. The
-    /// reducer NEVER wraps — truncation is safe (it clips columns only, never
-    /// changing line counts or cursor line), mirroring Issues mode.
+    pub inline_state: &'a InlineState,
+    /// Content width (terminal cols) for truncating PR-detail text.
     ///
     /// @plan PLAN-20260624-PR-MODE.P14
     /// @requirement REQ-PR-009
-    /// @pseudocode component-001 lines 1-12
     pub detail_content_width: usize,
     /// Theme colors.
     pub colors: ThemeColors,
-    /// Active text selection, if any (and if it targets this pane). Passed
-    /// through to the `ScrollableText` so selected cells render inverse-video.
+    /// Active text selection, if any (and if it targets this pane).
     pub selection: Option<TextSelection>,
 }
 
-/// Extract the active PR composer `(text, byte_cursor, prefix)`.
-///
-/// @plan PLAN-20260624-PR-MODE.P14
-/// @requirement REQ-PR-009
-/// @requirement REQ-PR-010
-/// @pseudocode component-001 lines 169-176
-fn active_pr_composer(inline_state: &InlineState) -> Option<(String, usize, &'static str)> {
-    match inline_state {
-        InlineState::Composer {
-            target: ComposerTarget::NewComment,
-            text,
-            cursor,
-        } => Some((
-            text.clone(),
-            *cursor,
-            crate::layout::NEW_COMMENT_COMPOSER_PREFIX,
-        )),
-        InlineState::Composer {
-            target: ComposerTarget::Reply { .. } | ComposerTarget::ReplyToReviewThread { .. },
-            text,
-            cursor,
-        } => Some((text.clone(), *cursor, crate::layout::REPLY_COMPOSER_PREFIX)),
-        InlineState::Composer {
-            target: ComposerTarget::NewIssue,
-            ..
-        }
-        | InlineState::Editor { .. }
-        | InlineState::None => None,
+/// Semantic state-row color for a PR: `Bright` when Open, `Dim` when Closed or
+/// Merged. Matches the pre-refactor component (`rc.bright` / `rc.dim`).
+fn pr_state_color(state: PrState) -> DetailHeaderColor {
+    match state {
+        PrState::Open => DetailHeaderColor::Bright,
+        PrState::Closed | PrState::Merged => DetailHeaderColor::Dim,
     }
 }
 
-/// PR detail view — fixed structure that NEVER changes layout.
+/// Compute the detail viewport rows (scrollable area) from the supplied pane
+/// height. Mirrors the pre-refactor component's height-derived viewport math.
+fn detail_viewport_rows(available_height: Option<u16>) -> usize {
+    if let Some(height) = available_height {
+        (height as usize).saturating_sub(HEADER_ROWS + 2)
+    } else {
+        crate::layout::prs_detail_viewport_rows(DEFAULT_PR_DETAIL_TERM_ROWS, false, false)
+    }
+}
+
+/// Build the five fixed header rows (title, state, branches, url, separator)
+/// with their semantic colors and selection-line indices.
+fn build_header_rows(
+    h_title: String,
+    h_state: String,
+    h_branches: String,
+    h_url: String,
+    state_color: DetailHeaderColor,
+) -> Vec<DetailHeaderRow> {
+    vec![
+        DetailHeaderRow {
+            content: h_title,
+            color: DetailHeaderColor::Fg,
+            line: 0,
+        },
+        DetailHeaderRow {
+            content: h_state,
+            color: state_color,
+            line: 1,
+        },
+        DetailHeaderRow {
+            content: h_branches,
+            color: DetailHeaderColor::Dim,
+            line: 2,
+        },
+        DetailHeaderRow {
+            content: h_url,
+            color: DetailHeaderColor::Dim,
+            line: 3,
+        },
+        DetailHeaderRow {
+            content: "─────────────────────────────────────────".to_string(),
+            color: DetailHeaderColor::Dim,
+            line: 4,
+        },
+    ]
+}
+
+/// Resolve the content + header for a loaded PR detail.
+fn loaded_pr_content(
+    detail: &PullRequestDetail,
+    subfocus: PrDetailSubfocus,
+    inline_state: &InlineState,
+    detail_loading: bool,
+    comments_loading: bool,
+) -> (
+    Vec<DetailHeaderRow>,
+    crate::issue_detail_content::DetailContent,
+) {
+    let header = pr_detail_header_view(detail);
+    let rows = build_header_rows(
+        header.title,
+        header.state,
+        header.branches,
+        header.url,
+        pr_state_color(detail.state),
+    );
+    (
+        rows,
+        build_pr_detail_content(
+            detail,
+            subfocus,
+            inline_state,
+            detail_loading,
+            comments_loading,
+        ),
+    )
+}
+
+/// Resolve the content + header for the "no PR selected" placeholder branch.
+fn empty_pr_content() -> (
+    Vec<DetailHeaderRow>,
+    crate::issue_detail_content::DetailContent,
+) {
+    let rows = build_header_rows(
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        DetailHeaderColor::Dim,
+    );
+    (
+        rows,
+        crate::issue_detail_content::DetailContent {
+            text: "No pull request selected".to_string(),
+            cursor: None,
+        },
+    )
+}
+
+/// Pure projection of the PR detail pane into a [`DetailPaneProps`].
 ///
-/// ALWAYS renders: border box → `HEADER_ROWS` header rows → fixed-row scrollable viewport.
-/// When no PR is selected, header rows are blank and viewport shows a message.
-/// When a NewComment composer is active, an embedded `TextBox` is rendered
-/// below the scroll viewport (the read-only document no longer flattens the
-/// composer text/cursor, so the document scroll offset stays stable while
-/// typing and the TextBox owns its own local caret viewport).
+/// Encapsulates ALL the logic the pre-refactor `PrDetailView` component body
+/// owned: the loaded-detail / empty branching, the viewport/composer row math,
+/// the semantic state color, and the composer extraction. The result is
+/// rendered byte-identically by the generic [`DetailPane`] via
+/// [`pr_detail_element`].
+///
+/// This function is iocraft-free: it emits semantic [`DetailHeaderColor`] roles
+/// (never concrete `Color`), keeping the pure-views invariant.
 ///
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @plan PLAN-20260624-PR-MODE.P14
 /// @requirement REQ-PR-009
 /// @requirement REQ-PR-010
 /// @pseudocode component-001 lines 169-176
-#[component]
-pub fn PrDetailView(props: &PrDetailViewProps) -> impl Into<AnyElement<'static>> {
-    let rc = ResolvedColors::from_theme(Some(&props.colors));
-    let border_style = if props.focused {
-        BorderStyle::Double
-    } else {
-        BorderStyle::Round
-    };
-
-    // Detect an active PR composer so we can reserve space for the embedded
-    // TextBox and reduce the scroll viewport accordingly.
-    let composer = active_pr_composer(&props.inline_state);
+#[must_use]
+pub fn pr_detail_props(inputs: PrDetailProjectionInputs<'_>) -> DetailPaneProps {
+    let detail_viewport_rows = detail_viewport_rows(inputs.viewport_rows);
+    let composer = composer_from_inline_state(inputs.inline_state);
     let text_box_active = composer.is_some();
 
-    // Compute viewport rows. Production screens pass the actual pane height;
-    // the fallback is a pure test/default path and intentionally avoids reading
-    // terminal size inside this component. Use the shared helper so the state
-    // scroll bounds and ScrollableText row count stay in the same coordinate
-    // system, including tiny panes where one read-only row is preserved.
-    let detail_viewport_rows = if let Some(height) = props.viewport_rows {
-        (height as usize).saturating_sub(HEADER_ROWS + 2)
-    } else {
-        crate::layout::prs_detail_viewport_rows(DEFAULT_PR_DETAIL_TERM_ROWS, false, false)
-    };
     let scroll_rows =
         crate::layout::pr_detail_document_viewport_rows(detail_viewport_rows, text_box_active);
     let composer_rows = detail_viewport_rows.saturating_sub(scroll_rows);
 
-    let (h_title, h_state, h_branches, h_url, detail_content, state_color) =
-        if let Some(detail) = props.detail.as_ref() {
-            let sc = match detail.state {
-                crate::domain::PrState::Open => rc.bright,
-                crate::domain::PrState::Closed | crate::domain::PrState::Merged => rc.dim,
-            };
-            let header = pr_detail_header_view(detail);
-            (
-                header.title,
-                header.state,
-                header.branches,
-                header.url,
-                build_pr_detail_content(
-                    detail,
-                    props.subfocus,
-                    &props.inline_state,
-                    props.detail_loading,
-                    props.comments_loading,
-                ),
-                sc,
-            )
-        } else {
-            (
-                String::new(),
-                String::new(),
-                String::new(),
-                String::new(),
-                crate::issue_detail_content::DetailContent {
-                    text: "No pull request selected".to_string(),
-                    cursor: None,
-                },
-                rc.dim,
-            )
-        };
+    let (header_rows, detail_content) = if let Some(detail) = inputs.detail {
+        loaded_pr_content(
+            detail,
+            inputs.subfocus,
+            inputs.inline_state,
+            inputs.detail_loading,
+            inputs.comments_loading,
+        )
+    } else {
+        empty_pr_content()
+    };
 
-    // Compute the TextBox props for the active PR composer (if any). The
-    // composer content width mirrors the detail content width so gutter-aligned
-    // text lines up with the read-only document.
-    let composer_element: Option<AnyElement<'static>> =
-        composer.map(|(text, byte_cursor, prefix)| {
-            element! {
-                Box(width: 100pct, padding_left: 1u32) {
-                    TextBox(
-                        text: text,
-                        byte_cursor: byte_cursor,
-                        viewport_rows: composer_rows,
-                        content_width: props.detail_content_width,
-                        prefix: prefix.to_string(),
-                        color: rc.fg,
-                        caret_color: rc.bg,
-                        caret_bg: rc.bright,
-                    )
-                }
-            }
-            .into()
-        });
+    let composer_props = composer.map(|(text, byte_cursor, prefix)| DetailComposerProps {
+        text,
+        byte_cursor,
+        content_width: inputs.detail_content_width,
+        prefix: prefix.to_string(),
+    });
 
-    element! {
-        Box(
-            flex_direction: FlexDirection::Column,
-            width: 100pct,
-            height: 100pct,
-            border_style: border_style,
-            border_color: rc.border,
-            background_color: rc.bg,
-        ) {
-            // ── Metadata header — always exactly HEADER_ROWS rows ─────────
-            Box(flex_direction: FlexDirection::Column, padding_left: 1u32, padding_right: 1u32) {
-                #(header_row(h_title, rc.fg, 0, props.selection.as_ref(), SelectablePane::PrDetail, &rc))
-                #(header_row(h_state, state_color, 1, props.selection.as_ref(), SelectablePane::PrDetail, &rc))
-                #(header_row(h_branches, rc.dim, 2, props.selection.as_ref(), SelectablePane::PrDetail, &rc))
-                #(header_row(h_url, rc.dim, 3, props.selection.as_ref(), SelectablePane::PrDetail, &rc))
-                #(header_row(
-                    "─────────────────────────────────────────".to_string(),
-                    rc.dim,
-                    4,
-                    props.selection.as_ref(),
-                    SelectablePane::PrDetail,
-                    &rc,
-                ))
-            }
-
-            // ── Scrollable viewport — always exactly scroll_rows rows ─────
-            Box(width: 100pct, padding_left: 1u32) {
-                ScrollableText(
-                    content: detail_content.text,
-                    scroll_offset: props.scroll_offset,
-                    viewport_rows: scroll_rows,
-                    max_line_width: props.detail_content_width,
-                    cursor_line: detail_content.cursor.map(|(l, _)| l),
-                    cursor_col: detail_content.cursor.map(|(_, c)| c),
-                    color: rc.fg,
-                    cursor_color: rc.bg,
-                    cursor_bg: rc.bright,
-                    track_color: rc.dim,
-                    thumb_color: rc.bright,
-                    selection: props
-                        .selection
-                        .filter(|s| s.pane() == crate::selection::SelectablePane::PrDetail),
-                    selection_bg: Some(rc.sel_bg),
-                    selection_fg: Some(rc.sel_fg),
-                    bg: Some(rc.bg),
-                    content_line_offset: HEADER_ROWS,
-                )
-            }
-
-            // ── Embedded NewComment TextBox composer (when active) ────────
-            #(composer_element)
-        }
+    DetailPaneProps {
+        header_rows,
+        content: detail_content.text,
+        content_cursor: detail_content.cursor,
+        scroll_offset: inputs.scroll_offset,
+        viewport_rows: scroll_rows,
+        content_line_offset: HEADER_ROWS,
+        max_line_width: inputs.detail_content_width,
+        focused: inputs.focused,
+        pane: SelectablePane::PrDetail,
+        colors: inputs.colors,
+        selection: inputs.selection,
+        composer: composer_props,
+        composer_rows,
     }
 }

--- a/src/ui/components/pr_detail.rs
+++ b/src/ui/components/pr_detail.rs
@@ -85,7 +85,6 @@ pub fn pr_detail_header_view(detail: &PullRequestDetail) -> PrDetailHeaderView {
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-009
 /// @pseudocode component-001 lines 1-12
-#[derive(Clone)]
 pub struct PrDetailProjectionInputs<'a> {
     /// Full PR detail (metadata, body, reviews, checks, comments).
     pub detail: Option<&'a PullRequestDetail>,

--- a/src/ui/components/pr_detail_render_tests.rs
+++ b/src/ui/components/pr_detail_render_tests.rs
@@ -10,7 +10,7 @@
 use crate::domain::{IssueComment, PrCheckStatus, PrState, PullRequestDetail};
 use crate::state::{ComposerTarget, InlineState, PrDetailSubfocus};
 use crate::theme::ThemeColors;
-use crate::ui::components::PrDetailView;
+use crate::ui::components::{PrDetailProjectionInputs, detail_pane_element, pr_detail_props};
 
 use iocraft::prelude::*;
 
@@ -80,18 +80,21 @@ fn render_detail_canvas(p: RenderParams) -> iocraft::Canvas {
     let rows: u16 = p.pane_height + 10;
     let mut elem = element! {
         Box(width: u32::from(p.cols), height: u32::from(rows)) {
-            PrDetailView(
-                detail: Some(p.detail.clone()),
-                subfocus: p.subfocus,
-                inline_state: p.inline_state.clone(),
-                detail_loading: false,
-                comments_loading: false,
-                focused: true,
-                scroll_offset: p.scroll_offset,
-                detail_content_width: p.detail_content_width,
-                colors: ThemeColors::default(),
-                viewport_rows: Some(p.pane_height),
-            )
+            #(vec![detail_pane_element(pr_detail_props(
+                PrDetailProjectionInputs {
+                    detail: Some(p.detail),
+                    subfocus: p.subfocus,
+                    inline_state: p.inline_state,
+                    detail_loading: false,
+                    comments_loading: false,
+                    focused: true,
+                    scroll_offset: p.scroll_offset,
+                    detail_content_width: p.detail_content_width,
+                    colors: ThemeColors::default(),
+                    viewport_rows: Some(p.pane_height),
+                    selection: None,
+                },
+            ))])
         }
     };
     elem.render(Some(usize::from(p.cols)))

--- a/src/ui/components/pr_filter_controls.rs
+++ b/src/ui/components/pr_filter_controls.rs
@@ -1,28 +1,30 @@
-//! PR filter controls component.
+//! PR filter bar projection (pure, iocraft-free).
+//!
+//! Extracts the PR filter field views, action hints, and full
+//! [`FilterBarProps`] for the generic [`super::filter_bar::FilterBar`] to
+//! render. This module owns NO iocraft types (`Color`, `Props`,
+//! `AnyElement`) — it is a pure projection per the pure-views pattern
+//! (see `dev-docs/standards/architecture.md`). The screen calls
+//! `filter_bar_element(pr_filter_props(...))`.
+//!
 //! @plan PLAN-20260624-PR-MODE.P12
 //! @requirement REQ-PR-008
 
-use iocraft::prelude::*;
-
 use crate::domain::{ChecksFilter, PrFilter, PrFilterState, ReviewDecisionFilter};
-use crate::theme::{ResolvedColors, ThemeColors};
+use crate::theme::ThemeColors;
 
-/// Projected PR filter field exactly as the component renders it (label,
-/// display value, and active highlight state). The `#[component]` delegates
-/// to a list of these so tests assert the SAME fields the component renders
-/// (REQ-PR-008).
-///
-/// @plan PLAN-20260624-PR-MODE.P13
-/// @requirement REQ-PR-008
-/// @pseudocode component-001 lines 1-12
-pub struct PrFilterFieldView {
-    /// Field label ("state", "draft", ...).
-    pub label: &'static str,
-    /// Display value WITHOUT brackets (e.g. "open", "any", "approved").
-    pub value: String,
-    /// Whether this field is the active (highlighted) field.
-    pub active: bool,
-}
+use super::filter_bar::{FilterBarProps, FilterFieldView};
+
+/// Row-1 prefix text before the first field (matches the pre-refactor
+/// `PrFilterControls` component exactly).
+const ROW_PREFIX: &str = "Filter: ";
+
+/// Row-2+ continuation prefix: 7 spaces (matches the pre-refactor
+/// `PrFilterControls` component exactly — `"       "`).
+const CONTINUATION_PREFIX: &str = "       ";
+
+/// Number of fields per row (matches the pre-refactor two-row layout).
+const FIELDS_PER_ROW: usize = 4;
 
 /// The display value for the state filter field (without brackets).
 ///
@@ -94,166 +96,102 @@ fn text_or_any(value: &str) -> String {
     }
 }
 
-/// Pure projection of the eight PR filter fields exactly as the component
-/// renders them (labels + display values + active highlighting). Returns
-/// exactly 8 entries in field order: state, draft, review, checks, author,
-/// assignee, reviewer, labels.
+/// Pure projection of the eight PR filter fields (state, draft, review,
+/// checks, author, assignee, reviewer, labels) with display values + active
+/// highlighting.
 ///
 /// @plan PLAN-20260624-PR-MODE.P13
 /// @requirement REQ-PR-008
 /// @pseudocode component-001 lines 1-12
+#[must_use]
 pub fn pr_filter_field_views(
     filter: &PrFilter,
     draft_labels_text: &str,
     active_index: usize,
-) -> Vec<PrFilterFieldView> {
+) -> Vec<FilterFieldView> {
     vec![
-        PrFilterFieldView {
-            label: "state",
+        FilterFieldView {
+            label: "state".to_string(),
             value: state_filter_value(filter.state).to_string(),
             active: active_index == 0,
         },
-        PrFilterFieldView {
-            label: "draft",
+        FilterFieldView {
+            label: "draft".to_string(),
             value: draft_filter_value(filter.is_draft).to_string(),
             active: active_index == 1,
         },
-        PrFilterFieldView {
-            label: "review",
+        FilterFieldView {
+            label: "review".to_string(),
             value: review_filter_value(filter.review_decision).to_string(),
             active: active_index == 2,
         },
-        PrFilterFieldView {
-            label: "checks",
+        FilterFieldView {
+            label: "checks".to_string(),
             value: checks_filter_value(filter.checks_status).to_string(),
             active: active_index == 3,
         },
-        PrFilterFieldView {
-            label: "author",
+        FilterFieldView {
+            label: "author".to_string(),
             value: text_or_any(&filter.author),
             active: active_index == 4,
         },
-        PrFilterFieldView {
-            label: "assignee",
+        FilterFieldView {
+            label: "assignee".to_string(),
             value: text_or_any(&filter.assignee),
             active: active_index == 5,
         },
-        PrFilterFieldView {
-            label: "reviewer",
+        FilterFieldView {
+            label: "reviewer".to_string(),
             value: text_or_any(&filter.reviewer),
             active: active_index == 6,
         },
-        PrFilterFieldView {
-            label: "labels",
+        FilterFieldView {
+            label: "labels".to_string(),
             value: text_or_any(draft_labels_text),
             active: active_index == 7,
         },
     ]
 }
 
-/// Props for the PR filter controls pane.
+/// Action-hint segments for the PR filter bar (matches the pre-refactor
+/// `PrFilterControls` action-hints row exactly).
 ///
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-008
-/// @pseudocode component-001 lines 1-12
-#[derive(Default, Props)]
-pub struct PrFilterControlsProps {
-    /// Current draft filter values.
-    pub draft_filter: PrFilter,
-    /// Whether the controls are visible.
-    pub visible: bool,
-    /// Theme colors.
-    pub colors: ThemeColors,
-    /// Index of the currently focused filter field.
-    pub active_field_index: usize,
-    /// Raw labels text for display during editing.
-    pub draft_labels_text: String,
+#[must_use]
+pub fn pr_filter_action_hints() -> Vec<String> {
+    vec![
+        "Tab next  ".to_string(),
+        "Space cycle  ".to_string(),
+        "Enter apply  ".to_string(),
+        "Ctrl-c clear  ".to_string(),
+        "Esc cancel".to_string(),
+    ]
 }
 
-/// PR filter controls — compact band showing the eight filter fields and action hints.
+/// Build the full [`FilterBarProps`] for the PR filter bar.
+///
+/// The screen calls `filter_bar_element(pr_filter_props(...))` to render
+/// the generic component. This projection owns the field computation, the
+/// row-prefix text, the continuation-prefix alignment, and the action hints.
 ///
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-008
-/// @pseudocode component-001 lines 1-12
-#[component]
-pub fn PrFilterControls(props: &PrFilterControlsProps) -> impl Into<AnyElement<'static>> {
-    if !props.visible {
-        return element! {
-            Box(width: 0u32, height: 0u32) {}
-        };
-    }
-
-    let rc = ResolvedColors::from_theme(Some(&props.colors));
-
-    let fields = pr_filter_field_views(
-        &props.draft_filter,
-        &props.draft_labels_text,
-        props.active_field_index,
-    );
-
-    // Active field: inverted colors (bright bg, dark fg). Inactive: normal.
-    let val_color = |active: bool| if active { rc.bg } else { rc.fg };
-    let val_bg = |active: bool| if active { rc.bright } else { rc.bg };
-    let label_color = |active: bool| if active { rc.bright } else { rc.dim };
-
-    element! {
-        Box(
-            flex_direction: FlexDirection::Column,
-            width: 100pct,
-            border_style: BorderStyle::Round,
-            border_color: rc.bright,
-            background_color: rc.bg,
-            padding_left: 1u32,
-            padding_right: 1u32,
-        ) {
-            // Filter values row 1: state, draft, review, checks
-            Box(height: 1u32) {
-                Text(content: "Filter: ", color: rc.dim)
-                Text(content: format!("{}:", fields[0].label), color: label_color(fields[0].active))
-                Box(background_color: val_bg(fields[0].active)) {
-                    Text(content: format!("[{}]", fields[0].value), color: val_color(fields[0].active))
-                }
-                Text(content: format!("  {}:", fields[1].label), color: label_color(fields[1].active))
-                Box(background_color: val_bg(fields[1].active)) {
-                    Text(content: format!("[{}]", fields[1].value), color: val_color(fields[1].active))
-                }
-                Text(content: format!("  {}:", fields[2].label), color: label_color(fields[2].active))
-                Box(background_color: val_bg(fields[2].active)) {
-                    Text(content: format!("[{}]", fields[2].value), color: val_color(fields[2].active))
-                }
-                Text(content: format!("  {}:", fields[3].label), color: label_color(fields[3].active))
-                Box(background_color: val_bg(fields[3].active)) {
-                    Text(content: format!("[{}]", fields[3].value), color: val_color(fields[3].active))
-                }
-            }
-            // Filter values row 2: author, assignee, reviewer, labels
-            Box(height: 1u32) {
-                Text(content: "       ", color: rc.dim)
-                Text(content: format!("{}:", fields[4].label), color: label_color(fields[4].active))
-                Box(background_color: val_bg(fields[4].active)) {
-                    Text(content: format!("[{}]", fields[4].value), color: val_color(fields[4].active))
-                }
-                Text(content: format!("  {}:", fields[5].label), color: label_color(fields[5].active))
-                Box(background_color: val_bg(fields[5].active)) {
-                    Text(content: format!("[{}]", fields[5].value), color: val_color(fields[5].active))
-                }
-                Text(content: format!("  {}:", fields[6].label), color: label_color(fields[6].active))
-                Box(background_color: val_bg(fields[6].active)) {
-                    Text(content: format!("[{}]", fields[6].value), color: val_color(fields[6].active))
-                }
-                Text(content: format!("  {}:", fields[7].label), color: label_color(fields[7].active))
-                Box(background_color: val_bg(fields[7].active)) {
-                    Text(content: format!("[{}]", fields[7].value), color: val_color(fields[7].active))
-                }
-            }
-            // Actions hint row
-            Box(height: 1u32) {
-                Text(content: "Tab next  ", color: rc.dim)
-                Text(content: "Space cycle  ", color: rc.dim)
-                Text(content: "Enter apply  ", color: rc.dim)
-                Text(content: "Ctrl-c clear  ", color: rc.dim)
-                Text(content: "Esc cancel", color: rc.dim)
-            }
-        }
+#[must_use]
+pub fn pr_filter_props(
+    filter: &PrFilter,
+    draft_labels_text: &str,
+    active_index: usize,
+    visible: bool,
+    colors: ThemeColors,
+) -> FilterBarProps {
+    FilterBarProps {
+        fields: pr_filter_field_views(filter, draft_labels_text, active_index),
+        visible,
+        row_prefix: ROW_PREFIX.to_string(),
+        continuation_prefix: CONTINUATION_PREFIX.to_string(),
+        fields_per_row: FIELDS_PER_ROW,
+        action_hints: pr_filter_action_hints(),
+        colors,
     }
 }

--- a/src/ui/components/pr_filter_controls.rs
+++ b/src/ui/components/pr_filter_controls.rs
@@ -26,6 +26,11 @@ const CONTINUATION_PREFIX: &str = "       ";
 /// Number of fields per row (matches the pre-refactor two-row layout).
 const FIELDS_PER_ROW: usize = 4;
 
+// Note: ROW_PREFIX ("Filter: ", 8 chars) and CONTINUATION_PREFIX (7 spaces)
+// intentionally differ in length — this mirrors the pre-refactor
+// `PrFilterControls` component exactly, which used a 7-space continuation
+// indent. Changing it would alter the rendered output.
+
 /// The display value for the state filter field (without brackets).
 ///
 /// @plan PLAN-20260624-PR-MODE.P13

--- a/src/ui/components/pr_filter_controls.rs
+++ b/src/ui/components/pr_filter_controls.rs
@@ -156,16 +156,18 @@ pub fn pr_filter_field_views(
 /// Action-hint segments for the PR filter bar (matches the pre-refactor
 /// `PrFilterControls` action-hints row exactly).
 ///
+/// Returns `&'static str` slices to avoid per-render heap allocation.
+///
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-008
 #[must_use]
-pub fn pr_filter_action_hints() -> Vec<String> {
+pub fn pr_filter_action_hints() -> Vec<&'static str> {
     vec![
-        "Tab next  ".to_string(),
-        "Space cycle  ".to_string(),
-        "Enter apply  ".to_string(),
-        "Ctrl-c clear  ".to_string(),
-        "Esc cancel".to_string(),
+        "Tab next  ",
+        "Space cycle  ",
+        "Enter apply  ",
+        "Ctrl-c clear  ",
+        "Esc cancel",
     ]
 }
 
@@ -188,8 +190,8 @@ pub fn pr_filter_props(
     FilterBarProps {
         fields: pr_filter_field_views(filter, draft_labels_text, active_index),
         visible,
-        row_prefix: ROW_PREFIX.to_string(),
-        continuation_prefix: CONTINUATION_PREFIX.to_string(),
+        row_prefix: ROW_PREFIX,
+        continuation_prefix: CONTINUATION_PREFIX,
         fields_per_row: FIELDS_PER_ROW,
         action_hints: pr_filter_action_hints(),
         colors,

--- a/src/ui/components/pr_filter_controls.rs
+++ b/src/ui/components/pr_filter_controls.rs
@@ -156,13 +156,14 @@ pub fn pr_filter_field_views(
 /// Action-hint segments for the PR filter bar (matches the pre-refactor
 /// `PrFilterControls` action-hints row exactly).
 ///
-/// Returns `&'static str` slices to avoid per-render heap allocation.
+/// Returns a `&'static [&'static str]` slice to avoid per-render heap
+/// allocation — the hints are compile-time constants.
 ///
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-008
 #[must_use]
-pub fn pr_filter_action_hints() -> Vec<&'static str> {
-    vec![
+pub fn pr_filter_action_hints() -> &'static [&'static str] {
+    &[
         "Tab next  ",
         "Space cycle  ",
         "Enter apply  ",

--- a/src/ui/components/pr_render_screen_tests.rs
+++ b/src/ui/components/pr_render_screen_tests.rs
@@ -44,7 +44,7 @@ fn assert_filter_fields_contract(filter: &PrFilter, labels_text: &str, active_in
         8,
         "exactly 8 filter fields must render (active_index={active_index})"
     );
-    let labels: Vec<&str> = views.iter().map(|v| v.label).collect();
+    let labels: Vec<&str> = views.iter().map(|v| v.label.as_str()).collect();
     assert_eq!(
         labels, EXPECTED_PR_FILTER_LABELS,
         "field labels must be in the documented order (active_index={active_index})"

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -11,8 +11,9 @@ use crate::state::{AppState, IssueFocus, PaneFocus, ScreenMode};
 use crate::theme::{ResolvedColors, ThemeColors};
 
 use super::super::components::{
-    AgentChooser, FilterControls, IssueDetailView, IssueListLayout, IssueListWindow, KeybindBar,
-    Sidebar, StatusBar, issue_list_props, issue_list_status_message, selectable_list_element,
+    AgentChooser, IssueDetailProjectionInputs, IssueListLayout, IssueListWindow, KeybindBar,
+    Sidebar, StatusBar, detail_pane_element, filter_bar_element, issue_detail_props,
+    issue_filter_props, issue_list_props, issue_list_status_message, selectable_list_element,
 };
 
 /// Props for the issues mode screen.
@@ -183,13 +184,13 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                     #(if filter_controls_open {
                         vec![element! {
                             Box(width: 100pct) {
-                                FilterControls(
-                                    draft_filter: draft_filter.clone(),
-                                    visible: true,
-                                    colors: colors.clone(),
-                                    active_field_index: filter_field_index,
-                                    draft_labels_text: draft_labels_text.clone(),
-                                )
+                                #(vec![filter_bar_element(issue_filter_props(
+                                    &draft_filter,
+                                    &draft_labels_text,
+                                    filter_field_index,
+                                    true,
+                                    colors.clone(),
+                                ))])
                             }
                         }]
                     } else {
@@ -214,18 +215,20 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                         ))])
                     }
                     Box(flex_grow: 1.0, width: 100pct) {
-                        IssueDetailView(
-                            issue_detail: issue_detail.clone(),
-                            detail_subfocus: detail_subfocus,
-                            inline_state: inline_state.clone(),
-                            comments_loading: comments_loading,
-                            focused: detail_focused,
-                            scroll_offset: detail_scroll_offset,
-                            colors: colors.clone(),
-                            available_height: Some(detail_pane_height),
-                            available_width: Some(crate::layout::issues_detail_content_width(term_cols)),
-                            selection: selection,
-                        )
+                        #(vec![detail_pane_element(issue_detail_props(
+                            IssueDetailProjectionInputs {
+                                issue_detail: issue_detail.as_ref(),
+                                detail_subfocus,
+                                inline_state: &inline_state,
+                                comments_loading,
+                                focused: detail_focused,
+                                scroll_offset: detail_scroll_offset,
+                                colors: colors.clone(),
+                                available_height: Some(detail_pane_height),
+                                available_width: Some(crate::layout::issues_detail_content_width(term_cols)),
+                                selection,
+                            },
+                        ))])
                     }
 
                     // Agent chooser overlay (anchored inside workspace)

--- a/src/ui/screens/pull_requests.rs
+++ b/src/ui/screens/pull_requests.rs
@@ -10,9 +10,9 @@ use crate::state::{AppState, PaneFocus, PrFocus, ScreenMode};
 use crate::theme::{ResolvedColors, ThemeColors};
 
 use super::super::components::{
-    AgentChooser, KeybindBar, MergeChooser, PrDetailView, PrFilterControls, PrListLayout,
-    PrListWindow, Sidebar, StatusBar, pr_list_props, pr_list_status_message,
-    selectable_list_element,
+    AgentChooser, KeybindBar, MergeChooser, PrDetailProjectionInputs, PrListLayout, PrListWindow,
+    Sidebar, StatusBar, detail_pane_element, filter_bar_element, pr_detail_props, pr_filter_props,
+    pr_list_props, pr_list_status_message, selectable_list_element,
 };
 
 /// Props for the pull requests mode screen.
@@ -212,13 +212,13 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                     #(if filter_controls_open {
                         vec![element! {
                             Box(width: 100pct) {
-                                PrFilterControls(
-                                    draft_filter: draft_filter.clone(),
-                                    visible: true,
-                                    colors: colors.clone(),
-                                    active_field_index: filter_field_index,
-                                    draft_labels_text: draft_labels_text.clone(),
-                                )
+                                #(vec![filter_bar_element(pr_filter_props(
+                                    &draft_filter,
+                                    &draft_labels_text,
+                                    filter_field_index,
+                                    true,
+                                    colors.clone(),
+                                ))])
                             }
                         }]
                     } else {
@@ -247,19 +247,21 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                         ))])
                     }
                     Box(flex_grow: 1.0, width: 100pct) {
-                        PrDetailView(
-                            detail: pr_detail.clone(),
-                            subfocus: detail_subfocus,
-                            inline_state: inline_state.clone(),
-                            detail_loading: detail_loading,
-                            comments_loading: comments_loading,
-                            focused: detail_focused,
-                            scroll_offset: detail_scroll_offset,
-                            detail_content_width: detail_content_width,
-                            colors: colors.clone(),
-                            viewport_rows: Some(detail_pane_height),
-                            selection: selection,
-                        )
+                        #(vec![detail_pane_element(pr_detail_props(
+                            PrDetailProjectionInputs {
+                                detail: pr_detail.as_ref(),
+                                subfocus: detail_subfocus,
+                                inline_state: &inline_state,
+                                detail_loading,
+                                comments_loading,
+                                focused: detail_focused,
+                                scroll_offset: detail_scroll_offset,
+                                detail_content_width,
+                                colors: colors.clone(),
+                                viewport_rows: Some(detail_pane_height),
+                                selection,
+                            },
+                        ))])
                     }
 
                     // Agent chooser overlay (anchored inside workspace)


### PR DESCRIPTION
## Summary

Completes the View-layer DRY epic (#142) by extracting the last two generic UI controls from duplicated domain components. This is a **pure refactoring** — all rendered output is byte-identical, verified by the existing render tests passing unchanged.

Closes #145, closes #146. Parent epic: #142.

## What changed

### DetailPane (sub-issue #145)

Extracted a generic `DetailPane` iocraft component from the duplicated rendering structure in `IssueDetailView` and `PrDetailView`. Both rendered: bordered box → N header rows (via the shared `header_row` helper) → `ScrollableText` viewport → optional `TextBox` composer.

- **New `src/ui/components/detail_pane.rs`** — the generic `#[component] fn DetailPane` + `DetailPaneProps` + `detail_pane_element` helper. Owns the shared iocraft structure once. The `header_row` / `header_highlight` selection-highlight helpers and the unified `composer_from_inline_state` (replacing the byte-identical `active_issue_composer` / `active_pr_composer`) live here.
- **`issue_detail.rs` / `pr_detail.rs`** — slimmed to **iocraft-free pure projection modules** returning `DetailPaneProps`. They carry semantic color roles (`DetailHeaderColor::{Fg, Bright, Dim}`) instead of concrete `Color`, keeping the pure-views invariant. All layout math (viewport rows, composer rows, content-line offset, the issue-vs-PR composer-row difference) lives in the projection.
- **Screens** call `detail_pane_element(issue_detail_props(...))` / `detail_pane_element(pr_detail_props(...))`.

### FilterBar (sub-issue #146)

Extracted a generic `FilterBar` iocraft component from the duplicated rendering in `FilterControls` (Issues) and `PrFilterControls` (PRs). Both rendered: bordered column → rows of labeled `[value]` fields with active-field inverted-color highlighting → action-hints row.

- **New `src/ui/components/filter_bar.rs`** — the generic `#[component] fn FilterBar` + `FilterBarProps` + `FilterFieldView` + `filter_bar_element` helper. Owns the shared rendering once.
- **`filter_controls.rs` / `pr_filter_controls.rs`** — slimmed to **iocraft-free pure projection modules**. The inline Issues field computation is extracted into `issue_filter_fields()`; `pr_filter_field_views()` now returns the generic `FilterFieldView`.
- **Byte-sensitive asymmetry preserved:** the Issues row-2 continuation prefix is 8 spaces; the PR row-2 continuation prefix is 7 spaces. This is carried in the projection props (`continuation_prefix`), not hardcoded in the generic component.

### Pattern consistency

Follows the exact pattern established by the already-merged `selectable_list.rs` (#144) and `shared UI utilities` (#143) refactors:
- Generic component + element-helper lives in its own module.
- Domain modules are pure iocraft-free projections.
- Screens call the generic element helper with projected props.

## Files

| File | Change |
|------|--------|
| `src/ui/components/detail_pane.rs` | **New** — generic DetailPane component |
| `src/ui/components/detail_pane_render_tests.rs` | **New** — 5 render tests |
| `src/ui/components/filter_bar.rs` | **New** — generic FilterBar component |
| `src/ui/components/filter_bar_render_tests.rs` | **New** — 9 render tests |
| `src/ui/components/issue_detail.rs` | Slimmed to pure projection |
| `src/ui/components/pr_detail.rs` | Slimmed to pure projection |
| `src/ui/components/filter_controls.rs` | Slimmed to pure projection |
| `src/ui/components/pr_filter_controls.rs` | Slimmed to pure projection |
| `src/ui/components/mod.rs` | Module + re-export updates |
| `src/ui/screens/issues.rs` | Use generic element helpers |
| `src/ui/screens/pull_requests.rs` | Use generic element helpers |
| `src/ui/components/issue_detail_render_tests.rs` | Harness updated (assertions unchanged) |
| `src/ui/components/pr_detail_render_tests.rs` | Harness updated (assertions unchanged) |
| `src/ui/components/pr_render_screen_tests.rs` | `.label.as_str()` for String labels |

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- Complexity-only clippy pass ✅
- `cargo llvm-cov --fail-under-lines 30` ✅ (65.4%)
- `cargo build --workspace --all-features --locked` ✅
- `cargo test --workspace --all-features --locked` ✅ (1289 tests, 0 failures)
- Existing render tests pass with assertions unchanged (byte-identical output)