### PR TITLE
Allow issue titles to be edited (Fixes #216)

### DIFF
--- a/src/app_input/issues_mutation.rs
+++ b/src/app_input/issues_mutation.rs
@@ -282,6 +282,17 @@ fn update_issue_body(
     mutation_id: u64,
     text: String,
 ) {
+    let (title, body) = split_issue_title_body(&text);
+    if title.is_empty() {
+        apply_mutation_failed(
+            app_state,
+            ctx,
+            mutation_failure_target(app_state),
+            Some(mutation_id),
+            "Issue title cannot be empty".to_string(),
+        );
+        return;
+    }
     let Some(target) = current_issue_target(app_state) else {
         let failure_target = mutation_failure_target(app_state);
         apply_mutation_failed(
@@ -300,14 +311,8 @@ fn update_issue_body(
         app_state,
         ctx,
         move |mut app_state, ctx| {
-            let event = update_issue_body_event(
-                &ctx,
-                &repo_target.owner,
-                &repo_target.repo,
-                &text,
-                &target,
-                mutation_id,
-            );
+            let event =
+                update_issue_body_event(&ctx, &repo_target, &title, &body, &target, mutation_id);
             match event {
                 Some(event) => apply_and_persist(&mut app_state, &ctx, event),
                 None => {
@@ -408,20 +413,23 @@ fn create_comment_event(
 
 fn update_issue_body_event(
     ctx: &SharedContext,
-    owner: &str,
-    repo: &str,
-    text: &str,
+    repo: &GhRepoTarget,
+    title: &str,
+    body: &str,
     target: &IssueMutationTarget,
     mutation_id: u64,
 ) -> Option<AppEvent> {
     github_client(ctx)
-        .map(|client| client.update_issue_body(owner, repo, target.issue_number, text))
+        .map(|client| {
+            client.update_issue(&repo.owner, &repo.repo, target.issue_number, title, body)
+        })
         .map(|result| match result {
             Ok(()) => AppEvent::IssueBodyUpdated {
                 scope_repo_id: target.scope_repo_id.clone(),
                 issue_number: target.issue_number,
                 mutation_id,
-                body: text.to_string(),
+                title: title.to_string(),
+                body: body.to_string(),
             },
             Err(error) => AppEvent::MutationFailed {
                 scope_repo_id: target.scope_repo_id.clone(),

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -463,16 +463,17 @@ impl GhClient {
         Ok(())
     }
 
-    /// Update an issue's body text.
+    /// Update an issue's title and body text.
     ///
     /// @plan PLAN-20260329-ISSUES-MODE.P08
     /// @requirement REQ-ISS-011
     /// @pseudocode component-002 lines 57-61
-    pub fn update_issue_body(
+    pub fn update_issue(
         &self,
         owner: &str,
         repo: &str,
         number: u64,
+        title: &str,
         body: &str,
     ) -> Result<(), GhError> {
         let output = Command::new("gh")
@@ -482,6 +483,8 @@ impl GhClient {
                 "--repo",
                 &format!("{owner}/{repo}"),
                 &number.to_string(),
+                "--title",
+                title,
                 "--body",
                 body,
             ])

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -291,6 +291,7 @@ pub enum IssuesMessage {
         scope_repo_id: RepositoryId,
         issue_number: u64,
         mutation_id: u64,
+        title: String,
         body: String,
     },
     CommentUpdated {

--- a/src/messages/issues_conversion.rs
+++ b/src/messages/issues_conversion.rs
@@ -358,11 +358,13 @@ impl IssuesMessage {
                 scope_repo_id,
                 issue_number,
                 mutation_id,
+                title,
                 body,
             } => Self::IssueBodyUpdated {
                 scope_repo_id,
                 issue_number,
                 mutation_id,
+                title,
                 body,
             },
             AppEvent::CommentUpdated {
@@ -753,11 +755,13 @@ impl IssuesMessage {
                 scope_repo_id,
                 issue_number,
                 mutation_id,
+                title,
                 body,
             } => AppEvent::IssueBodyUpdated {
                 scope_repo_id,
                 issue_number,
                 mutation_id,
+                title,
                 body,
             },
             Self::CommentUpdated {

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -250,6 +250,7 @@ pub enum AppEvent {
         scope_repo_id: RepositoryId,
         issue_number: u64,
         mutation_id: u64,
+        title: String,
         body: String,
     },
     CommentUpdated {

--- a/src/state/issues_inline_ops.rs
+++ b/src/state/issues_inline_ops.rs
@@ -185,7 +185,7 @@ impl AppState {
                     .issues_state
                     .issue_detail
                     .as_ref()
-                    .map(|d| d.body.clone())
+                    .map(|detail| format!("{}\n{}", detail.title, detail.body))
                     .unwrap_or_default(),
                 EditorTarget::Comment { comment_index } => self
                     .issues_state

--- a/src/state/issues_mutation_ops.rs
+++ b/src/state/issues_mutation_ops.rs
@@ -100,12 +100,14 @@ impl AppState {
                 scope_repo_id,
                 issue_number,
                 mutation_id,
+                title,
                 body,
             } => self.with_matching_pending_detail(
                 mutation_id,
                 scope_repo_id,
                 issue_number,
                 |detail| {
+                    detail.title = title;
                     detail.body = body;
                     true
                 },

--- a/src/state/issues_tests_detail.rs
+++ b/src/state/issues_tests_detail.rs
@@ -58,6 +58,22 @@ fn test_keybind_bar_issues_mode() {
 // P15 Integration Tests — Full State Flow Verification
 // =========================================================================
 
+#[test]
+fn test_issue_editor_includes_title_and_body() {
+    let mut state = dashboard_issues_state();
+    state.issues_state.issue_detail = Some(p15_detail(42));
+
+    let state = state.apply(AppEvent::OpenInlineEditor {
+        target: EditorTarget::IssueBody,
+    });
+
+    assert!(matches!(
+        state.issues_state.inline_state,
+        InlineState::Editor { text, cursor, .. }
+            if text == "Issue #42\nIssue body" && cursor == text.len()
+    ));
+}
+
 /// Helper: create a state already in issues mode with a selected repository.
 fn issues_mode_state_with_repo(repo_id: &str) -> AppState {
     let mut state = AppState::default();
@@ -849,6 +865,7 @@ fn test_stale_mutation_events_same_repo_different_issue_do_not_mutate_or_clear_i
             scope_repo_id: repo_id.clone(),
             issue_number: 99,
             mutation_id: 1,
+            title: "stale title".to_string(),
             body: "stale body".to_string(),
         })
         .apply(AppEvent::CommentUpdated {


### PR DESCRIPTION
## Summary

- include the current issue title as the first line of the issue editor
- split edited issue content into title and body on submission, matching the existing new-issue composer convention
- send both `--title` and `--body` through `gh issue edit`
- update the in-memory issue detail with both values after a successful mutation
- reject an empty edited title with the existing mutation error flow

## User experience

Selecting an issue body and pressing `e` now opens editable content in this form:

```text
Issue title
Issue body
```

The first line is the title; all remaining lines are the body. `Ctrl+Enter` saves both fields and `Esc` cancels as before.

## Test-first evidence

1. Added `test_issue_editor_includes_title_and_body`.
2. Ran it before production changes and observed the expected failure because only the body was loaded.
3. Implemented the title/body edit path and reran the regression test successfully.

## Verification

- `make quick-check`
- `make ci-check`

Both pass locally.

Fixes #216
