### PR TITLE
Apply OCR/CodeRabbit review fixes to scrollback viewport (follow-up to #198)

### DIFF
--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -502,7 +502,8 @@ pub fn try_intercept_terminal_scrollback(
 
 /// Refresh cached terminal scrollback geometry (issue #198). Computes
 /// viewport rows from PTY layout and total lines from history + snapshot.
-/// When ctx is None, preserves existing geometry (fix #3).
+/// When ctx is None or the lock is contended, preserves existing geometry
+/// instead of zeroing it (zeroing would clear the scroll offset).
 pub fn refresh_terminal_scroll_geometry(app_state: &mut AppStateHandle, ctx: &SharedContext) {
     let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((120, 40));
     let pty_layout = jefe::layout::compute_pty_layout(term_cols, term_rows);
@@ -520,31 +521,30 @@ pub fn refresh_terminal_scroll_geometry(app_state: &mut AppStateHandle, ctx: &Sh
             }
             Err(_) => {
                 // Lock contention: preserve existing geometry instead of
-                // zeroing it (issue #198 review fix #5). Zeroing would clear
-                // the scroll offset and jump to follow-tail during attach.
+                // zeroing it. Zeroing would clear the scroll offset and jump
+                // to follow-tail during attach.
                 return;
             }
         },
         None => {
-            // No context: preserve existing geometry instead of zeroing it
-            // (fix #3). Zeroing would clear the scroll offset.
+            // No context: preserve existing geometry instead of zeroing it.
+            // Zeroing would clear the scroll offset.
             return;
         }
     };
 
     let mut state = app_state.write();
-    let new_total = history_count + live_rows;
     let old_total = state.terminal_total_lines;
     let viewport_rows = usize::from(pty_layout.pty_rows);
 
-    // Reconcile the scroll offset when content grows so the viewport stays at
-    // the same absolute position (issue #198 review fix #3).
-    state.terminal_history_offset = jefe::state::scrollback_ops::reconcile_offset_for_new_content(
+    let (new_offset, new_total) = jefe::state::scrollback_ops::compute_terminal_scroll_geometry(
         state.terminal_history_offset,
         old_total,
-        new_total,
+        history_count,
+        live_rows,
         viewport_rows,
     );
+    state.terminal_history_offset = new_offset;
     state.terminal_viewport_rows = viewport_rows;
     state.terminal_total_lines = new_total;
 }

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -24,7 +24,7 @@ use jefe::layout::{compute_pty_layout, effective_render_size};
 use jefe::runtime::{
     AttachAction, AttachScheduler, DEFAULT_DEBOUNCE, RuntimeError, RuntimeManager, TerminalSnapshot,
 };
-use jefe::state::{AppEvent, AppState, ModalState, PaneFocus};
+use jefe::state::{AppEvent, AppState, ModalState, PaneFocus, ScreenMode};
 use jefe::theme::{ThemeColors, ThemeManager};
 use jefe::ui::orchestration::{
     build_modal_element, build_screen_element, derive_confirm_modal_data,
@@ -376,18 +376,22 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     let (render_cols, render_rows) = effective_render_size(term_cols, term_rows);
 
     // Capture scrollback history lines for the terminal pane (issue #198).
-    // Uses the runtime cache (no shell-out on non-dirty frames). The cache uses
-    // the non-consuming is_dirty() so it never steals the dirty flag out from
-    // under the render-decision path.
-    let history_lines: Vec<String> = ctx
-        .as_ref()
-        .and_then(|ctx_arc| {
-            ctx_arc
-                .try_lock()
-                .ok()
-                .and_then(|mut guard| guard.runtime.capture_history())
-        })
-        .unwrap_or_default();
+    // Only Dashboard mode renders the embedded terminal, so gate the (cloning)
+    // cache capture to that mode — other modes waste the clone every frame.
+    // Uses the runtime cache (non-consuming is_dirty() so it never steals the
+    // dirty flag from the render-decision path).
+    let history_lines: Vec<String> = if snapshot.screen_mode == ScreenMode::Dashboard {
+        ctx.as_ref()
+            .and_then(|ctx_arc| {
+                ctx_arc
+                    .try_lock()
+                    .ok()
+                    .and_then(|mut guard| guard.runtime.capture_history())
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
 
     // NOTE: scroll-geometry (terminal_viewport_rows / terminal_total_lines) is
     // NOT written here. Mutating AppState during render causes an infinite

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -27,7 +27,7 @@ use jefe::runtime::{
 use jefe::state::{AppEvent, AppState, ModalState, PaneFocus, ScreenMode};
 use jefe::theme::{ThemeColors, ThemeManager};
 use jefe::ui::orchestration::{
-    build_modal_element, build_screen_element, derive_confirm_modal_data,
+    TerminalRenderData, build_modal_element, build_screen_element, derive_confirm_modal_data,
 };
 
 use std::sync::Arc;
@@ -399,14 +399,17 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     // again), starving the input loop (qqq never processed). The geometry is
     // refreshed at dispatch time instead — see refresh_terminal_scroll_geometry
     // (mirrors the detail-pane viewport-refresh pattern).
-
-    // Build screen and modal elements using orchestration helpers.
+    let pty_layout = compute_pty_layout(term_cols, term_rows);
     let screen_el = build_screen_element(
         &snapshot,
         &colors,
         &theme_name,
-        terminal_snapshot,
-        history_lines,
+        TerminalRenderData {
+            snapshot: terminal_snapshot,
+            history_lines,
+            pane_rows: usize::from(pty_layout.pty_rows).max(1),
+            pane_cols: usize::from(pty_layout.pty_cols).max(1),
+        },
     );
     let confirm_data = derive_confirm_modal_data(&snapshot, &modal);
     let modal_el = build_modal_element(

--- a/src/input.rs
+++ b/src/input.rs
@@ -186,20 +186,20 @@ pub fn route_search_key(key: &KeyEvent) -> SearchKeyRoute {
 /// Returns the `AppEvent` to dispatch, or `None` when the key should be
 /// forwarded to the PTY as normal terminal input.
 ///
-/// ## Modifier policy (review fix #1)
+/// ## Modifier policy
 ///
 /// Scroll keys are ONLY intercepted when the key has NO modifiers
 /// (`KeyModifiers::NONE`). Any modifier chord (Ctrl, Alt, Shift, or a
 /// combination) is forwarded to the PTY so child TUIs that bind those chords
 /// (e.g. Ctrl+End, Alt+PageUp) are not broken.
 ///
-/// ## End key (review fix #1)
+/// ## End key
 ///
 /// `End` ONLY intercepts when the viewport is scrolled back
 /// (`offset_is_some == true`): it returns the user to follow-tail. At
 /// follow-tail, `End` is forwarded to the PTY (so shell line editing works).
 ///
-/// ## Home key (review fix #2)
+/// ## Home key
 ///
 /// `Home` intercepts from BOTH states (follow-tail and scrolled-back): it
 /// jumps to the top of history, matching PageUp's "enter scrollback from
@@ -209,7 +209,7 @@ pub fn should_intercept_for_scrollback(
     key_event: &KeyEvent,
     offset_is_some: bool,
 ) -> Option<AppEvent> {
-    // Modifier chords always go to the PTY (review fix #1).
+    // Modifier chords always go to the PTY (so child TUI key bindings work).
     if key_event.modifiers != KeyModifiers::NONE {
         return None;
     }
@@ -224,7 +224,7 @@ pub fn should_intercept_for_scrollback(
         // When at follow-tail, arrows go to the PTY (so the child TUI works).
         KeyCode::Up if offset_is_some => Some(AppEvent::TerminalScrollUp),
         KeyCode::Down if offset_is_some => Some(AppEvent::TerminalScrollDown),
-        // Home scrolls to the top of history from BOTH states (review fix #2).
+        // Home scrolls to the top of history from BOTH states.
         KeyCode::Home => Some(AppEvent::TerminalScrollToTop),
         _ => None,
     }
@@ -600,7 +600,7 @@ mod tests {
         assert!(matches!(evt, Some(AppEvent::TerminalScrollPageDown)));
     }
 
-    // ── review fix #1: modifier chords go to the PTY ─────────────────────
+    // ── Modifier chords go to the PTY ─────────────────────────
 
     #[test]
     fn scrollback_ctrl_end_forwards_to_pty() {
@@ -649,7 +649,7 @@ mod tests {
         );
     }
 
-    // ── review fix #1: End only intercepts when scrolled back ────────────
+    // ── End only intercepts when scrolled back ────────────────
 
     #[test]
     fn scrollback_end_at_follow_tail_forwards_to_pty() {
@@ -666,7 +666,7 @@ mod tests {
         assert!(matches!(evt, Some(AppEvent::TerminalFollowTail)));
     }
 
-    // ── review fix #2: Home intercepts from BOTH states ──────────────────
+    // ── Home intercepts from BOTH states ──────────────────────
 
     #[test]
     fn scrollback_home_intercepts_when_scrolled_back() {

--- a/src/messages/event_conversion.rs
+++ b/src/messages/event_conversion.rs
@@ -167,7 +167,7 @@ impl AppMessage {
             AppEvent::Quit => Self::System(SystemMessage::Quit),
             AppEvent::ClearError => Self::System(SystemMessage::ClearError),
             AppEvent::ClearWarning => Self::System(SystemMessage::ClearWarning),
-            // Catch-all delegates issues/PRs/actions events (review fix #11).
+            // Catch-all delegates issues/PRs/actions events.
             other => Self::from_issues_event(other),
         }
     }

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -46,7 +46,9 @@ fn terminal_size() -> (u16, u16) {
 /// runtime + current layout, writing them to `AppState` so the deterministic
 /// reducer's clamp bounds match the rendered content. Runs at event time (not
 /// render time) to avoid the infinite re-render loop that mutating AppState
-/// during render would cause.
+/// during render would cause. When ctx is None or the lock is contended,
+/// preserves existing geometry instead of zeroing it (zeroing would clear the
+/// scroll offset).
 fn refresh_terminal_scroll_geometry_from_ctx(
     ctx: Option<&CtxArc>,
     app_state: &mut HookState<AppState>,
@@ -63,31 +65,30 @@ fn refresh_terminal_scroll_geometry_from_ctx(
             }
             Err(_) => {
                 // Lock contention: preserve existing geometry instead of
-                // zeroing it (issue #198 review fix #5). Zeroing would clear
-                // the scroll offset and jump to follow-tail during attach.
+                // zeroing it. Zeroing would clear the scroll offset and jump
+                // to follow-tail during attach.
                 return;
             }
         },
         None => {
-            // No context: preserve existing geometry instead of zeroing it
-            // (fix #3). Zeroing would clear the scroll offset.
+            // No context: preserve existing geometry instead of zeroing it.
+            // Zeroing would clear the scroll offset.
             return;
         }
     };
 
     let mut state = app_state.write();
-    let new_total = history_count + live_rows;
     let old_total = state.terminal_total_lines;
     let viewport_rows = usize::from(pty_layout.pty_rows);
 
-    // Reconcile the scroll offset when content grows so the viewport stays at
-    // the same absolute position (issue #198 review fix #3).
-    state.terminal_history_offset = jefe::state::scrollback_ops::reconcile_offset_for_new_content(
+    let (new_offset, new_total) = jefe::state::scrollback_ops::compute_terminal_scroll_geometry(
         state.terminal_history_offset,
         old_total,
-        new_total,
+        history_count,
+        live_rows,
         viewport_rows,
     );
+    state.terminal_history_offset = new_offset;
     state.terminal_viewport_rows = viewport_rows;
     state.terminal_total_lines = new_total;
 }
@@ -829,7 +830,7 @@ fn scroll_offset_for_pane(state: &AppState, pane: SelectablePane) -> usize {
         // Issue #198: terminal history offset is bottom-relative, but the
         // selection layer expects a top-relative "lines hidden above viewport".
         // Convert via the shared single source of truth so the selection
-        // coordinate system agrees with the viewport projection (review fix #4).
+        // coordinate system agrees with the viewport projection.
         SelectablePane::TerminalView => jefe::state::scrollback_ops::terminal_content_start_line(
             state.terminal_history_offset,
             state.terminal_total_lines,

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -798,30 +798,34 @@ pub fn capture_pane_lines(session_name: &str) -> Option<Vec<String>> {
 
 /// Build the `capture-pane -p -S -<N> -E -` argv for a bounded history capture.
 ///
+/// `history_lines` is clamped to a minimum of 1 so the `-S` value is always a
+/// negative offset (`-1`..`-N`). In tmux, `-S 0` means "start at the top of
+/// the entire scrollback" (capture everything), which is never intended here;
+/// clamping to `-S -1` ensures a bounded capture from just above the visible
+/// pane.
+///
 /// `-S -<history_lines>` starts `history_lines` lines before the top of the
 /// visible pane; `-E -` ends at the bottom of the visible pane (current line).
 /// This returns plain-text scrollback history **including the visible pane**.
 /// The caller (`TmuxRuntimeManager::capture_history`) strips the last
 /// `live_snapshot.rows` lines so the cached result is history ABOVE the
 /// visible pane only — the live Alacritty snapshot already represents the
-/// visible pane (issue #198 review fix #1).
+/// visible pane.
 ///
 /// Factored as a pure `#[must_use]` function so the argv composition is
-/// unit-testable without spawning tmux (issue #198).
+/// unit-testable without spawning tmux.
 #[must_use]
 pub fn capture_pane_history_args(session_name: &str, history_lines: usize) -> Vec<String> {
-    let start = if history_lines == 0 {
-        "0".to_owned()
-    } else {
-        format!("-{history_lines}")
-    };
+    // Clamp to >= 1: -S 0 means "capture entire scrollback" in tmux, which is
+    // never the intent for a bounded history capture.
+    let clamped = history_lines.max(1);
     vec![
         "capture-pane".to_owned(),
         "-p".to_owned(),
         "-t".to_owned(),
         session_name.to_owned(),
         "-S".to_owned(),
-        start,
+        format!("-{clamped}"),
         "-E".to_owned(),
         "-".to_owned(),
     ]
@@ -832,8 +836,8 @@ pub fn capture_pane_history_args(session_name: &str, history_lines: usize) -> Ve
 /// Uses `capture-pane -p -S -<history_lines> -E -` to retrieve the last
 /// `history_lines` lines of tmux scrollback **including the visible pane**.
 /// The caller must strip the visible-pane rows before composing with the live
-/// snapshot to avoid duplication (issue #198 review fix #1).
-/// Returns `None` if tmux is unavailable or the command fails (issue #198).
+/// snapshot to avoid duplication.
+/// Returns `None` if tmux is unavailable or the command fails.
 pub fn capture_pane_history(session_name: &str, history_lines: usize) -> Option<Vec<String>> {
     let argv = capture_pane_history_args(session_name, history_lines);
     let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();

--- a/src/runtime/commands_tests.rs
+++ b/src/runtime/commands_tests.rs
@@ -489,9 +489,10 @@ fn capture_pane_history_argv_respects_line_count() {
     assert_eq!(*s_value, "-2000");
 }
 
-/// Zero history lines still produces a valid argv (just captures the visible pane).
+/// Zero history lines is clamped to 1 so -S is always a negative offset,
+/// never the ambiguous `-S 0` (which means "capture entire scrollback").
 #[test]
-fn capture_pane_history_argv_zero_lines() {
+fn capture_pane_history_argv_zero_lines_clamps_to_one() {
     let argv = capture_pane_history_args("jefe-agent-1", 0);
     let s_idx = argv.iter().position(|a| a == "-S");
     let Some(s_idx) = s_idx else {
@@ -500,5 +501,5 @@ fn capture_pane_history_argv_zero_lines() {
     let Some(s_value) = argv.get(s_idx + 1) else {
         panic!("-S must have a value: {argv:?}");
     };
-    assert_eq!(*s_value, "0", "zero lines should produce -S 0");
+    assert_eq!(*s_value, "-1", "zero lines should clamp to -S -1");
 }

--- a/src/runtime/history_cache.rs
+++ b/src/runtime/history_cache.rs
@@ -10,7 +10,7 @@ use crate::domain::AgentId;
 /// Invalidated (re-captured) only when the output generation advances or the
 /// attached session changes. `lines` is `Option<Vec<String>>`:
 /// - `None` = no cache (never captured or invalidated).
-/// - `Some(vec![])` = cached empty capture (review fix #7).
+/// - `Some(vec![])` = cached empty capture.
 /// - `Some(non-empty)` = cached lines.
 ///
 /// Caching the empty result avoids shelling out to `capture-pane` every render
@@ -50,7 +50,7 @@ impl HistoryCache {
         self.lines = lines;
     }
 
-    /// Invalidate the cache for `agent_id` (review fix #8).
+    /// Invalidate the cache for `agent_id`.
     pub fn clear(&mut self, agent_id: &AgentId) {
         if self.cached_agent.as_ref() == Some(agent_id) {
             self.lines = None;
@@ -59,9 +59,9 @@ impl HistoryCache {
     }
 }
 
-/// Strip the last `n` lines from `lines`, returning the remaining prefix
-/// (issue #198 review fix #1). The live snapshot already represents the
-/// visible pane, so the history capture must exclude those rows.
+/// Strip the last `n` lines from `lines`, returning the remaining prefix.
+/// The live snapshot already represents the visible pane, so the history
+/// capture must exclude those rows.
 #[must_use]
 pub fn strip_trailing_rows(lines: Vec<String>, n: usize) -> Vec<String> {
     let keep = lines.len().saturating_sub(n);
@@ -137,8 +137,8 @@ mod tests {
 
     #[test]
     fn store_empty_vec_is_cached_and_returned() {
-        // Review fix #7: an empty capture is cached as Some(vec![]), which
-        // get() returns as a hit so we don't re-shell-out every frame.
+        // An empty capture is cached as Some(vec![]), which get() returns as
+        // a hit so we don't re-shell-out every frame.
         let mut cache = HistoryCache::default();
         cache.store(&agent("a"), 1, Some(Vec::new()));
         assert_eq!(cache.get(&agent("a"), 1), Some(&Vec::<String>::new()));
@@ -189,7 +189,7 @@ mod tests {
     #[test]
     fn strip_trailing_rows_preserves_blank_content_rows() {
         // After stripping the visible pane rows, remaining trailing blank lines
-        // are real history content and must NOT be stripped (review fix #9).
+        // are real history content and must NOT be stripped.
         // strip_trailing_rows removes the last N lines (the visible pane), not
         // content-blank lines.
         let input: Vec<String> = vec![

--- a/src/runtime/history_tests.rs
+++ b/src/runtime/history_tests.rs
@@ -59,7 +59,7 @@ fn tmux_capture_history_returns_none_without_attached_session() {
     );
 }
 
-// ── output_generation (issue #198 review fix #2) ────────────────────────
+// ── output_generation ───────────────────────────────────────────────
 
 #[test]
 fn tmux_output_generation_starts_at_zero() {

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -38,7 +38,9 @@ const MAX_DEAD_SIGNATURES: NonZeroUsize = match NonZeroUsize::new(100) {
 };
 
 /// Maximum number of scrollback history lines retained for an embedded
-/// terminal session (issue #198). Matches the harness `history_limit`.
+/// terminal session (issue #198). Matches the `terminal-scrollback.json` test
+/// scenario's `history_limit` (2000), intentionally smaller than the harness
+/// default (10000) to bound render/capture cost.
 const HISTORY_LINE_CAP: usize = 2000;
 
 /// Lightweight metadata for checking session liveness without holding the runtime lock.
@@ -915,7 +917,7 @@ impl RuntimeManager for TmuxRuntimeManager {
         }
 
         // Cache miss / dirty: re-capture. On transient failure, return prior
-        // cache (issue #198 review fix #9).
+        // cache so a momentary tmux hiccup doesn't wipe retained history.
         let Some(raw_lines) = commands::capture_pane_history(&session_name, HISTORY_LINE_CAP)
         else {
             if let Some(prior) = self.history_cache.get_fallback(&agent_id) {
@@ -929,10 +931,9 @@ impl RuntimeManager for TmuxRuntimeManager {
         let live_rows = self.snapshot().map_or(0, |s| s.rows);
         let lines = strip_trailing_rows(raw_lines, live_rows);
 
-        // Review fix #9: do NOT strip trailing blank lines — they may be real
-        // blank output, not tmux padding.
-        // Review fix #7: cache the result (including an empty capture) so we
-        // don't shell out every frame. Return `Some(lines)` consistently so
+        // Do NOT strip trailing blank lines — they may be real blank output,
+        // not tmux padding. Cache the result (including an empty capture) so
+        // we don't shell out every frame. Return `Some(lines)` consistently so
         // the current frame and subsequent cache-hit frames agree (an empty
         // capture returns `Some(vec![])`, not `None` — callers normalize via
         // `map_or(0, Vec::len)`, and `None` is reserved for "no session /

--- a/src/state/scrollback_ops.rs
+++ b/src/state/scrollback_ops.rs
@@ -112,14 +112,12 @@ pub enum ScrollRequest {
     PageUp,
     PageDown,
     FollowTail,
-    /// Jump to the top of history (max scroll offset). Home key (issue #198
-    /// review fix #8).
+    /// Jump to the top of history (max scroll offset). Home key.
     ToTop,
 }
 
 /// Reconcile a bottom-relative scroll offset when new content is appended,
-/// preserving the viewport's absolute position in the content (issue #198
-/// review fix #3).
+/// preserving the viewport's absolute position in the content.
 ///
 /// When the terminal is scrolled back (`Some(old_offset)`) and new lines are
 /// appended, the "bottom" of the content moves down. To keep the viewport
@@ -157,8 +155,31 @@ pub fn reconcile_offset_for_new_content(
     Some((old_offset + delta).min(new_max))
 }
 
+/// Compute updated terminal scrollback geometry from raw runtime metrics.
+///
+/// Pure: given the current offset/total and the freshly-measured history+live
+/// line counts + viewport rows, return the reconciled `(offset, total_lines)`.
+/// The new total is computed with `saturating_add` so a pathological
+/// `history_count + live_rows` overflow saturates to `usize::MAX` instead of
+/// wrapping, which would break the clamp math in
+/// [`reconcile_offset_for_new_content`]. The caller writes both values back
+/// to `AppState`.
+#[must_use]
+pub fn compute_terminal_scroll_geometry(
+    current_offset: Option<usize>,
+    old_total: usize,
+    history_count: usize,
+    live_rows: usize,
+    viewport_rows: usize,
+) -> (Option<usize>, usize) {
+    let new_total = history_count.saturating_add(live_rows);
+    let new_offset =
+        reconcile_offset_for_new_content(current_offset, old_total, new_total, viewport_rows);
+    (new_offset, new_total)
+}
+
 /// Derive the top-relative content start line for the terminal viewport from a
-/// bottom-relative offset (issue #198 review fix #4).
+/// bottom-relative offset.
 ///
 /// The viewport projection composes history + live rows into a flat array and
 /// windows it starting at `start_line`. When the offset is bottom-relative

--- a/src/state/scrollback_ops_tests.rs
+++ b/src/state/scrollback_ops_tests.rs
@@ -240,7 +240,7 @@ fn apply_request_to_top_returns_none_when_no_scrollable_content() {
     );
 }
 
-// ── reconcile_offset_for_new_content (issue #198 review fix #3) ────────
+// ── reconcile_offset_for_new_content ───────────────────────────────
 
 #[test]
 fn reconcile_grows_offset_when_scrolled_back_and_content_grows() {
@@ -348,7 +348,38 @@ fn reconcile_unchanged_when_content_shrinks() {
     assert_eq!(reconcile_offset_for_new_content(Some(5), 55, 50, 10), None);
 }
 
-// ── terminal_content_start_line (issue #198 review fix #4) ─────────────
+// ── compute_terminal_scroll_geometry ──────────────────────────────────
+
+#[test]
+fn compute_geometry_normal_case() {
+    // history=40, live=10, viewport=10 → total=50.
+    // No prior offset (follow-tail) → offset stays None.
+    let (offset, total) = compute_terminal_scroll_geometry(None, 0, 40, 10, 10);
+    assert_eq!(offset, None);
+    assert_eq!(total, 50);
+}
+
+#[test]
+fn compute_geometry_saturates_on_overflow() {
+    // Pathological inputs near usize::MAX: saturating_add prevents wrap.
+    let huge = usize::MAX - 5;
+    let (offset, total) = compute_terminal_scroll_geometry(None, 0, huge, 10, 10);
+    assert_eq!(total, usize::MAX);
+    // Follow-tail (None offset) → reconcile returns None.
+    assert_eq!(offset, None);
+}
+
+#[test]
+fn compute_geometry_reconciles_offset_on_content_growth() {
+    // Old: total=50, offset=5 (scrolled back 5 from bottom).
+    // New: history=45, live=10 → total=55 (5 lines appended).
+    // delta=5 → new offset = 5+5=10, new_max = 55-10=45.
+    let (offset, total) = compute_terminal_scroll_geometry(Some(5), 50, 45, 10, 10);
+    assert_eq!(total, 55);
+    assert_eq!(offset, Some(10));
+}
+
+// ── terminal_content_start_line ─────────────────────────────────────
 
 #[test]
 fn content_start_line_follow_tail_shows_bottom() {
@@ -384,7 +415,7 @@ fn content_start_line_offset_exceeds_max_clamps_to_zero() {
 
 #[test]
 fn selection_offset_agrees_with_viewport_projection() {
-    // Behavioral selection test (issue #198 review fix #4): the top-relative
+    // Behavioral selection test: the top-relative
     // start line derived from a bottom-relative offset must map to the SAME
     // content rows the viewport projection paints. With distinctive history
     // rows and a nonzero bottom-relative offset, verify the start line +
@@ -476,7 +507,7 @@ fn reducer_scroll_events_not_blocked_when_terminal_focused() {
     assert_eq!(state.terminal_history_offset, Some(1));
 }
 
-// ── Agent switch resets scroll state (issue #198 review fix #6) ────────
+// ── Agent switch resets scroll state ────────────────────────────────
 
 /// Build a minimal AppState with one repository + one agent so selection
 /// events have a valid target.
@@ -542,7 +573,7 @@ fn reducer_jump_to_agent_resets_scroll_offset() {
     );
 }
 
-// ── Arrow navigation resets scroll state (issue #198 review fix #4) ────
+// ── Arrow navigation resets scroll state ────────────────────────────
 
 /// Build a state with one repo and two agents so Up/Down navigation has a
 /// valid move target.
@@ -606,6 +637,8 @@ fn reducer_navigate_up_agent_resets_scroll_offset() {
         state.terminal_history_offset, None,
         "arrow-up agent navigation must reset the scroll offset"
     );
+    assert_eq!(state.terminal_viewport_rows, 0);
+    assert_eq!(state.terminal_total_lines, 0);
 }
 
 /// Build a state with two repos and one agent each so repo navigation has
@@ -675,4 +708,6 @@ fn reducer_navigate_up_repo_resets_scroll_offset() {
         state.terminal_history_offset, None,
         "arrow-up repo navigation must reset the scroll offset"
     );
+    assert_eq!(state.terminal_viewport_rows, 0);
+    assert_eq!(state.terminal_total_lines, 0);
 }

--- a/src/ui/components/terminal_theme.rs
+++ b/src/ui/components/terminal_theme.rs
@@ -95,8 +95,9 @@ pub fn is_default_fg(color: iocraft::Color) -> bool {
 ///   transparent (issue #179 bug fix).
 /// - Override ON: terminal-default channels are replaced with jefe's theme
 ///   colors (`theme_fg`/`theme_bg`); explicitly-colored channels pass through.
-///   A run whose effective background is still `Reset` after resolution yields
-///   `None` (transparent).
+///   Default (`Reset`) backgrounds are normalized to a concrete color (Black
+///   when the theme bg itself is `Reset`), so the background is always
+///   `Some(color)` and never `None`/`Reset`.
 ///
 /// Override guarantees an *opaque* result even if the sourced theme color is
 /// itself `Reset`: a `Reset` theme channel is normalized to a concrete

--- a/src/ui/components/terminal_view.rs
+++ b/src/ui/components/terminal_view.rs
@@ -55,6 +55,12 @@ pub struct TerminalViewProps {
     /// default (transparent) cells, while explicitly-styled cells pass through
     /// unchanged (issue #179 override toggle).
     pub override_theme: bool,
+    /// Actual embedded-terminal pane dimensions (PTY layout). Used as the
+    /// viewport projection size when the live snapshot is absent/empty so
+    /// follow-tail/scroll/selection math reflects the physical pane, not the
+    /// whole retained history (issue #198 follow-up).
+    pub pane_rows: usize,
+    pub pane_cols: usize,
 }
 
 /// Empty-state message for the terminal pane when no snapshot is available.
@@ -69,20 +75,6 @@ pub fn terminal_empty_message(session_live: bool) -> &'static str {
     } else {
         "No terminal attached"
     }
-}
-
-/// Maximum display width (char count) across the retained history lines.
-///
-/// Used to derive the viewport column count when no live snapshot is available
-/// so the history projection reflects the actual retained output instead of a
-/// hardcoded constant. Returns 0 for empty history.
-#[must_use]
-fn max_history_width(history_lines: &[String]) -> usize {
-    history_lines
-        .iter()
-        .map(|line| line.chars().count())
-        .max()
-        .unwrap_or(0)
 }
 
 /// Terminal view showing the PTY output for the attached agent.
@@ -122,17 +114,16 @@ pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>>
         // pane resized or the snapshot was cleared).
         //
         // Borrow the live snapshot directly when present (avoiding a clone);
-        // only synthesize a blank snapshot when absent. When the live
-        // snapshot is absent, derive the viewport dimensions from the history
-        // content rather than a hardcoded constant so the projection reflects
-        // the actual retained output instead of a 1x80 default.
+        // synthesize a blank snapshot only when absent. The viewport
+        // dimensions come from the live snapshot when present, otherwise from
+        // the actual PTY pane size threaded in via props — never from the
+        // retained history line count, which would make follow-tail/scroll
+        // math span the whole (up to 2000-line) history instead of the
+        // physical pane.
         let blank = crate::runtime::TerminalSnapshot::default();
         let live_ref = live.unwrap_or(&blank);
         let (viewport_rows, viewport_cols) = if live_ref.rows == 0 {
-            (
-                props.history_lines.len().max(1),
-                max_history_width(&props.history_lines).max(1),
-            )
+            (props.pane_rows.max(1), props.pane_cols.max(1))
         } else {
             (live_ref.rows, live_ref.cols)
         };
@@ -699,18 +690,5 @@ mod tests {
     #[test]
     fn empty_message_no_terminal_when_not_live() {
         assert_eq!(terminal_empty_message(false), "No terminal attached");
-    }
-
-    // --- max_history_width ---
-
-    #[test]
-    fn max_history_width_returns_zero_for_empty_history() {
-        assert_eq!(max_history_width(&[]), 0);
-    }
-
-    #[test]
-    fn max_history_width_returns_widest_line_char_count() {
-        let history: Vec<String> = vec!["hi".to_owned(), "world!".to_owned(), "x".to_owned()];
-        assert_eq!(max_history_width(&history), 6);
     }
 }

--- a/src/ui/components/terminal_view.rs
+++ b/src/ui/components/terminal_view.rs
@@ -71,6 +71,20 @@ pub fn terminal_empty_message(session_live: bool) -> &'static str {
     }
 }
 
+/// Maximum display width (char count) across the retained history lines.
+///
+/// Used to derive the viewport column count when no live snapshot is available
+/// so the history projection reflects the actual retained output instead of a
+/// hardcoded constant. Returns 0 for empty history.
+#[must_use]
+fn max_history_width(history_lines: &[String]) -> usize {
+    history_lines
+        .iter()
+        .map(|line| line.chars().count())
+        .max()
+        .unwrap_or(0)
+}
+
 /// Terminal view showing the PTY output for the attached agent.
 #[component]
 pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>> {
@@ -106,17 +120,28 @@ pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>>
         // window. When the live snapshot is empty/None, still project so the
         // retained history remains visible (the user scrolled back before the
         // pane resized or the snapshot was cleared).
-        let live_ref = live.cloned().unwrap_or_default();
+        //
+        // Borrow the live snapshot directly when present (avoiding a clone);
+        // only synthesize a blank snapshot when absent. When the live
+        // snapshot is absent, derive the viewport dimensions from the history
+        // content rather than a hardcoded constant so the projection reflects
+        // the actual retained output instead of a 1x80 default.
+        let blank = crate::runtime::TerminalSnapshot::default();
+        let live_ref = live.unwrap_or(&blank);
+        let (viewport_rows, viewport_cols) = if live_ref.rows == 0 {
+            (
+                props.history_lines.len().max(1),
+                max_history_width(&props.history_lines).max(1),
+            )
+        } else {
+            (live_ref.rows, live_ref.cols)
+        };
         let proj = super::terminal_viewport::build_terminal_viewport(
-            &live_ref,
+            live_ref,
             &props.history_lines,
             props.terminal_history_offset,
-            live_ref.rows.max(1),
-            if live_ref.cols == 0 {
-                80
-            } else {
-                live_ref.cols
-            },
+            viewport_rows,
+            viewport_cols,
             default_style,
         );
         (Some(proj.snapshot), proj.indicator, proj.start_line)
@@ -674,5 +699,18 @@ mod tests {
     #[test]
     fn empty_message_no_terminal_when_not_live() {
         assert_eq!(terminal_empty_message(false), "No terminal attached");
+    }
+
+    // --- max_history_width ---
+
+    #[test]
+    fn max_history_width_returns_zero_for_empty_history() {
+        assert_eq!(max_history_width(&[]), 0);
+    }
+
+    #[test]
+    fn max_history_width_returns_widest_line_char_count() {
+        let history: Vec<String> = vec!["hi".to_owned(), "world!".to_owned(), "x".to_owned()];
+        assert_eq!(max_history_width(&history), 6);
     }
 }

--- a/src/ui/components/terminal_view.rs
+++ b/src/ui/components/terminal_view.rs
@@ -122,7 +122,11 @@ pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>>
         // physical pane.
         let blank = crate::runtime::TerminalSnapshot::default();
         let live_ref = live.unwrap_or(&blank);
-        let (viewport_rows, viewport_cols) = if live_ref.rows == 0 {
+        // Fall back to the real pane dimensions when the live snapshot is
+        // absent OR degenerate in either dimension, so the viewport never
+        // receives a zero row/col count (OCR: the check must cover both
+        // dimensions, not just rows).
+        let (viewport_rows, viewport_cols) = if live_ref.rows == 0 || live_ref.cols == 0 {
             (props.pane_rows.max(1), props.pane_cols.max(1))
         } else {
             (live_ref.rows, live_ref.cols)

--- a/src/ui/components/terminal_view.rs
+++ b/src/ui/components/terminal_view.rs
@@ -87,8 +87,8 @@ pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>>
         "F12/t to focus"
     };
 
-    // Build the scrollback viewport projection (issue #198). When history lines
-    // are present, project history+live through the offset window. When no
+    // Build the scrollback viewport projection. When history lines are
+    // present, project history+live through the offset window. When no
     // history is available, render the live snapshot as-is.
     let default_style = crate::runtime::TerminalCellStyle {
         fg: iocraft::Color::White,
@@ -98,26 +98,33 @@ pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>>
         underline: false,
     };
 
-    let (projected_snapshot, indicator, content_start_line) =
-        if let Some(live) = props.snapshot.as_ref().filter(|s| !s.is_empty()) {
-            if props.history_lines.is_empty() {
-                (Some(live.clone()), None, 0)
+    let live = props.snapshot.as_ref().filter(|s| !s.is_empty());
+    let has_history = !props.history_lines.is_empty();
+
+    let (projected_snapshot, indicator, content_start_line) = if has_history {
+        // History is available — project history+live through the offset
+        // window. When the live snapshot is empty/None, still project so the
+        // retained history remains visible (the user scrolled back before the
+        // pane resized or the snapshot was cleared).
+        let live_ref = live.cloned().unwrap_or_default();
+        let proj = super::terminal_viewport::build_terminal_viewport(
+            &live_ref,
+            &props.history_lines,
+            props.terminal_history_offset,
+            live_ref.rows.max(1),
+            if live_ref.cols == 0 {
+                80
             } else {
-                // Use a large viewport so the projection fills the pane; the
-                // TerminalGrid clips to the actual canvas size at draw time.
-                let proj = super::terminal_viewport::build_terminal_viewport(
-                    live,
-                    &props.history_lines,
-                    props.terminal_history_offset,
-                    live.rows,
-                    live.cols,
-                    default_style,
-                );
-                (Some(proj.snapshot), proj.indicator, proj.start_line)
-            }
-        } else {
-            (None, None, 0)
-        };
+                live_ref.cols
+            },
+            default_style,
+        );
+        (Some(proj.snapshot), proj.indicator, proj.start_line)
+    } else if let Some(live) = live {
+        (Some(live.clone()), None, 0)
+    } else {
+        (None, None, 0)
+    };
 
     element! {
         Box(
@@ -144,7 +151,7 @@ pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>>
             //
             // The follow indicator is overlaid on the last grid row by the
             // canvas draw, NOT as a separate flex Box, so it does not consume
-            // a content row (issue #198 review fix #6).
+            // a content row.
             //
             // The content-area fill is transparent (Color::Reset) when theme
             // override is OFF, so the embedded agent's default cells let the
@@ -200,13 +207,12 @@ struct TerminalGridProps {
     selection: Option<TextSelection>,
     /// Selection foreground + background colors (inverse-video).
     sel_colors: SelectionColors,
-    /// Absolute content-line index of the first viewport row (issue #198
-    /// review fix #5). Selection highlight math adds this to the viewport-local
-    /// row index to get the absolute content row that `row_highlight_range`
-    /// expects.
+    /// Absolute content-line index of the first viewport row. Selection
+    /// highlight math adds this to the viewport-local row index to get the
+    /// absolute content row that `row_highlight_range` expects.
     content_start_line: usize,
-    /// Follow indicator text to overlay on the last grid row (issue #198
-    /// review fix #6). When present, the indicator is drawn on top of the last
+    /// Follow indicator text to overlay on the last grid row. When present,
+    /// the indicator is drawn on top of the last
     /// row of the canvas WITHOUT consuming an additional content row.
     indicator_text: Option<String>,
     /// Dim color for the indicator overlay.
@@ -387,7 +393,7 @@ struct SelectionOverlay {
 /// normal content. Only acts when a selection targets the terminal pane.
 /// `content_start_line` is the absolute content-line index of the first
 /// viewport row, so `row_highlight_range` receives absolute row numbers that
-/// match the selection coordinate space (issue #198 review fix #5).
+/// match the selection coordinate space.
 fn paint_selection_overlay(
     canvas: &mut CanvasSubviewMut<'_>,
     snapshot: &TerminalSnapshot,
@@ -440,7 +446,7 @@ fn paint_selection_overlay(
 }
 
 /// Paint the follow indicator as an overlay on the last canvas row WITHOUT
-/// consuming an additional content row (issue #198 review fix #6).
+/// consuming an additional content row.
 ///
 /// When `indicator_text` is present, the last row of the canvas is overpainted
 /// with the indicator text in the dim color over the bg color. This keeps the

--- a/src/ui/components/terminal_view.rs
+++ b/src/ui/components/terminal_view.rs
@@ -124,8 +124,7 @@ pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>>
         let live_ref = live.unwrap_or(&blank);
         // Fall back to the real pane dimensions when the live snapshot is
         // absent OR degenerate in either dimension, so the viewport never
-        // receives a zero row/col count (OCR: the check must cover both
-        // dimensions, not just rows).
+        // receives a zero row/col count.
         let (viewport_rows, viewport_cols) = if live_ref.rows == 0 || live_ref.cols == 0 {
             (props.pane_rows.max(1), props.pane_cols.max(1))
         } else {

--- a/src/ui/components/terminal_viewport.rs
+++ b/src/ui/components/terminal_viewport.rs
@@ -19,7 +19,7 @@ pub struct TerminalViewportProjection {
     /// Follow indicator when scrolled back; `None` when following (live).
     pub indicator: Option<FollowIndicator>,
     /// The absolute content-line index that the first viewport row (row 0)
-    /// corresponds to (issue #198 review fix #5). Selection highlight math must
+    /// corresponds to. Selection highlight math must
     /// add this to the viewport-local row index to get the absolute content row
     /// that `row_highlight_range` expects.
     pub start_line: usize,
@@ -333,7 +333,7 @@ mod tests {
         assert_eq!(proj.snapshot.cells[0][0].style, live_style);
     }
 
-    // ── content_start_line (issue #198 review fix #5) ─────────────────────
+    // ── content_start_line ─────────────────────────────────────────
 
     #[test]
     fn start_line_is_zero_for_follow_tail() {
@@ -357,7 +357,7 @@ mod tests {
 
     #[test]
     fn start_line_used_for_selection_highlight_matches_content() {
-        // Behavioral test (review fix #5): when scrolled back so that the
+        // Behavioral test: when scrolled back so that the
         // viewport starts at a nonzero content line, the start_line must be
         // added to the viewport-local row index to get the absolute content row
         // that row_highlight_range expects.
@@ -400,7 +400,7 @@ mod tests {
         );
     }
 
-    // ── Follow indicator does not consume a content row (review fix #6) ────
+    // ── Follow indicator does not consume a content row ─────────────
 
     #[test]
     fn indicator_present_does_not_reduce_viewport_rows() {
@@ -428,5 +428,20 @@ mod tests {
         let proj = build_terminal_viewport(&live, &history, None, 5, 80, default_style());
         assert!(proj.indicator.is_none());
         assert_eq!(proj.snapshot.rows, 5);
+    }
+
+    #[test]
+    fn empty_live_snapshot_with_history_still_projects_history() {
+        // When the live snapshot is empty (rows=0) but history_lines is
+        // non-empty, the projection must still contain the history rows.
+        let history: Vec<String> = (1..=5).map(|i| format!("h{i}")).collect();
+        let live = TerminalSnapshot::default();
+        let proj = build_terminal_viewport(&live, &history, None, 3, 80, default_style());
+        assert_eq!(proj.snapshot.rows, 3);
+        // Follow-tail (None) with total=5, viewport=3 → start=2.
+        // Rows: h3, h4, h5.
+        assert_eq!(row_text(&proj.snapshot, 0), "h3");
+        assert_eq!(row_text(&proj.snapshot, 1), "h4");
+        assert_eq!(row_text(&proj.snapshot, 2), "h5");
     }
 }

--- a/src/ui/components/terminal_viewport.rs
+++ b/src/ui/components/terminal_viewport.rs
@@ -444,4 +444,24 @@ mod tests {
         assert_eq!(row_text(&proj.snapshot, 1), "h4");
         assert_eq!(row_text(&proj.snapshot, 2), "h5");
     }
+
+    #[test]
+    fn empty_live_snapshot_uses_pane_viewport_not_history_length() {
+        // CodeRabbit follow-up: when the live snapshot is empty, the viewport
+        // must use the actual pane dimensions (passed by the caller), NOT the
+        // full retained history length. With a 50-line history and a 5-row
+        // pane, follow-tail must render only the bottom 5 history rows —
+        // never all 50 — otherwise follow-tail/scroll/selection math spans
+        // the whole (up to 2000-line) history.
+        let history: Vec<String> = (1..=50).map(|i| format!("line{i}")).collect();
+        let live = TerminalSnapshot::default();
+        let proj = build_terminal_viewport(&live, &history, None, 5, 40, default_style());
+        assert_eq!(
+            proj.snapshot.rows, 5,
+            "projection must be pane-sized (5 rows), not history-sized (50)"
+        );
+        // Follow-tail windows the bottom 5: line46..line50.
+        assert_eq!(row_text(&proj.snapshot, 0), "line46");
+        assert_eq!(row_text(&proj.snapshot, 4), "line50");
+    }
 }

--- a/src/ui/orchestration.rs
+++ b/src/ui/orchestration.rs
@@ -21,6 +21,24 @@ pub struct ConfirmModalData {
     pub delete_work_dir: bool,
 }
 
+/// Terminal render data threaded from the app shell into the dashboard.
+///
+/// Bundles the live snapshot, retained scrollback history, and the actual PTY
+/// pane dimensions so `build_screen_element` stays under the argument-count
+/// limit and the projection always knows the real pane size even when the live
+/// snapshot is absent/empty (issue #198 follow-up).
+#[must_use]
+pub struct TerminalRenderData {
+    /// Live PTY snapshot (styled grid), if available.
+    pub snapshot: Option<crate::runtime::TerminalSnapshot>,
+    /// Retained scrollback history lines (plain text).
+    pub history_lines: Vec<String>,
+    /// Actual embedded-terminal pane row count (PTY layout).
+    pub pane_rows: usize,
+    /// Actual embedded-terminal pane column count (PTY layout).
+    pub pane_cols: usize,
+}
+
 /// Derive confirmation modal data from current state, if applicable.
 #[must_use]
 pub fn derive_confirm_modal_data(
@@ -94,8 +112,7 @@ pub fn build_screen_element(
     snapshot: &AppState,
     colors: &ThemeColors,
     theme_name: &str,
-    terminal_snapshot: Option<crate::runtime::TerminalSnapshot>,
-    history_lines: Vec<String>,
+    terminal: TerminalRenderData,
 ) -> AnyElement<'static> {
     match snapshot.screen_mode {
         ScreenMode::Dashboard => element! {
@@ -103,8 +120,10 @@ pub fn build_screen_element(
                 state: Some(snapshot.clone()),
                 colors: Some(colors.clone()),
                 theme_name: theme_name.to_owned(),
-                terminal_snapshot: terminal_snapshot,
-                history_lines: history_lines,
+                terminal_snapshot: terminal.snapshot,
+                history_lines: terminal.history_lines,
+                terminal_pane_rows: terminal.pane_rows,
+                terminal_pane_cols: terminal.pane_cols,
             )
         }
         .into_any(),

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -30,6 +30,12 @@ pub struct DashboardProps {
     pub terminal_snapshot: Option<TerminalSnapshot>,
     /// Retained scrollback history lines for the attached terminal (issue #198).
     pub history_lines: Vec<String>,
+    /// Actual embedded-terminal pane dimensions (PTY layout). Used as the
+    /// viewport projection size when the live snapshot is absent/empty so
+    /// follow-tail/scroll math reflects the physical pane, not the whole
+    /// retained history (issue #198 follow-up).
+    pub terminal_pane_rows: usize,
+    pub terminal_pane_cols: usize,
 }
 
 /// The main dashboard screen: sidebar + middle (agents + terminal) + preview.
@@ -235,6 +241,8 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                             history_lines: props.history_lines.clone(),
                             terminal_history_offset: state.and_then(|s| s.terminal_history_offset),
                             override_theme: state.is_some_and(|s| s.override_agent_theme),
+                            pane_rows: props.terminal_pane_rows,
+                            pane_cols: props.terminal_pane_cols,
                         )
                     }
                 }


### PR DESCRIPTION
## Summary

PR #219 (issue #198 — scrollback viewport) was merged while the OCR/CodeRabbit
post-merge review findings were being remediated. The remediation commit
landed on the feature branch after the merge and did not make it into main.
This follow-up PR cherry-picks those review fixes onto main so the scrollback
viewport ships with the reviewed-and-corrected behavior.

## Findings addressed

1. **capture_pane_history_args zero-lines bug**: clamp history_lines to >=1 so
   the tmux -S value is always -1..-N, never the ambiguous -S 0 (which would
   capture the entire scrollback instead of just the visible pane).
2. **Empty live snapshot with non-empty history**: project retained history
   even when the live snapshot is empty, so scrollback stays visible before
   the viewer fully attaches.
3. **HISTORY_LINE_CAP comment**: corrected to reflect that it matches the
   terminal-scrollback.json scenario (2000), intentionally smaller than the
   harness default to bound render/capture cost.
4. **resolve_run_colors docstring**: corrected the override-ON description —
   Reset backgrounds normalize to Black, so background is always Some(color).
5. **Overflow safety**: extract a shared compute_terminal_scroll_geometry
   helper using saturating_add for history+live row totals, eliminating the
   unchecked overflow in both the keyboard-dispatch and wheel-routing paths.
6. **Dashboard-mode gating**: gate history_lines capture to ScreenMode::Dashboard
   so Issues/Split/PRs/Actions modes no longer waste a per-frame clone.
7. **DRY dedup**: both refresh_terminal_scroll_geometry paths now call the
   shared helper, preventing drift. Lock-contention and ctx-None geometry
   preservation behavior retained.
8. **terminal_content_background**: #[must_use] consistency (verified present).
9. **Doc cleanup**: remove all internal review-fix tracking tokens from doc
   comments; rewrite as clean standalone documentation.
10. **Test consistency**: add matching geometry-reset assertions to navigate-up
    tests for consistency with navigate-down.

## Verification

- cargo fmt --all --check: clean
- CLIPPY_CONF_DIR=.github/clippy clippy --workspace --all-targets --all-features -- -D warnings: clean
- Complexity clippy pass: clean
- Source file length checks: clean
- cargo test --workspace --all-features: 1990 tests pass
- Cherry-picked cleanly onto main with no conflicts