### PR TITLE
Preserve --yolo mode flag on issue/PR-driven LLxprt launches (Fixes #210)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,7 +73,8 @@ With your repository selected, press `n` (lowercase n) to open **New Agent**.
 
 - **Mode Flags**
   - Extra llxprt CLI flags.
-  - Defaults to `--yolo` when empty.
+  - The new-agent form pre-fills `--yolo`; clear it to run non-yolo. What you
+    save is what is passed.
 
 - **LLXPRT_DEBUG**
   - Optional debug env value for llxprt.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -94,7 +94,7 @@ Pressing `n` opens a form to launch a new agent under the currently selected rep
 | **Description**    | Optional. Longer explanation of the agent's purpose.                         |
 | **Work dir**       | Auto-populated from repo base dir + name slug. User-editable.                |
 | **Profile**        | Inherited from repository default. Editable. Empty means agent CLI defaults. |
-| **Mode**           | Defaults to `--yolo`. Free-text for arbitrary flags.                         |
+| **Mode**           | Pre-filled with `--yolo`. Free-text for arbitrary flags; clear it to run non-yolo. |
 | **Pass --continue**| Checkbox (default on). Appends `--continue` to the mode flags.               |
 
 On submit, Jefe creates the working directory on disk, spawns a tmux session running the agent CLI in that directory with the configured profile and mode flags, allocates a PTY slot, and returns to the dashboard with the new agent selected.

--- a/src/app_input/fresh_prompt.rs
+++ b/src/app_input/fresh_prompt.rs
@@ -30,10 +30,23 @@ pub(super) fn prepare_fresh_prompt_signature(
         "Read and work on the GitHub {} described in {prompt_relative_path}",
         prompt_kind.label()
     );
-    sig.mode_flags = match sig.agent_kind {
-        AgentKind::Llxprt => vec!["-i".to_owned(), instruction],
-        AgentKind::CodePuppy => vec![instruction],
-    };
+    match sig.agent_kind {
+        // LLxprt keeps the agent's persisted mode flags (e.g. `--yolo`) and
+        // appends the fresh instruction. Replacing them here dropped `--yolo`,
+        // starting every issue/PR-driven LLxprt session in non-yolo mode (#210).
+        //
+        // `--continue` is stripped because continuation is owned by
+        // `pass_continue`, which fresh prompts force off: a stale persisted
+        // `--continue` must not resume a prior session on a fresh launch.
+        AgentKind::Llxprt => {
+            sig.mode_flags.retain(|flag| flag != "--continue");
+            sig.mode_flags.push("-i".to_owned());
+            sig.mode_flags.push(instruction);
+        }
+        // CodePuppy does not consume any LLxprt flags (#184): the instruction
+        // is the sole positional argument.
+        AgentKind::CodePuppy => sig.mode_flags = vec![instruction],
+    }
     sig
 }
 
@@ -66,9 +79,11 @@ mod tests {
             ".jefe/issue-prompt.md",
         );
         assert!(!result.pass_continue);
+        // Persisted mode flags are preserved and the instruction is appended.
         assert_eq!(
             result.mode_flags,
             vec![
+                "--stale",
                 "-i",
                 "Read and work on the GitHub issue described in .jefe/issue-prompt.md"
             ]
@@ -104,6 +119,47 @@ mod tests {
     }
 
     #[test]
+    fn llxprt_preserves_existing_mode_flags_including_yolo() {
+        // Regression for issue #210: the fresh-prompt path for LLxprt agents
+        // must not drop the agent's persisted mode flags (e.g. `--yolo`).
+        // Appending the instruction while keeping `--yolo` is what makes the
+        // fresh session launch in yolo mode, matching a normal launch.
+        let mut sig = base_sig(AgentKind::Llxprt);
+        sig.mode_flags = vec!["--yolo".to_owned()];
+        let result =
+            prepare_fresh_prompt_signature(sig, FreshPromptKind::Issue, ".jefe/issue-prompt.md");
+        assert!(!result.pass_continue);
+        assert_eq!(
+            result.mode_flags,
+            vec![
+                "--yolo",
+                "-i",
+                "Read and work on the GitHub issue described in .jefe/issue-prompt.md"
+            ]
+        );
+    }
+
+    #[test]
+    fn llxprt_fresh_prompt_strips_persisted_continue() {
+        // Fresh launches must never resume a prior session. `--continue` is
+        // owned by `pass_continue` (forced off here), so a stale persisted
+        // `--continue` in the mode string must be dropped, not forwarded.
+        let mut sig = base_sig(AgentKind::Llxprt);
+        sig.mode_flags = vec!["--yolo".to_owned(), "--continue".to_owned()];
+        let result =
+            prepare_fresh_prompt_signature(sig, FreshPromptKind::PullRequest, ".jefe/pr-prompt.md");
+        assert!(!result.pass_continue);
+        assert_eq!(
+            result.mode_flags,
+            vec![
+                "--yolo",
+                "-i",
+                "Read and work on the GitHub PR described in .jefe/pr-prompt.md"
+            ]
+        );
+    }
+
+    #[test]
     fn llxprt_pr_uses_fresh_pr_instruction() {
         let result = prepare_fresh_prompt_signature(
             base_sig(AgentKind::Llxprt),
@@ -111,9 +167,11 @@ mod tests {
             ".jefe/pr-prompt.md",
         );
         assert!(!result.pass_continue);
+        // Persisted mode flags are preserved and the instruction is appended.
         assert_eq!(
             result.mode_flags,
             vec![
+                "--stale",
                 "-i",
                 "Read and work on the GitHub PR described in .jefe/pr-prompt.md"
             ]

--- a/src/app_input/fresh_prompt.rs
+++ b/src/app_input/fresh_prompt.rs
@@ -140,6 +140,25 @@ mod tests {
     }
 
     #[test]
+    fn llxprt_fresh_prompt_does_not_add_yolo_to_empty_mode() {
+        // The other half of #210: an agent whose mode was cleared (non-yolo)
+        // must stay non-yolo on a fresh-prompt launch. --yolo is never
+        // synthesized here; only the instruction is appended.
+        let mut sig = base_sig(AgentKind::Llxprt);
+        sig.mode_flags.clear();
+        let result =
+            prepare_fresh_prompt_signature(sig, FreshPromptKind::Issue, ".jefe/issue-prompt.md");
+        assert!(!result.pass_continue);
+        assert_eq!(
+            result.mode_flags,
+            vec![
+                "-i",
+                "Read and work on the GitHub issue described in .jefe/issue-prompt.md"
+            ]
+        );
+    }
+
+    #[test]
     fn llxprt_fresh_prompt_strips_persisted_continue() {
         // Fresh launches must never resume a prior session. `--continue` is
         // owned by `pass_continue` (forced off here), so a stale persisted

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -107,11 +107,10 @@ pub fn create_agent(params: CreateAgentParams<'_>) -> Option<Agent> {
 
     let work_dir = resolve_agent_work_dir(params.repository, params.work_dir)?;
 
-    let mode_flags: Vec<String> = if params.mode.trim().is_empty() {
-        vec!["--yolo".to_owned()]
-    } else {
-        params.mode.split_whitespace().map(String::from).collect()
-    };
+    // The mode field is the single source of truth for whether --yolo (or any
+    // flag) is passed. An empty mode yields no flags so an agent can run
+    // non-yolo; the new-agent form pre-fills --yolo as the default instead.
+    let mode_flags: Vec<String> = params.mode.split_whitespace().map(String::from).collect();
 
     let caps = PlatformCapabilities::current();
     let sandbox_engine = SandboxEngine::from_form_value(params.sandbox_engine)

--- a/src/services/tests.rs
+++ b/src/services/tests.rs
@@ -112,8 +112,10 @@ fn create_agent_normalizes_profile() {
 fn create_agent_normalizes_mode_flags() {
     let repo = local_repository();
 
-    let default_mode = created(params(&repo, "Agent", "/tmp/agent"));
-    assert_eq!(default_mode.mode_flags, vec!["--yolo".to_owned()]);
+    // An empty mode must stay empty: yolo is opt-in via the form's pre-filled
+    // mode field, not injected here. This lets an agent run non-yolo (#210).
+    let empty_mode = created(params(&repo, "Agent", "/tmp/agent"));
+    assert!(empty_mode.mode_flags.is_empty());
 
     let explicit = created(CreateAgentParams {
         mode: "--fast --verbose",
@@ -123,6 +125,13 @@ fn create_agent_normalizes_mode_flags() {
         explicit.mode_flags,
         vec!["--fast".to_owned(), "--verbose".to_owned()]
     );
+
+    // The pre-filled new-agent default still round-trips through create.
+    let yolo_default = created(CreateAgentParams {
+        mode: "--yolo",
+        ..params(&repo, "Agent", "/tmp/agent")
+    });
+    assert_eq!(yolo_default.mode_flags, vec!["--yolo".to_owned()]);
 }
 
 #[test]

--- a/src/state/form_build.rs
+++ b/src/state/form_build.rs
@@ -254,18 +254,10 @@ impl AppState {
         agent.profile = normalize_profile(&fields.profile);
         agent.agent_kind =
             AgentKind::from_form_value(&fields.agent_kind).unwrap_or(agent.agent_kind);
-        if fields.mode.trim().is_empty() {
-            // Match the create path: an empty mode for Llxprt resets to
-            // --yolo so update and create behave identically. CodePuppy has
-            // no default mode flags.
-            if agent.agent_kind == AgentKind::Llxprt {
-                agent.mode_flags = vec!["--yolo".to_owned()];
-            } else {
-                agent.mode_flags = Vec::new();
-            }
-        } else {
-            agent.mode_flags = fields.mode.split_whitespace().map(String::from).collect();
-        }
+        // The mode field is the single source of truth for mode flags. An
+        // empty mode yields no flags so yolo can be turned off on update; the
+        // new-agent form pre-fills --yolo as the create default instead.
+        agent.mode_flags = fields.mode.split_whitespace().map(String::from).collect();
         agent.llxprt_debug = normalize_llxprt_debug(&fields.llxprt_debug);
         agent.pass_continue = fields.pass_continue;
         agent.sandbox_enabled = fields.sandbox_enabled;

--- a/src/state/form_ops_tests.rs
+++ b/src/state/form_ops_tests.rs
@@ -300,9 +300,10 @@ fn update_agent_ignores_whitespace_only_work_dir() {
 }
 
 #[test]
-fn update_agent_empty_llxprt_mode_resets_to_yolo() {
-    // Consistent with create: clearing the mode field for Llxprt must reset
-    // to --yolo, not preserve an old non-yolo value.
+fn update_agent_empty_llxprt_mode_stays_empty() {
+    // Clearing the mode field for Llxprt must persist as empty flags, letting
+    // the agent run non-yolo. The agent config is the source of truth for
+    // whether --yolo is passed (#210).
     let repository = seed_repository();
     let mut agent = Agent {
         id: crate::domain::AgentId("agent-yolo".to_owned()),
@@ -338,10 +339,10 @@ fn update_agent_empty_llxprt_mode_resets_to_yolo() {
         sandbox_flags: String::new(),
     };
     AppState::update_agent_from_fields(&mut agent, &repository, &fields);
-    assert_eq!(
-        agent.mode_flags,
-        vec!["--yolo".to_owned()],
-        "empty Llxprt mode must reset to --yolo, not preserve --fast"
+    assert!(
+        agent.mode_flags.is_empty(),
+        "empty Llxprt mode must stay empty so yolo can be turned off, got {:?}",
+        agent.mode_flags
     );
 }
 


### PR DESCRIPTION
## Problem

Closes #210. Two facets of broken `--yolo` handling:

1. **Yolo not passed on issue/PR-driven launches.** After pulling main, `--yolo` was no longer sent to llxprt for issue/PR-driven (fresh-prompt) launches, so every such session started non-yolo. The issue correctly suspected the Code Puppy changes.

2. **Yolo could not be turned off.** Deleting `--yolo` from an agent and saving brought it straight back, so LLxprt always launched yolo with no way to run interactive/supervised. The agent mode config was not the source of truth.

## Root cause

**Facet 1:** The Code Puppy work (#184/#193) refactored the fresh-prompt path into `prepare_fresh_prompt_signature`, which **replaced** `mode_flags` entirely for LLxprt agents — discarding persisted flags including `--yolo`. Before #184 the old code **pushed** onto the existing flags.

**Facet 2:** `create_agent` (services) and `update_agent_from_fields` (state) silently re-injected `--yolo` whenever the mode field was empty. So clearing the field always reset to yolo.

## Fix

**Facet 1 — `src/app_input/fresh_prompt.rs`:** For `AgentKind::Llxprt`, keep the persisted `mode_flags` and append `-i` + the instruction (restoring pre-#184 behavior). CodePuppy unchanged. Also strip any persisted `--continue` (continuation is owned by `pass_continue`, forced off for fresh prompts) so a `--yolo --continue` mode string cannot bypass the fresh-launch guarantee.

**Facet 2 — `src/services/mod.rs` + `src/state/form_build.rs`:** Stop injecting `--yolo` on empty mode. Empty mode now yields empty `mode_flags`. The new-agent form still pre-fills `--yolo` (`modal_ops.rs`), so new agents default to yolo; the only change is that what you save is what you get, on both create and edit. The agent config is the single source of truth.

## Tests (TDD)

Facet 1:
- `llxprt_preserves_existing_mode_flags_including_yolo` — `--yolo` survives fresh-prompt transform
- `llxprt_fresh_prompt_strips_persisted_continue` — stale `--continue` dropped, fresh launches never resume
- `llxprt_fresh_prompt_does_not_add_yolo_to_empty_mode` — a non-yolo agent stays non-yolo on fresh launches

Facet 2:
- `create_agent_normalizes_mode_flags` — empty mode -> empty flags; explicit `--yolo` round-trips
- `update_agent_empty_llxprt_mode_stays_empty` — clearing the field on edit persists as empty (was: reset to `--yolo`)

## Verification

    cargo fmt --all --check
    cargo clippy --workspace --all-targets --all-features -- -D warnings
    cargo build --workspace --all-features --locked
    cargo test --workspace --all-features --locked   # 1822 passed, 0 failed