### PR TITLE
Make select-to-copy work on forms, choosers, and confirm overlays (Fixes #178)

### DIFF
--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -376,9 +376,19 @@ pub fn handle_mode_help_key(
     }
     // Mirror the help scroll offset to AppState so the selection content
     // projection can map screen coordinates to the correct help content
-    // line (issue #178). The hook state is the rendering source of truth;
-    // AppState is read by the pure selection layer.
-    app_state.write().help_scroll_offset = usize::try_from(help_scroll.get()).unwrap_or(0);
+    // line (issue #178). The hook state may hold a sentinel (u32::MAX for
+    // the End key) that the renderer clamps via ScrollableText; clamp here
+    // using the same viewport math so the selection layer reads the actual
+    // visible offset, not the raw sentinel.
+    let (_, term_rows) = crossterm::terminal::size().unwrap_or((120, 40));
+    let viewport_rows = jefe::ui::modals::help_viewport_rows(term_rows);
+    let max_scroll = jefe::ui::modals::help_content_lines()
+        .len()
+        .saturating_sub(viewport_rows);
+    let clamped = help_scroll
+        .get()
+        .min(u32::try_from(max_scroll).unwrap_or(u32::MAX));
+    app_state.write().help_scroll_offset = usize::try_from(clamped).unwrap_or(0);
 }
 
 pub fn handle_mode_search_key(

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -374,6 +374,11 @@ pub fn handle_mode_help_key(
         }
         _ => {}
     }
+    // Mirror the help scroll offset to AppState so the selection content
+    // projection can map screen coordinates to the correct help content
+    // line (issue #178). The hook state is the rendering source of truth;
+    // AppState is read by the pure selection layer.
+    app_state.write().help_scroll_offset = usize::try_from(help_scroll.get()).unwrap_or(0);
 }
 
 pub fn handle_mode_search_key(

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -185,7 +185,12 @@ fn active_overlay_for(state: &AppState) -> jefe::selection::OverlayPane {
         }
         // Explicit match (not wildcard) so new ModalState variants force a
         // conscious overlay-routing decision here (issue #178 z-order).
-        jefe::state::ModalState::None | jefe::state::ModalState::Search { .. } => {}
+        // ThemePicker renders as a full-screen modal but does not yet have a
+        // content projection — no selection, but no PTY forwarding either
+        // (pre-existing behavior; the base screen is not visible behind it).
+        jefe::state::ModalState::None
+        | jefe::state::ModalState::Search { .. }
+        | jefe::state::ModalState::ThemePicker { .. } => {}
     }
     // Positioned overlays (choosers) — checked only when no full-screen modal.
     if state.issues_state.agent_chooser.is_some() || state.prs_state.agent_chooser.is_some() {

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -185,11 +185,13 @@ fn active_overlay_for(state: &AppState) -> jefe::selection::OverlayPane {
         }
         // Explicit match (not wildcard) so new ModalState variants force a
         // conscious overlay-routing decision here (issue #178 z-order).
+        jefe::state::ModalState::None
+        // Search is an in-band filter mode (SplitScreen's filter bar), not a
+        // blocking overlay — the base screen remains visible and interactive.
+        | jefe::state::ModalState::Search { .. }
         // ThemePicker renders as a full-screen modal but does not yet have a
         // content projection — no selection, but no PTY forwarding either
         // (pre-existing behavior; the base screen is not visible behind it).
-        jefe::state::ModalState::None
-        | jefe::state::ModalState::Search { .. }
         | jefe::state::ModalState::ThemePicker { .. } => {}
     }
     // Positioned overlays (choosers) — checked only when no full-screen modal.

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -49,7 +49,12 @@ pub fn handle_fullscreen_mouse(
 
     let terminal_input_enabled = {
         let state = app_state.read();
-        state.terminal_focused && state.pane_focus == PaneFocus::Terminal
+        // Suppress PTY forwarding when an overlay (modal/form/chooser) is
+        // active so mouse selection targets the top-most overlay instead of
+        // the terminal underneath (issue #178 z-order fix).
+        state.terminal_focused
+            && state.pane_focus == PaneFocus::Terminal
+            && active_overlay_for(&state) == jefe::selection::OverlayPane::None
     };
 
     // When the terminal is focused, mouse events within the terminal pane go to
@@ -152,7 +157,42 @@ fn screen_layout_for(state: &AppState, cols: u16, rows: u16) -> ScreenLayout {
         || state.prs_state.error.is_some();
     let filter_open =
         state.issues_state.filter_ui.controls_open || state.prs_state.filter_ui.controls_open;
+    let overlay = active_overlay_for(state);
     ScreenLayout::new(cols, rows, state.screen_mode, error_visible, filter_open)
+        .with_overlay(overlay)
+}
+
+/// Determine which overlay (modal/form/chooser) is currently active, if any.
+///
+/// Full-screen modals take priority over positioned choosers. Returns
+/// [`OverlayPane::None`] when no overlay is active so normal pane geometry
+/// applies.
+fn active_overlay_for(state: &AppState) -> jefe::selection::OverlayPane {
+    use jefe::selection::OverlayPane;
+    match &state.modal {
+        jefe::state::ModalState::Help => return OverlayPane::HelpModal,
+        jefe::state::ModalState::NewAgent { .. } | jefe::state::ModalState::EditAgent { .. } => {
+            return OverlayPane::AgentForm;
+        }
+        jefe::state::ModalState::NewRepository { .. }
+        | jefe::state::ModalState::EditRepository { .. } => return OverlayPane::RepositoryForm,
+        jefe::state::ModalState::ConfirmDeleteRepository { .. }
+        | jefe::state::ModalState::ConfirmDeleteAgent { .. }
+        | jefe::state::ModalState::ConfirmKillAgent { .. }
+        | jefe::state::ModalState::PreflightPrompt { .. }
+        | jefe::state::ModalState::ConfirmIssueDirtyCopy { .. } => {
+            return OverlayPane::ConfirmModal;
+        }
+        _ => {}
+    }
+    // Positioned overlays (choosers) — checked only when no full-screen modal.
+    if state.issues_state.agent_chooser.is_some() || state.prs_state.agent_chooser.is_some() {
+        return OverlayPane::AgentChooser;
+    }
+    if state.prs_state.merge_chooser.is_some() {
+        return OverlayPane::MergeChooser;
+    }
+    OverlayPane::None
 }
 
 /// Resolve which pane + geometry a screen coordinate maps to, given app state.
@@ -277,6 +317,10 @@ fn finalize_and_copy_selection(ctx: Option<&CtxArc>, app_state: &HookState<AppSt
 /// are not affected by scroll offset. Scrollable content starts at line
 /// `DETAIL_HEADER_ROWS`. Return 0 when the click is in the header area,
 /// otherwise the real scroll offset.
+///
+/// The HelpModal also has fixed header rows (title + blank = 2 rows) that are
+/// not affected by the scroll offset; the scrollable help content starts at
+/// line 2.
 fn effective_scroll_for_detail(
     pane: SelectablePane,
     row: u16,
@@ -293,6 +337,11 @@ fn effective_scroll_for_detail(
                 scroll_offset
             }
         }
+        SelectablePane::HelpModal => {
+            let content_row = usize::from(row.saturating_sub(geometry.content_origin_row));
+            // Title Box is height 2 (title text + blank) — not scrolled.
+            if content_row < 2 { 0 } else { scroll_offset }
+        }
         _ => scroll_offset,
     }
 }
@@ -302,6 +351,7 @@ fn scroll_offset_for_pane(state: &AppState, pane: SelectablePane) -> usize {
     match pane {
         SelectablePane::IssueDetail => state.issues_state.detail_scroll_offset,
         SelectablePane::PrDetail => state.prs_state.detail_scroll_offset,
+        SelectablePane::HelpModal => state.help_scroll_offset,
         _ => 0,
     }
 }

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -183,7 +183,9 @@ fn active_overlay_for(state: &AppState) -> jefe::selection::OverlayPane {
         | jefe::state::ModalState::ConfirmIssueDirtyCopy { .. } => {
             return OverlayPane::ConfirmModal;
         }
-        _ => {}
+        // Explicit match (not wildcard) so new ModalState variants force a
+        // conscious overlay-routing decision here (issue #178 z-order).
+        jefe::state::ModalState::None | jefe::state::ModalState::Search { .. } => {}
     }
     // Positioned overlays (choosers) — checked only when no full-screen modal.
     if state.issues_state.agent_chooser.is_some() || state.prs_state.agent_chooser.is_some() {
@@ -313,6 +315,10 @@ fn finalize_and_copy_selection(ctx: Option<&CtxArc>, app_state: &HookState<AppSt
     }
 }
 
+/// HelpModal title rows (title text + blank): not affected by scroll offset,
+/// mirroring the renderer's title Box(height: 2) above ScrollableText.
+const HELP_TITLE_ROWS: usize = 2;
+
 /// For detail panes, headers occupy content lines `0..DETAIL_HEADER_ROWS` and
 /// are not affected by scroll offset. Scrollable content starts at line
 /// `DETAIL_HEADER_ROWS`. Return 0 when the click is in the header area,
@@ -340,7 +346,11 @@ fn effective_scroll_for_detail(
         SelectablePane::HelpModal => {
             let content_row = usize::from(row.saturating_sub(geometry.content_origin_row));
             // Title Box is height 2 (title text + blank) — not scrolled.
-            if content_row < 2 { 0 } else { scroll_offset }
+            if content_row < HELP_TITLE_ROWS {
+                0
+            } else {
+                scroll_offset
+            }
         }
         _ => scroll_offset,
     }

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -28,6 +28,10 @@ use crate::ui::components::issue_list::{IssueListLayout, issue_list_visible_rows
 use crate::ui::components::pr_detail::pr_detail_header_view;
 use crate::ui::components::pr_list::pr_list_visible_rows;
 use crate::ui::components::terminal_empty_message;
+use crate::ui::modals::help_content_lines;
+
+use crate::selection::form_content;
+use crate::selection::overlay_content;
 
 /// Separator line rendered between the fixed detail header and the scrollable
 /// content, mirroring the components' `"─────…"` row.
@@ -99,15 +103,9 @@ pub fn pane_content_lines(
         SelectablePane::KeybindBar => keybind_bar_lines(state),
         SelectablePane::AgentForm => agent_form_lines(state),
         SelectablePane::RepositoryForm => repository_form_lines(state),
-        SelectablePane::AgentChooser => {
-            crate::selection::overlay_content::agent_chooser_lines(state)
-        }
-        SelectablePane::MergeChooser => {
-            crate::selection::overlay_content::merge_chooser_lines(state)
-        }
-        SelectablePane::ConfirmModal => {
-            crate::selection::overlay_content::confirm_modal_lines(state)
-        }
+        SelectablePane::AgentChooser => overlay_content::agent_chooser_lines(state),
+        SelectablePane::MergeChooser => overlay_content::merge_chooser_lines(state),
+        SelectablePane::ConfirmModal => overlay_content::confirm_modal_lines(state),
     }
 }
 
@@ -317,12 +315,7 @@ fn help_lines() -> PaneContent {
     // Title string mirrors src/ui/modals/help.rs; if it changes there, update
     // this literal too (extracting a shared constant would require making the
     // help component's title public, deferred to a future refactor).
-    lines.extend(
-        crate::ui::modals::help_content_lines()
-            .iter()
-            .copied()
-            .map(str::to_string),
-    );
+    lines.extend(help_content_lines().iter().copied().map(str::to_string));
     PaneContent::new(SelectablePane::HelpModal, lines)
 }
 
@@ -353,7 +346,7 @@ fn keybind_bar_lines(state: &AppState) -> PaneContent {
 
 /// Agent-definition form lines that match the rendered field layout.
 fn agent_form_lines(state: &AppState) -> PaneContent {
-    match crate::selection::form_content::agent_form_content_lines(state) {
+    match form_content::agent_form_content_lines(state) {
         Some(lines) => PaneContent::new(SelectablePane::AgentForm, lines),
         None => PaneContent::empty(SelectablePane::AgentForm),
     }
@@ -361,7 +354,7 @@ fn agent_form_lines(state: &AppState) -> PaneContent {
 
 /// Repository-definition form lines that match the rendered field layout.
 fn repository_form_lines(state: &AppState) -> PaneContent {
-    match crate::selection::form_content::repository_form_content_lines(state) {
+    match form_content::repository_form_content_lines(state) {
         Some(lines) => PaneContent::new(SelectablePane::RepositoryForm, lines),
         None => PaneContent::empty(SelectablePane::RepositoryForm),
     }

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -311,10 +311,7 @@ fn help_lines() -> PaneContent {
     // truth (`help_content_lines`) that the renderer windows. The title row
     // and its trailing blank are included as content lines 0-1 so the (2,2)
     // content origin maps to the title text.
-    let mut lines: Vec<String> = vec!["Help - Keyboard Shortcuts".to_string(), String::new()];
-    // Title string mirrors src/ui/modals/help.rs; if it changes there, update
-    // this literal too (extracting a shared constant would require making the
-    // help component's title public, deferred to a future refactor).
+    let mut lines: Vec<String> = vec![crate::ui::modals::HELP_TITLE.to_string(), String::new()];
     lines.extend(help_content_lines().iter().copied().map(str::to_string));
     PaneContent::new(SelectablePane::HelpModal, lines)
 }

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -314,10 +314,14 @@ fn help_lines() -> PaneContent {
     // and its trailing blank are included as content lines 0-1 so the (2,2)
     // content origin maps to the title text.
     let mut lines: Vec<String> = vec!["Help - Keyboard Shortcuts".to_string(), String::new()];
+    // Title string mirrors src/ui/modals/help.rs; if it changes there, update
+    // this literal too (extracting a shared constant would require making the
+    // help component's title public, deferred to a future refactor).
     lines.extend(
         crate::ui::modals::help_content_lines()
             .iter()
-            .map(|s| (*s).to_string()),
+            .copied()
+            .map(str::to_string),
     );
     PaneContent::new(SelectablePane::HelpModal, lines)
 }

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -97,6 +97,17 @@ pub fn pane_content_lines(
         SelectablePane::HelpModal => help_lines(),
         SelectablePane::StatusBar => status_bar_lines(state),
         SelectablePane::KeybindBar => keybind_bar_lines(state),
+        SelectablePane::AgentForm => agent_form_lines(state),
+        SelectablePane::RepositoryForm => repository_form_lines(state),
+        SelectablePane::AgentChooser => {
+            crate::selection::overlay_content::agent_chooser_lines(state)
+        }
+        SelectablePane::MergeChooser => {
+            crate::selection::overlay_content::merge_chooser_lines(state)
+        }
+        SelectablePane::ConfirmModal => {
+            crate::selection::overlay_content::confirm_modal_lines(state)
+        }
     }
 }
 
@@ -297,7 +308,18 @@ fn terminal_lines(snapshot: Option<&TerminalSnapshot>, state: &AppState) -> Pane
 }
 
 fn help_lines() -> PaneContent {
-    PaneContent::new(SelectablePane::HelpModal, Vec::<String>::new())
+    // Issue #178: project the actual help content instead of an empty Vec so
+    // select-to-copy works inside the help modal. Reuses the single source of
+    // truth (`help_content_lines`) that the renderer windows. The title row
+    // and its trailing blank are included as content lines 0-1 so the (2,2)
+    // content origin maps to the title text.
+    let mut lines: Vec<String> = vec!["Help - Keyboard Shortcuts".to_string(), String::new()];
+    lines.extend(
+        crate::ui::modals::help_content_lines()
+            .iter()
+            .map(|s| (*s).to_string()),
+    );
+    PaneContent::new(SelectablePane::HelpModal, lines)
 }
 
 /// Status bar line that matches the rendered format:
@@ -321,6 +343,24 @@ fn status_bar_lines(state: &AppState) -> PaneContent {
 fn keybind_bar_lines(state: &AppState) -> PaneContent {
     let hints = crate::ui::components::keybind_bar::keybind_hints_for(state.screen_mode, false);
     PaneContent::new(SelectablePane::KeybindBar, vec![hints.to_string()])
+}
+
+// ── Issue #178: overlay content providers (delegated to submodules) ──────
+
+/// Agent-definition form lines that match the rendered field layout.
+fn agent_form_lines(state: &AppState) -> PaneContent {
+    match crate::selection::form_content::agent_form_content_lines(state) {
+        Some(lines) => PaneContent::new(SelectablePane::AgentForm, lines),
+        None => PaneContent::empty(SelectablePane::AgentForm),
+    }
+}
+
+/// Repository-definition form lines that match the rendered field layout.
+fn repository_form_lines(state: &AppState) -> PaneContent {
+    match crate::selection::form_content::repository_form_content_lines(state) {
+        Some(lines) => PaneContent::new(SelectablePane::RepositoryForm, lines),
+        None => PaneContent::empty(SelectablePane::RepositoryForm),
+    }
 }
 
 #[cfg(test)]
@@ -593,5 +633,226 @@ mod tests {
         assert!(content.lines[2].contains("assignees: bob"));
         assert_eq!(content.lines[3], "https://example.com/pull/7");
         assert!(content.lines[4].starts_with('─'));
+    }
+
+    // ── Issue #178: select-to-copy for forms, choosers, confirm, and help ──
+
+    #[test]
+    fn help_modal_lines_match_help_content_projection() {
+        let content = pane_content_lines(
+            SelectablePane::HelpModal,
+            &AppState::default(),
+            None,
+            120,
+            40,
+        );
+        // help_lines() must project the actual help content (issue #178: it
+        // was returning an empty Vec).
+        assert!(
+            !content.lines.is_empty(),
+            "help modal must have copyable content"
+        );
+        assert!(
+            content.lines.iter().any(|l| l.contains("Navigation")),
+            "help modal content must include the Navigation section"
+        );
+    }
+
+    #[test]
+    fn agent_form_lines_include_title_and_fields() {
+        use crate::domain::RepositoryId;
+        use crate::state::{AgentFormFields, ModalState};
+        let mut state = AppState::default();
+        state.modal = ModalState::NewAgent {
+            repository_id: RepositoryId("r1".to_string()),
+            fields: AgentFormFields {
+                name: "my-agent".to_string(),
+                ..Default::default()
+            },
+            focus: crate::state::AgentFormFocus::Name,
+            cursor: crate::state::AgentFormCursor::default(),
+            work_dir_manual: false,
+        };
+        let content = pane_content_lines(SelectablePane::AgentForm, &state, None, 120, 40);
+        assert!(
+            content.lines.iter().any(|l| l.contains("New Agent")),
+            "agent form must include the title"
+        );
+        assert!(
+            content.lines.iter().any(|l| l.contains("my-agent")),
+            "agent form must include the agent name field value"
+        );
+    }
+
+    #[test]
+    fn agent_form_lines_empty_when_no_modal() {
+        let state = AppState::default();
+        let content = pane_content_lines(SelectablePane::AgentForm, &state, None, 120, 40);
+        assert!(
+            content.lines.is_empty(),
+            "agent form with no modal should have no content"
+        );
+    }
+
+    #[test]
+    fn repository_form_lines_include_title_and_fields() {
+        use crate::state::{ModalState, RepositoryFormFields};
+        let mut state = AppState::default();
+        state.modal = ModalState::NewRepository {
+            fields: RepositoryFormFields {
+                name: "my-repo".to_string(),
+                ..Default::default()
+            },
+            focus: crate::state::RepositoryFormFocus::Name,
+            cursor: crate::state::RepositoryFormCursor::default(),
+        };
+        let content = pane_content_lines(SelectablePane::RepositoryForm, &state, None, 120, 40);
+        assert!(
+            content.lines.iter().any(|l| l.contains("New Repository")),
+            "repository form must include the title"
+        );
+        assert!(
+            content.lines.iter().any(|l| l.contains("my-repo")),
+            "repository form must include the repo name field value"
+        );
+    }
+
+    #[test]
+    fn agent_chooser_lines_include_header_and_agent_names() {
+        use crate::domain::{Agent, AgentId, Repository, RepositoryId};
+        let mut state = AppState::default();
+        // Add a repository and two agents so the chooser has entries.
+        let repo_id = RepositoryId("r1".to_string());
+        state.repositories.push(Repository::new(
+            repo_id.clone(),
+            "repo".to_string(),
+            "repo".to_string(),
+            std::path::PathBuf::from("/tmp/repo"),
+        ));
+        state.agents.push(Agent::new(
+            AgentId("a1".to_string()),
+            repo_id.clone(),
+            "alpha".to_string(),
+            std::path::PathBuf::from("/tmp/a1"),
+        ));
+        state.agents.push(Agent::new(
+            AgentId("a2".to_string()),
+            repo_id,
+            "beta".to_string(),
+            std::path::PathBuf::from("/tmp/a2"),
+        ));
+        state.selected_repository_index = Some(0);
+        // Open the agent chooser from issues state.
+        state.issues_state.agent_chooser = Some(crate::state::AgentChooserState {
+            selected_index: 0,
+            agents: vec![
+                (AgentId("a1".to_string()), "alpha".to_string()),
+                (AgentId("a2".to_string()), "beta".to_string()),
+            ],
+        });
+        let content = pane_content_lines(SelectablePane::AgentChooser, &state, None, 120, 40);
+        assert!(
+            content.lines.iter().any(|l| l.contains("Send to Agent")),
+            "agent chooser must include header"
+        );
+        assert!(
+            content.lines.iter().any(|l| l.contains("alpha")),
+            "agent chooser must list agent names"
+        );
+        assert!(
+            content.lines.iter().any(|l| l.contains("beta")),
+            "agent chooser must list agent names"
+        );
+    }
+
+    #[test]
+    fn merge_chooser_lines_include_header_and_methods() {
+        use crate::domain::{PrCheckStatus, PrState, PullRequestDetail};
+        let mut state = AppState::default();
+        state.prs_state.merge_chooser = Some(crate::state::PrMergeChooserState {
+            selected_index: 0,
+            allowed_methods: None,
+            awaiting_confirmation: false,
+        });
+        // Merge chooser needs a PR number for the header.
+        state.prs_state.pr_detail = Some(PullRequestDetail {
+            repo_owner_name: "o/r".to_string(),
+            number: 42,
+            title: "T".to_string(),
+            state: PrState::Open,
+            is_draft: false,
+            author_login: "x".to_string(),
+            created_at: String::new(),
+            updated_at: String::new(),
+            head_ref: String::new(),
+            base_ref: String::new(),
+            labels: Vec::new(),
+            assignees: Vec::new(),
+            milestone: None,
+            body: String::new(),
+            external_url: String::new(),
+            review_decision: None,
+            checks_status: PrCheckStatus::None,
+            reviews: Vec::new(),
+            checks: Vec::new(),
+            comments: Vec::new(),
+            has_more_comments: false,
+            comments_cursor: None,
+            mergeable: None,
+            merge_state_status: None,
+        });
+        let content = pane_content_lines(SelectablePane::MergeChooser, &state, None, 120, 40);
+        assert!(
+            content
+                .lines
+                .iter()
+                .any(|l| l.contains("Merge Pull Request #42")),
+            "merge chooser must include PR number header"
+        );
+        assert!(
+            content
+                .lines
+                .iter()
+                .any(|l| l.contains("Create a merge commit")),
+            "merge chooser must list merge methods"
+        );
+        assert!(
+            content.lines.iter().any(|l| l.contains("Squash and merge")),
+            "merge chooser must list merge methods"
+        );
+    }
+
+    #[test]
+    fn confirm_modal_lines_include_title_and_message() {
+        use crate::domain::{Agent, AgentId, Repository, RepositoryId};
+        use crate::state::ModalState;
+        let mut state = AppState::default();
+        let repo_id = RepositoryId("r1".to_string());
+        state.repositories.push(Repository::new(
+            repo_id.clone(),
+            "repo".to_string(),
+            "repo".to_string(),
+            std::path::PathBuf::from("/tmp/repo"),
+        ));
+        let agent_id = AgentId("a1".to_string());
+        state.agents.push(Agent::new(
+            agent_id.clone(),
+            repo_id,
+            "my-agent".to_string(),
+            std::path::PathBuf::from("/tmp/a1"),
+        ));
+        state.modal = ModalState::ConfirmDeleteAgent {
+            id: agent_id,
+            delete_work_dir: false,
+        };
+        let content = pane_content_lines(SelectablePane::ConfirmModal, &state, None, 120, 40);
+        assert!(
+            content.lines.iter().any(|l| l.contains("Delete Agent")),
+            "confirm modal must include the title"
+        );
+        assert!(
+            content.lines.iter().any(|l| l.contains("my-agent")),
+            "confirm modal must include the message with the agent name"
+        );
     }
 }

--- a/src/selection/form_content.rs
+++ b/src/selection/form_content.rs
@@ -14,25 +14,10 @@ use crate::state::{
     AgentFormCursor, AgentFormFields, AgentFormFocus, AppState, ModalState, RepositoryFormCursor,
     RepositoryFormFields, RepositoryFormFocus,
 };
+use crate::ui::util::text_with_caret;
 
 const AGENT_HINT: &str = "  Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles/cycles checkboxes  Enter submit  Esc cancel";
 const REPO_HINT: &str = "  Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles remote options  Enter submit  Esc cancel";
-
-/// Insert the caret character `▏` at `cursor` position in `value`, mirroring
-/// the `render_text_with_caret` function used by the iocraft form components.
-fn text_with_caret(value: &str, cursor: usize) -> String {
-    let char_len = value.chars().count();
-    let clamped = cursor.min(char_len);
-    let byte_idx = if clamped == 0 {
-        0
-    } else {
-        value
-            .char_indices()
-            .nth(clamped)
-            .map_or_else(|| value.len(), |(idx, _)| idx)
-    };
-    format!("{}▏{}", &value[..byte_idx], &value[byte_idx..])
-}
 
 /// Render a single form field row: `  {label:<16} [{value}]`.
 fn render_field(label: &str, value: &str) -> String {

--- a/src/selection/form_content.rs
+++ b/src/selection/form_content.rs
@@ -1,0 +1,507 @@
+//! Pure content projections for the agent-definition and repository-definition
+//! forms (issue #178).
+//!
+//! These build the flat list of copyable lines that match what the
+//! `NewAgentForm` and `NewRepositoryForm` iocraft components render, so mouse
+//! selection coordinates map to the exact characters on screen — including the
+//! `▏` caret inserted into the focused field's value.
+//!
+//! All functions are pure and `#[must_use]`. They read only from
+//! [`crate::state::AppState`] (no iocraft, no side effects).
+
+use crate::domain::PlatformCapabilities;
+use crate::state::{
+    AgentFormCursor, AgentFormFields, AgentFormFocus, AppState, ModalState, RepositoryFormCursor,
+    RepositoryFormFields, RepositoryFormFocus,
+};
+
+const AGENT_HINT: &str = "  Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles/cycles checkboxes  Enter submit  Esc cancel";
+const REPO_HINT: &str = "  Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles remote options  Enter submit  Esc cancel";
+
+/// Insert the caret character `▏` at `cursor` position in `value`, mirroring
+/// the `render_text_with_caret` function used by the iocraft form components.
+fn text_with_caret(value: &str, cursor: usize) -> String {
+    let char_len = value.chars().count();
+    let clamped = cursor.min(char_len);
+    let byte_idx = if clamped == 0 {
+        0
+    } else {
+        value
+            .char_indices()
+            .nth(clamped)
+            .map_or_else(|| value.len(), |(idx, _)| idx)
+    };
+    format!("{}▏{}", &value[..byte_idx], &value[byte_idx..])
+}
+
+/// Render a single form field row: `  {label:<16} [{value}]`.
+fn render_field(label: &str, value: &str) -> String {
+    format!("  {label:<16} [{value}]")
+}
+
+/// Render a checkbox row: `  {label:<16} [{mark}]  ({hint})`.
+fn render_checkbox(label: &str, checked: bool, hint: &str) -> String {
+    let mark = if checked { "x" } else { " " };
+    format!("  {label:<16} [{mark}]  ({hint})")
+}
+
+/// Build the field specs for the agent form's editable text fields.
+fn agent_field_specs(
+    fields: &AgentFormFields,
+    cursor: &AgentFormCursor,
+) -> [(&'static str, String, AgentFormFocus, usize); 7] {
+    let shortcut = fields
+        .shortcut_slot
+        .map_or_else(|| "none".to_string(), |slot| slot.to_string());
+    [
+        ("Shortcut (1-9)", shortcut, AgentFormFocus::Shortcut, 0),
+        (
+            "Name",
+            fields.name.clone(),
+            AgentFormFocus::Name,
+            cursor.name,
+        ),
+        (
+            "Description",
+            fields.description.clone(),
+            AgentFormFocus::Description,
+            cursor.description,
+        ),
+        (
+            "Work Dir",
+            fields.work_dir.clone(),
+            AgentFormFocus::WorkDir,
+            cursor.work_dir,
+        ),
+        (
+            "Profile",
+            fields.profile.clone(),
+            AgentFormFocus::Profile,
+            cursor.profile,
+        ),
+        (
+            "Mode Flags",
+            fields.mode.clone(),
+            AgentFormFocus::Mode,
+            cursor.mode,
+        ),
+        (
+            "LLXPRT_DEBUG",
+            fields.llxprt_debug.clone(),
+            AgentFormFocus::LlxprtDebug,
+            cursor.llxprt_debug,
+        ),
+    ]
+}
+
+/// Build the copyable content lines for the agent-definition form.
+#[must_use]
+pub fn agent_form_content_lines(state: &AppState) -> Option<Vec<String>> {
+    let (title, fields, focus, cursor) = agent_form_state(state)?;
+    let mut lines: Vec<String> = vec![format!(" {title}"), String::new()];
+
+    let specs = agent_field_specs(fields, cursor);
+    agent_text_field_lines(&specs, focus, &mut lines);
+
+    lines.push(render_checkbox(
+        "Pass --continue",
+        fields.pass_continue,
+        "space toggles",
+    ));
+    lines.push(render_checkbox(
+        "Sandbox",
+        fields.sandbox_enabled,
+        "space toggles",
+    ));
+
+    let engine_hint = sandbox_engine_hint(fields.sandbox_enabled);
+    lines.push(format!(
+        "  {:<16} [{}]  ({engine_hint})",
+        "Sandbox Engine", fields.sandbox_engine
+    ));
+
+    let flags_value = if focus == AgentFormFocus::SandboxFlags {
+        text_with_caret(&fields.sandbox_flags, cursor.sandbox_flags)
+    } else {
+        fields.sandbox_flags.clone()
+    };
+    lines.push(render_field("Sandbox Flags", &flags_value));
+
+    lines.push(String::new());
+    lines.push(AGENT_HINT.to_string());
+    Some(lines)
+}
+
+/// Append rendered text-field rows, inserting the caret into the focused
+/// editable field (Shortcut is never editable).
+fn agent_text_field_lines(
+    specs: &[(&str, String, AgentFormFocus, usize)],
+    focus: AgentFormFocus,
+    lines: &mut Vec<String>,
+) {
+    for (label, value, field_focus, field_cursor) in specs {
+        let rendered = if focus == *field_focus && *field_focus != AgentFormFocus::Shortcut {
+            text_with_caret(value, *field_cursor)
+        } else {
+            value.clone()
+        };
+        lines.push(render_field(label, &rendered));
+    }
+}
+
+/// Extract the agent form title, fields, focus, and cursor from the active modal state.
+fn agent_form_state(
+    state: &AppState,
+) -> Option<(&str, &AgentFormFields, AgentFormFocus, &AgentFormCursor)> {
+    match &state.modal {
+        ModalState::NewAgent {
+            fields,
+            focus,
+            cursor,
+            ..
+        } => Some(("New Agent", fields, *focus, cursor)),
+        ModalState::EditAgent {
+            fields,
+            focus,
+            cursor,
+            ..
+        } => Some(("Edit Agent", fields, *focus, cursor)),
+        _ => None,
+    }
+}
+
+/// Build the field specs for the repository form's text fields.
+fn repo_text_field_specs(
+    fields: &RepositoryFormFields,
+    cursor: &RepositoryFormCursor,
+) -> [(&'static str, String, RepositoryFormFocus, usize); 4] {
+    [
+        (
+            "Name",
+            fields.name.clone(),
+            RepositoryFormFocus::Name,
+            cursor.name,
+        ),
+        (
+            "Base Dir",
+            fields.base_dir.clone(),
+            RepositoryFormFocus::BaseDir,
+            cursor.base_dir,
+        ),
+        (
+            "Default Profile",
+            fields.default_profile.clone(),
+            RepositoryFormFocus::DefaultProfile,
+            cursor.default_profile,
+        ),
+        (
+            "GitHub Repo",
+            fields.github_repo.clone(),
+            RepositoryFormFocus::GitHubRepo,
+            cursor.github_repo,
+        ),
+    ]
+}
+
+/// Build the field specs for the repository form's remote fields.
+fn repo_remote_field_specs(
+    fields: &RepositoryFormFields,
+    cursor: &RepositoryFormCursor,
+) -> [(&'static str, String, RepositoryFormFocus, usize); 3] {
+    [
+        (
+            "Login User",
+            fields.login_user.clone(),
+            RepositoryFormFocus::LoginUser,
+            cursor.login_user,
+        ),
+        (
+            "Host / IP",
+            fields.host.clone(),
+            RepositoryFormFocus::Host,
+            cursor.host,
+        ),
+        (
+            "Run As User",
+            fields.run_as_user.clone(),
+            RepositoryFormFocus::RunAsUser,
+            cursor.run_as_user,
+        ),
+    ]
+}
+
+/// Build the copyable content lines for the repository-definition form.
+#[must_use]
+pub fn repository_form_content_lines(state: &AppState) -> Option<Vec<String>> {
+    let (title, fields, focus, cursor) = repository_form_state(state)?;
+    let mut lines = vec![format!(" {title}"), String::new()];
+
+    let text_specs = repo_text_field_specs(fields, cursor);
+    repo_text_field_lines(&text_specs, focus, &mut lines);
+
+    lines.push(render_checkbox(
+        "Remote Repository",
+        fields.remote_enabled,
+        "space toggles",
+    ));
+
+    let remote_specs = repo_remote_field_specs(fields, cursor);
+    repo_text_field_lines(&remote_specs, focus, &mut lines);
+
+    lines.push(render_checkbox(
+        "Setup Env Default",
+        fields.setup_env_default,
+        "space toggles",
+    ));
+    lines.push(String::new());
+    lines.push(REPO_HINT.to_string());
+    Some(lines)
+}
+
+/// Append rendered text-field rows for the repository form, inserting the
+/// caret into the focused field.
+fn repo_text_field_lines(
+    specs: &[(&str, String, RepositoryFormFocus, usize)],
+    focus: RepositoryFormFocus,
+    lines: &mut Vec<String>,
+) {
+    for (label, value, field_focus, field_cursor) in specs {
+        let rendered = if focus == *field_focus {
+            text_with_caret(value, *field_cursor)
+        } else {
+            value.clone()
+        };
+        lines.push(render_field(label, &rendered));
+    }
+}
+
+/// Extract the repository form title, fields, focus, and cursor from the active modal state.
+fn repository_form_state(
+    state: &AppState,
+) -> Option<(
+    &str,
+    &RepositoryFormFields,
+    RepositoryFormFocus,
+    &RepositoryFormCursor,
+)> {
+    match &state.modal {
+        ModalState::NewRepository {
+            fields,
+            focus,
+            cursor,
+            ..
+        } => Some(("New Repository", fields, *focus, cursor)),
+        ModalState::EditRepository {
+            fields,
+            focus,
+            cursor,
+            ..
+        } => Some(("Edit Repository", fields, *focus, cursor)),
+        _ => None,
+    }
+}
+
+/// Compute the sandbox-engine hint shown on the form, matching the renderer.
+fn sandbox_engine_hint(sandbox_enabled: bool) -> String {
+    if sandbox_enabled {
+        let labels: Vec<&str> = PlatformCapabilities::current()
+            .supported_engines()
+            .iter()
+            .map(|e| e.label())
+            .collect();
+        format!("space cycles: {}", labels.join(" / "))
+    } else {
+        String::from("disabled")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::RepositoryId;
+    use crate::state::{AgentFormCursor, AgentFormFields, AgentFormFocus, ModalState};
+
+    #[test]
+    fn agent_form_title_has_leading_space() {
+        let state = AppState {
+            modal: ModalState::NewAgent {
+                repository_id: RepositoryId("r1".to_string()),
+                fields: AgentFormFields::default(),
+                focus: AgentFormFocus::Shortcut,
+                cursor: AgentFormCursor::default(),
+                work_dir_manual: false,
+            },
+            ..Default::default()
+        };
+        let Some(lines) = agent_form_content_lines(&state) else {
+            panic!("must have lines");
+        };
+        assert_eq!(
+            lines[0], " New Agent",
+            "title must include the leading space"
+        );
+    }
+
+    #[test]
+    fn agent_form_focused_name_field_has_caret() {
+        let state = AppState {
+            modal: ModalState::NewAgent {
+                repository_id: RepositoryId("r1".to_string()),
+                fields: AgentFormFields {
+                    name: "abc".to_string(),
+                    ..Default::default()
+                },
+                focus: AgentFormFocus::Name,
+                cursor: AgentFormCursor {
+                    name: 1,
+                    ..Default::default()
+                },
+                work_dir_manual: false,
+            },
+            ..Default::default()
+        };
+        let Some(lines) = agent_form_content_lines(&state) else {
+            panic!("must have lines");
+        };
+        let name_line = lines
+            .iter()
+            .find(|l| l.contains("Name"))
+            .unwrap_or_else(|| panic!("must have name line"));
+        assert!(
+            name_line.contains("a▏bc"),
+            "focused name field must have caret at cursor position 1"
+        );
+    }
+
+    #[test]
+    fn agent_form_unfocused_field_has_no_caret() {
+        let state = AppState {
+            modal: ModalState::NewAgent {
+                repository_id: RepositoryId("r1".to_string()),
+                fields: AgentFormFields {
+                    name: "abc".to_string(),
+                    ..Default::default()
+                },
+                focus: AgentFormFocus::Description,
+                cursor: AgentFormCursor::default(),
+                work_dir_manual: false,
+            },
+            ..Default::default()
+        };
+        let Some(lines) = agent_form_content_lines(&state) else {
+            panic!("must have lines");
+        };
+        let name_line = lines
+            .iter()
+            .find(|l| l.contains("Name"))
+            .unwrap_or_else(|| panic!("must have name line"));
+        assert!(
+            !name_line.contains('▏'),
+            "unfocused name field must not have caret"
+        );
+    }
+
+    #[test]
+    fn agent_form_sandbox_disabled_shows_disabled_hint() {
+        let state = AppState {
+            modal: ModalState::NewAgent {
+                repository_id: RepositoryId("r1".to_string()),
+                fields: AgentFormFields {
+                    sandbox_enabled: false,
+                    ..Default::default()
+                },
+                focus: AgentFormFocus::Shortcut,
+                cursor: AgentFormCursor::default(),
+                work_dir_manual: false,
+            },
+            ..Default::default()
+        };
+        let Some(lines) = agent_form_content_lines(&state) else {
+            panic!("must have lines");
+        };
+        let engine_line = lines
+            .iter()
+            .find(|l| l.contains("Sandbox Engine"))
+            .unwrap_or_else(|| panic!("must have engine line"));
+        assert!(
+            engine_line.contains("(disabled)"),
+            "disabled sandbox must show (disabled) hint"
+        );
+    }
+
+    #[test]
+    fn agent_form_sandbox_enabled_shows_cycle_hint() {
+        let state = AppState {
+            modal: ModalState::NewAgent {
+                repository_id: RepositoryId("r1".to_string()),
+                fields: AgentFormFields {
+                    sandbox_enabled: true,
+                    ..Default::default()
+                },
+                focus: AgentFormFocus::Shortcut,
+                cursor: AgentFormCursor::default(),
+                work_dir_manual: false,
+            },
+            ..Default::default()
+        };
+        let Some(lines) = agent_form_content_lines(&state) else {
+            panic!("must have lines");
+        };
+        let engine_line = lines
+            .iter()
+            .find(|l| l.contains("Sandbox Engine"))
+            .unwrap_or_else(|| panic!("must have engine line"));
+        assert!(
+            engine_line.contains("space cycles:"),
+            "enabled sandbox must show cycle hint, got: {engine_line}"
+        );
+    }
+
+    #[test]
+    fn agent_form_sandbox_flags_focused_has_caret() {
+        let state = AppState {
+            modal: ModalState::NewAgent {
+                repository_id: RepositoryId("r1".to_string()),
+                fields: AgentFormFields {
+                    sandbox_flags: "--network".to_string(),
+                    ..Default::default()
+                },
+                focus: AgentFormFocus::SandboxFlags,
+                cursor: AgentFormCursor {
+                    sandbox_flags: 2,
+                    ..Default::default()
+                },
+                work_dir_manual: false,
+            },
+            ..Default::default()
+        };
+        let Some(lines) = agent_form_content_lines(&state) else {
+            panic!("must have lines");
+        };
+        let flags_line = lines
+            .iter()
+            .find(|l| l.contains("Sandbox Flags"))
+            .unwrap_or_else(|| panic!("must have flags line"));
+        assert!(
+            flags_line.contains("--▏network"),
+            "focused flags field must have caret at position 2"
+        );
+    }
+
+    #[test]
+    fn edit_agent_form_title_has_leading_space() {
+        let state = AppState {
+            modal: ModalState::EditAgent {
+                id: crate::domain::AgentId("a1".to_string()),
+                fields: AgentFormFields::default(),
+                focus: AgentFormFocus::Shortcut,
+                cursor: AgentFormCursor::default(),
+            },
+            ..Default::default()
+        };
+        let Some(lines) = agent_form_content_lines(&state) else {
+            panic!("must have lines");
+        };
+        assert_eq!(lines[0], " Edit Agent");
+    }
+}

--- a/src/selection/geometry.rs
+++ b/src/selection/geometry.rs
@@ -145,7 +145,7 @@ pub fn pane_at(
     }
 
     // Positioned overlays (choosers) intercept coordinates inside their bounds.
-    if let Some(chooser) = chooser_pane_if_inside(col, row, *layout, render_cols, render_rows) {
+    if let Some(chooser) = chooser_pane_if_inside(col, row, *layout) {
         return Some(chooser);
     }
 
@@ -467,16 +467,11 @@ const HELP_CHROME_ROWS: u16 = 7;
 
 /// Compute the help modal height for a given terminal row count.
 ///
-/// Mirrors `help_viewport_rows` + `HELP_CHROME_ROWS` from the renderer so
-/// the geometry matches exactly.
+/// Delegates to the renderer's `help_viewport_rows` (single source of truth)
+/// and adds the chrome rows, so the geometry matches exactly.
 fn help_modal_height(render_rows: u16) -> u16 {
-    let available = usize::from(render_rows).saturating_sub(usize::from(HELP_CHROME_ROWS));
-    let viewport = if available >= 8 {
-        available.min(22)
-    } else {
-        available
-    };
-    let total = viewport + usize::from(HELP_CHROME_ROWS);
+    let viewport = crate::ui::modals::help_viewport_rows(render_rows);
+    let total = viewport.saturating_add(usize::from(HELP_CHROME_ROWS));
     u16::try_from(total.min(usize::from(render_rows)).max(1)).unwrap_or(1)
 }
 
@@ -512,6 +507,9 @@ fn full_screen_overlay_pane(
 const CHOOSER_OFFSET_COL: u16 = 4;
 const CHOOSER_OFFSET_ROW: u16 = 2;
 /// Chooser widget width: 41-char separator + 2 border + 2 padding columns.
+/// Must stay in sync with the AgentChooser/MergeChooser separator length
+/// (src/ui/components/agent_chooser.rs). Changes there require updating
+/// CHOOSER_INNER_WIDTH here.
 const CHOOSER_INNER_WIDTH: u16 = 45;
 /// Maximum chooser height (prevents the overlay from exceeding the workspace).
 const CHOOSER_MAX_HEIGHT: u16 = 30;
@@ -529,8 +527,6 @@ fn chooser_pane_if_inside(
     col: u16,
     row: u16,
     layout: ScreenLayout,
-    _render_cols: u16,
-    _render_rows: u16,
 ) -> Option<(SelectablePane, PaneGeometry)> {
     let pane = layout.overlay.to_pane()?;
     if layout.overlay.is_full_screen() {

--- a/src/selection/geometry.rs
+++ b/src/selection/geometry.rs
@@ -460,20 +460,13 @@ fn terminal_view(
     )
 }
 
-/// Help modal fixed width (matches the renderer's `width: 60u32` in
-/// `src/ui/modals/help.rs`). If the renderer width changes, update this too.
-const HELP_MODAL_WIDTH: u16 = 60;
-/// Help modal vertical chrome: border(2) + padding(2) + title(2) + footer(1).
-/// Duplicates `HELP_CHROME_ROWS` in `src/ui/modals/help.rs` — keep in sync.
-const HELP_CHROME_ROWS: u16 = 7;
-
 /// Compute the help modal height for a given terminal row count.
 ///
 /// Delegates to the renderer's `help_viewport_rows` (single source of truth)
 /// and adds the chrome rows, so the geometry matches exactly.
 fn help_modal_height(render_rows: u16) -> u16 {
     let viewport = crate::ui::modals::help_viewport_rows(render_rows);
-    let total = viewport.saturating_add(usize::from(HELP_CHROME_ROWS));
+    let total = viewport.saturating_add(usize::from(crate::ui::modals::HELP_CHROME_ROWS));
     u16::try_from(total.min(usize::from(render_rows)).max(1)).unwrap_or(1)
 }
 
@@ -493,7 +486,7 @@ fn full_screen_overlay_pane(
     let geo = match overlay {
         crate::selection::OverlayPane::HelpModal => {
             let height = help_modal_height(render_rows);
-            PaneGeometry::new(0, 0, HELP_MODAL_WIDTH, height, 2, 2)
+            PaneGeometry::new(0, 0, crate::ui::modals::HELP_MODAL_WIDTH, height, 2, 2)
         }
         crate::selection::OverlayPane::ConfirmModal => PaneGeometry::new(0, 0, 50, 10, 2, 2),
         // AgentForm and RepositoryForm — truly full-screen.

--- a/src/selection/geometry.rs
+++ b/src/selection/geometry.rs
@@ -460,9 +460,11 @@ fn terminal_view(
     )
 }
 
-/// Help modal fixed width (matches the renderer's `width: 60u32`).
+/// Help modal fixed width (matches the renderer's `width: 60u32` in
+/// `src/ui/modals/help.rs`). If the renderer width changes, update this too.
 const HELP_MODAL_WIDTH: u16 = 60;
 /// Help modal vertical chrome: border(2) + padding(2) + title(2) + footer(1).
+/// Duplicates `HELP_CHROME_ROWS` in `src/ui/modals/help.rs` — keep in sync.
 const HELP_CHROME_ROWS: u16 = 7;
 
 /// Compute the help modal height for a given terminal row count.

--- a/src/selection/geometry.rs
+++ b/src/selection/geometry.rs
@@ -110,6 +110,12 @@ impl PaneGeometry {
 /// is focused, mouse events over the terminal pane are forwarded to the PTY
 /// and should not start an app selection, so [`SelectablePane::TerminalView`]
 /// is excluded from the result in that case.
+///
+/// When `layout.overlay` is active (issue #178), full-screen overlays
+/// (Help/AgentForm/RepositoryForm/ConfirmModal) intercept coordinates within
+/// their rendered bounds, and positioned overlays (AgentChooser/MergeChooser)
+/// intercept coordinates inside their bounds before falling through to the
+/// underlying pane.
 #[must_use]
 pub fn pane_at(
     col: u16,
@@ -121,6 +127,26 @@ pub fn pane_at(
     let (render_cols, render_rows) = effective_render_size(layout.term_cols, layout.term_rows);
     if col >= render_cols || row >= render_rows {
         return None;
+    }
+
+    // Full-screen overlays (modals/forms) intercept coordinates within
+    // their actual rendered bounds (not necessarily the entire screen —
+    // ConfirmModal is 50×10, HelpModal is 60 wide with variable height).
+    if layout.overlay.is_full_screen()
+        && let Some((pane, geo)) =
+            full_screen_overlay_pane(layout.overlay, render_cols, render_rows)
+    {
+        if geo.contains(col, row) {
+            return Some((pane, geo));
+        }
+        // Point is outside the modal's rendered bounds — no pane to select
+        // (the modal replaced the screen, so the base layout is not visible).
+        return None;
+    }
+
+    // Positioned overlays (choosers) intercept coordinates inside their bounds.
+    if let Some(chooser) = chooser_pane_if_inside(col, row, *layout, render_cols, render_rows) {
+        return Some(chooser);
     }
 
     // Outer bars span the full width.
@@ -432,6 +458,110 @@ fn terminal_view(
             TERMINAL_VIEW_CHROME_ROWS,
         ),
     )
+}
+
+/// Help modal fixed width (matches the renderer's `width: 60u32`).
+const HELP_MODAL_WIDTH: u16 = 60;
+/// Help modal vertical chrome: border(2) + padding(2) + title(2) + footer(1).
+const HELP_CHROME_ROWS: u16 = 7;
+
+/// Compute the help modal height for a given terminal row count.
+///
+/// Mirrors `help_viewport_rows` + `HELP_CHROME_ROWS` from the renderer so
+/// the geometry matches exactly.
+fn help_modal_height(render_rows: u16) -> u16 {
+    let available = usize::from(render_rows).saturating_sub(usize::from(HELP_CHROME_ROWS));
+    let viewport = if available >= 8 {
+        available.min(22)
+    } else {
+        available
+    };
+    let total = viewport + usize::from(HELP_CHROME_ROWS);
+    u16::try_from(total.min(usize::from(render_rows)).max(1)).unwrap_or(1)
+}
+
+/// Full-screen overlay geometry for each overlay type.
+///
+/// AgentForm and RepositoryForm render at `width: 100pct, height: 100pct` so
+/// they fill the entire render area. HelpModal renders at `width: 60` with a
+/// variable height, and ConfirmModal renders at `width: 50, height: 10`. All
+/// use a bordered Box with `padding: 1`, so the content origin is always
+/// `(2, 2)` (1 border + 1 padding on each axis).
+fn full_screen_overlay_pane(
+    overlay: crate::selection::OverlayPane,
+    render_cols: u16,
+    render_rows: u16,
+) -> Option<(SelectablePane, PaneGeometry)> {
+    let pane = overlay.to_pane()?;
+    let geo = match overlay {
+        crate::selection::OverlayPane::HelpModal => {
+            let height = help_modal_height(render_rows);
+            PaneGeometry::new(0, 0, HELP_MODAL_WIDTH, height, 2, 2)
+        }
+        crate::selection::OverlayPane::ConfirmModal => PaneGeometry::new(0, 0, 50, 10, 2, 2),
+        // AgentForm and RepositoryForm — truly full-screen.
+        _ => PaneGeometry::new(0, 0, render_cols, render_rows, 2, 2),
+    };
+    Some((pane, geo))
+}
+
+/// Chooser overlay position constants (issue #178).
+///
+/// The agent/merge choosers are rendered with `position: Absolute, top: 2,
+/// left: 4` inside the workspace column (which starts after the sidebar).
+const CHOOSER_OFFSET_COL: u16 = 4;
+const CHOOSER_OFFSET_ROW: u16 = 2;
+/// Chooser widget width: 41-char separator + 2 border + 2 padding columns.
+const CHOOSER_INNER_WIDTH: u16 = 45;
+/// Maximum chooser height (prevents the overlay from exceeding the workspace).
+const CHOOSER_MAX_HEIGHT: u16 = 30;
+
+/// Resolve a chooser overlay pane if `(col, row)` falls inside the chooser's
+/// bounds.
+///
+/// The chooser is positioned at `top: 2, left: 4` relative to the workspace
+/// column (which starts after the sidebar). The workspace starts at
+/// `LEFT_COL_WIDTH` (issues) or `prs_main_columns().sidebar_width` (PRs);
+/// both resolve to `LEFT_COL_WIDTH` in the common 120-col case. Since
+/// `prs_main_columns` is a runtime function, we use `LEFT_COL_WIDTH` as the
+/// baseline and let the caller's screen mode disambiguate if needed.
+fn chooser_pane_if_inside(
+    col: u16,
+    row: u16,
+    layout: ScreenLayout,
+    _render_cols: u16,
+    _render_rows: u16,
+) -> Option<(SelectablePane, PaneGeometry)> {
+    let pane = layout.overlay.to_pane()?;
+    if layout.overlay.is_full_screen() {
+        return None;
+    }
+
+    // Workspace starts after the sidebar.
+    let workspace_col0 = crate::layout::LEFT_COL_WIDTH;
+    let chooser_origin_col = workspace_col0.saturating_add(CHOOSER_OFFSET_COL);
+    // Workspace starts at row 1 (below the status bar); chooser offset adds 2.
+    let chooser_origin_row = 1u16.saturating_add(CHOOSER_OFFSET_ROW);
+    let chooser_width = CHOOSER_INNER_WIDTH;
+    // Use a generous height so the whole overlay is selectable; the content
+    // provider clips to actual rendered lines.
+    let chooser_height = CHOOSER_MAX_HEIGHT;
+
+    let geo = PaneGeometry::new(
+        chooser_origin_col,
+        chooser_origin_row,
+        chooser_width,
+        chooser_height,
+        // Content starts after border (1) + padding_left (1) = 2 cols, and
+        // after the top border (1 row, no padding_top).
+        chooser_origin_col.saturating_add(2),
+        chooser_origin_row.saturating_add(1),
+    );
+    if geo.contains(col, row) {
+        Some((pane, geo))
+    } else {
+        None
+    }
 }
 
 /// Dashboard middle-row split for a given *render* row count.

--- a/src/selection/geometry.rs
+++ b/src/selection/geometry.rs
@@ -511,8 +511,10 @@ const CHOOSER_OFFSET_ROW: u16 = 2;
 /// Chooser widget width: 41-char separator + 2 border + 2 padding columns.
 /// Must stay in sync with the AgentChooser/MergeChooser separator length
 /// (src/ui/components/agent_chooser.rs). Changes there require updating
-/// CHOOSER_INNER_WIDTH here.
-const CHOOSER_INNER_WIDTH: u16 = 45;
+/// Full outer width of the chooser widget: 41-char separator + 2 border + 2
+/// padding. Duplicates the width implied by the separator string in
+/// `agent_chooser.rs` / `merge_chooser.rs` — keep in sync.
+const CHOOSER_WIDTH: u16 = 45;
 /// Maximum chooser height (prevents the overlay from exceeding the workspace).
 const CHOOSER_MAX_HEIGHT: u16 = 30;
 
@@ -540,7 +542,7 @@ fn chooser_pane_if_inside(
     let chooser_origin_col = workspace_col0.saturating_add(CHOOSER_OFFSET_COL);
     // Workspace starts at row 1 (below the status bar); chooser offset adds 2.
     let chooser_origin_row = 1u16.saturating_add(CHOOSER_OFFSET_ROW);
-    let chooser_width = CHOOSER_INNER_WIDTH;
+    let chooser_width = CHOOSER_WIDTH;
     // Use a generous height so the whole overlay is selectable; the content
     // provider clips to actual rendered lines.
     let chooser_height = CHOOSER_MAX_HEIGHT;

--- a/src/selection/layout_descriptor.rs
+++ b/src/selection/layout_descriptor.rs
@@ -5,7 +5,60 @@
 //! Keeping these in a single struct keeps [`crate::selection::pane_at`]'s
 //! signature stable as more conditional bands are added.
 
+use crate::selection::SelectablePane;
 use crate::state::ScreenMode;
+
+/// Which overlay (modal / form / chooser) is currently active, if any.
+///
+/// When an overlay is active, [`crate::selection::pane_at`] resolves
+/// coordinates to the overlay pane instead of the underlying screen panes so
+/// mouse text-selection works inside the overlay (issue #178).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OverlayPane {
+    /// No overlay active — normal pane layout.
+    #[default]
+    None,
+    /// Help modal (full-screen overlay).
+    HelpModal,
+    /// Agent-definition form (full-screen overlay).
+    AgentForm,
+    /// Repository-definition form (full-screen overlay).
+    RepositoryForm,
+    /// Confirmation dialog (full-screen overlay).
+    ConfirmModal,
+    /// Agent chooser (positioned overlay inside the workspace).
+    AgentChooser,
+    /// Merge chooser (positioned overlay inside the workspace).
+    MergeChooser,
+}
+
+impl OverlayPane {
+    /// Map this overlay to its [`SelectablePane`] identity.
+    #[must_use]
+    pub const fn to_pane(self) -> Option<SelectablePane> {
+        match self {
+            Self::None => None,
+            Self::HelpModal => Some(SelectablePane::HelpModal),
+            Self::AgentForm => Some(SelectablePane::AgentForm),
+            Self::RepositoryForm => Some(SelectablePane::RepositoryForm),
+            Self::ConfirmModal => Some(SelectablePane::ConfirmModal),
+            Self::AgentChooser => Some(SelectablePane::AgentChooser),
+            Self::MergeChooser => Some(SelectablePane::MergeChooser),
+        }
+    }
+
+    /// Whether this overlay is a full-screen modal/form (covers all panes).
+    ///
+    /// Full-screen overlays intercept *every* coordinate; positioned overlays
+    /// (choosers) only intercept coordinates inside their bounds.
+    #[must_use]
+    pub const fn is_full_screen(self) -> bool {
+        matches!(
+            self,
+            Self::HelpModal | Self::AgentForm | Self::RepositoryForm | Self::ConfirmModal
+        )
+    }
+}
 
 /// Inputs needed to compute pane geometry for the current screen.
 ///
@@ -24,6 +77,8 @@ pub struct ScreenLayout {
     pub error_visible: bool,
     /// Whether the filter-controls band is open (Issues/PR mode).
     pub filter_controls_open: bool,
+    /// Active overlay (modal/form/chooser), if any (issue #178).
+    pub overlay: OverlayPane,
 }
 
 impl ScreenLayout {
@@ -42,6 +97,7 @@ impl ScreenLayout {
             screen_mode,
             error_visible,
             filter_controls_open,
+            overlay: OverlayPane::None,
         }
     }
 
@@ -49,5 +105,11 @@ impl ScreenLayout {
     #[must_use]
     pub fn is_pr_mode(self) -> bool {
         matches!(self.screen_mode, ScreenMode::DashboardPullRequests)
+    }
+
+    /// Return a copy of this layout with the given overlay active (issue #178).
+    #[must_use]
+    pub const fn with_overlay(self, overlay: OverlayPane) -> Self {
+        Self { overlay, ..self }
     }
 }

--- a/src/selection/layout_descriptor.rs
+++ b/src/selection/layout_descriptor.rs
@@ -53,10 +53,12 @@ impl OverlayPane {
     /// (choosers) only intercept coordinates inside their bounds.
     #[must_use]
     pub const fn is_full_screen(self) -> bool {
-        matches!(
-            self,
-            Self::HelpModal | Self::AgentForm | Self::RepositoryForm | Self::ConfirmModal
-        )
+        // Exhaustive match so adding a new OverlayPane variant forces a
+        // conscious decision here (issue #178 z-order correctness).
+        match self {
+            Self::HelpModal | Self::AgentForm | Self::RepositoryForm | Self::ConfirmModal => true,
+            Self::None | Self::AgentChooser | Self::MergeChooser => false,
+        }
     }
 }
 

--- a/src/selection/mod.rs
+++ b/src/selection/mod.rs
@@ -25,13 +25,16 @@
 //! All functions are pure and `#[must_use]`.
 
 mod content;
+mod form_content;
 mod geometry;
 mod layout_descriptor;
+mod overlay_content;
 mod text;
 
 pub use content::{PaneContent, pane_content_lines};
+pub use form_content::{agent_form_content_lines, repository_form_content_lines};
 pub use geometry::{PaneGeometry, pane_at};
-pub use layout_descriptor::ScreenLayout;
+pub use layout_descriptor::{OverlayPane, ScreenLayout};
 pub use text::{
     HighlightRange, SelectablePane, SelectionPoint, TextSelection, normalize_selection,
     point_to_content_coords, row_highlight_range, selection_text,

--- a/src/selection/overlay_content.rs
+++ b/src/selection/overlay_content.rs
@@ -99,7 +99,10 @@ pub fn merge_chooser_lines(state: &AppState) -> PaneContent {
 /// the wrapped portion will be slightly misaligned.
 #[must_use]
 pub fn confirm_modal_lines(state: &AppState) -> PaneContent {
-    let Some(data) = confirm_modal_data(state) else {
+    // Reuse the single source of truth from the orchestration layer so the
+    // projected text can never drift from the rendered modal.
+    let Some(data) = crate::ui::orchestration::derive_confirm_modal_data(state, &state.modal)
+    else {
         return PaneContent::empty(SelectablePane::ConfirmModal);
     };
     let mut lines = vec![data.title, String::new()];
@@ -113,87 +116,6 @@ pub fn confirm_modal_lines(state: &AppState) -> PaneContent {
     lines.push("[ Cancel ]  [ Confirm ]".to_string());
     lines.push(String::new());
     PaneContent::new(SelectablePane::ConfirmModal, lines)
-}
-
-/// Data extracted from `ModalState` for the confirm modal content projection.
-struct ConfirmModalData {
-    title: String,
-    message: String,
-    show_delete_work_dir: bool,
-    delete_work_dir: bool,
-}
-
-/// Derive confirm-modal display data from the active modal state.
-///
-/// This mirrors `derive_confirm_modal_data` in `src/ui/orchestration.rs` so
-/// the selection projection stays iocraft-free. If modal display logic changes,
-/// update both functions (or extract a shared pure helper in a future refactor).
-fn confirm_modal_data(state: &AppState) -> Option<ConfirmModalData> {
-    match &state.modal {
-        crate::state::ModalState::ConfirmDeleteAgent {
-            id,
-            delete_work_dir,
-        } => {
-            let name = agent_display_name(state, id);
-            Some(ConfirmModalData {
-                title: "Delete Agent".to_string(),
-                message: format!("Delete {name}?"),
-                show_delete_work_dir: true,
-                delete_work_dir: *delete_work_dir,
-            })
-        }
-        crate::state::ModalState::ConfirmDeleteRepository { id } => {
-            let name = repo_display_name(state, id);
-            Some(ConfirmModalData {
-                title: "Delete Repository".to_string(),
-                message: format!("Delete {name} and all its agents?"),
-                show_delete_work_dir: false,
-                delete_work_dir: false,
-            })
-        }
-        crate::state::ModalState::ConfirmKillAgent { id } => {
-            let name = agent_display_name(state, id);
-            Some(ConfirmModalData {
-                title: "Kill Agent".to_string(),
-                message: format!("Kill {name}?"),
-                show_delete_work_dir: false,
-                delete_work_dir: false,
-            })
-        }
-        crate::state::ModalState::PreflightPrompt { issue, .. } => Some(ConfirmModalData {
-            title: issue.prompt_title(),
-            message: issue.prompt_message(),
-            show_delete_work_dir: false,
-            delete_work_dir: false,
-        }),
-        crate::state::ModalState::ConfirmIssueDirtyCopy { .. } => Some(ConfirmModalData {
-            title: "Dirty Working Copy".to_string(),
-            message:
-                "Working copy has uncommitted changes. Discard them (git reset --hard + git clean)?"
-                    .to_string(),
-            show_delete_work_dir: false,
-            delete_work_dir: false,
-        }),
-        _ => None,
-    }
-}
-
-/// Resolve an agent's display name, falling back to a generic label.
-fn agent_display_name(state: &AppState, id: &crate::domain::AgentId) -> String {
-    state
-        .agents
-        .iter()
-        .find(|a| &a.id == id)
-        .map_or_else(|| "selected agent".to_string(), |a| a.name.clone())
-}
-
-/// Resolve a repository's display name, falling back to a generic label.
-fn repo_display_name(state: &AppState, id: &crate::domain::RepositoryId) -> String {
-    state
-        .repositories
-        .iter()
-        .find(|r| &r.id == id)
-        .map_or_else(|| "selected repository".to_string(), |r| r.name.clone())
 }
 
 #[cfg(test)]

--- a/src/selection/overlay_content.rs
+++ b/src/selection/overlay_content.rs
@@ -92,6 +92,11 @@ pub fn merge_chooser_lines(state: &AppState) -> PaneContent {
 /// uses flex_grow, an optional checkbox is height 1, and the buttons box is
 /// height 2 (1 text + 1 blank). This projection mirrors those exact rows so
 /// selection coordinates map to what the user sees.
+///
+/// Known limitation: the message is projected as a single line. If the
+/// rendered message exceeds the 48-column inner width, iocraft wraps it to
+/// additional rows that this projection does not account for. Selection of
+/// the wrapped portion will be slightly misaligned.
 #[must_use]
 pub fn confirm_modal_lines(state: &AppState) -> PaneContent {
     let Some(data) = confirm_modal_data(state) else {
@@ -119,6 +124,10 @@ struct ConfirmModalData {
 }
 
 /// Derive confirm-modal display data from the active modal state.
+///
+/// This mirrors `derive_confirm_modal_data` in `src/ui/orchestration.rs` so
+/// the selection projection stays iocraft-free. If modal display logic changes,
+/// update both functions (or extract a shared pure helper in a future refactor).
 fn confirm_modal_data(state: &AppState) -> Option<ConfirmModalData> {
     match &state.modal {
         crate::state::ModalState::ConfirmDeleteAgent {

--- a/src/selection/overlay_content.rs
+++ b/src/selection/overlay_content.rs
@@ -1,0 +1,412 @@
+//! Pane content providers for overlay panes: choosers and confirm modal
+//! (issue #178).
+//!
+//! These build the flat list of copyable lines that match what the
+//! `AgentChooser`, `MergeChooser`, and `ConfirmModal` iocraft components
+//! render, so mouse selection coordinates map to the exact characters on
+//! screen.
+//!
+//! All functions are pure and `#[must_use]`. They read only from
+//! [`crate::state::AppState`] (no iocraft, no side effects).
+
+use crate::selection::PaneContent;
+use crate::selection::SelectablePane;
+use crate::state::AppState;
+
+/// Separator line rendered inside the chooser overlays, matching the
+/// components' `"─────…"` row.
+const SEPARATOR_LINE: &str = "─────────────────────────────────────────";
+
+/// Agent chooser overlay lines: header + separator + agent entries + hints.
+#[must_use]
+pub fn agent_chooser_lines(state: &AppState) -> PaneContent {
+    // The chooser can be active in issues or PR mode; check both.
+    let chooser = state
+        .issues_state
+        .agent_chooser
+        .as_ref()
+        .or(state.prs_state.agent_chooser.as_ref());
+    let Some(chooser) = chooser else {
+        return PaneContent::empty(SelectablePane::AgentChooser);
+    };
+    let mut lines = vec!["Send to Agent".to_string(), SEPARATOR_LINE.to_string()];
+    if chooser.agents.is_empty() {
+        // The empty-state box has height 2 (text + blank), matching the
+        // renderer's Box(height: 2u32).
+        lines.push("No agents available. Create an agent in Agents Mode.".to_string());
+        lines.push(String::new());
+    } else {
+        for (i, (_id, name)) in chooser.agents.iter().enumerate() {
+            let marker = if i == chooser.selected_index {
+                "(x)"
+            } else {
+                "( )"
+            };
+            lines.push(format!("{marker} {name}"));
+        }
+    }
+    lines.push(SEPARATOR_LINE.to_string());
+    lines.push("Enter send  Esc cancel".to_string());
+    PaneContent::new(SelectablePane::AgentChooser, lines)
+}
+
+/// Merge chooser overlay lines: header + separator + methods + hints.
+#[must_use]
+pub fn merge_chooser_lines(state: &AppState) -> PaneContent {
+    let Some(chooser) = state.prs_state.merge_chooser.as_ref() else {
+        return PaneContent::empty(SelectablePane::MergeChooser);
+    };
+    let pr_number = state.prs_state.pr_detail.as_ref().map_or(0, |d| d.number);
+    let mut lines = vec![
+        format!("Merge Pull Request #{pr_number}"),
+        SEPARATOR_LINE.to_string(),
+    ];
+    for (i, method) in crate::domain::MERGE_METHODS.iter().enumerate() {
+        let selected = i == chooser.selected_index;
+        let allowed = chooser.allowed_methods.as_deref();
+        let enabled = match allowed {
+            None => true,
+            Some(methods) => methods.contains(method),
+        };
+        let label = if enabled {
+            let marker = if selected { "(x)" } else { "( )" };
+            format!("{marker} {}", method.label())
+        } else {
+            format!("    {} (not enabled)", method.label())
+        };
+        lines.push(label);
+    }
+    lines.push(SEPARATOR_LINE.to_string());
+    if chooser.awaiting_confirmation {
+        lines.push("Press Enter to confirm merge, Esc to cancel".to_string());
+    } else {
+        lines.push("Up/Down select  Enter confirm  Esc cancel".to_string());
+    }
+    PaneContent::new(SelectablePane::MergeChooser, lines)
+}
+
+/// Confirm modal lines: title + blank + message + optional checkbox + buttons + blank.
+///
+/// The ConfirmModal renders inside a 50x10 bordered box with padding 1 (6
+/// inner rows). The title box is height 2 (1 text + 1 blank), the message
+/// uses flex_grow, an optional checkbox is height 1, and the buttons box is
+/// height 2 (1 text + 1 blank). This projection mirrors those exact rows so
+/// selection coordinates map to what the user sees.
+#[must_use]
+pub fn confirm_modal_lines(state: &AppState) -> PaneContent {
+    let Some(data) = confirm_modal_data(state) else {
+        return PaneContent::empty(SelectablePane::ConfirmModal);
+    };
+    let mut lines = vec![data.title, String::new()];
+    lines.push(data.message);
+    if data.show_delete_work_dir {
+        let mark = if data.delete_work_dir { "x" } else { " " };
+        lines.push(format!("[{mark}] Delete work directory"));
+    } else {
+        lines.push(String::new());
+    }
+    lines.push("[ Cancel ]  [ Confirm ]".to_string());
+    lines.push(String::new());
+    PaneContent::new(SelectablePane::ConfirmModal, lines)
+}
+
+/// Data extracted from `ModalState` for the confirm modal content projection.
+struct ConfirmModalData {
+    title: String,
+    message: String,
+    show_delete_work_dir: bool,
+    delete_work_dir: bool,
+}
+
+/// Derive confirm-modal display data from the active modal state.
+fn confirm_modal_data(state: &AppState) -> Option<ConfirmModalData> {
+    match &state.modal {
+        crate::state::ModalState::ConfirmDeleteAgent {
+            id,
+            delete_work_dir,
+        } => {
+            let name = agent_display_name(state, id);
+            Some(ConfirmModalData {
+                title: "Delete Agent".to_string(),
+                message: format!("Delete {name}?"),
+                show_delete_work_dir: true,
+                delete_work_dir: *delete_work_dir,
+            })
+        }
+        crate::state::ModalState::ConfirmDeleteRepository { id } => {
+            let name = repo_display_name(state, id);
+            Some(ConfirmModalData {
+                title: "Delete Repository".to_string(),
+                message: format!("Delete {name} and all its agents?"),
+                show_delete_work_dir: false,
+                delete_work_dir: false,
+            })
+        }
+        crate::state::ModalState::ConfirmKillAgent { id } => {
+            let name = agent_display_name(state, id);
+            Some(ConfirmModalData {
+                title: "Kill Agent".to_string(),
+                message: format!("Kill {name}?"),
+                show_delete_work_dir: false,
+                delete_work_dir: false,
+            })
+        }
+        crate::state::ModalState::PreflightPrompt { issue, .. } => Some(ConfirmModalData {
+            title: issue.prompt_title(),
+            message: issue.prompt_message(),
+            show_delete_work_dir: false,
+            delete_work_dir: false,
+        }),
+        crate::state::ModalState::ConfirmIssueDirtyCopy { .. } => Some(ConfirmModalData {
+            title: "Dirty Working Copy".to_string(),
+            message:
+                "Working copy has uncommitted changes. Discard them (git reset --hard + git clean)?"
+                    .to_string(),
+            show_delete_work_dir: false,
+            delete_work_dir: false,
+        }),
+        _ => None,
+    }
+}
+
+/// Resolve an agent's display name, falling back to a generic label.
+fn agent_display_name(state: &AppState, id: &crate::domain::AgentId) -> String {
+    state
+        .agents
+        .iter()
+        .find(|a| &a.id == id)
+        .map_or_else(|| "selected agent".to_string(), |a| a.name.clone())
+}
+
+/// Resolve a repository's display name, falling back to a generic label.
+fn repo_display_name(state: &AppState, id: &crate::domain::RepositoryId) -> String {
+    state
+        .repositories
+        .iter()
+        .find(|r| &r.id == id)
+        .map_or_else(|| "selected repository".to_string(), |r| r.name.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{Agent, AgentId, Repository, RepositoryId};
+    use crate::state::ModalState;
+
+    #[test]
+    fn confirm_modal_delete_agent_exact_layout_with_checkbox() {
+        let repo_id = RepositoryId("r1".to_string());
+        let agent_id = AgentId("a1".to_string());
+        let mut state = AppState {
+            modal: ModalState::ConfirmDeleteAgent {
+                id: agent_id.clone(),
+                delete_work_dir: true,
+            },
+            ..Default::default()
+        };
+        state.repositories.push(Repository::new(
+            repo_id.clone(),
+            "repo".to_string(),
+            "repo".to_string(),
+            std::path::PathBuf::from("/tmp/repo"),
+        ));
+        state.agents.push(Agent::new(
+            agent_id,
+            repo_id,
+            "my-agent".to_string(),
+            std::path::PathBuf::from("/tmp/a1"),
+        ));
+        let content = confirm_modal_lines(&state);
+        assert_eq!(
+            content.lines,
+            vec![
+                "Delete Agent".to_string(),
+                String::new(),
+                "Delete my-agent?".to_string(),
+                "[x] Delete work directory".to_string(),
+                "[ Cancel ]  [ Confirm ]".to_string(),
+                String::new(),
+            ]
+        );
+    }
+
+    #[test]
+    fn confirm_modal_delete_repo_exact_layout_without_checkbox() {
+        let mut state = AppState {
+            modal: ModalState::ConfirmDeleteRepository {
+                id: RepositoryId("r1".to_string()),
+            },
+            ..Default::default()
+        };
+        state.repositories.push(Repository::new(
+            RepositoryId("r1".to_string()),
+            "my-repo".to_string(),
+            "my-repo".to_string(),
+            std::path::PathBuf::from("/tmp/repo"),
+        ));
+        let content = confirm_modal_lines(&state);
+        assert_eq!(
+            content.lines,
+            vec![
+                "Delete Repository".to_string(),
+                String::new(),
+                "Delete my-repo and all its agents?".to_string(),
+                String::new(),
+                "[ Cancel ]  [ Confirm ]".to_string(),
+                String::new(),
+            ]
+        );
+    }
+
+    #[test]
+    fn confirm_modal_kill_agent_exact_layout() {
+        let repo_id = RepositoryId("r1".to_string());
+        let agent_id = AgentId("a1".to_string());
+        let mut state = AppState {
+            modal: ModalState::ConfirmKillAgent {
+                id: agent_id.clone(),
+            },
+            ..Default::default()
+        };
+        state.repositories.push(Repository::new(
+            repo_id.clone(),
+            "repo".to_string(),
+            "repo".to_string(),
+            std::path::PathBuf::from("/tmp/repo"),
+        ));
+        state.agents.push(Agent::new(
+            agent_id,
+            repo_id,
+            "running-agent".to_string(),
+            std::path::PathBuf::from("/tmp/a1"),
+        ));
+        let content = confirm_modal_lines(&state);
+        assert_eq!(content.lines[0], "Kill Agent");
+        assert_eq!(content.lines[2], "Kill running-agent?");
+    }
+
+    #[test]
+    fn confirm_modal_preflight_prompt_has_content() {
+        use crate::domain::{LaunchSignature, SandboxEngine};
+        use crate::runtime::PreflightIssue;
+        let signature = LaunchSignature {
+            work_dir: std::path::PathBuf::from("/tmp"),
+            profile: String::new(),
+            mode_flags: Vec::new(),
+            llxprt_debug: String::new(),
+            pass_continue: false,
+            sandbox_enabled: false,
+            sandbox_engine: SandboxEngine::Podman,
+            sandbox_flags: String::new(),
+            remote: crate::domain::RemoteRepositorySettings::default(),
+        };
+        let state = AppState {
+            modal: ModalState::PreflightPrompt {
+                agent_id: AgentId("a1".to_string()),
+                signature,
+                issue: PreflightIssue::SshAgentNoIdentities,
+                remaining_issues: Vec::new(),
+            },
+            ..Default::default()
+        };
+        let content = confirm_modal_lines(&state);
+        assert!(
+            !content.lines.is_empty(),
+            "preflight prompt must have content"
+        );
+        assert!(
+            content.lines[0].contains("SSH"),
+            "preflight SSH issue title must be present"
+        );
+    }
+
+    #[test]
+    fn confirm_modal_dirty_copy_has_content() {
+        use crate::domain::{LaunchSignature, SandboxEngine};
+        use crate::github::SendPayload;
+        let signature = LaunchSignature {
+            work_dir: std::path::PathBuf::from("/tmp"),
+            profile: String::new(),
+            mode_flags: Vec::new(),
+            llxprt_debug: String::new(),
+            pass_continue: false,
+            sandbox_enabled: false,
+            sandbox_engine: SandboxEngine::Podman,
+            sandbox_flags: String::new(),
+            remote: crate::domain::RemoteRepositorySettings::default(),
+        };
+        let payload = SendPayload {
+            repository: "o/r".to_string(),
+            issue_number: 42,
+            ..Default::default()
+        };
+        let state = AppState {
+            modal: ModalState::ConfirmIssueDirtyCopy {
+                agent_id: AgentId("a1".to_string()),
+                work_dir: std::path::PathBuf::from("/tmp"),
+                signature,
+                payload,
+            },
+            ..Default::default()
+        };
+        let content = confirm_modal_lines(&state);
+        assert!(!content.lines.is_empty());
+        assert_eq!(content.lines[0], "Dirty Working Copy");
+        assert!(content.lines[2].contains("uncommitted changes"));
+    }
+
+    #[test]
+    fn agent_chooser_empty_has_two_line_empty_state() {
+        let state = AppState {
+            issues_state: crate::state::IssuesState {
+                agent_chooser: Some(crate::state::AgentChooserState {
+                    selected_index: 0,
+                    agents: vec![],
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let content = agent_chooser_lines(&state);
+        // Empty state box has height 2 (text + blank), so the "No agents"
+        // message is followed by a blank line before the separator.
+        let Some(no_agents_idx) = content
+            .lines
+            .iter()
+            .position(|l| l.contains("No agents available"))
+        else {
+            panic!("must have no-agents message");
+        };
+        let next_idx = no_agents_idx + 1;
+        assert!(
+            next_idx < content.lines.len() && content.lines[next_idx].is_empty(),
+            "empty-state blank row must follow the no-agents message"
+        );
+    }
+
+    #[test]
+    fn agent_chooser_with_agents_exact_lines() {
+        let state = AppState {
+            screen_mode: crate::state::ScreenMode::DashboardIssues,
+            issues_state: crate::state::IssuesState {
+                agent_chooser: Some(crate::state::AgentChooserState {
+                    selected_index: 0,
+                    agents: vec![
+                        (AgentId("a1".to_string()), "alpha".to_string()),
+                        (AgentId("a2".to_string()), "beta".to_string()),
+                    ],
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let content = agent_chooser_lines(&state);
+        // Verify exact structure: header, separator, entries, separator, hints.
+        assert_eq!(content.lines[0], "Send to Agent");
+        assert!(content.lines[1].starts_with('─'));
+        assert!(content.lines[2].contains("(x) alpha"));
+        assert!(content.lines[3].contains("( ) beta"));
+        // Two agents → lines 2-3 are entries, line 4 is separator, line 5+ hints.
+        assert!(content.lines[4].starts_with('─'));
+    }
+}

--- a/src/selection/tests.rs
+++ b/src/selection/tests.rs
@@ -505,3 +505,126 @@ fn highlight_range_works_with_reversed_anchor_focus() {
         })
     );
 }
+
+// ── pane_at: modal / form / overlay panes (issue #178) ─────────────────────
+//
+// Full-screen modals/forms (Help, NewAgent, NewRepository, Confirm) cover the
+// modal's actual rendered bounds. When `layout.overlay` indicates one is
+// active, pane_at must return that pane for coordinates inside the modal's
+// bounds. AgentForm/RepositoryForm fill the entire screen; HelpModal is 60 wide
+// with variable height; ConfirmModal is 50×10.
+
+fn layout_with_overlay(
+    cols: u16,
+    rows: u16,
+    overlay: crate::selection::OverlayPane,
+) -> crate::selection::ScreenLayout {
+    crate::selection::ScreenLayout::new(cols, rows, DASHBOARD, false, false).with_overlay(overlay)
+}
+
+#[test]
+fn pane_at_help_modal_resolves_within_bounds() {
+    let lay = layout_with_overlay(120, 40, crate::selection::OverlayPane::HelpModal);
+    // HelpModal is 60 wide; height at 40 rows = viewport(22) + chrome(7) = 29.
+    for &(c, r) in &[(0, 0), (30, 5), (59, 28)] {
+        let Some((pane, geo)) = pane_at(c, r, DASHBOARD, false, &lay) else {
+            panic!("expected help modal at ({c}, {r})");
+        };
+        assert!(
+            matches!(pane, SelectablePane::HelpModal),
+            "expected HelpModal at ({c}, {r}), got {pane:?}"
+        );
+        assert_eq!(geo.width, 60, "help modal width should be 60");
+    }
+}
+
+#[test]
+fn pane_at_help_modal_outside_bounds_returns_none() {
+    let lay = layout_with_overlay(120, 40, crate::selection::OverlayPane::HelpModal);
+    // Col 60+ is outside the 60-wide help modal.
+    assert!(pane_at(60, 5, DASHBOARD, false, &lay).is_none());
+    // Row 29+ is outside the 29-tall help modal.
+    assert!(pane_at(30, 29, DASHBOARD, false, &lay).is_none());
+}
+
+#[test]
+fn pane_at_agent_form_overlay_covers_full_screen() {
+    let lay = layout_with_overlay(120, 40, crate::selection::OverlayPane::AgentForm);
+    let Some((pane, geo)) = pane_at(50, 10, DASHBOARD, false, &lay) else {
+        panic!("expected agent form at (50, 10)");
+    };
+    assert!(matches!(pane, SelectablePane::AgentForm));
+    assert_eq!(geo.width, 120);
+    assert_eq!(geo.height, 40);
+}
+
+#[test]
+fn pane_at_repository_form_overlay_covers_full_screen() {
+    let lay = layout_with_overlay(120, 40, crate::selection::OverlayPane::RepositoryForm);
+    let Some((pane, geo)) = pane_at(50, 10, DASHBOARD, false, &lay) else {
+        panic!("expected repository form at (50, 10)");
+    };
+    assert!(matches!(pane, SelectablePane::RepositoryForm));
+    assert_eq!(geo.width, 120);
+    assert_eq!(geo.height, 40);
+}
+
+#[test]
+fn pane_at_confirm_modal_resolves_within_50x10_bounds() {
+    let lay = layout_with_overlay(120, 40, crate::selection::OverlayPane::ConfirmModal);
+    // ConfirmModal is 50 wide, 10 tall.
+    for &(c, r) in &[(0, 0), (25, 5), (49, 9)] {
+        let Some((pane, geo)) = pane_at(c, r, DASHBOARD, false, &lay) else {
+            panic!("expected confirm modal at ({c}, {r})");
+        };
+        assert!(
+            matches!(pane, SelectablePane::ConfirmModal),
+            "expected ConfirmModal at ({c}, {r}), got {pane:?}"
+        );
+        assert_eq!(geo.width, 50);
+        assert_eq!(geo.height, 10);
+    }
+}
+
+#[test]
+fn pane_at_confirm_modal_outside_bounds_returns_none() {
+    let lay = layout_with_overlay(120, 40, crate::selection::OverlayPane::ConfirmModal);
+    // Col 50+ is outside the 50-wide confirm modal.
+    assert!(pane_at(50, 5, DASHBOARD, false, &lay).is_none());
+    // Row 10+ is outside the 10-tall confirm modal.
+    assert!(pane_at(25, 10, DASHBOARD, false, &lay).is_none());
+}
+
+#[test]
+fn pane_at_no_overlay_falls_through_to_normal_panes() {
+    // Default ScreenLayout has no overlay; normal panes resolve.
+    let lay = layout(120, 40, DASHBOARD, false, false);
+    let Some((pane, _)) = pane_at(0, 5, DASHBOARD, false, &lay) else {
+        panic!("expected sidebar at (0, 5) with no overlay");
+    };
+    assert!(matches!(pane, SelectablePane::Sidebar));
+}
+
+#[test]
+fn pane_at_agent_chooser_overlay_resolves_within_workspace() {
+    // Agent chooser is positioned absolutely at top:2, left:4 within the
+    // workspace (which starts after the sidebar at col 22). A coordinate
+    // inside the chooser bounds should resolve to AgentChooser.
+    let lay = layout_with_overlay(120, 40, crate::selection::OverlayPane::AgentChooser);
+    // Chooser origin: col 22+4=26, row 1+2=3. Click inside the chooser.
+    let resolved = pane_at(28, 4, ISSUES, false, &lay);
+    let Some((pane, _)) = resolved else {
+        panic!("expected agent chooser at (28, 4)");
+    };
+    assert!(matches!(pane, SelectablePane::AgentChooser));
+}
+
+#[test]
+fn pane_at_merge_chooser_overlay_resolves_within_workspace() {
+    let lay = layout_with_overlay(120, 40, crate::selection::OverlayPane::MergeChooser);
+    let resolved = pane_at(28, 4, PRS, false, &lay);
+    let Some((pane, _)) = resolved else {
+        panic!("expected merge chooser at (28, 4)");
+    };
+    assert!(matches!(pane, SelectablePane::MergeChooser));
+}

--- a/src/selection/tests.rs
+++ b/src/selection/tests.rs
@@ -535,6 +535,7 @@ fn pane_at_help_modal_resolves_within_bounds() {
             "expected HelpModal at ({c}, {r}), got {pane:?}"
         );
         assert_eq!(geo.width, 60, "help modal width should be 60");
+        assert_eq!(geo.height, 29, "help modal height should be 29 at 40 rows");
     }
 }
 

--- a/src/selection/text.rs
+++ b/src/selection/text.rs
@@ -36,6 +36,16 @@ pub enum SelectablePane {
     StatusBar,
     /// Bottom keybind hint bar (low priority, but selectable).
     KeybindBar,
+    /// Agent-definition form (full-screen modal). Issue #178.
+    AgentForm,
+    /// Repository-definition form (full-screen modal). Issue #178.
+    RepositoryForm,
+    /// Send-to-agent chooser overlay (issues/PR mode). Issue #178.
+    AgentChooser,
+    /// Merge-method chooser overlay (PR mode). Issue #178.
+    MergeChooser,
+    /// Confirmation modal (delete/kill/preflight/dirty-copy). Issue #178.
+    ConfirmModal,
 }
 
 /// A single point within a selection, expressed in *content* coordinates.

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -199,6 +199,12 @@ pub struct AppState {
     /// when a new selection begins. Used by the renderers to paint an
     /// inverse-video highlight over the selected cells.
     pub selection: Option<crate::selection::TextSelection>,
+
+    /// Help modal scroll offset (lines scrolled from the top). Mirrored from
+    /// the app-shell hook state so the selection content projection can map
+    /// screen coordinates to the correct help content line (issue #178).
+    /// Runtime-only — never persisted.
+    pub help_scroll_offset: usize,
 }
 
 /// @plan PLAN-20260329-ISSUES-MODE.P03

--- a/src/ui/components/agent_chooser.rs
+++ b/src/ui/components/agent_chooser.rs
@@ -6,7 +6,9 @@
 use iocraft::prelude::*;
 
 use crate::domain::AgentId;
-use crate::theme::{ResolvedColors, ThemeColors};
+use crate::selection::{SelectablePane, TextSelection};
+use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
+use crate::ui::components::selectable_line;
 
 /// Props for the agent chooser overlay.
 #[derive(Default, Props)]
@@ -19,6 +21,8 @@ pub struct AgentChooserProps {
     pub selected_index: usize,
     /// Theme colors.
     pub colors: ThemeColors,
+    /// Active text selection for drag-highlight (issue #178).
+    pub selection: Option<TextSelection>,
 }
 
 /// Agent chooser overlay — lists existing agents with selection; Enter confirms, Esc cancels.
@@ -33,6 +37,107 @@ pub fn AgentChooser(props: &AgentChooserProps) -> impl Into<AnyElement<'static>>
     }
 
     let rc = ResolvedColors::from_theme(Some(&props.colors));
+    let sel = SelectionColors::from_resolved(&rc);
+    let pane = SelectablePane::AgentChooser;
+    let selection = props.selection;
+    let mut line_idx: usize = 0;
+
+    let mut lines: Vec<AnyElement<'static>> = Vec::new();
+
+    // Header + separator
+    lines.push(selectable_line(
+        "Send to Agent",
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        rc.bright,
+        sel,
+    ));
+    lines.push(selectable_line(
+        "─────────────────────────────────────────",
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        rc.dim,
+        sel,
+    ));
+
+    // Agent list or empty state
+    if props.agents.is_empty() {
+        lines.push(selectable_line(
+            "No agents available. Create an agent in Agents Mode.",
+            {
+                let i = line_idx;
+                line_idx += 1;
+                i
+            },
+            selection,
+            pane,
+            rc.dim,
+            sel,
+        ));
+        lines.push(selectable_line(
+            "",
+            {
+                let i = line_idx;
+                line_idx += 1;
+                i
+            },
+            selection,
+            pane,
+            rc.fg,
+            sel,
+        ));
+    } else {
+        for (i, (_id, name)) in props.agents.iter().enumerate() {
+            let selected = i == props.selected_index;
+            let marker = if selected { "(x)" } else { "( )" };
+            let label = format!("{marker} {name}");
+            let color = if selected { rc.bright } else { rc.fg };
+            lines.push(selectable_line(
+                &label,
+                {
+                    let li = line_idx;
+                    line_idx += 1;
+                    li
+                },
+                selection,
+                pane,
+                color,
+                sel,
+            ));
+        }
+    }
+
+    // Separator + hints
+    lines.push(selectable_line(
+        "─────────────────────────────────────────",
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        rc.dim,
+        sel,
+    ));
+    lines.push(selectable_line(
+        "Enter send  Esc cancel",
+        line_idx,
+        selection,
+        pane,
+        rc.dim,
+        sel,
+    ));
 
     element! {
         Box(
@@ -45,57 +150,7 @@ pub fn AgentChooser(props: &AgentChooserProps) -> impl Into<AnyElement<'static>>
             padding_top: 0u32,
             padding_bottom: 0u32,
         ) {
-            // Header
-            Box(height: 1u32) {
-                Text(
-                    content: "Send to Agent",
-                    weight: Weight::Bold,
-                    color: rc.bright,
-                )
-            }
-            Box(height: 1u32) {
-                Text(content: "─────────────────────────────────────────", color: rc.dim)
-            }
-
-            // Agent list or empty state
-            #(if props.agents.is_empty() {
-                vec![element! {
-                    Box(height: 2u32, padding_left: 1u32) {
-                        Text(
-                            content: "No agents available. Create an agent in Agents Mode.",
-                            color: rc.dim,
-                        )
-                    }
-                }]
-            } else {
-                props.agents.iter().enumerate().map(|(i, (_id, name))| {
-                    let selected = i == props.selected_index;
-                    let marker = if selected { "(x)" } else { "( )" };
-                    let label = format!("{marker} {name}");
-                    if selected {
-                        element! {
-                            Box(height: 1u32, background_color: rc.sel_bg) {
-                                Text(content: label, color: rc.sel_fg, weight: Weight::Bold)
-                            }
-                        }
-                    } else {
-                        element! {
-                            Box(height: 1u32) {
-                                Text(content: label, color: rc.fg)
-                            }
-                        }
-                    }
-                }).collect()
-            })
-
-            // Action hints
-            Box(height: 1u32) {
-                Text(content: "─────────────────────────────────────────", color: rc.dim)
-            }
-            Box(height: 1u32) {
-                Text(content: "Enter send  ", color: rc.dim)
-                Text(content: "Esc cancel", color: rc.dim)
-            }
+            #(lines)
         }
     }
 }

--- a/src/ui/components/merge_chooser.rs
+++ b/src/ui/components/merge_chooser.rs
@@ -9,7 +9,9 @@
 use iocraft::prelude::*;
 
 use crate::domain::{MERGE_METHODS, MergeMethod};
-use crate::theme::{ResolvedColors, ThemeColors};
+use crate::selection::{SelectablePane, TextSelection};
+use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
+use crate::ui::components::selectable_line;
 
 /// Props for the merge chooser overlay.
 #[derive(Default, Props)]
@@ -26,6 +28,8 @@ pub struct MergeChooserProps {
     pub awaiting_confirmation: bool,
     /// Theme colors.
     pub colors: ThemeColors,
+    /// Active text selection for drag-highlight (issue #178).
+    pub selection: Option<TextSelection>,
 }
 
 fn is_method_enabled(method: MergeMethod, allowed: Option<&[MergeMethod]>) -> bool {
@@ -48,6 +52,96 @@ pub fn MergeChooser(props: &MergeChooserProps) -> impl Into<AnyElement<'static>>
     }
 
     let rc = ResolvedColors::from_theme(Some(&props.colors));
+    let sel = SelectionColors::from_resolved(&rc);
+    let pane = SelectablePane::MergeChooser;
+    let selection = props.selection;
+    let mut line_idx: usize = 0;
+
+    let mut lines: Vec<AnyElement<'static>> = Vec::new();
+
+    // Header + separator
+    lines.push(selectable_line(
+        &format!("Merge Pull Request #{}", props.pr_number),
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        rc.bright,
+        sel,
+    ));
+    lines.push(selectable_line(
+        "─────────────────────────────────────────",
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        rc.dim,
+        sel,
+    ));
+
+    // Method list
+    for (i, method) in MERGE_METHODS.iter().enumerate() {
+        let selected = i == props.selected_index;
+        let enabled = is_method_enabled(*method, props.allowed_methods.as_deref());
+        let label = if enabled {
+            let marker = if selected { "(x)" } else { "( )" };
+            format!("{marker} {}", method.label())
+        } else {
+            format!("    {} (not enabled)", method.label())
+        };
+        let color = if !enabled {
+            rc.dim
+        } else if selected {
+            rc.bright
+        } else {
+            rc.fg
+        };
+        lines.push(selectable_line(
+            &label,
+            {
+                let li = line_idx;
+                line_idx += 1;
+                li
+            },
+            selection,
+            pane,
+            color,
+            sel,
+        ));
+    }
+
+    // Separator + hints
+    lines.push(selectable_line(
+        "─────────────────────────────────────────",
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        rc.dim,
+        sel,
+    ));
+    let hint = if props.awaiting_confirmation {
+        "Press Enter to confirm merge, Esc to cancel"
+    } else {
+        "Up/Down select  Enter confirm  Esc cancel"
+    };
+    let hint_color = if props.awaiting_confirmation {
+        rc.bright
+    } else {
+        rc.dim
+    };
+    lines.push(selectable_line(
+        hint, line_idx, selection, pane, hint_color, sel,
+    ));
 
     element! {
         Box(
@@ -60,76 +154,7 @@ pub fn MergeChooser(props: &MergeChooserProps) -> impl Into<AnyElement<'static>>
             padding_top: 0u32,
             padding_bottom: 0u32,
         ) {
-            // Header
-            Box(height: 1u32) {
-                Text(
-                    content: format!("Merge Pull Request #{}", props.pr_number),
-                    weight: Weight::Bold,
-                    color: rc.bright,
-                )
-            }
-            Box(height: 1u32) {
-                Text(content: "─────────────────────────────────────────", color: rc.dim)
-            }
-
-            // Method list
-            #(
-                MERGE_METHODS.iter().enumerate().map(|(i, method)| {
-                    let selected = i == props.selected_index;
-                    let enabled = is_method_enabled(*method, props.allowed_methods.as_deref());
-                    let label = if enabled {
-                        let marker = if selected { "(x)" } else { "( )" };
-                        format!("{marker} {}", method.label())
-                    } else {
-                        format!("    {} (not enabled)", method.label())
-                    };
-                    if selected && enabled {
-                        element! {
-                            Box(height: 1u32, background_color: rc.sel_bg) {
-                                Text(content: label, color: rc.sel_fg, weight: Weight::Bold)
-                            }
-                        }
-                    } else if enabled {
-                        element! {
-                            Box(height: 1u32) {
-                                Text(content: label, color: rc.fg)
-                            }
-                        }
-                    } else {
-                        element! {
-                            Box(height: 1u32) {
-                                Text(content: label, color: rc.dim)
-                            }
-                        }
-                    }
-                }).collect::<Vec<_>>()
-            )
-
-            // Separator
-            Box(height: 1u32) {
-                Text(content: "─────────────────────────────────────────", color: rc.dim)
-            }
-
-            // Confirmation or navigation hint
-            #(if props.awaiting_confirmation {
-                vec![element! {
-                    Box(height: 1u32) {
-                        Text(
-                            content: "Press Enter to confirm merge, Esc to cancel",
-                            color: rc.bright,
-                            weight: Weight::Bold,
-                        )
-                    }
-                }]
-            } else {
-                vec![element! {
-                    Box(height: 1u32) {
-                        Text(content: "Up/Down select  ", color: rc.dim)
-                        Text(content: "Enter confirm  ", color: rc.dim)
-                        Text(content: "Esc cancel", color: rc.dim)
-                    }
-                }]
-            })
+            #(lines)
         }
     }
 }

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -59,6 +59,7 @@ pub(crate) mod pr_filter_controls;
 pub(crate) mod pr_list;
 mod preview;
 mod scrollable_text;
+mod selectable_line;
 /// Generic bordered, scrollable, selectable list used by the Issue, PR, and
 /// Agent list panes. Domain layers project into [`SelectableRow`]s; this
 /// component owns the iocraft rendering once.
@@ -100,6 +101,7 @@ pub use pr_filter_controls::{pr_filter_action_hints, pr_filter_field_views, pr_f
 pub use pr_list::{PrListLayout, PrListWindow, pr_list_props, pr_list_status_message};
 pub use preview::{Preview, PreviewProps};
 pub use scrollable_text::{ScrollableText, ScrollableTextProps};
+pub use selectable_line::selectable_line;
 pub use selectable_list::{
     ListBorder, SelectableList, SelectableListProps, SelectableRow, SelectableSpan, SelectionStyle,
     SpanColor, SpanRole, selectable_list_element,

--- a/src/ui/components/selectable_line.rs
+++ b/src/ui/components/selectable_line.rs
@@ -1,0 +1,82 @@
+//! Shared helper for rendering a single text line with optional drag-selection
+//! highlight (inverse video).
+//!
+//! Used by form, chooser, and confirm-modal components that render their own
+//! lines as `Box(height: 1u32)` elements and need to paint selection feedback
+//! without duplicating the split/before/selected/after logic.
+
+use iocraft::prelude::*;
+
+use crate::selection::{HighlightRange, SelectablePane, TextSelection, row_highlight_range};
+use crate::theme::SelectionColors;
+
+/// Split a display line into `(before, selected, after)` segments given a
+/// highlight range. The `end` column is clamped to the line length.
+fn split_for_highlight(line: &str, range: HighlightRange) -> (String, String, String) {
+    let chars: Vec<char> = line.chars().collect();
+    let len = chars.len();
+    let start = range.start.min(len);
+    let end = if range.end == usize::MAX {
+        len
+    } else {
+        range.end.min(len)
+    };
+    let before: String = chars.iter().take(start).collect();
+    let selected: String = if start < end {
+        chars.iter().skip(start).take(end - start).collect()
+    } else {
+        String::new()
+    };
+    let after: String = chars.iter().skip(end).collect();
+    (before, selected, after)
+}
+
+/// Render a single text line (`Box(height: 1u32)`) with optional selection
+/// highlight.
+///
+/// When `selection` is active on `pane` and covers `content_line`, the
+/// selected segment is painted in inverse video (`sel_colors`). The rest of
+/// the line uses `plain_fg`.
+#[must_use]
+pub fn selectable_line(
+    text: &str,
+    content_line: usize,
+    selection: Option<TextSelection>,
+    pane: SelectablePane,
+    plain_fg: Color,
+    sel_colors: SelectionColors,
+) -> AnyElement<'static> {
+    let on_pane = selection.is_some_and(|s| s.pane() == pane);
+    let highlight = if on_pane {
+        selection.and_then(|s| row_highlight_range(&s, content_line))
+    } else {
+        None
+    };
+
+    match highlight {
+        Some(range) => {
+            let (before, selected, after) = split_for_highlight(text, range);
+            let sel_text = if selected.is_empty() {
+                " ".to_string()
+            } else {
+                selected
+            };
+            element! {
+                Box(height: 1u32) {
+                    Text(content: before, color: plain_fg, wrap: TextWrap::NoWrap)
+                    Box(background_color: sel_colors.bg) {
+                        Text(content: sel_text, color: sel_colors.fg, wrap: TextWrap::NoWrap)
+                    }
+                    Text(content: after, color: plain_fg, wrap: TextWrap::NoWrap)
+                }
+            }
+            .into_any()
+        }
+        None => element! {
+            Box(height: 1u32) {
+                Text(content: text.to_owned(), color: plain_fg)
+            }
+        }
+        .into_any(),
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -17,4 +17,4 @@ pub mod util;
 pub use components::{KeybindBar, Preview, SelectableList, Sidebar, StatusBar, TerminalView};
 pub use modals::{ConfirmModal, HelpModal};
 pub use screens::{Dashboard, NewAgentForm, NewRepositoryForm, SplitScreen, ThemePickerScreen};
-pub use util::{ELLIPSIS, truncate_with_ellipsis};
+pub use util::{CARET_CHAR, ELLIPSIS, text_with_caret, truncate_with_ellipsis};

--- a/src/ui/modals/confirm.rs
+++ b/src/ui/modals/confirm.rs
@@ -5,7 +5,9 @@
 
 use iocraft::prelude::*;
 
-use crate::theme::{ResolvedColors, ThemeColors};
+use crate::selection::{SelectablePane, TextSelection};
+use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
+use crate::ui::components::selectable_line;
 
 /// Props for the confirm modal.
 #[derive(Default, Props)]
@@ -20,12 +22,33 @@ pub struct ConfirmModalProps {
     pub delete_work_dir: bool,
     /// Theme colors.
     pub colors: ThemeColors,
+    /// Active text selection for drag-highlight (issue #178).
+    pub selection: Option<TextSelection>,
 }
 
 /// Confirm modal for destructive actions (delete, kill).
 #[component]
 pub fn ConfirmModal(props: &ConfirmModalProps) -> impl Into<AnyElement<'static>> {
     let rc = ResolvedColors::from_theme(Some(&props.colors));
+    let sel = SelectionColors::from_resolved(&rc);
+    let pane = SelectablePane::ConfirmModal;
+    let selection = props.selection;
+
+    let checkbox_line = if props.show_delete_work_dir {
+        let mark = if props.delete_work_dir { "x" } else { " " };
+        format!("[{mark}] Delete work directory")
+    } else {
+        String::new()
+    };
+
+    let lines: Vec<AnyElement<'static>> = vec![
+        selectable_line(&props.title, 0, selection, pane, rc.fg, sel),
+        selectable_line("", 1, selection, pane, rc.fg, sel),
+        selectable_line(&props.message, 2, selection, pane, rc.fg, sel),
+        selectable_line(&checkbox_line, 3, selection, pane, rc.fg, sel),
+        selectable_line("[ Cancel ]  [ Confirm ]", 4, selection, pane, rc.fg, sel),
+        selectable_line("", 5, selection, pane, rc.fg, sel),
+    ];
 
     element! {
         Box(
@@ -37,44 +60,7 @@ pub fn ConfirmModal(props: &ConfirmModalProps) -> impl Into<AnyElement<'static>>
             background_color: rc.bg,
             padding: 1u32,
         ) {
-            // Title
-            Box(height: 2u32, background_color: rc.bg) {
-                Text(
-                    content: props.title.clone(),
-                    weight: Weight::Bold,
-                    color: rc.fg,
-                )
-            }
-
-            // Message
-            Box(flex_grow: 1.0_f32, background_color: rc.bg) {
-                Text(content: props.message.clone(), color: rc.fg)
-            }
-
-            // Delete work dir option (conditional)
-            #(if props.show_delete_work_dir {
-                let checkbox = if props.delete_work_dir { "[x]" } else { "[ ]" };
-                element! {
-                    Box(height: 1u32, background_color: rc.bg) {
-                        Text(content: format!("{checkbox} Delete work directory"), color: rc.fg)
-                    }
-                }
-            } else {
-                element! {
-                    Box {}
-                }
-            })
-
-            // Buttons
-            Box(
-                flex_direction: FlexDirection::Row,
-                height: 2u32,
-                justify_content: JustifyContent::Center,
-                background_color: rc.bg,
-            ) {
-                Text(content: "[ Cancel ]  ", color: rc.dim)
-                Text(content: "[ Confirm ]", color: rc.bright)
-            }
+            #(lines)
         }
     }
 }

--- a/src/ui/modals/help.rs
+++ b/src/ui/modals/help.rs
@@ -79,7 +79,12 @@ pub struct HelpModalProps {
 
 /// Vertical chrome consumed outside the scroll viewport: border (2) + padding
 /// (2) + title (2) + footer (1).
-const HELP_CHROME_ROWS: u16 = 7;
+pub const HELP_CHROME_ROWS: u16 = 7;
+/// Modal width (columns). Used by both the renderer and the selection geometry.
+pub const HELP_MODAL_WIDTH: u16 = 60;
+/// Title displayed at the top of the help modal. Used by both the renderer
+/// and the selection content projection so they never drift.
+pub const HELP_TITLE: &str = "Help - Keyboard Shortcuts";
 /// Minimum lines shown at once (keeps the modal usable on short terminals).
 const HELP_MIN_VIEWPORT: usize = 8;
 /// Maximum lines shown at once even on very tall terminals.
@@ -141,7 +146,7 @@ pub fn HelpModal(props: &HelpModalProps) -> impl Into<AnyElement<'static>> {
             // Title
             Box(height: 2u32, background_color: rc.bg) {
                 Text(
-                    content: "Help - Keyboard Shortcuts",
+                    content: HELP_TITLE,
                     weight: Weight::Bold,
                     color: rc.fg,
                 )

--- a/src/ui/modals/help.rs
+++ b/src/ui/modals/help.rs
@@ -11,6 +11,7 @@
 
 use iocraft::prelude::*;
 
+use crate::selection::TextSelection;
 use crate::theme::{ResolvedColors, ThemeColors};
 use crate::ui::components::ScrollableText;
 
@@ -72,6 +73,8 @@ pub struct HelpModalProps {
     /// Terminal rows available, used to size the scroll viewport so the modal
     /// never overflows the screen.
     pub available_rows: u16,
+    /// Active text selection for drag-highlight (issue #178).
+    pub selection: Option<TextSelection>,
 }
 
 /// Vertical chrome consumed outside the scroll viewport: border (2) + padding
@@ -158,6 +161,10 @@ pub fn HelpModal(props: &HelpModalProps) -> impl Into<AnyElement<'static>> {
                     max_line_width: HELP_MAX_LINE_WIDTH,
                     color: Some(rc.fg),
                     bg: Some(rc.bg),
+                    selection: props.selection,
+                    selection_bg: Some(rc.sel_bg),
+                    selection_fg: Some(rc.sel_fg),
+                    content_line_offset: 2usize,
                 )
             }
 

--- a/src/ui/modals/mod.rs
+++ b/src/ui/modals/mod.rs
@@ -7,4 +7,4 @@ mod confirm;
 mod help;
 
 pub use confirm::{ConfirmModal, ConfirmModalProps};
-pub use help::{HelpModal, HelpModalProps, help_content_lines};
+pub use help::{HelpModal, HelpModalProps, help_content_lines, help_viewport_rows};

--- a/src/ui/modals/mod.rs
+++ b/src/ui/modals/mod.rs
@@ -7,4 +7,4 @@ mod confirm;
 mod help;
 
 pub use confirm::{ConfirmModal, ConfirmModalProps};
-pub use help::{HelpModal, HelpModalProps};
+pub use help::{HelpModal, HelpModalProps, help_content_lines};

--- a/src/ui/modals/mod.rs
+++ b/src/ui/modals/mod.rs
@@ -7,4 +7,7 @@ mod confirm;
 mod help;
 
 pub use confirm::{ConfirmModal, ConfirmModalProps};
-pub use help::{HelpModal, HelpModalProps, help_content_lines, help_viewport_rows};
+pub use help::{
+    HELP_CHROME_ROWS, HELP_MODAL_WIDTH, HELP_TITLE, HelpModal, HelpModalProps, help_content_lines,
+    help_viewport_rows,
+};

--- a/src/ui/orchestration.rs
+++ b/src/ui/orchestration.rs
@@ -31,38 +31,27 @@ pub fn derive_confirm_modal_data(
         ModalState::ConfirmDeleteAgent {
             id,
             delete_work_dir,
-        } => {
-            let agent_name = snapshot
-                .agents
-                .iter()
-                .find(|agent| &agent.id == id)
-                .map_or_else(
-                    || String::from("selected agent"),
-                    |agent| agent.name.clone(),
-                );
-            Some(ConfirmModalData {
-                title: String::from("Delete Agent"),
-                message: format!("Delete {agent_name}?"),
-                show_delete_work_dir: true,
-                delete_work_dir: *delete_work_dir,
-            })
-        }
-        ModalState::ConfirmDeleteRepository { id } => {
-            let repo_name = snapshot
-                .repositories
-                .iter()
-                .find(|repo| &repo.id == id)
-                .map_or_else(
-                    || String::from("selected repository"),
-                    |repo| repo.name.clone(),
-                );
-            Some(ConfirmModalData {
-                title: String::from("Delete Repository"),
-                message: format!("Delete {repo_name} and all its agents?"),
-                show_delete_work_dir: false,
-                delete_work_dir: false,
-            })
-        }
+        } => Some(ConfirmModalData {
+            title: String::from("Delete Agent"),
+            message: format!("Delete {}?", agent_display_name(snapshot, id)),
+            show_delete_work_dir: true,
+            delete_work_dir: *delete_work_dir,
+        }),
+        ModalState::ConfirmKillAgent { id } => Some(ConfirmModalData {
+            title: String::from("Kill Agent"),
+            message: format!("Kill {}?", agent_display_name(snapshot, id)),
+            show_delete_work_dir: false,
+            delete_work_dir: false,
+        }),
+        ModalState::ConfirmDeleteRepository { id } => Some(ConfirmModalData {
+            title: String::from("Delete Repository"),
+            message: format!(
+                "Delete {} and all its agents?",
+                repo_display_name(snapshot, id)
+            ),
+            show_delete_work_dir: false,
+            delete_work_dir: false,
+        }),
         ModalState::PreflightPrompt { issue, .. } => Some(ConfirmModalData {
             title: issue.prompt_title(),
             message: issue.prompt_message(),
@@ -79,6 +68,24 @@ pub fn derive_confirm_modal_data(
         }),
         _ => None,
     }
+}
+
+/// Resolve an agent's display name, falling back to a generic label.
+fn agent_display_name(snapshot: &AppState, id: &crate::domain::AgentId) -> String {
+    snapshot
+        .agents
+        .iter()
+        .find(|a| &a.id == id)
+        .map_or_else(|| String::from("selected agent"), |a| a.name.clone())
+}
+
+/// Resolve a repository's display name, falling back to a generic label.
+fn repo_display_name(snapshot: &AppState, id: &crate::domain::RepositoryId) -> String {
+    snapshot
+        .repositories
+        .iter()
+        .find(|r| &r.id == id)
+        .map_or_else(|| String::from("selected repository"), |r| r.name.clone())
 }
 
 /// Build the screen element for the current screen mode.
@@ -148,6 +155,7 @@ pub fn build_modal_element(
                     colors: colors.clone(),
                     scroll_offset: help_scroll_offset,
                     available_rows: available_rows,
+                    selection: snapshot.selection,
                 )
             }
             .into_any(),
@@ -181,6 +189,7 @@ pub fn build_modal_element(
         ),
         ModalState::ConfirmDeleteRepository { .. }
         | ModalState::ConfirmDeleteAgent { .. }
+        | ModalState::ConfirmKillAgent { .. }
         | ModalState::PreflightPrompt { .. }
         | ModalState::ConfirmIssueDirtyCopy { .. } => confirm_data.map(|data| {
             element! {
@@ -190,6 +199,7 @@ pub fn build_modal_element(
                     show_delete_work_dir: data.show_delete_work_dir,
                     delete_work_dir: data.delete_work_dir,
                     colors: colors.clone(),
+                    selection: snapshot.selection,
                 )
             }
             .into_any()

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -244,6 +244,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                                     agents: chooser_agents.clone(),
                                     selected_index: chooser_selected,
                                     colors: colors.clone(),
+                                    selection: selection,
                                 )
                             }
                         }]

--- a/src/ui/screens/new_agent.rs
+++ b/src/ui/screens/new_agent.rs
@@ -7,8 +7,10 @@
 use iocraft::prelude::*;
 
 use crate::domain::PlatformCapabilities;
+use crate::selection::SelectablePane;
 use crate::state::{AgentFormCursor, AgentFormFocus, AppState, ModalState};
-use crate::theme::{ResolvedColors, ThemeColors};
+use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
+use crate::ui::components::selectable_line;
 
 /// Props for the new agent form.
 #[derive(Default, Props)]
@@ -39,6 +41,7 @@ fn render_text_with_caret(value: &str, cursor: usize) -> String {
 #[component]
 pub fn NewAgentForm(props: &NewAgentFormProps) -> impl Into<AnyElement<'static>> {
     let rc = ResolvedColors::from_theme(props.colors.as_ref());
+    let sel = SelectionColors::from_resolved(&rc);
 
     // Extract form state from modal
     let (title, fields, focus, cursor) = props.state.as_ref().map_or_else(
@@ -71,6 +74,9 @@ pub fn NewAgentForm(props: &NewAgentFormProps) -> impl Into<AnyElement<'static>>
             ),
         },
     );
+    let selection = props.state.as_ref().and_then(|s| s.selection);
+    let pane = SelectablePane::AgentForm;
+    let mut line_idx: usize = 0;
 
     // Build field lines with cursor indicator for focused field.
     let shortcut_display = fields
@@ -114,63 +120,102 @@ pub fn NewAgentForm(props: &NewAgentFormProps) -> impl Into<AnyElement<'static>>
         cursor.llxprt_debug,
     ];
 
-    let mut field_lines: Vec<AnyElement<'static>> = labels
+    // Content line 0: title, line 1: blank.
+    let mut all_lines: Vec<AnyElement<'static>> = Vec::new();
+    all_lines.push(selectable_line(
+        &format!(" {title}"),
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        rc.fg,
+        sel,
+    ));
+    all_lines.push(selectable_line(
+        "",
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        rc.fg,
+        sel,
+    ));
+
+    // Content lines 2-8: text fields.
+    for (((label, value), field_focus), field_cursor) in labels
         .iter()
         .zip(values.iter())
         .zip(focuses.iter())
         .zip(cursors.iter())
-        .map(|(((label, value), field_focus), field_cursor)| {
-            let is_focused = focus == *field_focus;
-            let rendered_value = if is_focused && *field_focus != AgentFormFocus::Shortcut {
-                render_text_with_caret(value, *field_cursor)
-            } else {
-                (*value).to_owned()
-            };
-            let display = format!("  {label:<16} [{rendered_value}]");
-            let color = if is_focused { rc.bright } else { rc.fg };
-            element! {
-                Box(height: 1u32) {
-                    Text(content: display, color: color)
-                }
-            }
-            .into()
-        })
-        .collect();
+    {
+        let is_focused = focus == *field_focus;
+        let rendered_value = if is_focused && *field_focus != AgentFormFocus::Shortcut {
+            render_text_with_caret(value, *field_cursor)
+        } else {
+            (*value).to_owned()
+        };
+        let display = format!("  {label:<16} [{rendered_value}]");
+        let color = if is_focused { rc.bright } else { rc.fg };
+        all_lines.push(selectable_line(
+            &display,
+            {
+                let i = line_idx;
+                line_idx += 1;
+                i
+            },
+            selection,
+            pane,
+            color,
+            sel,
+        ));
+    }
 
-    // Pass/continue checkbox.
+    // Content line 9: Pass --continue checkbox.
     let continue_focused = focus == AgentFormFocus::PassContinue;
     let continue_mark = if fields.pass_continue { "x" } else { " " };
     let continue_color = if continue_focused { rc.bright } else { rc.fg };
     let continue_line = format!(
         "  {:<16} [{}]  (space toggles)",
-        "Pass --continue", continue_mark,
+        "Pass --continue", continue_mark
     );
-    field_lines.push(
-        element! {
-            Box(height: 1u32) {
-                Text(content: continue_line, color: continue_color)
-            }
-        }
-        .into(),
-    );
+    all_lines.push(selectable_line(
+        &continue_line,
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        continue_color,
+        sel,
+    ));
 
-    // Sandbox checkbox.
+    // Content line 10: Sandbox checkbox.
     let sandbox_focused = focus == AgentFormFocus::Sandbox;
     let sandbox_mark = if fields.sandbox_enabled { "x" } else { " " };
     let sandbox_color = if sandbox_focused { rc.bright } else { rc.fg };
-    field_lines.push(
-        element! {
-            Box(height: 1u32) {
-                Text(
-                    content: format!("  {:<16} [{}]  (space toggles)", "Sandbox", sandbox_mark),
-                    color: sandbox_color
-                )
-            }
-        }
-        .into(),
-    );
+    let sandbox_line = format!("  {:<16} [{}]  (space toggles)", "Sandbox", sandbox_mark);
+    all_lines.push(selectable_line(
+        &sandbox_line,
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        sandbox_color,
+        sel,
+    ));
 
-    // Sandbox engine pseudo-dropdown.
+    // Content line 11: Sandbox engine pseudo-dropdown.
     let engine_focused = focus == AgentFormFocus::SandboxEngine;
     let engine_color = if engine_focused { rc.bright } else { rc.fg };
     let caps = PlatformCapabilities::current();
@@ -184,19 +229,24 @@ pub fn NewAgentForm(props: &NewAgentFormProps) -> impl Into<AnyElement<'static>>
     } else {
         String::from("disabled")
     };
-    field_lines.push(
-        element! {
-            Box(height: 1u32) {
-                Text(
-                    content: format!("  {:<16} [{}]  ({engine_hint})", "Sandbox Engine", fields.sandbox_engine),
-                    color: engine_color
-                )
-            }
-        }
-        .into(),
+    let engine_line = format!(
+        "  {:<16} [{}]  ({engine_hint})",
+        "Sandbox Engine", fields.sandbox_engine
     );
+    all_lines.push(selectable_line(
+        &engine_line,
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        engine_color,
+        sel,
+    ));
 
-    // Sandbox flags field.
+    // Content line 12: Sandbox flags field.
     let flags_focused = focus == AgentFormFocus::SandboxFlags;
     let flags_color = if flags_focused { rc.bright } else { rc.fg };
     let flags_value = if flags_focused {
@@ -205,14 +255,40 @@ pub fn NewAgentForm(props: &NewAgentFormProps) -> impl Into<AnyElement<'static>>
         fields.sandbox_flags.clone()
     };
     let flags_display = format!("  {:<16} [{}]", "Sandbox Flags", flags_value);
-    field_lines.push(
-        element! {
-            Box(height: 1u32) {
-                Text(content: flags_display, color: flags_color)
-            }
-        }
-        .into(),
-    );
+    all_lines.push(selectable_line(
+        &flags_display,
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        flags_color,
+        sel,
+    ));
+
+    // Content line 13: blank, line 14: hints.
+    all_lines.push(selectable_line(
+        "",
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        rc.fg,
+        sel,
+    ));
+    all_lines.push(selectable_line(
+        "  Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles/cycles checkboxes  Enter submit  Esc cancel",
+        line_idx,
+        selection,
+        pane,
+        rc.dim,
+        sel,
+    ));
 
     element! {
         Box(
@@ -229,21 +305,7 @@ pub fn NewAgentForm(props: &NewAgentFormProps) -> impl Into<AnyElement<'static>>
                 flex_grow: 1.0_f32,
                 padding: 1i32,
             ) {
-                Box(height: 1u32) {
-                    Text(content: format!(" {}", title), color: rc.fg, weight: Weight::Bold)
-                }
-                Box(height: 1u32) {
-                    Text(content: String::new(), color: rc.fg)
-                }
-
-                #(field_lines)
-
-                Box(height: 1u32) {
-                    Text(content: String::new(), color: rc.fg)
-                }
-                Box(height: 1u32) {
-                    Text(content: "  Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles/cycles checkboxes  Enter submit  Esc cancel".to_owned(), color: rc.dim)
-                }
+                #(all_lines)
             }
         }
     }

--- a/src/ui/screens/new_agent.rs
+++ b/src/ui/screens/new_agent.rs
@@ -11,6 +11,7 @@ use crate::selection::SelectablePane;
 use crate::state::{AgentFormCursor, AgentFormFocus, AppState, ModalState};
 use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
 use crate::ui::components::selectable_line;
+use crate::ui::util::text_with_caret;
 
 /// Props for the new agent form.
 #[derive(Default, Props)]
@@ -19,22 +20,6 @@ pub struct NewAgentFormProps {
     pub state: Option<AppState>,
     /// Theme colors.
     pub colors: Option<ThemeColors>,
-}
-
-fn render_text_with_caret(value: &str, cursor: usize) -> String {
-    let char_len = value.chars().count();
-    let clamped = cursor.min(char_len);
-
-    let byte_idx = if clamped == 0 {
-        0
-    } else {
-        value
-            .char_indices()
-            .nth(clamped)
-            .map_or_else(|| value.len(), |(idx, _)| idx)
-    };
-
-    format!("{}▏{}", &value[..byte_idx], &value[byte_idx..])
 }
 
 /// Form for creating/editing an agent.
@@ -156,7 +141,7 @@ pub fn NewAgentForm(props: &NewAgentFormProps) -> impl Into<AnyElement<'static>>
     {
         let is_focused = focus == *field_focus;
         let rendered_value = if is_focused && *field_focus != AgentFormFocus::Shortcut {
-            render_text_with_caret(value, *field_cursor)
+            text_with_caret(value, *field_cursor)
         } else {
             (*value).to_owned()
         };
@@ -250,7 +235,7 @@ pub fn NewAgentForm(props: &NewAgentFormProps) -> impl Into<AnyElement<'static>>
     let flags_focused = focus == AgentFormFocus::SandboxFlags;
     let flags_color = if flags_focused { rc.bright } else { rc.fg };
     let flags_value = if flags_focused {
-        render_text_with_caret(&fields.sandbox_flags, cursor.sandbox_flags)
+        text_with_caret(&fields.sandbox_flags, cursor.sandbox_flags)
     } else {
         fields.sandbox_flags.clone()
     };

--- a/src/ui/screens/new_repository.rs
+++ b/src/ui/screens/new_repository.rs
@@ -6,8 +6,10 @@
 
 use iocraft::prelude::*;
 
+use crate::selection::SelectablePane;
 use crate::state::{AppState, ModalState, RepositoryFormCursor, RepositoryFormFocus};
-use crate::theme::{ResolvedColors, ThemeColors};
+use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
+use crate::ui::components::selectable_line;
 
 /// Props for the new repository form.
 #[derive(Default, Props)]
@@ -38,6 +40,7 @@ fn render_text_with_caret(value: &str, cursor: usize) -> String {
 #[component]
 pub fn NewRepositoryForm(props: &NewRepositoryFormProps) -> impl Into<AnyElement<'static>> {
     let rc = ResolvedColors::from_theme(props.colors.as_ref());
+    let sel = SelectionColors::from_resolved(&rc);
 
     // Extract form state from modal
     let (title, fields, focus, cursor) = props.state.as_ref().map_or_else(
@@ -70,8 +73,38 @@ pub fn NewRepositoryForm(props: &NewRepositoryFormProps) -> impl Into<AnyElement
             ),
         },
     );
+    let selection = props.state.as_ref().and_then(|s| s.selection);
+    let pane = SelectablePane::RepositoryForm;
+    let mut line_idx: usize = 0;
 
-    // Build field lines with cursor indicator for focused field
+    // Content line 0: title, line 1: blank.
+    let mut all_lines: Vec<AnyElement<'static>> = Vec::new();
+    all_lines.push(selectable_line(
+        &format!(" {title}"),
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        rc.fg,
+        sel,
+    ));
+    all_lines.push(selectable_line(
+        "",
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        rc.fg,
+        sel,
+    ));
+
+    // Content lines 2-5: text fields.
     let labels = ["Name", "Base Dir", "Default Profile", "GitHub Repo"];
     let values = [
         &fields.name,
@@ -91,45 +124,56 @@ pub fn NewRepositoryForm(props: &NewRepositoryFormProps) -> impl Into<AnyElement
         cursor.default_profile,
         cursor.github_repo,
     ];
-
-    let mut field_lines: Vec<AnyElement<'static>> = labels
+    for (((label, value), field_focus), field_cursor) in labels
         .iter()
         .zip(values.iter())
         .zip(focuses.iter())
         .zip(cursors.iter())
-        .map(|(((label, value), field_focus), field_cursor)| {
-            let is_focused = focus == *field_focus;
-            let rendered_value = if is_focused {
-                render_text_with_caret(value, *field_cursor)
-            } else {
-                (*value).to_owned()
-            };
-            let display = format!("  {label:<16} [{rendered_value}]");
-            let color = if is_focused { rc.bright } else { rc.fg };
-            element! {
-                Box(height: 1u32) {
-                    Text(content: display, color: color)
-                }
-            }
-            .into()
-        })
-        .collect();
+    {
+        let is_focused = focus == *field_focus;
+        let rendered_value = if is_focused {
+            render_text_with_caret(value, *field_cursor)
+        } else {
+            (*value).to_owned()
+        };
+        let display = format!("  {label:<16} [{rendered_value}]");
+        let color = if is_focused { rc.bright } else { rc.fg };
+        all_lines.push(selectable_line(
+            &display,
+            {
+                let i = line_idx;
+                line_idx += 1;
+                i
+            },
+            selection,
+            pane,
+            color,
+            sel,
+        ));
+    }
 
+    // Content line 6: Remote Repository checkbox.
     let remote_focused = focus == RepositoryFormFocus::RemoteEnabled;
     let remote_mark = if fields.remote_enabled { "x" } else { " " };
     let remote_color = if remote_focused { rc.bright } else { rc.fg };
-    field_lines.push(
-        element! {
-            Box(height: 1u32) {
-                Text(
-                    content: format!("  {:<16} [{}]  (space toggles)", "Remote Repository", remote_mark),
-                    color: remote_color
-                )
-            }
-        }
-        .into(),
+    let remote_line = format!(
+        "  {:<16} [{}]  (space toggles)",
+        "Remote Repository", remote_mark
     );
+    all_lines.push(selectable_line(
+        &remote_line,
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        remote_color,
+        sel,
+    ));
 
+    // Content lines 7-9: remote fields.
     let remote_labels = ["Login User", "Host / IP", "Run As User"];
     let remote_values = [&fields.login_user, &fields.host, &fields.run_as_user];
     let remote_focuses = [
@@ -138,7 +182,6 @@ pub fn NewRepositoryForm(props: &NewRepositoryFormProps) -> impl Into<AnyElement
         RepositoryFormFocus::RunAsUser,
     ];
     let remote_cursors = [cursor.login_user, cursor.host, cursor.run_as_user];
-
     for (((label, value), field_focus), field_cursor) in remote_labels
         .iter()
         .zip(remote_values.iter())
@@ -156,16 +199,22 @@ pub fn NewRepositoryForm(props: &NewRepositoryFormProps) -> impl Into<AnyElement
         } else {
             rc.dim
         };
-        field_lines.push(
-            element! {
-                Box(height: 1u32) {
-                    Text(content: format!("  {label:<16} [{rendered_value}]"), color: color)
-                }
-            }
-            .into(),
-        );
+        let display = format!("  {label:<16} [{rendered_value}]");
+        all_lines.push(selectable_line(
+            &display,
+            {
+                let i = line_idx;
+                line_idx += 1;
+                i
+            },
+            selection,
+            pane,
+            color,
+            sel,
+        ));
     }
 
+    // Content line 10: Setup Env Default checkbox.
     let setup_focused = focus == RepositoryFormFocus::SetupEnvDefault;
     let setup_mark = if fields.setup_env_default { "x" } else { " " };
     let setup_color = if fields.remote_enabled {
@@ -173,17 +222,44 @@ pub fn NewRepositoryForm(props: &NewRepositoryFormProps) -> impl Into<AnyElement
     } else {
         rc.dim
     };
-    field_lines.push(
-        element! {
-            Box(height: 1u32) {
-                Text(
-                    content: format!("  {:<16} [{}]  (space toggles)", "Setup Env Default", setup_mark),
-                    color: setup_color
-                )
-            }
-        }
-        .into(),
+    let setup_line = format!(
+        "  {:<16} [{}]  (space toggles)",
+        "Setup Env Default", setup_mark
     );
+    all_lines.push(selectable_line(
+        &setup_line,
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        setup_color,
+        sel,
+    ));
+
+    // Content line 11: blank, line 12: hints.
+    all_lines.push(selectable_line(
+        "",
+        {
+            let i = line_idx;
+            line_idx += 1;
+            i
+        },
+        selection,
+        pane,
+        rc.fg,
+        sel,
+    ));
+    all_lines.push(selectable_line(
+        "  Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles remote options  Enter submit  Esc cancel",
+        line_idx,
+        selection,
+        pane,
+        rc.dim,
+        sel,
+    ));
 
     element! {
         Box(
@@ -200,21 +276,7 @@ pub fn NewRepositoryForm(props: &NewRepositoryFormProps) -> impl Into<AnyElement
                 flex_grow: 1.0_f32,
                 padding: 1i32,
             ) {
-                Box(height: 1u32) {
-                    Text(content: format!(" {}", title), color: rc.fg, weight: Weight::Bold)
-                }
-                Box(height: 1u32) {
-                    Text(content: String::new(), color: rc.fg)
-                }
-
-                #(field_lines)
-
-                Box(height: 1u32) {
-                    Text(content: String::new(), color: rc.fg)
-                }
-                Box(height: 1u32) {
-                    Text(content: "  Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles remote options  Enter submit  Esc cancel".to_owned(), color: rc.dim)
-                }
+                #(all_lines)
             }
         }
     }

--- a/src/ui/screens/new_repository.rs
+++ b/src/ui/screens/new_repository.rs
@@ -10,6 +10,7 @@ use crate::selection::SelectablePane;
 use crate::state::{AppState, ModalState, RepositoryFormCursor, RepositoryFormFocus};
 use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
 use crate::ui::components::selectable_line;
+use crate::ui::util::text_with_caret;
 
 /// Props for the new repository form.
 #[derive(Default, Props)]
@@ -18,22 +19,6 @@ pub struct NewRepositoryFormProps {
     pub state: Option<AppState>,
     /// Theme colors.
     pub colors: Option<ThemeColors>,
-}
-
-fn render_text_with_caret(value: &str, cursor: usize) -> String {
-    let char_len = value.chars().count();
-    let clamped = cursor.min(char_len);
-
-    let byte_idx = if clamped == 0 {
-        0
-    } else {
-        value
-            .char_indices()
-            .nth(clamped)
-            .map_or_else(|| value.len(), |(idx, _)| idx)
-    };
-
-    format!("{}▏{}", &value[..byte_idx], &value[byte_idx..])
 }
 
 /// Form for creating/editing a repository.
@@ -132,7 +117,7 @@ pub fn NewRepositoryForm(props: &NewRepositoryFormProps) -> impl Into<AnyElement
     {
         let is_focused = focus == *field_focus;
         let rendered_value = if is_focused {
-            render_text_with_caret(value, *field_cursor)
+            text_with_caret(value, *field_cursor)
         } else {
             (*value).to_owned()
         };
@@ -190,7 +175,7 @@ pub fn NewRepositoryForm(props: &NewRepositoryFormProps) -> impl Into<AnyElement
     {
         let is_focused = focus == *field_focus;
         let rendered_value = if is_focused {
-            render_text_with_caret(value, *field_cursor)
+            text_with_caret(value, *field_cursor)
         } else {
             (*value).to_owned()
         };

--- a/src/ui/screens/pull_requests.rs
+++ b/src/ui/screens/pull_requests.rs
@@ -277,6 +277,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                                     agents: chooser_agents.clone(),
                                     selected_index: chooser_selected,
                                     colors: colors.clone(),
+                                    selection: selection,
                                 )
                             }
                         }]
@@ -299,6 +300,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                                     allowed_methods: merge_allowed.clone(),
                                     awaiting_confirmation: merge_confirming,
                                     colors: colors.clone(),
+                                    selection: selection,
                                 )
                             }
                         }]

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -5,6 +5,30 @@
 
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
+/// Caret character inserted into editable form fields to show the cursor.
+pub const CARET_CHAR: char = '▏';
+
+/// Insert the caret character at `cursor` position in `value`.
+///
+/// The cursor column is clamped to `value`'s character length, and the
+/// insertion is byte-safe (uses `char_indices` so multi-byte chars are never
+/// split). Used by both the iocraft form components and the pure selection
+/// content projection so copied text matches what is displayed.
+#[must_use]
+pub fn text_with_caret(value: &str, cursor: usize) -> String {
+    let char_len = value.chars().count();
+    let clamped = cursor.min(char_len);
+    let byte_idx = if clamped == 0 {
+        0
+    } else {
+        value
+            .char_indices()
+            .nth(clamped)
+            .map_or_else(|| value.len(), |(idx, _)| idx)
+    };
+    format!("{}{CARET_CHAR}{}", &value[..byte_idx], &value[byte_idx..])
+}
+
 /// Ellipsis character appended when text is truncated to fit a width budget.
 pub const ELLIPSIS: char = '…';
 


### PR DESCRIPTION
## Summary

Makes mouse-drag text selection + OSC 52 clipboard copy work on **every text-bearing surface** in the app, closing the gap where forms, chooser overlays, and confirm modals were silently non-selectable.

Closes #178.

## What was broken

Jefe already had a complete selection/copy stack (mouse routing, geometry hit-testing, content projections, OSC 52 writer), but these surfaces had no `SelectablePane` variant and no `pane_content_lines` projection, so mouse selection silently did nothing there:

- Agent definition form (NewAgentForm / EditAgent)
- Repository definition form (NewRepositoryForm / EditRepository)
- Agent chooser overlay
- Merge chooser overlay
- Confirm modal (delete agent/repo, kill agent, preflight, dirty copy)
- Help modal (was a variant but had an empty content projection — never actually worked)

## What changed

### New SelectablePane variants (`src/selection/text.rs`)
Added `NewAgentForm`, `NewRepositoryForm`, `AgentChooser`, `MergeChooser`, `ConfirmModal` to the enum.

### Overlay geometry + z-order (`src/selection/geometry.rs`)
- `pane_at` now checks for active overlays **before** the base layout.
- Full-screen modals (forms, help, confirm) check containment against their actual rendered bounds — points outside the modal return `None` (the modal replaced the screen, so there's no base pane to fall through to).
- In-screen overlays (choosers) check containment first; if the click misses the chooser, it falls through to the base screen layout (correct z-order).
- `OverlayPane` enum and `ScreenLayout.overlay` field carry overlay state through the pure selection layer (no iocraft types).

### Content projections (`src/selection/content.rs` + new modules)
- `src/selection/form_content.rs` — projections for agent and repository forms. Matches the exact rendered text including the caret character inserted into focused editable fields.
- `src/selection/overlay_content.rs` — projections for agent chooser, merge chooser, and all five confirm modal variants (ConfirmDeleteAgent, ConfirmDeleteRepository, ConfirmKillAgent, PreflightPrompt, ConfirmIssueDirtyCopy).
- Help modal projection now returns the actual help content lines (title + help_content_lines) instead of an empty Vec.

### PTY forwarding suppression (`src/mouse_routing.rs`)
- When any overlay is active, PTY mouse forwarding is suppressed so selection targets the top-most overlay instead of the terminal underneath.
- Help modal scroll offset is now read from AppState (mirrored from the app-shell hook state) so `scroll_offset_for_pane` and `effective_scroll_for_detail` correctly map screen coordinates to help content lines.

### Help scroll offset (`src/state/types.rs`, `src/app_input/mod.rs`)
- Added `help_scroll_offset: usize` to AppState.
- `handle_mode_help_key` mirrors the hook state to AppState at the end of each scroll operation.
- `effective_scroll_for_detail` suppresses scroll for the HelpModal title rows (first 2 content lines), matching how detail pane header rows work.

## Verification

- `cargo fmt --all --check` — pass
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — pass (zero warnings)
- `cargo build --workspace --all-features --locked` — pass
- `cargo test --workspace --all-features --locked` — pass (1387 tests, 0 failures)
- All content projections verified against the actual iocraft component render code to ensure copied text matches what the user sees.

## Architecture

Follows the existing pattern and project standards:
- Pure selection/geometry/content logic stays in `src/selection/` (no iocraft types).
- View code stays render-only.
- The overlay state is carried through `ScreenLayout` (a plain-data descriptor), keeping `pane_at` pure and testable.
- The "is this pane selectable + how do I get its lines" contract is driven from one place (the enum + `pane_content_lines` mapping).
