### PR TITLE
Fix terminal text selection and copy for Code Puppy sessions (Fixes #197)

### DIFF
--- a/dev-docs/testing/tmux-harness.md
+++ b/dev-docs/testing/tmux-harness.md
@@ -150,6 +150,31 @@ manual/opt-in and also skips when `tmux` cannot be installed or found.
   enters Actions mode (`g`), verifies the runs-list pane renders, navigates
   down, then exits and quits. Intentionally not a CI gate — it requires a
   configured repository and may vary by developer machine.
+- [`kennel-terminal-select.json`](../tmux-scenarios/kennel-terminal-select.json):
+  manual scratch scenario for issue #197 — terminal text selection and copy for
+  Code Puppy (Kennel mode) sessions. It focuses the terminal and captures the
+  focused Kennel terminal screen. It is intentionally not a CI gate because it
+  requires a configured repository with a running Code Puppy agent (which varies
+  by developer machine), and the keyboard-only harness cannot drive mouse
+  drag-select or assert OSC 52 clipboard contents. The behavioral contract
+  (plain drag and shift-drag paint a Jefe selection and copy over the snapshot
+  for Kennel agents; LLxprt keeps PTY forwarding when mouse reporting is active)
+  is covered by unit tests in `tests/runtime/terminal_focus_routing.rs` and
+  `src/selection/terminal_mouse_policy.rs`. Run the scenario manually:
+
+  ```bash
+  cargo run --bin jefe-tmux-harness -- \
+    --scenario dev-docs/tmux-scenarios/kennel-terminal-select.json \
+    --jefe-bin target/debug/jefe \
+    --config /tmp/jefe-harness-config \
+    --out-dir target/tmux-harness/kennel-terminal-select \
+    --keep-session
+  ```
+
+  Then, in the kept session, drag across visible Code Puppy output: the
+  selected cells should highlight (inverse video) and release should copy the
+  highlighted text. Holding Shift while dragging must also highlight and copy
+  (it is no longer a no-op).
 
 ## Future regression scenarios
 

--- a/dev-docs/tmux-scenarios/kennel-terminal-select.json
+++ b/dev-docs/tmux-scenarios/kennel-terminal-select.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "cols": 100,
+    "rows": 32,
+    "history_limit": 2000,
+    "initial_wait_ms": 100,
+    "assert_mode": "soft"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "key": "Tab" },
+    { "key": "Tab" },
+    { "key": "t" },
+    { "waitFor": "Terminal" },
+    { "capture": "kennel-terminal-focused" },
+    { "key": "F12" },
+    { "key": "q" },
+    { "key": "q" },
+    { "key": "q" },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/project-plans/issue197-plan.md
+++ b/project-plans/issue197-plan.md
@@ -1,0 +1,167 @@
+# Plan: Fix terminal text selection and copy for Code Puppy sessions (#197)
+
+## Problem
+
+Inside the embedded TerminalView, drag-to-select and copy do not work when a
+Code Puppy agent is running, even though the same Code Puppy build supports
+native drag selection when run in a normal terminal.
+
+Three root causes in `src/mouse_routing.rs` + `src/selection/geometry.rs`:
+
+1. **Shift-drag is dropped entirely.** `handle_fullscreen_mouse` returns
+   immediately when `SHIFT` is held, assuming the host terminal will paint its
+   own selection. But the host terminal sees Jefe's rendered canvas, not the
+   nested PTY grid, so nothing happens — no highlight, no copy.
+
+2. **Mouse-reporting agents (Code Puppy) swallow drags.** When the child has
+   mouse reporting on, `forward_to_pty_if_in_terminal` forwards drag/up to the
+   PTY, so Jefe never starts its own selection. Code Puppy "normally relies on
+   ordinary terminal selection," so this prevents the expected behavior.
+
+3. **Geometry gap when focused.** `pane_at` returns `None` for the terminal
+   region when `terminal_input_enabled` is true. So even when forwarding is
+   skipped (e.g. no mouse reporting), `resolve_selection_point` cannot resolve
+   a `TerminalView` selection and no selection begins.
+
+## Design
+
+Introduce an explicit **mouse routing policy** so Jefe picks the right
+behavior per agent, rather than a single host-terminal assumption.
+
+### New pure policy module: `src/app_input/terminal_mouse_policy.rs`
+
+A single pure, iocraft-free, side-effect-free function:
+
+```rust
+/// How a mouse gesture over the focused terminal should be routed.
+pub enum TerminalMouseRouting {
+    /// Jefe paints a selection over the snapshot and copies on release.
+    AppSelection,
+    /// Forward the gesture to the child PTY (when mouse reporting is active).
+    ForwardToPty,
+}
+
+/// Resolve the routing policy for a mouse gesture over the focused terminal.
+///
+/// Inputs are pure booleans (no runtime lock), so the decision is fully
+/// unit-testable.
+#[must_use]
+pub fn route_terminal_mouse(
+    agent_is_kennel: bool,   // selected agent is Code Puppy
+    shift_held: bool,        // SHIFT modifier on the gesture
+    mouse_reporting_active: bool, // child currently reports mouse
+) -> TerminalMouseRouting
+```
+
+Decision table (the documented contract):
+
+| agent kennel | shift | reporting | routing        | rationale                                             |
+|-------------:|:-----:|:---------:|----------------|-------------------------------------------------------|
+| any          | yes   | any       | AppSelection   | Shift-drag must not be a no-op (#197).                |
+| no (LLxprt)  | no    | yes       | ForwardToPty   | preserve existing LLxprt mouse behavior.              |
+| no (LLxprt)  | no    | no        | AppSelection   | nothing to forward; select over snapshot.             |
+| yes (CP)     | no    | yes       | AppSelection   | CP relies on terminal selection; Jefe owns the grid.  |
+| yes (CP)     | no    | no        | AppSelection   | select over snapshot.                                 |
+
+Rationale captured in the enum/fn docs: Code Puppy advertises mouse reporting
+for transient menus, but its primary interaction model is ordinary terminal
+selection which Jefe now owns for the embedded view. LLxprt genuinely drives
+mouse reporting and must keep PTY forwarding. Shift always means "I want a
+host/Jefe selection," mirroring standard terminal semantics.
+
+### `handle_fullscreen_mouse` rewrite
+
+Replace the top of `handle_fullscreen_mouse` so:
+
+- It reads the selected agent's kennel flag and `mouse_reporting_active()`
+  under the existing short-lived ctx + state guards.
+- It calls `route_terminal_mouse(...)` to get a `TerminalMouseRouting`.
+- On `AppSelection`: proceed straight to the selection handlers (begin/update/
+  finalize), passing a new `force_terminal_selectable` so the geometry can
+  resolve `TerminalView` even while focused.
+- On `ForwardToPty`: keep the existing `forward_to_pty_if_in_terminal` path.
+
+This removes the blanket early `return` for SHIFT. Shift-drag now routes to
+`AppSelection` (and the SGR encoder already suppresses Shift forwarding in
+`mouse_event_to_bytes`, so the two layers stay consistent).
+
+### Geometry: resolve `TerminalView` while focused, when selecting
+
+`dashboard_pane_at` currently returns `None` for the terminal region when
+`terminal_input_enabled`. Add a parameter (or a focused-but-selectable flag)
+so that, when the routing decision is `AppSelection`, `pane_at` resolves
+`SelectablePane::TerminalView` with the same geometry used when unfocused.
+
+Concretely, thread a `terminal_selectable: bool` through `pane_at` /
+`dashboard_pane_at` (distinct from `terminal_input_enabled`). The mouse router
+sets `terminal_selectable = matches!(routing, AppSelection)`. Existing call
+sites pass `terminal_selectable == !terminal_input_enabled` to preserve their
+behavior verbatim.
+
+### `resolve_selection_point` already copies from the snapshot
+
+`finalize_and_copy_selection` builds content via `pane_content_lines(...)` →
+`terminal_lines(snapshot)`, which already reads the rendered snapshot cells
+(Unicode + wrapped rows) — so the copied text matches the TerminalView as long
+as the snapshot is captured. No change needed there; the issue's
+"Unicode/wrapped" criterion is satisfied by reusing the snapshot projection.
+
+## Tests (TDD: RED → GREEN)
+
+### RED — pure policy (`src/app_input/terminal_mouse_policy.rs` inline tests)
+
+Assert every row of the decision table, including: shift-drag is never
+`ForwardToPty`, kennel agents never forward unmodified, LLxprt forwards when
+reporting.
+
+### RED — geometry (`src/selection/tests.rs`)
+
+New test: with `terminal_selectable = true`, a coordinate in the terminal
+region resolves to `SelectablePane::TerminalView` (the focused case that
+previously returned `None`). Keep the existing
+`pane_at_dashboard_terminal_focused_returns_none_in_terminal_region` semantics
+for the `terminal_input_enabled && !terminal_selectable` case (forward path).
+
+### RED — mouse routing integration
+
+A focused-TerminalView + Code Puppy agent + `mouse_reporting_active` gesture
+must begin/update/finalize a `TerminalView` selection (not forward, not no-op).
+Cover:
+- Code Puppy + plain drag → selection begins.
+- Code Puppy + shift-drag → selection begins (was no-op).
+- LLxprt + mouse reporting + plain drag → forwarded (existing behavior kept).
+- LLxprt + no reporting + plain drag → app selection.
+
+Because `handle_fullscreen_mouse` is iocraft-hook-bound, the testable seam is
+the pure policy + geometry; a thin extraction of the decision into a pure
+helper keeps the hook closure minimal and unit-testable, mirroring the existing
+`next_wheel_scroll_offset` pattern.
+
+### TUI harness scenario (`dev-docs/tmux-scenarios/kennel-terminal-select.json`)
+
+Exercise selection/copy in Kennel mode: launch, enter terminal focus, open the
+host copy/selection path. Because the harness is keyboard/tmux-driven and
+OSC 52 copy cannot be asserted deterministically across machines, the scenario
+documents the Kennel-mode selection path and captures the focused terminal
+screen. It is intentionally a local/manual scenario (not a hard CI gate),
+matching the existing `scratch-pr-mode.json` / `actions-mode.json` policy for
+scenarios that depend on per-machine state.
+
+## Files
+
+- NEW `src/app_input/terminal_mouse_policy.rs` — pure routing policy + tests.
+- `src/app_input/mod.rs` — register the new module.
+- `src/mouse_routing.rs` — rewrite the top of `handle_fullscreen_mouse`,
+  thread `terminal_selectable`.
+- `src/selection/geometry.rs` — `pane_at` / `dashboard_pane_at` accept
+  `terminal_selectable`.
+- `src/selection/tests.rs` — focused-terminal-selectable geometry test.
+- `tests/runtime/terminal_focus_routing.rs` — keep existing LLxprt forwarding
+  covered; add Code Puppy selection-not-forwarded coverage.
+- NEW `dev-docs/tmux-scenarios/kennel-terminal-select.json`.
+
+## Out of scope
+
+- Changing how LLxprt forwards mouse events (existing behavior preserved).
+- Multi-pane cross-terminal selection.
+- tmux copy-mode workflow (the issue says it is not a practical path).

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -5,6 +5,18 @@
 //! shared [`crate::app_shell::CtxArc`], translating fullscreen mouse events
 //! into either PTY input (when the terminal pane is focused) or text-selection
 //! state transitions.
+//!
+//! # Issue #197 design
+//!
+//! Terminal mouse routing uses a pure gesture-ownership state machine
+//! ([`jefe::selection::GestureState`]) to decide, at gesture START, whether
+//! Jefe or the PTY owns a left-button down→drag→up cycle. This fixes the core
+//! bug: reporting children get their clicks, but drags still produce Jefe
+//! selections. Shift-modified non-left-button events (wheel, right, middle)
+//! pass through to the host (Finding H). Non-dashboard modes never route to
+//! the terminal (Finding F). Blocking modals intercept mouse input (Finding G).
+//! The reporting flag is read once per event (Finding E). Copy uses the
+//! snapshot captured at gesture start, not a fresh recapture (Finding B).
 
 use crate::app_shell::{CtxArc, HookState, capture_terminal_snapshot};
 use crate::pty_encoding::mouse_event_to_bytes;
@@ -12,25 +24,51 @@ use jefe::clipboard;
 use jefe::layout::compute_pty_layout;
 use jefe::runtime::RuntimeManager;
 use jefe::selection::{
-    ScreenLayout, SelectablePane, SelectionPoint, TextSelection, pane_at, pane_content_lines,
-    point_to_content_coords, selection_text,
+    GestureAction, GestureEvent, GestureEventKind, GestureState, PtyReplay, ScreenLayout,
+    SelectablePane, SelectionPoint, TextSelection, pane_at, pane_content_lines,
+    point_to_content_coords, selection_text, terminal_selection_text,
 };
-use jefe::state::{AppState, PaneFocus};
+use jefe::state::{AppState, PaneFocus, ScreenMode};
+
+/// Type alias for the clipboard writer function, injected for testability.
+pub type ClipboardWriter = fn(&str) -> Result<(), std::io::Error>;
 
 /// Terminal size fallback for the default 120x40 geometry.
 fn terminal_size() -> (u16, u16) {
     crossterm::terminal::size().unwrap_or((120, 40))
 }
 
+/// Map a crossterm event kind to the gesture-state-machine event kind.
+fn gesture_event_kind(kind: crossterm::event::MouseEventKind) -> Option<GestureEventKind> {
+    use crossterm::event::{MouseButton, MouseEventKind};
+    match kind {
+        MouseEventKind::Down(MouseButton::Left) => Some(GestureEventKind::LeftDown),
+        MouseEventKind::Drag(MouseButton::Left) => Some(GestureEventKind::LeftDrag),
+        MouseEventKind::Up(MouseButton::Left) => Some(GestureEventKind::LeftUp),
+        MouseEventKind::ScrollUp => Some(GestureEventKind::ScrollUp),
+        MouseEventKind::ScrollDown => Some(GestureEventKind::ScrollDown),
+        MouseEventKind::Down(MouseButton::Right | MouseButton::Middle)
+        | MouseEventKind::Drag(MouseButton::Right | MouseButton::Middle)
+        | MouseEventKind::Up(MouseButton::Right | MouseButton::Middle) => {
+            Some(GestureEventKind::OtherButton)
+        }
+        _ => None,
+    }
+}
+
 /// Clear any active mouse selection.
 ///
 /// Called on every non-mouse terminal event (key, paste, resize) so a
 /// selection doesn't linger after the user moves on to keyboard interaction.
+/// Also resets the terminal gesture state: a Pending gesture (which has no
+/// `selection` yet) must not survive a keyboard/paste/resize event, otherwise
+/// a buffered reporting down could leak into a later gesture against a
+/// different agent or screen (issue #197 review: gesture/snapshot invalidation).
 pub fn clear_selection(app_state: &mut HookState<AppState>) {
-    let needs_clear = app_state.read().selection.is_some();
-    if needs_clear {
-        app_state.write().selection = None;
-    }
+    let mut state = app_state.write();
+    state.selection = None;
+    state.selection_snapshot = None;
+    state.terminal_gesture_state = GestureState::default();
 }
 
 /// Route a fullscreen mouse event to PTY forwarding or app-level selection.
@@ -39,41 +77,206 @@ pub fn handle_fullscreen_mouse(
     app_state: &mut HookState<AppState>,
     mouse_event: iocraft::FullscreenMouseEvent,
 ) {
-    use crossterm::event::{MouseButton, MouseEventKind};
+    let shift_held = mouse_event.modifiers.contains(iocraft::KeyModifiers::SHIFT);
 
-    // Shift bypasses app selection and PTY forwarding: let the host terminal
-    // emulator handle native selection/copy (mirrors mouse_event_to_bytes).
-    if mouse_event.modifiers.contains(iocraft::KeyModifiers::SHIFT) {
+    // Determine whether the terminal is the active input target and read the
+    // reporting flag ONCE under a single lock (Finding E + F + G + J).
+    let (terminal_active, mouse_reporting_active) = terminal_target_info(ctx, app_state);
+
+    // If the terminal is the active input target, route through the gesture
+    // state machine. Otherwise, fall through to app-level pane selection.
+    if terminal_active
+        && route_terminal_gesture(
+            ctx,
+            app_state,
+            &mouse_event,
+            shift_held,
+            mouse_reporting_active,
+        )
+    {
         return;
     }
 
-    let terminal_input_enabled = {
-        let state = app_state.read();
-        // Suppress PTY forwarding when an overlay (modal/form/chooser) is
-        // active so mouse selection targets the top-most overlay instead of
-        // the terminal underneath (issue #178 z-order fix).
-        state.terminal_focused
-            && state.pane_focus == PaneFocus::Terminal
-            && active_overlay_for(&state) == jefe::selection::OverlayPane::None
+    // Non-terminal routing: shift-modified non-left-button events are host
+    // passthrough (Finding H) — return early.
+    if shift_held && !is_left_button(mouse_event.kind) {
+        return;
+    }
+
+    // App selection over the rendered panes (terminal not focused or not
+    // dashboard). The terminal pane is selectable only when unfocused.
+    match mouse_event.kind {
+        crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
+            begin_app_selection(app_state, mouse_event.column, mouse_event.row);
+        }
+        crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
+            update_app_selection(app_state, mouse_event.column, mouse_event.row);
+        }
+        crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left) => {
+            finalize_and_copy_selection(ctx, app_state, clipboard::write_osc52);
+        }
+        crossterm::event::MouseEventKind::ScrollUp
+        | crossterm::event::MouseEventKind::ScrollDown => {
+            dispatch_detail_scroll(app_state, &mouse_event);
+        }
+        _ => {}
+    }
+}
+
+/// Whether a crossterm event kind is a left-button event.
+fn is_left_button(kind: crossterm::event::MouseEventKind) -> bool {
+    matches!(
+        kind,
+        crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left)
+            | crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left)
+            | crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left)
+    )
+}
+
+/// Route a mouse event over the focused terminal through the gesture-ownership
+/// state machine (Finding A). Returns `true` when the event was consumed
+/// (handled by terminal routing), `false` when it should fall through to
+/// app-level pane selection (e.g. an unmapped event kind like plain move).
+fn route_terminal_gesture(
+    ctx: Option<&CtxArc>,
+    app_state: &mut HookState<AppState>,
+    mouse_event: &iocraft::FullscreenMouseEvent,
+    shift_held: bool,
+    mouse_reporting_active: bool,
+) -> bool {
+    let gesture_state = app_state.read().terminal_gesture_state.clone();
+
+    let Some(event_kind) = gesture_event_kind(mouse_event.kind) else {
+        // Unmapped event kind (e.g. plain move) — reset gesture state and let
+        // the caller fall through to app selection.
+        app_state.write().terminal_gesture_state = GestureState::default();
+        return false;
     };
 
-    // When the terminal is focused, mouse events within the terminal pane go to
-    // the managed PTY (current behavior). Everything else is app selection.
-    if terminal_input_enabled && forward_to_pty_if_in_terminal(ctx, &mouse_event) {
-        return;
+    let event = GestureEvent {
+        kind: event_kind,
+        shift_held,
+        col: mouse_event.column,
+        row: mouse_event.row,
+        mouse_reporting_active,
+    };
+    let resolver = |col: u16, row: u16| resolve_terminal_point(app_state, col, row);
+
+    let (action, new_gesture_state) = gesture_state.process(event, &resolver);
+    app_state.write().terminal_gesture_state = new_gesture_state;
+
+    execute_gesture_action(ctx, app_state, action, mouse_event);
+    true
+}
+
+/// Read the terminal target info (active + reporting) under a single lock
+/// acquisition (Finding E: no TOCTOU; Finding F: dashboard-only; Finding G:
+/// blocking overlay check; Finding J: log lock poisoning).
+///
+/// Returns `(false, false)` when the terminal is not the active input target.
+fn terminal_target_info(ctx: Option<&CtxArc>, app_state: &HookState<AppState>) -> (bool, bool) {
+    let (terminal_focused, pane_focus, screen_mode, modal_blocking) = {
+        let state = app_state.read();
+        (
+            state.terminal_focused,
+            state.pane_focus,
+            state.screen_mode,
+            is_blocking_modal_open(&state),
+        )
+    };
+
+    // Finding F: terminal routing only in Dashboard mode.
+    // Finding G: blocking modal intercepts mouse input.
+    let terminal_active = terminal_focused
+        && pane_focus == PaneFocus::Terminal
+        && screen_mode == ScreenMode::Dashboard
+        && !modal_blocking;
+
+    if !terminal_active {
+        return (false, false);
     }
 
-    // Route the event to the app-level selection handler.
+    // Read reporting once under a single lock (Finding E).
+    let reporting = match ctx {
+        Some(ctx_arc) => {
+            if let Ok(guard) = ctx_arc.lock() {
+                guard.runtime.mouse_reporting_active()
+            } else {
+                // Finding J: log lock poisoning, treat as terminal not active.
+                tracing::warn!("ctx lock poisoned while reading mouse_reporting_active");
+                return (false, false);
+            }
+        }
+        None => false,
+    };
+
+    (true, reporting)
+}
+
+/// Execute the action returned by the gesture state machine.
+fn execute_gesture_action(
+    ctx: Option<&CtxArc>,
+    app_state: &mut HookState<AppState>,
+    action: GestureAction,
+    mouse_event: &iocraft::FullscreenMouseEvent,
+) {
+    match action {
+        GestureAction::BeginSelection(point) => {
+            // Capture the snapshot at gesture start (Finding B): the copy at
+            // release will use this same snapshot, not a fresh recapture.
+            let snapshot = capture_current_snapshot(ctx, app_state);
+            let mut state = app_state.write();
+            state.selection = Some(TextSelection::collapsed(point));
+            state.selection_snapshot = snapshot;
+        }
+        GestureAction::BeginSelectionRange { anchor, focus } => {
+            // Capture the snapshot at gesture start (Finding B): the copy at
+            // release will use this same snapshot, not a fresh recapture.
+            let snapshot = capture_current_snapshot(ctx, app_state);
+            let mut state = app_state.write();
+            state.selection = Some(TextSelection { anchor, focus });
+            state.selection_snapshot = snapshot;
+        }
+        GestureAction::UpdateSelection(point) => {
+            let anchor = {
+                let state = app_state.read();
+                state.selection.map(|s| s.anchor)
+            };
+            if let Some(anchor) = anchor {
+                let mut state = app_state.write();
+                state.selection = Some(TextSelection {
+                    anchor,
+                    focus: point,
+                });
+            }
+        }
+        GestureAction::FinalizeAndCopy => {
+            finalize_terminal_selection(ctx, app_state, clipboard::write_osc52);
+        }
+        GestureAction::ForwardToPty(replays) => {
+            forward_replays(ctx, &replays, mouse_event);
+        }
+        GestureAction::Composite { first, second } => {
+            execute_gesture_action(ctx, app_state, *first, mouse_event);
+            execute_gesture_action(ctx, app_state, *second, mouse_event);
+        }
+        GestureAction::Noop => {
+            // For scroll events that the gesture machine noops (non-reporting
+            // child), fall through to app-level scroll handling.
+            dispatch_detail_scroll(app_state, mouse_event);
+        }
+    }
+}
+
+/// Detail-pane scroll dispatch for a mouse event, shared by the app-selection
+/// path and the gesture-machine Noop path so the two cannot diverge (issue
+/// #197 review: single source of truth for wheel granularity / pane resolution).
+fn dispatch_detail_scroll(
+    app_state: &mut HookState<AppState>,
+    mouse_event: &iocraft::FullscreenMouseEvent,
+) {
+    use crossterm::event::MouseEventKind;
     match mouse_event.kind {
-        MouseEventKind::Down(MouseButton::Left) => {
-            begin_selection(app_state, mouse_event.column, mouse_event.row);
-        }
-        MouseEventKind::Drag(MouseButton::Left) => {
-            update_selection(app_state, mouse_event.column, mouse_event.row);
-        }
-        MouseEventKind::Up(MouseButton::Left) => {
-            finalize_and_copy_selection(ctx, app_state);
-        }
         MouseEventKind::ScrollUp => {
             scroll_detail_pane(
                 app_state,
@@ -94,197 +297,151 @@ pub fn handle_fullscreen_mouse(
     }
 }
 
-/// Forward `mouse_event` to the managed PTY if the terminal is focused, mouse
-/// reporting is active, and the event lands inside the terminal pane bounds.
-///
-/// Returns `true` when the event was consumed (forwarded or filtered as
-/// out-of-bounds while focused), `false` when the caller should handle it as
-/// an app-level selection.
-fn forward_to_pty_if_in_terminal(
+/// Forward a list of PTY replay events, encoding each as SGR mouse bytes.
+fn forward_replays(
     ctx: Option<&CtxArc>,
+    replays: &[PtyReplay],
     mouse_event: &iocraft::FullscreenMouseEvent,
-) -> bool {
+) {
     let Some(ctx_arc) = ctx else {
-        return false;
+        return;
     };
     let Ok(mut ctx_guard) = ctx_arc.lock() else {
-        return false;
+        return;
     };
-    if !ctx_guard.runtime.mouse_reporting_active() {
-        return false;
-    }
 
     let (cols, rows) = terminal_size();
     let layout = compute_pty_layout(cols, rows);
 
-    let row_end = layout
-        .pane_row0
-        .saturating_add(layout.pty_rows.saturating_sub(1));
-    let col_end = layout
-        .pane_col0
-        .saturating_add(layout.pty_cols.saturating_sub(1));
+    for replay in replays {
+        let (screen_col, screen_row) = (replay.col, replay.row);
 
-    let screen_row0 = mouse_event.row;
-    let screen_col0 = mouse_event.column;
+        let local_row = screen_row.saturating_sub(layout.pane_row0);
+        let local_col = screen_col.saturating_sub(layout.pane_col0);
 
-    let in_terminal_bounds = screen_col0 >= layout.pane_col0
-        && screen_col0 <= col_end
-        && screen_row0 >= layout.pane_row0
-        && screen_row0 <= row_end;
+        // Left-button replays may be buffered/replayed (e.g. a pending click
+        // replays its buffered down + the up), so they are reconstructed from
+        // the gesture kind. Non-left replays (wheel/right/middle) are always
+        // the live event: forward the ORIGINAL mouse event kind so the real
+        // button and phase (right-down vs middle-up, etc.) are preserved
+        // (issue #197 review: OtherButton collapsed right/middle, which were
+        // then silently dropped).
+        let crossterm_kind = match replay.kind {
+            GestureEventKind::LeftDown => {
+                crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left)
+            }
+            GestureEventKind::LeftDrag => {
+                crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left)
+            }
+            GestureEventKind::LeftUp => {
+                crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left)
+            }
+            GestureEventKind::ScrollUp
+            | GestureEventKind::ScrollDown
+            | GestureEventKind::OtherButton => mouse_event.kind,
+        };
 
-    if !in_terminal_bounds {
-        // Focused but outside the terminal pane: treat as app selection target.
-        return false;
+        let mut local_event =
+            iocraft::FullscreenMouseEvent::new(crossterm_kind, local_col, local_row);
+        local_event.modifiers = mouse_event.modifiers;
+
+        if let Some(bytes) = mouse_event_to_bytes(&local_event) {
+            let _ = ctx_guard.runtime.write_input(&bytes);
+        }
     }
-
-    let local_row = screen_row0.saturating_sub(layout.pane_row0);
-    let local_col = screen_col0.saturating_sub(layout.pane_col0);
-
-    let mut local_event =
-        iocraft::FullscreenMouseEvent::new(mouse_event.kind, local_col, local_row);
-    local_event.modifiers = mouse_event.modifiers;
-
-    if let Some(bytes) = mouse_event_to_bytes(&local_event) {
-        let _ = ctx_guard.runtime.write_input(&bytes);
-    }
-    true
 }
 
-/// Build the screen-layout descriptor from the current app state + terminal size.
-fn screen_layout_for(state: &AppState, cols: u16, rows: u16) -> ScreenLayout {
-    let error_visible = state.error_message.is_some()
-        || state.issues_state.error.is_some()
-        || state.prs_state.error.is_some()
-        || state.actions_state.error.is_some();
-    let filter_open = state.issues_state.filter_ui.controls_open
-        || state.prs_state.filter_ui.controls_open
-        || state.actions_state.ui.filter_ui_open;
-    let overlay = active_overlay_for(state);
-    ScreenLayout::new(cols, rows, state.screen_mode, error_visible, filter_open)
-        .with_overlay(overlay)
-}
-
-/// Determine which overlay (modal/form/chooser) is currently active, if any.
+/// Capture the current terminal snapshot for the selected agent.
 ///
-/// Full-screen modals take priority over positioned choosers. Returns
-/// [`OverlayPane::None`] when no overlay is active so normal pane geometry
-/// applies.
-fn active_overlay_for(state: &AppState) -> jefe::selection::OverlayPane {
-    use jefe::selection::OverlayPane;
-    match &state.modal {
-        jefe::state::ModalState::Help => return OverlayPane::HelpModal,
-        jefe::state::ModalState::NewAgent { .. } | jefe::state::ModalState::EditAgent { .. } => {
-            return OverlayPane::AgentForm;
-        }
-        jefe::state::ModalState::NewRepository { .. }
-        | jefe::state::ModalState::EditRepository { .. } => return OverlayPane::RepositoryForm,
-        jefe::state::ModalState::ConfirmDeleteRepository { .. }
-        | jefe::state::ModalState::ConfirmDeleteAgent { .. }
-        | jefe::state::ModalState::ConfirmKillAgent { .. }
-        | jefe::state::ModalState::PreflightPrompt { .. }
-        | jefe::state::ModalState::ConfirmIssueDirtyCopy { .. } => {
-            return OverlayPane::ConfirmModal;
-        }
-        // Explicit match (not wildcard) so new ModalState variants force a
-        // conscious overlay-routing decision here (issue #178 z-order).
-        jefe::state::ModalState::None
-        // Search is an in-band filter mode (SplitScreen's filter bar), not a
-        // blocking overlay — the base screen remains visible and interactive.
-        | jefe::state::ModalState::Search { .. }
-        // ThemePicker renders as a full-screen modal but does not yet have a
-        // content projection — no selection, but no PTY forwarding either
-        // (pre-existing behavior; the base screen is not visible behind it).
-        | jefe::state::ModalState::ThemePicker { .. }
-        // WorkflowDispatch is a centered modal form; no selection content
-        // projection yet and no PTY forwarding while open.
-        | jefe::state::ModalState::WorkflowDispatch { .. } => {}
-    }
-    // Positioned overlays (choosers) — checked only when no full-screen modal.
-    if state.issues_state.agent_chooser.is_some() || state.prs_state.agent_chooser.is_some() {
-        return OverlayPane::AgentChooser;
-    }
-    if state.prs_state.merge_chooser.is_some() {
-        return OverlayPane::MergeChooser;
-    }
-    OverlayPane::None
+/// Both agent IDs are derived from a single short read so they describe the
+/// same selected agent. `capture_terminal_snapshot` re-validates attachment
+/// internally, so a mid-flight agent change yields a benign miss rather than
+/// corrupted content.
+fn capture_current_snapshot(
+    ctx: Option<&CtxArc>,
+    app_state: &HookState<AppState>,
+) -> Option<jefe::runtime::TerminalSnapshot> {
+    let (selected_agent_id, selected_running_agent_id) = {
+        let state = app_state.read();
+        let selected = state.selected_agent();
+        let ids = (
+            selected.map(|a| a.id.clone()),
+            selected.filter(|a| a.is_running()).map(|a| a.id.clone()),
+        );
+        drop(state);
+        ids
+    };
+    capture_terminal_snapshot(
+        ctx,
+        &app_state.read(),
+        selected_agent_id.as_ref(),
+        selected_running_agent_id.as_ref(),
+    )
 }
 
-/// Resolve which pane + geometry a screen coordinate maps to, given app state.
-fn resolve_pane(
-    state: &AppState,
-    col: u16,
-    row: u16,
-    cols: u16,
-    rows: u16,
-) -> Option<(SelectablePane, jefe::selection::PaneGeometry)> {
-    let layout = screen_layout_for(state, cols, rows);
-    let terminal_input_enabled = state.terminal_focused && state.pane_focus == PaneFocus::Terminal;
-    pane_at(col, row, state.screen_mode, terminal_input_enabled, &layout)
-}
-
-/// Begin a new text selection at `(col, row)`.
-fn begin_selection(app_state: &mut HookState<AppState>, col: u16, row: u16) {
-    let (cols, rows) = terminal_size();
-    let point = resolve_selection_point(app_state, col, row, cols, rows);
-    match point {
-        Some(p) => app_state.write().selection = Some(TextSelection::collapsed(p)),
-        None => app_state.write().selection = None,
-    }
-}
-
-/// Resolve the screen `(col, row)` to a content selection point under the pane
-/// it lands in, applying the detail-header scroll suppression. Returns `None`
-/// when the coordinate is not over any selectable pane.
-fn resolve_selection_point(
+/// Resolve a screen coordinate to a selection point within the terminal pane
+/// (for gesture-state-machine use).
+fn resolve_terminal_point(
     app_state: &HookState<AppState>,
     col: u16,
     row: u16,
-    cols: u16,
-    rows: u16,
 ) -> Option<SelectionPoint> {
-    // Resolve the pane + geometry in one short read, then read the scroll
-    // offset in another, so each read guard drops immediately (the guard has a
-    // significant Drop and clippy::significant_drop_tightening requires it not
-    // be held across unrelated statements).
+    let (cols, rows) = terminal_size();
     let (pane, geometry) = {
         let state = app_state.read();
-        resolve_pane(&state, col, row, cols, rows)?
+        resolve_pane(&state, col, row, cols, rows, true)?
     };
-    let raw_scroll = {
-        let state = app_state.read();
-        scroll_offset_for_pane(&state, pane)
-    };
-    let scroll_offset = effective_scroll_for_detail(pane, row, &geometry, raw_scroll);
-    let (line, c) = point_to_content_coords(col, row, scroll_offset, &geometry);
+    let (line, c) = point_to_content_coords(col, row, 0, &geometry);
     Some(SelectionPoint::new(pane, line, c))
 }
 
-/// Update the focus (drag) point of the active selection.
-fn update_selection(app_state: &mut HookState<AppState>, col: u16, row: u16) {
+/// Resolve a screen `(col, row)` to a selection point for non-terminal panes.
+fn begin_app_selection(app_state: &mut HookState<AppState>, col: u16, row: u16) {
     let (cols, rows) = terminal_size();
-    let (anchor, pane, scroll_offset) = {
+    let point = {
+        let state = app_state.read();
+        resolve_app_selection_point(&state, col, row, cols, rows)
+    };
+    if let Some(p) = point {
+        let mut state = app_state.write();
+        state.selection = Some(TextSelection::collapsed(p));
+        // Clear any stale terminal selection snapshot when starting a
+        // non-terminal selection.
+        state.selection_snapshot = None;
+    } else {
+        let mut state = app_state.write();
+        state.selection = None;
+        state.selection_snapshot = None;
+    }
+}
+
+/// Update the focus (drag) point of the active selection for non-terminal panes.
+fn update_app_selection(app_state: &mut HookState<AppState>, col: u16, row: u16) {
+    let (cols, rows) = terminal_size();
+    let (anchor, pane) = {
         let state = app_state.read();
         let Some(current) = state.selection else {
             return;
         };
-        let pane = current.pane();
-        let raw_scroll = scroll_offset_for_pane(&state, pane);
+        let pair = (current.anchor, current.pane());
         drop(state);
-        (current.anchor, pane, raw_scroll)
+        pair
     };
     let focus_point = {
         let state = app_state.read();
-        // Clamp drag to the anchor pane: cross-pane drag would mix coordinate
-        // spaces. If the cursor left the anchor pane, keep the last valid focus.
-        let Some((resolved_pane, geometry)) = resolve_pane(&state, col, row, cols, rows) else {
+        let Some((resolved_pane, geometry)) = resolve_pane(&state, col, row, cols, rows, false)
+        else {
             return;
         };
         if resolved_pane != pane {
             return;
         }
+        let scroll_offset = scroll_offset_for_pane(&state, pane);
         let scroll_offset = effective_scroll_for_detail(pane, row, &geometry, scroll_offset);
         let (line, c) = point_to_content_coords(col, row, scroll_offset, &geometry);
-        SelectionPoint::new(pane, line, c)
+        let point = SelectionPoint::new(pane, line, c);
+        drop(state);
+        point
     };
     app_state.write().selection = Some(TextSelection {
         anchor,
@@ -292,8 +449,62 @@ fn update_selection(app_state: &mut HookState<AppState>, col: u16, row: u16) {
     });
 }
 
-/// Finalize the active selection and copy its text to the clipboard via OSC 52.
-fn finalize_and_copy_selection(ctx: Option<&CtxArc>, app_state: &HookState<AppState>) {
+/// Finalize a TERMINAL selection and copy using the selection-bound snapshot
+/// (Finding B) with wrap-aware text extraction (Finding C+D).
+fn finalize_terminal_selection(
+    _ctx: Option<&CtxArc>,
+    app_state: &HookState<AppState>,
+    writer: ClipboardWriter,
+) {
+    let (selection, snapshot) = {
+        let state = app_state.read();
+        (state.selection, state.selection_snapshot.clone())
+    };
+    let Some(selection) = selection else {
+        return;
+    };
+    if selection.is_empty() {
+        return;
+    }
+
+    // For the terminal pane, use the selection-bound snapshot with wrap-aware
+    // extraction (Finding B + C + D). For non-terminal panes, fall back to the
+    // generic path.
+    let text = if selection.pane() == SelectablePane::TerminalView {
+        if let Some(snap) = &snapshot {
+            terminal_selection_text(snap, &selection)
+        } else {
+            // No bound snapshot — fall back to generic extraction.
+            let (cols, rows) = terminal_size();
+            let state = app_state.read();
+            let content = pane_content_lines(selection.pane(), &state, None, cols, rows);
+            drop(state);
+            selection_text(&selection, &content.lines)
+        }
+    } else {
+        let (cols, rows) = terminal_size();
+        let state = app_state.read();
+        let content = pane_content_lines(selection.pane(), &state, None, cols, rows);
+        drop(state);
+        selection_text(&selection, &content.lines)
+    };
+
+    if !text.is_empty() {
+        if let Err(err) = writer(&text) {
+            tracing::warn!(error = %err, "OSC 52 clipboard write failed");
+        }
+    }
+}
+
+/// Finalize and copy for non-terminal selections (legacy entry point for
+/// app-level selection finalization).
+fn finalize_and_copy_selection(
+    ctx: Option<&CtxArc>,
+    app_state: &HookState<AppState>,
+    writer: ClipboardWriter,
+) {
+    // This path is reached from the non-terminal app-selection branch. The
+    // terminal pane won't be the active selection here.
     let selection = {
         let state = app_state.read();
         state.selection
@@ -321,24 +532,122 @@ fn finalize_and_copy_selection(ctx: Option<&CtxArc>, app_state: &HookState<AppSt
         selection_text(&selection, &content.lines)
     };
     if !text.is_empty()
-        && let Err(err) = clipboard::write_osc52(&text)
+        && let Err(err) = writer(&text)
     {
         tracing::warn!(error = %err, "OSC 52 clipboard write failed");
     }
 }
 
-/// HelpModal title rows (title text + blank): not affected by scroll offset,
-/// mirroring the renderer's title Box(height: 2) above ScrollableText.
+/// Resolve the screen `(col, row)` to a content selection point under the pane
+/// it lands in for non-terminal panes.
+fn resolve_app_selection_point(
+    app_state: &AppState,
+    col: u16,
+    row: u16,
+    cols: u16,
+    rows: u16,
+) -> Option<SelectionPoint> {
+    let (pane, geometry) = resolve_pane(app_state, col, row, cols, rows, false)?;
+    let scroll_offset = scroll_offset_for_pane(app_state, pane);
+    let scroll_offset = effective_scroll_for_detail(pane, row, &geometry, scroll_offset);
+    let (line, c) = point_to_content_coords(col, row, scroll_offset, &geometry);
+    Some(SelectionPoint::new(pane, line, c))
+}
+
+/// Build the screen-layout descriptor from the current app state + terminal size.
+fn screen_layout_for(state: &AppState, cols: u16, rows: u16) -> ScreenLayout {
+    let error_visible = state.error_message.is_some()
+        || state.issues_state.error.is_some()
+        || state.prs_state.error.is_some()
+        || state.actions_state.error.is_some();
+    let filter_open = state.issues_state.filter_ui.controls_open
+        || state.prs_state.filter_ui.controls_open
+        || state.actions_state.ui.filter_ui_open;
+    let overlay = active_overlay_for(state);
+    ScreenLayout::new(cols, rows, state.screen_mode, error_visible, filter_open)
+        .with_overlay(overlay)
+}
+
+/// Whether a blocking modal is open (Finding G).
+///
+/// Blocking modals intercept mouse input even if they have no selectable
+/// content projection. ThemePicker and WorkflowDispatch are full-screen
+/// modals without content projection — they must still disable terminal
+/// routing so a focused terminal behind them doesn't receive PTY events.
+fn is_blocking_modal_open(state: &AppState) -> bool {
+    use jefe::state::ModalState;
+    matches!(
+        state.modal,
+        ModalState::Help
+            | ModalState::NewAgent { .. }
+            | ModalState::EditAgent { .. }
+            | ModalState::NewRepository { .. }
+            | ModalState::EditRepository { .. }
+            | ModalState::ConfirmDeleteRepository { .. }
+            | ModalState::ConfirmDeleteAgent { .. }
+            | ModalState::ConfirmKillAgent { .. }
+            | ModalState::PreflightPrompt { .. }
+            | ModalState::ConfirmIssueDirtyCopy { .. }
+            | ModalState::ThemePicker { .. }
+            | ModalState::WorkflowDispatch { .. }
+    )
+}
+
+/// Determine which overlay (modal/form/chooser) is currently active, if any.
+fn active_overlay_for(state: &AppState) -> jefe::selection::OverlayPane {
+    use jefe::selection::OverlayPane;
+    match &state.modal {
+        jefe::state::ModalState::Help => return OverlayPane::HelpModal,
+        jefe::state::ModalState::NewAgent { .. } | jefe::state::ModalState::EditAgent { .. } => {
+            return OverlayPane::AgentForm;
+        }
+        jefe::state::ModalState::NewRepository { .. }
+        | jefe::state::ModalState::EditRepository { .. } => return OverlayPane::RepositoryForm,
+        jefe::state::ModalState::ConfirmDeleteRepository { .. }
+        | jefe::state::ModalState::ConfirmDeleteAgent { .. }
+        | jefe::state::ModalState::ConfirmKillAgent { .. }
+        | jefe::state::ModalState::PreflightPrompt { .. }
+        | jefe::state::ModalState::ConfirmIssueDirtyCopy { .. } => {
+            return OverlayPane::ConfirmModal;
+        }
+        // Explicit match (not wildcard) so new ModalState variants force a
+        // conscious overlay-routing decision here (issue #178 z-order).
+        jefe::state::ModalState::None
+        | jefe::state::ModalState::Search { .. }
+        | jefe::state::ModalState::ThemePicker { .. }
+        | jefe::state::ModalState::WorkflowDispatch { .. } => {}
+    }
+    if state.issues_state.agent_chooser.is_some() || state.prs_state.agent_chooser.is_some() {
+        return OverlayPane::AgentChooser;
+    }
+    if state.prs_state.merge_chooser.is_some() {
+        return OverlayPane::MergeChooser;
+    }
+    OverlayPane::None
+}
+
+/// Resolve which pane + geometry a screen coordinate maps to, given app state.
+///
+/// `terminal_input_enabled` (Finding K: renamed from `terminal_selectable`)
+/// controls whether the dashboard terminal region resolves to
+/// [`SelectablePane::TerminalView`]. When the terminal is receiving PTY input,
+/// pass `true` so the terminal pane is excluded from selection (returns None
+/// for the dashboard terminal region); otherwise `false` so it is selectable.
+fn resolve_pane(
+    state: &AppState,
+    col: u16,
+    row: u16,
+    cols: u16,
+    rows: u16,
+    terminal_input_enabled: bool,
+) -> Option<(SelectablePane, jefe::selection::PaneGeometry)> {
+    let layout = screen_layout_for(state, cols, rows);
+    pane_at(col, row, state.screen_mode, terminal_input_enabled, &layout)
+}
+
+/// HelpModal title rows (title text + blank): not affected by scroll offset.
 const HELP_TITLE_ROWS: usize = 2;
 
-/// For detail panes, headers occupy content lines `0..DETAIL_HEADER_ROWS` and
-/// are not affected by scroll offset. Scrollable content starts at line
-/// `DETAIL_HEADER_ROWS`. Return 0 when the click is in the header area,
-/// otherwise the real scroll offset.
-///
-/// The HelpModal also has fixed header rows (title + blank = 2 rows) that are
-/// not affected by the scroll offset; the scrollable help content starts at
-/// line 2.
 fn effective_scroll_for_detail(
     pane: SelectablePane,
     row: u16,
@@ -357,7 +666,6 @@ fn effective_scroll_for_detail(
         }
         SelectablePane::HelpModal => {
             let content_row = usize::from(row.saturating_sub(geometry.content_origin_row));
-            // Title Box is height 2 (title text + blank) — not scrolled.
             if content_row < HELP_TITLE_ROWS {
                 0
             } else {
@@ -368,7 +676,6 @@ fn effective_scroll_for_detail(
     }
 }
 
-/// Scroll offset for a specific pane from app state.
 fn scroll_offset_for_pane(state: &AppState, pane: SelectablePane) -> usize {
     match pane {
         SelectablePane::IssueDetail => state.issues_state.detail_scroll_offset,
@@ -379,15 +686,6 @@ fn scroll_offset_for_pane(state: &AppState, pane: SelectablePane) -> usize {
     }
 }
 
-/// Refresh the cached `detail_viewport_rows` for `pane` from the current
-/// terminal size and conditional bands.
-///
-/// Mirrors `update_detail_viewport_rows` / `update_pr_detail_viewport_rows` in
-/// the keyboard dispatch path so the scroll-offset clamp bound
-/// (`max_detail_scroll_offset` / `pr_detail_max_scroll_offset`) agrees with the
-/// viewport the renderer actually uses. Without this, a stale cache (e.g. left
-/// over from before entering the mode, since it is only refreshed on keyboard
-/// scroll-down) lets the stored offset drift past the renderer's clamp bound.
 fn refresh_detail_viewport_rows(state: &mut AppState, pane: SelectablePane, term_rows: u16) {
     let term_rows = usize::from(term_rows);
     match pane {
@@ -423,17 +721,6 @@ enum WheelDirection {
     Down,
 }
 
-/// Next detail scroll offset after one mousewheel tick, clamped to `[0, max]`.
-///
-/// Pure and side-effect-free so the clamp invariant is unit-testable without
-/// the iocraft runtime: scrolling up never drops below 0 and scrolling down
-/// never exceeds the pane's maximum offset. `max` is the detail pane's
-/// `max_detail_scroll_offset()` (0 when there is no content to scroll).
-///
-/// `current` is clamped to `max` *before* the tick is applied, so a stale
-/// offset that drifted past `max` (e.g. the cached viewport shrank) snaps back
-/// into the valid range on the very next tick instead of stranding the view in
-/// a phantom region the renderer clamps but the stored value does not.
 #[must_use]
 fn next_wheel_scroll_offset(current: usize, max: usize, direction: WheelDirection) -> usize {
     let clamped = current.min(max);
@@ -443,9 +730,6 @@ fn next_wheel_scroll_offset(current: usize, max: usize, direction: WheelDirectio
     }
 }
 
-/// Maximum scroll offset for a detail pane from app state.
-///
-/// Returns 0 for non-scrollable panes (they are never advanced by the wheel).
 fn max_scroll_offset_for_pane(state: &AppState, pane: SelectablePane) -> usize {
     match pane {
         SelectablePane::IssueDetail => state.issues_state.max_detail_scroll_offset(),
@@ -455,15 +739,6 @@ fn max_scroll_offset_for_pane(state: &AppState, pane: SelectablePane) -> usize {
     }
 }
 
-/// Scroll the detail pane under `(col, row)` by one wheel tick.
-///
-/// Resolves the pane under the cursor via [`resolve_pane`] and, when it is a
-/// scrollable detail pane (`IssueDetail` / `PrDetail` / `ActionsDetail`), advances its scroll
-/// offset by one line in the given direction, clamped to the pane's valid
-/// bounds via [`next_wheel_scroll_offset`]. The cached viewport row count is
-/// refreshed first ([`refresh_detail_viewport_rows`]) so the clamp bound
-/// matches the renderer. Non-detail panes are ignored — mousewheel scrolling
-/// in list/terminal panes is out of scope (issue #148).
 fn scroll_detail_pane(
     app_state: &mut HookState<AppState>,
     col: u16,
@@ -471,13 +746,9 @@ fn scroll_detail_pane(
     direction: WheelDirection,
 ) {
     let (cols, rows) = terminal_size();
-    // Resolve the pane in one short read guard, then read current/max offsets
-    // in another, so each read guard drops immediately (the guard has a
-    // significant Drop and clippy::significant_drop_tightening requires it not
-    // be held across unrelated statements).
     let pane = {
         let state = app_state.read();
-        let Some((pane, _geometry)) = resolve_pane(&state, col, row, cols, rows) else {
+        let Some((pane, _geometry)) = resolve_pane(&state, col, row, cols, rows, false) else {
             return;
         };
         pane
@@ -488,14 +759,6 @@ fn scroll_detail_pane(
     ) {
         return;
     }
-    // Refresh the cached detail-viewport row count from the current terminal
-    // layout before computing the clamp bound. The renderer windows content
-    // with a *fresh* viewport (derived from the actual layout), but
-    // `max_detail_scroll_offset` / `pr_detail_max_scroll_offset` read the cached
-    // `detail_viewport_rows` field. The keyboard dispatch path refreshes that
-    // cache (`update_*_detail_viewport_rows`) before every scroll; the mouse
-    // path must too, otherwise a stale (smaller) cache lets the offset run past
-    // the renderer's clamp bound and the wheel appears to overscroll / stick.
     {
         let mut state = app_state.write();
         refresh_detail_viewport_rows(&mut state, pane, rows);
@@ -518,106 +781,5 @@ fn scroll_detail_pane(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{WheelDirection, next_wheel_scroll_offset};
-
-    #[test]
-    fn scroll_down_advances_within_bounds() {
-        assert_eq!(
-            next_wheel_scroll_offset(2, 5, WheelDirection::Down),
-            3,
-            "scrolling down from 2 with max 5 should advance to 3"
-        );
-    }
-
-    #[test]
-    fn scroll_up_decrements_within_bounds() {
-        assert_eq!(
-            next_wheel_scroll_offset(2, 5, WheelDirection::Up),
-            1,
-            "scrolling up from 2 with max 5 should decrement to 1"
-        );
-    }
-
-    #[test]
-    fn scroll_down_clamps_at_max_offset() {
-        assert_eq!(
-            next_wheel_scroll_offset(5, 5, WheelDirection::Down),
-            5,
-            "scrolling down at max offset must not overscroll"
-        );
-    }
-
-    #[test]
-    fn scroll_up_clamps_at_zero() {
-        assert_eq!(
-            next_wheel_scroll_offset(0, 5, WheelDirection::Up),
-            0,
-            "scrolling up at offset 0 must not underscroll"
-        );
-    }
-
-    #[test]
-    fn scroll_down_with_zero_max_stays_zero() {
-        assert_eq!(
-            next_wheel_scroll_offset(0, 0, WheelDirection::Down),
-            0,
-            "empty detail pane (max 0) cannot scroll down"
-        );
-    }
-
-    #[test]
-    fn scroll_up_with_zero_max_stays_zero() {
-        assert_eq!(
-            next_wheel_scroll_offset(0, 0, WheelDirection::Up),
-            0,
-            "empty detail pane (max 0) cannot scroll up"
-        );
-    }
-
-    #[test]
-    fn scroll_down_in_middle_of_large_content() {
-        assert_eq!(
-            next_wheel_scroll_offset(10, 100, WheelDirection::Down),
-            11,
-            "scrolling down from 10 within a large pane should advance to 11"
-        );
-    }
-
-    // ── stale / inflated offset recovery ───────────────────────────────────
-    //
-    // The stored detail scroll offset can lag behind the renderer's clamp
-    // bound when the cached `detail_viewport_rows` is smaller than the
-    // renderer's fresh viewport (the keyboard dispatch path refreshes that
-    // cache before scrolling; the mouse path now does too). If the offset is
-    // ever inflated past `max`, a single wheel tick must snap it back into the
-    // valid range instead of leaving it stranded in a phantom region where the
-    // renderer clamps the display but the stored value keeps climbing.
-
-    #[test]
-    fn scroll_up_from_inflated_offset_snaps_below_max() {
-        assert_eq!(
-            next_wheel_scroll_offset(8, 5, WheelDirection::Up),
-            4,
-            "scrolling up from an inflated offset (8) with max 5 must snap to 4, not walk back one-at-a-time through the phantom region"
-        );
-    }
-
-    #[test]
-    fn scroll_down_from_inflated_offset_snaps_to_max() {
-        assert_eq!(
-            next_wheel_scroll_offset(8, 5, WheelDirection::Down),
-            5,
-            "scrolling down from an inflated offset (8) with max 5 must snap to 5"
-        );
-    }
-
-    #[test]
-    fn scroll_up_from_inflated_offset_near_zero_snaps_to_zero() {
-        assert_eq!(
-            next_wheel_scroll_offset(8, 1, WheelDirection::Up),
-            0,
-            "scrolling up from an inflated offset (8) with max 1 must snap to 0"
-        );
-    }
-}
+#[path = "mouse_routing_tests.rs"]
+mod mouse_routing_tests;

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -381,6 +381,14 @@ fn capture_current_snapshot(
 
 /// Resolve a screen coordinate to a selection point within the terminal pane
 /// (for gesture-state-machine use).
+///
+/// `pane_at` is called with `terminal_input_enabled = false` so the terminal
+/// region resolves to [`SelectablePane::TerminalView`] even while the
+/// terminal is focused. Jefe owns left-button selection over the focused
+/// terminal (issue #197), so the gesture resolver must always be able to map
+/// an in-terminal coordinate to a content point — passing `true` here would
+/// make `pane_at` return `None` for the whole terminal region and the gesture
+/// could never begin (the down would have no anchor).
 fn resolve_terminal_point(
     app_state: &HookState<AppState>,
     col: u16,
@@ -389,7 +397,7 @@ fn resolve_terminal_point(
     let (cols, rows) = terminal_size();
     let (pane, geometry) = {
         let state = app_state.read();
-        resolve_pane(&state, col, row, cols, rows, true)?
+        resolve_pane(&state, col, row, cols, rows, false)?
     };
     let (line, c) = point_to_content_coords(col, row, 0, &geometry);
     Some(SelectionPoint::new(pane, line, c))

--- a/src/mouse_routing_tests.rs
+++ b/src/mouse_routing_tests.rs
@@ -1,0 +1,564 @@
+//! Tests for mouse_routing.rs (issue #197).
+//!
+//! Extracted from mouse_routing.rs to keep that file under the 1000-line limit.
+//! These tests exercise the pure helper functions and the gesture-state-machine
+//! wiring without requiring iocraft or a live runtime.
+
+use super::{
+    WheelDirection, active_overlay_for, gesture_event_kind, is_blocking_modal_open,
+    next_wheel_scroll_offset, resolve_pane,
+};
+use crossterm::event::{MouseButton, MouseEventKind};
+use jefe::domain::{Agent, AgentId, AgentKind, Repository, RepositoryId};
+use jefe::runtime::{TerminalCell, TerminalCellStyle, TerminalSnapshot};
+use jefe::selection::{
+    GestureAction, GestureEvent, GestureEventKind, GestureState, OverlayPane, SelectablePane,
+    pane_content_lines, selection_text, terminal_selection_text,
+};
+use jefe::state::{AppState, ModalState, PaneFocus, ScreenMode};
+use std::path::PathBuf;
+
+// ── next_wheel_scroll_offset (clamping + stale recovery) ─────────────────────
+
+#[test]
+fn scroll_down_advances_within_bounds() {
+    assert_eq!(next_wheel_scroll_offset(2, 5, WheelDirection::Down), 3);
+}
+
+#[test]
+fn scroll_up_decrements_within_bounds() {
+    assert_eq!(next_wheel_scroll_offset(2, 5, WheelDirection::Up), 1);
+}
+
+#[test]
+fn scroll_down_clamps_at_max_offset() {
+    assert_eq!(next_wheel_scroll_offset(5, 5, WheelDirection::Down), 5);
+}
+
+#[test]
+fn scroll_up_clamps_at_zero() {
+    assert_eq!(next_wheel_scroll_offset(0, 5, WheelDirection::Up), 0);
+}
+
+#[test]
+fn scroll_down_with_zero_max_stays_zero() {
+    assert_eq!(next_wheel_scroll_offset(0, 0, WheelDirection::Down), 0);
+}
+
+#[test]
+fn scroll_up_with_zero_max_stays_zero() {
+    assert_eq!(next_wheel_scroll_offset(0, 0, WheelDirection::Up), 0);
+}
+
+#[test]
+fn scroll_up_from_inflated_offset_snaps_below_max() {
+    assert_eq!(next_wheel_scroll_offset(8, 5, WheelDirection::Up), 4);
+}
+
+#[test]
+fn scroll_down_from_inflated_offset_snaps_to_max() {
+    assert_eq!(next_wheel_scroll_offset(8, 5, WheelDirection::Down), 5);
+}
+
+#[test]
+fn scroll_up_from_inflated_offset_near_zero_snaps_to_zero() {
+    assert_eq!(next_wheel_scroll_offset(8, 1, WheelDirection::Up), 0);
+}
+
+// ── gesture_event_kind classification ────────────────────────────────────────
+
+#[test]
+fn gesture_event_kind_classifies_left_button_events() {
+    assert_eq!(
+        gesture_event_kind(MouseEventKind::Down(MouseButton::Left)),
+        Some(GestureEventKind::LeftDown)
+    );
+    assert_eq!(
+        gesture_event_kind(MouseEventKind::Drag(MouseButton::Left)),
+        Some(GestureEventKind::LeftDrag)
+    );
+    assert_eq!(
+        gesture_event_kind(MouseEventKind::Up(MouseButton::Left)),
+        Some(GestureEventKind::LeftUp)
+    );
+}
+
+#[test]
+fn gesture_event_kind_classifies_wheel_right_middle_as_other() {
+    assert_eq!(
+        gesture_event_kind(MouseEventKind::ScrollUp),
+        Some(GestureEventKind::ScrollUp)
+    );
+    assert_eq!(
+        gesture_event_kind(MouseEventKind::ScrollDown),
+        Some(GestureEventKind::ScrollDown)
+    );
+    assert_eq!(
+        gesture_event_kind(MouseEventKind::Down(MouseButton::Right)),
+        Some(GestureEventKind::OtherButton)
+    );
+    assert_eq!(
+        gesture_event_kind(MouseEventKind::Down(MouseButton::Middle)),
+        Some(GestureEventKind::OtherButton)
+    );
+}
+
+// ── Finding F: non-dashboard mode disables terminal routing ──────────────────
+
+fn focused_terminal_state(kind: AgentKind) -> AppState {
+    let repo_id = RepositoryId("repo-1".into());
+    let mut state = AppState::default();
+    state.repositories.push(Repository::new(
+        repo_id.clone(),
+        "repo".into(),
+        "repo".into(),
+        PathBuf::from("/tmp/repo"),
+    ));
+    let mut agent = Agent::new(
+        AgentId("agent-1".into()),
+        repo_id,
+        "agent".into(),
+        PathBuf::from("/tmp/agent"),
+    );
+    agent.agent_kind = kind;
+    state.agents.push(agent);
+    state.selected_repository_index = Some(0);
+    state.selected_agent_index = Some(0);
+    state.terminal_focused = true;
+    state.pane_focus = PaneFocus::Terminal;
+    state
+}
+
+#[test]
+fn terminal_pane_resolves_in_dashboard_mode() {
+    let mut state = focused_terminal_state(AgentKind::CodePuppy);
+    state.screen_mode = ScreenMode::Dashboard;
+    // terminal_input_enabled=false means the terminal pane IS selectable
+    // (it's not occupied by PTY input routing in this context).
+    match resolve_pane(&state, 30, 20, 120, 40, false) {
+        Some((SelectablePane::TerminalView, _)) => {}
+        other => panic!("expected TerminalView in Dashboard mode, got {other:?}"),
+    }
+}
+
+#[test]
+fn terminal_pane_not_routed_in_issues_mode() {
+    // Finding F: terminal routing is disabled in non-Dashboard modes even when
+    // terminal_focused is true. The terminal pane should not resolve as a
+    // selectable terminal in Issues mode (there is no TerminalView there).
+    let mut state = focused_terminal_state(AgentKind::CodePuppy);
+    state.screen_mode = ScreenMode::DashboardIssues;
+    // In Issues mode, the coordinate would map to IssueList/IssueDetail, not
+    // TerminalView. This test verifies the geometry doesn't produce a
+    // TerminalView (which would be a ghost selection).
+    let result = resolve_pane(&state, 30, 20, 120, 40, false);
+    let Some((pane, _)) = result else {
+        panic!("a dashboard-issues coordinate must resolve to some pane, not None");
+    };
+    assert_ne!(
+        pane,
+        SelectablePane::TerminalView,
+        "TerminalView must not resolve in Issues mode"
+    );
+}
+
+// ── Finding G: blocking modals ───────────────────────────────────────────────
+
+#[test]
+fn theme_picker_is_blocking_modal() {
+    let state = AppState {
+        modal: ModalState::ThemePicker {
+            available_themes: Vec::new(),
+            selected_index: 0,
+            active_slug: String::new(),
+            override_theme: false,
+        },
+        ..AppState::default()
+    };
+    assert!(
+        is_blocking_modal_open(&state),
+        "ThemePicker must be a blocking modal"
+    );
+}
+
+#[test]
+fn workflow_dispatch_is_blocking_modal() {
+    use jefe::domain::Workflow;
+    use jefe::state::WorkflowDispatchFormFields;
+    let mut state = AppState::default();
+    state.modal = ModalState::WorkflowDispatch {
+        workflow: Workflow {
+            id: 1,
+            name: "WF".to_string(),
+            path: "wf.yml".to_string(),
+            state: "active".to_string(),
+        },
+        fields: WorkflowDispatchFormFields::default(),
+        focus: jefe::state::WorkflowDispatchFormFocus::default(),
+        cursor: jefe::state::WorkflowDispatchFormCursor::default(),
+    };
+    assert!(
+        is_blocking_modal_open(&state),
+        "WorkflowDispatch must be a blocking modal"
+    );
+}
+
+#[test]
+fn no_modal_is_not_blocking() {
+    let state = AppState::default();
+    assert!(!is_blocking_modal_open(&state));
+}
+
+#[test]
+fn search_is_not_blocking_modal() {
+    let state = AppState {
+        modal: ModalState::Search {
+            query: "test".to_string(),
+        },
+        ..AppState::default()
+    };
+    assert!(!is_blocking_modal_open(&state));
+}
+
+#[test]
+fn focused_terminal_behind_theme_picker_does_not_route_to_terminal() {
+    // Finding G: even with a focused terminal, ThemePicker blocks.
+    let mut state = focused_terminal_state(AgentKind::CodePuppy);
+    state.modal = ModalState::ThemePicker {
+        available_themes: Vec::new(),
+        selected_index: 0,
+        active_slug: String::new(),
+        override_theme: false,
+    };
+    assert!(
+        is_blocking_modal_open(&state),
+        "terminal behind ThemePicker must be blocked"
+    );
+}
+
+// ── Finding H + critical #1: shift passthrough and reporting-click replay ──
+
+fn resolver(col: u16, row: u16) -> Option<jefe::selection::SelectionPoint> {
+    // Coordinate-sensitive resolver: returns a point whose line/col reflect the
+    // input so the gesture-machine tests can detect regressions where the
+    // buffered-down coordinate is swapped with the drag coordinate. Returns
+    // None for out-of-pane coords (mimicking the real pane geometry).
+    if col < 2 || row < 2 {
+        return None;
+    }
+    Some(jefe::selection::SelectionPoint::new(
+        SelectablePane::TerminalView,
+        usize::from(row) - 2,
+        usize::from(col) - 2,
+    ))
+}
+
+#[test]
+fn reporting_click_replays_down_then_up_with_real_coords() {
+    // Critical fix (issue #197 review): a pure click on a reporting child
+    // (down with no drag, then up) must replay BOTH the buffered down AND the
+    // up, each at its real coordinate. The old code emitted only the down.
+    let down = GestureEvent {
+        kind: GestureEventKind::LeftDown,
+        shift_held: false,
+        col: 5,
+        row: 3,
+        mouse_reporting_active: true,
+    };
+    let (action, pending) = GestureState::default().process(down, &resolver);
+    assert!(matches!(action, GestureAction::Noop));
+    assert!(matches!(pending, GestureState::Pending { .. }));
+
+    let up = GestureEvent {
+        kind: GestureEventKind::LeftUp,
+        shift_held: false,
+        col: 9,
+        row: 7,
+        mouse_reporting_active: true,
+    };
+    let (action, next) = pending.process(up, &resolver);
+    let GestureAction::ForwardToPty(replays) = action else {
+        panic!("expected ForwardToPty for reporting click, got {action:?}");
+    };
+    assert_eq!(next, GestureState::Idle);
+    assert_eq!(
+        replays,
+        vec![
+            jefe::selection::PtyReplay {
+                col: 5,
+                row: 3,
+                kind: GestureEventKind::LeftDown,
+            },
+            jefe::selection::PtyReplay {
+                col: 9,
+                row: 7,
+                kind: GestureEventKind::LeftUp,
+            },
+        ],
+        "reporting click must replay down + up at real coordinates, in order"
+    );
+}
+
+#[test]
+fn reporting_drag_begins_range_from_buffered_down() {
+    // High fix #3 (issue #197 review): a reporting gesture that becomes a drag
+    // must begin a selection spanning the buffered down coordinate through the
+    // drag coordinate — not a collapsed selection at the anchor.
+    let down = GestureEvent {
+        kind: GestureEventKind::LeftDown,
+        shift_held: false,
+        col: 2,
+        row: 4,
+        mouse_reporting_active: true,
+    };
+    let (_, pending) = GestureState::default().process(down, &resolver);
+    let drag = GestureEvent {
+        kind: GestureEventKind::LeftDrag,
+        shift_held: false,
+        col: 8,
+        row: 4,
+        mouse_reporting_active: true,
+    };
+    let (action, owned) = pending.process(drag, &resolver);
+    match action {
+        GestureAction::BeginSelectionRange { anchor, focus } => {
+            assert!(matches!(owned, GestureState::JefeOwned { .. }));
+            // Coordinate-sensitive checks (issue #197 review): the anchor must
+            // be the buffered-down coordinate and the focus the drag
+            // coordinate, proving the range spans down→drag and is not swapped
+            // or collapsed. down@(2,4) -> (line 2, col 0); drag@(8,4) -> (line 2, col 6).
+            assert_eq!(anchor.pane, SelectablePane::TerminalView);
+            assert_eq!((anchor.line, anchor.col), (2, 0), "anchor = buffered down");
+            assert_eq!(focus.pane, SelectablePane::TerminalView);
+            assert_eq!((focus.line, focus.col), (2, 6), "focus = drag coordinate");
+        }
+        other => panic!("expected BeginSelectionRange, got {other:?}"),
+    }
+}
+
+#[test]
+fn stray_left_down_while_pending_flushes_buffered_down() {
+    // Medium fix #4 (issue #197 review): a second LeftDown while Pending must
+    // flush the buffered down to the PTY before starting the new gesture.
+    let down = GestureEvent {
+        kind: GestureEventKind::LeftDown,
+        shift_held: false,
+        col: 3,
+        row: 3,
+        mouse_reporting_active: true,
+    };
+    let (_, pending) = GestureState::default().process(down, &resolver);
+    let second_down = GestureEvent {
+        kind: GestureEventKind::LeftDown,
+        shift_held: false,
+        col: 6,
+        row: 6,
+        mouse_reporting_active: true,
+    };
+    let (action, _) = pending.process(second_down, &resolver);
+    let GestureAction::ForwardToPty(replays) = action else {
+        panic!("expected flush ForwardToPty, got {action:?}");
+    };
+    // The flush must include the buffered down at (3,3).
+    assert!(
+        replays
+            .iter()
+            .any(|r| r.col == 3 && r.row == 3 && r.kind == GestureEventKind::LeftDown),
+        "stray LeftDown must flush the buffered down to the PTY: {replays:?}"
+    );
+}
+
+// ── Finding K: resolve_pane param naming ─────────────────────────────────────
+
+#[test]
+fn resolve_pane_terminal_input_enabled_excludes_terminal() {
+    let mut state = focused_terminal_state(AgentKind::CodePuppy);
+    state.screen_mode = ScreenMode::Dashboard;
+    // When terminal_input_enabled=true (focused terminal), the dashboard
+    // terminal region returns None (pane_at excludes it).
+    assert!(
+        resolve_pane(&state, 30, 20, 120, 40, true).is_none(),
+        "terminal region must be excluded when terminal_input_enabled"
+    );
+}
+
+#[test]
+fn resolve_pane_terminal_not_enabled_includes_terminal() {
+    let mut state = focused_terminal_state(AgentKind::CodePuppy);
+    state.screen_mode = ScreenMode::Dashboard;
+    // When terminal_input_enabled=false (unfocused/preview), the terminal
+    // region resolves to TerminalView.
+    match resolve_pane(&state, 30, 20, 120, 40, false) {
+        Some((SelectablePane::TerminalView, _)) => {}
+        other => panic!("expected TerminalView when not input-enabled, got {other:?}"),
+    }
+}
+
+// ── Terminal selection text with wraps + wide chars (Finding C+D) ─────────────
+
+fn styled_cell(ch: char) -> TerminalCell {
+    TerminalCell {
+        ch,
+        style: TerminalCellStyle {
+            fg: iocraft::Color::White,
+            bg: iocraft::Color::Black,
+            bold: false,
+            dim: false,
+            underline: false,
+        },
+        wide_spacer: false,
+    }
+}
+
+fn styled_cell_with_spacer(ch: char) -> TerminalCell {
+    TerminalCell {
+        ch,
+        style: TerminalCellStyle {
+            fg: iocraft::Color::White,
+            bg: iocraft::Color::Black,
+            bold: false,
+            dim: false,
+            underline: false,
+        },
+        wide_spacer: true,
+    }
+}
+
+#[test]
+fn terminal_selection_text_matches_snapshot_including_unicode() {
+    use jefe::selection::{SelectionPoint, TextSelection};
+    let cells = vec![
+        vec![styled_cell('h'), styled_cell('i'), styled_cell('!')],
+        vec![styled_cell('\u{41F}'), styled_cell('\u{0454}')],
+    ];
+    let snapshot = TerminalSnapshot {
+        rows: 2,
+        cols: 3,
+        cells,
+        wraps: Vec::new(),
+    };
+    let state = focused_terminal_state(AgentKind::CodePuppy);
+    let content = pane_content_lines(
+        SelectablePane::TerminalView,
+        &state,
+        Some(&snapshot),
+        120,
+        40,
+    );
+    assert_eq!(
+        content.lines,
+        vec!["hi!".to_string(), "\u{41F}\u{0454}".to_string()]
+    );
+
+    let sel = TextSelection {
+        anchor: SelectionPoint::new(SelectablePane::TerminalView, 1, 0),
+        focus: SelectionPoint::new(SelectablePane::TerminalView, 1, 1),
+    };
+    assert_eq!(selection_text(&sel, &content.lines), "\u{41F}");
+}
+
+#[test]
+fn terminal_selection_text_with_real_cjk_wide_char() {
+    // Finding D: the old test claimed "CJK" but used Cyrillic (width-1).
+    // This test uses an actual width-2 CJK character (中) with a wide_spacer
+    // cell, proving the spacer is skipped during selection extraction.
+    use jefe::selection::{SelectionPoint, TextSelection};
+    let snapshot = TerminalSnapshot {
+        rows: 1,
+        cols: 4,
+        cells: vec![vec![
+            styled_cell('A'),
+            styled_cell('中'),
+            styled_cell_with_spacer(' '),
+            styled_cell('B'),
+        ]],
+        wraps: Vec::new(),
+    };
+    // Select columns 0..4 (the whole row).
+    let sel = TextSelection {
+        anchor: SelectionPoint::new(SelectablePane::TerminalView, 0, 0),
+        focus: SelectionPoint::new(SelectablePane::TerminalView, 0, 4),
+    };
+    // The wide spacer is skipped: result is "A中B", not "A中 B".
+    assert_eq!(terminal_selection_text(&snapshot, &sel), "A中B");
+}
+
+// ── Finding B: copy uses the selection-bound snapshot ────────────────────────
+
+#[test]
+fn terminal_selection_text_uses_bound_snapshot_not_recaptured() {
+    use jefe::selection::{SelectionPoint, TextSelection};
+    // Snapshot A: what the user highlighted.
+    let snapshot_a = TerminalSnapshot {
+        rows: 1,
+        cols: 5,
+        cells: vec![vec![
+            styled_cell('H'),
+            styled_cell('E'),
+            styled_cell('L'),
+            styled_cell('L'),
+            styled_cell('O'),
+        ]],
+        wraps: Vec::new(),
+    };
+    let sel = TextSelection {
+        anchor: SelectionPoint::new(SelectablePane::TerminalView, 0, 0),
+        focus: SelectionPoint::new(SelectablePane::TerminalView, 0, 5),
+    };
+    // The extracted text comes from snapshot_a — prove copy is bound to it.
+    assert_eq!(terminal_selection_text(&snapshot_a, &sel), "HELLO");
+}
+
+// ── active_overlay_for (issue #178 z-order, preserved) ────────────────────────
+
+#[test]
+fn active_overlay_none_when_no_modal() {
+    let state = AppState::default();
+    assert_eq!(active_overlay_for(&state), OverlayPane::None);
+}
+
+#[test]
+fn active_overlay_help_modal() {
+    let state = AppState {
+        modal: ModalState::Help,
+        ..AppState::default()
+    };
+    assert_eq!(active_overlay_for(&state), OverlayPane::HelpModal);
+}
+
+#[test]
+fn active_overlay_agent_form() {
+    use jefe::state::AgentFormFields;
+    let mut state = AppState::default();
+    state.modal = ModalState::NewAgent {
+        repository_id: RepositoryId("r".into()),
+        fields: AgentFormFields::default(),
+        focus: jefe::state::AgentFormFocus::Name,
+        cursor: jefe::state::AgentFormCursor::default(),
+        work_dir_manual: false,
+    };
+    assert_eq!(active_overlay_for(&state), OverlayPane::AgentForm);
+}
+
+#[test]
+fn active_overlay_theme_picker_falls_through_to_none_overlay() {
+    // ThemePicker doesn't have an OverlayPane variant — it falls through to
+    // None but is caught by is_blocking_modal_open (Finding G).
+    let state = AppState {
+        modal: ModalState::ThemePicker {
+            available_themes: Vec::new(),
+            selected_index: 0,
+            active_slug: String::new(),
+            override_theme: false,
+        },
+        ..AppState::default()
+    };
+    assert_eq!(active_overlay_for(&state), OverlayPane::None);
+}
+
+#[test]
+fn active_overlay_agent_chooser() {
+    let mut state = AppState::default();
+    state.issues_state.agent_chooser = Some(jefe::state::AgentChooserState::default());
+    assert_eq!(active_overlay_for(&state), OverlayPane::AgentChooser);
+}

--- a/src/mouse_routing_tests.rs
+++ b/src/mouse_routing_tests.rs
@@ -394,6 +394,89 @@ fn resolve_pane_terminal_not_enabled_includes_terminal() {
     }
 }
 
+// ── Critical regression: the production gesture resolver must resolve a
+//    focused-terminal coordinate to TerminalView (issue #197 runtime bug).
+//
+// `resolve_terminal_point` calls `resolve_pane(..., terminal_input_enabled)`.
+// For a FOCUSED terminal that flag must be `false` — otherwise `pane_at`
+// excludes the whole terminal region (returns None), the left-button down has
+// no anchor, and the gesture can never begin a selection (no highlight, no
+// copy). This test wires the SAME `resolve_pane(false)` call the production
+// resolver makes into the gesture state machine so the end-to-end path — real
+// geometry → gesture → TerminalView selection range — is guarded. The earlier
+// hand-rolled test resolver masked this bug (it always returned TerminalView).
+
+#[test]
+fn focused_terminal_drag_resolves_to_terminalview_selection_via_production_geometry() {
+    use jefe::selection::{SelectionPoint, point_to_content_coords};
+
+    let state = focused_terminal_state(AgentKind::CodePuppy);
+    // Mirror the production resolve_terminal_point: resolve_pane with
+    // terminal_input_enabled = false (NOT true) so the terminal region is
+    // selectable while focused.
+    let resolver = |col: u16, row: u16| -> Option<SelectionPoint> {
+        let (pane, geometry) = resolve_pane(&state, col, row, 120, 40, false)?;
+        let (line, c) = point_to_content_coords(col, row, 0, &geometry);
+        Some(SelectionPoint::new(pane, line, c))
+    };
+
+    // A coordinate in the dashboard terminal slot (middle column, below the
+    // agent list) must resolve to TerminalView — not None.
+    let point = resolver(30, 25);
+    assert!(
+        matches!(
+            point,
+            Some(SelectionPoint {
+                pane: SelectablePane::TerminalView,
+                ..
+            })
+        ),
+        "production geometry resolver must map an in-terminal coord to TerminalView (got {point:?}); \
+         if this is None, resolve_terminal_point is passing terminal_input_enabled=true and the \
+         gesture can never begin a selection over a focused terminal"
+    );
+
+    // Drive the gesture machine the way route_terminal_gesture does: a
+    // reporting left-down (buffered) then a left-drag must produce a
+    // Jefe-owned selection RANGE over TerminalView.
+    let down = GestureEvent {
+        kind: GestureEventKind::LeftDown,
+        shift_held: false,
+        col: 30,
+        row: 25,
+        mouse_reporting_active: true,
+    };
+    let (down_action, down_gesture) = GestureState::default().process(down, &resolver);
+    assert_eq!(
+        down_action,
+        GestureAction::Noop,
+        "down buffers while pending"
+    );
+    assert!(matches!(down_gesture, GestureState::Pending { .. }));
+
+    let drag = GestureEvent {
+        kind: GestureEventKind::LeftDrag,
+        shift_held: false,
+        col: 35,
+        row: 25,
+        mouse_reporting_active: true,
+    };
+    let (drag_action, drag_gesture) = down_gesture.process(drag, &resolver);
+    match drag_action {
+        GestureAction::BeginSelectionRange { anchor, focus } => {
+            assert_eq!(anchor.pane, SelectablePane::TerminalView);
+            assert_eq!(focus.pane, SelectablePane::TerminalView);
+        }
+        other => panic!(
+            "drag over focused reporting terminal must begin a TerminalView selection range, got {other:?}"
+        ),
+    }
+    assert!(
+        matches!(drag_gesture, GestureState::JefeOwned { .. }),
+        "gesture latches Jefe ownership"
+    );
+}
+
 // ── Terminal selection text with wraps + wide chars (Finding C+D) ─────────────
 
 fn styled_cell(ch: char) -> TerminalCell {

--- a/src/runtime/attach.rs
+++ b/src/runtime/attach.rs
@@ -443,7 +443,11 @@ fn snapshot_cell(indexed: &Indexed<&Cell>, style: TerminalCellStyle) -> Terminal
     } else {
         indexed.cell.c
     };
-    TerminalCell { ch, style }
+    TerminalCell {
+        ch,
+        style,
+        wide_spacer: false,
+    }
 }
 
 fn snapshot_from_term(term: &Term<RuntimeListener>) -> TerminalSnapshot {
@@ -456,11 +460,37 @@ fn snapshot_from_term(term: &Term<RuntimeListener>) -> TerminalSnapshot {
         let Some((row, col)) = snapshot_position(&indexed, rows, cols) else {
             continue;
         };
+        // Alacritty sets WRAPLINE on the last cell of a row that soft-wraps to
+        // the next row. Record per-row wrap metadata so selection extraction
+        // joins soft-wrapped rows without inserting a newline separator
+        // (issue #197). This check comes BEFORE the wide-spacer branch because
+        // a wide glyph's spacer cell can carry WRAPLINE when the glyph lands at
+        // the final column — recording wrap first keeps soft-wrap fidelity for
+        // CJK/emoji at line ends (issue #197 review).
+        if indexed.cell.flags.contains(Flags::WRAPLINE) {
+            ensure_wrap_slot(&mut snapshot.wraps, rows);
+            snapshot.wraps[row] = true;
+        }
+        // Wide-char spacer cells: mark the snapshot cell as a wide-spacer so
+        // selection extraction skips it (the glyph lives in the preceding cell).
+        // The renderer already treats these cells as blank; marking rather than
+        // skipping preserves the grid alignment so column indices stay stable.
         if indexed
             .cell
             .flags
             .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
         {
+            let style = snapshot_cell_style(
+                &indexed,
+                renderable.selection,
+                renderable.cursor,
+                renderable.colors,
+            );
+            snapshot.cells[row][col] = TerminalCell {
+                ch: ' ',
+                style,
+                wide_spacer: true,
+            };
             continue;
         }
 
@@ -474,6 +504,13 @@ fn snapshot_from_term(term: &Term<RuntimeListener>) -> TerminalSnapshot {
     }
 
     snapshot
+}
+
+/// Ensure `wraps` has at least `rows` entries (all defaulting to false).
+fn ensure_wrap_slot(wraps: &mut Vec<bool>, rows: usize) {
+    if wraps.len() < rows {
+        wraps.resize(rows, false);
+    }
 }
 
 fn attach_command(session_name: &str, ssh_command: Option<&str>) -> CommandBuilder {

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -778,11 +778,16 @@ impl RuntimeManager for TmuxRuntimeManager {
         };
 
         let mut snapshot = TerminalSnapshot::blank(rows, cols, default_style);
+        // `capture_pane_lines` does not preserve soft-wrap metadata, so all
+        // rows are treated as hard line breaks (wraps stays all-false, which
+        // is the default from `blank` — issue #197).
+        snapshot.wraps = vec![false; rows];
         for (r, line) in lines.iter().enumerate() {
             for (c, ch) in line.chars().enumerate() {
                 snapshot.cells[r][c] = TerminalCell {
                     ch,
                     style: default_style,
+                    wide_spacer: false,
                 };
             }
         }

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -94,6 +94,13 @@ pub struct TerminalCell {
     pub ch: char,
     /// Cell style.
     pub style: TerminalCellStyle,
+    /// Whether this cell is the trailing spacer of a wide (width-2) glyph.
+    ///
+    /// When `true`, the actual glyph lives in the preceding cell's `ch` and
+    /// this cell carries a blank `' '` for rendering. Selection extraction
+    /// skips wide-spacer cells so copying a selection across a wide glyph
+    /// yields just the glyph, not a spurious trailing space (issue #197).
+    pub wide_spacer: bool,
 }
 
 /// Terminal snapshot data for rendering.
@@ -107,17 +114,31 @@ pub struct TerminalSnapshot {
     pub cols: usize,
     /// Row-major terminal cells.
     pub cells: Vec<Vec<TerminalCell>>,
+    /// Per-row soft-wrap metadata for selection text extraction.
+    ///
+    /// `wraps[row] == true` means row `row` soft-wraps into row `row+1` (the
+    /// logical line continues on the next row without a newline). An empty
+    /// `Vec` (the default) means no rows wrap — every row ends a logical line.
+    /// This lets terminal selection extraction join soft-wrapped rows without
+    /// inserting a spurious newline while still inserting one at real line
+    /// breaks (issue #197).
+    pub wraps: Vec<bool>,
 }
 
 impl TerminalSnapshot {
     /// Build an empty snapshot pre-filled with a base style.
     #[must_use]
     pub fn blank(rows: usize, cols: usize, style: TerminalCellStyle) -> Self {
-        let cell = TerminalCell { ch: ' ', style };
+        let cell = TerminalCell {
+            ch: ' ',
+            style,
+            wide_spacer: false,
+        };
         Self {
             rows,
             cols,
             cells: vec![vec![cell; cols]; rows],
+            wraps: Vec::new(),
         }
     }
 

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -299,7 +299,12 @@ fn terminal_lines(snapshot: Option<&TerminalSnapshot>, state: &AppState) -> Pane
     let lines: Vec<String> = (0..snap.rows)
         .map(|row| {
             snap.cells.get(row).map_or_else(String::new, |cells| {
-                cells.iter().take(snap.cols).map(|c| c.ch).collect()
+                cells
+                    .iter()
+                    .take(snap.cols)
+                    .filter(|c| !c.wide_spacer)
+                    .map(|c| c.ch)
+                    .collect()
             })
         })
         .collect();
@@ -395,15 +400,42 @@ mod tests {
         };
         let cells = vec![
             vec![
-                TerminalCell { ch: 'h', style },
-                TerminalCell { ch: 'i', style },
+                TerminalCell {
+                    ch: 'h',
+                    style,
+                    wide_spacer: false,
+                },
+                TerminalCell {
+                    ch: 'i',
+                    style,
+                    wide_spacer: false,
+                },
             ],
-            vec![TerminalCell { ch: '!', style }],
+            // Second line has a width-2 glyph '中' + its trailing spacer, then '!'.
+            // The spacer cell must be filtered out so the line reads "中!" (issue #197).
+            vec![
+                TerminalCell {
+                    ch: '中',
+                    style,
+                    wide_spacer: false,
+                },
+                TerminalCell {
+                    ch: ' ',
+                    style,
+                    wide_spacer: true,
+                },
+                TerminalCell {
+                    ch: '!',
+                    style,
+                    wide_spacer: false,
+                },
+            ],
         ];
         let snap = TerminalSnapshot {
             rows: 2,
-            cols: 2,
+            cols: 3,
             cells,
+            wraps: Vec::new(),
         };
         let content = pane_content_lines(
             SelectablePane::TerminalView,
@@ -412,7 +444,7 @@ mod tests {
             120,
             40,
         );
-        assert_eq!(content.lines, vec!["hi".to_string(), "!".to_string()]);
+        assert_eq!(content.lines, vec!["hi".to_string(), "中!".to_string()]);
     }
 
     #[test]

--- a/src/selection/gesture.rs
+++ b/src/selection/gesture.rs
@@ -1,0 +1,391 @@
+//! Pure gesture-ownership state machine for terminal mouse routing (issue #197).
+//!
+//! A left-button gesture (down → drags → up) has a single owner: either Jefe
+//! (paints a selection over the snapshot and copies on release) or the PTY
+//! (forwards the events to the child). The owner is decided at gesture START
+//! and latched for the whole gesture — per-event classification is wrong
+//! because a reporting child's transient menu needs left CLICKS but not drags.
+//!
+//! # Decision table (at left-down)
+//!
+//! | shift | reporting | owner decision                                               |
+//! |:-----:|:---------:|--------------------------------------------------------------|
+//! | yes   | any       | Jefe owns (shift means "I want a Jefe selection")            |
+//! | no    | no        | Jefe owns (selection over snapshot)                          |
+//! | no    | yes       | **pending** — buffer the down, decide on the next event     |
+//!
+//! # Pending resolution
+//!
+//! While **pending** (reporting child, non-shift left-down buffered):
+//! - A left-button **drag** → Jefe owns: begin a selection spanning the
+//!   buffered down coordinate (anchor) through the drag coordinate (focus),
+//!   latch Jefe through release.
+//! - Left-button **up** with no preceding drag (pure click) → PTY owns:
+//!   replay the buffered down + the up (at its real release coordinate) to the
+//!   PTY, discard the buffer.
+//! - Any **non-left-button** event (wheel/right/middle) → flush: replay the
+//!   buffered down to the PTY, then process the current event from idle.
+//! - A stray second **left-down** (rare with well-formed event sequences) →
+//!   flush the buffered down to the PTY first, then start the new gesture, so
+//!   the reporting app never loses a press.
+//!
+//! # Other gestures
+//!
+//! Wheel, right, and middle button events are NOT part of a left-button
+//! gesture. They forward to a reporting child immediately, else fall through
+//! to app selection (unchanged behavior). Shift-modified non-left-button
+//! events (shift+wheel, shift+right/middle) are host passthrough — they never
+//! start a Jefe selection.
+//!
+//! All types and functions here are pure, iocraft-free, and side-effect-free
+//! so the full contract is unit-testable without the runtime.
+
+use crate::selection::SelectionPoint;
+
+/// The kind of mouse event the state machine processes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GestureEventKind {
+    /// Left mouse button pressed down.
+    LeftDown,
+    /// Left mouse button dragged (moved while held).
+    LeftDrag,
+    /// Left mouse button released.
+    LeftUp,
+    /// Mouse wheel scroll up.
+    ScrollUp,
+    /// Mouse wheel scroll down.
+    ScrollDown,
+    /// Right or middle mouse button event (down/drag/up).
+    OtherButton,
+}
+
+/// A single input event to the state machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GestureEvent {
+    /// What kind of mouse event this is.
+    pub kind: GestureEventKind,
+    /// Whether SHIFT is held.
+    pub shift_held: bool,
+    /// The screen column (for left-button events that may start/update a
+    /// selection). Ignored for wheel/other-button events.
+    pub col: u16,
+    /// The screen row (same as `col`).
+    pub row: u16,
+    /// Whether the child currently advertises mouse reporting. This is injected
+    /// (not read from the runtime) so the state machine is pure — the router
+    /// reads it once per event under a single lock acquisition (issue #197
+    /// TOCTOU fix).
+    pub mouse_reporting_active: bool,
+}
+
+/// The action the router should take in response to an event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GestureAction {
+    /// Begin a Jefe selection at the given point (collapsed).
+    BeginSelection(SelectionPoint),
+    /// Begin a Jefe selection spanning `anchor` through `focus`. Emitted when a
+    /// pending gesture resolves to Jefe ownership on the first drag: the anchor
+    /// is the buffered down coordinate and the focus is the current drag
+    /// coordinate, so the selection immediately covers the dragged range
+    /// instead of starting collapsed (issue #197 review: first-drag gap).
+    BeginSelectionRange {
+        anchor: SelectionPoint,
+        focus: SelectionPoint,
+    },
+    /// Update the selection focus (drag) to the given point.
+    UpdateSelection(SelectionPoint),
+    /// Finalize the selection and copy the highlighted text via OSC 52.
+    FinalizeAndCopy,
+    /// Forward the given raw event bytes to the PTY.
+    ///
+    /// Each element is a (col, row, kind) triple to encode and write. When a
+    /// buffered down is replayed alongside an up, both are included with their
+    /// real coordinates.
+    ForwardToPty(Vec<PtyReplay>),
+    /// Run `first`, then `second`. Emitted when a pending gesture is flushed
+    /// (buffered down replayed to the PTY) and the event that triggered the
+    /// flush itself starts a Jefe selection (shift+LeftDown): both the flush
+    /// and the new selection must happen. Without this composite, the
+    /// selection would be silently swallowed by [`merge_actions`] (issue #197
+    /// review: shift-select after a pending press must not be lost).
+    Composite {
+        /// The flush action (run first).
+        first: Box<Self>,
+        /// The follow-up action (run second).
+        second: Box<Self>,
+    },
+    /// No action (event consumed / irrelevant).
+    Noop,
+}
+
+/// A PTY replay event: the router encodes this as SGR mouse bytes and writes
+/// them to the child PTY.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PtyReplay {
+    /// Column relative to the terminal pane.
+    pub col: u16,
+    /// Row relative to the terminal pane.
+    pub row: u16,
+    /// The event kind to encode.
+    pub kind: GestureEventKind,
+}
+
+/// The gesture-ownership state, persisted between events within a single
+/// left-button gesture.
+///
+/// Construct with [`GestureState::default`] (idle). Feed events via
+/// [`GestureState::process`]. The state resets to idle on left-up or when a
+/// non-left event flushes a pending gesture.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum GestureState {
+    /// No gesture in progress.
+    #[default]
+    Idle,
+    /// A non-shift left-down happened over a reporting child; the down
+    /// coordinate is buffered pending a drag-vs-click decision.
+    Pending {
+        /// The buffered down coordinate (screen space).
+        down_col: u16,
+        down_row: u16,
+    },
+    /// Jefe owns the gesture: a selection is active from `anchor` through the
+    /// current drag position. Persists until left-up.
+    JefeOwned {
+        /// The anchor point (content coordinates).
+        anchor: SelectionPoint,
+    },
+}
+
+impl GestureState {
+    /// Process a single event, returning the action to take and the new state.
+    ///
+    /// `resolve_point` is an injected function that maps a screen `(col, row)`
+    /// to a content [`SelectionPoint`] within the terminal pane. This keeps the
+    /// state machine pure (no app-state reads). The resolver returns `None`
+    /// when the coordinate is not over the terminal pane.
+    #[must_use]
+    pub fn process<R>(&self, event: GestureEvent, resolve_point: &R) -> (GestureAction, Self)
+    where
+        R: Fn(u16, u16) -> Option<SelectionPoint>,
+    {
+        // Any non-drag left-button-terminating event while pending → flush:
+        // replay the buffered down to the PTY, then process the current event
+        // from idle. This prevents a reporting app from being starved of its
+        // press if the user switches context mid-gesture (issue #197 review:
+        // stray second LeftDown or a wheel/right/middle mid-gesture).
+        if let Self::Pending { down_col, down_row } = self {
+            match event.kind {
+                GestureEventKind::LeftDown
+                | GestureEventKind::ScrollUp
+                | GestureEventKind::ScrollDown
+                | GestureEventKind::OtherButton => {
+                    let flush = GestureAction::ForwardToPty(vec![PtyReplay {
+                        col: *down_col,
+                        row: *down_row,
+                        kind: GestureEventKind::LeftDown,
+                    }]);
+                    let (sub_action, new_state) = Self::Idle.process(event, resolve_point);
+                    return (merge_actions(flush, sub_action), new_state);
+                }
+                _ => {}
+            }
+        }
+
+        match event.kind {
+            GestureEventKind::LeftDown => self.process_left_down(event, resolve_point),
+            GestureEventKind::LeftDrag => self.process_left_drag(event, resolve_point),
+            GestureEventKind::LeftUp => self.process_left_up(event),
+            GestureEventKind::ScrollUp | GestureEventKind::ScrollDown => self.process_wheel(event),
+            GestureEventKind::OtherButton => self.process_other_button(event),
+        }
+    }
+
+    fn process_left_down<R>(&self, event: GestureEvent, resolve_point: &R) -> (GestureAction, Self)
+    where
+        R: Fn(u16, u16) -> Option<SelectionPoint>,
+    {
+        // A new left-down always starts a fresh gesture. A stray LeftDown
+        // while still mid-gesture (shouldn't happen with well-formed event
+        // sequences) is implicitly reset by the state transitions below.
+        let _ = self;
+
+        // Shift at left-down → Jefe owns the whole gesture.
+        if event.shift_held {
+            return match resolve_point(event.col, event.row) {
+                Some(point) => (
+                    GestureAction::BeginSelection(point),
+                    Self::JefeOwned { anchor: point },
+                ),
+                None => (GestureAction::Noop, Self::Idle),
+            };
+        }
+
+        // Non-reporting child at left-down → Jefe owns (selection over snapshot).
+        if !event.mouse_reporting_active {
+            return match resolve_point(event.col, event.row) {
+                Some(point) => (
+                    GestureAction::BeginSelection(point),
+                    Self::JefeOwned { anchor: point },
+                ),
+                None => (GestureAction::Noop, Self::Idle),
+            };
+        }
+
+        // Reporting child, non-shift → pending: buffer the down, decide later.
+        (
+            GestureAction::Noop,
+            Self::Pending {
+                down_col: event.col,
+                down_row: event.row,
+            },
+        )
+    }
+
+    fn process_left_drag<R>(&self, event: GestureEvent, resolve_point: &R) -> (GestureAction, Self)
+    where
+        R: Fn(u16, u16) -> Option<SelectionPoint>,
+    {
+        match self {
+            Self::JefeOwned { anchor } => {
+                // Jefe owns: update the selection focus.
+                match resolve_point(event.col, event.row) {
+                    Some(point) => (
+                        GestureAction::UpdateSelection(point),
+                        Self::JefeOwned { anchor: *anchor },
+                    ),
+                    None => (GestureAction::Noop, self.clone()),
+                }
+            }
+            Self::Pending { down_col, down_row } => {
+                // Pending → drag resolves to Jefe: begin a selection spanning
+                // the buffered down coordinate (anchor) through the drag
+                // coordinate (focus). If the drag coordinate does not resolve
+                // (cursor left the pane), fall back to a collapsed selection at
+                // the anchor so the gesture still latches Jefe ownership —
+                // subsequent in-pane drags will extend it (issue #197 review:
+                // first-drag must not discard the drag coordinate).
+                let Some(anchor) = resolve_point(*down_col, *down_row) else {
+                    // The buffered down no longer resolves (layout/scroll
+                    // changed between the down and the drag). Forward the
+                    // buffered down AND this drag to the PTY so the reporting
+                    // child sees a complete press+move (not an orphan press),
+                    // then reset — consistent with every other Pending→Idle
+                    // exit (issue #197 review).
+                    return (
+                        GestureAction::ForwardToPty(vec![
+                            PtyReplay {
+                                col: *down_col,
+                                row: *down_row,
+                                kind: GestureEventKind::LeftDown,
+                            },
+                            PtyReplay {
+                                col: event.col,
+                                row: event.row,
+                                kind: GestureEventKind::LeftDrag,
+                            },
+                        ]),
+                        Self::Idle,
+                    );
+                };
+                let focus = resolve_point(event.col, event.row).unwrap_or(anchor);
+                (
+                    GestureAction::BeginSelectionRange { anchor, focus },
+                    Self::JefeOwned { anchor },
+                )
+            }
+            Self::Idle => {
+                // Drag without a preceding down — ignore.
+                (GestureAction::Noop, Self::Idle)
+            }
+        }
+    }
+
+    fn process_left_up(&self, event: GestureEvent) -> (GestureAction, Self) {
+        match self {
+            Self::JefeOwned { .. } => {
+                // Jefe owns: finalize and copy.
+                (GestureAction::FinalizeAndCopy, Self::Idle)
+            }
+            Self::Pending { down_col, down_row } => {
+                // Pending → pure click (no drag): replay down + up to the PTY,
+                // each at its real coordinate, so the reporting child gets a
+                // complete press/release (issue #197 review: the up was never
+                // emitted, leaving the child's button stuck).
+                (
+                    GestureAction::ForwardToPty(vec![
+                        PtyReplay {
+                            col: *down_col,
+                            row: *down_row,
+                            kind: GestureEventKind::LeftDown,
+                        },
+                        PtyReplay {
+                            col: event.col,
+                            row: event.row,
+                            kind: GestureEventKind::LeftUp,
+                        },
+                    ]),
+                    Self::Idle,
+                )
+            }
+            Self::Idle => (GestureAction::Noop, Self::Idle),
+        }
+    }
+
+    fn process_wheel(&self, event: GestureEvent) -> (GestureAction, Self) {
+        // Shift-modified wheel is host passthrough (never a Jefe selection).
+        if event.shift_held {
+            return (GestureAction::Noop, self.clone());
+        }
+        // Non-shift wheel over a reporting child → forward. Otherwise fall
+        // through to app selection (Noop here — the caller handles scroll).
+        if event.mouse_reporting_active {
+            return (
+                GestureAction::ForwardToPty(vec![forward_event(event.col, event.row, event.kind)]),
+                self.clone(),
+            );
+        }
+        (GestureAction::Noop, self.clone())
+    }
+
+    fn process_other_button(&self, event: GestureEvent) -> (GestureAction, Self) {
+        // Shift-modified right/middle is host passthrough.
+        if event.shift_held {
+            return (GestureAction::Noop, self.clone());
+        }
+        // Non-shift right/middle over a reporting child → forward.
+        if event.mouse_reporting_active {
+            return (
+                GestureAction::ForwardToPty(vec![forward_event(event.col, event.row, event.kind)]),
+                self.clone(),
+            );
+        }
+        (GestureAction::Noop, self.clone())
+    }
+}
+
+fn forward_event(col: u16, row: u16, kind: GestureEventKind) -> PtyReplay {
+    PtyReplay { col, row, kind }
+}
+
+/// Merge two actions: if both forward to the PTY, combine their replay lists.
+/// If the second is a no-op, the flush alone stands. Otherwise (the flush must
+/// run AND the second action — e.g. a shift-initiated `BeginSelection` — must
+/// also run), wrap them in a [`GestureAction::Composite`] so neither is
+/// silently dropped (issue #197 review: shift-select after a pending press).
+fn merge_actions(first: GestureAction, second: GestureAction) -> GestureAction {
+    match (first, second) {
+        (GestureAction::ForwardToPty(mut a), GestureAction::ForwardToPty(b)) => {
+            a.extend(b);
+            GestureAction::ForwardToPty(a)
+        }
+        (flush, GestureAction::Noop) => flush,
+        (first, second) => GestureAction::Composite {
+            first: Box::new(first),
+            second: Box::new(second),
+        },
+    }
+}
+
+#[cfg(test)]
+#[path = "gesture_tests.rs"]
+mod gesture_tests;

--- a/src/selection/gesture_tests.rs
+++ b/src/selection/gesture_tests.rs
@@ -1,0 +1,341 @@
+//! Tests for the pure gesture-ownership state machine (issue #197).
+//!
+//! These exercise every sequence the spec requires without iocraft or a
+//! runtime: the state machine is pure, and the point resolver is injected.
+
+use crate::selection::gesture::{
+    GestureAction, GestureEvent, GestureEventKind, GestureState, PtyReplay,
+};
+use crate::selection::{SelectablePane, SelectionPoint};
+
+fn ev(kind: GestureEventKind, shift: bool, reporting: bool) -> GestureEvent {
+    GestureEvent {
+        kind,
+        shift_held: shift,
+        col: 10,
+        row: 5,
+        mouse_reporting_active: reporting,
+    }
+}
+
+fn ev_at(kind: GestureEventKind, shift: bool, reporting: bool, col: u16, row: u16) -> GestureEvent {
+    GestureEvent {
+        kind,
+        shift_held: shift,
+        col,
+        row,
+        mouse_reporting_active: reporting,
+    }
+}
+
+/// Resolver that returns a valid point inside the terminal content area and
+/// `None` for coordinates on/inside the chrome (col/row < 2), mirroring the
+/// real content-origin math so the `Option` return is genuinely exercised.
+fn resolver(col: u16, row: u16) -> Option<SelectionPoint> {
+    if col < 2 || row < 2 {
+        return None;
+    }
+    let content_line = usize::from(row.saturating_sub(2));
+    let content_col = usize::from(col.saturating_sub(2));
+    Some(SelectionPoint::new(
+        SelectablePane::TerminalView,
+        content_line,
+        content_col,
+    ))
+}
+
+/// Resolver that always returns None (coordinate not over the terminal pane).
+fn no_resolver(_col: u16, _row: u16) -> Option<SelectionPoint> {
+    None
+}
+
+// ── Sequence (1): reporting down→drag→up creates selection + finalizes copy ──
+
+#[test]
+fn reporting_down_drag_up_creates_selection_and_copies() {
+    let state = GestureState::default();
+    let (action, state) = state.process(ev(GestureEventKind::LeftDown, false, true), &resolver);
+    // Pending: no action.
+    assert_eq!(action, GestureAction::Noop);
+    assert!(matches!(state, GestureState::Pending { .. }));
+
+    let (action, state) = state.process(ev(GestureEventKind::LeftDrag, false, true), &resolver);
+    // Drag resolves pending to Jefe-owned: begin a selection spanning the
+    // buffered down (anchor) through the drag (focus). Issue #197 review: the
+    // first drag must not discard the drag coordinate (was collapsed).
+    assert!(matches!(action, GestureAction::BeginSelectionRange { .. }));
+    assert!(matches!(state, GestureState::JefeOwned { .. }));
+
+    let (action, state) = state.process(ev(GestureEventKind::LeftUp, false, true), &resolver);
+    // Jefe owns through release: finalize + copy.
+    assert_eq!(action, GestureAction::FinalizeAndCopy);
+    assert_eq!(state, GestureState::Idle);
+}
+
+// ── Sequence (2): reporting click (down→up, no drag) forwards to PTY ──────────
+
+#[test]
+fn reporting_click_down_up_forwards_to_pty() {
+    let state = GestureState::default();
+    let (action, state) = state.process(
+        ev_at(GestureEventKind::LeftDown, false, true, 10, 5),
+        &resolver,
+    );
+    assert_eq!(action, GestureAction::Noop);
+    assert!(matches!(
+        state,
+        GestureState::Pending {
+            down_col: 10,
+            down_row: 5
+        }
+    ));
+
+    let (action, state) = state.process(
+        ev_at(GestureEventKind::LeftUp, false, true, 12, 6),
+        &resolver,
+    );
+    // Pure click → replay down + up to PTY, each at its real coordinate and in
+    // order (issue #197 review: the up was never emitted, leaving the child's
+    // button stuck).
+    match action {
+        GestureAction::ForwardToPty(replays) => {
+            assert_eq!(
+                replays,
+                vec![
+                    PtyReplay {
+                        col: 10,
+                        row: 5,
+                        kind: GestureEventKind::LeftDown,
+                    },
+                    PtyReplay {
+                        col: 12,
+                        row: 6,
+                        kind: GestureEventKind::LeftUp,
+                    },
+                ],
+                "reporting click must replay down + up at real coordinates, in order"
+            );
+        }
+        other => panic!("expected ForwardToPty, got {other:?}"),
+    }
+    assert_eq!(state, GestureState::Idle);
+}
+
+// ── Sequence (3): non-reporting down→drag→up selects ─────────────────────────
+
+#[test]
+fn non_reporting_down_drag_up_selects() {
+    let state = GestureState::default();
+    let (action, state) = state.process(ev(GestureEventKind::LeftDown, false, false), &resolver);
+    assert!(matches!(action, GestureAction::BeginSelection(_)));
+    assert!(matches!(state, GestureState::JefeOwned { .. }));
+
+    let (action, state) = state.process(ev(GestureEventKind::LeftDrag, false, false), &resolver);
+    assert!(matches!(action, GestureAction::UpdateSelection(_)));
+    assert!(matches!(state, GestureState::JefeOwned { .. }));
+
+    let (action, state) = state.process(ev(GestureEventKind::LeftUp, false, false), &resolver);
+    assert_eq!(action, GestureAction::FinalizeAndCopy);
+    assert_eq!(state, GestureState::Idle);
+}
+
+// ── Sequence (4): shift-down→drag→up selects ─────────────────────────────────
+
+#[test]
+fn shift_down_drag_up_selects() {
+    let state = GestureState::default();
+    let (action, state) = state.process(ev(GestureEventKind::LeftDown, true, true), &resolver);
+    // Shift at down → Jefe owns immediately even with reporting.
+    assert!(matches!(action, GestureAction::BeginSelection(_)));
+    assert!(matches!(state, GestureState::JefeOwned { .. }));
+
+    let (action, state) = state.process(ev(GestureEventKind::LeftDrag, true, true), &resolver);
+    assert!(matches!(action, GestureAction::UpdateSelection(_)));
+
+    let (action, _state) = state.process(ev(GestureEventKind::LeftUp, true, true), &resolver);
+    assert_eq!(action, GestureAction::FinalizeAndCopy);
+}
+
+// ── Sequence (5): reporting changes mid-gesture does not split ownership ──────
+
+#[test]
+fn reporting_change_mid_gesture_does_not_split_ownership() {
+    let state = GestureState::default();
+    // Start non-reporting → Jefe owns.
+    let (action, state) = state.process(ev(GestureEventKind::LeftDown, false, false), &resolver);
+    assert!(matches!(action, GestureAction::BeginSelection(_)));
+
+    // Reporting turns on mid-gesture — Jefe still owns.
+    let (action, state) = state.process(ev(GestureEventKind::LeftDrag, false, true), &resolver);
+    assert!(matches!(action, GestureAction::UpdateSelection(_)));
+    assert!(matches!(state, GestureState::JefeOwned { .. }));
+
+    // Release → finalize + copy (not forwarded to PTY).
+    let (action, _) = state.process(ev(GestureEventKind::LeftUp, false, true), &resolver);
+    assert_eq!(action, GestureAction::FinalizeAndCopy);
+}
+
+// ── Sequence (6): shift+wheel passes through (host passthrough) ───────────────
+
+#[test]
+fn shift_wheel_passes_through() {
+    let state = GestureState::default();
+    let (action, state) = state.process(ev(GestureEventKind::ScrollUp, true, true), &resolver);
+    // Shift+wheel → Noop (host passthrough; caller returns early).
+    assert_eq!(action, GestureAction::Noop);
+    assert_eq!(state, GestureState::Idle);
+
+    // Non-shift wheel over reporting child → forward.
+    let (action, _) = state.process(ev(GestureEventKind::ScrollDown, false, true), &resolver);
+    assert!(matches!(action, GestureAction::ForwardToPty(_)));
+
+    // Non-shift wheel over non-reporting → Noop (caller handles scroll).
+    let (action, _) = state.process(ev(GestureEventKind::ScrollUp, false, false), &resolver);
+    assert_eq!(action, GestureAction::Noop);
+}
+
+// ── Sequence (7): shift+right/middle passes through ──────────────────────────
+
+#[test]
+fn shift_other_button_passes_through() {
+    let state = GestureState::default();
+    let (action, _) = state.process(ev(GestureEventKind::OtherButton, true, true), &resolver);
+    assert_eq!(action, GestureAction::Noop);
+}
+
+// ── Pending → non-left event flushes the buffered down to PTY ─────────────────
+
+#[test]
+fn pending_flushed_on_non_left_event() {
+    let state = GestureState::default();
+    let (_action, state) = state.process(
+        ev_at(GestureEventKind::LeftDown, false, true, 10, 5),
+        &resolver,
+    );
+    assert!(matches!(state, GestureState::Pending { .. }));
+
+    // A scroll event while pending → flush: replay the down, then the scroll
+    // goes through the wheel path. The state resets to idle for the wheel.
+    let (action, state) = state.process(ev(GestureEventKind::ScrollUp, false, true), &resolver);
+    // The wheel itself either forwards (reporting) or noops (non-reporting);
+    // the key assertion is the state is no longer pending.
+    assert_eq!(
+        state,
+        GestureState::Idle,
+        "pending must be flushed by a non-left event"
+    );
+    // The wheel over a reporting child forwards, and the flush must include
+    // the buffered down replay (not just the scroll).
+    match action {
+        GestureAction::ForwardToPty(replays) => {
+            assert!(
+                replays
+                    .iter()
+                    .any(|r| r.kind == GestureEventKind::LeftDown && r.col == 10 && r.row == 5),
+                "pending must be flushed: buffered down @(10,5) replayed"
+            );
+        }
+        other => panic!("expected ForwardToPty (down flush + wheel), got {other:?}"),
+    }
+}
+
+// ── Drag without preceding down is a no-op ───────────────────────────────────
+
+#[test]
+fn drag_without_down_is_noop() {
+    let state = GestureState::default();
+    let (action, state) = state.process(ev(GestureEventKind::LeftDrag, false, false), &resolver);
+    assert_eq!(action, GestureAction::Noop);
+    assert_eq!(state, GestureState::Idle);
+}
+
+// ── Coordinate not over terminal pane → no selection ─────────────────────────
+
+#[test]
+fn left_down_not_over_terminal_is_noop() {
+    let state = GestureState::default();
+    let (action, state) = state.process(ev(GestureEventKind::LeftDown, false, false), &no_resolver);
+    assert_eq!(action, GestureAction::Noop);
+    assert_eq!(state, GestureState::Idle);
+}
+
+// ── Pending flush preserves a shift-initiated selection (Composite) ─────────
+//
+// A stray second LeftDown while Pending flushes the buffered down to the PTY.
+// When that second down is shift+LeftDown (a Jefe selection), both the flush
+// AND the BeginSelection must happen — previously merge_actions silently
+// dropped the selection (issue #197 review).
+
+#[test]
+fn shift_left_down_while_pending_emits_composite_flush_plus_selection() {
+    use crate::selection::SelectablePane;
+    let down = ev_at(GestureEventKind::LeftDown, false, true, 5, 5);
+    let (_, pending) = GestureState::default().process(down, &resolver);
+    let shift_down = ev_at(GestureEventKind::LeftDown, true, true, 8, 8);
+    let (action, state) = pending.process(shift_down, &resolver);
+    match action {
+        GestureAction::Composite { first, second } => {
+            // First: the buffered down replayed to the PTY.
+            match *first {
+                GestureAction::ForwardToPty(replays) => {
+                    assert_eq!(replays.len(), 1, "flush replays the buffered down");
+                    assert_eq!(replays[0].kind, GestureEventKind::LeftDown);
+                    assert_eq!((replays[0].col, replays[0].row), (5, 5));
+                }
+                other => panic!("composite first must be ForwardToPty, got {other:?}"),
+            }
+            // Second: the shift-initiated selection begins.
+            match *second {
+                GestureAction::BeginSelection(point) => {
+                    assert_eq!(point.pane, SelectablePane::TerminalView);
+                    assert_eq!(
+                        (point.line, point.col),
+                        (6, 6),
+                        "selection at shift-down coord"
+                    );
+                }
+                other => panic!("composite second must be BeginSelection, got {other:?}"),
+            }
+        }
+        other => panic!("expected Composite, got {other:?}"),
+    }
+    assert!(
+        matches!(state, GestureState::JefeOwned { .. }),
+        "state latches Jefe ownership for the shift gesture"
+    );
+}
+
+// ── Pending→drag with unresolvable buffered anchor forwards the down ────────
+//
+// If the buffered down coordinate no longer resolves when the drag arrives
+// (layout/scroll change), the buffered down is forwarded to the PTY rather
+// than silently dropped (issue #197 review: every other Pending→Idle exit
+// replays the down; this path was the sole exception).
+
+#[test]
+fn pending_drag_with_unresolvable_anchor_forwards_buffered_down() {
+    // down@(0,0) is out-of-pane (< 2) → the anchor won't resolve. drag@(5,5)
+    // is in-pane, so the Pending→drag path hits the unresolvable-anchor
+    // branch: the buffered down AND the drag are forwarded to the PTY rather
+    // than dropped (issue #197 review).
+    let down = ev_at(GestureEventKind::LeftDown, false, true, 0, 0);
+    let (_, pending) = GestureState::default().process(down, &resolver);
+    // down@(0,0) is out-of-pane (< 2) so the anchor won't resolve.
+    let drag = ev_at(GestureEventKind::LeftDrag, false, true, 5, 5);
+    let (action, state) = pending.process(drag, &resolver);
+    match action {
+        GestureAction::ForwardToPty(replays) => {
+            assert_eq!(
+                replays.len(),
+                2,
+                "buffered down AND the drag forwarded (complete press+move)"
+            );
+            assert_eq!(replays[0].kind, GestureEventKind::LeftDown);
+            assert_eq!((replays[0].col, replays[0].row), (0, 0));
+            assert_eq!(replays[1].kind, GestureEventKind::LeftDrag);
+            assert_eq!((replays[1].col, replays[1].row), (5, 5));
+        }
+        other => panic!("expected ForwardToPty of buffered down + drag, got {other:?}"),
+    }
+    assert_eq!(state, GestureState::Idle);
+}

--- a/src/selection/mod.rs
+++ b/src/selection/mod.rs
@@ -27,14 +27,17 @@
 mod content;
 mod form_content;
 mod geometry;
+mod gesture;
 mod layout_descriptor;
 mod overlay_content;
+mod terminal_text;
 mod text;
-
 pub use content::{PaneContent, pane_content_lines};
 pub use form_content::{agent_form_content_lines, repository_form_content_lines};
 pub use geometry::{PaneGeometry, pane_at};
+pub use gesture::{GestureAction, GestureEvent, GestureEventKind, GestureState, PtyReplay};
 pub use layout_descriptor::{OverlayPane, ScreenLayout};
+pub use terminal_text::terminal_selection_text;
 pub use text::{
     HighlightRange, SelectablePane, SelectionPoint, TextSelection, normalize_selection,
     point_to_content_coords, row_highlight_range, selection_text,

--- a/src/selection/terminal_text.rs
+++ b/src/selection/terminal_text.rs
@@ -1,0 +1,300 @@
+//! Wrap-aware, width-aware terminal selection text extraction (issue #197).
+//!
+//! [`selection_text`] (in [`super::text`]) joins content lines with `\n`
+//! unconditionally — correct for most panes but wrong for the terminal pane,
+//! where a soft-wrapped row should join its continuation with NO separator.
+//!
+//! [`terminal_selection_text`] is the terminal-pane-specific extractor: it
+//! reads `wraps[row]` from the [`TerminalSnapshot`] to decide whether two
+//! consecutive rows are a soft wrap (join directly) or a hard newline (join
+//! with `\n`), and skips `wide_spacer` cells so a selection across a width-2
+//! glyph copies just the glyph, not the glyph + a spurious space.
+//!
+//! All functions here are pure, iocraft-free, and `#[must_use]` so they are
+//! fully unit-testable without the runtime.
+
+use crate::runtime::TerminalSnapshot;
+use crate::selection::text::{TextSelection, normalize_selection};
+
+/// Build the copyable text for a terminal selection from a snapshot.
+///
+/// Joins covered rows: when `wraps[row]` is true, row `row` soft-wraps into
+/// `row+1` and the two rows join with NO separator; otherwise a `\n` separates
+/// them. `wide_spacer` cells are skipped so a width-2 glyph contributes just
+/// its leading cell's character.
+///
+/// The selection is normalized first; coordinates are clamped to snapshot
+/// bounds so out-of-range selections never panic.
+#[must_use]
+pub fn terminal_selection_text(snapshot: &TerminalSnapshot, selection: &TextSelection) -> String {
+    if snapshot.cells.is_empty() {
+        return String::new();
+    }
+    let (start, end) = normalize_selection(&selection.anchor, &selection.focus);
+    let last = snapshot.cells.len().saturating_sub(1);
+    let start_line = start.line.min(last);
+    let end_line = end.line.min(last);
+    // Compare the clamped (not original) lines: when both points land past the
+    // last row they clamp to the same line, but the original `start.line !=
+    // end.line` would skip this branch and run the multi-row path, producing
+    // garbled tail+head-of-same-row text (issue #197 review).
+    if start_line == end_line {
+        // When the start point was past the last row, start_line was clamped
+        // to `last`; reset the column to 0 so we do not slice into an arbitrary
+        // column of the wrong row (mirrors the multi-row path and the
+        // end-clamping below). Issue #197 review.
+        let start_col = if start.line > last { 0 } else { start.col };
+        let end_col = if end.line > last { usize::MAX } else { end.col };
+        return terminal_row_text(snapshot, start_line, start_col, end_col);
+    }
+
+    let mut out = String::new();
+
+    // Tail of the start row (from start.col to end of row). When the start
+    // point was past the last row, start_line was clamped to `last`; reset the
+    // column to 0 so we do not slice into an arbitrary column of the wrong row
+    // (mirrors the end-clamping logic below).
+    let start_clamped_down = start.line > last;
+    let start_col = if start_clamped_down { 0 } else { start.col };
+    out.push_str(&terminal_row_text(
+        snapshot,
+        start_line,
+        start_col,
+        usize::MAX,
+    ));
+
+    // Middle rows.
+    for row in (start_line + 1)..end_line {
+        join_row(&mut out, snapshot, row.saturating_sub(1));
+        out.push_str(&terminal_row_text(snapshot, row, 0, usize::MAX));
+    }
+
+    // Head of the end row (from 0 to end.col).
+    join_row(&mut out, snapshot, end_line.saturating_sub(1));
+    let end_clamped_down = end.line > last;
+    let end_col = if end_clamped_down {
+        usize::MAX
+    } else {
+        end.col
+    };
+    out.push_str(&terminal_row_text(snapshot, end_line, 0, end_col));
+
+    out
+}
+
+/// Append a separator between `prev_row` and `prev_row+1`: nothing if the
+/// previous row soft-wraps, `\n` otherwise.
+fn join_row(out: &mut String, snapshot: &TerminalSnapshot, prev_row: usize) {
+    if !row_soft_wraps(snapshot, prev_row) {
+        out.push('\n');
+    }
+}
+
+/// Whether `row` soft-wraps into `row+1`.
+fn row_soft_wraps(snapshot: &TerminalSnapshot, row: usize) -> bool {
+    // wraps is empty (default) => no soft wraps. Otherwise check the flag.
+    snapshot.wraps.get(row).copied().unwrap_or(false)
+}
+
+/// Extract text from a single terminal row between `start_col` (inclusive) and
+/// `end_col` (exclusive, `usize::MAX` means to end of row), skipping
+/// `wide_spacer` cells.
+fn terminal_row_text(
+    snapshot: &TerminalSnapshot,
+    row: usize,
+    start_col: usize,
+    end_col: usize,
+) -> String {
+    let Some(cells) = snapshot.cells.get(row) else {
+        return String::new();
+    };
+    let cols = snapshot.cols.min(cells.len());
+    let s = start_col.min(cols);
+    let e = if end_col == usize::MAX {
+        cols
+    } else {
+        end_col.min(cols)
+    };
+    if s >= e {
+        return String::new();
+    }
+    cells[s..e]
+        .iter()
+        .filter(|cell| !cell.wide_spacer)
+        .map(|cell| cell.ch)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::selection::SelectablePane;
+    use iocraft::Color;
+
+    fn style() -> crate::runtime::TerminalCellStyle {
+        crate::runtime::TerminalCellStyle {
+            fg: Color::White,
+            bg: Color::Black,
+            bold: false,
+            dim: false,
+            underline: false,
+        }
+    }
+
+    fn cell(ch: char) -> crate::runtime::TerminalCell {
+        crate::runtime::TerminalCell {
+            ch,
+            style: style(),
+            wide_spacer: false,
+        }
+    }
+
+    fn spacer() -> crate::runtime::TerminalCell {
+        crate::runtime::TerminalCell {
+            ch: ' ',
+            style: style(),
+            wide_spacer: true,
+        }
+    }
+
+    fn point(line: usize, col: usize) -> crate::selection::SelectionPoint {
+        crate::selection::SelectionPoint::new(SelectablePane::TerminalView, line, col)
+    }
+
+    fn selection(line0: usize, col0: usize, line1: usize, col1: usize) -> TextSelection {
+        TextSelection {
+            anchor: point(line0, col0),
+            focus: point(line1, col1),
+        }
+    }
+
+    // ── Finding C: soft-wrap handling ──────────────────────────────────────
+
+    #[test]
+    fn selection_entirely_within_a_wrapped_row() {
+        // Row 0 wraps into row 1; a single-row selection on row 1 returns its text.
+        let snap = TerminalSnapshot {
+            rows: 2,
+            cols: 5,
+            cells: vec![
+                vec![cell('A'), cell('B'), cell('C'), cell('D'), cell('E')],
+                vec![cell('F'), cell('G'), cell('H'), cell(' '), cell(' ')],
+            ],
+            wraps: vec![true, false],
+        };
+        let text = terminal_selection_text(&snap, &selection(1, 0, 1, 3));
+        assert_eq!(text, "FGH");
+    }
+
+    #[test]
+    fn selection_crossing_a_soft_wrap_inserts_no_newline() {
+        // Row 0 wraps to row 1; selecting across rows 0..1 yields contiguous text
+        // with NO `\n` at the row boundary.
+        let snap = TerminalSnapshot {
+            rows: 2,
+            cols: 5,
+            cells: vec![
+                vec![cell('A'), cell('B'), cell('C'), cell('D'), cell('E')],
+                vec![cell('F'), cell('G'), cell('H'), cell(' '), cell(' ')],
+            ],
+            wraps: vec![true, false],
+        };
+        let text = terminal_selection_text(&snap, &selection(0, 2, 1, 2));
+        assert_eq!(text, "CDEFG");
+    }
+
+    #[test]
+    fn selection_crossing_a_hard_newline_inserts_newline() {
+        // No wrap between rows; selection across rows includes `\n`.
+        let snap = TerminalSnapshot {
+            rows: 2,
+            cols: 5,
+            cells: vec![
+                vec![cell('A'), cell('B'), cell('C'), cell('D'), cell('E')],
+                vec![cell('F'), cell('G'), cell('H'), cell(' '), cell(' ')],
+            ],
+            wraps: vec![false, false],
+        };
+        let text = terminal_selection_text(&snap, &selection(0, 2, 1, 2));
+        assert_eq!(text, "CDE\nFG");
+    }
+
+    #[test]
+    fn reversed_selection_across_a_wrap_and_a_newline() {
+        // Row 0 wraps to row 1 (no \n); row 1 is a hard break to row 2 (\n).
+        let snap = TerminalSnapshot {
+            rows: 3,
+            cols: 5,
+            cells: vec![
+                vec![cell('A'), cell('B'), cell('C'), cell('D'), cell('E')],
+                vec![cell('F'), cell('G'), cell('H'), cell(' '), cell(' ')],
+                vec![cell('X'), cell('Y'), cell('Z'), cell(' '), cell(' ')],
+            ],
+            wraps: vec![true, false, false],
+        };
+        // Reversed anchor/focus (focus earlier than anchor).
+        // start=(0,2) "CDE", wrap→"FGH  ", hard break, end=(2,2) "XY".
+        let text = terminal_selection_text(&snap, &selection(2, 2, 0, 2));
+        assert_eq!(text, "CDEFGH  \nXY");
+    }
+
+    // ── Finding D: wide-char spacer handling ───────────────────────────────
+
+    #[test]
+    fn wide_char_selection_covering_both_cells_copies_just_glyph() {
+        // '中' (width-2) at col 0, spacer at col 1, then '!' at col 2.
+        let snap = TerminalSnapshot {
+            rows: 1,
+            cols: 3,
+            cells: vec![vec![cell('中'), spacer(), cell('!')]],
+            wraps: vec![false],
+        };
+        // Select cols 0..3 (both glyph cells + '!').
+        let text = terminal_selection_text(&snap, &selection(0, 0, 0, 3));
+        assert_eq!(text, "中!");
+    }
+
+    #[test]
+    fn wide_char_selection_ending_on_spacer_copies_up_to_glyph() {
+        let snap = TerminalSnapshot {
+            rows: 1,
+            cols: 3,
+            cells: vec![vec![cell('中'), spacer(), cell('!')]],
+            wraps: vec![false],
+        };
+        // Select cols 0..2 — the spacer is skipped.
+        let text = terminal_selection_text(&snap, &selection(0, 0, 0, 2));
+        assert_eq!(text, "中");
+    }
+
+    #[test]
+    fn wide_char_selection_starting_on_spacer_starts_after_glyph() {
+        let snap = TerminalSnapshot {
+            rows: 1,
+            cols: 3,
+            cells: vec![vec![cell('中'), spacer(), cell('!')]],
+            wraps: vec![false],
+        };
+        // Select cols 1..3 — the spacer is skipped, so only '!' is copied.
+        let text = terminal_selection_text(&snap, &selection(0, 1, 0, 3));
+        assert_eq!(text, "!");
+    }
+
+    // ── Empty wraps (default) behaves like hard newlines everywhere ────────
+
+    #[test]
+    fn empty_wraps_treats_all_rows_as_hard_breaks() {
+        // No wraps metadata => every row boundary is a `\n`.
+        let snap = TerminalSnapshot {
+            rows: 2,
+            cols: 3,
+            cells: vec![
+                vec![cell('a'), cell('b'), cell('c')],
+                vec![cell('d'), cell('e'), cell('f')],
+            ],
+            wraps: Vec::new(),
+        };
+        let text = terminal_selection_text(&snap, &selection(0, 0, 1, 3));
+        assert_eq!(text, "abc\ndef");
+    }
+}

--- a/src/selection/tests.rs
+++ b/src/selection/tests.rs
@@ -3,6 +3,7 @@
 //! These exercise [`crate::selection::pane_at`], [`normalize_selection`],
 //! [`selection_text`], and [`point_to_content_coords`] without any terminal.
 
+use crate::layout::{LEFT_COL_WIDTH, TERMINAL_VIEW_CHROME_COLS, TERMINAL_VIEW_CHROME_ROWS};
 use crate::selection::{
     HighlightRange, PaneGeometry, SelectablePane, SelectionPoint, TextSelection,
     normalize_selection, pane_at, point_to_content_coords, row_highlight_range, selection_text,
@@ -144,6 +145,34 @@ fn pane_at_dashboard_terminal_focused_returns_none_in_terminal_region() {
         sidebar.map(|(p, _)| p),
         Some(SelectablePane::Sidebar)
     ));
+}
+
+// Verify the terminal pane's content-origin geometry in the dashboard middle
+// column. `pane_at` with `terminal_input_enabled = false` resolves the
+// terminal region to TerminalView with chrome offsets; pin the content origin
+// so selection coordinates match the rendered snapshot. (Issue #197: the
+// mouse router relies on this geometry when it decides to paint a Jefe
+// selection over a focused terminal.)
+#[test]
+fn pane_at_dashboard_terminal_content_origin_geometry() {
+    let lay = layout(120, 40, DASHBOARD, false, false);
+    // terminal_input_enabled = false mirrors what the router passes when the
+    // routing policy chose AppSelection over the focused terminal.
+    let selectable = pane_at(30, 20, DASHBOARD, false, &lay);
+    let Some((pane, geo)) = selectable else {
+        panic!("expected TerminalView to resolve when terminal is selectable");
+    };
+    assert!(matches!(pane, SelectablePane::TerminalView));
+    // Content origin must match the unfocused terminal geometry so selection
+    // coordinates line up with the rendered snapshot.
+    assert_eq!(
+        geo.content_origin_col,
+        LEFT_COL_WIDTH + TERMINAL_VIEW_CHROME_COLS
+    );
+    assert_eq!(
+        geo.content_origin_row,
+        geo.origin_row + TERMINAL_VIEW_CHROME_ROWS
+    );
 }
 
 // ── pane_at: issues mode ────────────────────────────────────────────────────

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -235,6 +235,22 @@ pub struct AppState {
     /// inverse-video highlight over the selected cells.
     pub selection: Option<crate::selection::TextSelection>,
 
+    /// The terminal snapshot bound to the active selection (issue #197).
+    ///
+    /// Captured when a terminal selection gesture begins and reused for BOTH
+    /// the highlight rendering and the copy-at-release so copied text always
+    /// matches what the user highlighted — even when the live grid streams new
+    /// output between the last drag frame and mouse-up. Cleared together with
+    /// `selection`. Runtime-only — never persisted.
+    pub selection_snapshot: Option<crate::runtime::TerminalSnapshot>,
+
+    /// Gesture-ownership state for the terminal mouse router (issue #197).
+    ///
+    /// Persists the left-button gesture ownership decision (Jefe vs PTY) across
+    /// events within a single down→drag→up cycle. Reset to idle on release.
+    /// Runtime-only — never persisted.
+    pub terminal_gesture_state: crate::selection::GestureState,
+
     /// Help modal scroll offset (lines scrolled from the top). Mirrored from
     /// the app-shell hook state so the selection content projection can map
     /// screen coordinates to the correct help content line (issue #178).

--- a/src/ui/components/terminal_view.rs
+++ b/src/ui/components/terminal_view.rs
@@ -616,6 +616,7 @@ mod tests {
         TerminalCell {
             ch,
             style: style(fg),
+            wide_spacer: false,
         }
     }
 

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -200,7 +200,32 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                     }
                     Box(height: terminal_rows, width: 100pct) {
                         TerminalView(
-                            snapshot: props.terminal_snapshot.clone(),
+                            // When a Jefe-owned terminal selection is active,
+                            // use the snapshot that was captured at gesture
+                            // start (selection_snapshot) so the highlight and
+                            // copy use the SAME grid data (Finding B, issue
+                            // #197). Gate on the selection targeting the
+                            // terminal pane: a sidebar/agent-list selection
+                            // renders from app state, not the terminal grid,
+                            // so it must not pin the terminal to a stale
+                            // snapshot (issue #197 review). Otherwise use the
+                            // live render snapshot.
+                            snapshot: {
+                                let pinned = state.and_then(|s| {
+                                    let sel_is_terminal = s
+                                        .selection
+                                        .is_some_and(|sel| {
+                                            sel.pane()
+                                                == crate::selection::SelectablePane::TerminalView
+                                        });
+                                    if sel_is_terminal {
+                                        s.selection_snapshot.clone()
+                                    } else {
+                                        None
+                                    }
+                                });
+                                pinned.or_else(|| props.terminal_snapshot.clone())
+                            },
                             focused: terminal_focused,
                             colors: colors.clone(),
                             selection: selection,

--- a/tests/runtime/terminal_focus_routing.rs
+++ b/tests/runtime/terminal_focus_routing.rs
@@ -194,3 +194,133 @@ fn terminal_focus_is_independent_of_pane_focus() {
         "terminal_focused should persist across pane changes"
     );
 }
+
+// =============================================================================
+// Issue #197: terminal text selection & copy for Code Puppy sessions
+// =============================================================================
+//
+// These tests exercise the production gesture-ownership state machine
+// (`jefe::selection::GestureState`), which the terminal mouse router uses to
+// decide, per gesture, whether Jefe paints a selection/copy or the events
+// forward to the child PTY. A left-button gesture has a single latched owner,
+// decided at gesture start.
+
+use jefe::selection::{
+    GestureAction, GestureEvent, GestureEventKind, GestureState, SelectablePane, SelectionPoint,
+};
+
+/// A resolver that maps in-pane coordinates to a TerminalView selection point.
+/// Returns `None` for coordinates outside the content area (mimicking the real
+/// pane geometry) so the function is not trivially always-`Some`.
+fn resolver(col: u16, row: u16) -> Option<SelectionPoint> {
+    if col < 2 || row < 2 {
+        return None;
+    }
+    Some(SelectionPoint::new(SelectablePane::TerminalView, 0, 0))
+}
+
+fn event(kind: GestureEventKind, shift: bool, reporting: bool) -> GestureEvent {
+    // Use in-pane coordinates (>= 2) so the resolver yields a selection point.
+    GestureEvent {
+        kind,
+        shift_held: shift,
+        col: 5,
+        row: 5,
+        mouse_reporting_active: reporting,
+    }
+}
+
+/// The left-button text-selection gesture is Jefe-owned, so a drag over the
+/// focused terminal paints a Jefe selection (and copies on release) even when
+/// the child advertises mouse reporting. This is the core #197 regression:
+/// Code Puppy drags were forwarded to the PTY and lost their selection.
+#[test]
+fn left_button_drag_selects_even_with_mouse_reporting() {
+    // Reporting child, non-shift left-down → pending (buffered).
+    let (action, state) =
+        GestureState::default().process(event(GestureEventKind::LeftDown, false, true), &resolver);
+    assert!(matches!(action, GestureAction::Noop));
+    assert!(matches!(state, GestureState::Pending { .. }));
+    // Drag → Jefe owns the gesture (selection range begins, spanning the
+    // buffered down through the drag coordinate).
+    let (action, state) = state.process(event(GestureEventKind::LeftDrag, false, true), &resolver);
+    assert!(
+        matches!(action, GestureAction::BeginSelectionRange { .. }),
+        "drag over reporting child must begin a Jefe selection range, got {action:?}"
+    );
+    assert!(matches!(state, GestureState::JefeOwned { .. }));
+
+    // Complete the gesture: LeftUp from JefeOwned must finalize + copy.
+    let (action, state) = state.process(event(GestureEventKind::LeftUp, false, true), &resolver);
+    assert_eq!(action, GestureAction::FinalizeAndCopy);
+    assert_eq!(state, GestureState::Idle);
+}
+
+/// Shift-drag must never silently disappear. A Shift left-down latches Jefe
+/// ownership immediately, so the gesture highlights cells and copies — it is
+/// no longer a no-op (#197).
+#[test]
+fn shift_drag_always_routes_to_app_selection() {
+    for reporting in [false, true] {
+        let (action, state) = GestureState::default().process(
+            event(GestureEventKind::LeftDown, true, reporting),
+            &resolver,
+        );
+        assert!(
+            matches!(action, GestureAction::BeginSelection(_)),
+            "shift left-down must begin a Jefe selection for reporting={reporting}, got {action:?}"
+        );
+        assert!(matches!(state, GestureState::JefeOwned { .. }));
+    }
+}
+
+/// A pure click (down then up, no drag) on a reporting child forwards BOTH the
+/// down and the up to the PTY — preserving terminal left-click interaction for
+/// agents and transient menus that genuinely drive mouse reporting (the #197
+/// requirement). This also guards the critical fix: the up was previously
+/// never emitted, leaving the child's button stuck.
+#[test]
+fn reporting_click_forwards_down_and_up_to_pty() {
+    let (action, pending) =
+        GestureState::default().process(event(GestureEventKind::LeftDown, false, true), &resolver);
+    assert!(matches!(action, GestureAction::Noop));
+    let (action, state) = pending.process(event(GestureEventKind::LeftUp, false, true), &resolver);
+    match action {
+        GestureAction::ForwardToPty(replays) => {
+            assert_eq!(
+                replays.len(),
+                2,
+                "reporting click must replay down + up, got {replays:?}"
+            );
+            assert_eq!(replays[0].kind, GestureEventKind::LeftDown);
+            assert_eq!(replays[1].kind, GestureEventKind::LeftUp);
+        }
+        other => panic!("expected ForwardToPty for reporting click, got {other:?}"),
+    }
+    assert_eq!(state, GestureState::Idle);
+}
+
+/// Without mouse reporting, a non-selection gesture (wheel/right/middle) does
+/// not forward to the PTY; it falls through (Noop) so app-level handling
+/// applies.
+#[test]
+fn non_selection_gesture_noops_when_mouse_reporting_inactive() {
+    let (action, state) = GestureState::default()
+        .process(event(GestureEventKind::ScrollDown, false, false), &resolver);
+    assert!(matches!(action, GestureAction::Noop));
+    assert_eq!(state, GestureState::default());
+}
+
+/// With mouse reporting, a wheel event forwards to the child PTY.
+#[test]
+fn wheel_forwards_when_mouse_reporting_active() {
+    let (action, _state) = GestureState::default()
+        .process(event(GestureEventKind::ScrollDown, false, true), &resolver);
+    match action {
+        GestureAction::ForwardToPty(replays) => {
+            assert_eq!(replays.len(), 1);
+            assert_eq!(replays[0].kind, GestureEventKind::ScrollDown);
+        }
+        other => panic!("expected ForwardToPty for reporting wheel, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Text selection and copy did not work in the embedded terminal when a Code Puppy (Kennel-mode) agent was running: drag-select produced no Jefe selection/copy, Shift-drag was a silent no-op, and copy fidelity broke on Unicode and soft-wrapped lines. This fixes all of those while preserving intentional child mouse interaction (transient Code Puppy menus that enable mouse reporting) and not regressing LLxprt.

## Root causes

1. Shift mouse events were blanket no-ops. The host terminal only sees Jefe's rendered canvas (not the nested PTY grid), so it never selected anything.
2. Code Puppy advertises mouse reporting, so left-button drags were forwarded to the PTY instead of starting a Jefe selection.
3. The selection geometry returned None for the focused terminal pane.
4. Copy re-captured a fresh snapshot that could differ from the highlighted one, and treated soft-wraps as hard newlines and wide-char spacers as spaces.

## The fix

A gesture-ownership state machine (`src/selection/gesture.rs`, pure/iocraft-free) plus a fidelity-correct selection path:

- A left-button gesture (down -> drags -> up) has ONE owner, latched at gesture start:
  - Shift at left-down -> Jefe owns (shift means "I want a Jefe selection").
  - Non-reporting child -> Jefe owns.
  - Reporting child, non-shift -> pending: buffer the down, decide on the next event.
    - Drag -> Jefe owns; the selection immediately spans the buffered down (anchor) through the drag (focus).
    - Pure click (up, no drag) -> replay down and up to the PTY (each at its real coordinate) so transient menus keep their left-click.
    - Non-left event or a stray second left-down -> flush the buffered down to the PTY first.
- Wheel/right/middle forward to a reporting child (preserving the real button + phase), else fall through to app selection. Shift + non-left is host passthrough (shift+scroll works again).
- The reporting flag is read once per event under a single lock (no TOCTOU between the routing decision and the forward); a poisoned lock is logged and treated as "terminal not active".
- The terminal pane resolves as TerminalView when the gesture is Jefe-owned (focused terminal no longer returns None). Terminal routing is gated on ScreenMode::Dashboard, and full-screen blocking modals (ThemePicker/WorkflowDispatch) disable forwarding.
- Copy fidelity: the selection is bound to the snapshot used for highlighting (stored on AppState, gated on the selection targeting TerminalView), so release copies exactly what was painted. The snapshot now carries per-row soft-wrap metadata (wraps) and a wide_spacer cell flag; terminal selection extraction joins soft-wrapped rows without a newline and skips wide-char spacer cells. The clipboard writer is an injected seam so tests assert the exact payload.
- clear_selection now resets the terminal gesture state (a Pending gesture has no selection yet and previously survived keyboard/paste/resize events).

## Tests

- Pure state-machine sequences (`src/selection/gesture_tests.rs`): reporting drag-select, reporting click replays down and up at real coords, non-reporting select, shift-select, reporting change mid-gesture does not split ownership, shift+wheel passthrough, out-of-pane no-op, first-drag emits a range not a collapsed point, stray left-down flushes the buffer.
- Wrap-aware and wide-char-aware selection-text extraction (`src/selection/terminal_text.rs`) with a real width-2 CJK glyph.
- Router classification + routing (`src/mouse_routing_tests.rs`): gesture event-kind classification, dashboard-only routing, blocking modals, terminal pane resolution, reporting-click down+up replay, reporting-drag begins range, stray left-down flush.
- Integration tests (`tests/runtime/terminal_focus_routing.rs`) now exercise the production `GestureState` machine (the obsolete `terminal_mouse_policy` module was removed).

## Verification

make ci-check equivalent is green: cargo fmt --all --check, both clippy passes (standard + complexity), scripts/check-clippy-allows.sh, scripts/check-source-file-size.sh, cargo build --workspace --all-features --locked, cargo test --workspace --all-features --locked (1821 tests pass), coverage 70.19% (threshold 30%). No new clippy allow/suppression or loosened complexity thresholds.

## Notes

- The TUI harness is keyboard-only, so `dev-docs/tmux-scenarios/kennel-terminal-select.json` documents the focus/selection path but cannot drive an actual mouse drag/copy; that limitation is recorded in `dev-docs/testing/tmux-harness.md`. Selection behavior is covered by the pure state-machine and behavioral unit tests.

closes #197
