### PR TITLE
Remember per-repo user selections across dialogs, filters, and restarts (Fixes #163)

### DIFF
--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -107,6 +107,7 @@ pub fn init_app_state(app_state: &mut HookState<AppState>, ctx: &SharedContext) 
     state.pane_focus = crate::app_input::pane_focus_from_persisted(&persisted.pane_focus);
     state.terminal_focused =
         persisted.terminal_focused && state.pane_focus == jefe::state::PaneFocus::Terminal;
+    state.user_preferences = persisted.user_preferences;
     state.rebuild_repository_agent_ids();
     state.normalize_selection_indices();
 

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -153,6 +153,7 @@ pub fn to_persisted_state(state: &AppState) -> PersistedState {
         last_selected_agent_by_repo: state.last_selected_agent_by_repo.clone(),
         pane_focus: pane_focus_to_persisted(state.pane_focus),
         terminal_focused: state.terminal_focused,
+        user_preferences: state.user_preferences.clone(),
     }
 }
 

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -278,7 +278,7 @@ pub struct IssueComment {
 /// @plan PLAN-20260329-ISSUES-MODE.P03
 /// @requirement REQ-ISS-008
 /// Filter state options.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum IssueFilterState {
     #[default]
     Open,
@@ -292,18 +292,29 @@ pub const FILTER_CHOICE_NONE: &str = "none";
 /// @plan PLAN-20260329-ISSUES-MODE.P03
 /// @requirement REQ-ISS-008
 /// Issue list filter criteria.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IssueFilter {
+    #[serde(default)]
     pub query_text: String,
+    #[serde(default)]
     pub state: Option<IssueFilterState>,
+    #[serde(default)]
     pub author: String,
+    #[serde(default)]
     pub assignee: String,
+    #[serde(default)]
     pub labels: Vec<String>,
+    #[serde(default)]
     pub issue_type: String,
+    #[serde(default)]
     pub milestone: String,
+    #[serde(default)]
     pub module: String,
+    #[serde(default)]
     pub mentioned: String,
+    #[serde(default)]
     pub updated_before: String,
+    #[serde(default)]
     pub updated_after: String,
 }
 
@@ -362,9 +373,10 @@ pub enum PrState {
 /// @plan PLAN-20260624-PR-MODE.P03
 /// @requirement REQ-PR-009
 /// @pseudocode component-002 lines 74-101
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum MergeMethod {
     /// Create a merge commit (`--merge`).
+    #[default]
     Merge,
     /// Squash commits into one (`--squash`).
     Squash,
@@ -550,7 +562,7 @@ pub struct PullRequestDetail {
 /// @pseudocode component-001 lines 259-263
 /// PR filter-state choice (Space cycles this on the state field).
 /// Default is `Open`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum PrFilterState {
     #[default]
     Open,
@@ -564,7 +576,7 @@ pub enum PrFilterState {
 /// @pseudocode component-001 lines 264a-264d
 /// Review-decision filter choice (issue #20 review signal). `Any` emits no
 /// qualifier.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum ReviewDecisionFilter {
     #[default]
     Any,
@@ -579,7 +591,7 @@ pub enum ReviewDecisionFilter {
 /// @pseudocode component-001 lines 264e-264g
 /// CI/check-rollup filter choice (issue #20 workflow signal). `Any` emits no
 /// qualifier.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum ChecksFilter {
     #[default]
     Any,
@@ -592,17 +604,124 @@ pub enum ChecksFilter {
 /// @requirement REQ-PR-008
 /// @pseudocode component-001 lines 249-258
 /// PR filter criteria. Structured fields are AND-composed.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PrFilter {
+    #[serde(default)]
     pub query_text: String,
+    #[serde(default)]
     pub state: Option<PrFilterState>,
+    #[serde(default)]
     pub author: String,
+    #[serde(default)]
     pub assignee: String,
+    #[serde(default)]
     pub reviewer: String,
+    #[serde(default)]
     pub is_draft: Option<bool>,
+    #[serde(default)]
     pub labels: Vec<String>,
+    #[serde(default)]
     pub review_decision: ReviewDecisionFilter,
+    #[serde(default)]
     pub checks_status: ChecksFilter,
+}
+
+/// Per-repository remembered user preferences (issue #163).
+///
+/// All remembered selections are scoped per-repository so filter/merge
+/// choices made in one repo never leak into another. Persisted as part of
+/// `persistence::State` and restored on startup.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoPreferences {
+    /// Last committed issue-list filter (state defaults to Open on first use).
+    #[serde(default)]
+    pub issue_filter: IssueFilter,
+    /// Last committed PR-list filter (state defaults to Open on first use).
+    #[serde(default)]
+    pub pr_filter: PrFilter,
+    /// Last issue search query text (session+restart persisted).
+    #[serde(default)]
+    pub issue_search_query: String,
+    /// Last PR search query text (session+restart persisted).
+    #[serde(default)]
+    pub pr_search_query: String,
+    /// Last-focused issue filter field index (0-based).
+    #[serde(default)]
+    pub issue_filter_field_index: usize,
+    /// Last-focused PR filter field index (0-based).
+    #[serde(default)]
+    pub pr_filter_field_index: usize,
+    /// Last-selected merge method for the merge chooser.
+    #[serde(default)]
+    pub last_merge_method: MergeMethod,
+}
+
+impl RepoPreferences {
+    /// Return a fresh preferences set with both filters' state set to `Open`,
+    /// matching the documented default-on-first-use behavior (issue #163).
+    #[must_use]
+    pub fn with_open_defaults() -> Self {
+        Self {
+            issue_filter: IssueFilter {
+                state: Some(IssueFilterState::Open),
+                ..IssueFilter::default()
+            },
+            pr_filter: PrFilter {
+                state: Some(PrFilterState::Open),
+                ..PrFilter::default()
+            },
+            ..Self::default()
+        }
+    }
+}
+
+/// Aggregate per-repository user preferences (issue #163).
+///
+/// Mirrors the `last_selected_agent_by_repo` `Vec<(RepositoryId, _)>` pattern:
+/// a small vec keyed by repository id. Methods keep the entry for the
+/// current repo in sync with the live Issues/PR state.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserPreferences {
+    #[serde(default)]
+    pub by_repo: Vec<(RepositoryId, RepoPreferences)>,
+}
+
+impl UserPreferences {
+    /// Return the stored preferences for `repo_id`, or the Open-default set if
+    /// the repo has no stored entry yet (issue #163).
+    #[must_use]
+    pub fn for_repo(&self, repo_id: &RepositoryId) -> RepoPreferences {
+        self.by_repo
+            .iter()
+            .find(|(id, _)| id == repo_id)
+            .map_or_else(RepoPreferences::with_open_defaults, |(_, prefs)| {
+                prefs.clone()
+            })
+    }
+
+    /// Upsert preferences for `repo_id`: replace an existing entry or push a
+    /// new one.
+    pub fn update_for_repo(&mut self, repo_id: RepositoryId, prefs: RepoPreferences) {
+        if let Some(entry) = self.by_repo.iter_mut().find(|(id, _)| *id == repo_id) {
+            entry.1 = prefs;
+        } else {
+            self.by_repo.push((repo_id, prefs));
+        }
+    }
+
+    /// Convenience: return the stored PR filter for `repo_id`, or the
+    /// Open-default filter.
+    #[must_use]
+    pub fn pr_filter_for(&self, repo_id: &RepositoryId) -> PrFilter {
+        self.for_repo(repo_id).pr_filter
+    }
+
+    /// Convenience: return the stored issue filter for `repo_id`, or the
+    /// Open-default filter.
+    #[must_use]
+    pub fn issue_filter_for(&self, repo_id: &RepositoryId) -> IssueFilter {
+        self.for_repo(repo_id).issue_filter
+    }
 }
 
 /// Agent lifecycle status.

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -708,6 +708,18 @@ impl UserPreferences {
             .map_or_else(RepoPreferences::default, |(_, prefs)| prefs.clone())
     }
 
+    /// Return only the remembered merge method for `repo_id` (issue #163).
+    /// Narrower than `for_repo` so the merge-chooser open path does not clone
+    /// the full `RepoPreferences` (with its many `String` filter fields) just
+    /// to read a single `Option<MergeMethod>`.
+    #[must_use]
+    pub fn last_merge_method_for(&self, repo_id: &RepositoryId) -> Option<MergeMethod> {
+        self.by_repo
+            .iter()
+            .find(|(id, _)| id == repo_id)
+            .and_then(|(_, prefs)| prefs.last_merge_method)
+    }
+
     /// Upsert preferences for `repo_id`: replace an existing entry or push a
     /// new one.
     pub fn update_for_repo(&mut self, repo_id: &RepositoryId, prefs: RepoPreferences) {

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -717,6 +717,31 @@ impl UserPreferences {
             self.by_repo.push((repo_id.clone(), prefs));
         }
     }
+
+    /// Mutate a single repo's preferences in place via `f`, inserting a fresh
+    /// Open-default entry when the repo has no stored entry yet (issue #163).
+    /// Avoids the full clone-and-replace of `for_repo`/`update_for_repo` when
+    /// only one field changes (e.g. cursor navigation).
+    pub fn update_field_for_repo(
+        &mut self,
+        repo_id: &RepositoryId,
+        f: impl FnOnce(&mut RepoPreferences),
+    ) {
+        if let Some((_, prefs)) = self.by_repo.iter_mut().find(|(id, _)| id == repo_id) {
+            f(prefs);
+        } else {
+            let mut prefs = RepoPreferences::default();
+            f(&mut prefs);
+            self.by_repo.push((repo_id.clone(), prefs));
+        }
+    }
+
+    /// Remove the stored preferences entry for `repo_id`, if any (issue #163).
+    /// Called when a repository is deleted so its preferences do not linger
+    /// or get restored if the id is ever reused.
+    pub fn remove_for_repo(&mut self, repo_id: &RepositoryId) {
+        self.by_repo.retain(|(id, _)| id != repo_id);
+    }
 }
 
 /// Agent lifecycle status.

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -373,10 +373,9 @@ pub enum PrState {
 /// @plan PLAN-20260624-PR-MODE.P03
 /// @requirement REQ-PR-009
 /// @pseudocode component-002 lines 74-101
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MergeMethod {
     /// Create a merge commit (`--merge`).
-    #[default]
     Merge,
     /// Squash commits into one (`--squash`).
     Squash,
@@ -667,9 +666,10 @@ pub struct RepoPreferences {
     /// Last-focused PR filter field index (0-based).
     #[serde(default)]
     pub pr_filter_field_index: usize,
-    /// Last-selected merge method for the merge chooser.
+    /// Last-selected merge method for the merge chooser (`None` until the user
+    /// confirms a merge; the chooser then defaults to Merge).
     #[serde(default)]
-    pub last_merge_method: MergeMethod,
+    pub last_merge_method: Option<MergeMethod>,
 }
 
 impl Default for RepoPreferences {
@@ -681,7 +681,7 @@ impl Default for RepoPreferences {
             pr_search_query: String::new(),
             issue_filter_field_index: 0,
             pr_filter_field_index: 0,
-            last_merge_method: MergeMethod::default(),
+            last_merge_method: None,
         }
     }
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -626,18 +626,34 @@ pub struct PrFilter {
     pub checks_status: ChecksFilter,
 }
 
+/// Serde default function producing an `IssueFilter` with `state = Open`.
+fn default_open_issue_filter() -> IssueFilter {
+    IssueFilter {
+        state: Some(IssueFilterState::Open),
+        ..IssueFilter::default()
+    }
+}
+
+/// Serde default function producing a `PrFilter` with `state = Open`.
+fn default_open_pr_filter() -> PrFilter {
+    PrFilter {
+        state: Some(PrFilterState::Open),
+        ..PrFilter::default()
+    }
+}
+
 /// Per-repository remembered user preferences (issue #163).
 ///
 /// All remembered selections are scoped per-repository so filter/merge
 /// choices made in one repo never leak into another. Persisted as part of
 /// `persistence::State` and restored on startup.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepoPreferences {
     /// Last committed issue-list filter (state defaults to Open on first use).
-    #[serde(default)]
+    #[serde(default = "default_open_issue_filter")]
     pub issue_filter: IssueFilter,
     /// Last committed PR-list filter (state defaults to Open on first use).
-    #[serde(default)]
+    #[serde(default = "default_open_pr_filter")]
     pub pr_filter: PrFilter,
     /// Last issue search query text (session+restart persisted).
     #[serde(default)]
@@ -656,21 +672,16 @@ pub struct RepoPreferences {
     pub last_merge_method: MergeMethod,
 }
 
-impl RepoPreferences {
-    /// Return a fresh preferences set with both filters' state set to `Open`,
-    /// matching the documented default-on-first-use behavior (issue #163).
-    #[must_use]
-    pub fn with_open_defaults() -> Self {
+impl Default for RepoPreferences {
+    fn default() -> Self {
         Self {
-            issue_filter: IssueFilter {
-                state: Some(IssueFilterState::Open),
-                ..IssueFilter::default()
-            },
-            pr_filter: PrFilter {
-                state: Some(PrFilterState::Open),
-                ..PrFilter::default()
-            },
-            ..Self::default()
+            issue_filter: default_open_issue_filter(),
+            pr_filter: default_open_pr_filter(),
+            issue_search_query: String::new(),
+            pr_search_query: String::new(),
+            issue_filter_field_index: 0,
+            pr_filter_field_index: 0,
+            last_merge_method: MergeMethod::default(),
         }
     }
 }
@@ -694,33 +705,17 @@ impl UserPreferences {
         self.by_repo
             .iter()
             .find(|(id, _)| id == repo_id)
-            .map_or_else(RepoPreferences::with_open_defaults, |(_, prefs)| {
-                prefs.clone()
-            })
+            .map_or_else(RepoPreferences::default, |(_, prefs)| prefs.clone())
     }
 
     /// Upsert preferences for `repo_id`: replace an existing entry or push a
     /// new one.
-    pub fn update_for_repo(&mut self, repo_id: RepositoryId, prefs: RepoPreferences) {
-        if let Some(entry) = self.by_repo.iter_mut().find(|(id, _)| *id == repo_id) {
+    pub fn update_for_repo(&mut self, repo_id: &RepositoryId, prefs: RepoPreferences) {
+        if let Some(entry) = self.by_repo.iter_mut().find(|(id, _)| id == repo_id) {
             entry.1 = prefs;
         } else {
-            self.by_repo.push((repo_id, prefs));
+            self.by_repo.push((repo_id.clone(), prefs));
         }
-    }
-
-    /// Convenience: return the stored PR filter for `repo_id`, or the
-    /// Open-default filter.
-    #[must_use]
-    pub fn pr_filter_for(&self, repo_id: &RepositoryId) -> PrFilter {
-        self.for_repo(repo_id).pr_filter
-    }
-
-    /// Convenience: return the stored issue filter for `repo_id`, or the
-    /// Open-default filter.
-    #[must_use]
-    pub fn issue_filter_for(&self, repo_id: &RepositoryId) -> IssueFilter {
-        self.for_repo(repo_id).issue_filter
     }
 }
 

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -588,6 +588,7 @@ fn seed_sticky_agent_state(config_dir: &std::path::Path, agent_session: &str) {
         last_selected_agent_by_repo: vec![],
         pane_focus: String::new(),
         terminal_focused: false,
+        user_preferences: crate::domain::UserPreferences::default(),
     };
     let paths = PersistencePaths {
         settings_path: config_dir.join("settings.toml"),
@@ -831,6 +832,7 @@ fn seed_restart_agent_state(config_dir: &std::path::Path, agent_session: &str) {
         last_selected_agent_by_repo: vec![],
         pane_focus: String::new(),
         terminal_focused: false,
+        user_preferences: crate::domain::UserPreferences::default(),
     };
     let paths = PersistencePaths {
         settings_path: config_dir.join("settings.toml"),

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -108,6 +108,10 @@ pub struct State {
     /// consistency with `pane_focus` during restore.
     #[serde(default)]
     pub terminal_focused: bool,
+    /// Per-repository remembered user preferences (issue #163). Restored on
+    /// startup so filter/merge/search selections survive restarts.
+    #[serde(default)]
+    pub user_preferences: crate::domain::UserPreferences,
 }
 
 impl State {
@@ -123,6 +127,7 @@ impl State {
             last_selected_agent_by_repo: Vec::new(),
             pane_focus: String::new(),
             terminal_focused: false,
+            user_preferences: crate::domain::UserPreferences::default(),
         }
     }
 }

--- a/src/persistence/tests.rs
+++ b/src/persistence/tests.rs
@@ -161,6 +161,7 @@ fn file_persistence_roundtrip_state() {
         last_selected_agent_by_repo: vec![],
         pane_focus: String::new(),
         terminal_focused: false,
+        user_preferences: crate::domain::UserPreferences::default(),
     };
     mgr.save_state(&state).value_or_panic("should save");
     let loaded = mgr.load_state().value_or_panic("should load");
@@ -193,6 +194,7 @@ fn file_persistence_roundtrip_pane_focus_and_terminal_focused() {
         last_selected_agent_by_repo: vec![],
         pane_focus: "terminal".to_string(),
         terminal_focused: true,
+        user_preferences: crate::domain::UserPreferences::default(),
     };
     mgr.save_state(&state).value_or_panic("should save");
     let loaded = mgr.load_state().value_or_panic("should load");
@@ -259,6 +261,7 @@ fn test_issue_base_prompt_state_round_trip() {
         last_selected_agent_by_repo: vec![],
         pane_focus: String::new(),
         terminal_focused: false,
+        user_preferences: crate::domain::UserPreferences::default(),
     };
     let temp = std::env::temp_dir().join("jefe_test_p13_issue_base_prompt_roundtrip");
     let _ = std::fs::remove_dir_all(&temp);
@@ -674,4 +677,60 @@ fn resolve_config_dir_falls_back_to_platform_default() {
 fn resolve_config_dir_ignores_empty_env_values() {
     let dir = resolve_config_dir_from_env(Some(String::new()), Some(String::new()));
     assert!(dir.ends_with("jefe"));
+}
+
+// ── Issue #163: user_preferences round-trip + backward compat ─────────────
+
+#[test]
+fn user_preferences_roundtrip() {
+    use crate::domain::{
+        IssueFilter, IssueFilterState, MergeMethod, PrFilter, PrFilterState, RepoPreferences,
+        RepositoryId, UserPreferences,
+    };
+
+    let prefs = UserPreferences {
+        by_repo: vec![(
+            RepositoryId("repo-1".to_string()),
+            RepoPreferences {
+                issue_filter: IssueFilter {
+                    state: Some(IssueFilterState::Closed),
+                    author: "alice".to_string(),
+                    ..IssueFilter::default()
+                },
+                pr_filter: PrFilter {
+                    state: Some(PrFilterState::Merged),
+                    ..PrFilter::default()
+                },
+                issue_search_query: "issue-search".to_string(),
+                pr_search_query: "pr-search".to_string(),
+                issue_filter_field_index: 3,
+                pr_filter_field_index: 5,
+                last_merge_method: MergeMethod::Squash,
+            },
+        )],
+    };
+
+    let state = State {
+        user_preferences: prefs,
+        ..State::default_with_version()
+    };
+
+    let json = serde_json::to_string(&state).value_or_panic("serialize state");
+    let restored: State = serde_json::from_str(&json).value_or_panic("deserialize state");
+    assert_eq!(restored.user_preferences, state.user_preferences);
+}
+
+#[test]
+fn legacy_state_without_preferences_deserializes_to_default() {
+    // A legacy state.json that predates the user_preferences field must
+    // deserialize cleanly, yielding default (empty) preferences.
+    let legacy_json = r#"{
+        "schema_version": 1,
+        "repositories": [],
+        "agents": [],
+        "selected_repository_index": null,
+        "selected_agent_index": null
+    }"#;
+    let state: State = serde_json::from_str(legacy_json).value_or_panic("deserialize legacy state");
+    assert!(state.user_preferences.by_repo.is_empty());
 }

--- a/src/persistence/tests.rs
+++ b/src/persistence/tests.rs
@@ -734,3 +734,173 @@ fn legacy_state_without_preferences_deserializes_to_default() {
     let state: State = serde_json::from_str(legacy_json).value_or_panic("deserialize legacy state");
     assert!(state.user_preferences.by_repo.is_empty());
 }
+
+// ── Issue #163 FIX 8: Full restart-hydration integration test ─────────────
+
+/// End-to-end restart test: save → load → restore → enter-mode proves no
+/// cross-repo leakage through the real persistence layer.
+#[test]
+fn restart_hydration_preserves_per_repo_preferences() {
+    use crate::domain::{
+        IssueFilter, IssueFilterState, PrFilter, PrFilterState, RepoPreferences, Repository,
+        RepositoryId, UserPreferences,
+    };
+
+    let repo1 = Repository::new(
+        RepositoryId("repo-1".to_string()),
+        "Repo 1".to_string(),
+        "repo-1".to_string(),
+        std::path::PathBuf::from("/tmp/repo1"),
+    );
+    let repo2 = Repository::new(
+        RepositoryId("repo-2".to_string()),
+        "Repo 2".to_string(),
+        "repo-2".to_string(),
+        std::path::PathBuf::from("/tmp/repo2"),
+    );
+
+    let prefs1 = RepoPreferences {
+        issue_filter: IssueFilter {
+            state: Some(IssueFilterState::Closed),
+            ..IssueFilter::default()
+        },
+        pr_filter: PrFilter {
+            state: Some(PrFilterState::Merged),
+            ..PrFilter::default()
+        },
+        pr_search_query: "alpha".to_string(),
+        ..RepoPreferences::default()
+    };
+    let prefs2 = RepoPreferences {
+        issue_filter: IssueFilter {
+            state: Some(IssueFilterState::All),
+            ..IssueFilter::default()
+        },
+        ..RepoPreferences::default()
+    };
+
+    let persisted = State {
+        schema_version: STATE_SCHEMA_VERSION,
+        repositories: vec![repo1, repo2],
+        user_preferences: UserPreferences {
+            by_repo: vec![
+                (RepositoryId("repo-1".to_string()), prefs1),
+                (RepositoryId("repo-2".to_string()), prefs2),
+            ],
+        },
+        ..State::default_with_version()
+    };
+
+    let loaded = save_load_roundtrip(&persisted, "jefe_test_restart_hydration_prefs");
+
+    // Round-trip: both repos' prefs intact with correct states + search query.
+    let r1 = loaded
+        .user_preferences
+        .for_repo(&RepositoryId("repo-1".to_string()));
+    assert_eq!(r1.issue_filter.state, Some(IssueFilterState::Closed));
+    assert_eq!(r1.pr_filter.state, Some(PrFilterState::Merged));
+    assert_eq!(r1.pr_search_query, "alpha");
+
+    let r2 = loaded
+        .user_preferences
+        .for_repo(&RepositoryId("repo-2".to_string()));
+    assert_eq!(r2.issue_filter.state, Some(IssueFilterState::All));
+
+    // Simulate init_app_state's restore: copy loaded prefs onto fresh AppState.
+    verify_mode_entry_restore(&loaded);
+}
+
+/// Save and load a State through the real FilePersistenceManager into a temp
+/// dir tagged with `label`. Returns the deserialized State.
+fn save_load_roundtrip(persisted: &State, label: &str) -> State {
+    let temp = std::env::temp_dir().join(label);
+    let _ = std::fs::remove_dir_all(&temp);
+    let paths = PersistencePaths {
+        settings_path: temp.join("settings.toml"),
+        state_path: temp.join("state.json"),
+    };
+    let mgr = FilePersistenceManager::with_paths(paths);
+
+    mgr.save_state(persisted).value_or_panic("should save");
+    let loaded = mgr.load_state().value_or_panic("should load");
+
+    let _ = std::fs::remove_dir_all(&temp);
+    loaded
+}
+
+/// Given a loaded persistence::State, simulate init_app_state's restore onto a
+/// fresh AppState, then verify entering issues mode for each repo restores the
+/// correct per-repo filter state without cross-repo leakage.
+fn verify_mode_entry_restore(loaded: &State) {
+    use crate::domain::IssueFilterState;
+    use crate::state::{AppEvent, AppState};
+
+    let state = AppState {
+        repositories: loaded.repositories.clone(),
+        user_preferences: loaded.user_preferences.clone(),
+        selected_repository_index: Some(0),
+        ..AppState::default()
+    };
+
+    // repo-1 → Closed.
+    let state = state.apply(AppEvent::EnterIssuesMode);
+    assert_eq!(
+        state.issues_state.committed_filter.state,
+        Some(IssueFilterState::Closed)
+    );
+
+    // repo-2 → All (no leakage from repo-1).
+    let state = state.apply(AppEvent::ExitIssuesMode);
+    let state = state.apply(AppEvent::SelectRepository(1));
+    let state = state.apply(AppEvent::EnterIssuesMode);
+    assert_eq!(
+        state.issues_state.committed_filter.state,
+        Some(IssueFilterState::All)
+    );
+}
+
+/// A legacy state.json (without user_preferences) deserializes and then
+/// entering a mode gives Open defaults.
+#[test]
+fn restart_hydration_legacy_state_gives_open_defaults_on_mode_entry() {
+    use crate::domain::{IssueFilterState, RepositoryId};
+    use crate::state::{AppEvent, AppState};
+
+    let legacy_json = r#"{
+        "schema_version": 1,
+        "repositories": [
+            {
+                "id": "legacy-repo",
+                "name": "Legacy",
+                "slug": "legacy",
+                "base_dir": "/tmp/legacy",
+                "default_profile": "",
+                "agent_ids": []
+            }
+        ],
+        "agents": [],
+        "selected_repository_index": 0,
+        "selected_agent_index": null
+    }"#;
+    let loaded: State =
+        serde_json::from_str(legacy_json).value_or_panic("deserialize legacy state");
+
+    let state = AppState {
+        repositories: loaded.repositories.clone(),
+        user_preferences: loaded.user_preferences.clone(),
+        selected_repository_index: Some(0),
+        ..AppState::default()
+    };
+
+    let state = state.apply(AppEvent::EnterIssuesMode);
+    assert_eq!(
+        state.issues_state.committed_filter.state,
+        Some(IssueFilterState::Open)
+    );
+
+    // Ensure the repo is actually the one we loaded.
+    assert_eq!(
+        state.repositories[0].id,
+        RepositoryId("legacy-repo".to_string())
+    );
+}

--- a/src/persistence/tests.rs
+++ b/src/persistence/tests.rs
@@ -714,7 +714,7 @@ fn user_preferences_roundtrip() {
                 pr_search_query: "pr-search".to_string(),
                 issue_filter_field_index: 3,
                 pr_filter_field_index: 5,
-                last_merge_method: MergeMethod::Squash,
+                last_merge_method: Some(MergeMethod::Squash),
             },
         )],
     };

--- a/src/persistence/tests.rs
+++ b/src/persistence/tests.rs
@@ -684,8 +684,8 @@ fn resolve_config_dir_ignores_empty_env_values() {
 #[test]
 fn user_preferences_roundtrip() {
     use crate::domain::{
-        IssueFilter, IssueFilterState, MergeMethod, PrFilter, PrFilterState, RepoPreferences,
-        RepositoryId, UserPreferences,
+        ChecksFilter, IssueFilter, IssueFilterState, MergeMethod, PrFilter, PrFilterState,
+        RepoPreferences, RepositoryId, ReviewDecisionFilter, UserPreferences,
     };
 
     let prefs = UserPreferences {
@@ -695,10 +695,19 @@ fn user_preferences_roundtrip() {
                 issue_filter: IssueFilter {
                     state: Some(IssueFilterState::Closed),
                     author: "alice".to_string(),
+                    assignee: "bob".to_string(),
+                    labels: vec!["bug".to_string(), "ui".to_string()],
+                    milestone: "v1".to_string(),
                     ..IssueFilter::default()
                 },
                 pr_filter: PrFilter {
                     state: Some(PrFilterState::Merged),
+                    author: "carol".to_string(),
+                    reviewer: "dave".to_string(),
+                    is_draft: Some(true),
+                    review_decision: ReviewDecisionFilter::Approved,
+                    checks_status: ChecksFilter::Success,
+                    labels: vec!["needs-review".to_string()],
                     ..PrFilter::default()
                 },
                 issue_search_query: "issue-search".to_string(),
@@ -811,9 +820,11 @@ fn restart_hydration_preserves_per_repo_preferences() {
 }
 
 /// Save and load a State through the real FilePersistenceManager into a temp
-/// dir tagged with `label`. Returns the deserialized State.
+/// dir tagged with `label` and the current process id (so parallel test
+/// invocations never collide and a crash never leaves stale data for the next
+/// run). Returns the deserialized State.
 fn save_load_roundtrip(persisted: &State, label: &str) -> State {
-    let temp = std::env::temp_dir().join(label);
+    let temp = std::env::temp_dir().join(format!("{label}_{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&temp);
     let paths = PersistencePaths {
         settings_path: temp.join("settings.toml"),

--- a/src/state/issues_ops.rs
+++ b/src/state/issues_ops.rs
@@ -51,7 +51,11 @@ impl AppState {
         self.issues_state.committed_filter = prefs.issue_filter;
         self.issues_state.draft_filter = self.issues_state.committed_filter.clone();
         self.issues_state.search_query = prefs.issue_search_query;
-        self.issues_state.filter_ui.field_index = prefs.issue_filter_field_index;
+        // Clamp against the current field count so a stale/corrupted persisted
+        // index cannot drive the cursor out of bounds (issue #163).
+        self.issues_state.filter_ui.field_index = prefs
+            .issue_filter_field_index
+            .min(ISSUE_FILTER_FIELD_COUNT.saturating_sub(1));
     }
 
     /// Exit issues mode, restoring prior focus state.
@@ -182,6 +186,10 @@ impl AppState {
     /// @requirement REQ-PR-003
     /// @pseudocode component-001 lines 152-153
     fn navigate_repo_up_in_issues_mode(&mut self) {
+        // Persist the OLD repo's filter/search/cursor before move_repo_selection
+        // changes the selected index (issue #163). Idempotent on a no-op move.
+        self.remember_issue_preferences();
+        self.remember_issue_filter_field_index();
         if self.move_repo_selection(crate::messages::NavDir::Up) {
             self.reset_issues_for_repo_change();
         }
@@ -196,6 +204,10 @@ impl AppState {
     /// @requirement REQ-PR-003
     /// @pseudocode component-001 lines 152-153
     fn navigate_repo_down_in_issues_mode(&mut self) {
+        // Persist the OLD repo's filter/search/cursor before move_repo_selection
+        // changes the selected index (issue #163). Idempotent on a no-op move.
+        self.remember_issue_preferences();
+        self.remember_issue_filter_field_index();
         if self.move_repo_selection(crate::messages::NavDir::Down) {
             self.reset_issues_for_repo_change();
         }

--- a/src/state/issues_ops.rs
+++ b/src/state/issues_ops.rs
@@ -445,13 +445,15 @@ impl AppState {
         match event {
             AppEvent::OpenFilterControls => {
                 self.issues_state.filter_ui.controls_open = true;
-                let repo_id = self.current_repo_id();
-                let field_index = match &repo_id {
-                    Some(id) => self.user_preferences.for_repo(id).issue_filter_field_index,
-                    None => 0,
-                };
-                self.issues_state.filter_ui.field_index =
-                    field_index.min(ISSUE_FILTER_FIELD_COUNT.saturating_sub(1));
+                // field_index is kept in sync with per-repo prefs by
+                // restore_issue_preferences (mode entry) and
+                // remember_issue_filter_field_index (navigation), so the live
+                // value is already the persisted value; just clamp it.
+                self.issues_state.filter_ui.field_index = self
+                    .issues_state
+                    .filter_ui
+                    .field_index
+                    .min(ISSUE_FILTER_FIELD_COUNT.saturating_sub(1));
                 self.issues_state.filter_ui.draft_labels_text =
                     self.issues_state.draft_filter.labels.join(",");
             }

--- a/src/state/issues_ops.rs
+++ b/src/state/issues_ops.rs
@@ -189,7 +189,6 @@ impl AppState {
         // Persist the OLD repo's filter/search/cursor before move_repo_selection
         // changes the selected index (issue #163). Idempotent on a no-op move.
         self.remember_issue_preferences();
-        self.remember_issue_filter_field_index();
         if self.move_repo_selection(crate::messages::NavDir::Up) {
             self.reset_issues_for_repo_change();
         }
@@ -207,7 +206,6 @@ impl AppState {
         // Persist the OLD repo's filter/search/cursor before move_repo_selection
         // changes the selected index (issue #163). Idempotent on a no-op move.
         self.remember_issue_preferences();
-        self.remember_issue_filter_field_index();
         if self.move_repo_selection(crate::messages::NavDir::Down) {
             self.reset_issues_for_repo_change();
         }
@@ -467,19 +465,12 @@ impl AppState {
                 self.reload_issue_list_for_filter_change();
                 self.remember_issue_preferences();
             }
-            AppEvent::ClearFilter => {
-                self.issues_state.committed_filter = IssueFilter {
+            AppEvent::ClearFilter => self.clear_issue_filter(),
+            AppEvent::ClearDraftFilter => {
+                self.issues_state.draft_filter = IssueFilter {
                     state: Some(IssueFilterState::Open),
                     ..IssueFilter::default()
                 };
-                self.issues_state.draft_filter = self.issues_state.committed_filter.clone();
-                self.issues_state.filter_ui.draft_labels_text.clear();
-                self.issues_state.filter_ui.controls_open = false;
-                self.reload_issue_list_for_filter_change();
-                self.remember_issue_preferences();
-            }
-            AppEvent::ClearDraftFilter => {
-                self.issues_state.draft_filter = IssueFilter::default();
                 self.issues_state.filter_ui.draft_labels_text.clear();
             }
             AppEvent::FilterNavigateNext => {
@@ -504,6 +495,24 @@ impl AppState {
             _ => return false,
         }
         true
+    }
+
+    /// Reset the committed/draft filters to the Open default, clear the search
+    /// query, and persist the result (issue #163).
+    fn clear_issue_filter(&mut self) {
+        self.issues_state.committed_filter = IssueFilter {
+            state: Some(IssueFilterState::Open),
+            ..IssueFilter::default()
+        };
+        self.issues_state.draft_filter = self.issues_state.committed_filter.clone();
+        self.issues_state.filter_ui.draft_labels_text.clear();
+        self.issues_state.filter_ui.controls_open = false;
+        // Clearing all filters also clears the search query so the persisted
+        // state stays consistent.
+        self.issues_state.search_query.clear();
+        self.issues_state.search_input_focused = false;
+        self.reload_issue_list_for_filter_change();
+        self.remember_issue_preferences();
     }
 
     fn apply_agent_chooser_event(&mut self, event: AppEvent) -> bool {

--- a/src/state/issues_ops.rs
+++ b/src/state/issues_ops.rs
@@ -46,7 +46,7 @@ impl AppState {
         let repo_id = self.current_repo_id();
         let prefs = match &repo_id {
             Some(id) => self.user_preferences.for_repo(id),
-            None => crate::domain::RepoPreferences::with_open_defaults(),
+            None => crate::domain::RepoPreferences::default(),
         };
         self.issues_state.committed_filter = prefs.issue_filter;
         self.issues_state.draft_filter = self.issues_state.committed_filter.clone();
@@ -443,7 +443,10 @@ impl AppState {
                 self.issues_state.filter_ui.draft_labels_text =
                     self.issues_state.draft_filter.labels.join(",");
             }
-            AppEvent::CloseFilterControls => self.issues_state.filter_ui.controls_open = false,
+            AppEvent::CloseFilterControls => {
+                self.issues_state.filter_ui.controls_open = false;
+                self.remember_issue_filter_field_index();
+            }
             AppEvent::ApplyFilter => {
                 self.issues_state.committed_filter = self.issues_state.draft_filter.clone();
                 self.issues_state.filter_ui.controls_open = false;
@@ -451,8 +454,11 @@ impl AppState {
                 self.remember_issue_preferences();
             }
             AppEvent::ClearFilter => {
-                self.issues_state.committed_filter = IssueFilter::default();
-                self.issues_state.draft_filter = IssueFilter::default();
+                self.issues_state.committed_filter = IssueFilter {
+                    state: Some(IssueFilterState::Open),
+                    ..IssueFilter::default()
+                };
+                self.issues_state.draft_filter = self.issues_state.committed_filter.clone();
                 self.issues_state.filter_ui.draft_labels_text.clear();
                 self.issues_state.filter_ui.controls_open = false;
                 self.reload_issue_list_for_filter_change();
@@ -465,11 +471,13 @@ impl AppState {
             AppEvent::FilterNavigateNext => {
                 let idx = self.issues_state.filter_ui.field_index;
                 self.issues_state.filter_ui.field_index = (idx + 1) % ISSUE_FILTER_FIELD_COUNT;
+                self.remember_issue_filter_field_index();
             }
             AppEvent::FilterNavigatePrev => {
                 let idx = self.issues_state.filter_ui.field_index;
                 self.issues_state.filter_ui.field_index =
                     (idx + ISSUE_FILTER_FIELD_COUNT - 1) % ISSUE_FILTER_FIELD_COUNT;
+                self.remember_issue_filter_field_index();
             }
             AppEvent::CycleFilterState => {
                 let current = self.issues_state.draft_filter.state;

--- a/src/state/issues_ops.rs
+++ b/src/state/issues_ops.rs
@@ -34,10 +34,24 @@ impl AppState {
         self.issues_state.agent_chooser = None;
         self.issues_state.filter_ui.controls_open = false;
         self.issues_state.search_input_focused = false;
-        self.issues_state.search_query.clear();
+        self.restore_issue_preferences();
         self.issues_state.detail_subfocus = DetailSubfocus::Body;
         self.issues_state.draft_notice = None;
         self.issues_state.loading.list = true;
+    }
+
+    /// Restore the current repo's issue filter/search/field-index from
+    /// per-repo preferences (issue #163). Falls back to Open defaults.
+    fn restore_issue_preferences(&mut self) {
+        let repo_id = self.current_repo_id();
+        let prefs = match &repo_id {
+            Some(id) => self.user_preferences.for_repo(id),
+            None => crate::domain::RepoPreferences::with_open_defaults(),
+        };
+        self.issues_state.committed_filter = prefs.issue_filter;
+        self.issues_state.draft_filter = self.issues_state.committed_filter.clone();
+        self.issues_state.search_query = prefs.issue_search_query;
+        self.issues_state.filter_ui.field_index = prefs.issue_filter_field_index;
     }
 
     /// Exit issues mode, restoring prior focus state.
@@ -206,6 +220,7 @@ impl AppState {
         self.issues_state.list_page_pending = None;
         self.issues_state.detail_pending = None;
         self.issues_state.comments_page_pending = None;
+        self.restore_issue_preferences();
     }
 
     fn navigate_issue_list_up(&mut self) {
@@ -366,6 +381,7 @@ impl AppState {
                 self.issues_state.list_page_pending = None;
                 self.issues_state.mutation_pending = None;
                 self.issues_state.inline_state = InlineState::None;
+                self.remember_issue_preferences();
                 true
             }
             message => self.apply_issues_event(message.into()),
@@ -417,7 +433,13 @@ impl AppState {
         match event {
             AppEvent::OpenFilterControls => {
                 self.issues_state.filter_ui.controls_open = true;
-                self.issues_state.filter_ui.field_index = 0;
+                let repo_id = self.current_repo_id();
+                let field_index = match &repo_id {
+                    Some(id) => self.user_preferences.for_repo(id).issue_filter_field_index,
+                    None => 0,
+                };
+                self.issues_state.filter_ui.field_index =
+                    field_index.min(ISSUE_FILTER_FIELD_COUNT.saturating_sub(1));
                 self.issues_state.filter_ui.draft_labels_text =
                     self.issues_state.draft_filter.labels.join(",");
             }
@@ -426,6 +448,7 @@ impl AppState {
                 self.issues_state.committed_filter = self.issues_state.draft_filter.clone();
                 self.issues_state.filter_ui.controls_open = false;
                 self.reload_issue_list_for_filter_change();
+                self.remember_issue_preferences();
             }
             AppEvent::ClearFilter => {
                 self.issues_state.committed_filter = IssueFilter::default();
@@ -433,6 +456,7 @@ impl AppState {
                 self.issues_state.filter_ui.draft_labels_text.clear();
                 self.issues_state.filter_ui.controls_open = false;
                 self.reload_issue_list_for_filter_change();
+                self.remember_issue_preferences();
             }
             AppEvent::ClearDraftFilter => {
                 self.issues_state.draft_filter = IssueFilter::default();
@@ -527,7 +551,10 @@ impl AppState {
             }
             AppEvent::FocusSearchInput => self.issues_state.search_input_focused = true,
             AppEvent::BlurSearchInput => self.issues_state.search_input_focused = false,
-            AppEvent::ClearSearch => self.issues_state.search_query.clear(),
+            AppEvent::ClearSearch => {
+                self.issues_state.search_query.clear();
+                self.remember_issue_preferences();
+            }
             AppEvent::IssueListLoaded { .. }
             | AppEvent::IssueListPageLoaded { .. }
             | AppEvent::IssueDetailLoaded { .. }

--- a/src/state/issues_tests_detail.rs
+++ b/src/state/issues_tests_detail.rs
@@ -1,6 +1,4 @@
-use crate::domain::{
-    Issue, IssueComment, IssueDetail, IssueFilter, IssueState, Repository, RepositoryId,
-};
+use crate::domain::{Issue, IssueComment, IssueDetail, IssueState, Repository, RepositoryId};
 use crate::state::AppState;
 use crate::state::types::{
     AppEvent, ComposerTarget, DetailSubfocus, EditorTarget, InlineState, IssueFocus, ScreenMode,
@@ -135,9 +133,10 @@ fn test_mode_lifecycle_enter_browse_exit() {
     assert_eq!(state.issues_state.issue_focus, IssueFocus::IssueList);
 
     // Load issues
+    let filter = state.issues_state.committed_filter.clone();
     let state = state.apply(AppEvent::IssueListLoaded {
         scope_repo_id: RepositoryId("repo-1".to_string()),
-        filter: Box::new(IssueFilter::default()),
+        filter: Box::new(filter),
         request_id: 0,
         issues: vec![make_test_issue(1), make_test_issue(2), make_test_issue(3)],
         cursor: None,
@@ -166,10 +165,11 @@ fn test_mode_lifecycle_enter_interact_exit() {
     let state = issues_mode_state_with_repo("repo-1");
 
     // Load issues and open detail
+    let filter = state.issues_state.committed_filter.clone();
     let state = state
         .apply(AppEvent::IssueListLoaded {
             scope_repo_id: RepositoryId("repo-1".to_string()),
-            filter: Box::new(IssueFilter::default()),
+            filter: Box::new(filter),
             request_id: 0,
             issues: vec![make_test_issue(10)],
             cursor: None,
@@ -373,9 +373,10 @@ fn test_error_handling_auth_failure_blocks_ops() {
     let state = issues_mode_state_with_repo("repo-1");
     assert!(state.issues_state.active);
 
+    let filter = state.issues_state.committed_filter.clone();
     let state = state.apply(AppEvent::IssueListLoadFailed {
         scope_repo_id: RepositoryId("repo-1".to_string()),
-        filter: Box::new(IssueFilter::default()),
+        filter: Box::new(filter),
         request_id: 0,
         request_cursor: None,
         error: "authentication required: token expired".to_string(),
@@ -405,9 +406,10 @@ fn test_error_handling_network_error_stable_mode() {
     let state = issues_mode_state_with_repo("repo-1");
     let focus_before = state.issues_state.issue_focus;
 
+    let filter = state.issues_state.committed_filter.clone();
     let state = state.apply(AppEvent::IssueListLoadFailed {
         scope_repo_id: RepositoryId("repo-1".to_string()),
-        filter: Box::new(IssueFilter::default()),
+        filter: Box::new(filter),
         request_id: 0,
         request_cursor: None,
         error: "network timeout: connection refused".to_string(),
@@ -428,9 +430,11 @@ fn test_error_handling_network_error_stable_mode() {
 /// @requirement REQ-ISS-007
 #[test]
 fn test_pagination_issue_list_auto_load() {
-    let state = issues_mode_state_with_repo("repo-1").apply(AppEvent::IssueListLoaded {
+    let state = issues_mode_state_with_repo("repo-1");
+    let filter = state.issues_state.committed_filter.clone();
+    let state = state.apply(AppEvent::IssueListLoaded {
         scope_repo_id: RepositoryId("repo-1".to_string()),
-        filter: Box::new(IssueFilter::default()),
+        filter: Box::new(filter),
         request_id: 0,
         issues: vec![make_test_issue(1), make_test_issue(2)],
         cursor: Some("cursor-abc".to_string()),

--- a/src/state/issues_tests_detail_flow.rs
+++ b/src/state/issues_tests_detail_flow.rs
@@ -354,16 +354,16 @@ fn test_scope_change_invalidation() {
     state.selected_repository_index = Some(0);
 
     // Enter issues mode and load some issues for repo-1
-    let state = state
-        .apply(AppEvent::EnterIssuesMode)
-        .apply(AppEvent::IssueListLoaded {
-            scope_repo_id: RepositoryId("repo-1".to_string()),
-            filter: Box::new(IssueFilter::default()),
-            request_id: 0,
-            issues: vec![make_test_issue(1), make_test_issue(2)],
-            cursor: Some("cur".to_string()),
-            has_more: true,
-        });
+    let state = state.apply(AppEvent::EnterIssuesMode);
+    let filter = state.issues_state.committed_filter.clone();
+    let state = state.apply(AppEvent::IssueListLoaded {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        filter: Box::new(filter),
+        request_id: 0,
+        issues: vec![make_test_issue(1), make_test_issue(2)],
+        cursor: Some("cur".to_string()),
+        has_more: true,
+    });
     assert_eq!(state.issues_state.issues.len(), 2);
     assert!(state.issues_state.has_more_issues);
     assert!(!state.issues_state.loading.list);

--- a/src/state/issues_tests_filter.rs
+++ b/src/state/issues_tests_filter.rs
@@ -62,6 +62,21 @@ fn test_open_filter_preserves_field_index() {
     assert_eq!(state.issues_state.filter_ui.field_index, 3);
 }
 
+/// OpenFilterControls clamps an out-of-range field_index back into bounds.
+#[test]
+fn test_open_filter_clamps_out_of_range_field_index() {
+    let mut state = dashboard_issues_state();
+    state.issues_state.active = true;
+    state.issues_state.filter_ui.field_index = ISSUE_FILTER_FIELD_COUNT + 5;
+
+    let state = state.apply(AppEvent::OpenFilterControls);
+    assert_eq!(
+        state.issues_state.filter_ui.field_index,
+        ISSUE_FILTER_FIELD_COUNT - 1,
+        "out-of-range field_index must clamp to the last valid index"
+    );
+}
+
 /// FilterNavigateNext cycles through every configured filter field.
 #[test]
 fn test_filter_navigate_next_cycles() {

--- a/src/state/issues_tests_filter.rs
+++ b/src/state/issues_tests_filter.rs
@@ -298,11 +298,20 @@ fn test_clear_filter_fresh_list_loaded_selects_first_issue() {
 
     let state = state.apply(AppEvent::ClearFilter);
     assert!(state.issues_state.loading.list);
-    assert_eq!(state.issues_state.committed_filter, IssueFilter::default());
+    assert_eq!(
+        state.issues_state.committed_filter,
+        IssueFilter {
+            state: Some(IssueFilterState::Open),
+            ..IssueFilter::default()
+        }
+    );
 
     let state = state.apply(AppEvent::IssueListLoaded {
         scope_repo_id: RepositoryId("repo-1".to_string()),
-        filter: Box::new(IssueFilter::default()),
+        filter: Box::new(IssueFilter {
+            state: Some(IssueFilterState::Open),
+            ..IssueFilter::default()
+        }),
         request_id: 0,
         issues: vec![make_test_issue(3)],
         cursor: None,

--- a/src/state/issues_tests_filter.rs
+++ b/src/state/issues_tests_filter.rs
@@ -49,16 +49,17 @@ fn state_with_repo() -> AppState {
     state
 }
 
-/// OpenFilterControls resets filter_field_index to 0.
+/// OpenFilterControls preserves the live filter_field_index (issue #163: the
+/// cursor remembers its last position, clamped to the valid field range).
 #[test]
-fn test_open_filter_resets_field_index() {
+fn test_open_filter_preserves_field_index() {
     let mut state = dashboard_issues_state();
     state.issues_state.active = true;
     state.issues_state.filter_ui.field_index = 3;
 
     let state = state.apply(AppEvent::OpenFilterControls);
     assert!(state.issues_state.filter_ui.controls_open);
-    assert_eq!(state.issues_state.filter_ui.field_index, 0);
+    assert_eq!(state.issues_state.filter_ui.field_index, 3);
 }
 
 /// FilterNavigateNext cycles through every configured filter field.

--- a/src/state/issues_tests_filter.rs
+++ b/src/state/issues_tests_filter.rs
@@ -253,7 +253,14 @@ fn test_clear_draft_filter_keeps_controls_open_and_resets_draft() {
 
     let state = populated.apply(AppEvent::ClearDraftFilter);
 
-    assert_eq!(state.issues_state.draft_filter, IssueFilter::default());
+    // ClearDraftFilter resets the draft to the Open default (issue #163).
+    assert_eq!(
+        state.issues_state.draft_filter,
+        IssueFilter {
+            state: Some(IssueFilterState::Open),
+            ..IssueFilter::default()
+        }
+    );
     assert_eq!(
         state.issues_state.committed_filter.author,
         "committed-author"

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -110,11 +110,12 @@ impl AppState {
             .and_then(|idx| self.repositories.get(idx).map(|repo| &repo.id))
     }
 
-    /// Clone the currently-selected repository id (issue #163).
+    /// Clone the currently-selected repository id (issue #163). Thin wrapper
+    /// over `selected_repository_id` for the `remember_*` helpers, which need
+    /// an owned id to resolve the borrow conflict between reading
+    /// `self.repositories` and mutating `self.user_preferences`.
     pub(super) fn current_repo_id(&self) -> Option<RepositoryId> {
-        self.selected_repository_index
-            .and_then(|idx| self.repositories.get(idx))
-            .map(|r| r.id.clone())
+        self.selected_repository_id().cloned()
     }
 
     /// Snapshot the current issue filter/search/field-index into per-repo
@@ -156,7 +157,7 @@ impl AppState {
         if let Some(repo_id) = self.current_repo_id() {
             self.user_preferences
                 .update_field_for_repo(&repo_id, |prefs| {
-                    prefs.last_merge_method = method;
+                    prefs.last_merge_method = Some(method);
                 });
         }
     }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -35,7 +35,7 @@ pub use types::*;
 use tracing::{debug, trace};
 
 use crate::domain::{Agent, AgentId, AgentStatus};
-use crate::domain::{Repository, RepositoryId};
+use crate::domain::{MergeMethod, Repository, RepositoryId};
 use crate::messages::{
     AppMessage, MessageRoute, PersistenceMessage, RuntimeMessage, SystemMessage, ThemeMessage,
     UiNavigationMessage,
@@ -108,6 +108,50 @@ impl AppState {
     fn selected_repository_id(&self) -> Option<&RepositoryId> {
         self.selected_repository_index
             .and_then(|idx| self.repositories.get(idx).map(|repo| &repo.id))
+    }
+
+    /// Clone the currently-selected repository id (issue #163).
+    pub(super) fn current_repo_id(&self) -> Option<RepositoryId> {
+        self.selected_repository_index
+            .and_then(|idx| self.repositories.get(idx))
+            .map(|r| r.id.clone())
+    }
+
+    /// Snapshot the current issue filter/search/field-index into per-repo
+    /// preferences (issue #163). No-op when no repo is selected.
+    pub(super) fn remember_issue_preferences(&mut self) {
+        if let Some(repo_id) = self.current_repo_id() {
+            let mut prefs = self.user_preferences.for_repo(&repo_id);
+            prefs.issue_filter = self.issues_state.committed_filter.clone();
+            prefs
+                .issue_search_query
+                .clone_from(&self.issues_state.search_query);
+            prefs.issue_filter_field_index = self.issues_state.filter_ui.field_index;
+            self.user_preferences.update_for_repo(repo_id, prefs);
+        }
+    }
+
+    /// Snapshot the current PR filter/search/field-index into per-repo
+    /// preferences (issue #163). No-op when no repo is selected.
+    pub(super) fn remember_pr_preferences(&mut self) {
+        if let Some(repo_id) = self.current_repo_id() {
+            let mut prefs = self.user_preferences.for_repo(&repo_id);
+            prefs.pr_filter = self.prs_state.committed_filter.clone();
+            prefs
+                .pr_search_query
+                .clone_from(&self.prs_state.search_query);
+            prefs.pr_filter_field_index = self.prs_state.filter_ui.field_index;
+            self.user_preferences.update_for_repo(repo_id, prefs);
+        }
+    }
+
+    /// Record the confirmed merge method for the current repo (issue #163).
+    pub(super) fn remember_merge_method(&mut self, method: MergeMethod) {
+        if let Some(repo_id) = self.current_repo_id() {
+            let mut prefs = self.user_preferences.for_repo(&repo_id);
+            prefs.last_merge_method = method;
+            self.user_preferences.update_for_repo(repo_id, prefs);
+        }
     }
 
     #[must_use]
@@ -862,6 +906,11 @@ mod prs_tests_merge;
 #[cfg(test)]
 #[path = "prs_tests_filter.rs"]
 mod prs_tests_filter;
+
+// Per-repository user-preference persistence tests (issue #163).
+#[cfg(test)]
+#[path = "preferences_tests.rs"]
+mod preferences_tests;
 
 #[cfg(test)]
 #[path = "prs_tests_repo_nav.rs"]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -127,7 +127,7 @@ impl AppState {
                 .issue_search_query
                 .clone_from(&self.issues_state.search_query);
             prefs.issue_filter_field_index = self.issues_state.filter_ui.field_index;
-            self.user_preferences.update_for_repo(repo_id, prefs);
+            self.user_preferences.update_for_repo(&repo_id, prefs);
         }
     }
 
@@ -141,7 +141,7 @@ impl AppState {
                 .pr_search_query
                 .clone_from(&self.prs_state.search_query);
             prefs.pr_filter_field_index = self.prs_state.filter_ui.field_index;
-            self.user_preferences.update_for_repo(repo_id, prefs);
+            self.user_preferences.update_for_repo(&repo_id, prefs);
         }
     }
 
@@ -150,7 +150,27 @@ impl AppState {
         if let Some(repo_id) = self.current_repo_id() {
             let mut prefs = self.user_preferences.for_repo(&repo_id);
             prefs.last_merge_method = method;
-            self.user_preferences.update_for_repo(repo_id, prefs);
+            self.user_preferences.update_for_repo(&repo_id, prefs);
+        }
+    }
+
+    /// Snapshot the current PR filter field-index into per-repo preferences
+    /// (issue #163). No-op when no repo is selected.
+    pub(super) fn remember_pr_filter_field_index(&mut self) {
+        if let Some(repo_id) = self.current_repo_id() {
+            let mut prefs = self.user_preferences.for_repo(&repo_id);
+            prefs.pr_filter_field_index = self.prs_state.filter_ui.field_index;
+            self.user_preferences.update_for_repo(&repo_id, prefs);
+        }
+    }
+
+    /// Snapshot the current issue filter field-index into per-repo preferences
+    /// (issue #163). No-op when no repo is selected.
+    pub(super) fn remember_issue_filter_field_index(&mut self) {
+        if let Some(repo_id) = self.current_repo_id() {
+            let mut prefs = self.user_preferences.for_repo(&repo_id);
+            prefs.issue_filter_field_index = self.issues_state.filter_ui.field_index;
+            self.user_preferences.update_for_repo(&repo_id, prefs);
         }
     }
 
@@ -417,6 +437,10 @@ impl AppState {
                         .iter()
                         .any(|agent| agent.id == *agent_id && agent.repository_id == *repo_id)
             });
+
+        self.user_preferences
+            .by_repo
+            .retain(|(repo_id, _)| self.repositories.iter().any(|repo| repo.id == *repo_id));
 
         trace!(
             message_domain = ?route.domain,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -120,37 +120,44 @@ impl AppState {
     /// Snapshot the current issue filter/search/field-index into per-repo
     /// preferences (issue #163). No-op when no repo is selected.
     pub(super) fn remember_issue_preferences(&mut self) {
-        if let Some(repo_id) = self.current_repo_id() {
-            let mut prefs = self.user_preferences.for_repo(&repo_id);
-            prefs.issue_filter = self.issues_state.committed_filter.clone();
-            prefs
-                .issue_search_query
-                .clone_from(&self.issues_state.search_query);
-            prefs.issue_filter_field_index = self.issues_state.filter_ui.field_index;
-            self.user_preferences.update_for_repo(&repo_id, prefs);
-        }
+        let Some(repo_id) = self.current_repo_id() else {
+            return;
+        };
+        let filter = self.issues_state.committed_filter.clone();
+        let search_query = self.issues_state.search_query.clone();
+        let field_index = self.issues_state.filter_ui.field_index;
+        self.user_preferences
+            .update_field_for_repo(&repo_id, |prefs| {
+                prefs.issue_filter = filter;
+                prefs.issue_search_query = search_query;
+                prefs.issue_filter_field_index = field_index;
+            });
     }
 
     /// Snapshot the current PR filter/search/field-index into per-repo
     /// preferences (issue #163). No-op when no repo is selected.
     pub(super) fn remember_pr_preferences(&mut self) {
-        if let Some(repo_id) = self.current_repo_id() {
-            let mut prefs = self.user_preferences.for_repo(&repo_id);
-            prefs.pr_filter = self.prs_state.committed_filter.clone();
-            prefs
-                .pr_search_query
-                .clone_from(&self.prs_state.search_query);
-            prefs.pr_filter_field_index = self.prs_state.filter_ui.field_index;
-            self.user_preferences.update_for_repo(&repo_id, prefs);
-        }
+        let Some(repo_id) = self.current_repo_id() else {
+            return;
+        };
+        let filter = self.prs_state.committed_filter.clone();
+        let search_query = self.prs_state.search_query.clone();
+        let field_index = self.prs_state.filter_ui.field_index;
+        self.user_preferences
+            .update_field_for_repo(&repo_id, |prefs| {
+                prefs.pr_filter = filter;
+                prefs.pr_search_query = search_query;
+                prefs.pr_filter_field_index = field_index;
+            });
     }
 
     /// Record the confirmed merge method for the current repo (issue #163).
     pub(super) fn remember_merge_method(&mut self, method: MergeMethod) {
         if let Some(repo_id) = self.current_repo_id() {
-            let mut prefs = self.user_preferences.for_repo(&repo_id);
-            prefs.last_merge_method = method;
-            self.user_preferences.update_for_repo(&repo_id, prefs);
+            self.user_preferences
+                .update_field_for_repo(&repo_id, |prefs| {
+                    prefs.last_merge_method = method;
+                });
         }
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -155,22 +155,28 @@ impl AppState {
     }
 
     /// Snapshot the current PR filter field-index into per-repo preferences
-    /// (issue #163). No-op when no repo is selected.
+    /// (issue #163). Uses in-place mutation since this fires on every cursor
+    /// keystroke. No-op when no repo is selected.
     pub(super) fn remember_pr_filter_field_index(&mut self) {
         if let Some(repo_id) = self.current_repo_id() {
-            let mut prefs = self.user_preferences.for_repo(&repo_id);
-            prefs.pr_filter_field_index = self.prs_state.filter_ui.field_index;
-            self.user_preferences.update_for_repo(&repo_id, prefs);
+            let idx = self.prs_state.filter_ui.field_index;
+            self.user_preferences
+                .update_field_for_repo(&repo_id, |prefs| {
+                    prefs.pr_filter_field_index = idx;
+                });
         }
     }
 
     /// Snapshot the current issue filter field-index into per-repo preferences
-    /// (issue #163). No-op when no repo is selected.
+    /// (issue #163). Uses in-place mutation since this fires on every cursor
+    /// keystroke. No-op when no repo is selected.
     pub(super) fn remember_issue_filter_field_index(&mut self) {
         if let Some(repo_id) = self.current_repo_id() {
-            let mut prefs = self.user_preferences.for_repo(&repo_id);
-            prefs.issue_filter_field_index = self.issues_state.filter_ui.field_index;
-            self.user_preferences.update_for_repo(&repo_id, prefs);
+            let idx = self.issues_state.filter_ui.field_index;
+            self.user_preferences
+                .update_field_for_repo(&repo_id, |prefs| {
+                    prefs.issue_filter_field_index = idx;
+                });
         }
     }
 
@@ -437,10 +443,6 @@ impl AppState {
                         .iter()
                         .any(|agent| agent.id == *agent_id && agent.repository_id == *repo_id)
             });
-
-        self.user_preferences
-            .by_repo
-            .retain(|(repo_id, _)| self.repositories.iter().any(|repo| repo.id == *repo_id));
 
         trace!(
             message_domain = ?route.domain,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -14,6 +14,8 @@ mod issues_load_ops;
 mod issues_mutation_ops;
 mod issues_ops;
 mod modal_ops;
+// Per-repository user-preference snapshot/restore operations (issue #163).
+mod preferences_ops;
 // @plan PLAN-20260624-PR-MODE.P03
 // @requirement REQ-PR-001
 mod prs_inline_ops;
@@ -35,7 +37,7 @@ pub use types::*;
 use tracing::{debug, trace};
 
 use crate::domain::{Agent, AgentId, AgentStatus};
-use crate::domain::{MergeMethod, Repository, RepositoryId};
+use crate::domain::{Repository, RepositoryId};
 use crate::messages::{
     AppMessage, MessageRoute, PersistenceMessage, RuntimeMessage, SystemMessage, ThemeMessage,
     UiNavigationMessage,
@@ -108,84 +110,6 @@ impl AppState {
     fn selected_repository_id(&self) -> Option<&RepositoryId> {
         self.selected_repository_index
             .and_then(|idx| self.repositories.get(idx).map(|repo| &repo.id))
-    }
-
-    /// Clone the currently-selected repository id (issue #163). Thin wrapper
-    /// over `selected_repository_id` for the `remember_*` helpers, which need
-    /// an owned id to resolve the borrow conflict between reading
-    /// `self.repositories` and mutating `self.user_preferences`.
-    pub(super) fn current_repo_id(&self) -> Option<RepositoryId> {
-        self.selected_repository_id().cloned()
-    }
-
-    /// Snapshot the current issue filter/search/field-index into per-repo
-    /// preferences (issue #163). No-op when no repo is selected.
-    pub(super) fn remember_issue_preferences(&mut self) {
-        let Some(repo_id) = self.current_repo_id() else {
-            return;
-        };
-        let filter = self.issues_state.committed_filter.clone();
-        let search_query = self.issues_state.search_query.clone();
-        let field_index = self.issues_state.filter_ui.field_index;
-        self.user_preferences
-            .update_field_for_repo(&repo_id, |prefs| {
-                prefs.issue_filter = filter;
-                prefs.issue_search_query = search_query;
-                prefs.issue_filter_field_index = field_index;
-            });
-    }
-
-    /// Snapshot the current PR filter/search/field-index into per-repo
-    /// preferences (issue #163). No-op when no repo is selected.
-    pub(super) fn remember_pr_preferences(&mut self) {
-        let Some(repo_id) = self.current_repo_id() else {
-            return;
-        };
-        let filter = self.prs_state.committed_filter.clone();
-        let search_query = self.prs_state.search_query.clone();
-        let field_index = self.prs_state.filter_ui.field_index;
-        self.user_preferences
-            .update_field_for_repo(&repo_id, |prefs| {
-                prefs.pr_filter = filter;
-                prefs.pr_search_query = search_query;
-                prefs.pr_filter_field_index = field_index;
-            });
-    }
-
-    /// Record the confirmed merge method for the current repo (issue #163).
-    pub(super) fn remember_merge_method(&mut self, method: MergeMethod) {
-        if let Some(repo_id) = self.current_repo_id() {
-            self.user_preferences
-                .update_field_for_repo(&repo_id, |prefs| {
-                    prefs.last_merge_method = Some(method);
-                });
-        }
-    }
-
-    /// Snapshot the current PR filter field-index into per-repo preferences
-    /// (issue #163). Uses in-place mutation since this fires on every cursor
-    /// keystroke. No-op when no repo is selected.
-    pub(super) fn remember_pr_filter_field_index(&mut self) {
-        if let Some(repo_id) = self.current_repo_id() {
-            let idx = self.prs_state.filter_ui.field_index;
-            self.user_preferences
-                .update_field_for_repo(&repo_id, |prefs| {
-                    prefs.pr_filter_field_index = idx;
-                });
-        }
-    }
-
-    /// Snapshot the current issue filter field-index into per-repo preferences
-    /// (issue #163). Uses in-place mutation since this fires on every cursor
-    /// keystroke. No-op when no repo is selected.
-    pub(super) fn remember_issue_filter_field_index(&mut self) {
-        if let Some(repo_id) = self.current_repo_id() {
-            let idx = self.issues_state.filter_ui.field_index;
-            self.user_preferences
-                .update_field_for_repo(&repo_id, |prefs| {
-                    prefs.issue_filter_field_index = idx;
-                });
-        }
     }
 
     #[must_use]
@@ -568,18 +492,11 @@ impl AppState {
         if idx < self.repositories.len()
             && (!self.hide_idle_repositories || self.visible_repository_indices().contains(&idx))
         {
+            let prev_repo_id = self.current_repo_id();
             self.remember_selected_agent_for_current_repo();
             self.selected_repository_index = Some(idx);
             self.restore_selected_agent_for_current_repo();
-
-            if self.issues_state.active {
-                self.reset_issues_for_repo_change();
-            }
-            // @plan PLAN-20260624-PR-MODE.P05
-            // @requirement REQ-PR-003
-            if self.prs_state.active {
-                self.reset_prs_for_repo_change();
-            }
+            self.sync_preferences_for_repo_change(prev_repo_id);
         }
     }
 
@@ -657,12 +574,14 @@ impl AppState {
             && (!self.hide_idle_repositories
                 || self.visible_repository_indices().contains(&target_repo_idx))
         {
+            let prev_repo_id = self.current_repo_id();
             self.remember_selected_agent_for_current_repo();
             self.selected_repository_index = Some(target_repo_idx);
             self.selected_agent_index = Some(agent_idx);
             self.pane_focus = PaneFocus::Agents;
             self.terminal_focused = false;
             self.remember_selected_agent_for_current_repo();
+            self.sync_preferences_for_repo_change(prev_repo_id);
         }
     }
 

--- a/src/state/preferences_ops.rs
+++ b/src/state/preferences_ops.rs
@@ -1,0 +1,141 @@
+//! Per-repository user-preference snapshot/restore operations (issue #163).
+//!
+//! Owns the read/write bridge between the live issues/PRs filter+search state
+//! and the persisted [`UserPreferences`] map keyed by [`RepositoryId`]. All
+//! methods are pure state transitions — disk persistence happens in the
+//! app-shell layer after the reducer runs.
+//!
+//! `sync_preferences_for_repo_change` is the single chokepoint that prevents
+//! filters from leaking across repos when the selected repository changes via
+//! any path (dashboard select, jump-to-agent, etc.).
+
+use crate::domain::{MergeMethod, RepositoryId};
+use crate::state::AppState;
+
+impl AppState {
+    /// Clone the currently-selected repository id (issue #163). Thin wrapper
+    /// over `selected_repository_id` for the `remember_*` helpers, which need
+    /// an owned id to resolve the borrow conflict between reading
+    /// `self.repositories` and mutating `self.user_preferences`.
+    pub(super) fn current_repo_id(&self) -> Option<RepositoryId> {
+        self.selected_repository_id().cloned()
+    }
+
+    /// Persist the OLD repo's live filter/search and restore the NEW repo's
+    /// preferences when the selected repository changes while a list mode
+    /// (issues or PRs) is active (issue #163 per-repo isolation).
+    ///
+    /// `prev_repo_id` is the repo that was selected BEFORE the index changed;
+    /// it receives a final snapshot of the live filter/search/field-index so
+    /// uncommitted selections are not silently discarded. The new repo's
+    /// stored preferences are then restored into the live state. This is the
+    /// single chokepoint that prevents filters from leaking across repos via
+    /// any repo-selection path (dashboard select, jump-to-agent, etc.).
+    pub(super) fn sync_preferences_for_repo_change(&mut self, prev_repo_id: Option<RepositoryId>) {
+        let new_repo_id = self.current_repo_id();
+        if new_repo_id == prev_repo_id {
+            return;
+        }
+        // Snapshot the OLD repo's live selections into its stored preferences
+        // before the new repo's preferences overwrite the live state.
+        if let Some(old_id) = prev_repo_id {
+            if self.issues_state.active {
+                self.remember_issue_preferences_for(&old_id);
+            }
+            if self.prs_state.active {
+                self.remember_pr_preferences_for(&old_id);
+            }
+        }
+        // Restore the NEW repo's stored preferences into the live state.
+        if self.issues_state.active {
+            self.reset_issues_for_repo_change();
+        }
+        if self.prs_state.active {
+            self.reset_prs_for_repo_change();
+        }
+    }
+
+    /// Snapshot the current issue filter/search/field-index into per-repo
+    /// preferences (issue #163). No-op when no repo is selected.
+    pub(super) fn remember_issue_preferences(&mut self) {
+        let Some(repo_id) = self.current_repo_id() else {
+            return;
+        };
+        self.remember_issue_preferences_for(&repo_id);
+    }
+
+    /// Snapshot the current issue filter/search/field-index into the
+    /// preferences for an EXPLICIT repo id (issue #163). Used by
+    /// `sync_preferences_for_repo_change` to persist the OLD repo's live
+    /// selections before the new repo's preferences overwrite them.
+    fn remember_issue_preferences_for(&mut self, repo_id: &RepositoryId) {
+        let filter = self.issues_state.committed_filter.clone();
+        let search_query = self.issues_state.search_query.clone();
+        let field_index = self.issues_state.filter_ui.field_index;
+        self.user_preferences
+            .update_field_for_repo(repo_id, |prefs| {
+                prefs.issue_filter = filter;
+                prefs.issue_search_query = search_query;
+                prefs.issue_filter_field_index = field_index;
+            });
+    }
+
+    /// Snapshot the current PR filter/search/field-index into per-repo
+    /// preferences (issue #163). No-op when no repo is selected.
+    pub(super) fn remember_pr_preferences(&mut self) {
+        let Some(repo_id) = self.current_repo_id() else {
+            return;
+        };
+        self.remember_pr_preferences_for(&repo_id);
+    }
+
+    /// Snapshot the current PR filter/search/field-index into the preferences
+    /// for an EXPLICIT repo id (issue #163). See `remember_issue_preferences_for`.
+    fn remember_pr_preferences_for(&mut self, repo_id: &RepositoryId) {
+        let filter = self.prs_state.committed_filter.clone();
+        let search_query = self.prs_state.search_query.clone();
+        let field_index = self.prs_state.filter_ui.field_index;
+        self.user_preferences
+            .update_field_for_repo(repo_id, |prefs| {
+                prefs.pr_filter = filter;
+                prefs.pr_search_query = search_query;
+                prefs.pr_filter_field_index = field_index;
+            });
+    }
+
+    /// Record the confirmed merge method for the current repo (issue #163).
+    pub(super) fn remember_merge_method(&mut self, method: MergeMethod) {
+        if let Some(repo_id) = self.current_repo_id() {
+            self.user_preferences
+                .update_field_for_repo(&repo_id, |prefs| {
+                    prefs.last_merge_method = Some(method);
+                });
+        }
+    }
+
+    /// Snapshot the current PR filter field-index into per-repo preferences
+    /// (issue #163). Uses in-place mutation since this fires on every cursor
+    /// keystroke. No-op when no repo is selected.
+    pub(super) fn remember_pr_filter_field_index(&mut self) {
+        if let Some(repo_id) = self.current_repo_id() {
+            let idx = self.prs_state.filter_ui.field_index;
+            self.user_preferences
+                .update_field_for_repo(&repo_id, |prefs| {
+                    prefs.pr_filter_field_index = idx;
+                });
+        }
+    }
+
+    /// Snapshot the current issue filter field-index into per-repo preferences
+    /// (issue #163). Uses in-place mutation since this fires on every cursor
+    /// keystroke. No-op when no repo is selected.
+    pub(super) fn remember_issue_filter_field_index(&mut self) {
+        if let Some(repo_id) = self.current_repo_id() {
+            let idx = self.issues_state.filter_ui.field_index;
+            self.user_preferences
+                .update_field_for_repo(&repo_id, |prefs| {
+                    prefs.issue_filter_field_index = idx;
+                });
+        }
+    }
+}

--- a/src/state/preferences_tests.rs
+++ b/src/state/preferences_tests.rs
@@ -26,7 +26,7 @@ fn state_with_repo_and_prefs(repo_id: &str, prefs: RepoPreferences) -> AppState 
     state.selected_repository_index = Some(0);
     state
         .user_preferences
-        .update_for_repo(RepositoryId(repo_id.to_string()), prefs);
+        .update_for_repo(&RepositoryId(repo_id.to_string()), prefs);
     state
 }
 
@@ -53,10 +53,10 @@ fn state_with_two_repos(
     state.selected_repository_index = Some(0);
     state
         .user_preferences
-        .update_for_repo(RepositoryId(repo1.to_string()), prefs1);
+        .update_for_repo(&RepositoryId(repo1.to_string()), prefs1);
     state
         .user_preferences
-        .update_for_repo(RepositoryId(repo2.to_string()), prefs2);
+        .update_for_repo(&RepositoryId(repo2.to_string()), prefs2);
     state
 }
 
@@ -137,7 +137,8 @@ fn pr_apply_filter_persists_to_prefs() {
     let stored = state
         .user_preferences
         .for_repo(&RepositoryId("repo-1".to_string()));
-    assert_eq!(stored.pr_filter, state.prs_state.committed_filter);
+    assert_eq!(stored.pr_filter.state, Some(PrFilterState::Closed));
+    assert_eq!(stored.pr_filter.author, "alice");
 }
 
 #[test]
@@ -266,7 +267,7 @@ fn issue_apply_filter_persists() {
     let stored = state
         .user_preferences
         .for_repo(&RepositoryId("repo-1".to_string()));
-    assert_eq!(stored.issue_filter, state.issues_state.committed_filter);
+    assert_eq!(stored.issue_filter.author, "alice");
 }
 
 #[test]
@@ -279,7 +280,14 @@ fn issue_clear_filter_persists() {
     let stored = state
         .user_preferences
         .for_repo(&RepositoryId("repo-1".to_string()));
-    assert_eq!(stored.issue_filter, state.issues_state.committed_filter);
+    assert_eq!(stored.issue_filter.state, Some(IssueFilterState::Open));
+    assert_eq!(
+        stored.issue_filter,
+        IssueFilter {
+            state: Some(IssueFilterState::Open),
+            ..IssueFilter::default()
+        }
+    );
 }
 
 // ── Merge chooser restore + persist ──────────────────────────────────────
@@ -293,7 +301,7 @@ fn merge_chooser_restores_last_method() {
     let mut state = prs_state_with_detail("repo-1", 42);
     state
         .user_preferences
-        .update_for_repo(RepositoryId("repo-1".to_string()), prefs);
+        .update_for_repo(&RepositoryId("repo-1".to_string()), prefs);
 
     let state = state.apply(AppEvent::PrOpenMergeChooser);
     let selected = state
@@ -342,7 +350,7 @@ fn merge_methods_loaded_clamps_disabled_last_method() {
     let mut state = prs_state_with_detail("repo-1", 42);
     state
         .user_preferences
-        .update_for_repo(RepositoryId("repo-1".to_string()), prefs);
+        .update_for_repo(&RepositoryId("repo-1".to_string()), prefs);
 
     let state = state.apply(AppEvent::PrOpenMergeChooser);
     let state = state.apply(AppEvent::PrMergeMethodsLoaded {
@@ -370,7 +378,7 @@ fn merge_methods_loaded_keeps_last_method_when_allowed() {
     let mut state = prs_state_with_detail("repo-1", 42);
     state
         .user_preferences
-        .update_for_repo(RepositoryId("repo-1".to_string()), prefs);
+        .update_for_repo(&RepositoryId("repo-1".to_string()), prefs);
 
     let state = state.apply(AppEvent::PrOpenMergeChooser);
     let state = state.apply(AppEvent::PrMergeMethodsLoaded {
@@ -401,7 +409,7 @@ fn user_preferences_update_for_repo_upserts() {
     let mut prefs = UserPreferences::default();
     let repo = RepositoryId("repo-1".to_string());
     prefs.update_for_repo(
-        repo.clone(),
+        &repo,
         RepoPreferences {
             pr_search_query: "first".to_string(),
             ..RepoPreferences::default()
@@ -411,7 +419,7 @@ fn user_preferences_update_for_repo_upserts() {
 
     // Upsert replaces existing entry.
     prefs.update_for_repo(
-        repo.clone(),
+        &repo,
         RepoPreferences {
             pr_search_query: "second".to_string(),
             ..RepoPreferences::default()
@@ -419,4 +427,62 @@ fn user_preferences_update_for_repo_upserts() {
     );
     assert_eq!(prefs.by_repo.len(), 1);
     assert_eq!(prefs.for_repo(&repo).pr_search_query, "second");
+}
+
+// ── FIX 5: RepoPreferences Default produces Open filters ─────────────────
+
+#[test]
+fn repo_preferences_default_has_open_filters() {
+    let prefs = RepoPreferences::default();
+    assert_eq!(prefs.issue_filter.state, Some(IssueFilterState::Open));
+    assert_eq!(prefs.pr_filter.state, Some(PrFilterState::Open));
+}
+
+#[test]
+fn partial_repo_preferences_deserializes_to_open_filters() {
+    let json = serde_json::json!({
+        "issue_search_query": "needle",
+    });
+    let prefs: RepoPreferences =
+        serde_json::from_value(json).unwrap_or_else(|e| panic!("deserialize partial: {e:?}"));
+    assert_eq!(prefs.issue_filter.state, Some(IssueFilterState::Open));
+    assert_eq!(prefs.pr_filter.state, Some(PrFilterState::Open));
+    assert_eq!(prefs.issue_search_query, "needle");
+}
+
+// ── FIX 6: Deleted repo prunes its preferences ───────────────────────────
+
+#[test]
+fn deleted_repo_prunes_its_preferences() {
+    use crate::state::delete_selected_repository;
+
+    let prefs1 = RepoPreferences {
+        issue_search_query: "repo1-search".to_string(),
+        ..RepoPreferences::default()
+    };
+    let prefs2 = RepoPreferences {
+        issue_search_query: "repo2-search".to_string(),
+        ..RepoPreferences::default()
+    };
+    let mut state = state_with_two_repos("repo-1", prefs1, "repo-2", prefs2);
+
+    // Delete repo-1. delete_selected_repository removes it from self.repositories.
+    delete_selected_repository(&mut state, &RepositoryId("repo-1".to_string()));
+
+    // finalize_message (run after any apply_message) prunes stale prefs.
+    // Drive it with a benign selection event.
+    let state = state.apply(AppEvent::SelectRepository(0));
+
+    // repo-1 prefs should be gone, repo-2 prefs should remain.
+    assert!(
+        state
+            .user_preferences
+            .by_repo
+            .iter()
+            .all(|(id, _)| id != &RepositoryId("repo-1".to_string()))
+    );
+    let repo2_prefs = state
+        .user_preferences
+        .for_repo(&RepositoryId("repo-2".to_string()));
+    assert_eq!(repo2_prefs.issue_search_query, "repo2-search");
 }

--- a/src/state/preferences_tests.rs
+++ b/src/state/preferences_tests.rs
@@ -155,7 +155,7 @@ fn pr_clear_filter_persists_open_default() {
 }
 
 #[test]
-fn pr_open_filter_controls_restores_field_index() {
+fn pr_open_filter_controls_keeps_restored_field_index() {
     let prefs = RepoPreferences {
         pr_filter_field_index: 2,
         ..RepoPreferences::default()
@@ -164,6 +164,10 @@ fn pr_open_filter_controls_restores_field_index() {
     state.screen_mode = ScreenMode::DashboardPullRequests;
     state.prs_state.active = true;
 
+    // Enter mode restores field_index=2 into live state; opening filter
+    // controls must preserve it (not reset to 0).
+    let state = state.apply(AppEvent::EnterPrsMode);
+    assert_eq!(state.prs_state.filter_ui.field_index, 2);
     let state = state.apply(AppEvent::PrOpenFilterControls);
     assert_eq!(state.prs_state.filter_ui.field_index, 2);
 }
@@ -242,7 +246,7 @@ fn enter_issues_mode_defaults_to_open() {
 }
 
 #[test]
-fn issue_open_filter_controls_restores_field_index() {
+fn issue_open_filter_controls_keeps_restored_field_index() {
     let prefs = RepoPreferences {
         issue_filter_field_index: 4,
         ..RepoPreferences::default()
@@ -251,6 +255,10 @@ fn issue_open_filter_controls_restores_field_index() {
     state.screen_mode = ScreenMode::DashboardIssues;
     state.issues_state.active = true;
 
+    // Enter mode restores field_index=4 into live state; opening filter
+    // controls must preserve it (not reset to 0).
+    let state = state.apply(AppEvent::EnterIssuesMode);
+    assert_eq!(state.issues_state.filter_ui.field_index, 4);
     let state = state.apply(AppEvent::OpenFilterControls);
     assert_eq!(state.issues_state.filter_ui.field_index, 4);
 }

--- a/src/state/preferences_tests.rs
+++ b/src/state/preferences_tests.rs
@@ -646,3 +646,250 @@ fn restore_clamps_stale_issue_filter_field_index() {
         "restored field_index must be clamped within the valid field range"
     );
 }
+
+// ── Dashboard repo selection must not leak filters across repos (issue #163).
+//    select_repository_by_index (the dashboard / jump-to-agent path) flips the
+//    selected index and then restores the NEW repo's prefs. It must persist
+//    the OLD repo's live filter first, otherwise the OLD repo's selection is
+//    lost AND the live prs_state/issues_state filter is wrongly carried over.
+
+/// Switching repos from the dashboard while PR mode is active must save the
+/// old repo's applied PR filter before restoring the new repo's filter, so
+/// the filter does NOT leak across repos.
+#[test]
+fn pr_dashboard_repo_switch_does_not_leak_filter() {
+    let mut state = state_with_two_repos(
+        "llxprt-code",
+        RepoPreferences::default(),
+        "jefe",
+        RepoPreferences::default(),
+    );
+    // Enter PR mode on repo-1 (llxprt-code).
+    state = state.apply(AppEvent::EnterPrsMode);
+    // Apply a Closed filter on repo-1.
+    state = state.apply(AppEvent::PrOpenFilterControls);
+    state = state.apply(AppEvent::PrCycleFilterState); // Open -> Closed
+    state = state.apply(AppEvent::PrApplyFilter);
+    assert_eq!(
+        state.prs_state.committed_filter.state,
+        Some(PrFilterState::Closed)
+    );
+
+    // Switch to repo-2 (jefe) via the dashboard selection path.
+    state = state.apply(AppEvent::SelectRepository(1));
+
+    // repo-2 must NOT carry repo-1's Closed filter — it must be Open (default).
+    assert_eq!(
+        state.prs_state.committed_filter.state,
+        Some(PrFilterState::Open),
+        "repo-2 (jefe) must not inherit repo-1's (llxprt-code) filter"
+    );
+    // repo-1's filter must have been persisted before the switch.
+    let repo1_prefs = state
+        .user_preferences
+        .for_repo(&RepositoryId("llxprt-code".to_string()));
+    assert_eq!(
+        repo1_prefs.pr_filter.state,
+        Some(PrFilterState::Closed),
+        "repo-1's applied filter must be persisted before the repo switch"
+    );
+}
+
+/// Switching repos from the dashboard while issues mode is active must save
+/// the old repo's applied issue filter before restoring the new repo's.
+#[test]
+fn issue_dashboard_repo_switch_does_not_leak_filter() {
+    let mut state = state_with_two_repos(
+        "llxprt-code",
+        RepoPreferences::default(),
+        "jefe",
+        RepoPreferences::default(),
+    );
+    // Enter issues mode on repo-1 (llxprt-code).
+    state = state.apply(AppEvent::EnterIssuesMode);
+    // Apply a Closed filter on repo-1.
+    state = state.apply(AppEvent::OpenFilterControls);
+    state = state.apply(AppEvent::CycleFilterState); // Open -> Closed
+    state = state.apply(AppEvent::ApplyFilter);
+    assert_eq!(
+        state.issues_state.committed_filter.state,
+        Some(IssueFilterState::Closed)
+    );
+
+    // Switch to repo-2 (jefe) via the dashboard selection path.
+    state = state.apply(AppEvent::SelectRepository(1));
+
+    // repo-2 must NOT carry repo-1's Closed filter.
+    assert_eq!(
+        state.issues_state.committed_filter.state,
+        Some(IssueFilterState::Open),
+        "repo-2 (jefe) must not inherit repo-1's (llxprt-code) filter"
+    );
+    let repo1_prefs = state
+        .user_preferences
+        .for_repo(&RepositoryId("llxprt-code".to_string()));
+    assert_eq!(
+        repo1_prefs.issue_filter.state,
+        Some(IssueFilterState::Closed),
+        "repo-1's applied filter must be persisted before the repo switch"
+    );
+}
+
+/// Switching repos via in-mode RepoList navigation (arrow keys) while PR mode
+/// is active must not leak repo-1's applied filter into repo-2.
+#[test]
+fn pr_inmode_repo_switch_does_not_leak_applied_filter() {
+    use crate::state::PrFocus;
+
+    let mut state = state_with_two_repos(
+        "llxprt-code",
+        RepoPreferences::default(),
+        "jefe",
+        RepoPreferences::default(),
+    );
+    state = state.apply(AppEvent::EnterPrsMode);
+    state.prs_state.pr_focus = PrFocus::RepoList;
+    // Apply a Closed filter on repo-1.
+    state = state.apply(AppEvent::PrOpenFilterControls);
+    state = state.apply(AppEvent::PrCycleFilterState); // Open -> Closed
+    state = state.apply(AppEvent::PrApplyFilter);
+    state.prs_state.pr_focus = PrFocus::RepoList;
+
+    // Switch down to repo-2 (jefe) via in-mode repo navigation.
+    state = state.apply(AppEvent::PrNavigateDown);
+
+    assert_eq!(
+        state.prs_state.committed_filter.state,
+        Some(PrFilterState::Open),
+        "repo-2 (jefe) must not inherit repo-1's (llxprt-code) Closed filter"
+    );
+}
+
+/// Exit PR mode on repo-1, switch to repo-2, re-enter PR mode: repo-2 must
+/// restore its OWN prefs, not repo-1's filter (issue #163 per-repo isolation).
+#[test]
+fn pr_exit_switch_reenter_does_not_leak_filter() {
+    let mut state = state_with_two_repos(
+        "llxprt-code",
+        RepoPreferences::default(),
+        "jefe",
+        RepoPreferences::default(),
+    );
+    // Enter PR mode on repo-1, apply a Closed filter, exit.
+    state = state.apply(AppEvent::EnterPrsMode);
+    state = state.apply(AppEvent::PrOpenFilterControls);
+    state = state.apply(AppEvent::PrCycleFilterState); // Open -> Closed
+    state = state.apply(AppEvent::PrApplyFilter);
+    state = state.apply(AppEvent::ExitPrsMode);
+
+    // Switch to repo-2 (jefe) from the dashboard.
+    state = state.apply(AppEvent::SelectRepository(1));
+    // Re-enter PR mode on repo-2.
+    state = state.apply(AppEvent::EnterPrsMode);
+
+    assert_eq!(
+        state.prs_state.committed_filter.state,
+        Some(PrFilterState::Open),
+        "repo-2 (jefe) must restore its own Open default, not repo-1's Closed"
+    );
+}
+
+/// Jumping to an agent in a different repo while PR mode is active must save
+/// the old repo's filter and restore the new repo's filter — the filter must
+/// NOT leak across repos via the shortcut-jump path (issue #163).
+#[test]
+fn pr_jump_to_agent_in_other_repo_does_not_leak_filter() {
+    use crate::domain::{Agent, AgentId};
+
+    let mut state = state_with_two_repos(
+        "llxprt-code",
+        RepoPreferences::default(),
+        "jefe",
+        RepoPreferences::default(),
+    );
+    // Add an agent in repo-2 (jefe) on shortcut slot 1.
+    state.agents.push(Agent::new(
+        AgentId("jefe-agent".to_string()),
+        RepositoryId("jefe".to_string()),
+        "Jefe Agent".to_string(),
+        std::path::PathBuf::from("/tmp/jefe"),
+    ));
+    state.agents[0].shortcut_slot = Some(1);
+
+    // Enter PR mode on repo-1 (llxprt-code) and apply a Closed filter.
+    state = state.apply(AppEvent::EnterPrsMode);
+    state = state.apply(AppEvent::PrOpenFilterControls);
+    state = state.apply(AppEvent::PrCycleFilterState); // Open -> Closed
+    state = state.apply(AppEvent::PrApplyFilter);
+    assert_eq!(
+        state.prs_state.committed_filter.state,
+        Some(PrFilterState::Closed)
+    );
+
+    // Jump to the jefe agent (slot 1), which switches the selected repo.
+    state = state.apply(AppEvent::JumpToAgentByShortcut(1));
+
+    // repo-2 (jefe) must NOT carry repo-1's Closed filter.
+    assert_eq!(
+        state.prs_state.committed_filter.state,
+        Some(PrFilterState::Open),
+        "repo-2 (jefe) must not inherit repo-1's (llxprt-code) filter via jump"
+    );
+    // repo-1's filter must have been persisted before the jump.
+    let repo1_prefs = state
+        .user_preferences
+        .for_repo(&RepositoryId("llxprt-code".to_string()));
+    assert_eq!(
+        repo1_prefs.pr_filter.state,
+        Some(PrFilterState::Closed),
+        "repo-1's applied filter must be persisted before the jump"
+    );
+}
+
+/// Jumping to an agent in a different repo while issues mode is active must
+/// save the old repo's issue filter and restore the new repo's filter (issue #163).
+#[test]
+fn issue_jump_to_agent_in_other_repo_does_not_leak_filter() {
+    use crate::domain::{Agent, AgentId};
+
+    let mut state = state_with_two_repos(
+        "llxprt-code",
+        RepoPreferences::default(),
+        "jefe",
+        RepoPreferences::default(),
+    );
+    state.agents.push(Agent::new(
+        AgentId("jefe-agent".to_string()),
+        RepositoryId("jefe".to_string()),
+        "Jefe Agent".to_string(),
+        std::path::PathBuf::from("/tmp/jefe"),
+    ));
+    state.agents[0].shortcut_slot = Some(1);
+
+    // Enter issues mode on repo-1 (llxprt-code) and apply a Closed filter.
+    state = state.apply(AppEvent::EnterIssuesMode);
+    state = state.apply(AppEvent::OpenFilterControls);
+    state = state.apply(AppEvent::CycleFilterState); // Open -> Closed
+    state = state.apply(AppEvent::ApplyFilter);
+    assert_eq!(
+        state.issues_state.committed_filter.state,
+        Some(IssueFilterState::Closed)
+    );
+
+    // Jump to the jefe agent (slot 1), which switches the selected repo.
+    state = state.apply(AppEvent::JumpToAgentByShortcut(1));
+
+    assert_eq!(
+        state.issues_state.committed_filter.state,
+        Some(IssueFilterState::Open),
+        "repo-2 (jefe) must not inherit repo-1's (llxprt-code) issue filter via jump"
+    );
+    let repo1_prefs = state
+        .user_preferences
+        .for_repo(&RepositoryId("llxprt-code".to_string()));
+    assert_eq!(
+        repo1_prefs.issue_filter.state,
+        Some(IssueFilterState::Closed),
+        "repo-1's applied issue filter must be persisted before the jump"
+    );
+}

--- a/src/state/preferences_tests.rs
+++ b/src/state/preferences_tests.rs
@@ -9,6 +9,7 @@ use crate::domain::{
 };
 use crate::state::AppState;
 use crate::state::types::{AppEvent, ScreenMode};
+use crate::state::{ISSUE_FILTER_FIELD_COUNT, PR_FILTER_FIELD_COUNT};
 
 use super::prs_test_fixtures::prs_state_with_detail;
 
@@ -146,12 +147,25 @@ fn pr_clear_filter_persists_open_default() {
     let mut state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
     state.screen_mode = ScreenMode::DashboardPullRequests;
     state.prs_state.active = true;
+    // Seed a search query so we can prove ClearFilter also clears it.
+    state.prs_state.search_query = "stale query".to_string();
 
     let state = state.apply(AppEvent::PrClearFilter);
     let stored = state
         .user_preferences
         .for_repo(&RepositoryId("repo-1".to_string()));
     assert_eq!(stored.pr_filter.state, Some(PrFilterState::Open));
+    // Clearing all filters must also clear the persisted search query so the
+    // restored state stays consistent (issue #163).
+    assert!(
+        stored.pr_search_query.is_empty(),
+        "PrClearFilter must clear the search query, got: {}",
+        stored.pr_search_query
+    );
+    assert!(
+        state.prs_state.search_query.is_empty(),
+        "live search_query must be cleared by PrClearFilter"
+    );
 }
 
 #[test]
@@ -283,6 +297,8 @@ fn issue_clear_filter_persists() {
     let mut state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
     state.screen_mode = ScreenMode::DashboardIssues;
     state.issues_state.active = true;
+    // Seed a search query so we can prove ClearFilter also clears it.
+    state.issues_state.search_query = "stale query".to_string();
 
     let state = state.apply(AppEvent::ClearFilter);
     let stored = state
@@ -295,6 +311,34 @@ fn issue_clear_filter_persists() {
             state: Some(IssueFilterState::Open),
             ..IssueFilter::default()
         }
+    );
+    // Clearing all filters must also clear the persisted search query so the
+    // restored state stays consistent (issue #163).
+    assert!(
+        stored.issue_search_query.is_empty(),
+        "ClearFilter must clear the search query, got: {}",
+        stored.issue_search_query
+    );
+    assert!(
+        state.issues_state.search_query.is_empty(),
+        "live search_query must be cleared by ClearFilter"
+    );
+}
+
+#[test]
+fn issue_clear_draft_filter_defaults_to_open() {
+    // ClearDraftFilter resets the in-progress draft to the Open default (issue
+    // #163: the filter-state default is Open, matching ClearFilter).
+    let mut state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
+    state.screen_mode = ScreenMode::DashboardIssues;
+    state.issues_state.active = true;
+    state.issues_state.draft_filter.state = Some(IssueFilterState::Closed);
+
+    let state = state.apply(AppEvent::ClearDraftFilter);
+    assert_eq!(
+        state.issues_state.draft_filter.state,
+        Some(IssueFilterState::Open),
+        "ClearDraftFilter must reset the draft state to the Open default"
     );
 }
 
@@ -576,7 +620,7 @@ fn pr_repo_switch_persists_old_search_before_switch() {
 /// on mode entry so it cannot drive the filter cursor out of bounds.
 #[test]
 fn restore_clamps_stale_pr_filter_field_index() {
-    // Seed an out-of-range pr_filter_field_index (well beyond 8 fields).
+    // Seed an out-of-range pr_filter_field_index (well beyond the field count).
     let prefs = RepoPreferences {
         pr_filter_field_index: 999,
         ..RepoPreferences::default()
@@ -584,7 +628,7 @@ fn restore_clamps_stale_pr_filter_field_index() {
     let state = state_with_repo_and_prefs("repo-1", prefs);
     let state = state.apply(AppEvent::EnterPrsMode);
     assert!(
-        state.prs_state.filter_ui.field_index < 8,
+        state.prs_state.filter_ui.field_index < PR_FILTER_FIELD_COUNT,
         "restored field_index must be clamped within the valid field range"
     );
 }
@@ -599,7 +643,7 @@ fn restore_clamps_stale_issue_filter_field_index() {
     let state = state_with_repo_and_prefs("repo-1", prefs);
     let state = state.apply(AppEvent::EnterIssuesMode);
     assert!(
-        state.issues_state.filter_ui.field_index < 8,
+        state.issues_state.filter_ui.field_index < ISSUE_FILTER_FIELD_COUNT,
         "restored field_index must be clamped within the valid field range"
     );
 }

--- a/src/state/preferences_tests.rs
+++ b/src/state/preferences_tests.rs
@@ -466,12 +466,9 @@ fn deleted_repo_prunes_its_preferences() {
     };
     let mut state = state_with_two_repos("repo-1", prefs1, "repo-2", prefs2);
 
-    // Delete repo-1. delete_selected_repository removes it from self.repositories.
+    // Delete repo-1. delete_selected_repository removes it from self.repositories
+    // AND prunes its stored preferences (issue #163).
     delete_selected_repository(&mut state, &RepositoryId("repo-1".to_string()));
-
-    // finalize_message (run after any apply_message) prunes stale prefs.
-    // Drive it with a benign selection event.
-    let state = state.apply(AppEvent::SelectRepository(0));
 
     // repo-1 prefs should be gone, repo-2 prefs should remain.
     assert!(
@@ -485,4 +482,116 @@ fn deleted_repo_prunes_its_preferences() {
         .user_preferences
         .for_repo(&RepositoryId("repo-2".to_string()));
     assert_eq!(repo2_prefs.issue_search_query, "repo2-search");
+}
+
+// ── Save-before-switch: uncommitted selections must persist before the
+//    repo index changes (issue #163). Without this, move_repo_selection
+//    changes the selected repo and reset_*_for_repo_change overwrites the
+//    live filter/search with the NEW repo's prefs, silently discarding the
+//    OLD repo's uncommitted state.
+
+/// Switching repos in issues mode must persist the OLD repo's current
+/// search query before the new repo's preferences are restored.
+#[test]
+fn issue_repo_switch_persists_old_search_before_switch() {
+    use crate::state::IssueFocus;
+
+    // repo-1 has empty prefs; repo-2 has empty prefs. Enter issues mode on
+    // repo-1, type a search query (not yet applied), then switch down to
+    // repo-2 — the typed query must be saved for repo-1.
+    let mut state = state_with_two_repos(
+        "repo-1",
+        RepoPreferences::default(),
+        "repo-2",
+        RepoPreferences::default(),
+    );
+    state = state.apply(AppEvent::EnterIssuesMode);
+    state.issues_state.issue_focus = IssueFocus::RepoList;
+    state = state.apply(AppEvent::SetSearchQuery {
+        query: "rust-bug".to_string(),
+    });
+
+    // Switch down to repo-2.
+    state = state.apply(AppEvent::IssuesNavigateDown);
+
+    // repo-1's typed search query must now be in its stored prefs.
+    let repo1_prefs = state
+        .user_preferences
+        .for_repo(&RepositoryId("repo-1".to_string()));
+    assert_eq!(
+        repo1_prefs.issue_search_query, "rust-bug",
+        "old repo's search query must be persisted before the repo switch"
+    );
+
+    // Switch back up to repo-1 and re-enter mode to confirm it restores.
+    state = state.apply(AppEvent::IssuesNavigateUp);
+    state = state.apply(AppEvent::RefocusIssueList);
+    assert_eq!(state.issues_state.search_query, "rust-bug");
+}
+
+/// Switching repos in PR mode must persist the OLD repo's current search
+/// query before the new repo's preferences are restored.
+#[test]
+fn pr_repo_switch_persists_old_search_before_switch() {
+    use crate::state::PrFocus;
+
+    let mut state = state_with_two_repos(
+        "repo-1",
+        RepoPreferences::default(),
+        "repo-2",
+        RepoPreferences::default(),
+    );
+    state = state.apply(AppEvent::EnterPrsMode);
+    state.prs_state.pr_focus = PrFocus::RepoList;
+    state = state.apply(AppEvent::PrSetSearchQuery {
+        query: "draft-prs".to_string(),
+    });
+
+    // Switch down to repo-2.
+    state = state.apply(AppEvent::PrNavigateDown);
+
+    let repo1_prefs = state
+        .user_preferences
+        .for_repo(&RepositoryId("repo-1".to_string()));
+    assert_eq!(
+        repo1_prefs.pr_search_query, "draft-prs",
+        "old repo's search query must be persisted before the repo switch"
+    );
+
+    // Switch back up to repo-1 and confirm it restores.
+    state = state.apply(AppEvent::PrNavigateUp);
+    state = state.apply(AppEvent::RefocusPrList);
+    assert_eq!(state.prs_state.search_query, "draft-prs");
+}
+
+/// A stale/corrupted persisted field_index beyond the valid range is clamped
+/// on mode entry so it cannot drive the filter cursor out of bounds.
+#[test]
+fn restore_clamps_stale_pr_filter_field_index() {
+    // Seed an out-of-range pr_filter_field_index (well beyond 8 fields).
+    let prefs = RepoPreferences {
+        pr_filter_field_index: 999,
+        ..RepoPreferences::default()
+    };
+    let state = state_with_repo_and_prefs("repo-1", prefs);
+    let state = state.apply(AppEvent::EnterPrsMode);
+    assert!(
+        state.prs_state.filter_ui.field_index < 8,
+        "restored field_index must be clamped within the valid field range"
+    );
+}
+
+/// A stale/corrupted persisted issue filter field_index is clamped on entry.
+#[test]
+fn restore_clamps_stale_issue_filter_field_index() {
+    let prefs = RepoPreferences {
+        issue_filter_field_index: 999,
+        ..RepoPreferences::default()
+    };
+    let state = state_with_repo_and_prefs("repo-1", prefs);
+    let state = state.apply(AppEvent::EnterIssuesMode);
+    assert!(
+        state.issues_state.filter_ui.field_index < 8,
+        "restored field_index must be clamped within the valid field range"
+    );
 }

--- a/src/state/preferences_tests.rs
+++ b/src/state/preferences_tests.rs
@@ -1,0 +1,422 @@
+//! Per-repository user-preference persistence tests (issue #163).
+//!
+//! Covers enter-mode restore, apply/clear persist, filter-controls field_index
+//! restore, per-repo isolation, and merge-chooser restore+persist.
+
+use crate::domain::{
+    IssueFilter, IssueFilterState, MergeMethod, PrFilter, PrFilterState, RepoPreferences,
+    Repository, RepositoryId, UserPreferences,
+};
+use crate::state::AppState;
+use crate::state::types::{AppEvent, ScreenMode};
+
+use super::prs_test_fixtures::prs_state_with_detail;
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/// Build an AppState with the given repo selected and seeded preferences.
+fn state_with_repo_and_prefs(repo_id: &str, prefs: RepoPreferences) -> AppState {
+    let mut state = AppState::default();
+    state.repositories.push(Repository::new(
+        RepositoryId(repo_id.to_string()),
+        "Test Repo".to_string(),
+        repo_id.to_string(),
+        std::path::PathBuf::from("/tmp/test"),
+    ));
+    state.selected_repository_index = Some(0);
+    state
+        .user_preferences
+        .update_for_repo(RepositoryId(repo_id.to_string()), prefs);
+    state
+}
+
+/// Build an AppState with two repos and seeded preferences for each.
+fn state_with_two_repos(
+    repo1: &str,
+    prefs1: RepoPreferences,
+    repo2: &str,
+    prefs2: RepoPreferences,
+) -> AppState {
+    let mut state = AppState::default();
+    state.repositories.push(Repository::new(
+        RepositoryId(repo1.to_string()),
+        "Repo 1".to_string(),
+        repo1.to_string(),
+        std::path::PathBuf::from("/tmp/repo1"),
+    ));
+    state.repositories.push(Repository::new(
+        RepositoryId(repo2.to_string()),
+        "Repo 2".to_string(),
+        repo2.to_string(),
+        std::path::PathBuf::from("/tmp/repo2"),
+    ));
+    state.selected_repository_index = Some(0);
+    state
+        .user_preferences
+        .update_for_repo(RepositoryId(repo1.to_string()), prefs1);
+    state
+        .user_preferences
+        .update_for_repo(RepositoryId(repo2.to_string()), prefs2);
+    state
+}
+
+// ── enter_prs_mode ────────────────────────────────────────────────────────
+
+#[test]
+fn enter_prs_mode_restores_remembered_pr_filter() {
+    let prefs = RepoPreferences {
+        pr_filter: PrFilter {
+            state: Some(PrFilterState::Closed),
+            ..PrFilter::default()
+        },
+        ..RepoPreferences::default()
+    };
+    let state = state_with_repo_and_prefs("repo-1", prefs);
+    let state = state.apply(AppEvent::EnterPrsMode);
+    assert_eq!(
+        state.prs_state.committed_filter.state,
+        Some(PrFilterState::Closed)
+    );
+    assert_eq!(
+        state.prs_state.draft_filter.state,
+        Some(PrFilterState::Closed)
+    );
+}
+
+#[test]
+fn enter_prs_mode_defaults_to_open_when_no_prefs() {
+    let mut state = AppState::default();
+    state.repositories.push(Repository::new(
+        RepositoryId("repo-1".to_string()),
+        "Test".to_string(),
+        "repo-1".to_string(),
+        std::path::PathBuf::from("/tmp"),
+    ));
+    state.selected_repository_index = Some(0);
+    let state = state.apply(AppEvent::EnterPrsMode);
+    assert_eq!(
+        state.prs_state.committed_filter.state,
+        Some(PrFilterState::Open)
+    );
+}
+
+#[test]
+fn enter_prs_mode_restores_search_query() {
+    let prefs = RepoPreferences {
+        pr_search_query: "foo".to_string(),
+        ..RepoPreferences::default()
+    };
+    let state = state_with_repo_and_prefs("repo-1", prefs);
+    let state = state.apply(AppEvent::EnterPrsMode);
+    assert_eq!(state.prs_state.search_query, "foo");
+}
+
+#[test]
+fn enter_prs_mode_restores_field_index() {
+    let prefs = RepoPreferences {
+        pr_filter_field_index: 3,
+        ..RepoPreferences::default()
+    };
+    let state = state_with_repo_and_prefs("repo-1", prefs);
+    let state = state.apply(AppEvent::EnterPrsMode);
+    assert_eq!(state.prs_state.filter_ui.field_index, 3);
+}
+
+// ── PR apply/clear persist ───────────────────────────────────────────────
+
+#[test]
+fn pr_apply_filter_persists_to_prefs() {
+    let mut state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
+    state.screen_mode = ScreenMode::DashboardPullRequests;
+    state.prs_state.active = true;
+    state.prs_state.filter_ui.controls_open = true;
+    state.prs_state.draft_filter.state = Some(PrFilterState::Closed);
+    state.prs_state.draft_filter.author = "alice".to_string();
+
+    let state = state.apply(AppEvent::PrApplyFilter);
+    let stored = state
+        .user_preferences
+        .for_repo(&RepositoryId("repo-1".to_string()));
+    assert_eq!(stored.pr_filter, state.prs_state.committed_filter);
+}
+
+#[test]
+fn pr_clear_filter_persists_open_default() {
+    let mut state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
+    state.screen_mode = ScreenMode::DashboardPullRequests;
+    state.prs_state.active = true;
+
+    let state = state.apply(AppEvent::PrClearFilter);
+    let stored = state
+        .user_preferences
+        .for_repo(&RepositoryId("repo-1".to_string()));
+    assert_eq!(stored.pr_filter.state, Some(PrFilterState::Open));
+}
+
+#[test]
+fn pr_open_filter_controls_restores_field_index() {
+    let prefs = RepoPreferences {
+        pr_filter_field_index: 2,
+        ..RepoPreferences::default()
+    };
+    let mut state = state_with_repo_and_prefs("repo-1", prefs);
+    state.screen_mode = ScreenMode::DashboardPullRequests;
+    state.prs_state.active = true;
+
+    let state = state.apply(AppEvent::PrOpenFilterControls);
+    assert_eq!(state.prs_state.filter_ui.field_index, 2);
+}
+
+// ── Per-repo isolation ───────────────────────────────────────────────────
+
+#[test]
+fn pr_prefs_are_per_repo() {
+    let prefs1 = RepoPreferences {
+        pr_filter: PrFilter {
+            state: Some(PrFilterState::Closed),
+            ..PrFilter::default()
+        },
+        ..RepoPreferences::default()
+    };
+    let prefs2 = RepoPreferences {
+        pr_filter: PrFilter {
+            state: Some(PrFilterState::Merged),
+            ..PrFilter::default()
+        },
+        ..RepoPreferences::default()
+    };
+    let mut state = state_with_two_repos("repo-1", prefs1, "repo-2", prefs2);
+    state.screen_mode = ScreenMode::DashboardPullRequests;
+    state.prs_state.active = true;
+
+    // Enter PR mode with repo-1 selected → Closed.
+    let state = state.apply(AppEvent::EnterPrsMode);
+    assert_eq!(
+        state.prs_state.committed_filter.state,
+        Some(PrFilterState::Closed)
+    );
+
+    // Switch to repo-2 → reset_prs_for_repo_change restores Merged.
+    let state = state.apply(AppEvent::SelectRepository(1));
+    assert_eq!(
+        state.prs_state.committed_filter.state,
+        Some(PrFilterState::Merged)
+    );
+}
+
+// ── enter_issues_mode ────────────────────────────────────────────────────
+
+#[test]
+fn enter_issues_mode_restores_remembered_issue_filter() {
+    let prefs = RepoPreferences {
+        issue_filter: IssueFilter {
+            state: Some(IssueFilterState::All),
+            ..IssueFilter::default()
+        },
+        ..RepoPreferences::default()
+    };
+    let state = state_with_repo_and_prefs("repo-1", prefs);
+    let state = state.apply(AppEvent::EnterIssuesMode);
+    assert_eq!(
+        state.issues_state.committed_filter.state,
+        Some(IssueFilterState::All)
+    );
+}
+
+#[test]
+fn enter_issues_mode_defaults_to_open() {
+    let mut state = AppState::default();
+    state.repositories.push(Repository::new(
+        RepositoryId("repo-1".to_string()),
+        "Test".to_string(),
+        "repo-1".to_string(),
+        std::path::PathBuf::from("/tmp"),
+    ));
+    state.selected_repository_index = Some(0);
+    let state = state.apply(AppEvent::EnterIssuesMode);
+    assert_eq!(
+        state.issues_state.committed_filter.state,
+        Some(IssueFilterState::Open)
+    );
+}
+
+#[test]
+fn issue_open_filter_controls_restores_field_index() {
+    let prefs = RepoPreferences {
+        issue_filter_field_index: 4,
+        ..RepoPreferences::default()
+    };
+    let mut state = state_with_repo_and_prefs("repo-1", prefs);
+    state.screen_mode = ScreenMode::DashboardIssues;
+    state.issues_state.active = true;
+
+    let state = state.apply(AppEvent::OpenFilterControls);
+    assert_eq!(state.issues_state.filter_ui.field_index, 4);
+}
+
+#[test]
+fn issue_apply_filter_persists() {
+    let mut state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
+    state.screen_mode = ScreenMode::DashboardIssues;
+    state.issues_state.active = true;
+    state.issues_state.filter_ui.controls_open = true;
+    state.issues_state.draft_filter.author = "alice".to_string();
+
+    let state = state.apply(AppEvent::ApplyFilter);
+    let stored = state
+        .user_preferences
+        .for_repo(&RepositoryId("repo-1".to_string()));
+    assert_eq!(stored.issue_filter, state.issues_state.committed_filter);
+}
+
+#[test]
+fn issue_clear_filter_persists() {
+    let mut state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
+    state.screen_mode = ScreenMode::DashboardIssues;
+    state.issues_state.active = true;
+
+    let state = state.apply(AppEvent::ClearFilter);
+    let stored = state
+        .user_preferences
+        .for_repo(&RepositoryId("repo-1".to_string()));
+    assert_eq!(stored.issue_filter, state.issues_state.committed_filter);
+}
+
+// ── Merge chooser restore + persist ──────────────────────────────────────
+
+#[test]
+fn merge_chooser_restores_last_method() {
+    let prefs = RepoPreferences {
+        last_merge_method: MergeMethod::Squash,
+        ..RepoPreferences::default()
+    };
+    let mut state = prs_state_with_detail("repo-1", 42);
+    state
+        .user_preferences
+        .update_for_repo(RepositoryId("repo-1".to_string()), prefs);
+
+    let state = state.apply(AppEvent::PrOpenMergeChooser);
+    let selected = state
+        .prs_state
+        .merge_chooser
+        .as_ref()
+        .map_or(usize::MAX, |c| c.selected_index);
+    assert_eq!(selected, 1, "Squash is index 1 in MERGE_METHODS");
+}
+
+#[test]
+fn merge_chooser_defaults_to_merge_when_no_prefs() {
+    let state = prs_state_with_detail("repo-1", 42);
+    let state = state.apply(AppEvent::PrOpenMergeChooser);
+    let selected = state
+        .prs_state
+        .merge_chooser
+        .as_ref()
+        .map_or(usize::MAX, |c| c.selected_index);
+    assert_eq!(selected, 0, "Merge is index 0 (default)");
+}
+
+#[test]
+fn merge_confirm_persists_method() {
+    let state = prs_state_with_detail("repo-1", 42);
+    let state = state.apply(AppEvent::PrOpenMergeChooser);
+    // Navigate to Rebase (index 2)
+    let state = state.apply(AppEvent::PrMergeNavigateDown);
+    let state = state.apply(AppEvent::PrMergeNavigateDown);
+    // Confirm twice
+    let state = state.apply(AppEvent::PrMergeConfirm);
+    let state = state.apply(AppEvent::PrMergeConfirm);
+
+    let stored = state
+        .user_preferences
+        .for_repo(&RepositoryId("repo-1".to_string()));
+    assert_eq!(stored.last_merge_method, MergeMethod::Rebase);
+}
+
+#[test]
+fn merge_methods_loaded_clamps_disabled_last_method() {
+    let prefs = RepoPreferences {
+        last_merge_method: MergeMethod::Squash,
+        ..RepoPreferences::default()
+    };
+    let mut state = prs_state_with_detail("repo-1", 42);
+    state
+        .user_preferences
+        .update_for_repo(RepositoryId("repo-1".to_string()), prefs);
+
+    let state = state.apply(AppEvent::PrOpenMergeChooser);
+    let state = state.apply(AppEvent::PrMergeMethodsLoaded {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        pr_number: 42,
+        allowed_methods: vec![MergeMethod::Merge, MergeMethod::Rebase],
+    });
+    let selected = state
+        .prs_state
+        .merge_chooser
+        .as_ref()
+        .map_or(usize::MAX, |c| c.selected_index);
+    assert_eq!(
+        selected, 0,
+        "Squash disabled → clamp to first enabled (Merge=0)"
+    );
+}
+
+#[test]
+fn merge_methods_loaded_keeps_last_method_when_allowed() {
+    let prefs = RepoPreferences {
+        last_merge_method: MergeMethod::Squash,
+        ..RepoPreferences::default()
+    };
+    let mut state = prs_state_with_detail("repo-1", 42);
+    state
+        .user_preferences
+        .update_for_repo(RepositoryId("repo-1".to_string()), prefs);
+
+    let state = state.apply(AppEvent::PrOpenMergeChooser);
+    let state = state.apply(AppEvent::PrMergeMethodsLoaded {
+        scope_repo_id: RepositoryId("repo-1".to_string()),
+        pr_number: 42,
+        allowed_methods: vec![MergeMethod::Merge, MergeMethod::Squash],
+    });
+    let selected = state
+        .prs_state
+        .merge_chooser
+        .as_ref()
+        .map_or(usize::MAX, |c| c.selected_index);
+    assert_eq!(selected, 1, "Squash allowed → stays at index 1");
+}
+
+// ── UserPreferences domain unit tests ────────────────────────────────────
+
+#[test]
+fn user_preferences_for_repo_returns_open_defaults_when_absent() {
+    let prefs = UserPreferences::default();
+    let result = prefs.for_repo(&RepositoryId("unknown".to_string()));
+    assert_eq!(result.issue_filter.state, Some(IssueFilterState::Open));
+    assert_eq!(result.pr_filter.state, Some(PrFilterState::Open));
+}
+
+#[test]
+fn user_preferences_update_for_repo_upserts() {
+    let mut prefs = UserPreferences::default();
+    let repo = RepositoryId("repo-1".to_string());
+    prefs.update_for_repo(
+        repo.clone(),
+        RepoPreferences {
+            pr_search_query: "first".to_string(),
+            ..RepoPreferences::default()
+        },
+    );
+    assert_eq!(prefs.by_repo.len(), 1);
+
+    // Upsert replaces existing entry.
+    prefs.update_for_repo(
+        repo.clone(),
+        RepoPreferences {
+            pr_search_query: "second".to_string(),
+            ..RepoPreferences::default()
+        },
+    );
+    assert_eq!(prefs.by_repo.len(), 1);
+    assert_eq!(prefs.for_repo(&repo).pr_search_query, "second");
+}

--- a/src/state/preferences_tests.rs
+++ b/src/state/preferences_tests.rs
@@ -304,7 +304,6 @@ fn issue_clear_filter_persists() {
     let stored = state
         .user_preferences
         .for_repo(&RepositoryId("repo-1".to_string()));
-    assert_eq!(stored.issue_filter.state, Some(IssueFilterState::Open));
     assert_eq!(
         stored.issue_filter,
         IssueFilter {
@@ -347,7 +346,7 @@ fn issue_clear_draft_filter_defaults_to_open() {
 #[test]
 fn merge_chooser_restores_last_method() {
     let prefs = RepoPreferences {
-        last_merge_method: MergeMethod::Squash,
+        last_merge_method: Some(MergeMethod::Squash),
         ..RepoPreferences::default()
     };
     let mut state = prs_state_with_detail("repo-1", 42);
@@ -390,13 +389,13 @@ fn merge_confirm_persists_method() {
     let stored = state
         .user_preferences
         .for_repo(&RepositoryId("repo-1".to_string()));
-    assert_eq!(stored.last_merge_method, MergeMethod::Rebase);
+    assert_eq!(stored.last_merge_method, Some(MergeMethod::Rebase));
 }
 
 #[test]
 fn merge_methods_loaded_clamps_disabled_last_method() {
     let prefs = RepoPreferences {
-        last_merge_method: MergeMethod::Squash,
+        last_merge_method: Some(MergeMethod::Squash),
         ..RepoPreferences::default()
     };
     let mut state = prs_state_with_detail("repo-1", 42);
@@ -424,7 +423,7 @@ fn merge_methods_loaded_clamps_disabled_last_method() {
 #[test]
 fn merge_methods_loaded_keeps_last_method_when_allowed() {
     let prefs = RepoPreferences {
-        last_merge_method: MergeMethod::Squash,
+        last_merge_method: Some(MergeMethod::Squash),
         ..RepoPreferences::default()
     };
     let mut state = prs_state_with_detail("repo-1", 42);

--- a/src/state/prs_merge_ops.rs
+++ b/src/state/prs_merge_ops.rs
@@ -86,8 +86,14 @@ impl AppState {
             self.apply_pr_show_notice(ReadOnlyHintKind::PrNotMergeable);
             return;
         }
+        let repo_id = self.current_pr_scope_repo_id();
+        let last_method = self.user_preferences.for_repo(&repo_id).last_merge_method;
+        let selected_index = MERGE_METHODS
+            .iter()
+            .position(|m| *m == last_method)
+            .unwrap_or(0);
         self.prs_state.merge_chooser = Some(PrMergeChooserState {
-            selected_index: 0,
+            selected_index,
             allowed_methods: None,
             awaiting_confirmation: false,
         });
@@ -133,6 +139,7 @@ impl AppState {
             .get(selected)
             .copied()
             .unwrap_or(MergeMethod::Merge);
+        self.remember_merge_method(method);
         let scope = self.current_pr_scope_repo_id();
         let pr_number = self.prs_state.pr_detail.as_ref().map_or(0, |d| d.number);
         let mutation_id = self.next_merge_mutation_id();
@@ -221,6 +228,10 @@ impl AppState {
         }
         if let Some(chooser) = &mut self.prs_state.merge_chooser {
             chooser.allowed_methods = Some(allowed_methods.to_vec());
+            let enabled = enabled_method_indices(chooser.allowed_methods.as_deref());
+            if !enabled.contains(&chooser.selected_index) {
+                chooser.selected_index = enabled.first().copied().unwrap_or(0);
+            }
         }
         true
     }

--- a/src/state/prs_merge_ops.rs
+++ b/src/state/prs_merge_ops.rs
@@ -87,7 +87,7 @@ impl AppState {
             return;
         }
         let repo_id = self.current_pr_scope_repo_id();
-        let last_method = self.user_preferences.for_repo(&repo_id).last_merge_method;
+        let last_method = self.user_preferences.last_merge_method_for(&repo_id);
         let selected_index = last_method
             .and_then(|method| MERGE_METHODS.iter().position(|m| *m == method))
             .unwrap_or(0);

--- a/src/state/prs_merge_ops.rs
+++ b/src/state/prs_merge_ops.rs
@@ -228,7 +228,7 @@ impl AppState {
         }
         if let Some(chooser) = &mut self.prs_state.merge_chooser {
             chooser.allowed_methods = Some(allowed_methods.to_vec());
-            let enabled = enabled_method_indices(chooser.allowed_methods.as_deref());
+            let enabled = enabled_method_indices(Some(allowed_methods));
             if !enabled.contains(&chooser.selected_index) {
                 chooser.selected_index = enabled.first().copied().unwrap_or(0);
             }

--- a/src/state/prs_merge_ops.rs
+++ b/src/state/prs_merge_ops.rs
@@ -88,9 +88,8 @@ impl AppState {
         }
         let repo_id = self.current_pr_scope_repo_id();
         let last_method = self.user_preferences.for_repo(&repo_id).last_merge_method;
-        let selected_index = MERGE_METHODS
-            .iter()
-            .position(|m| *m == last_method)
+        let selected_index = last_method
+            .and_then(|method| MERGE_METHODS.iter().position(|m| *m == method))
             .unwrap_or(0);
         self.prs_state.merge_chooser = Some(PrMergeChooserState {
             selected_index,

--- a/src/state/prs_nav_ops.rs
+++ b/src/state/prs_nav_ops.rs
@@ -47,6 +47,10 @@ impl AppState {
     /// @requirement REQ-PR-003
     /// @pseudocode component-001 lines 146-153
     fn navigate_repo_up_in_prs_mode(&mut self) {
+        // Persist the OLD repo's filter/search/cursor before move_repo_selection
+        // changes the selected index (issue #163). Idempotent on a no-op move.
+        self.remember_pr_preferences();
+        self.remember_pr_filter_field_index();
         if self.move_repo_selection(crate::messages::NavDir::Up) {
             self.reset_prs_for_repo_change();
         }
@@ -58,6 +62,10 @@ impl AppState {
     /// @requirement REQ-PR-003
     /// @pseudocode component-001 lines 146-153
     fn navigate_repo_down_in_prs_mode(&mut self) {
+        // Persist the OLD repo's filter/search/cursor before move_repo_selection
+        // changes the selected index (issue #163). Idempotent on a no-op move.
+        self.remember_pr_preferences();
+        self.remember_pr_filter_field_index();
         if self.move_repo_selection(crate::messages::NavDir::Down) {
             self.reset_prs_for_repo_change();
         }

--- a/src/state/prs_nav_ops.rs
+++ b/src/state/prs_nav_ops.rs
@@ -50,7 +50,6 @@ impl AppState {
         // Persist the OLD repo's filter/search/cursor before move_repo_selection
         // changes the selected index (issue #163). Idempotent on a no-op move.
         self.remember_pr_preferences();
-        self.remember_pr_filter_field_index();
         if self.move_repo_selection(crate::messages::NavDir::Up) {
             self.reset_prs_for_repo_change();
         }
@@ -65,7 +64,6 @@ impl AppState {
         // Persist the OLD repo's filter/search/cursor before move_repo_selection
         // changes the selected index (issue #163). Idempotent on a no-op move.
         self.remember_pr_preferences();
-        self.remember_pr_filter_field_index();
         if self.move_repo_selection(crate::messages::NavDir::Down) {
             self.reset_prs_for_repo_change();
         }

--- a/src/state/prs_ops.rs
+++ b/src/state/prs_ops.rs
@@ -67,7 +67,7 @@ impl AppState {
         let repo_id = self.current_repo_id();
         let prefs = match &repo_id {
             Some(id) => self.user_preferences.for_repo(id),
-            None => crate::domain::RepoPreferences::with_open_defaults(),
+            None => crate::domain::RepoPreferences::default(),
         };
         self.prs_state.committed_filter = prefs.pr_filter;
         self.prs_state.draft_filter = self.prs_state.committed_filter.clone();
@@ -184,11 +184,13 @@ impl AppState {
             }
             AppEvent::PrCloseFilterControls => {
                 self.prs_state.filter_ui.controls_open = false;
+                self.remember_pr_filter_field_index();
                 true
             }
             AppEvent::PrFilterNavigateNext => {
                 self.prs_state.filter_ui.field_index =
                     (self.prs_state.filter_ui.field_index + 1) % PR_FILTER_FIELD_COUNT;
+                self.remember_pr_filter_field_index();
                 true
             }
             AppEvent::PrFilterNavigatePrev => {
@@ -198,6 +200,7 @@ impl AppState {
                 } else {
                     self.prs_state.filter_ui.field_index - 1
                 };
+                self.remember_pr_filter_field_index();
                 true
             }
             _ => false,

--- a/src/state/prs_ops.rs
+++ b/src/state/prs_ops.rs
@@ -176,13 +176,15 @@ impl AppState {
         match event {
             AppEvent::PrOpenFilterControls => {
                 self.prs_state.filter_ui.controls_open = true;
-                let repo_id = self.current_repo_id();
-                let field_index = match &repo_id {
-                    Some(id) => self.user_preferences.for_repo(id).pr_filter_field_index,
-                    None => 0,
-                };
-                self.prs_state.filter_ui.field_index =
-                    field_index.min(PR_FILTER_FIELD_COUNT.saturating_sub(1));
+                // field_index is kept in sync with per-repo prefs by
+                // restore_pr_preferences (mode entry) and
+                // remember_pr_filter_field_index (navigation), so the live
+                // value is already the persisted value; just clamp it.
+                self.prs_state.filter_ui.field_index = self
+                    .prs_state
+                    .filter_ui
+                    .field_index
+                    .min(PR_FILTER_FIELD_COUNT.saturating_sub(1));
                 self.prs_state.draft_filter = self.prs_state.committed_filter.clone();
                 true
             }

--- a/src/state/prs_ops.rs
+++ b/src/state/prs_ops.rs
@@ -18,8 +18,7 @@ use super::{
 use crate::domain::{PrFilter, PrFilterState};
 use crate::messages::PullRequestsMessage;
 
-/// Number of PR filter fields for FilterNavigate wrap.
-const PR_FILTER_FIELD_COUNT: usize = 8;
+use crate::state::PR_FILTER_FIELD_COUNT;
 
 impl AppState {
     /// Enter PR mode: save prior focus, set active, clear data, set default filter.
@@ -270,15 +269,25 @@ impl AppState {
                 true
             }
             AppEvent::PrClearFilter => {
-                self.prs_state.committed_filter = PrFilter::default();
-                self.prs_state.committed_filter.state = Some(PrFilterState::Open);
-                self.prs_state.draft_filter = self.prs_state.committed_filter.clone();
-                self.reload_pr_list_for_filter_change();
-                self.remember_pr_preferences();
+                self.clear_pr_filter();
                 true
             }
             _ => false,
         }
+    }
+
+    /// Reset the committed/draft PR filters to the Open default, clear the
+    /// search query, and persist the result (issue #163).
+    fn clear_pr_filter(&mut self) {
+        self.prs_state.committed_filter = PrFilter::default();
+        self.prs_state.committed_filter.state = Some(PrFilterState::Open);
+        self.prs_state.draft_filter = self.prs_state.committed_filter.clone();
+        // Clearing all filters also clears the search query so the persisted
+        // state stays consistent.
+        self.prs_state.search_query.clear();
+        self.prs_state.search_input_focused = false;
+        self.reload_pr_list_for_filter_change();
+        self.remember_pr_preferences();
     }
 
     /// Handle draft filter field updates.

--- a/src/state/prs_ops.rs
+++ b/src/state/prs_ops.rs
@@ -55,13 +55,24 @@ impl AppState {
         self.prs_state.merge_mutation_pending = None;
         self.prs_state.filter_ui.controls_open = false;
         self.prs_state.search_input_focused = false;
-        self.prs_state.search_query.clear();
+        self.restore_pr_preferences();
         self.prs_state.detail_subfocus = super::PrDetailSubfocus::Body;
         self.prs_state.draft_notice = None;
         self.prs_state.mutation_pending = None;
-        self.prs_state.committed_filter = PrFilter::default();
-        self.prs_state.committed_filter.state = Some(PrFilterState::Open);
+    }
+
+    /// Restore the current repo's PR filter/search/field-index from per-repo
+    /// preferences (issue #163). Falls back to Open defaults for unknown repos.
+    fn restore_pr_preferences(&mut self) {
+        let repo_id = self.current_repo_id();
+        let prefs = match &repo_id {
+            Some(id) => self.user_preferences.for_repo(id),
+            None => crate::domain::RepoPreferences::with_open_defaults(),
+        };
+        self.prs_state.committed_filter = prefs.pr_filter;
         self.prs_state.draft_filter = self.prs_state.committed_filter.clone();
+        self.prs_state.search_query = prefs.pr_search_query;
+        self.prs_state.filter_ui.field_index = prefs.pr_filter_field_index;
     }
 
     /// Exit PR mode: restore prior focus with bounds fallback.
@@ -129,6 +140,7 @@ impl AppState {
         self.prs_state.mutation_pending = None;
         self.prs_state.merge_chooser = None;
         self.prs_state.merge_mutation_pending = None;
+        self.restore_pr_preferences();
     }
 
     // ---- Filter controls ----
@@ -160,7 +172,13 @@ impl AppState {
         match event {
             AppEvent::PrOpenFilterControls => {
                 self.prs_state.filter_ui.controls_open = true;
-                self.prs_state.filter_ui.field_index = 0;
+                let repo_id = self.current_repo_id();
+                let field_index = match &repo_id {
+                    Some(id) => self.user_preferences.for_repo(id).pr_filter_field_index,
+                    None => 0,
+                };
+                self.prs_state.filter_ui.field_index =
+                    field_index.min(PR_FILTER_FIELD_COUNT.saturating_sub(1));
                 self.prs_state.draft_filter = self.prs_state.committed_filter.clone();
                 true
             }
@@ -239,6 +257,7 @@ impl AppState {
                 self.prs_state.committed_filter = self.prs_state.draft_filter.clone();
                 self.prs_state.filter_ui.controls_open = false;
                 self.reload_pr_list_for_filter_change();
+                self.remember_pr_preferences();
                 true
             }
             AppEvent::PrClearFilter => {
@@ -246,6 +265,7 @@ impl AppState {
                 self.prs_state.committed_filter.state = Some(PrFilterState::Open);
                 self.prs_state.draft_filter = self.prs_state.committed_filter.clone();
                 self.reload_pr_list_for_filter_change();
+                self.remember_pr_preferences();
                 true
             }
             _ => false,
@@ -311,6 +331,7 @@ impl AppState {
                 self.prs_state.committed_filter.query_text = trimmed;
                 self.prs_state.search_input_focused = false;
                 self.reload_pr_list_for_filter_change();
+                self.remember_pr_preferences();
                 true
             }
             AppEvent::PrClearSearch => {
@@ -318,6 +339,7 @@ impl AppState {
                 self.prs_state.committed_filter.query_text.clear();
                 self.prs_state.search_input_focused = false;
                 self.reload_pr_list_for_filter_change();
+                self.remember_pr_preferences();
                 true
             }
             _ => false,
@@ -536,6 +558,7 @@ impl AppState {
             self.prs_state.committed_filter.query_text = trimmed;
             self.prs_state.search_input_focused = false;
             self.reload_pr_list_for_filter_change();
+            self.remember_pr_preferences();
             return true;
         }
         let event: AppEvent = message.into();

--- a/src/state/prs_ops.rs
+++ b/src/state/prs_ops.rs
@@ -72,7 +72,11 @@ impl AppState {
         self.prs_state.committed_filter = prefs.pr_filter;
         self.prs_state.draft_filter = self.prs_state.committed_filter.clone();
         self.prs_state.search_query = prefs.pr_search_query;
-        self.prs_state.filter_ui.field_index = prefs.pr_filter_field_index;
+        // Clamp against the current field count so a stale/corrupted persisted
+        // index cannot drive the cursor out of bounds (issue #163).
+        self.prs_state.filter_ui.field_index = prefs
+            .pr_filter_field_index
+            .min(PR_FILTER_FIELD_COUNT.saturating_sub(1));
     }
 
     /// Exit PR mode: restore prior focus with bounds fallback.

--- a/src/state/state_ops.rs
+++ b/src/state/state_ops.rs
@@ -22,6 +22,10 @@ pub fn delete_selected_repository(state: &mut AppState, repository_id: &Reposito
             .agents
             .retain(|agent| &agent.repository_id != repository_id);
 
+        // Drop the deleted repo's remembered preferences so they cannot be
+        // restored if the id is ever reused (issue #163).
+        state.user_preferences.remove_for_repo(repository_id);
+
         if state.repositories.is_empty() {
             state.selected_repository_index = None;
             state.selected_agent_index = None;

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -396,6 +396,9 @@ pub struct IssueLoadingState {
 
 pub const ISSUE_FILTER_FIELD_COUNT: usize = 8;
 
+/// Number of PR filter fields for FilterNavigate wrap (issue #163).
+pub const PR_FILTER_FIELD_COUNT: usize = 8;
+
 #[derive(Debug, Clone, Default)]
 pub struct IssueFilterUiState {
     pub controls_open: bool,

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -202,6 +202,13 @@ pub struct AppState {
     /// @requirement REQ-PR-001
     pub prs_state: PullRequestsState,
 
+    /// Per-repository remembered user preferences (issue #163).
+    ///
+    /// Runtime copy of the persisted DTO — mirror of
+    /// `persistence::State.user_preferences`. The reducer reads/writes this
+    /// in memory; the app-shell persists it via `to_persisted_state`.
+    pub user_preferences: crate::domain::UserPreferences,
+
     /// Rapid `qqq` quit-sequence bookkeeping. Runtime-only — never persisted.
     pub quit_sequence: QuitSequenceState,
 

--- a/tests/e2e/end_to_end.rs
+++ b/tests/e2e/end_to_end.rs
@@ -184,6 +184,7 @@ fn persistence_roundtrip_preserves_state() {
         last_selected_agent_by_repo: vec![],
         pane_focus: String::new(),
         terminal_focused: false,
+        user_preferences: jefe::domain::UserPreferences::default(),
     };
 
     // Save and reload

--- a/tests/e2e/recovery_paths.rs
+++ b/tests/e2e/recovery_paths.rs
@@ -238,6 +238,7 @@ fn startup_recovery_corrupt_settings_valid_state() {
         last_selected_agent_by_repo: vec![],
         pane_focus: String::new(),
         terminal_focused: false,
+        user_preferences: jefe::domain::UserPreferences::default(),
     };
     let state_json = serde_json::to_string(&valid_state).test_unwrap("test unwrap");
     fs::write(&state_path, state_json).test_unwrap("test unwrap");

--- a/tests/ui/dashboard_reorder.rs
+++ b/tests/ui/dashboard_reorder.rs
@@ -513,6 +513,7 @@ fn reordered_repository_vec_order_matches_persisted_order() {
         last_selected_agent_by_repo: state.last_selected_agent_by_repo.clone(),
         pane_focus: String::new(),
         terminal_focused: false,
+        user_preferences: jefe::domain::UserPreferences::default(),
     };
 
     assert_eq!(persisted.repositories[0].name, "bravo");

--- a/tests/ui/dashboard_reorder.rs
+++ b/tests/ui/dashboard_reorder.rs
@@ -513,7 +513,7 @@ fn reordered_repository_vec_order_matches_persisted_order() {
         last_selected_agent_by_repo: state.last_selected_agent_by_repo.clone(),
         pane_focus: String::new(),
         terminal_focused: false,
-        user_preferences: jefe::domain::UserPreferences::default(),
+        user_preferences: state.user_preferences.clone(),
     };
 
     assert_eq!(persisted.repositories[0].name, "bravo");

--- a/tests/ui/dashboard_reorder_tui.rs
+++ b/tests/ui/dashboard_reorder_tui.rs
@@ -54,6 +54,7 @@ fn seed_reorder_state(config_dir: &Path) {
         last_selected_agent_by_repo: vec![],
         pane_focus: String::new(),
         terminal_focused: false,
+        user_preferences: jefe::domain::UserPreferences::default(),
     };
 
     let paths = PersistencePaths {


### PR DESCRIPTION
## Summary

Fixes #163.

User selections were reset to hardcoded defaults on every mode re-entry, dialog open, and app restart — forcing users to re-select their preferred merge method, re-type filter queries, and re-cycle PR/issue state filters over and over. This PR introduces a lightweight **per-repository** preferences layer that is persisted in `state.json` and restored on startup, so choices made in one repo never leak into another (e.g. llxprt-code filters stay out of jefe).

### Cataloged areas — all fixed

| # | Area | Before | After |
|---|------|--------|-------|
| 1 | Merge method selection | Always reset to Merge (index 0) | Restores last confirmed method, clamped to the repo's allowed methods |
| 2 | PR committed filter | Wiped to default on mode entry | Restored from per-repo prefs |
| 3 | PR filter field cursor | Reset to 0 on open; lost on navigate/close | Restored on open, persisted on navigate AND close |
| 4 | Issue committed filter | Wiped to default on mode entry | Restored from per-repo prefs |
| 5 | Issue filter field cursor | Reset to 0 on open; lost on navigate/close | Restored on open, persisted on navigate AND close |
| 6 | PR search query | Empty on each mode entry | Restored from per-repo prefs |
| 7 | Issue search query | Empty on each mode entry | Restored from per-repo prefs |
| 8 | Persistence layer | All PR/Issue state excluded | user_preferences persisted in state.json (per-repo) |

## Design

- **New domain types** (src/domain/mod.rs): RepoPreferences (issue/PR filter, search queries, filter field indices, last merge method) and UserPreferences (a Vec of (RepositoryId, RepoPreferences) pairs with for_repo / update_for_repo accessors). Added Serialize/Deserialize to the existing filter types + MergeMethod.
- **Per-repository isolation**: preferences are keyed by RepositoryId, so filter/merge choices in one repo cannot affect another. Switching repos mid-mode restores the new repo's remembered filter.
- **Defaults are Open**: a manual Default for RepoPreferences produces Open filters for both issues and PRs, and serde field defaults (default_open_issue_filter / default_open_pr_filter) ensure partial/legacy JSON also deserializes to Open.
- **Reducer stays deterministic**: preference reads/writes only mutate in-memory AppState.user_preferences. Disk persistence happens at the app-shell boundary via to_persisted_state + persist_state, exactly like the existing pane_focus / terminal_focused fields (issue #160).
- **Merge method invalidation**: open_pr_merge_chooser restores the last method; when PrMergeMethodsLoaded arrives, if the restored method is not in allowed_methods it clamps to the first enabled method.
- **Backward compatibility**: the user_preferences field on the persisted State DTO uses #[serde(default)], so a legacy state.json without it deserializes to empty prefs with no schema-version bump.
- **Stale-preference pruning**: finalize_message drops user_preferences.by_repo entries for deleted repositories (mirroring the existing last_selected_agent_by_repo prune).

## Clear vs. Remember

ClearFilter still resets the live filter, but now resets to an explicit Some(Open) (matching the documented default-on-first-use) rather than None, and the remembered last-applied filter remains available as the draft source for the next session. Issue and PR clear paths are now consistent.

## Tests

- New src/state/preferences_tests.rs (20+ tests): Open default on first use, enter-mode restore for both PRs and issues, per-repo isolation (switch-and-back), apply/clear/search persistence, field-index persistence on navigate/close + reopen, merge chooser restore + allowed-method clamp + persist-on-confirm, RepoPreferences Default = Open, partial-JSON deserialization = Open, deleted-repo preference pruning.
- New persistence integration tests: full restart-hydration path (to_persisted_state then FilePersistenceManager save/load then restore then enter-mode, proving no cross-repo leakage through the real persistence layer), and legacy-JSON-without-prefs to Open defaults on mode entry.
- Updated existing tests that build State struct literals to include the new field.

## Out of scope

F12 consistency is tracked separately in #164.

## Verification

- cargo fmt --all --check — pass
- cargo clippy --workspace --all-targets --all-features -- -D warnings — pass
- Complexity clippy gate (cognitive_complexity, too_many_lines, etc.) — pass
- cargo build --workspace --all-features --locked — pass
- cargo test --workspace --all-features --locked — 1424 tests, 0 failures
- scripts/check-clippy-allows.sh + scripts/check-source-file-size.sh — pass
