### PR TITLE
Match Code Puppy repository model defaults to LLxprt

### DIFF
--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -468,6 +468,56 @@ fn apply_restored_state(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use jefe::domain::{AgentKind, Repository, RepositoryId};
+
+    fn code_puppy_agent_and_repository() -> (Agent, Repository) {
+        let repository_id = RepositoryId("repo-model".to_owned());
+        let mut repository = Repository::new(
+            repository_id.clone(),
+            "Model Repo".to_owned(),
+            "model-repo".to_owned(),
+            std::path::PathBuf::from("/tmp/model-repo"),
+        );
+        repository.default_code_puppy_model = "  repo/default-model  ".to_owned();
+
+        let mut agent = Agent::new(
+            AgentId("agent-model".to_owned()),
+            repository_id,
+            "Model Agent".to_owned(),
+            std::path::PathBuf::from("/tmp/model-agent"),
+        );
+        agent.agent_kind = AgentKind::CodePuppy;
+        (agent, repository)
+    }
+
+    #[test]
+    fn launch_signature_inherits_repository_code_puppy_model() {
+        let (agent, repository) = code_puppy_agent_and_repository();
+
+        let signature = launch_signature_for_agent(&agent, &repository);
+
+        assert_eq!(signature.code_puppy_model, "repo/default-model");
+    }
+
+    #[test]
+    fn launch_signature_prefers_agent_code_puppy_model_override() {
+        let (mut agent, repository) = code_puppy_agent_and_repository();
+        agent.code_puppy_model = "  agent/override-model  ".to_owned();
+
+        let signature = launch_signature_for_agent(&agent, &repository);
+
+        assert_eq!(signature.code_puppy_model, "agent/override-model");
+    }
+
+    #[test]
+    fn launch_signature_keeps_code_puppy_model_empty_when_unconfigured() {
+        let (agent, mut repository) = code_puppy_agent_and_repository();
+        repository.default_code_puppy_model = "   ".to_owned();
+
+        let signature = launch_signature_for_agent(&agent, &repository);
+
+        assert!(signature.code_puppy_model.is_empty());
+    }
 
     /// Session still exists → never dead, regardless of PID.
     #[test]

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -23,11 +23,7 @@ fn launch_signature_for_agent(
     LaunchSignature {
         work_dir: agent.work_dir.clone(),
         profile: agent.profile.clone(),
-        code_puppy_model: if agent.code_puppy_model.trim().is_empty() {
-            repository.default_code_puppy_model.trim().to_owned()
-        } else {
-            agent.code_puppy_model.trim().to_owned()
-        },
+        code_puppy_model: agent.code_puppy_model.trim().to_owned(),
         code_puppy_yolo: agent.code_puppy_yolo,
         code_puppy_quick_resume: agent.code_puppy_quick_resume,
         mode_flags: agent.mode_flags.clone(),
@@ -491,28 +487,18 @@ mod tests {
     }
 
     #[test]
-    fn launch_signature_inherits_repository_code_puppy_model() {
-        let (agent, repository) = code_puppy_agent_and_repository();
-
-        let signature = launch_signature_for_agent(&agent, &repository);
-
-        assert_eq!(signature.code_puppy_model, "repo/default-model");
-    }
-
-    #[test]
-    fn launch_signature_prefers_agent_code_puppy_model_override() {
+    fn launch_signature_uses_agent_code_puppy_model() {
         let (mut agent, repository) = code_puppy_agent_and_repository();
-        agent.code_puppy_model = "  agent/override-model  ".to_owned();
+        agent.code_puppy_model = "  agent/model  ".to_owned();
 
         let signature = launch_signature_for_agent(&agent, &repository);
 
-        assert_eq!(signature.code_puppy_model, "agent/override-model");
+        assert_eq!(signature.code_puppy_model, "agent/model");
     }
 
     #[test]
-    fn launch_signature_keeps_code_puppy_model_empty_when_unconfigured() {
-        let (agent, mut repository) = code_puppy_agent_and_repository();
-        repository.default_code_puppy_model = "   ".to_owned();
+    fn launch_signature_does_not_dynamically_inherit_repository_model() {
+        let (agent, repository) = code_puppy_agent_and_repository();
 
         let signature = launch_signature_for_agent(&agent, &repository);
 

--- a/src/runtime/commands_tests.rs
+++ b/src/runtime/commands_tests.rs
@@ -91,6 +91,17 @@ fn code_puppy_passes_configured_model_as_exact_argv() {
 }
 
 #[test]
+fn llxprt_ignores_code_puppy_model() {
+    let mut signature = base_signature();
+    signature.code_puppy_model = "puppy-only".to_owned();
+
+    let args = llxprt_launch_args(&signature);
+
+    assert!(!args.iter().any(|arg| arg == "--model"));
+    assert!(!args.iter().any(|arg| arg == "puppy-only"));
+}
+
+#[test]
 fn code_puppy_passes_explicit_true_yolo_value() {
     let mut signature = base_signature();
     signature.agent_kind = AgentKind::CodePuppy;

--- a/src/state/form_ops_tests.rs
+++ b/src/state/form_ops_tests.rs
@@ -54,6 +54,27 @@ fn open_new_agent_initializes_llxprt_debug_blank() {
 }
 
 #[test]
+fn open_new_agent_copies_repository_code_puppy_model() {
+    let mut repo = seed_repository();
+    repo.default_code_puppy_model = "repo/default-model".to_owned();
+    let mut state = AppState {
+        repositories: vec![repo],
+        ..AppState::default()
+    };
+
+    state = state.apply(AppEvent::OpenNewAgent(RepositoryId("repo-1".to_owned())));
+
+    let ModalState::NewAgent { fields, cursor, .. } = state.modal else {
+        panic!("expected new-agent modal, got {:?}", state.modal);
+    };
+    assert_eq!(fields.code_puppy_model, "repo/default-model");
+    assert_eq!(
+        cursor.code_puppy_model,
+        "repo/default-model".chars().count()
+    );
+}
+
+#[test]
 fn open_new_agent_defaults_to_repo_kind_when_installed() {
     let mut repo = seed_repository();
     repo.default_agent_kind = crate::domain::AgentKind::CodePuppy;

--- a/src/state/modal_ops.rs
+++ b/src/state/modal_ops.rs
@@ -4,7 +4,9 @@
 //! length limit. These methods open/close/edit modal forms and handle
 //! repository/agent-related UI messages.
 
-use crate::domain::{AgentId, DEFAULT_SANDBOX_FLAGS, RepositoryId, SandboxEngine};
+use crate::domain::{
+    AgentId, AgentKind, DEFAULT_SANDBOX_FLAGS, Repository, RepositoryId, SandboxEngine,
+};
 use crate::messages::{ModalMessage, RepositoryAgentMessage};
 
 use super::AppState;
@@ -12,6 +14,27 @@ use super::types::{
     AgentFormCursor, AgentFormFields, AgentFormFocus, ModalState, RepositoryFormCursor,
     RepositoryFormFields, RepositoryFormFocus,
 };
+
+type NewAgentRepositoryDefaults = (String, String, String, AgentKind, bool);
+
+fn new_agent_repository_defaults(
+    repositories: &[Repository],
+    repository_id: &RepositoryId,
+) -> NewAgentRepositoryDefaults {
+    repositories
+        .iter()
+        .find(|repository| repository.id == *repository_id)
+        .map(|repository| {
+            (
+                repository.base_dir.to_string_lossy().into_owned(),
+                repository.default_profile.clone(),
+                repository.default_code_puppy_model.clone(),
+                repository.default_agent_kind,
+                repository.remote.enabled,
+            )
+        })
+        .unwrap_or_default()
+}
 
 impl AppState {
     pub(super) fn apply_modal_message(&mut self, message: ModalMessage) {
@@ -109,23 +132,16 @@ impl AppState {
     }
 
     fn open_new_agent_modal(&mut self, repository_id: RepositoryId) {
-        let (base_dir, default_profile, repo_default_kind, remote_enabled) = self
-            .repositories
-            .iter()
-            .find(|r| r.id == repository_id)
-            .map(|r| {
-                (
-                    r.base_dir.to_string_lossy().into_owned(),
-                    r.default_profile.clone(),
-                    r.default_agent_kind,
-                    r.remote.enabled,
-                )
-            })
-            .unwrap_or_default();
+        let (
+            base_dir,
+            default_profile,
+            default_code_puppy_model,
+            repo_default_kind,
+            remote_enabled,
+        ) = new_agent_repository_defaults(&self.repositories, &repository_id);
 
-        // Initialize the agent kind to the repository's default when it is
-        // installed (or the repo is remote — remote resolution is
-        // authoritative). Otherwise fall back to the first installed kind.
+        // Remote repositories trust their configured runtime; local ones must
+        // fall back when that runtime is not installed.
         let agent_kind =
             if remote_enabled || self.installed_agent_kinds.contains(&repo_default_kind) {
                 repo_default_kind
@@ -138,10 +154,8 @@ impl AppState {
 
         let work_dir_len = base_dir.chars().count();
         let profile_len = default_profile.chars().count();
+        let code_puppy_model_len = default_code_puppy_model.chars().count();
 
-        // Default mode string: LLxprt agents launch with `--yolo`; others
-        // start empty. Computed once and reused for both the field value and
-        // the cursor length to keep them in sync.
         let default_mode = if agent_kind == crate::domain::AgentKind::Llxprt {
             "--yolo"
         } else {
@@ -156,7 +170,7 @@ impl AppState {
                 description: String::new(),
                 work_dir: base_dir,
                 profile: default_profile,
-                code_puppy_model: String::new(),
+                code_puppy_model: default_code_puppy_model,
                 code_puppy_yolo: false,
                 code_puppy_quick_resume: crate::domain::QuickResume::default(),
                 agent_kind: agent_kind.label().to_owned(),
@@ -170,7 +184,7 @@ impl AppState {
             cursor: AgentFormCursor {
                 work_dir: work_dir_len,
                 profile: profile_len,
-                code_puppy_model: 0,
+                code_puppy_model: code_puppy_model_len,
                 mode: default_mode.chars().count(),
                 sandbox_flags: DEFAULT_SANDBOX_FLAGS.chars().count(),
                 ..AgentFormCursor::default()

--- a/src/state/modal_ops.rs
+++ b/src/state/modal_ops.rs
@@ -15,7 +15,14 @@ use super::types::{
     RepositoryFormFields, RepositoryFormFocus,
 };
 
-type NewAgentRepositoryDefaults = (String, String, String, AgentKind, bool);
+#[derive(Default)]
+struct NewAgentRepositoryDefaults {
+    base_dir: String,
+    profile: String,
+    code_puppy_model: String,
+    agent_kind: AgentKind,
+    remote_enabled: bool,
+}
 
 fn new_agent_repository_defaults(
     repositories: &[Repository],
@@ -24,14 +31,12 @@ fn new_agent_repository_defaults(
     repositories
         .iter()
         .find(|repository| repository.id == *repository_id)
-        .map(|repository| {
-            (
-                repository.base_dir.to_string_lossy().into_owned(),
-                repository.default_profile.clone(),
-                repository.default_code_puppy_model.clone(),
-                repository.default_agent_kind,
-                repository.remote.enabled,
-            )
+        .map(|repository| NewAgentRepositoryDefaults {
+            base_dir: repository.base_dir.to_string_lossy().into_owned(),
+            profile: repository.default_profile.clone(),
+            code_puppy_model: repository.default_code_puppy_model.clone(),
+            agent_kind: repository.default_agent_kind,
+            remote_enabled: repository.remote.enabled,
         })
         .unwrap_or_default()
 }
@@ -132,13 +137,13 @@ impl AppState {
     }
 
     fn open_new_agent_modal(&mut self, repository_id: RepositoryId) {
-        let (
+        let NewAgentRepositoryDefaults {
             base_dir,
-            default_profile,
-            default_code_puppy_model,
-            repo_default_kind,
+            profile: default_profile,
+            code_puppy_model: default_code_puppy_model,
+            agent_kind: repo_default_kind,
             remote_enabled,
-        ) = new_agent_repository_defaults(&self.repositories, &repository_id);
+        } = new_agent_repository_defaults(&self.repositories, &repository_id);
 
         // Remote repositories trust their configured runtime; local ones must
         // fall back when that runtime is not installed.


### PR DESCRIPTION
Closes #224

## Summary
- copy the repository Code Puppy model into the new-agent form, matching LLxprt default-profile behavior
- persist that copied or edited value on the agent
- launch exclusively from the agent model rather than dynamically consulting the repository
- preserve agent-specific edits and empty-model behavior
- verify LLxprt argv ignores Code Puppy model configuration

Repository model changes therefore affect future agents only; existing agents retain their own saved model.

## Verification
- `make ci-check`