### PR TITLE
Add generic end-to-end issue delivery contract

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,6 +108,28 @@ After submit, the agent is created and selected.
 
 ---
 
+## Sending a GitHub issue to an agent
+
+**Send Issue** writes the selected issue's details to `.jefe/issue-prompt.md` and
+launches the agent with Jefe's generic end-to-end delivery contract. The agent
+is instructed to create an issue branch, implement and verify the change,
+commit and push it, open a linked pull request, watch required workflows to
+completion, and loop on failures and actionable review feedback. It must reply
+in the relevant review threads and resolve addressed threads where the hosting
+platform supports that operation.
+
+This contract is the same for LLxprt, Code Puppy, and future runtimes; only the
+runtime-specific command-line transport differs. Repository-local instructions
+such as `AGENTS.md`, `.llxprt/LLXPRT.md`, or other agent memories may supplement
+project conventions, but Jefe does not require them to provide the delivery
+workflow.
+
+If a workflow-watch command or shell invocation times out while checks are
+pending, the agent is told to continue polling with a bounded delay. Pending
+checks alone are not completion and should not cause the agent to return.
+
+---
+
 ## Recommended baseline for most users
 
 - Set a real repository **Base Dir**.

--- a/src/app_input/fresh_prompt.rs
+++ b/src/app_input/fresh_prompt.rs
@@ -21,7 +21,22 @@ impl FreshPromptKind {
 /// Runtime-neutral delivery contract appended to every fresh Send Issue
 /// instruction. Issue-specific content remains in the prompt file; this text
 /// defines how an agent must carry that issue through review and CI.
-const ISSUE_DELIVERY_WORKFLOW: &str = "Complete the issue end to end: start from the latest base branch without deleting unrelated or agent-configuration files; create a dedicated issue branch before changing code; use gh to fetch the issue and all comments; research the codebase and make a test-first implementation plan; implement the change and run the repository's complete verification suite; commit and push the branch; create a detailed pull request linked to the issue; watch every pull-request workflow until terminal completion, continuing to poll with a bounded delay even when a watch command or shell invocation times out; inspect failed workflow logs, fix failures, rerun verification, commit, push, and watch again; collect all project review feedback, including ordinary reviews, inline threads, and automated review comments; address every actionable finding, reply in the corresponding review thread with the fix or why it does not apply, and resolve addressed threads where supported; repeat the checks, reviews, fixes, replies, and workflow watches until all required checks pass and no actionable unresolved review feedback remains. Do not return merely because workflows are pending; report only completion or a genuine external blocker.";
+const ISSUE_DELIVERY_WORKFLOW: &str = concat!(
+    "Complete the issue end to end: start from the latest base branch without deleting unrelated ",
+    "or agent-configuration files; create a dedicated issue branch before changing code; use gh ",
+    "to fetch the issue and all comments; research the codebase and make a test-first ",
+    "implementation plan; implement the change and run the repository's complete verification ",
+    "suite; commit and push the branch; create a detailed pull request linked to the issue; watch ",
+    "every pull-request workflow until terminal completion, continuing to poll with a bounded delay ",
+    "even when a watch command or shell invocation times out; inspect failed workflow logs, fix ",
+    "failures, rerun verification, commit, push, and watch again; collect all project review ",
+    "feedback, including ordinary reviews, inline threads, and automated review comments; address ",
+    "every actionable finding, reply in the corresponding review thread with the fix or why it does ",
+    "not apply, and resolve addressed threads where supported; repeat the checks, reviews, fixes, ",
+    "replies, and workflow watches until all required checks pass and no actionable unresolved review ",
+    "feedback remains. Do not return merely because workflows are pending; report only completion or ",
+    "a genuine external blocker."
+);
 
 fn fresh_prompt_instruction(prompt_kind: FreshPromptKind, prompt_relative_path: &str) -> String {
     let base = format!(

--- a/src/app_input/fresh_prompt.rs
+++ b/src/app_input/fresh_prompt.rs
@@ -18,6 +18,22 @@ impl FreshPromptKind {
     }
 }
 
+/// Runtime-neutral delivery contract appended to every fresh Send Issue
+/// instruction. Issue-specific content remains in the prompt file; this text
+/// defines how an agent must carry that issue through review and CI.
+const ISSUE_DELIVERY_WORKFLOW: &str = "Complete the issue end to end: start from the latest base branch without deleting unrelated or agent-configuration files; create a dedicated issue branch before changing code; use gh to fetch the issue and all comments; research the codebase and make a test-first implementation plan; implement the change and run the repository's complete verification suite; commit and push the branch; create a detailed pull request linked to the issue; watch every pull-request workflow until terminal completion, continuing to poll with a bounded delay even when a watch command or shell invocation times out; inspect failed workflow logs, fix failures, rerun verification, commit, push, and watch again; collect all project review feedback, including ordinary reviews, inline threads, and automated review comments; address every actionable finding, reply in the corresponding review thread with the fix or why it does not apply, and resolve addressed threads where supported; repeat the checks, reviews, fixes, replies, and workflow watches until all required checks pass and no actionable unresolved review feedback remains. Do not return merely because workflows are pending; report only completion or a genuine external blocker.";
+
+fn fresh_prompt_instruction(prompt_kind: FreshPromptKind, prompt_relative_path: &str) -> String {
+    let base = format!(
+        "Read and work on the GitHub {} described in {prompt_relative_path}",
+        prompt_kind.label()
+    );
+    match prompt_kind {
+        FreshPromptKind::Issue => format!("{base}. {ISSUE_DELIVERY_WORKFLOW}"),
+        FreshPromptKind::PullRequest => base,
+    }
+}
+
 /// Transform a base signature into a fresh, non-resuming prompt launch.
 #[must_use]
 pub(super) fn prepare_fresh_prompt_signature(
@@ -26,10 +42,7 @@ pub(super) fn prepare_fresh_prompt_signature(
     prompt_relative_path: &str,
 ) -> LaunchSignature {
     sig.pass_continue = false;
-    let instruction = format!(
-        "Read and work on the GitHub {} described in {prompt_relative_path}",
-        prompt_kind.label()
-    );
+    let instruction = fresh_prompt_instruction(prompt_kind, prompt_relative_path);
     match sig.agent_kind {
         // LLxprt keeps the agent's persisted mode flags (e.g. `--yolo`) and
         // appends the fresh instruction. Replacing them here dropped `--yolo`,
@@ -74,6 +87,39 @@ mod tests {
     }
 
     #[test]
+    fn issue_delivery_workflow_is_exact_and_runtime_neutral() {
+        let expected = concat!(
+            "Read and work on the GitHub issue described in .jefe/issue-prompt.md. ",
+            "Complete the issue end to end: start from the latest base branch without deleting unrelated or agent-configuration files; create a dedicated issue branch before changing code; use gh to fetch the issue and all comments; research the codebase and make a test-first implementation plan; implement the change and run the repository's complete verification suite; commit and push the branch; create a detailed pull request linked to the issue; watch every pull-request workflow until terminal completion, continuing to poll with a bounded delay even when a watch command or shell invocation times out; inspect failed workflow logs, fix failures, rerun verification, commit, push, and watch again; collect all project review feedback, including ordinary reviews, inline threads, and automated review comments; address every actionable finding, reply in the corresponding review thread with the fix or why it does not apply, and resolve addressed threads where supported; repeat the checks, reviews, fixes, replies, and workflow watches until all required checks pass and no actionable unresolved review feedback remains. Do not return merely because workflows are pending; report only completion or a genuine external blocker."
+        );
+
+        assert_eq!(
+            fresh_prompt_instruction(FreshPromptKind::Issue, ".jefe/issue-prompt.md"),
+            expected
+        );
+        assert!(!ISSUE_DELIVERY_WORKFLOW.contains("OCR"));
+        assert!(!ISSUE_DELIVERY_WORKFLOW.contains("CodeRabbit"));
+    }
+
+    #[test]
+    fn llxprt_and_code_puppy_project_the_identical_issue_contract() {
+        let llxprt = prepare_fresh_prompt_signature(
+            base_sig(AgentKind::Llxprt),
+            FreshPromptKind::Issue,
+            ".jefe/issue-prompt.md",
+        );
+        let code_puppy = prepare_fresh_prompt_signature(
+            base_sig(AgentKind::CodePuppy),
+            FreshPromptKind::Issue,
+            ".jefe/issue-prompt.md",
+        );
+
+        assert_eq!(llxprt.mode_flags.last(), code_puppy.mode_flags.first());
+        assert_eq!(llxprt.mode_flags[llxprt.mode_flags.len() - 2], "-i");
+        assert_eq!(code_puppy.mode_flags.len(), 1);
+    }
+
+    #[test]
     fn llxprt_issue_uses_fresh_issue_instruction() {
         let result = prepare_fresh_prompt_signature(
             base_sig(AgentKind::Llxprt),
@@ -85,9 +131,9 @@ mod tests {
         assert_eq!(
             result.mode_flags,
             vec![
-                "--stale",
-                "-i",
-                "Read and work on the GitHub issue described in .jefe/issue-prompt.md"
+                "--stale".to_owned(),
+                "-i".to_owned(),
+                fresh_prompt_instruction(FreshPromptKind::Issue, ".jefe/issue-prompt.md")
             ]
         );
     }
@@ -116,7 +162,10 @@ mod tests {
         assert!(!result.pass_continue);
         assert_eq!(
             result.mode_flags,
-            vec!["Read and work on the GitHub issue described in .jefe/issue-prompt.md"]
+            vec![fresh_prompt_instruction(
+                FreshPromptKind::Issue,
+                ".jefe/issue-prompt.md"
+            )]
         );
     }
 
@@ -134,9 +183,9 @@ mod tests {
         assert_eq!(
             result.mode_flags,
             vec![
-                "--yolo",
-                "-i",
-                "Read and work on the GitHub issue described in .jefe/issue-prompt.md"
+                "--yolo".to_owned(),
+                "-i".to_owned(),
+                fresh_prompt_instruction(FreshPromptKind::Issue, ".jefe/issue-prompt.md")
             ]
         );
     }
@@ -154,8 +203,8 @@ mod tests {
         assert_eq!(
             result.mode_flags,
             vec![
-                "-i",
-                "Read and work on the GitHub issue described in .jefe/issue-prompt.md"
+                "-i".to_owned(),
+                fresh_prompt_instruction(FreshPromptKind::Issue, ".jefe/issue-prompt.md")
             ]
         );
     }

--- a/src/app_input/issue_send_modal_tests.rs
+++ b/src/app_input/issue_send_modal_tests.rs
@@ -111,7 +111,8 @@ fn issue_send_forces_pass_continue_false_on_launch_signature() {
     );
     let instruction = launch_sig
         .mode_flags
-        .last()
+        .iter()
+        .find(|arg| arg.contains(".jefe/issue-prompt.md"))
         .value_or_panic("issue launch signature must include an instruction");
     assert!(instruction.contains(".jefe/issue-prompt.md"));
     assert!(instruction.contains("create a dedicated issue branch"));

--- a/src/app_input/issue_send_modal_tests.rs
+++ b/src/app_input/issue_send_modal_tests.rs
@@ -109,13 +109,17 @@ fn issue_send_forces_pass_continue_false_on_launch_signature() {
         !launch_sig.pass_continue,
         "issue-driven launches must force pass_continue = false"
     );
-    assert!(
-        launch_sig
-            .mode_flags
-            .iter()
-            .any(|flag| flag.contains(".jefe/issue-prompt.md")),
-        "issue launch signature must include the issue prompt instruction"
-    );
+    let instruction = launch_sig
+        .mode_flags
+        .last()
+        .value_or_panic("issue launch signature must include an instruction");
+    assert!(instruction.contains(".jefe/issue-prompt.md"));
+    assert!(instruction.contains("create a dedicated issue branch"));
+    assert!(instruction.contains("create a detailed pull request"));
+    assert!(instruction.contains("continuing to poll with a bounded delay"));
+    assert!(instruction.contains("ordinary reviews, inline threads"));
+    assert!(instruction.contains("reply in the corresponding review thread"));
+    assert!(instruction.contains("no actionable unresolved review feedback remains"));
 }
 
 #[test]

--- a/src/selection/overlay_content.rs
+++ b/src/selection/overlay_content.rs
@@ -299,6 +299,8 @@ mod tests {
         let signature = LaunchSignature {
             work_dir: std::path::PathBuf::from("/tmp"),
             profile: String::new(),
+            code_puppy_model: String::new(),
+            code_puppy_yolo: None,
             mode_flags: Vec::new(),
             llxprt_debug: String::new(),
             pass_continue: false,


### PR DESCRIPTION
## Summary

- append a centralized, runtime-neutral end-to-end delivery contract to every fresh Send Issue instruction
- require branch creation, test-first planning, full verification, linked PR creation, workflow polling through terminal completion, failure remediation, and review-thread handling
- keep LLxprt and Code Puppy instruction text identical while preserving their runtime-specific argv projection
- document that repository-local agent memories may supplement, but are not required for, the delivery workflow
- repair a stale `LaunchSignature` test fixture exposed by the complete verification suite

## Testing

- `make ci-check`
  - formatting and repository policy checks
  - source-length checks
  - strict Clippy and complexity Clippy
  - coverage threshold
  - locked all-feature build
  - locked all-feature tests and doctests

Fixes #227
