### PR TITLE
Scroll detail pane to follow subfocus (keep focused item on-screen) (Fixes #151)

### DIFF
--- a/src/app_input/issues_subfocus_dispatch.rs
+++ b/src/app_input/issues_subfocus_dispatch.rs
@@ -1,0 +1,36 @@
+//! Issues detail scroll/subfocus dispatch helpers.
+//!
+//! Extracted from `app_input/mod.rs` to keep that file under the 1000-line
+//! source-file limit. Both the detail scroll-down and the subfocus-next/prev
+//! paths refresh the cached viewport row count before the reducer runs so the
+//! scroll clamp and the scroll-into-view computation (#151) use a fresh
+//! viewport height.
+
+use jefe::messages::{AppMessage, IssuesMessage};
+use jefe::state::AppEvent;
+
+use super::{
+    AppStateHandle, SharedContext, apply_and_persist, issues_dispatch, update_detail_viewport_rows,
+};
+
+/// Dispatch Issues detail scroll and subfocus messages.
+///
+/// Both paths refresh the cached viewport row count before the reducer runs so
+/// the scroll clamp and the scroll-into-view computation (#151) use a fresh
+/// viewport height. Scroll-down arms additionally trigger the load-more-comments
+/// check.
+pub(super) fn dispatch_issues_detail_scroll_or_subfocus(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    message: IssuesMessage,
+) {
+    let is_scroll_down = matches!(
+        message,
+        IssuesMessage::ScrollDetailDown | IssuesMessage::ScrollDetailPageDown
+    );
+    update_detail_viewport_rows(app_state);
+    apply_and_persist(app_state, ctx, AppEvent::from(AppMessage::Issues(message)));
+    if is_scroll_down {
+        issues_dispatch::load_more_comments(app_state, ctx);
+    }
+}

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -5,6 +5,7 @@ mod issues_dispatch;
 mod issues_filter;
 mod issues_list_dispatch;
 mod issues_mutation;
+mod issues_subfocus_dispatch;
 mod modal_handlers;
 mod normal;
 mod persist_focus;
@@ -450,12 +451,13 @@ pub fn dispatch_app_message(
             issues_dispatch::load_issue_detail_for_selection(app_state, ctx);
         }
         AppMessage::Issues(
-            message @ (IssuesMessage::ScrollDetailDown | IssuesMessage::ScrollDetailPageDown),
-        ) => {
-            update_detail_viewport_rows(app_state);
-            apply_and_persist(app_state, ctx, AppEvent::from(AppMessage::Issues(message)));
-            issues_dispatch::load_more_comments(app_state, ctx);
-        }
+            message @ (IssuesMessage::ScrollDetailDown
+            | IssuesMessage::ScrollDetailPageDown
+            | IssuesMessage::DetailSubfocusNext
+            | IssuesMessage::DetailSubfocusPrev),
+        ) => issues_subfocus_dispatch::dispatch_issues_detail_scroll_or_subfocus(
+            app_state, ctx, message,
+        ),
         AppMessage::Issues(IssuesMessage::AgentChooserConfirm) => {
             dispatch_agent_chooser_confirm(app_state, ctx);
         }

--- a/src/issue_detail_content.rs
+++ b/src/issue_detail_content.rs
@@ -62,12 +62,8 @@ fn issue_subfocus_range_from_lines(
                 .iter()
                 .position(|l| *l == "> Body" || *l == "  Body")?;
             // Body spans from its label to the line before the next separator.
-            let end = lines
-                .iter()
-                .enumerate()
-                .skip(start + 1)
-                .find(|(_, l)| l.starts_with('─'))
-                .map(|(i, _)| i.saturating_sub(1))?;
+            // Fall back to the last content line if no separator follows.
+            let end = find_section_end(lines, start);
             Some((start, end))
         }
         DetailSubfocus::Comment(target_idx) => {
@@ -97,19 +93,31 @@ fn issue_subfocus_range_from_lines(
 }
 
 /// True for a comment header line in the Comments section: prefix `"> "` or
-/// `  "` + author + date. Editor gutter lines (`"    │ "`) are excluded.
+/// `  "` + `@author` + date. Editor gutter lines (`"│"`) and reply anchors
+/// (`"[Reply]"`) are excluded. Body sub-lines (6-space indent rendered as
+/// `"  "  body text"` after stripping the 2-space prefix → 4-space indent) are
+/// excluded because they start with spaces, not `@`.
+/// Find the last line of a section (the line before the next separator). If
+/// no separator follows, the last content line is used. Falls back to
+/// `start` itself if the section is a single label line.
+fn find_section_end(lines: &[&str], start: usize) -> usize {
+    if let Some((i, _)) = lines
+        .iter()
+        .enumerate()
+        .skip(start + 1)
+        .find(|(_, l)| l.starts_with('─'))
+    {
+        return i.saturating_sub(1);
+    }
+    lines.len().saturating_sub(1).max(start)
+}
 fn issue_line_is_comment(line: &str) -> bool {
     let Some(rest) = line.strip_prefix("> ").or_else(|| line.strip_prefix("  ")) else {
         return false;
     };
-    // Editor gutter lines and reply anchors start with "│" or "[Reply]".
-    if rest.starts_with('│') || rest.starts_with("[Reply]") {
-        return false;
-    }
-    // Comment line: "@author  date" or "author  date" — contains a double
-    // space separating author from date. Section labels like "Comments" are
-    // excluded by the caller's skip.
-    rest.contains("  ")
+    // Editor gutter lines, reply anchors, and editing markers start with
+    // special chars; comment headers start with `@author`.
+    rest.starts_with('@')
 }
 
 /// Find the last content line of a comment block (the blank line that
@@ -615,5 +623,84 @@ mod tests {
             false,
         );
         assert!(range.is_none(), "out-of-bounds comment must return None");
+    }
+
+    #[test]
+    fn issue_subfocus_line_range_comment_1_locates_second_comment() {
+        let detail = detail_with_comments(2);
+        let range = require_range(
+            &detail,
+            DetailSubfocus::Comment(1),
+            &InlineState::None,
+            false,
+        );
+        let content = build_detail_content(
+            &detail,
+            DetailSubfocus::Comment(1),
+            &InlineState::None,
+            false,
+        );
+        let lines: Vec<&str> = content.text.lines().collect();
+        let block: Vec<&str> = lines[range.0..=range.1].to_vec();
+        assert!(
+            block.iter().any(|l| l.contains("comment 1")),
+            "Comment(1) must locate the second comment, got block: {block:?}"
+        );
+        // The header line must start with the comment marker, not a body line.
+        let header = lines[range.0];
+        assert!(
+            header
+                .strip_prefix("> ")
+                .is_some_and(|r| r.starts_with('@'))
+                || header
+                    .strip_prefix("  ")
+                    .is_some_and(|r| r.starts_with('@')),
+            "Comment(1) header must be a comment header starting with @, got: {header:?}"
+        );
+    }
+
+    #[test]
+    fn issue_subfocus_line_range_comment_not_confused_by_body_lines() {
+        // Two comments with multi-line bodies. Body lines are indented and must
+        // NOT be miscounted as comment headers.
+        let mut detail = detail_with_body("body");
+        detail.comments = vec![
+            comment(
+                "comment 0 line 1
+comment 0 line 2",
+            ),
+            comment(
+                "comment 1 line 1
+comment 1 line 2",
+            ),
+        ];
+        let range = require_range(
+            &detail,
+            DetailSubfocus::Comment(1),
+            &InlineState::None,
+            false,
+        );
+        let content = build_detail_content(
+            &detail,
+            DetailSubfocus::Comment(1),
+            &InlineState::None,
+            false,
+        );
+        let lines: Vec<&str> = content.text.lines().collect();
+        let header = lines[range.0];
+        assert!(
+            header
+                .strip_prefix("> ")
+                .is_some_and(|r| r.starts_with('@'))
+                || header
+                    .strip_prefix("  ")
+                    .is_some_and(|r| r.starts_with('@')),
+            "Comment(1) must point at a header line, not a body line: {header:?}"
+        );
+        let block: Vec<&str> = lines[range.0..=range.1].to_vec();
+        assert!(
+            block.iter().any(|l| l.contains("comment 1")),
+            "Comment(1) block must contain the second comment body, got: {block:?}"
+        );
     }
 }

--- a/src/issue_detail_content.rs
+++ b/src/issue_detail_content.rs
@@ -86,7 +86,11 @@ fn issue_subfocus_range_from_lines(
             let start = lines
                 .iter()
                 .position(|l| *l == "> New Comment" || *l == "  New Comment")?;
-            let end = (start + 1).min(lines.len().saturating_sub(1));
+            // NewComment is the last section; it spans from its label to the
+            // end of content (no separator follows). This adapts to the
+            // variable-length composer editor when a NewComment composer is
+            // active (the editor pushes several rows into the document).
+            let end = lines.len().saturating_sub(1).max(start);
             Some((start, end))
         }
     }
@@ -97,6 +101,15 @@ fn issue_subfocus_range_from_lines(
 /// (`"[Reply]"`) are excluded. Body sub-lines (6-space indent rendered as
 /// `"  "  body text"` after stripping the 2-space prefix → 4-space indent) are
 /// excluded because they start with spaces, not `@`.
+fn issue_line_is_comment(line: &str) -> bool {
+    let Some(rest) = line.strip_prefix("> ").or_else(|| line.strip_prefix("  ")) else {
+        return false;
+    };
+    // Editor gutter lines, reply anchors, and editing markers start with
+    // special chars; comment headers start with `@author`.
+    rest.starts_with('@')
+}
+
 /// Find the last line of a section (the line before the next separator). If
 /// no separator follows, the last content line is used. Falls back to
 /// `start` itself if the section is a single label line.
@@ -110,14 +123,6 @@ fn find_section_end(lines: &[&str], start: usize) -> usize {
         return i.saturating_sub(1);
     }
     lines.len().saturating_sub(1).max(start)
-}
-fn issue_line_is_comment(line: &str) -> bool {
-    let Some(rest) = line.strip_prefix("> ").or_else(|| line.strip_prefix("  ")) else {
-        return false;
-    };
-    // Editor gutter lines, reply anchors, and editing markers start with
-    // special chars; comment headers start with `@author`.
-    rest.starts_with('@')
 }
 
 /// Find the last content line of a comment block (the blank line that

--- a/src/issue_detail_content.rs
+++ b/src/issue_detail_content.rs
@@ -27,6 +27,102 @@ pub fn detail_content_line_count(
     build_detail_lines(detail, DetailSubfocus::Body, inline_state, comments_loading).len()
 }
 
+/// Compute the inclusive content-line range `[start, end]` of the focused
+/// issue detail subfocus item, so the reducer can scroll it into view (#151).
+///
+/// This is a pure projection over the rendered content — no AppState, no side
+/// effects — and uses the same `build_detail_content` output the renderer
+/// paints, so it cannot drift.
+///
+/// Returns `None` when the subfocus item cannot be located (e.g. empty
+/// detail or an index beyond the available comments) — the caller should
+/// leave the offset unchanged in that case.
+#[must_use]
+pub fn issue_subfocus_line_range(
+    detail: &IssueDetail,
+    subfocus: DetailSubfocus,
+    inline_state: &InlineState,
+    comments_loading: bool,
+) -> Option<(usize, usize)> {
+    let content = build_detail_content(detail, subfocus, inline_state, comments_loading);
+    let lines: Vec<&str> = content.text.lines().collect();
+    issue_subfocus_range_from_lines(&lines, &subfocus)
+}
+
+/// Resolve the content-line range for `subfocus` by scanning the rendered
+/// lines. Issue detail renders Body with a `"> Body"` label, comments with a
+/// `"> "` prefix, and NewComment with a `"> New Comment"` label.
+fn issue_subfocus_range_from_lines(
+    lines: &[&str],
+    subfocus: &DetailSubfocus,
+) -> Option<(usize, usize)> {
+    match subfocus {
+        DetailSubfocus::Body => {
+            let start = lines
+                .iter()
+                .position(|l| *l == "> Body" || *l == "  Body")?;
+            // Body spans from its label to the line before the next separator.
+            let end = lines
+                .iter()
+                .enumerate()
+                .skip(start + 1)
+                .find(|(_, l)| l.starts_with('─'))
+                .map(|(i, _)| i.saturating_sub(1))?;
+            Some((start, end))
+        }
+        DetailSubfocus::Comment(target_idx) => {
+            // Comments live in the Comments section (after the "Comments"
+            // label). Each comment starts with "> " or "  " + author + date.
+            let comments_start = lines.iter().position(|l| *l == "Comments")?;
+            let mut comment_count = 0usize;
+            for (i, line) in lines.iter().enumerate().skip(comments_start + 1) {
+                if issue_line_is_comment(line) {
+                    if comment_count == *target_idx {
+                        let end = issue_comment_end_line(lines, i);
+                        return Some((i, end));
+                    }
+                    comment_count += 1;
+                }
+            }
+            None
+        }
+        DetailSubfocus::NewComment => {
+            let start = lines
+                .iter()
+                .position(|l| *l == "> New Comment" || *l == "  New Comment")?;
+            let end = (start + 1).min(lines.len().saturating_sub(1));
+            Some((start, end))
+        }
+    }
+}
+
+/// True for a comment header line in the Comments section: prefix `"> "` or
+/// `  "` + author + date. Editor gutter lines (`"    │ "`) are excluded.
+fn issue_line_is_comment(line: &str) -> bool {
+    let Some(rest) = line.strip_prefix("> ").or_else(|| line.strip_prefix("  ")) else {
+        return false;
+    };
+    // Editor gutter lines and reply anchors start with "│" or "[Reply]".
+    if rest.starts_with('│') || rest.starts_with("[Reply]") {
+        return false;
+    }
+    // Comment line: "@author  date" or "author  date" — contains a double
+    // space separating author from date. Section labels like "Comments" are
+    // excluded by the caller's skip.
+    rest.contains("  ")
+}
+
+/// Find the last content line of a comment block (the blank line that
+/// terminates each comment, or the next separator).
+fn issue_comment_end_line(lines: &[&str], start: usize) -> usize {
+    for (i, line) in lines.iter().enumerate().skip(start + 1) {
+        if line.is_empty() || line.starts_with('─') {
+            return i.saturating_sub(1).max(start);
+        }
+    }
+    start
+}
+
 /// Build the scrollable content string for the body + comments + new-comment area.
 #[must_use]
 pub fn build_detail_content(
@@ -411,5 +507,113 @@ mod tests {
             cursor: 0,
         };
         assert_count_matches_rendered(&detail, &inline, false);
+    }
+
+    fn detail_with_comments(n: usize) -> IssueDetail {
+        let mut detail = detail_with_body("body line one\nbody line two");
+        detail.comments = (0..n)
+            .map(|i| comment(format!("comment {i} body").as_str()))
+            .collect();
+        detail
+    }
+
+    fn require_range(
+        detail: &IssueDetail,
+        subfocus: DetailSubfocus,
+        inline: &InlineState,
+        loading: bool,
+    ) -> (usize, usize) {
+        let Some(range) = issue_subfocus_line_range(detail, subfocus, inline, loading) else {
+            panic!("expected subfocus range for {subfocus:?}");
+        };
+        range
+    }
+
+    // ── issue_subfocus_line_range (#151) ─────────────────────────────────
+
+    #[test]
+    fn issue_subfocus_line_range_body_covers_body_section() {
+        let detail = detail_with_body("body line");
+        let range = require_range(&detail, DetailSubfocus::Body, &InlineState::None, false);
+        let content =
+            build_detail_content(&detail, DetailSubfocus::Body, &InlineState::None, false);
+        let lines: Vec<&str> = content.text.lines().collect();
+        // The range starts at the Body label.
+        assert!(lines[range.0] == "> Body" || lines[range.0] == "  Body");
+        // The line after the range must be the separator.
+        if range.1 + 1 < lines.len() {
+            assert!(
+                lines[range.1 + 1].starts_with('─'),
+                "line after Body range must be a separator"
+            );
+        }
+    }
+
+    #[test]
+    fn issue_subfocus_line_range_comment_locates_focused_comment() {
+        let detail = detail_with_comments(2);
+        let range = require_range(
+            &detail,
+            DetailSubfocus::Comment(0),
+            &InlineState::None,
+            false,
+        );
+        let content = build_detail_content(
+            &detail,
+            DetailSubfocus::Comment(0),
+            &InlineState::None,
+            false,
+        );
+        let lines: Vec<&str> = content.text.lines().collect();
+        let header = lines[range.0];
+        assert!(
+            header.starts_with("> "),
+            "focused comment must have > marker"
+        );
+        // The range must span the full comment block (header + body lines),
+        // ending at the blank line that terminates the comment.
+        let block: Vec<&str> = lines[range.0..=range.1].to_vec();
+        assert!(
+            block
+                .iter()
+                .any(|l| l.contains("comment 0 body") || l.contains("comment 0")),
+            "comment block must include the comment body within its range: {block:?}"
+        );
+    }
+
+    #[test]
+    fn issue_subfocus_line_range_new_comment_locates_label_and_hint() {
+        let detail = detail_with_body("body");
+        let range = require_range(
+            &detail,
+            DetailSubfocus::NewComment,
+            &InlineState::None,
+            false,
+        );
+        let content = build_detail_content(
+            &detail,
+            DetailSubfocus::NewComment,
+            &InlineState::None,
+            false,
+        );
+        let lines: Vec<&str> = content.text.lines().collect();
+        assert!(lines[range.0] == "> New Comment" || lines[range.0] == "  New Comment");
+        assert!(
+            lines[range.1].contains("Press c to add a comment")
+                || lines[range.1].contains("Ctrl+Enter submit"),
+            "NewComment range must include the hint line"
+        );
+    }
+
+    #[test]
+    fn issue_subfocus_line_range_returns_none_for_out_of_bounds_comment() {
+        let detail = detail_with_comments(1);
+        let range = issue_subfocus_line_range(
+            &detail,
+            DetailSubfocus::Comment(99),
+            &InlineState::None,
+            false,
+        );
+        assert!(range.is_none(), "out-of-bounds comment must return None");
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -672,6 +672,9 @@ pub fn list_visible_window<T>(rows: &[T], selected_index: usize, viewport_rows: 
 /// - If the item is entirely below or straddles the bottom edge, scroll down so
 ///   its last line is the bottom viewport row — unless the item is taller than
 ///   the viewport, in which case anchor on its first line (top) instead.
+/// - If the item straddles the top edge (its tail is inside the viewport but its
+///   head is scrolled off the top), scroll up to `item_start` so the whole item
+///   is visible from its first line.
 ///
 /// Returns `offset` unchanged when `viewport_rows == 0` (no viewport).
 #[must_use]
@@ -691,6 +694,12 @@ pub fn reveal_range_scroll_offset(
     }
     // Entirely above the viewport: snap the first line to the top.
     if item_end < offset {
+        return item_start;
+    }
+    // Straddling the top edge: the item's tail is inside the viewport but its
+    // head is scrolled off the top. Scroll up to reveal the whole item from
+    // its first line (minimal movement that makes it fully visible).
+    if item_start < offset {
         return item_start;
     }
     // Entirely below or straddling the bottom: bring the last line into view as

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -648,6 +648,58 @@ pub fn list_visible_window<T>(rows: &[T], selected_index: usize, viewport_rows: 
     &rows[first..last]
 }
 
+// -----------------------------------------------------------------------------
+// Detail-pane scroll-into-view helper (#151)
+//
+// When the detail-pane subfocus moves to an item that is scrolled out of view,
+// the scroll offset must follow so the focused item stays visible — mirroring
+// how list panes keep the selected row on screen. This pure helper computes
+// the minimal offset adjustment from (item line range, current offset,
+// viewport height). The caller MUST clamp the result to
+// `[0, max_scroll_offset]` because this helper does not know the total content
+// length.
+// -----------------------------------------------------------------------------
+
+/// Compute the scroll offset that minimally reveals a content-line range.
+///
+/// Given an item occupying content lines `[item_start, item_end]` (inclusive),
+/// the current scroll `offset`, and the `viewport_rows` height, return the
+/// offset that keeps the item on-screen with minimal movement:
+///
+/// - If the item is already fully visible, return `offset` unchanged.
+/// - If the item is entirely above the viewport, scroll up so its first line
+///   sits at the top (`item_start`).
+/// - If the item is entirely below or straddles the bottom edge, scroll down so
+///   its last line is the bottom viewport row — unless the item is taller than
+///   the viewport, in which case anchor on its first line (top) instead.
+///
+/// Returns `offset` unchanged when `viewport_rows == 0` (no viewport).
+#[must_use]
+pub fn reveal_range_scroll_offset(
+    item_start: usize,
+    item_end: usize,
+    offset: usize,
+    viewport_rows: usize,
+) -> usize {
+    if viewport_rows == 0 {
+        return offset;
+    }
+    let last_visible = offset.saturating_add(viewport_rows).saturating_sub(1);
+    // Fully visible: no movement.
+    if item_start >= offset && item_end <= last_visible {
+        return offset;
+    }
+    // Entirely above the viewport: snap the first line to the top.
+    if item_end < offset {
+        return item_start;
+    }
+    // Entirely below or straddling the bottom: bring the last line into view as
+    // the bottom row. For an item taller than the viewport this would push the
+    // top off-screen, so anchor on the first line instead.
+    let anchor_bottom = item_end.saturating_sub(viewport_rows.saturating_sub(1));
+    anchor_bottom.min(item_start)
+}
+
 #[cfg(test)]
 #[path = "layout_tests.rs"]
 mod tests;

--- a/src/layout_tests.rs
+++ b/src/layout_tests.rs
@@ -702,3 +702,67 @@ fn test_list_visible_window_returns_exact_n_rows_and_bounds() {
         window.len()
     );
 }
+
+// ── reveal_range_scroll_offset (#151) ───────────────────────────────────────
+//
+// Pure scroll-into-view math: given a content-line range [start, end], the
+// current offset, and the viewport height, compute the minimal offset that
+// keeps the range visible. These tests cover the no-op, above, below,
+// straddle, and taller-than-viewport cases.
+
+#[test]
+fn reveal_range_noop_when_item_already_visible() {
+    // item lines 3..5, viewport 0..9 (10 rows): fully visible.
+    assert_eq!(reveal_range_scroll_offset(3, 5, 0, 10), 0);
+    // Scrolled mid-document, item in the middle: no movement.
+    assert_eq!(reveal_range_scroll_offset(12, 14, 10, 10), 10);
+}
+
+#[test]
+fn reveal_range_scrolls_up_when_item_above_viewport() {
+    // item lines 2..3, offset 10 (viewport 10..19): snap first line to top.
+    assert_eq!(reveal_range_scroll_offset(2, 3, 10, 10), 2);
+    // Single-line item far above.
+    assert_eq!(reveal_range_scroll_offset(0, 0, 5, 10), 0);
+}
+
+#[test]
+fn reveal_range_scrolls_down_when_item_below_viewport() {
+    // item lines 20..20, offset 0, viewport 10 rows (0..9): bring last line
+    // to the bottom row → offset = 20 - 9 = 11.
+    assert_eq!(reveal_range_scroll_offset(20, 20, 0, 10), 11);
+    // Multi-line item entirely below: anchor its last line at the bottom.
+    assert_eq!(reveal_range_scroll_offset(25, 27, 0, 10), 18);
+}
+
+#[test]
+fn reveal_range_handles_item_straddling_bottom_edge() {
+    // item lines 8..12, offset 0, viewport 10 (0..9): line 8 is visible but
+    // lines 10-12 are below. Bring line 12 to the bottom row:
+    // offset = 12 - 9 = 3.
+    assert_eq!(reveal_range_scroll_offset(8, 12, 0, 10), 3);
+}
+
+#[test]
+fn reveal_range_anchors_top_when_item_taller_than_viewport() {
+    // item lines 5..20 (16 lines), viewport 10 rows. Anchoring the bottom
+    // would put the top off-screen; instead anchor the first line at the top.
+    assert_eq!(reveal_range_scroll_offset(5, 20, 0, 10), 5);
+    // Already scrolled: item taller than viewport but top is visible.
+    assert_eq!(reveal_range_scroll_offset(5, 20, 5, 10), 5);
+}
+
+#[test]
+fn reveal_range_returns_offset_when_viewport_rows_is_zero() {
+    // Degenerate: no viewport → no movement (caller guards this).
+    assert_eq!(reveal_range_scroll_offset(5, 10, 3, 0), 3);
+}
+
+#[test]
+fn reveal_range_noop_when_item_partially_visible_at_top() {
+    // item lines 0..2, offset 1, viewport 10 (1..10): line 0 is above but
+    // 1-2 are visible. Since item_start (0) < offset (1) but item_end (2) is
+    // within the viewport, the item is NOT fully visible — it straddles the
+    // top. Scroll up so line 0 is at the top.
+    assert_eq!(reveal_range_scroll_offset(0, 2, 1, 10), 0);
+}

--- a/src/layout_tests.rs
+++ b/src/layout_tests.rs
@@ -759,10 +759,14 @@ fn reveal_range_returns_offset_when_viewport_rows_is_zero() {
 }
 
 #[test]
-fn reveal_range_noop_when_item_partially_visible_at_top() {
+fn reveal_range_scrolls_up_when_item_straddles_top_edge() {
     // item lines 0..2, offset 1, viewport 10 (1..10): line 0 is above but
     // 1-2 are visible. Since item_start (0) < offset (1) but item_end (2) is
     // within the viewport, the item is NOT fully visible — it straddles the
     // top. Scroll up so line 0 is at the top.
     assert_eq!(reveal_range_scroll_offset(0, 2, 1, 10), 0);
+    // item lines 3..7, offset 5, viewport 10 (5..14): lines 3-4 are scrolled
+    // off the top while 5-7 are visible. Scroll up to item_start so the whole
+    // item is revealed from its first line.
+    assert_eq!(reveal_range_scroll_offset(3, 7, 5, 10), 3);
 }

--- a/src/pr_detail_content.rs
+++ b/src/pr_detail_content.rs
@@ -52,6 +52,225 @@ pub fn pr_detail_content_line_count(
     .count()
 }
 
+/// Compute the inclusive content-line range `[start, end]` of the focused
+/// subfocus item, so the reducer can scroll it into view (#151).
+///
+/// The range is derived from the rendered content by locating the focus
+/// marker (`"> "`) or section label of the focused item. This is a pure
+/// projection over the rendered text — no AppState, no side effects — and
+/// uses the same `build_pr_detail_content` output the renderer paints, so it
+/// cannot drift.
+///
+/// Returns `None` when the subfocus item cannot be located (e.g. empty
+/// detail or an index beyond the available items) — the caller should leave
+/// the offset unchanged in that case.
+///
+/// @plan PLAN-20260624-PR-MODE.P14
+/// @requirement REQ-PR-009
+#[must_use]
+pub fn pr_subfocus_line_range(
+    detail: &PullRequestDetail,
+    subfocus: PrDetailSubfocus,
+    inline_state: &InlineState,
+    detail_loading: bool,
+    comments_loading: bool,
+) -> Option<(usize, usize)> {
+    let content = build_pr_detail_content(
+        detail,
+        subfocus,
+        inline_state,
+        detail_loading,
+        comments_loading,
+    );
+    let lines: Vec<&str> = content.text.lines().collect();
+    pr_subfocus_range_from_lines(&lines, &subfocus)
+}
+
+/// Resolve the content-line range for `subfocus` by scanning the rendered
+/// lines. The PR detail renders each focusable item with a `"> "` prefix
+/// (reviews, checks, comments) or a `"> New comment"` label (NewComment) or
+/// the `"Description"` label (Body). Review threads use a `">     ` prefix
+/// (four spaces after the marker) to distinguish them from reviews.
+fn pr_subfocus_range_from_lines(
+    lines: &[&str],
+    subfocus: &PrDetailSubfocus,
+) -> Option<(usize, usize)> {
+    match subfocus {
+        PrDetailSubfocus::Body => pr_body_range(lines),
+        PrDetailSubfocus::Review(target_idx) => {
+            pr_indexed_single_line(lines, *target_idx, pr_line_is_review_header)
+        }
+        PrDetailSubfocus::ReviewThread(target_flat_idx) => pr_indexed_block(
+            lines,
+            *target_flat_idx,
+            pr_line_is_review_thread_header,
+            pr_thread_end_line,
+        ),
+        PrDetailSubfocus::Check(target_idx) => {
+            pr_indexed_single_line(lines, *target_idx, pr_line_is_check)
+        }
+        PrDetailSubfocus::Comment(target_idx) => pr_comment_range(lines, *target_idx),
+        PrDetailSubfocus::NewComment => {
+            let start = lines.iter().position(|l| *l == "> New comment")?;
+            let end = (start + 1).min(lines.len().saturating_sub(1));
+            Some((start, end))
+        }
+    }
+}
+
+/// Body section: the "Description" label through the line before the next
+/// separator.
+fn pr_body_range(lines: &[&str]) -> Option<(usize, usize)> {
+    let start = lines.iter().position(|l| *l == "Description")?;
+    let end = lines
+        .iter()
+        .enumerate()
+        .skip(start + 1)
+        .find(|(_, l)| l.starts_with('─'))
+        .map(|(i, _)| i.saturating_sub(1))?;
+    Some((start, end))
+}
+
+/// Scan for the `target_idx`-th line matching `predicate`, returning its
+/// single-line range. Used for reviews and checks (one rendered line each).
+fn pr_indexed_single_line(
+    lines: &[&str],
+    target_idx: usize,
+    predicate: fn(&str) -> bool,
+) -> Option<(usize, usize)> {
+    let mut count = 0usize;
+    for (i, line) in lines.iter().enumerate() {
+        if predicate(line) {
+            if count == target_idx {
+                return Some((i, i));
+            }
+            count += 1;
+        }
+    }
+    None
+}
+
+/// Scan for the `target_idx`-th header matching `predicate`, returning the
+/// block range from the header through `end_fn`. Used for review threads and
+/// comments.
+fn pr_indexed_block(
+    lines: &[&str],
+    target_idx: usize,
+    predicate: fn(&str) -> bool,
+    end_fn: fn(&[&str], usize) -> usize,
+) -> Option<(usize, usize)> {
+    let mut count = 0usize;
+    for (i, line) in lines.iter().enumerate() {
+        if predicate(line) {
+            if count == target_idx {
+                let end = end_fn(lines, i);
+                return Some((i, end));
+            }
+            count += 1;
+        }
+    }
+    None
+}
+
+/// Comment range: comment lines live in the Comments section (after the
+/// "Comments" label).
+fn pr_comment_range(lines: &[&str], target_idx: usize) -> Option<(usize, usize)> {
+    let comments_start = lines.iter().position(|l| *l == "Comments")?;
+    let mut comment_count = 0usize;
+    for (i, line) in lines.iter().enumerate().skip(comments_start + 1) {
+        if pr_line_is_comment(line) {
+            if comment_count == target_idx {
+                let end = pr_comment_end_line(lines, i);
+                return Some((i, end));
+            }
+            comment_count += 1;
+        }
+    }
+    None
+}
+
+/// True for a review header line: starts with `"> "` or `"- "`, is NOT a
+/// thread header (no 4-space indent), and contains a review state token.
+fn pr_line_is_review_header(line: &str) -> bool {
+    let Some(rest) = line.strip_prefix("> ").or_else(|| line.strip_prefix("- ")) else {
+        return false;
+    };
+    if rest.starts_with("    ") {
+        return false;
+    }
+    [
+        "APPROVED",
+        "CHANGES_REQUESTED",
+        "COMMENTED",
+        "PENDING",
+        "DISMISSED",
+        "REVIEW_REQUIRED",
+    ]
+    .iter()
+    .any(|state| rest.contains(state))
+}
+
+/// True for a review-thread header line: marker (`">     ` or `      `)
+/// followed by a path/location and a `[RESOLVED]`/`[UNRESOLVED]` tag.
+fn pr_line_is_review_thread_header(line: &str) -> bool {
+    let Some(rest) = line
+        .strip_prefix(">     ")
+        .or_else(|| line.strip_prefix("      "))
+    else {
+        return false;
+    };
+    rest.contains("[RESOLVED]") || rest.contains("[UNRESOLVED]")
+}
+
+/// True for a check line: prefix `"> "` or `"- "` + a check status label.
+fn pr_line_is_check(line: &str) -> bool {
+    let Some(rest) = line.strip_prefix("> ").or_else(|| line.strip_prefix("- ")) else {
+        return false;
+    };
+    ["pending", "success", "failure", "neutral"]
+        .iter()
+        .any(|s| rest.contains(s))
+}
+
+/// True for a comment line in the Comments section: prefix `"> "` or `"- "`
+/// + author + date. Thread comment sub-lines (6-space indent) are excluded.
+fn pr_line_is_comment(line: &str) -> bool {
+    let Some(rest) = line.strip_prefix("> ").or_else(|| line.strip_prefix("- ")) else {
+        return false;
+    };
+    if rest.starts_with("    ") {
+        return false;
+    }
+    rest.contains("  ")
+}
+
+/// Find the last content line of a review thread (the blank line terminates
+/// the thread block).
+fn pr_thread_end_line(lines: &[&str], start: usize) -> usize {
+    let mut end = start;
+    for (i, line) in lines.iter().enumerate().skip(start + 1) {
+        if line.is_empty() {
+            return i.saturating_sub(1).max(start);
+        }
+        if pr_line_is_review_thread_header(line) || line.starts_with('─') {
+            return i.saturating_sub(1).max(start);
+        }
+        end = i;
+    }
+    end
+}
+
+/// Find the last content line of a comment block (the blank line that
+/// terminates each comment).
+fn pr_comment_end_line(lines: &[&str], start: usize) -> usize {
+    for (i, line) in lines.iter().enumerate().skip(start + 1) {
+        if line.is_empty() {
+            return i.saturating_sub(1).max(start);
+        }
+    }
+    start
+}
+
 /// Build the scrollable content string for the unified PR detail view.
 ///
 /// @plan PLAN-20260624-PR-MODE.P12

--- a/src/pr_detail_content.rs
+++ b/src/pr_detail_content.rs
@@ -257,12 +257,14 @@ fn pr_line_is_check(line: &str) -> bool {
 
 /// True for a comment line in the Comments section: prefix marker plus
 /// author login (no leading spaces) and date. The author/date separator is
-/// two spaces, so we verify the line is NOT an indented body line and uses
-/// the separator after stripping the marker prefix.
+/// True for a PR comment header line in the Comments section: starts with
+/// `"> "` or `"- "` followed by the author login and a two-space separator
+/// before the date. Indented body sub-lines (4-space indent) are excluded.
 ///
-/// `rest` is the text after the marker prefix. The two-space separator
-/// between the author login and the date distinguishes comment header lines
-/// from indented thread body lines.
+/// The check uses a structural marker: after stripping the marker prefix,
+/// the text must NOT start with a 4-space indent (which would be a body
+/// line) and must contain the two-space separator that precedes the date.
+/// This is more robust than a free-form substring match.
 fn pr_line_is_comment(line: &str) -> bool {
     let Some(rest) = line.strip_prefix("> ").or_else(|| line.strip_prefix("- ")) else {
         return false;

--- a/src/pr_detail_content.rs
+++ b/src/pr_detail_content.rs
@@ -98,7 +98,7 @@ fn pr_subfocus_range_from_lines(
     match subfocus {
         PrDetailSubfocus::Body => pr_body_range(lines),
         PrDetailSubfocus::Review(target_idx) => {
-            pr_indexed_single_line(lines, *target_idx, pr_line_is_review_header)
+            pr_section_single_line(lines, "Reviews", *target_idx, pr_line_is_review_header)
         }
         PrDetailSubfocus::ReviewThread(target_flat_idx) => pr_indexed_block(
             lines,
@@ -107,7 +107,7 @@ fn pr_subfocus_range_from_lines(
             pr_thread_end_line,
         ),
         PrDetailSubfocus::Check(target_idx) => {
-            pr_indexed_single_line(lines, *target_idx, pr_line_is_check)
+            pr_section_single_line(lines, "Checks", *target_idx, pr_line_is_check)
         }
         PrDetailSubfocus::Comment(target_idx) => pr_comment_range(lines, *target_idx),
         PrDetailSubfocus::NewComment => {
@@ -122,24 +122,48 @@ fn pr_subfocus_range_from_lines(
 /// separator.
 fn pr_body_range(lines: &[&str]) -> Option<(usize, usize)> {
     let start = lines.iter().position(|l| *l == "Description")?;
-    let end = lines
+    Some((start, pr_find_section_end(lines, start)))
+}
+
+/// Find the content-line range of a named section (e.g. "Reviews", "Checks").
+/// Returns `(start, end)` where `start` is the section-label line index and
+/// `end` is the last line before the next separator (or the last content line
+/// if no separator follows). The label match is a prefix match because the
+/// rendered section header includes a parenthetical suffix (e.g.
+/// "Reviews  (decision: APPROVED)").
+fn pr_section_range(lines: &[&str], label: &str) -> Option<(usize, usize)> {
+    let start = lines.iter().position(|l| l.starts_with(label))?;
+    Some((start, pr_find_section_end(lines, start)))
+}
+
+/// Find the last line of a section (the line before the next separator). If
+/// no separator follows, the last content line is used. Falls back to `start`
+/// itself if the section is a single label line.
+fn pr_find_section_end(lines: &[&str], start: usize) -> usize {
+    if let Some((i, _)) = lines
         .iter()
         .enumerate()
         .skip(start + 1)
         .find(|(_, l)| l.starts_with('─'))
-        .map(|(i, _)| i.saturating_sub(1))?;
-    Some((start, end))
+    {
+        return i.saturating_sub(1);
+    }
+    lines.len().saturating_sub(1).max(start)
 }
 
-/// Scan for the `target_idx`-th line matching `predicate`, returning its
-/// single-line range. Used for reviews and checks (one rendered line each).
-fn pr_indexed_single_line(
+/// Scan for the `target_idx`-th line matching `predicate` within a named
+/// section, returning its single-line range. Scoping to the section prevents
+/// index drift from similar-looking lines in other sections (e.g. a review
+/// body excerpt containing "pending" being miscounted as a check).
+fn pr_section_single_line(
     lines: &[&str],
+    section_label: &str,
     target_idx: usize,
     predicate: fn(&str) -> bool,
 ) -> Option<(usize, usize)> {
+    let (start, end) = pr_section_range(lines, section_label)?;
     let mut count = 0usize;
-    for (i, line) in lines.iter().enumerate() {
+    for (i, line) in lines.iter().enumerate().take(end + 1).skip(start + 1) {
         if predicate(line) {
             if count == target_idx {
                 return Some((i, i));
@@ -151,8 +175,7 @@ fn pr_indexed_single_line(
 }
 
 /// Scan for the `target_idx`-th header matching `predicate`, returning the
-/// block range from the header through `end_fn`. Used for review threads and
-/// comments.
+/// block range from the header through `end_fn`. Used for review threads.
 fn pr_indexed_block(
     lines: &[&str],
     target_idx: usize,
@@ -232,8 +255,14 @@ fn pr_line_is_check(line: &str) -> bool {
         .any(|s| rest.contains(s))
 }
 
-/// True for a comment line in the Comments section: prefix `"> "` or `"- "`
-/// + author + date. Thread comment sub-lines (6-space indent) are excluded.
+/// True for a comment line in the Comments section: prefix marker plus
+/// author login (no leading spaces) and date. The author/date separator is
+/// two spaces, so we verify the line is NOT an indented body line and uses
+/// the separator after stripping the marker prefix.
+///
+/// `rest` is the text after the marker prefix. The two-space separator
+/// between the author login and the date distinguishes comment header lines
+/// from indented thread body lines.
 fn pr_line_is_comment(line: &str) -> bool {
     let Some(rest) = line.strip_prefix("> ").or_else(|| line.strip_prefix("- ")) else {
         return false;
@@ -241,6 +270,9 @@ fn pr_line_is_comment(line: &str) -> bool {
     if rest.starts_with("    ") {
         return false;
     }
+    // Comment headers are `author  date`; body sub-lines are indented and
+    // excluded by the 4-space check above. The two-space separator is the
+    // distinguishing marker between the author and the date.
     rest.contains("  ")
 }
 

--- a/src/pr_detail_content_tests.rs
+++ b/src/pr_detail_content_tests.rs
@@ -3,6 +3,21 @@ use crate::domain::{
     IssueComment, PrCheck, PrCheckStatus, PrReview, PrReviewState, PrState, PullRequestDetail,
 };
 use crate::state::{ComposerTarget, InlineState};
+
+fn require_range(
+    detail: &PullRequestDetail,
+    subfocus: PrDetailSubfocus,
+    inline: &InlineState,
+    detail_loading: bool,
+    comments_loading: bool,
+) -> (usize, usize) {
+    let Some(range) =
+        pr_subfocus_line_range(detail, subfocus, inline, detail_loading, comments_loading)
+    else {
+        panic!("expected subfocus range");
+    };
+    range
+}
 /// @plan PLAN-20260624-PR-MODE.P12
 /// @requirement REQ-PR-009
 /// @pseudocode component-001 lines 1-12
@@ -480,5 +495,209 @@ fn pr_detail_line_count_with_threads_exceeds_base() {
     assert!(
         thread_count > base_count,
         "threads must add rendered lines: {thread_count} vs base {base_count}"
+    );
+}
+
+// ── pr_subfocus_line_range (#151) ────────────────────────────────────────
+//
+// The scroll-into-view feature needs the content-line range of the focused
+// subfocus item. These tests verify the pure projection returns correct
+// ranges for each subfocus variant using the rendered content as the source
+// of truth.
+
+#[test]
+fn pr_subfocus_line_range_body_covers_description_section() {
+    let detail = sample_detail();
+    let range = require_range(
+        &detail,
+        PrDetailSubfocus::Body,
+        &InlineState::None,
+        false,
+        false,
+    );
+    let content = build_pr_detail_content(
+        &detail,
+        PrDetailSubfocus::Body,
+        &InlineState::None,
+        false,
+        false,
+    );
+    let lines: Vec<&str> = content.text.lines().collect();
+    // The range must start at the "Description" label and end just before the
+    // first separator.
+    assert_eq!(lines[range.0], "Description");
+    assert!(
+        !lines[range.1].is_empty() && !lines[range.1].starts_with('─'),
+        "Body range end must be a content line, not a separator"
+    );
+    // The line after the range should be the separator.
+    if range.1 + 1 < lines.len() {
+        assert!(
+            lines[range.1 + 1].starts_with('─'),
+            "Line after Body range must be a separator"
+        );
+    }
+}
+
+#[test]
+fn pr_subfocus_line_range_review_locates_focused_review() {
+    let detail = sample_detail();
+    let range = require_range(
+        &detail,
+        PrDetailSubfocus::Review(0),
+        &InlineState::None,
+        false,
+        false,
+    );
+    let content = build_pr_detail_content(
+        &detail,
+        PrDetailSubfocus::Review(0),
+        &InlineState::None,
+        false,
+        false,
+    );
+    let lines: Vec<&str> = content.text.lines().collect();
+    // The focused review line starts with "> " and contains the author "ada".
+    let line = lines[range.0];
+    assert!(line.starts_with("> "), "focused review must have > marker");
+    assert!(line.contains("ada"), "focused review must contain author");
+    assert!(line.contains("CHANGES_REQUESTED"));
+    // Single-line item.
+    assert_eq!(range.0, range.1);
+}
+
+#[test]
+fn pr_subfocus_line_range_review_thread_spans_thread_block() {
+    let detail = detail_with_threads();
+    let range = require_range(
+        &detail,
+        PrDetailSubfocus::ReviewThread(0),
+        &InlineState::None,
+        false,
+        false,
+    );
+    let content = build_pr_detail_content(
+        &detail,
+        PrDetailSubfocus::ReviewThread(0),
+        &InlineState::None,
+        false,
+        false,
+    );
+    let lines: Vec<&str> = content.text.lines().collect();
+    let header = lines[range.0];
+    assert!(
+        header.contains("src/parser.rs:42"),
+        "thread header must contain location"
+    );
+    // The range must include the thread comments and the reply/resolve hint
+    // (since thread 0 is focused), ending at the last content line before the
+    // trailing blank.
+    let block: Vec<&str> = lines[range.0..=range.1].to_vec();
+    assert!(
+        block.iter().any(|l| l.contains("This unwrap can panic.")),
+        "thread block must include comment body"
+    );
+    assert!(
+        block.iter().any(|l| l.contains("[ r reply ]")),
+        "focused thread block must include reply hint"
+    );
+}
+
+#[test]
+fn pr_subfocus_line_range_check_locates_focused_check() {
+    let detail = sample_detail();
+    let range = require_range(
+        &detail,
+        PrDetailSubfocus::Check(0),
+        &InlineState::None,
+        false,
+        false,
+    );
+    let content = build_pr_detail_content(
+        &detail,
+        PrDetailSubfocus::Check(0),
+        &InlineState::None,
+        false,
+        false,
+    );
+    let lines: Vec<&str> = content.text.lines().collect();
+    let line = lines[range.0];
+    assert!(line.starts_with("> "), "focused check must have > marker");
+    assert!(line.contains("ci/fmt"));
+    assert!(line.contains("success"));
+    assert_eq!(range.0, range.1, "check is a single-line item");
+}
+
+#[test]
+fn pr_subfocus_line_range_comment_spans_comment_block() {
+    let detail = sample_detail();
+    let range = require_range(
+        &detail,
+        PrDetailSubfocus::Comment(0),
+        &InlineState::None,
+        false,
+        false,
+    );
+    let content = build_pr_detail_content(
+        &detail,
+        PrDetailSubfocus::Comment(0),
+        &InlineState::None,
+        false,
+        false,
+    );
+    let lines: Vec<&str> = content.text.lines().collect();
+    let header = lines[range.0];
+    assert!(
+        header.starts_with("> "),
+        "focused comment must have > marker"
+    );
+    assert!(header.contains("pat"), "comment header must contain author");
+    let block: Vec<&str> = lines[range.0..=range.1].to_vec();
+    assert!(
+        block.iter().any(|l| l.contains("ready for review")),
+        "comment block must include body"
+    );
+}
+
+#[test]
+fn pr_subfocus_line_range_new_comment_locates_label_and_hint() {
+    let detail = sample_detail();
+    let range = require_range(
+        &detail,
+        PrDetailSubfocus::NewComment,
+        &InlineState::None,
+        false,
+        false,
+    );
+    let content = build_pr_detail_content(
+        &detail,
+        PrDetailSubfocus::NewComment,
+        &InlineState::None,
+        false,
+        false,
+    );
+    let lines: Vec<&str> = content.text.lines().collect();
+    assert_eq!(lines[range.0], "> New comment");
+    // The hint line is the second line of the section.
+    assert!(
+        lines[range.1].contains("Press c to add a comment")
+            || lines[range.1].contains("Ctrl+Enter submit"),
+        "NewComment range must include the hint line"
+    );
+}
+
+#[test]
+fn pr_subfocus_line_range_returns_none_for_out_of_bounds_index() {
+    let detail = sample_detail();
+    let range = pr_subfocus_line_range(
+        &detail,
+        PrDetailSubfocus::Comment(99),
+        &InlineState::None,
+        false,
+        false,
+    );
+    assert!(
+        range.is_none(),
+        "out-of-bounds comment index must return None"
     );
 }

--- a/src/state/issues_ops.rs
+++ b/src/state/issues_ops.rs
@@ -2,8 +2,8 @@
 //! @plan PLAN-20260329-ISSUES-MODE.P05
 
 use super::{
-    AgentChooserState, AppEvent, AppState, DetailSubfocus, ISSUE_FILTER_FIELD_COUNT, InlineState,
-    IssueFocus, PaneFocus, PriorAgentFocus, ScreenMode,
+    AgentChooserState, AppEvent, AppState, ComposerTarget, DetailSubfocus,
+    ISSUE_FILTER_FIELD_COUNT, InlineState, IssueFocus, PaneFocus, PriorAgentFocus, ScreenMode,
 };
 use crate::domain::{IssueFilter, IssueFilterState};
 use crate::messages::IssuesMessage;
@@ -113,6 +113,50 @@ impl AppState {
                 }
             };
         }
+    }
+
+    /// Scroll the issue detail pane so the currently-focused subfocus item is
+    /// visible, using the pure `reveal_range_scroll_offset` helper and the
+    /// fresh viewport row count. Only fires on a subfocus *change* (Tab/j/k),
+    /// never on manual scroll ticks (#151).
+    fn scroll_issue_detail_to_subfocus(&mut self) {
+        let Some(detail) = &self.issues_state.issue_detail else {
+            return;
+        };
+        let Some((item_start, item_end)) = crate::issue_detail_content::issue_subfocus_line_range(
+            detail,
+            self.issues_state.detail_subfocus,
+            &self.issues_state.inline_state,
+            self.issues_state.loading.comments,
+        ) else {
+            return;
+        };
+        let viewport = self.issues_detail_scroll_viewport_rows();
+        let desired = crate::layout::reveal_range_scroll_offset(
+            item_start,
+            item_end,
+            self.issues_state.detail_scroll_offset,
+            viewport,
+        );
+        let max = self.issues_state.max_detail_scroll_offset();
+        self.issues_state.detail_scroll_offset = desired.min(max);
+    }
+
+    /// Rows available to the read-only issue detail document after an embedded
+    /// composer reserves rows. Mirrors the PR helper so the scroll-into-view
+    /// clamp bound stays fresh.
+    fn issues_detail_scroll_viewport_rows(&self) -> usize {
+        let composer_active = matches!(
+            self.issues_state.inline_state,
+            InlineState::Composer {
+                target: ComposerTarget::NewComment | ComposerTarget::Reply { .. },
+                ..
+            }
+        );
+        crate::layout::issue_detail_document_viewport_rows(
+            self.issues_state.detail_viewport_rows,
+            composer_active,
+        )
     }
 
     /// Navigate to the previous repository in issues mode.
@@ -473,8 +517,14 @@ impl AppState {
             | AppEvent::IssuesEnter
             | AppEvent::IssuesCycleFocus
             | AppEvent::IssuesCycleFocusReverse => self.apply_issues_navigation(event),
-            AppEvent::IssueDetailSubfocusNext => self.detail_subfocus_next(),
-            AppEvent::IssueDetailSubfocusPrev => self.detail_subfocus_prev(),
+            AppEvent::IssueDetailSubfocusNext => {
+                self.detail_subfocus_next();
+                self.scroll_issue_detail_to_subfocus();
+            }
+            AppEvent::IssueDetailSubfocusPrev => {
+                self.detail_subfocus_prev();
+                self.scroll_issue_detail_to_subfocus();
+            }
             AppEvent::FocusSearchInput => self.issues_state.search_input_focused = true,
             AppEvent::BlurSearchInput => self.issues_state.search_input_focused = false,
             AppEvent::ClearSearch => self.issues_state.search_query.clear(),

--- a/src/state/issues_tests_subfocus.rs
+++ b/src/state/issues_tests_subfocus.rs
@@ -1,0 +1,163 @@
+//! Scroll-into-view tests for issue detail subfocus navigation (#151).
+//!
+//! Extracted from `issues_tests_detail.rs` to keep that file under the
+//! 1000-line source-file limit.
+
+use crate::domain::{IssueComment, IssueDetail, IssueState};
+use crate::state::AppState;
+use crate::state::types::{AppEvent, DetailSubfocus, ScreenMode};
+
+fn dashboard_issues_state() -> AppState {
+    AppState {
+        screen_mode: ScreenMode::DashboardIssues,
+        ..AppState::default()
+    }
+}
+
+fn p15_detail(number: u64) -> IssueDetail {
+    IssueDetail {
+        repo_owner_name: "owner/repo".to_string(),
+        number,
+        title: format!("Issue #{number}"),
+        state: IssueState::Open,
+        author_login: "octocat".to_string(),
+        created_at: "2024-01-01".to_string(),
+        updated_at: "2024-01-02".to_string(),
+        labels: Vec::new(),
+        assignees: Vec::new(),
+        milestone: None,
+        body: String::new(),
+        external_url: format!("https://example.com/{number}"),
+        comments: Vec::new(),
+        has_more_comments: false,
+        comments_cursor: None,
+    }
+}
+
+fn p15_comment(comment_id: u64, author_login: &str, created_at: &str, body: &str) -> IssueComment {
+    IssueComment {
+        comment_id,
+        author_login: author_login.to_string(),
+        created_at: created_at.to_string(),
+        edited_at: None,
+        body: body.to_string(),
+    }
+}
+
+/// Tab forward to an offscreen issue comment must scroll the detail so the
+/// comment is visible (#151).
+#[test]
+fn test_issue_subfocus_next_scrolls_to_offscreen_comment() {
+    let mut state = dashboard_issues_state();
+    let mut detail = p15_detail(1);
+    detail.body = "Issue body".to_string();
+    detail.comments = (0u32..10)
+        .map(|i| {
+            p15_comment(
+                u64::from(i),
+                &format!("user{i}"),
+                "2024-01-01",
+                &format!("comment body {i}"),
+            )
+        })
+        .collect();
+    state.issues_state.issue_detail = Some(detail);
+    state.issues_state.detail_subfocus = DetailSubfocus::Body;
+    state.issues_state.detail_viewport_rows = 4; // small viewport
+    state.issues_state.detail_scroll_offset = 0;
+
+    // Advance subfocus forward through comments to comment #5.
+    // Body -> Comment(0)
+    state = state.apply(AppEvent::IssueDetailSubfocusNext);
+    // Advance through comments 0..=5
+    for _ in 0..5 {
+        state = state.apply(AppEvent::IssueDetailSubfocusNext);
+    }
+    assert_eq!(
+        state.issues_state.detail_subfocus,
+        DetailSubfocus::Comment(5),
+        "should have advanced to Comment(5)"
+    );
+    let offset = state.issues_state.detail_scroll_offset;
+    let viewport = state.issues_state.detail_viewport_rows;
+    assert!(
+        offset > 0,
+        "scroll offset should have advanced to reveal comment #5, got {offset}"
+    );
+    let detail = state
+        .issues_state
+        .issue_detail
+        .as_ref()
+        .unwrap_or_else(|| panic!("expected detail"));
+    let range = crate::issue_detail_content::issue_subfocus_line_range(
+        detail,
+        DetailSubfocus::Comment(5),
+        &state.issues_state.inline_state,
+        state.issues_state.loading.comments,
+    )
+    .unwrap_or_else(|| panic!("expected range for comment 5"));
+    assert!(
+        range.0 >= offset && range.0 < offset + viewport,
+        "comment 5 first line {} must be within viewport [{}, {})",
+        range.0,
+        offset,
+        offset + viewport
+    );
+}
+
+/// Tab backwards to an offscreen issue comment must scroll the detail so the
+/// comment is visible (#151).
+#[test]
+fn test_issue_subfocus_prev_scrolls_to_offscreen_comment() {
+    let mut state = dashboard_issues_state();
+    let mut detail = p15_detail(1);
+    detail.body = "Issue body".to_string();
+    detail.comments = (0u32..10)
+        .map(|i| {
+            p15_comment(
+                u64::from(i),
+                &format!("user{i}"),
+                "2024-01-01",
+                &format!("comment body {i}"),
+            )
+        })
+        .collect();
+    state.issues_state.issue_detail = Some(detail);
+    state.issues_state.detail_subfocus = DetailSubfocus::NewComment;
+    state.issues_state.detail_viewport_rows = 4; // small viewport
+    // Start scrolled near the bottom (NewComment is last section).
+    state.issues_state.detail_scroll_offset = 100;
+
+    // Prev from NewComment -> Comment(9) (last comment).
+    let state = state.apply(AppEvent::IssueDetailSubfocusPrev);
+    assert_eq!(
+        state.issues_state.detail_subfocus,
+        DetailSubfocus::Comment(9),
+        "should have moved to Comment(9)"
+    );
+    let offset = state.issues_state.detail_scroll_offset;
+    let viewport = state.issues_state.detail_viewport_rows;
+    assert!(
+        offset < 100,
+        "scroll offset should have decreased to reveal comment 9, got {offset}"
+    );
+    let detail = state
+        .issues_state
+        .issue_detail
+        .as_ref()
+        .unwrap_or_else(|| panic!("expected detail"));
+    let range = crate::issue_detail_content::issue_subfocus_line_range(
+        detail,
+        DetailSubfocus::Comment(9),
+        &state.issues_state.inline_state,
+        state.issues_state.loading.comments,
+    )
+    .unwrap_or_else(|| panic!("expected range for comment 9"));
+    assert!(
+        range.0 >= offset && range.0 < offset + viewport,
+        "comment 9 first line {} must be within viewport [{}, {})",
+        range.0,
+        offset,
+        offset + viewport
+    );
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -792,6 +792,10 @@ mod issues_tests_components;
 mod issues_tests_detail;
 
 #[cfg(test)]
+#[path = "issues_tests_subfocus.rs"]
+mod issues_tests_subfocus;
+
+#[cfg(test)]
 #[path = "issues_tests_detail_flow.rs"]
 mod issues_tests_detail_flow;
 

--- a/src/state/prs_nav_ops.rs
+++ b/src/state/prs_nav_ops.rs
@@ -477,6 +477,34 @@ impl AppState {
         true
     }
 
+    /// Scroll the detail pane so the currently-focused subfocus item is
+    /// visible, using the pure `reveal_range_scroll_offset` helper and the
+    /// fresh viewport row count. Only fires on a subfocus *change* (Tab/j/k),
+    /// never on manual scroll ticks (#151).
+    fn scroll_pr_detail_to_subfocus(&mut self) {
+        let Some(detail) = &self.prs_state.pr_detail else {
+            return;
+        };
+        let Some((item_start, item_end)) = crate::pr_detail_content::pr_subfocus_line_range(
+            detail,
+            self.prs_state.detail_subfocus,
+            &self.prs_state.inline_state,
+            self.prs_state.loading.detail,
+            self.prs_state.loading.comments,
+        ) else {
+            return;
+        };
+        let viewport = self.pr_detail_scroll_viewport_rows();
+        let desired = crate::layout::reveal_range_scroll_offset(
+            item_start,
+            item_end,
+            self.prs_state.detail_scroll_offset,
+            viewport,
+        );
+        let max = self.pr_detail_max_scroll_offset();
+        self.prs_state.detail_scroll_offset = desired.min(max);
+    }
+
     /// Maximum detail scroll offset derived from the REAL rendered content
     /// length (mirrors `IssuesState::max_detail_scroll_offset_for_viewport`),
     /// so the clamp cannot drift from `build_pr_detail_content`.
@@ -535,10 +563,12 @@ impl AppState {
             }
             AppEvent::PrDetailSubfocusNext => {
                 self.pr_detail_subfocus_next();
+                self.scroll_pr_detail_to_subfocus();
                 true
             }
             AppEvent::PrDetailSubfocusPrev => {
                 self.pr_detail_subfocus_prev();
+                self.scroll_pr_detail_to_subfocus();
                 true
             }
             _ => false,

--- a/src/state/prs_tests_detail.rs
+++ b/src/state/prs_tests_detail.rs
@@ -366,7 +366,7 @@ fn assert_pr_thread_visible(state: &AppState, thread_idx: usize) {
     )
     .unwrap_or_else(|| panic!("expected range for thread {thread_idx}"));
     assert!(
-        range.0 >= offset || range.0 < offset + viewport,
+        range.0 >= offset && range.0 < offset + viewport,
         "thread #{thread_idx} first line {} must be within viewport [{}, {})",
         range.0,
         offset,

--- a/src/state/prs_tests_detail.rs
+++ b/src/state/prs_tests_detail.rs
@@ -291,3 +291,145 @@ fn test_scroll_detail_down_advances_then_clamps() {
         "scroll offset should have advanced past 0 with long content"
     );
 }
+
+/// Tab to an offscreen review thread must scroll the detail so the thread is
+/// visible (#151).
+#[test]
+fn test_pr_subfocus_next_scrolls_to_offscreen_thread() {
+    use crate::domain::{IssueComment, PrReview, PrReviewState, PrReviewThread};
+
+    let mut state = prs_mode_state("repo-1");
+    let mut detail = make_test_pr_detail(1);
+    detail.body = "PR body".to_string();
+    // Build many review threads so thread #5 is below a small viewport.
+    let thread: PrReviewThread = PrReviewThread {
+        thread_id: "t1".to_string(),
+        path: Some("src/main.rs".to_string()),
+        line: Some(10),
+        is_resolved: false,
+        comments: vec![IssueComment {
+            comment_id: 1,
+            author_login: "alice".to_string(),
+            created_at: "2024-01-01".to_string(),
+            edited_at: None,
+            body: "thread body".to_string(),
+        }],
+    };
+    detail.reviews = vec![PrReview {
+        author_login: "reviewer".to_string(),
+        state: PrReviewState::Approved,
+        submitted_at: "2024-01-01".to_string(),
+        body: None,
+        review_threads: vec![thread; 8],
+    }];
+    state.prs_state.pr_detail = Some(detail);
+    state.prs_state.detail_subfocus = PrDetailSubfocus::Body;
+    state.prs_state.detail_viewport_rows = 4; // small viewport
+    state.prs_state.detail_scroll_offset = 0;
+
+    // Advance subfocus forward through Reviews and ReviewThreads to thread #5.
+    // Body -> Review(0)
+    state = state.apply(AppEvent::PrDetailSubfocusNext);
+    // Review(0) -> ReviewThread(0)
+    state = state.apply(AppEvent::PrDetailSubfocusNext);
+    // Advance through threads 0..=5
+    for _ in 0..5 {
+        state = state.apply(AppEvent::PrDetailSubfocusNext);
+    }
+    assert_eq!(
+        state.prs_state.detail_subfocus,
+        PrDetailSubfocus::ReviewThread(5),
+        "should have advanced to ReviewThread(5)"
+    );
+    assert_pr_thread_visible(&state, 5);
+}
+
+/// Assert the focused review thread is within the current viewport.
+fn assert_pr_thread_visible(state: &AppState, thread_idx: usize) {
+    let offset = state.prs_state.detail_scroll_offset;
+    let viewport = state.prs_state.detail_viewport_rows;
+    assert!(
+        offset > 0,
+        "scroll offset should have advanced to reveal thread #{thread_idx}, got {offset}"
+    );
+    let detail = state
+        .prs_state
+        .pr_detail
+        .as_ref()
+        .unwrap_or_else(|| panic!("expected detail"));
+    let range = crate::pr_detail_content::pr_subfocus_line_range(
+        detail,
+        PrDetailSubfocus::ReviewThread(thread_idx),
+        &state.prs_state.inline_state,
+        state.prs_state.loading.detail,
+        state.prs_state.loading.comments,
+    )
+    .unwrap_or_else(|| panic!("expected range for thread {thread_idx}"));
+    assert!(
+        range.0 >= offset || range.0 < offset + viewport,
+        "thread #{thread_idx} first line {} must be within viewport [{}, {})",
+        range.0,
+        offset,
+        offset + viewport
+    );
+}
+
+/// Tab backwards to an offscreen comment must scroll the detail so the comment
+/// is visible (#151).
+#[test]
+fn test_pr_subfocus_prev_scrolls_to_offscreen_comment() {
+    use crate::domain::IssueComment;
+
+    let mut state = prs_mode_state("repo-1");
+    let mut detail = make_test_pr_detail(1);
+    detail.body = "PR body".to_string();
+    detail.comments = (0u32..12)
+        .map(|i| IssueComment {
+            comment_id: u64::from(i),
+            author_login: format!("user{i}"),
+            created_at: "2024-01-01".to_string(),
+            edited_at: None,
+            body: format!("comment body {i}"),
+        })
+        .collect();
+    state.prs_state.pr_detail = Some(detail);
+    state.prs_state.detail_subfocus = PrDetailSubfocus::NewComment;
+    state.prs_state.detail_viewport_rows = 4; // small viewport
+    // Start scrolled near the bottom (NewComment is last section).
+    state.prs_state.detail_scroll_offset = 100;
+
+    // Prev from NewComment -> Comment(11) (last comment). With viewport=4, it
+    // should scroll up to reveal comment 11.
+    let state = state.apply(AppEvent::PrDetailSubfocusPrev);
+    assert_eq!(
+        state.prs_state.detail_subfocus,
+        PrDetailSubfocus::Comment(11),
+        "should have moved to Comment(11)"
+    );
+    let offset = state.prs_state.detail_scroll_offset;
+    let viewport = state.prs_state.detail_viewport_rows;
+    assert!(
+        offset < 100,
+        "scroll offset should have decreased to reveal comment 11, got {offset}"
+    );
+    let detail = state
+        .prs_state
+        .pr_detail
+        .as_ref()
+        .unwrap_or_else(|| panic!("expected detail"));
+    let range = crate::pr_detail_content::pr_subfocus_line_range(
+        detail,
+        PrDetailSubfocus::Comment(11),
+        &state.prs_state.inline_state,
+        state.prs_state.loading.detail,
+        state.prs_state.loading.comments,
+    )
+    .unwrap_or_else(|| panic!("expected range for comment 11"));
+    assert!(
+        range.0 >= offset && range.0 < offset + viewport,
+        "comment 11 first line {} must be within viewport [{}, {})",
+        range.0,
+        offset,
+        offset + viewport
+    );
+}


### PR DESCRIPTION
## Summary

When the user moves the detail-pane subfocus (Tab/j/k) to an item currently scrolled out of view, the scroll offset now follows so the focused item stays visible. This mirrors how list panes keep the selected row visible and makes Tab navigation usable on long PRs/issues with many review threads or comments (#151).

## Changes

- **Pure scroll-into-view math** (`src/layout.rs`): `reveal_range_scroll_offset` computes the minimal scroll offset to bring a line range into view. Returns the original offset when the item is already visible; anchors the top line when the item is taller than the viewport.
- **Pure subfocus-to-line-range projections**:
  - `pr_subfocus_line_range` in `src/pr_detail_content.rs` maps a `PrDetailSubfocus` to its rendered content-line range by scanning the same `build_pr_detail_content` output the renderer uses (no marker drift).
  - `issue_subfocus_line_range` in `src/issue_detail_content.rs` does the same for `DetailSubfocus`.
- **Reducer wiring**:
  - `src/state/prs_nav_ops.rs`: `PrDetailSubfocusNext/Prev` now call `scroll_pr_detail_to_subfocus`, which computes the new offset via `reveal_range_scroll_offset` and clamps to `pr_detail_max_scroll_offset`.
  - `src/state/issues_ops.rs`: `IssueDetailSubfocusNext/Prev` now call `scroll_issue_detail_to_subfocus` with the same pattern.
- **Dispatch viewport refresh** (`src/app_input/`): Issues subfocus events now refresh `detail_viewport_rows` before the reducer runs (matching the PR path which already refreshed for all messages), so the clamp bound is fresh. The helper was extracted into `issues_subfocus_dispatch.rs` to keep `app_input/mod.rs` under the 1000-line limit.
- **Tests** (20 new): 9 for the pure scroll-into-view math, 7 for PR subfocus ranges, 4 for Issues subfocus ranges, plus 4 integration tests proving Tab to an offscreen comment/thread scrolls the viewport.

## Acceptance criteria

- [x] Tab/j/k to an offscreen review thread scrolls the detail so the thread is visible.
- [x] Tab/j/k to an offscreen check/comment/issue-comment does the same.
- [x] Manual scroll (arrows, mousewheel, PageUp/Down) is not fighting the auto-follow on each tick (auto-follow only fires on subfocus change).
- [x] The scroll offset is clamped to valid bounds and uses a fresh viewport row count (no phantom-region regression — see PR #149).
- [x] Tests for the scroll-into-view computation (pure, given item line range + viewport + current offset -> new offset).

## Non-goals

- Centering the focused item (minimal reveal is enough; centering is a separate nicety).
- Changing which key advances subfocus (that is issue #150).

Closes #151