### PR TITLE
Harden harness TMUX_TMPDIR handling, de-duplicate tmux prefix, fix isolation-test Err-masking, rework tests (Fixes #173)

### DIFF
--- a/src/harness/tmux_driver.rs
+++ b/src/harness/tmux_driver.rs
@@ -36,6 +36,26 @@ fn harness_socket_name() -> &'static str {
     SOCKET_NAME.get_or_init(|| format!("jefe-harness-{}", std::process::id()))
 }
 
+/// The `["-f", "/dev/null", "-L", <socket>]` argv every harness tmux command
+/// begins with, for the `Command` builder. Single source of truth: the socket
+/// name flows from [`harness_socket_name`], so the `Command` builder
+/// (`tmux_command`) and the shell-string builders (`tmux_pane_wrapper_command`,
+/// `format_command`) can never drift apart (#173).
+#[must_use]
+fn harness_tmux_prefix_args() -> [&'static str; 4] {
+    ["-f", "/dev/null", "-L", harness_socket_name()]
+}
+
+/// The `"tmux -f /dev/null -L <socket>"` prefix for shell-string command
+/// formatting. Shares the socket resolution with [`harness_tmux_prefix_args`]
+/// so the `-L` target is identical between the spawned `Command` and any inline
+/// shell `tmux` calls (#173).
+#[must_use]
+fn harness_tmux_prefix_str() -> String {
+    let [conf, devnull, flag, socket] = harness_tmux_prefix_args();
+    format!("tmux {conf} {devnull} {flag} {socket}")
+}
+
 /// Start request for a harness-owned tmux session.
 ///
 /// @plan PLAN-20260629-TMUX-HARNESS.P03
@@ -410,8 +430,10 @@ fn tmux_command() -> Command {
     // `-f /dev/null` skips the user config; `-L <name>` isolates the harness
     // onto its own private server, and the env scrub ensures an inherited
     // `$TMUX` (e.g. when the suite runs inside a jefe pane) cannot redirect
-    // harness calls onto the outer server (#171).
-    cmd.args(["-f", "/dev/null", "-L", harness_socket_name()]);
+    // harness calls onto the outer server (#171). The prefix argv is shared via
+    // [`harness_tmux_prefix_args`] so the shell-string builders cannot drift
+    // (#173).
+    cmd.args(harness_tmux_prefix_args());
     for var in TMUX_ENV_VARS_TO_SCRUB {
         cmd.env_remove(var);
     }
@@ -437,10 +459,17 @@ fn new_session_args(request: &TmuxStartRequest) -> Vec<String> {
 fn tmux_pane_wrapper_command(request: &TmuxStartRequest) -> String {
     // These run inside the just-created pane. The pane's `$TMUX_PANE` is set by
     // the harness's own `-L` server, and the explicit `-L` keeps the inner
-    // calls pinned to that same private server (#171).
-    let socket = harness_socket_name();
+    // calls pinned to that same private server (#171). The leading
+    // `unset TMUX TMUX_PANE TMUX_TMPDIR;` scrubs the inherited env so the
+    // inner `tmux -L {socket}` calls resolve the socket in the SAME directory
+    // as `tmux_command()` — without it, an inherited `$TMUX_TMPDIR` (exactly
+    // the #171 scenario: suite running inside a jefe pane) would resolve
+    // `-L {socket}` against the outer server's socket directory, silently
+    // leaving `remain-on-exit`/`history-limit` unconfigured on the real
+    // harness session (#173).
+    let prefix = harness_tmux_prefix_str();
     format!(
-        "tmux -f /dev/null -L {socket} set-option -pt \"$TMUX_PANE\" remain-on-exit on; tmux -f /dev/null -L {socket} set-option -wt \"$TMUX_PANE\" history-limit {}; exec {}",
+        "unset TMUX TMUX_PANE TMUX_TMPDIR; {prefix} set-option -pt \"$TMUX_PANE\" remain-on-exit on; {prefix} set-option -wt \"$TMUX_PANE\" history-limit {}; exec {}",
         request.history_limit,
         shell_join(&request.command)
     )
@@ -554,7 +583,7 @@ fn output_lines(bytes: &[u8]) -> Vec<String> {
 }
 
 fn format_command(args: &[String]) -> String {
-    let prefix = format!("tmux -f /dev/null -L {}", harness_socket_name());
+    let prefix = harness_tmux_prefix_str();
     if args.is_empty() {
         return prefix;
     }

--- a/src/harness/tmux_driver_tests.rs
+++ b/src/harness/tmux_driver_tests.rs
@@ -125,9 +125,50 @@ fn new_session_command_shell_escapes_argv_parts() {
     let args = new_session_args(&request);
     let socket = harness_socket_name();
     let expected = format!(
-        "tmux -f /dev/null -L {socket} set-option -pt \"$TMUX_PANE\" remain-on-exit on; tmux -f /dev/null -L {socket} set-option -wt \"$TMUX_PANE\" history-limit 1000; exec '/bin/echo' 'a b' 'quote'\\''it'"
+        "unset TMUX TMUX_PANE TMUX_TMPDIR; tmux -f /dev/null -L {socket} set-option -pt \"$TMUX_PANE\" remain-on-exit on; tmux -f /dev/null -L {socket} set-option -wt \"$TMUX_PANE\" history-limit 1000; exec '/bin/echo' 'a b' 'quote'\\''it'"
     );
     assert_eq!(args.last().map(String::as_str), Some(expected.as_str()));
+}
+
+/// Inner pane commands must scrub the tmux client env (`TMUX`, `TMUX_PANE`,
+/// `TMUX_TMPDIR`) so the inner `tmux -L {socket}` calls resolve the harness
+/// socket in the SAME directory as the outer `tmux_command()`. An inherited
+/// `$TMUX_TMPDIR` (the #171 scenario) would otherwise redirect the inner calls
+/// at the outer server's socket directory, leaving
+/// `remain-on-exit`/`history-limit` unconfigured on the harness session (#173).
+///
+/// This is a pure-string assertion over the builder output (no tmux spawn), so
+/// the regression locks the wrapper string shape: the `unset` prefix MUST
+/// precede the first `tmux -f /dev/null -L {socket}` segment.
+#[test]
+fn tmux_pane_wrapper_command_scrubs_tmux_env_before_inner_calls() {
+    let request = TmuxStartRequest::command(
+        "env-scrub",
+        vec!["/bin/true".to_string()],
+        temp_path(),
+        80,
+        24,
+        1000,
+    )
+    .value_or_panic("request should be valid");
+
+    let wrapper = tmux_pane_wrapper_command(&request);
+    let unset_pos = wrapper
+        .find("unset TMUX TMUX_PANE TMUX_TMPDIR;")
+        .unwrap_or_else(|| panic!("unset prefix missing from wrapper: {wrapper}"));
+    let tmux_pos = wrapper
+        .find("tmux -f /dev/null -L")
+        .unwrap_or_else(|| panic!("inner tmux prefix missing from wrapper: {wrapper}"));
+
+    assert!(
+        unset_pos < tmux_pos,
+        "unset scrub must precede the inner tmux calls; got wrapper={wrapper}"
+    );
+    // The exec'd command must survive the scrub verbatim.
+    assert!(
+        wrapper.ends_with("exec '/bin/true'"),
+        "exec'd command must survive verbatim after the unset/inner calls; got {wrapper}"
+    );
 }
 
 /// Real jefe requests always include an isolated `--config` directory.
@@ -397,6 +438,8 @@ fn harness_socket_name_is_per_process_and_stable() {
 
 /// Every formatted harness tmux command must carry the dedicated `-L <socket>`
 /// flag so harness calls can never land on an inherited/outer server (#171).
+/// The shared prefix comes from [`harness_tmux_prefix_str`] so the `Command`
+/// builder and shell-string builders cannot drift (#173).
 #[test]
 fn format_command_carries_dedicated_socket_flag() {
     let socket = harness_socket_name();
@@ -408,6 +451,18 @@ fn format_command_carries_dedicated_socket_flag() {
         with_args,
         format!("tmux -f /dev/null -L {socket} has-session -t x")
     );
+}
+
+/// The shared `Command`-builder prefix and shell-string prefix must agree on
+/// the harness socket name so inline `tmux -L {socket}` calls and the spawned
+/// `Command` resolve the same server (#173 DRY guard).
+#[test]
+fn harness_tmux_prefix_args_and_str_resolve_same_socket() {
+    let args = harness_tmux_prefix_args();
+    assert_eq!(args, ["-f", "/dev/null", "-L", harness_socket_name()]);
+    let s = harness_tmux_prefix_str();
+    let expected = format!("tmux -f /dev/null -L {}", harness_socket_name());
+    assert_eq!(s, expected);
 }
 
 /// A harness session must run on the harness's dedicated `-L` socket, not on
@@ -461,13 +516,28 @@ fn harness_session_runs_on_dedicated_socket() {
         .env_remove("TMUX_PANE")
         .env_remove("TMUX_TMPDIR")
         .output();
-    if let Ok(out) = default_listing {
-        let listing = String::from_utf8_lossy(&out.stdout).to_string();
-        assert!(
-            !listing
-                .lines()
-                .any(|line| line.starts_with(&format!("{}:", guard.session.name))),
-            "harness session leaked onto the default/shared tmux server (#171); listing:\n{listing}"
-        );
-    }
+    let out = match default_listing {
+        Ok(out) => out,
+        Err(err) => {
+            // tmux was confirmed available above (`driver.is_available()`), so a
+            // spawn failure here is a genuine environment problem — NOT a pass.
+            // Surfacing it prevents the #171 isolation assertion from being
+            // skipped vacuously (#173).
+            panic!(
+                "tmux list-sessions probe failed to spawn even though tmux is available (#171 isolation assertion skipped): {err}"
+            );
+        }
+    };
+    let listing = String::from_utf8_lossy(&out.stdout).to_string();
+    // Two pass cases:
+    //  (a) no default server running → empty stdout (strongest pass).
+    //  (b) a default server is running but our harness session is not listed.
+    // A non-zero exit with empty stdout is the legitimate "no default server"
+    // case; only a non-empty listing containing our session name is a fail.
+    assert!(
+        !listing
+            .lines()
+            .any(|line| line.starts_with(&format!("{}:", guard.session.name))),
+        "harness session leaked onto the default/shared tmux server (#171); listing:\n{listing}"
+    );
 }

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -209,7 +209,7 @@ fn run_command_capture_with_timeout(
                     let _ = child.wait();
                     return Err(RuntimeError::RemoteExecutionFailed(format!(
                         "{error_context}: timed out after {}s",
-                        timeout.as_secs()
+                        timeout.as_secs_f64()
                     )));
                 }
                 std::thread::sleep(Duration::from_millis(50));

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -176,7 +176,18 @@ fn remote_effective_user(remote: &crate::domain::RemoteRepositorySettings) -> St
     }
 }
 
-fn run_command_capture(mut cmd: Command, error_context: &str) -> Result<Output, RuntimeError> {
+fn run_command_capture(cmd: Command, error_context: &str) -> Result<Output, RuntimeError> {
+    run_command_capture_with_timeout(cmd, REMOTE_SSH_COMMAND_TIMEOUT, error_context)
+}
+
+/// [`run_command_capture`] with an injectable deadline so tests can drive the
+/// timeout branch with a sub-second value instead of the 20s production
+/// default (#173).
+fn run_command_capture_with_timeout(
+    mut cmd: Command,
+    timeout: Duration,
+    error_context: &str,
+) -> Result<Output, RuntimeError> {
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
 
@@ -184,7 +195,7 @@ fn run_command_capture(mut cmd: Command, error_context: &str) -> Result<Output, 
         .spawn()
         .map_err(|e| RuntimeError::RemoteExecutionFailed(format!("{error_context}: {e}")))?;
 
-    let deadline = Instant::now() + REMOTE_SSH_COMMAND_TIMEOUT;
+    let deadline = Instant::now() + timeout;
     loop {
         match child.try_wait() {
             Ok(Some(_)) => {
@@ -198,7 +209,7 @@ fn run_command_capture(mut cmd: Command, error_context: &str) -> Result<Output, 
                     let _ = child.wait();
                     return Err(RuntimeError::RemoteExecutionFailed(format!(
                         "{error_context}: timed out after {}s",
-                        REMOTE_SSH_COMMAND_TIMEOUT.as_secs()
+                        timeout.as_secs()
                     )));
                 }
                 std::thread::sleep(Duration::from_millis(50));

--- a/src/runtime/commands_tests.rs
+++ b/src/runtime/commands_tests.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use crate::domain::SandboxEngine;
+use std::time::Duration;
 
 fn base_signature() -> LaunchSignature {
     LaunchSignature {
@@ -18,19 +19,30 @@ fn base_signature() -> LaunchSignature {
     }
 }
 
+/// The local launch plan omits the `LLXPRT_DEBUG` env assignment when the
+/// signature's `llxprt_debug` is empty, and that absence propagates through
+/// [`local_pane_command_args`] so the llxprt child never sees a stale debug
+/// flag.
+///
+/// Drives the real production path (`local_launch_plan` →
+/// `local_pane_command_args`) rather than re-deriving the env vector inline,
+/// so a regression in the env-building logic (a new condition, a renamed key)
+/// is caught here (#173).
 #[test]
 fn llxprt_debug_env_is_omitted_when_empty() {
     let signature = base_signature();
-    let mut launch_env: Vec<(String, String)> = Vec::new();
+    let plan = local_launch_plan(&signature);
+    assert!(
+        !plan.env.iter().any(|(key, _)| key == "LLXPRT_DEBUG"),
+        "empty llxprt_debug must not produce an LLXPRT_DEBUG env entry: {:?}",
+        plan.env
+    );
 
-    if signature.sandbox_enabled {
-        launch_env.push(("SANDBOX_FLAGS".to_owned(), signature.sandbox_flags.clone()));
-    }
-    if !signature.llxprt_debug.is_empty() {
-        launch_env.push(("LLXPRT_DEBUG".to_owned(), signature.llxprt_debug.clone()));
-    }
-
-    assert!(!launch_env.iter().any(|(key, _)| key == "LLXPRT_DEBUG"));
+    let args = local_pane_command_args(&plan);
+    assert!(
+        !args.iter().any(|arg| arg.starts_with("LLXPRT_DEBUG=")),
+        "local pane command must not carry an LLXPRT_DEBUG= arg when debug is empty: {args:?}"
+    );
 }
 
 #[test]
@@ -50,40 +62,67 @@ fn remote_tmux_command_wraps_run_as_user_once() {
     );
 }
 
+/// The remote-command timeout branch produces a `RuntimeError::RemoteExecutionFailed`
+/// whose message names the context and the timeout. Drives the real
+/// [`run_command_capture_with_timeout`] branch with a sub-second injectable
+/// deadline against a portable `sleep` probe, so the test is fast and hermetic
+/// (no `python3` dependency) (#173).
 #[test]
 fn remote_execution_timeout_returns_clear_error() {
-    let mut cmd = Command::new("python3");
-    cmd.args(["-c", "import time; time.sleep(30)"]);
+    // `sleep` is specified by POSIX and present on every CI platform jefe
+    // targets; a 2s sleep with a 1s deadline trips the timeout branch in well
+    // under the 20s production default, so this test runs in ~1s.
+    let mut cmd = Command::new("sleep");
+    cmd.arg("2");
 
     let Err(RuntimeError::RemoteExecutionFailed(message)) =
-        run_command_capture(cmd, "timeout probe")
+        run_command_capture_with_timeout(cmd, Duration::from_secs(1), "timeout probe")
     else {
         panic!("expected remote timeout failure");
     };
 
-    assert!(message.contains("timed out"));
-    assert!(message.contains("timeout probe"));
+    assert!(
+        message.contains("timed out"),
+        "message should name the timeout: {message}"
+    );
+    assert!(
+        message.contains("timeout probe"),
+        "message should name the context: {message}"
+    );
+    assert!(
+        message.contains("after 1s"),
+        "message should report the injected deadline: {message}"
+    );
 }
 
+/// A non-empty `llxprt_debug` signature produces an `LLXPRT_DEBUG=<value>`
+/// env entry in the launch plan, and that assignment flows through
+/// [`local_pane_command_args`] verbatim (single argv entry, no extra quoting),
+/// so the llxprt child inherits the intended debug level.
+///
+/// Drives the real production path (`local_launch_plan` →
+/// `local_pane_command_args`) instead of re-deriving the env vector inline
+/// (#173).
 #[test]
 fn llxprt_debug_env_is_included_when_non_empty() {
     let mut signature = base_signature();
     signature.llxprt_debug = "trace=1".to_owned();
 
-    let mut launch_env: Vec<(String, String)> = Vec::new();
-    if signature.sandbox_enabled {
-        launch_env.push(("SANDBOX_FLAGS".to_owned(), signature.sandbox_flags.clone()));
-    }
-    if !signature.llxprt_debug.is_empty() {
-        launch_env.push(("LLXPRT_DEBUG".to_owned(), signature.llxprt_debug.clone()));
-    }
-
+    let plan = local_launch_plan(&signature);
     assert_eq!(
-        launch_env
-            .into_iter()
+        plan.env
+            .iter()
             .find(|(key, _)| key == "LLXPRT_DEBUG")
-            .map(|(_, value)| value),
-        Some("trace=1".to_owned())
+            .map(|(_, value)| value.clone()),
+        Some("trace=1".to_owned()),
+        "non-empty llxprt_debug must produce an LLXPRT_DEBUG env entry: {:?}",
+        plan.env
+    );
+
+    let args = local_pane_command_args(&plan);
+    assert!(
+        args.iter().any(|arg| arg == "LLXPRT_DEBUG=trace=1"),
+        "local pane command must carry the LLXPRT_DEBUG=trace=1 argv entry verbatim: {args:?}"
     );
 }
 
@@ -201,18 +240,39 @@ fn remote_launch_command_scrubs_tmux_env_from_pane() {
     );
 }
 
+/// `SANDBOX_FLAGS` must reach the local pane command as a single raw
+/// `SANDBOX_FLAGS=--cpus=2 --memory=12288m --pids-limit=256` argv entry (no
+/// shell quoting), because tmux passes each argv element to `sh -c` as one
+/// token — shell-quoting the value would embed literal quote chars in the env
+/// var the agent child sees.
+///
+/// Drives the real production path (`local_launch_plan` →
+/// `local_pane_command_args`) with `sandbox_enabled: true` and asserts the raw
+/// argv entry appears, rather than re-deriving `format!` output (#173).
 #[test]
 fn sandbox_flags_env_value_is_raw_for_tmux_argv() {
-    let key = "SANDBOX_FLAGS";
-    let value = "--cpus=2 --memory=12288m --pids-limit=256";
-    let arg = format!("{key}={value}");
-    // Rust's Command::arg() passes this as a single argv entry to tmux.
-    // tmux escapes each argument when constructing its sh -c command, so
-    // spaces survive without extra quoting.  Adding shell_escape_single()
-    // would embed literal quote characters in the env var value.
+    let mut signature = base_signature();
+    signature.sandbox_enabled = true;
+    // Use the exact default flags the issue calls out so the assertion locks
+    // the real value, not a hand-built literal.
+    signature.sandbox_flags = "--cpus=2 --memory=12288m --pids-limit=256".to_owned();
+
+    let plan = local_launch_plan(&signature);
     assert_eq!(
-        arg,
-        "SANDBOX_FLAGS=--cpus=2 --memory=12288m --pids-limit=256"
+        plan.env
+            .iter()
+            .find(|(key, _)| key == "SANDBOX_FLAGS")
+            .map(|(_, value)| value.clone()),
+        Some("--cpus=2 --memory=12288m --pids-limit=256".to_owned()),
+        "sandbox-enabled plan must carry the raw SANDBOX_FLAGS value: {:?}",
+        plan.env
+    );
+
+    let args = local_pane_command_args(&plan);
+    assert!(
+        args.iter()
+            .any(|arg| arg == "SANDBOX_FLAGS=--cpus=2 --memory=12288m --pids-limit=256"),
+        "local pane command must carry the raw SANDBOX_FLAGS=... argv entry (no shell quoting): {args:?}"
     );
 }
 

--- a/src/runtime/commands_tests.rs
+++ b/src/runtime/commands_tests.rs
@@ -91,7 +91,7 @@ fn remote_execution_timeout_returns_clear_error() {
     );
     assert!(
         message.contains("after 1s"),
-        "message should report the injected deadline: {message}"
+        "message should report the injected deadline as fractional seconds: {message}"
     );
 }
 


### PR DESCRIPTION
## Summary

Follow-up hardening and test-quality cleanup for the TMUX-env-leak fix merged in #172 (commit 5d3010f37). The fix itself is correct and validated; this PR addresses one latent correctness gap, one DRY issue, and several tests that did not follow dev-docs/standards/testing-and-quality.md. Closes #173.

## Changes

### 1. Correctness hardening — harness inner pane calls now scrub TMUX_TMPDIR

src/harness/tmux_driver.rs — tmux_pane_wrapper_command() (the inner shell string) previously built the inner `tmux -L {socket} set-option` calls without scrubbing the inherited environment. The outer tmux_command() scrubs TMUX/TMUX_PANE/TMUX_TMPDIR via Command::env_remove, so the harness server socket is created under the default per-UID tmux directory. But the inner shell commands inherited the ambient environment, so an inherited $TMUX_TMPDIR (exactly the #171 scenario: the suite running inside a jefe-managed pane) caused the inner set-option calls to resolve `-L {socket}` in a *different* directory than where tmux_command() created the server — silently targeting the wrong (or a freshly spawned) server and leaving remain-on-exit/history-limit unconfigured on the real harness session.

**Fix:** prefix the inner shell command with `unset TMUX TMUX_PANE TMUX_TMPDIR;` so the inner `tmux -L {socket}` calls resolve the socket identically to tmux_command(). Added a pure-string regression test (tmux_pane_wrapper_command_scrubs_tmux_env_before_inner_calls) that locks the wrapper shape: the unset prefix must precede the first `tmux -f /dev/null -L {socket}` segment, and the exec'd command must survive verbatim.

### 2. Code quality (DRY) — single source of truth for the tmux invocation prefix

The `-f /dev/null -L <socket>` prefix (and its socket resolution) was constructed independently in three spots in src/harness/tmux_driver.rs:
- tmux_command() — `cmd.args(["-f", "/dev/null", "-L", harness_socket_name()])`
- tmux_pane_wrapper_command() — inline `"tmux -f /dev/null -L {socket} ..."`
- format_command() — `format!("tmux -f /dev/null -L {}", harness_socket_name())`

**Fix:** extract two shared helpers that both delegate to harness_socket_name():
- `harness_tmux_prefix_args() -> [&'static str; 4]` for the Command builder
- `harness_tmux_prefix_str() -> String` for the shell-string builders

All three sites now consume the single source of truth. Added harness_tmux_prefix_args_and_str_resolve_same_socket to guard against drift between the Command and shell-string prefixes.

### 3. Test robustness — isolation test no longer passes vacuously on probe spawn failure

src/harness/tmux_driver_tests.rs — harness_session_runs_on_dedicated_socket() wrapped the critical #171 isolation assertion inside `if let Ok(out) = default_listing { ... }` with no else. If `tmux list-sessions` failed to spawn (Err — PATH/I/O problem) the assertion was skipped and the test passed vacuously, giving false confidence about the isolation guarantee. driver.is_available() is already asserted at the top of the test, so a spawn failure here is a genuine environment problem that should surface.

**Fix:** handle the Err arm explicitly (panic with a clear message, since tmux is confirmed available). The Ok path still treats empty stdout (no default server running) as the strongest possible pass.

### 4. Tests reworked to exercise production code (per dev-docs/standards/testing-and-quality.md)

The standard forbids pure implementation-detail assertions as primary proof and tests that re-implement production logic inline. Three tests violated this:

- **4a. llxprt_debug_env_is_omitted_when_empty / llxprt_debug_env_is_included_when_non_empty** — both rebuilt the production env vector inline (`if signature.sandbox_enabled { ... } if !signature.llxprt_debug.is_empty() { ... }`) instead of calling local_launch_plan(). If the production env-building changed, these tests still passed while real behavior broke. Now drive local_launch_plan() + local_pane_command_args() and assert on the real output (both the plan env and the pane argv).

- **4b. sandbox_flags_env_value_is_raw_for_tmux_argv** — tautological: it constructed a string with format! and asserted it equaled the same literal. Now drives local_launch_plan() with sandbox_enabled: true and asserts the raw `SANDBOX_FLAGS=--cpus=2 --memory=12288m --pids-limit=256` argv entry appears in local_pane_command_args() (no shell quoting).

- **4c. remote_execution_timeout_returns_clear_error** — spawned a 30s python3 sleep to trip a 20s timeout (CI-slow, non-hermetic python3 dependency). Now uses an injectable sub-second deadline (run_command_capture_with_timeout, 1s) against a portable `sleep 2` probe. The production path (run_command_capture) is unchanged — it delegates to the new helper with the 20s default. Runs in ~1s.

## Verification

- `cargo fmt --all --check` OK
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (stable, CLIPPY_CONF_DIR=.github/clippy) OK
- Complexity-only clippy pass OK
- scripts/check-clippy-allows.sh OK
- scripts/check-source-file-size.sh OK (no new warnings; all four modified files well under the 1000-line hard limit)
- `cargo build --workspace --all-features --locked` OK
- `cargo test --workspace --all-features --locked` OK — 857 + 220 + 6 + 238 + 1 = 1322 passed, 0 failed
- `cargo llvm-cov --workspace --all-features --summary-only --fail-under-lines 30` OK — 71.60% line coverage (floor is 30%)

## Constraints honored

- No behavior change for the happy path — all rendered output and the isolation guarantee are unchanged.
- No unwrap()/expect() in production paths; tests use value_or_panic / let-else per the assertion-style standard.
- No lint/complexity/size threshold loosened; no suppression directives added.
- TDD: the new regression tests (tmux_pane_wrapper_command_scrubs_tmux_env_before_inner_calls, harness_tmux_prefix_args_and_str_resolve_same_socket) lock the new behavior; the reworked tests exercise the production path.
