### PR TITLE
Preflight Code Puppy yolo capability

### DIFF
--- a/src/app_input/preflight.rs
+++ b/src/app_input/preflight.rs
@@ -1,5 +1,8 @@
 use jefe::domain::{AgentId, AgentKind, LaunchSignature, PlatformCapabilities, SandboxEngine};
-use jefe::runtime::{PreflightAction, PreflightIssue, execute_preflight_action, sandbox_preflight};
+use jefe::runtime::{
+    PreflightAction, PreflightIssue, execute_preflight_action, sandbox_preflight,
+    validate_code_puppy_launch,
+};
 use jefe::state::ModalState;
 
 use super::{
@@ -23,27 +26,57 @@ pub fn preflight_or_prompt(
     signature: &LaunchSignature,
     issue_self_assignment: Option<&jefe::state::IssueSelfAssignmentFollowUp>,
 ) -> bool {
+    if let Err(diagnostic) = validate_code_puppy_launch(signature) {
+        open_preflight_prompt(
+            app_state,
+            ctx,
+            agent_id,
+            signature,
+            PreflightIssue::UnsupportedRuntimeOption { diagnostic },
+            issue_self_assignment,
+        );
+        return false;
+    }
+
     if !should_run_sandbox_preflight(signature) {
         return true;
     }
 
     if let Some(issue) = sandbox_preflight(signature.sandbox_engine) {
-        let mut state = app_state.write();
-        state.modal = ModalState::PreflightPrompt {
-            agent_id: agent_id.clone(),
-            signature: signature.clone(),
+        open_preflight_prompt(
+            app_state,
+            ctx,
+            agent_id,
+            signature,
             issue,
-            remaining_issues: Vec::new(),
-            issue_self_assignment: issue_self_assignment.cloned(),
-            confirm_focus: jefe::state::ConfirmFocus::Cancel,
-        };
-        let persisted = to_persisted_state(&state);
-        drop(state);
-        persist_state(ctx, &persisted);
+            issue_self_assignment,
+        );
         return false;
     }
 
     true
+}
+
+fn open_preflight_prompt(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    agent_id: &AgentId,
+    signature: &LaunchSignature,
+    issue: PreflightIssue,
+    issue_self_assignment: Option<&jefe::state::IssueSelfAssignmentFollowUp>,
+) {
+    let mut state = app_state.write();
+    state.modal = ModalState::PreflightPrompt {
+        agent_id: agent_id.clone(),
+        signature: signature.clone(),
+        issue,
+        remaining_issues: Vec::new(),
+        issue_self_assignment: issue_self_assignment.cloned(),
+        confirm_focus: jefe::state::ConfirmFocus::Cancel,
+    };
+    let persisted = to_persisted_state(&state);
+    drop(state);
+    persist_state(ctx, &persisted);
 }
 
 /// Pure predicate: should sandbox preflight run for this signature?

--- a/src/app_input/preflight.rs
+++ b/src/app_input/preflight.rs
@@ -32,7 +32,9 @@ pub fn preflight_or_prompt(
             ctx,
             agent_id,
             signature,
-            PreflightIssue::UnsupportedRuntimeOption { diagnostic },
+            PreflightIssue::UnsupportedRuntimeOption {
+                diagnostic: diagnostic.to_string(),
+            },
             issue_self_assignment,
         );
         return false;

--- a/src/runtime/capabilities.rs
+++ b/src/runtime/capabilities.rs
@@ -8,7 +8,8 @@ use std::process::Command;
 
 use crate::domain::{AgentKind, LaunchSignature};
 
-use super::commands::run_remote_ssh;
+use super::RuntimeError;
+use super::commands::{run_command_capture, run_remote_ssh};
 
 /// Model discovery support advertised by an agent runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,19 +49,17 @@ pub fn code_puppy_help_supports_yolo(help: &str) -> bool {
 /// `Ok(())` means launch is safe. A diagnostic is returned when the target is
 /// too old or cannot be probed; blindly passing an unsupported flag would turn
 /// a useful preflight error into a cryptic argparse failure.
-pub fn validate_code_puppy_launch(signature: &LaunchSignature) -> Result<(), String> {
+pub fn validate_code_puppy_launch(signature: &LaunchSignature) -> Result<(), RuntimeError> {
     if signature.agent_kind != AgentKind::CodePuppy || signature.code_puppy_yolo.is_none() {
         return Ok(());
     }
 
     let output = if signature.remote.enabled {
-        run_remote_ssh(&signature.remote, "code-puppy --help")
-            .map_err(|error| format!("could not inspect remote Code Puppy: {error}"))?
+        run_remote_ssh(&signature.remote, "code-puppy --help")?
     } else {
-        Command::new(AgentKind::CodePuppy.binary_name())
-            .arg("--help")
-            .output()
-            .map_err(|error| format!("could not inspect Code Puppy: {error}"))?
+        let mut command = Command::new(AgentKind::CodePuppy.binary_name());
+        command.arg("--help");
+        run_command_capture(command, "code-puppy --help")?
     };
 
     let help = format!(
@@ -68,11 +67,16 @@ pub fn validate_code_puppy_launch(signature: &LaunchSignature) -> Result<(), Str
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    if output.status.success() && code_puppy_help_supports_yolo(&help) {
-        Ok(())
-    } else {
-        Err("Code Puppy on the launch target does not advertise `--yolo true|false`. Upgrade Code Puppy or edit the agent with a supported version before launching.".to_owned())
+    validate_code_puppy_help(output.status.success(), &help)
+}
+
+fn validate_code_puppy_help(success: bool, help: &str) -> Result<(), RuntimeError> {
+    if success && code_puppy_help_supports_yolo(help) {
+        return Ok(());
     }
+    Err(RuntimeError::CapabilityCheckFailed(
+        "Code Puppy on the launch target does not advertise `--yolo true|false`. Upgrade Code Puppy or edit the agent with a supported version before launching.".to_owned(),
+    ))
 }
 
 fn strip_terminal_controls(value: &str) -> String {
@@ -102,7 +106,8 @@ fn strip_terminal_controls(value: &str) -> String {
                     }
                 }
             }
-            Some(_) | None => {}
+            Some(next) => plain.push(next),
+            None => {}
         }
     }
     plain
@@ -139,6 +144,21 @@ mod tests {
             "\u{1b}]11;#000000\u{7}\u{1b}[32m--yolo\u{1b}[0m {true,false}"
         ));
         assert!(!code_puppy_help_supports_yolo("--model MODEL"));
+    }
+
+    #[test]
+    fn rejects_help_without_explicit_yolo_support() {
+        let result = validate_code_puppy_help(true, "--model MODEL");
+        assert!(matches!(
+            result,
+            Err(RuntimeError::CapabilityCheckFailed(_))
+        ));
+        assert!(validate_code_puppy_help(false, "--yolo {true,false}").is_err());
+    }
+
+    #[test]
+    fn unknown_escape_sequence_preserves_its_printable_character() {
+        assert!(code_puppy_help_supports_yolo("\u{1b}%--yolo {true,false}"));
     }
 
     #[test]

--- a/src/runtime/capabilities.rs
+++ b/src/runtime/capabilities.rs
@@ -30,7 +30,7 @@ pub struct AgentRuntimeCapabilities {
 pub const fn static_capabilities(kind: AgentKind) -> AgentRuntimeCapabilities {
     match kind {
         AgentKind::Llxprt | AgentKind::CodePuppy => AgentRuntimeCapabilities {
-            // Code Puppy 0.0.634 has no stable non-interactive model-list API.
+            // Upstream has no stable non-interactive model-list API.
             model_discovery: ModelDiscovery::Unavailable,
             // Code Puppy YOLO support is feature-probed before a configured launch.
             explicit_yolo: false,
@@ -95,7 +95,7 @@ fn strip_terminal_controls(value: &str) -> String {
                     }
                 }
             }
-            Some(']') => {
+            Some(']' | 'P' | 'X' | '^' | '_') => {
                 while let Some(next) = chars.next() {
                     if next == '\u{7}' {
                         break;
@@ -159,6 +159,21 @@ mod tests {
     #[test]
     fn unknown_escape_sequence_preserves_its_printable_character() {
         assert!(code_puppy_help_supports_yolo("\u{1b}%--yolo {true,false}"));
+    }
+
+    #[test]
+    fn strips_terminal_string_sequences_and_handles_edge_cases() {
+        assert_eq!(strip_terminal_controls(""), "");
+        assert_eq!(strip_terminal_controls("\u{1b}[32m\u{1b}[0m"), "");
+        assert_eq!(strip_terminal_controls("\u{1b}]title\u{7}--yolo"), "--yolo");
+        assert_eq!(
+            strip_terminal_controls("\u{1b}Ppayload\u{1b}\\--yolo"),
+            "--yolo"
+        );
+        assert_eq!(
+            strip_terminal_controls("before\u{1b}]unterminated"),
+            "before"
+        );
     }
 
     #[test]

--- a/src/runtime/capabilities.rs
+++ b/src/runtime/capabilities.rs
@@ -71,7 +71,12 @@ pub fn validate_code_puppy_launch(signature: &LaunchSignature) -> Result<(), Run
 }
 
 fn validate_code_puppy_help(success: bool, help: &str) -> Result<(), RuntimeError> {
-    if success && code_puppy_help_supports_yolo(help) {
+    if !success {
+        return Err(RuntimeError::CapabilityProbeFailed(
+            "`code-puppy --help` exited unsuccessfully".to_owned(),
+        ));
+    }
+    if code_puppy_help_supports_yolo(help) {
         return Ok(());
     }
     Err(RuntimeError::CapabilityCheckFailed(
@@ -153,7 +158,10 @@ mod tests {
             result,
             Err(RuntimeError::CapabilityCheckFailed(_))
         ));
-        assert!(validate_code_puppy_help(false, "--yolo {true,false}").is_err());
+        assert!(matches!(
+            validate_code_puppy_help(false, "--yolo {true,false}"),
+            Err(RuntimeError::CapabilityProbeFailed(_))
+        ));
     }
 
     #[test]

--- a/src/runtime/capabilities.rs
+++ b/src/runtime/capabilities.rs
@@ -1,0 +1,157 @@
+//! Runtime-specific capability detection.
+//!
+//! Code Puppy currently has no stable, machine-readable model enumeration
+//! command. Model entry therefore remains free text behind this boundary until
+//! upstream publishes one; do not couple Jefe to Code Puppy's private config.
+
+use std::process::Command;
+
+use crate::domain::{AgentKind, LaunchSignature};
+
+use super::commands::run_remote_ssh;
+
+/// Model discovery support advertised by an agent runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelDiscovery {
+    /// The runtime has no stable model enumeration interface.
+    Unavailable,
+}
+
+/// Capabilities Jefe can safely use for an agent runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AgentRuntimeCapabilities {
+    pub model_discovery: ModelDiscovery,
+    pub explicit_yolo: bool,
+}
+
+/// Return static capabilities which do not require invoking the runtime.
+#[must_use]
+pub const fn static_capabilities(kind: AgentKind) -> AgentRuntimeCapabilities {
+    match kind {
+        AgentKind::Llxprt | AgentKind::CodePuppy => AgentRuntimeCapabilities {
+            // Code Puppy 0.0.634 has no stable non-interactive model-list API.
+            model_discovery: ModelDiscovery::Unavailable,
+            // Code Puppy YOLO support is feature-probed before a configured launch.
+            explicit_yolo: false,
+        },
+    }
+}
+
+/// Determine whether help output advertises explicit Code Puppy YOLO values.
+#[must_use]
+pub fn code_puppy_help_supports_yolo(help: &str) -> bool {
+    strip_terminal_controls(help).contains("--yolo")
+}
+
+/// Check configured Code Puppy launch options against the selected target.
+///
+/// `Ok(())` means launch is safe. A diagnostic is returned when the target is
+/// too old or cannot be probed; blindly passing an unsupported flag would turn
+/// a useful preflight error into a cryptic argparse failure.
+pub fn validate_code_puppy_launch(signature: &LaunchSignature) -> Result<(), String> {
+    if signature.agent_kind != AgentKind::CodePuppy || signature.code_puppy_yolo.is_none() {
+        return Ok(());
+    }
+
+    let output = if signature.remote.enabled {
+        run_remote_ssh(&signature.remote, "code-puppy --help")
+            .map_err(|error| format!("could not inspect remote Code Puppy: {error}"))?
+    } else {
+        Command::new(AgentKind::CodePuppy.binary_name())
+            .arg("--help")
+            .output()
+            .map_err(|error| format!("could not inspect Code Puppy: {error}"))?
+    };
+
+    let help = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if output.status.success() && code_puppy_help_supports_yolo(&help) {
+        Ok(())
+    } else {
+        Err("Code Puppy on the launch target does not advertise `--yolo true|false`. Upgrade Code Puppy or edit the agent with a supported version before launching.".to_owned())
+    }
+}
+
+fn strip_terminal_controls(value: &str) -> String {
+    let mut plain = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+    while let Some(character) = chars.next() {
+        if character != '\u{1b}' {
+            plain.push(character);
+            continue;
+        }
+        match chars.next() {
+            Some('[') => {
+                for next in chars.by_ref() {
+                    if ('@'..='~').contains(&next) {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                while let Some(next) = chars.next() {
+                    if next == '\u{7}' {
+                        break;
+                    }
+                    if next == '\u{1b}' && chars.peek() == Some(&'\\') {
+                        let _ = chars.next();
+                        break;
+                    }
+                }
+            }
+            Some(_) | None => {}
+        }
+    }
+    plain
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{RemoteRepositorySettings, SandboxEngine};
+    use std::path::PathBuf;
+
+    fn signature(kind: AgentKind, yolo: Option<bool>) -> LaunchSignature {
+        LaunchSignature {
+            work_dir: PathBuf::from("/tmp/puppy"),
+            profile: String::new(),
+            code_puppy_model: String::new(),
+            code_puppy_yolo: yolo,
+            code_puppy_quick_resume: false,
+            mode_flags: Vec::new(),
+            llxprt_debug: String::new(),
+            pass_continue: false,
+            sandbox_enabled: false,
+            sandbox_engine: SandboxEngine::Podman,
+            sandbox_flags: String::new(),
+            remote: RemoteRepositorySettings::default(),
+            agent_kind: kind,
+        }
+    }
+
+    #[test]
+    fn detects_yolo_in_plain_and_decorated_help() {
+        assert!(code_puppy_help_supports_yolo("--yolo {true,false}"));
+        assert!(code_puppy_help_supports_yolo(
+            "\u{1b}]11;#000000\u{7}\u{1b}[32m--yolo\u{1b}[0m {true,false}"
+        ));
+        assert!(!code_puppy_help_supports_yolo("--model MODEL"));
+    }
+
+    #[test]
+    fn model_discovery_is_explicitly_unavailable_without_stable_api() {
+        assert_eq!(
+            static_capabilities(AgentKind::CodePuppy).model_discovery,
+            ModelDiscovery::Unavailable
+        );
+    }
+
+    #[test]
+    fn llxprt_and_legacy_code_puppy_do_not_require_yolo_probe() {
+        assert!(validate_code_puppy_launch(&signature(AgentKind::Llxprt, Some(true))).is_ok());
+        assert!(validate_code_puppy_launch(&signature(AgentKind::CodePuppy, None)).is_ok());
+    }
+}

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -283,7 +283,10 @@ fn remote_effective_user(remote: &crate::domain::RemoteRepositorySettings) -> St
     }
 }
 
-fn run_command_capture(cmd: Command, error_context: &str) -> Result<Output, RuntimeError> {
+pub(super) fn run_command_capture(
+    cmd: Command,
+    error_context: &str,
+) -> Result<Output, RuntimeError> {
     run_command_capture_with_timeout(cmd, REMOTE_SSH_COMMAND_TIMEOUT, error_context)
 }
 

--- a/src/runtime/errors.rs
+++ b/src/runtime/errors.rs
@@ -16,6 +16,8 @@ pub enum RuntimeError {
     SpawnFailed(String),
     /// Failed to execute remote SSH session lifecycle command.
     RemoteExecutionFailed(String),
+    /// A runtime capability probe could not execute successfully.
+    CapabilityProbeFailed(String),
     /// A runtime capability required by the launch is unavailable.
     CapabilityCheckFailed(String),
     /// Failed to kill session.
@@ -39,6 +41,7 @@ impl std::fmt::Display for RuntimeError {
             Self::AttachFailed(msg) => write!(f, "attach failed: {msg}"),
             Self::SpawnFailed(msg) => write!(f, "spawn failed: {msg}"),
             Self::RemoteExecutionFailed(msg) => write!(f, "remote execution failed: {msg}"),
+            Self::CapabilityProbeFailed(msg) => write!(f, "capability probe failed: {msg}"),
             Self::CapabilityCheckFailed(msg) => write!(f, "capability check failed: {msg}"),
             Self::KillFailed(msg) => write!(f, "kill failed: {msg}"),
             Self::AlreadyRunning(id) => write!(f, "agent already running: {}", id.0),

--- a/src/runtime/errors.rs
+++ b/src/runtime/errors.rs
@@ -16,6 +16,8 @@ pub enum RuntimeError {
     SpawnFailed(String),
     /// Failed to execute remote SSH session lifecycle command.
     RemoteExecutionFailed(String),
+    /// A runtime capability required by the launch is unavailable.
+    CapabilityCheckFailed(String),
     /// Failed to kill session.
     KillFailed(String),
     /// Agent is already running.
@@ -37,6 +39,7 @@ impl std::fmt::Display for RuntimeError {
             Self::AttachFailed(msg) => write!(f, "attach failed: {msg}"),
             Self::SpawnFailed(msg) => write!(f, "spawn failed: {msg}"),
             Self::RemoteExecutionFailed(msg) => write!(f, "remote execution failed: {msg}"),
+            Self::CapabilityCheckFailed(msg) => write!(f, "capability check failed: {msg}"),
             Self::KillFailed(msg) => write!(f, "kill failed: {msg}"),
             Self::AlreadyRunning(id) => write!(f, "agent already running: {}", id.0),
             Self::NotRunning(id) => write!(f, "agent not running: {}", id.0),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -9,6 +9,7 @@
 
 mod attach;
 mod attach_scheduler;
+mod capabilities;
 mod commands;
 mod errors;
 mod liveness;
@@ -20,6 +21,10 @@ mod socket;
 mod stub_manager;
 
 pub use attach_scheduler::{AttachAction, AttachScheduler, DEFAULT_DEBOUNCE};
+pub use capabilities::{
+    AgentRuntimeCapabilities, ModelDiscovery, code_puppy_help_supports_yolo, static_capabilities,
+    validate_code_puppy_launch,
+};
 pub use errors::RuntimeError;
 pub use liveness::{check_remote_session_alive, check_session_alive, pid_alive};
 pub use manager::{LivenessCheck, RuntimeManager, TmuxRuntimeManager};

--- a/src/runtime/preflight.rs
+++ b/src/runtime/preflight.rs
@@ -22,6 +22,8 @@ pub enum PreflightIssue {
         platform: &'static str,
         fallback: Option<SandboxEngine>,
     },
+    /// A configured runtime option is unavailable on the launch target.
+    UnsupportedRuntimeOption { diagnostic: String },
 }
 
 /// Describes the kind of remediation the user can trigger.
@@ -76,6 +78,9 @@ impl PreflightIssue {
                     platform,
                 ),
             },
+            Self::UnsupportedRuntimeOption { diagnostic } => {
+                format!("{diagnostic}\n\n[Esc] cancel launch")
+            }
         }
     }
 
@@ -90,6 +95,7 @@ impl PreflightIssue {
             Self::UnsupportedEngine { engine, .. } => {
                 format!("{} unsupported", engine.label())
             }
+            Self::UnsupportedRuntimeOption { .. } => "Code Puppy option unsupported".to_owned(),
         }
     }
 
@@ -113,7 +119,8 @@ impl PreflightIssue {
                 fallback: Some(target),
                 ..
             } => PreflightAction::SwitchEngine(*target),
-            Self::UnsupportedEngine { fallback: None, .. } => PreflightAction::NoRemediation,
+            Self::UnsupportedEngine { fallback: None, .. }
+            | Self::UnsupportedRuntimeOption { .. } => PreflightAction::NoRemediation,
         }
     }
 }

--- a/src/runtime/preflight.rs
+++ b/src/runtime/preflight.rs
@@ -95,7 +95,7 @@ impl PreflightIssue {
             Self::UnsupportedEngine { engine, .. } => {
                 format!("{} unsupported", engine.label())
             }
-            Self::UnsupportedRuntimeOption { .. } => "Code Puppy option unsupported".to_owned(),
+            Self::UnsupportedRuntimeOption { .. } => "Unsupported runtime option".to_owned(),
         }
     }
 


### PR DESCRIPTION
## Summary

Completes the remaining launch-safety work for #195 after the model and typed YOLO configuration delivered by #225 and the creation-time repository model semantics corrected by #235.

- adds a runtime capability boundary for Code Puppy-specific features
- explicitly records that model discovery is unavailable until Code Puppy publishes a stable machine-readable enumeration interface; free-text model entry remains the supported fallback rather than coupling Jefe to private config files
- feature-detects `--yolo` from `code-puppy --help`, including ANSI/OSC-decorated output
- probes the actual launch target: local Code Puppy for local repositories and Code Puppy over the existing SSH path for remote repositories
- blocks configured YOLO launches with a clear, cancel-only preflight diagnostic when the target is old, unavailable, or does not advertise the option
- preserves legacy Code Puppy agents with no explicit YOLO value and leaves LLxprt launches untouched
- reuses the existing preflight modal projection instead of duplicating state/persistence plumbing

## Existing behavior retained

The merged implementation already provides:

- free-text Code Puppy model fields on repository and agent forms
- repository creation-time defaults and per-agent persistence/restore
- typed `Option<bool>` YOLO persistence
- exact `--model MODEL` and `--yolo true|false` argv projection
- Code Puppy-only form visibility and launch-path reuse for normal, issue, PR, local, remote, relaunch, and restore flows

Code Puppy 0.0.634 currently exposes no stable noninteractive model-list command. Consequently autosuggest/cache/refresh are deliberately not fabricated by parsing `~/.code_puppy/puppy.cfg`; the issue makes discovery conditional on a stable upstream source, while requiring free text to continue working when unavailable.

## Test plan

- [x] plain Code Puppy help detects YOLO
- [x] ANSI/OSC-decorated help detects YOLO
- [x] help without YOLO is rejected
- [x] LLxprt skips Code Puppy probing
- [x] legacy Code Puppy agents without explicit YOLO skip probing
- [x] model discovery capability reports unavailable without a stable API
- [x] `make ci-check`

## Verification

`make ci-check` passes, including formatting, allow-policy checks, source-size checks, both Clippy passes, coverage gate, locked all-feature build, all tests, and doctests.

Closes #195
