### PR TITLE
Detect unauthenticated gh and offer in-app device-code auth dialog (#244)

### DIFF
--- a/dev-docs/testing/tmux-harness.md
+++ b/dev-docs/testing/tmux-harness.md
@@ -185,6 +185,18 @@ manual/opt-in and also skips when `tmux` cannot be installed or found.
   selected cells should highlight (inverse video) and release should copy the
   highlighted text. Holding Shift while dragging must also highlight and copy
   (it is no longer a no-op).
+- [`auth-dialog.json`](../tmux-scenarios/auth-dialog.json): manual scenario for
+  issue #244 — the in-app device-code auth remediation dialog. It enters Issues
+  mode, waits for the "Authenticate with GitHub" dialog to appear (when `gh` is
+  unauthenticated), and cancels with Esc. It is intentionally **not** a CI gate
+  because it requires an unauthenticated `gh` and a real browser authorization
+  to complete the device-code flow. The deterministic proof that the dialog
+  opens on a `NotAuthenticated` failure, that the one-time code + URL are
+  parsed from `gh auth login --web` stderr, that the requested scopes are
+  exactly `repo`, `read:org`, `gist`, and that the state machine transitions
+  (idle → awaiting-code → confirming → success / failure / cancelled) live in
+  unit tests (`github_tests::auth_device`, `state::auth_ops_tests`,
+  `app_input::auth_remediation`, and `ui::modals::auth`).
 
 ## Future regression scenarios
 

--- a/dev-docs/tmux-scenarios/auth-dialog.json
+++ b/dev-docs/tmux-scenarios/auth-dialog.json
@@ -1,0 +1,34 @@
+{
+  "config": {
+    "cols": 100,
+    "rows": 32,
+    "history_limit": 2000,
+    "initial_wait_ms": 150,
+    "out_dir": "target/tmux-harness/auth-dialog",
+    "keep_session": false,
+    "assert_mode": "soft"
+  },
+  "macros": {
+    "enter_issues_mode": {
+      "params": [],
+      "steps": [
+        { "key": "i" }
+      ]
+    },
+    "quit": {
+      "params": [],
+      "steps": [
+        { "key": "q" },
+        { "waitForExit": 3000 }
+      ]
+    }
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "macro": "enter_issues_mode", "args": {} },
+    { "waitFor": "Authenticate with GitHub" },
+    { "expect": "Authenticate with GitHub" },
+    { "key": "Escape" },
+    { "macro": "quit", "args": {} }
+  ]
+}

--- a/project-plans/issue244/plan.md
+++ b/project-plans/issue244/plan.md
@@ -1,0 +1,227 @@
+# Plan: In-app device-code auth dialog for unauthenticated `gh`
+
+Plan ID: PLAN-20260712-AUTH-DIALOG
+Generated: 2026-07-12
+Issue: #244 — "Detect unauthenticated gh and offer in-app device-code auth dialog"
+Total Phases: 4
+Requirements: REQ-AUTH-001..006
+
+## Summary
+
+When `gh` is not authenticated, Jefe already detects the failure
+(`GhError::NotAuthenticated` via `categorize_error` / `check_auth`). Today the
+remediation is a static "run `gh auth login`" string that forces the user to
+leave the TUI. This plan adds an in-app modal that drives the **device-code
+OAuth flow** itself — surfacing the one-time code + URL, requesting exactly
+the scopes Jefe needs, and detecting success/failure/cancellation — so the
+user never leaves Jefe.
+
+## Critical findings (from `gh` source `internal/authflow/flow.go`)
+
+- `gh` ALWAYS requests minimum scopes `["repo", "read:org", "gist"]` — exactly
+  the scopes the issue names. Passing them explicitly via `--scopes` makes the
+  grant auditable and keeps a documented contract even if `gh`'s defaults
+  change.
+- The device code + URL are written to **stderr** (`IO.ErrOut`), NOT stdout:
+  - `DisplayCode` → `! First copy your one-time code: XXXX-XXXX`
+  - `BrowseURL` (non-interactive) → `Open this URL to continue in your web
+    browser: https://github.com/login/device/...`
+- `isInteractive` is `opts.IO.CanPrompt() && opts.Token == ""`. When stdin is
+  NOT a TTY (piped/closed), `CanPrompt()` is false → **non-interactive path**:
+  no "Press Enter" prompt, URL printed directly. This is what makes the flow
+  usable from a TUI subprocess.
+- To prevent `gh` from trying to spawn a browser on a headless/remote box, set
+  `GH_BROWSER=/bin/true`. The user opens the browser themselves on any device.
+- Exit 0 = success; non-zero = failure (code expired, network, denied).
+
+## Architecture (module boundaries — must respect)
+
+| Concern | Owner | File(s) |
+|---|---|---|
+| Auth state machine + reducer transitions | state layer | `src/state/auth_ops.rs`, `src/state/types.rs` (new `ModalState::Auth` + `AuthDialogState`), `src/state/events.rs` (new `AppEvent`s) |
+| Pure scope/args builder + stderr parser | github boundary (pure, no I/O) | `src/github/auth_device.rs` |
+| Spawning `gh auth login --web` + streaming | runtime layer | `src/runtime/gh_auth.rs` (new) — NOT tmux; this is a one-shot subprocess, not a PTY session. Lives in `runtime/` because the runtime layer "owns process orchestration". |
+| Message routing | messages layer | `src/messages.rs` (`SystemMessage` / new `AuthMessage`), `src/messages/event_conversion.rs` |
+| Key handling for the auth modal | app_input layer | `src/app_input/modal_handlers.rs` (`handle_mode_auth_key`) |
+| Triggering on `NotAuthenticated` | app_input dispatch | `src/app_input/gh_async.rs` + the `persist_*_failed` sites — convert `NotAuthenticated` errors into opening the modal instead of a bare error string |
+| Render-only modal | UI layer | `src/ui/modals/auth.rs` |
+
+The UI receives the code/URL/status as plain data (render-only). The runtime
+owns the subprocess. The state layer owns transitions. No boundary is crossed.
+
+## Non-interactive invocation
+
+```
+GH_BROWSER=/bin/true gh auth login \
+  --hostname github.com \
+  --git-protocol https \
+  --web \
+  --scopes repo \
+  --scopes read:org \
+  --scopes gist
+```
+Run with **stdin closed** (`Stdio::null`) so `CanPrompt()` is false. Capture
+stderr (where the code/URL are written) and stdout. Wait for exit.
+
+## Phase 0.5: Preflight Verification
+
+- [x] `cargo --version` / `rustc` available (project builds today)
+- [x] `serde_json` already a dependency (used throughout `github/`)
+- [x] `std::process::Command` already used by `GhClient` (no new deps)
+- [x] `check_auth()` and `categorize_error()` exist as the detection source of truth
+- [x] Existing modal pattern (`ModalState`, `handle_mode_*_key`, `input.rs::modal_input_mode`) confirmed
+- [x] `spawn_gh_task_with_panic` confirmed for off-thread gh calls
+- [x] `RuntimeManager` trait exists; auth subprocess is a one-shot (not a PTY session), so it does NOT go through `RuntimeManager` — it is a sibling helper in `runtime/`.
+
+## Phase 1: Pure github boundary — scopes, args, stderr parser (TDD)
+
+### Files to create
+- `src/github/auth_device.rs`
+  - `pub const AUTH_SCOPES: &[&str] = &["repo", "read:org", "gist"];`
+  - `pub fn build_auth_login_args(scopes: &[&str]) -> Vec<String>` — returns the
+    `gh auth login ... --web --scopes ...` argv (hostname/git-protocol fixed to
+    github.com/https per issue).
+  - `pub fn build_auth_login_env() -> Vec<(&'static str, &'static str)>` —
+    returns `("GH_BROWSER", "/bin/true")` (and is unit-testable).
+  - `pub struct DeviceCode { pub code: String, pub verification_url: String }`
+  - `pub fn parse_device_code(stderr: &str) -> Option<DeviceCode>` — extracts the
+    one-time code (`XXXX-XXXX`) and the verification URL from `gh`'s stderr
+    output. Tolerant of ANSI color codes (strip them first).
+- `src/github/tests/auth_device.rs` — unit tests for all of the above.
+
+### Tests (RED first)
+- `build_auth_login_args` produces exactly `["auth","login","--hostname","github.com","--git-protocol","https","--web","--scopes","repo","--scopes","read:org","--scopes","gist"]`.
+- `AUTH_SCOPES` is exactly `["repo","read:org","gist"]`.
+- `build_auth_login_env` includes `GH_BROWSER=/bin/true`.
+- `parse_device_code` extracts `7701-C5F6` + `https://github.com/login/device` from the real `gh` stderr sample (`! First copy your one-time code: 7701-C5F6\nOpen this URL to continue in your web browser: https://github.com/login/device/...`).
+- `parse_device_code` strips ANSI color escapes.
+- `parse_device_code` returns `None` for output without a code.
+
+### Wire into `src/github/mod.rs`
+- `mod auth_device;` + `pub use auth_device::{AUTH_SCOPES, DeviceCode, build_auth_login_args, build_auth_login_env, parse_device_code};`
+
+## Phase 2: State machine + reducer (TDD)
+
+### Files to create/modify
+- `src/state/auth_ops.rs` (new) — `AuthDialogState` + transitions.
+- `src/state/types.rs` — add `ModalState::Auth { state: AuthDialogState }` and the `AuthDialogState` type.
+- `src/state/events.rs` — add `AppEvent` variants:
+  - `OpenAuthDialog`
+  - `AuthCodeReceived { code: String, url: String }`
+  - `AuthSucceeded`
+  - `AuthFailed { error: String }`
+  - `AuthCancelled`
+  - `AuthRetry`
+- `src/state/mod.rs` — `mod auth_ops;` + route new events through a new
+  `SystemMessage::Auth*` or a dedicated `AuthMessage` domain channel.
+
+### `AuthDialogState` + state machine
+```
+AuthDialogState:
+  Idle                 // not shown (modal closed)
+  AwaitingCode         // subprocess spawned, waiting for code parse
+  Confirming { code, url }   // code+URL shown; user authorizes in browser; polling
+  Success
+  Failed { error }     // transient failure; retry offered
+  Cancelled
+```
+Transitions (deterministic, in `auth_ops.rs`):
+- `Idle --OpenAuthDialog--> AwaitingCode`
+- `AwaitingCode --AuthCodeReceived{code,url}--> Confirming{code,url}`
+- `AwaitingCode --AuthFailed{e}--> Failed{e}`
+- `Confirming --AuthSucceeded--> Success` (modal closes → `ModalState::None`)
+- `Confirming --AuthFailed{e}--> Failed{e}`
+- `Failed --AuthRetry--> AwaitingCode`
+- `* --AuthCancelled--> Cancelled` (modal closes → `ModalState::None`)
+
+### Tests (RED first) — `src/state/auth_ops_tests.rs`
+- Every transition above (GIVEN state + event → THEN next state).
+- `OpenAuthDialog` while another modal is open does NOT clobber it (defense: only opens when `modal == None` OR an explicit override). Decision: auth is high-priority remediation, so it CAN preempt a non-auth modal — but it stores the prior modal so Esc-restore is possible. (Simpler v1: only open when `modal == None`; the dispatch layer closes any bare error first.)
+- Success transitions clear the modal to `None`.
+- Cancel transitions clear the modal to `None` and set `error_message` to a helpful "auth cancelled" string.
+
+## Phase 3: Runtime subprocess + dispatch wiring (TDD)
+
+### Files to create/modify
+- `src/runtime/gh_auth.rs` (new) — `pub fn run_device_auth(client: &GhClient) -> AuthRunResult` that:
+  - builds args via `build_auth_login_args(AUTH_SCOPES)`,
+  - builds env via `build_auth_login_env()`,
+  - spawns `gh` with `Stdio::null` for stdin, piped stderr/stdout,
+  - waits for exit,
+  - parses stderr with `parse_device_code`,
+  - returns `AuthRunResult { code: Option<DeviceCode>, exit_success: bool, stderr: String }`.
+  - This is a **blocking** call intended to run inside `spawn_gh_task_with_panic`.
+- `src/app_input/gh_async.rs` (or a new `src/app_input/auth_remediation.rs`) — `spawn_auth_flow` that runs `run_device_auth` off-thread and delivers `AuthCodeReceived` / `AuthFailed` / `AuthSucceeded` events back to state.
+- Trigger sites: in the `persist_*_failed` helpers (issues/prs/actions list+detail), when the error string indicates `NotAuthenticated` (detected via a new `is_not_authenticated_error(&str) -> bool` helper that reuses the `categorize_error` contract), open the auth dialog INSTEAD OF (or in addition to) the bare error. To keep detection as the single source of truth, expose `pub fn is_not_authenticated(error_text: &str) -> bool` from `github/parse.rs` (or reuse `GhError` directly at the call site where the typed error is still available).
+
+### Tests (RED first)
+- `src/runtime/gh_auth_tests.rs` — `run_device_auth` parses a captured stderr fixture (using a fake `gh`-emitting helper binary is non-deterministic; instead test the **pure** parse path via `parse_device_code`, and test the args/env assembly). The subprocess spawn itself is integration-tested via the TUI scenario (Phase 4) and is kept thin.
+  - **Decision:** keep `run_device_auth` a thin wrapper; its correctness is proven by `parse_device_code` unit tests + the args/env assembly tests + the e2e scenario. No mock theater (per RULES.md).
+- `src/app_input/auth_remediation_tests.rs` — `is_not_authenticated("gh is not authenticated. Run: gh auth login")` is true; `is_not_authenticated("network error")` is false.
+- A state-level test proving: a `NotAuthenticated` failure on the issues list path opens `ModalState::Auth` (the dispatch layer calls `OpenAuthDialog`).
+
+### Message routing
+- New `SystemMessage` variants (or a small `AuthMessage` channel): `OpenAuthDialog`, `AuthCodeReceived{code,url}`, `AuthSucceeded`, `AuthFailed{error}`, `AuthCancelled`, `AuthRetry`.
+- `event_conversion.rs`: map the new `AppEvent` variants to the auth channel.
+- `input.rs::modal_input_mode`: `ModalState::Auth { .. } => Some(InputMode::Auth)`.
+- `app_shell.rs::dispatch_mode_specific_key`: `InputMode::Auth => handle_mode_auth_key(...); true`.
+- `modal_handlers.rs::handle_mode_auth_key`:
+  - `Esc` → `AuthCancelled` (and if a retry is mid-flight, the spawned `gh` is orphaned — it exits on its own when stdin is closed / the user never authorizes; v1 does not kill it, documented).
+  - `Enter`/`r` when `Failed` → `AuthRetry` (re-spawn the flow).
+  - Other keys ignored (the flow is not text-editable).
+
+## Phase 4: UI modal + TUI scenario
+
+### Files to create/modify
+- `src/ui/modals/auth.rs` (new) — `AuthModal` iocraft component, render-only.
+  Renders title, the one-time code (prominent), the verification URL,
+  instructions, and the current status (awaiting/confirming/failed/cancelled).
+  No state mutation.
+- `src/ui/modals/mod.rs` — `mod auth; pub use auth::{AuthModal, AuthModalProps};`
+- `src/ui/` root — render `AuthModal` when `state.modal == ModalState::Auth { .. }`.
+- `dev-docs/tmux-scenarios/auth-dialog.json` (new) — manual scenario (NOT a CI
+  gate, because it requires an unauthenticated `gh` + a real browser). Covers:
+  trigger a GitHub operation while unauthenticated → auth dialog appears →
+  (manual) authorize → success. Plus a cancellation scenario.
+- `dev-docs/testing/tmux-harness.md` — document the new scenario.
+
+### Tests (RED first)
+- `src/ui/modals/auth.rs` `#[cfg(test)]` — pure projection helper
+  `auth_dialog_view(&AuthDialogState) -> AuthDialogView` (iocraft-free, per the
+  pure-views pattern) returning the lines to render; unit-test the lines for
+  each state.
+- The TUI scenario JSON is manual (documented as non-CI).
+
+## Acceptance criteria mapping (issue → plan)
+
+- ✅ State machine transitions idle→awaiting-code→confirming→success/failure/cancelled/expired — Phase 2 tests.
+- ✅ Runtime parses one-time code + URL from `gh auth login --web` stderr — Phase 1 `parse_device_code` test.
+- ✅ Scopes exactly `repo`, `read:org`, `gist` — Phase 1 `AUTH_SCOPES`/`build_auth_login_args` test.
+- ✅ TUI scenario: trigger op while unauthenticated → dialog → success → op proceeds — Phase 4 scenario.
+- ✅ Cancellation + failed/expired retry scenario — Phase 4 scenario + Phase 2 cancel/fail tests.
+- ✅ `gh auth login` never invoked interactively (stdin null, `--web`, `GH_BROWSER=/bin/true`) — Phase 3 invocation.
+- ✅ `cargo fmt`, `clippy -D warnings`, build, full tests pass (`make ci-check`) — final verification.
+
+## Verification Commands
+
+```bash
+cargo fmt --all --check
+CLIPPY_CONF_DIR=.github/clippy rustup run stable cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo build --workspace --all-features --locked
+cargo test --workspace --all-features --locked
+make ci-check   # fmt + clippy gates + coverage (--fail-under-lines 30) + build + test
+```
+
+## Failure Recovery
+- `git restore <files>` for any phase that fails verification.
+- The new modules are additive; reverting `mod.rs`/`types.rs`/`events.rs`/`input.rs`/`app_shell.rs` registrations restores prior behavior.
+
+## Execution Tracker
+
+| Phase | Status | Verified | Semantic Verified | Notes |
+|------:|--------|----------|-------------------|-------|
+| P00.5 | done   | yes      | N/A               | preflight |
+| P01   | todo   | todo     | todo              | pure github boundary |
+| P02   | todo   | todo     | todo              | state machine |
+| P03   | todo   | todo     | todo              | runtime + dispatch |
+| P04   | todo   | todo     | todo              | UI + scenario |

--- a/src/app_input/actions_orchestration.rs
+++ b/src/app_input/actions_orchestration.rs
@@ -109,13 +109,20 @@ fn handle_list_reload_result(
             runs: res.runs,
             has_more: res.has_more,
         },
-        Err(e) => AppEvent::ActionsRunsLoadFailed {
-            scope_repo_id: repo_id,
-            filter: Box::new(filter),
-            page,
-            request_id,
-            error: e.to_string(),
-        },
+        Err(e) => {
+            let error = e.to_string();
+            // Offer the in-app auth dialog when gh is unauthenticated (issue #244).
+            if super::auth_remediation::offer_auth_remediation(&mut app_state, ctx, &error) {
+                return;
+            }
+            AppEvent::ActionsRunsLoadFailed {
+                scope_repo_id: repo_id,
+                filter: Box::new(filter),
+                page,
+                request_id,
+                error,
+            }
+        }
     };
     apply_and_persist(&mut app_state, ctx, event);
     // After a successful page-1 list load, launch detail loading for the

--- a/src/app_input/auth_remediation.rs
+++ b/src/app_input/auth_remediation.rs
@@ -11,7 +11,7 @@
 //! (`runtime::gh_auth`) owns the `gh auth login --web` subprocess; this module
 //! is the seam that connects them.
 
-use jefe::github::is_not_authenticated_error;
+use jefe::github::{is_not_authenticated_error, redact_device_codes};
 use jefe::runtime::run_device_auth;
 use jefe::state::AppEvent;
 
@@ -124,7 +124,7 @@ fn deliver_auth_result(
                 app_state,
                 ctx,
                 AppEvent::AuthFailed {
-                    error: error.to_string(),
+                    error: redact_device_codes(&error.to_string()),
                 },
             );
         }
@@ -132,12 +132,15 @@ fn deliver_auth_result(
 }
 
 /// Build a human-readable failure message from captured stderr.
+///
+/// Scrubs the GitHub device-code shape so a code that `gh` echoed back on a
+/// failed/expired flow cannot leak into state/logs (issue #244 OCR review).
 fn failure_message(stderr: &str) -> String {
     let trimmed = stderr.trim();
     if trimmed.is_empty() {
         "GitHub authentication did not complete.".to_string()
     } else {
-        trimmed.to_string()
+        redact_device_codes(trimmed)
     }
 }
 
@@ -159,6 +162,16 @@ mod tests {
         assert_eq!(
             failure_message("   "),
             "GitHub authentication did not complete."
+        );
+    }
+
+    #[test]
+    fn failure_message_redacts_device_code_from_stderr() {
+        // gh may echo the one-time code back on a failed/expired flow; it must
+        // not survive into state (issue #244 OCR review).
+        assert_eq!(
+            failure_message("error: code WDJB-MJHT has expired"),
+            "error: code <redacted> has expired"
         );
     }
 

--- a/src/app_input/auth_remediation.rs
+++ b/src/app_input/auth_remediation.rs
@@ -1,0 +1,189 @@
+//! Dispatch wiring for the in-app device-code auth remediation dialog
+//! (issue #244).
+//!
+//! When a GitHub operation fails with `NotAuthenticated`, the dispatch layer
+//! opens the auth modal (`OpenAuthDialog`) and spawns the non-interactive
+//! device-code flow off the UI thread. The parsed one-time code + URL and the
+//! final exit status are delivered back as `AuthCodeReceived` /
+//! `AuthSucceeded` / `AuthFailed` events.
+//!
+//! The state layer owns the dialog state machine; the runtime layer
+//! (`runtime::gh_auth`) owns the `gh auth login --web` subprocess; this module
+//! is the seam that connects them.
+
+use jefe::github::is_not_authenticated_error;
+use jefe::runtime::run_device_auth;
+use jefe::state::AppEvent;
+
+use super::{AppStateHandle, SharedContext, apply_and_persist, gh_async};
+
+/// Open the auth remediation dialog when no other modal is active, then start
+/// the device-code flow.
+///
+/// Returns `true` when the dialog was opened (the caller should NOT also surface
+/// a bare error string in that case — the dialog is the remediation surface).
+/// Returns `false` when a modal is already open (the caller surfaces the error
+/// normally) — this keeps the auth dialog from clobbering an in-flight form.
+pub(super) fn offer_auth_remediation(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    error: &str,
+) -> bool {
+    if !should_offer_auth_remediation(error, app_state) {
+        return false;
+    }
+    apply_and_persist(app_state, ctx, AppEvent::OpenAuthDialog);
+    spawn_device_auth_flow(app_state, ctx);
+    true
+}
+
+/// Pure decision: should we offer the auth dialog for this error, given the
+/// current modal state? Returns `true` when the error indicates gh is
+/// unauthenticated AND no modal is currently open.
+///
+/// Split out so the decision is unit-testable without spawning `gh` or
+/// constructing an iocraft `HookState`.
+pub(super) fn should_offer_auth_remediation(error: &str, app_state: &AppStateHandle) -> bool {
+    is_auth_remediation_candidate(error, &app_state.read().modal)
+}
+
+/// Pure predicate: the error indicates gh is unauthenticated and no modal is
+/// open, so the auth remediation dialog should be offered.
+#[must_use]
+pub(super) fn is_auth_remediation_candidate(error: &str, modal: &jefe::state::ModalState) -> bool {
+    is_not_authenticated_error(error) && *modal == jefe::state::ModalState::None
+}
+
+/// Spawn the non-interactive device-code flow off the UI thread, delivering
+/// `AuthCodeReceived` / `AuthSucceeded` / `AuthFailed` events back to state.
+///
+/// The flow blocks until `gh auth login --web` exits (success → exit 0; the
+/// user authorizes in a browser; failure → non-zero). Because it runs via
+/// `spawn_gh_task_with_panic` → `smol::unblock`, the UI is never blocked.
+pub(super) fn spawn_device_auth_flow(app_state: &AppStateHandle, ctx: &SharedContext) {
+    gh_async::spawn_gh_task_with_panic(
+        app_state,
+        ctx,
+        |mut app_state, ctx| {
+            let result = run_device_auth();
+            deliver_auth_result(&mut app_state, &ctx, result);
+        },
+        |mut app_state, ctx, message| {
+            // A panic in the auth flow is a transient failure — surface it and
+            // let the user retry, rather than leaving the dialog stuck.
+            apply_and_persist(
+                &mut app_state,
+                &ctx,
+                AppEvent::AuthFailed {
+                    error: format!("GitHub auth task panicked: {message}"),
+                },
+            );
+        },
+    );
+}
+
+/// Translate the `run_device_auth` outcome into the appropriate auth event and
+/// apply it. Called on the background thread.
+fn deliver_auth_result(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    result: Result<jefe::runtime::AuthRunResult, jefe::github::GhError>,
+) {
+    match result {
+        Ok(run) => {
+            // First, surface the code + URL as soon as they're available so the
+            // dialog shows them while the user authorizes in a browser.
+            if let Some(device_code) = run.code {
+                apply_and_persist(
+                    app_state,
+                    ctx,
+                    AppEvent::AuthCodeReceived {
+                        code: device_code.code,
+                        url: device_code.verification_url,
+                    },
+                );
+            }
+            // Then the terminal exit status decides success vs retryable
+            // failure. A non-zero exit after a code was shown means the code
+            // expired or the user denied — surface it so the dialog offers a
+            // retry instead of sticking in Confirming (issue #244).
+            if run.exit_success {
+                apply_and_persist(app_state, ctx, AppEvent::AuthSucceeded);
+            } else {
+                apply_and_persist(
+                    app_state,
+                    ctx,
+                    AppEvent::AuthFailed {
+                        error: failure_message(&run.stderr),
+                    },
+                );
+            }
+        }
+        Err(error) => {
+            apply_and_persist(
+                app_state,
+                ctx,
+                AppEvent::AuthFailed {
+                    error: error.to_string(),
+                },
+            );
+        }
+    }
+}
+
+/// Build a human-readable failure message from captured stderr.
+fn failure_message(stderr: &str) -> String {
+    let trimmed = stderr.trim();
+    if trimmed.is_empty() {
+        "GitHub authentication did not complete.".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jefe::state::ModalState;
+
+    #[test]
+    fn failure_message_uses_stderr_when_present() {
+        assert_eq!(
+            failure_message("  the device code expired  "),
+            "the device code expired"
+        );
+    }
+
+    #[test]
+    fn failure_message_falls_back_when_stderr_empty() {
+        assert_eq!(
+            failure_message("   "),
+            "GitHub authentication did not complete."
+        );
+    }
+
+    #[test]
+    fn is_auth_remediation_candidate_true_for_unauth_when_no_modal() {
+        assert!(is_auth_remediation_candidate(
+            "gh is not authenticated. Run: gh auth login",
+            &ModalState::None
+        ));
+    }
+
+    #[test]
+    fn is_auth_remediation_candidate_false_for_unrelated_error() {
+        assert!(!is_auth_remediation_candidate(
+            "network error: could not resolve host",
+            &ModalState::None
+        ));
+    }
+
+    #[test]
+    fn is_auth_remediation_candidate_false_when_a_modal_is_already_open() {
+        // Never clobber an existing modal (e.g. a form the user is editing).
+        assert!(!is_auth_remediation_candidate(
+            "gh is not authenticated. Run: gh auth login",
+            &ModalState::Help
+        ));
+    }
+}

--- a/src/app_input/issues_dispatch.rs
+++ b/src/app_input/issues_dispatch.rs
@@ -124,6 +124,12 @@ pub(super) fn load_issue_detail_for_selection(app_state: &mut AppStateHandle, ct
         ctx,
         move |mut app_state, ctx| {
             let event = detail_load_event(&ctx, params);
+            // Offer the in-app auth dialog when gh is unauthenticated (issue #244).
+            if let AppEvent::IssueDetailLoadFailed { error, .. } = &event {
+                if super::auth_remediation::offer_auth_remediation(&mut app_state, &ctx, error) {
+                    return;
+                }
+            }
             apply_and_persist(&mut app_state, &ctx, event);
         },
         move |mut app_state, ctx, message| {

--- a/src/app_input/issues_list_dispatch.rs
+++ b/src/app_input/issues_list_dispatch.rs
@@ -236,6 +236,13 @@ fn persist_issue_list_failed(
     params: &IssueFetchParams,
     error: String,
 ) {
+    // When gh is not authenticated, open the in-app device-code auth dialog
+    // instead of surfacing a bare "run gh auth login" error string (issue #244).
+    // The dialog is the remediation surface; the original operation can be
+    // retried after success.
+    if super::auth_remediation::offer_auth_remediation(app_state, ctx, &error) {
+        return;
+    }
     apply_and_persist(
         app_state,
         ctx,

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -32,6 +32,8 @@ mod prs_orchestration;
 
 mod actions;
 mod actions_orchestration;
+// In-app device-code auth remediation dispatch (issue #244).
+mod auth_remediation;
 mod gh_async;
 
 mod agent_runtime;
@@ -51,7 +53,8 @@ use agent_runtime::{
 };
 
 pub use modal_handlers::{
-    handle_f12_toggle, handle_mode_confirm_key, handle_mode_form_key, handle_mode_theme_picker_key,
+    handle_f12_toggle, handle_mode_auth_key, handle_mode_confirm_key, handle_mode_form_key,
+    handle_mode_theme_picker_key,
 };
 
 pub use normal::{handle_global_shortcut_key, handle_normal_key_event};

--- a/src/app_input/modal_handlers.rs
+++ b/src/app_input/modal_handlers.rs
@@ -115,7 +115,7 @@ pub fn handle_mode_confirm_key(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
     key_event: &KeyEvent,
-) {
+) -> bool {
     match key_event.code {
         KeyCode::Esc | KeyCode::Char('n' | 'N') => close_modal_and_persist(app_state, ctx),
         KeyCode::Left | KeyCode::Right | KeyCode::Tab | KeyCode::BackTab => {
@@ -127,6 +127,7 @@ pub fn handle_mode_confirm_key(
         }
         _ => {}
     }
+    true
 }
 
 /// Handle keys while the in-app device-code auth dialog is open (issue #244).
@@ -143,11 +144,14 @@ pub fn handle_mode_confirm_key(
 /// (~15 min), and with stdin null + `GH_BROWSER=/bin/true` it exits on its own
 /// once the code expires or the user authorizes elsewhere. The leak is bounded
 /// and inert (issue #244).
+///
+/// Returns `true` so the caller short-circuits (the auth modal consumes the
+/// key), mirroring the form/search handlers.
 pub fn handle_mode_auth_key(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
     key_event: &KeyEvent,
-) {
+) -> bool {
     let in_failed_phase = {
         let state = app_state.read();
         matches!(
@@ -166,6 +170,7 @@ pub fn handle_mode_auth_key(
         }
         _ => {}
     }
+    true
 }
 
 fn handle_confirm_enter(app_state: &mut AppStateHandle, ctx: &SharedContext) {

--- a/src/app_input/modal_handlers.rs
+++ b/src/app_input/modal_handlers.rs
@@ -9,14 +9,15 @@ use jefe::domain::{AgentId, LaunchSignature, SandboxEngine};
 use jefe::persistence::PersistenceManager;
 use jefe::runtime::{RuntimeError, RuntimeManager};
 use jefe::state::{
-    AgentFormFocus, AppEvent, ConfirmFocus, ModalState, PaneFocus, RepositoryFormFocus,
+    AgentFormFocus, AppEvent, AuthDialogPhase, ConfirmFocus, ModalState, PaneFocus,
+    RepositoryFormFocus,
 };
 use jefe::theme::ThemeManager;
 
 use super::{
-    AppStateHandle, SharedContext, apply_and_persist, clear_agent_runtime_attachment,
-    close_modal_and_persist, execute_agent_launch, launch_signature_for_agent,
-    mark_agent_runtime_attached, persist_state, preflight_or_prompt,
+    AppStateHandle, SharedContext, apply_and_persist, auth_remediation,
+    clear_agent_runtime_attachment, close_modal_and_persist, execute_agent_launch,
+    launch_signature_for_agent, mark_agent_runtime_attached, persist_state, preflight_or_prompt,
     repository_focus_toggles_checkbox, to_persisted_state,
 };
 
@@ -123,6 +124,45 @@ pub fn handle_mode_confirm_key(
         KeyCode::Enter => handle_confirm_enter(app_state, ctx),
         KeyCode::Char(' ' | 'd' | 'D') | KeyCode::Up | KeyCode::Down => {
             apply_and_persist(app_state, ctx, AppEvent::ToggleDeleteWorkDir);
+        }
+        _ => {}
+    }
+}
+
+/// Handle keys while the in-app device-code auth dialog is open (issue #244).
+///
+/// - Esc: cancel the flow (dismiss; sets an actionable error_message).
+/// - `r` / Enter when `Failed`: retry the device-code flow.
+/// - All other keys are ignored — the dialog is not text-editable; the code +
+///   URL are displayed for the user to act on in a browser.
+///
+/// # Orphaned `gh` on cancel
+/// Esc closes the modal but does NOT kill the background `gh auth login`
+/// subprocess (its `Child` handle is not retained across the dispatch seam).
+/// This is accepted for v1: `gh`'s device-code flow has a server-side expiry
+/// (~15 min), and with stdin null + `GH_BROWSER=/bin/true` it exits on its own
+/// once the code expires or the user authorizes elsewhere. The leak is bounded
+/// and inert (issue #244).
+pub fn handle_mode_auth_key(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    key_event: &KeyEvent,
+) {
+    let in_failed_phase = {
+        let state = app_state.read();
+        matches!(
+            &state.modal,
+            ModalState::Auth {
+                state: dialog
+            } if matches!(dialog.phase, AuthDialogPhase::Failed { .. })
+        )
+    };
+
+    match key_event.code {
+        KeyCode::Esc => apply_and_persist(app_state, ctx, AppEvent::AuthCancelled),
+        KeyCode::Char('r' | 'R') | KeyCode::Enter if in_failed_phase => {
+            apply_and_persist(app_state, ctx, AppEvent::AuthRetry);
+            auth_remediation::spawn_device_auth_flow(app_state, ctx);
         }
         _ => {}
     }

--- a/src/app_input/prs_dispatch.rs
+++ b/src/app_input/prs_dispatch.rs
@@ -114,6 +114,12 @@ pub(super) fn load_pr_detail_for_selection(app_state: &mut AppStateHandle, ctx: 
         ctx,
         move |mut app_state, ctx| {
             let event = pr_detail_load_event(&ctx, &params);
+            // Offer the in-app auth dialog when gh is unauthenticated (issue #244).
+            if let AppEvent::PrDetailLoadFailed { error, .. } = &event {
+                if super::auth_remediation::offer_auth_remediation(&mut app_state, &ctx, error) {
+                    return;
+                }
+            }
             apply_and_persist(&mut app_state, &ctx, event);
         },
         move |mut app_state, ctx, message| {

--- a/src/app_input/prs_list_dispatch.rs
+++ b/src/app_input/prs_list_dispatch.rs
@@ -331,6 +331,12 @@ fn persist_pr_list_failed(
             request_id: params.request_id,
         }
     } else {
+        // User-initiated load failed because gh is unauthenticated: offer the
+        // in-app device-code auth dialog (issue #244). Silent background
+        // refreshes must NOT pop the dialog.
+        if super::auth_remediation::offer_auth_remediation(app_state, ctx, &error) {
+            return;
+        }
         AppEvent::PrListLoadFailed {
             scope_repo_id: params.scope_repo_id.clone(),
             request_id: params.request_id,

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -9,8 +9,8 @@ use tracing::{debug, trace, warn};
 use crate::AppContext;
 use crate::app_input::{
     dispatch_app_event, forward_key_to_pty, handle_f12_toggle, handle_global_shortcut_key,
-    handle_mode_confirm_key, handle_mode_form_key, handle_mode_help_key, handle_mode_search_key,
-    handle_mode_theme_picker_key, handle_normal_key_event, persist_state,
+    handle_mode_auth_key, handle_mode_confirm_key, handle_mode_form_key, handle_mode_help_key,
+    handle_mode_search_key, handle_mode_theme_picker_key, handle_normal_key_event, persist_state,
     request_pr_background_refresh, to_persisted_state, try_ctrl_c_interrupt_passthrough,
     try_intercept_terminal_scrollback,
 };
@@ -763,6 +763,10 @@ fn dispatch_mode_specific_key(
         }
         InputMode::ThemePicker => {
             handle_mode_theme_picker_key(app_state, &ctx.cloned(), key_event);
+            true
+        }
+        InputMode::Auth => {
+            handle_mode_auth_key(app_state, &ctx.cloned(), key_event);
             true
         }
         InputMode::Search => handle_mode_search_key(app_state, &ctx.cloned(), key_event),

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -757,18 +757,12 @@ fn dispatch_mode_specific_key(
             handle_mode_help_key(app_state, &ctx.cloned(), help_scroll, key_event);
             true
         }
-        InputMode::Confirm => {
-            handle_mode_confirm_key(app_state, &ctx.cloned(), key_event);
-            true
-        }
+        InputMode::Confirm => handle_mode_confirm_key(app_state, &ctx.cloned(), key_event),
         InputMode::ThemePicker => {
             handle_mode_theme_picker_key(app_state, &ctx.cloned(), key_event);
             true
         }
-        InputMode::Auth => {
-            handle_mode_auth_key(app_state, &ctx.cloned(), key_event);
-            true
-        }
+        InputMode::Auth => handle_mode_auth_key(app_state, &ctx.cloned(), key_event),
         InputMode::Search => handle_mode_search_key(app_state, &ctx.cloned(), key_event),
         InputMode::Form => handle_mode_form_key(app_state, &ctx.cloned(), key_event),
         // @plan PLAN-20260329-ISSUES-MODE.P03

--- a/src/github/auth_device.rs
+++ b/src/github/auth_device.rs
@@ -218,14 +218,16 @@ fn extract_device_code(clean: &str) -> Option<String> {
     }
 }
 
-/// A device code is `XXXX-XXXX` (or longer segments separated by a single
-/// dash): letters/digits, a dash, letters/digits.
+/// A device code is exactly `XXXX-XXXX`: 4 ASCII alphanumerics, a dash, 4
+/// ASCII alphanumerics (GitHub's device-code format). Kept in lockstep with
+/// [`is_code_at_boundary`] so anything [`parse_device_code`] accepts is also
+/// redacted by [`redact_device_codes`] (defense-in-depth for the credential).
 fn is_valid_device_code(candidate: &str) -> bool {
     let Some((left, right)) = candidate.split_once('-') else {
         return false;
     };
-    !left.is_empty()
-        && !right.is_empty()
+    left.len() == 4
+        && right.len() == 4
         && segment_is_alphanumeric(left)
         && segment_is_alphanumeric(right)
 }
@@ -243,12 +245,14 @@ fn extract_verification_url(clean: &str) -> Option<String> {
     // Find the github.com device URL anywhere in the output.
     let url_start = clean.find("https://github.com/login/device")?;
     let rest = &clean[url_start..];
-    // URL ends at the first whitespace.
+    // URL ends at the first whitespace; then strip trailing sentence
+    // punctuation that gh may append when the URL ends a clause (issue #244
+    // OCR review: only trimming periods missed ')', ']', '}', etc.).
     let url = rest
         .split_whitespace()
         .next()
         .unwrap_or(rest)
-        .trim_end_matches('.');
+        .trim_end_matches(['.', ')', ']', '}', ',', ';', ':', '!', '?', '\'', '"']);
     Some(url.to_string())
 }
 
@@ -274,5 +278,54 @@ mod tests {
         assert!(!is_valid_device_code("1234"));
         assert!(!is_valid_device_code("-1234"));
         assert!(!is_valid_device_code("1234-"));
+    }
+
+    #[test]
+    fn is_valid_device_code_requires_strict_4_plus_4() {
+        // Anything other than exactly 4+4 is rejected, so the parser and the
+        // redactor stay in lockstep (issue #244 OCR review).
+        assert!(!is_valid_device_code("A-B"));
+        assert!(!is_valid_device_code("ABC-DEFG"));
+        assert!(!is_valid_device_code("ABCDE-FGHI"));
+        assert!(is_valid_device_code("7701-C5F6"));
+    }
+
+    #[test]
+    fn extract_verification_url_strips_trailing_punctuation() {
+        // Trailing sentence punctuation must not become part of the URL.
+        assert_eq!(
+            extract_verification_url("Open this URL: https://github.com/login/device/abc."),
+            Some("https://github.com/login/device/abc".to_string())
+        );
+        assert_eq!(
+            extract_verification_url("(see https://github.com/login/device/abc))"),
+            Some("https://github.com/login/device/abc".to_string())
+        );
+        assert_eq!(
+            extract_verification_url("url: https://github.com/login/device/abc]."),
+            Some("https://github.com/login/device/abc".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_verification_url_returns_none_when_absent() {
+        assert!(extract_verification_url("no url here").is_none());
+    }
+
+    #[test]
+    fn is_code_at_boundary_matches_standalone_code() {
+        let chars: Vec<char> = "code 7701-C5F6 done".chars().collect();
+        let pos = "code ".len();
+        assert!(is_code_at_boundary(&chars, pos));
+    }
+
+    #[test]
+    fn is_code_at_boundary_rejects_mid_token() {
+        // The 4+4 shape exists starting at index 4 of "tokenABCD-EFGH", but it
+        // is preceded by an alphanumeric, so it must not be treated as a code.
+        let s = "tokenABCD-EFGH";
+        let chars: Vec<char> = s.chars().collect();
+        let pos = "token".len();
+        assert!(!is_code_at_boundary(&chars, pos));
     }
 }

--- a/src/github/auth_device.rs
+++ b/src/github/auth_device.rs
@@ -73,11 +73,63 @@ pub fn build_auth_login_env() -> Vec<(&'static str, &'static str)> {
     vec![("GH_BROWSER", "/bin/true")]
 }
 
+/// Replace anything matching the GitHub device-code shape (`XXXX-XXXX`,
+/// case-insensitive alphanumeric, 4+dash+4) with `<redacted>`.
+///
+/// `gh auth login` can echo the one-time code back to stderr on failure
+/// (expired, denied). Because failure messages flow into `AuthDialogPhase::Failed`
+/// — which is part of `AppState` and therefore logged/printed — scrub the code
+/// shape before the string enters state, so a short-lived bearer credential
+/// cannot leak via crash reports or logs (issue #244 OCR review).
+#[must_use]
+pub fn redact_device_codes(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < chars.len() {
+        if is_code_at_boundary(&chars, i) {
+            out.push_str("<redacted>");
+            // Skip the 9-char code (4 + '-' + 4).
+            i += 9;
+        } else {
+            out.push(chars[i]);
+            i += 1;
+        }
+    }
+    out
+}
+
+/// True if `chars[pos..]` starts a standalone `XXXX-XXXX` token (4 alphanumerics,
+/// dash, 4 alphanumerics) with non-alphanumeric boundaries on both sides.
+fn is_code_at_boundary(chars: &[char], pos: usize) -> bool {
+    // 4 alnum, '-', 4 alnum = 9 chars at indices pos..=pos+8.
+    if pos + 8 >= chars.len() {
+        return false;
+    }
+    let code_chars = &chars[pos..=pos + 8];
+    if code_chars[4] != '-' {
+        return false;
+    }
+    let first_four = &code_chars[0..4];
+    let last_four = &code_chars[5..9];
+    if !first_four.iter().all(char::is_ascii_alphanumeric)
+        || !last_four.iter().all(char::is_ascii_alphanumeric)
+    {
+        return false;
+    }
+    // Word boundaries: the char before pos and the char after pos+8 must not
+    // be alphanumeric (so we don't redact a substring of a longer token).
+    let left_ok = pos == 0 || !chars[pos - 1].is_ascii_alphanumeric();
+    let right_ok = pos + 9 >= chars.len() || !chars[pos + 9].is_ascii_alphanumeric();
+    left_ok && right_ok
+}
+
 /// Returns true when an error string indicates a `gh` authentication failure.
 ///
-/// Delegates to [`crate::github::categorize_error`]'s shared
-/// `not_authenticated_matcher` so detection stays a single source of truth —
-/// the dispatch layer cannot drift from the error categorizer (issue #244).
+/// Delegates to the shared `not_authenticated_matcher` (in
+/// `crate::github::parse`) that [`crate::github::categorize_error`] also uses
+/// for its `NotAuthenticated` arm, so detection stays a single source of truth
+/// — the dispatch layer cannot drift from the error categorizer (issue #244).
 /// Used to decide whether to open the auth remediation dialog instead of
 /// surfacing a bare error string.
 #[must_use]
@@ -112,8 +164,10 @@ fn strip_ansi(input: &str) -> String {
                         break;
                     }
                     if inner == '\x1b' {
-                        // Re-feed for the next iteration; push nothing here.
-                        // Simplest correct behavior: stop.
+                        // A nested ESC starts a new sequence; consume it and
+                        // stop this scan (the outer loop's next `chars.next()`
+                        // picks up after it). gh's stderr uses SGR codes only,
+                        // so this branch is rarely hit.
                         break;
                     }
                 }

--- a/src/github/auth_device.rs
+++ b/src/github/auth_device.rs
@@ -1,0 +1,224 @@
+//! In-app device-code auth remediation boundary (issue #244).
+//!
+//! Pure helpers for driving `gh auth login --web` non-interactively from the
+//! TUI: the exact scopes Jefe requests, the assembled argv, the no-op-browser
+//! environment, and the parser that extracts the one-time code + verification
+//! URL from `gh`'s stderr.
+//!
+//! This module performs NO I/O. The runtime layer (`runtime/gh_auth.rs`) owns
+//! the subprocess spawn; the state layer owns the dialog state machine.
+//!
+//! # Why these scopes and flags
+//!
+//! `gh` always requests the minimum scopes `["repo", "read:org", "gist"]`
+//! (see `internal/authflow/flow.go` in cli/cli). Passing them explicitly via
+//! `--scopes` keeps the grant auditable at the call site even if `gh`'s
+//! defaults change. `--web` selects the device-code flow; with stdin not a
+//! TTY, `gh` takes its non-interactive path (no "Press Enter" prompt) and
+//! prints the code + URL to stderr. `GH_BROWSER=/bin/true` prevents `gh` from
+//! spawning a browser on a headless/remote host — the user opens the URL on
+//! any device themselves.
+
+/// The exact OAuth scopes Jefe requests for its `gh` token (issue #244).
+///
+/// `repo` (repo read/write + private), `read:org` (read org membership),
+/// `gist` (create gists). Mirrors `gh`'s own minimum scope set so the token
+/// is minimally privileged for Jefe's needs.
+pub const AUTH_SCOPES: &[&str] = &["repo", "read:org", "gist"];
+
+/// The fixed hostname Jefe authenticates against (github.com per the issue).
+const AUTH_HOSTNAME: &str = "github.com";
+/// The fixed git protocol (https per the issue).
+const AUTH_GIT_PROTOCOL: &str = "https";
+
+/// A parsed one-time device code and the URL the user must open in a browser.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeviceCode {
+    /// The one-time code, e.g. `7701-C5F6`.
+    pub code: String,
+    /// The verification URL, e.g. `https://github.com/login/device`.
+    pub verification_url: String,
+}
+
+/// Build the `gh auth login` argv for the non-interactive device-code flow.
+///
+/// Returns one `--scopes <scope>` pair per requested scope so the granted
+/// scopes are exactly the set passed in (no reliance on `gh`'s interactive
+/// default-scope prompt, which does not fit a TUI).
+#[must_use]
+pub fn build_auth_login_args(scopes: &[&str]) -> Vec<String> {
+    let mut args = vec![
+        "auth".to_string(),
+        "login".to_string(),
+        "--hostname".to_string(),
+        AUTH_HOSTNAME.to_string(),
+        "--git-protocol".to_string(),
+        AUTH_GIT_PROTOCOL.to_string(),
+        "--web".to_string(),
+    ];
+    for scope in scopes {
+        args.push("--scopes".to_string());
+        args.push((*scope).to_string());
+    }
+    args
+}
+
+/// Build the environment overrides for the non-interactive device-code flow.
+///
+/// `GH_BROWSER=/bin/true` makes `gh`'s browser-open step a no-op so it never
+/// spawns a browser on the Jefe host (which may be headless or remote over
+/// SSH). The user opens the verification URL on whatever device they choose.
+#[must_use]
+pub fn build_auth_login_env() -> Vec<(&'static str, &'static str)> {
+    vec![("GH_BROWSER", "/bin/true")]
+}
+
+/// Returns true when an error string indicates a `gh` authentication failure.
+///
+/// Delegates to [`crate::github::categorize_error`]'s shared
+/// `not_authenticated_matcher` so detection stays a single source of truth —
+/// the dispatch layer cannot drift from the error categorizer (issue #244).
+/// Used to decide whether to open the auth remediation dialog instead of
+/// surfacing a bare error string.
+#[must_use]
+pub fn is_not_authenticated_error(error_text: &str) -> bool {
+    super::parse::not_authenticated_matcher(&error_text.to_lowercase())
+}
+
+/// Strip ANSI/VT100 escape sequences from a string.
+///
+/// `gh` colorizes stderr when it believes the stream is a TTY; the parser must
+/// cope with colorized output. This removes CSI sequences (`\x1b[...m`) and
+/// other common escape forms.
+fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // Skip the rest of an escape sequence: ESC [ <params> <final byte>
+            // (0x40..=0x7E), or ESC ] ... BEL/ST. Be permissive: consume until
+            // a byte that cannot be inside a CSI sequence.
+            if matches!(chars.peek(), Some('[')) {
+                chars.next();
+                for inner in chars.by_ref() {
+                    if inner.is_ascii() && (0x40..=0x7E).contains(&(inner as u32)) {
+                        break;
+                    }
+                }
+            } else {
+                // OSC or other: consume until BEL (\x07) or a following ESC.
+                for inner in chars.by_ref() {
+                    if inner == '\x07' {
+                        break;
+                    }
+                    if inner == '\x1b' {
+                        // Re-feed for the next iteration; push nothing here.
+                        // Simplest correct behavior: stop.
+                        break;
+                    }
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Parse the one-time device code and verification URL from `gh auth login
+/// --web` stderr.
+///
+/// `gh` writes (to stderr):
+///   `! First copy your one-time code: XXXX-XXXX`
+///   `Open this URL to continue in your web browser: https://github.com/login/device[...]`
+///
+/// Returns `None` if no well-formed code (`XXXX-XXXX`, 4 hex/alphanumerics, a
+/// dash, 4 more) is present.
+#[must_use]
+pub fn parse_device_code(stderr: &str) -> Option<DeviceCode> {
+    let clean = strip_ansi(stderr);
+
+    let code = extract_device_code(&clean)?;
+    let verification_url = extract_verification_url(&clean).unwrap_or_else(|| {
+        // Fall back to the canonical device-login URL if gh omitted it.
+        "https://github.com/login/device".to_string()
+    });
+
+    Some(DeviceCode {
+        code,
+        verification_url,
+    })
+}
+
+/// Extract the `XXXX-XXXX` one-time code following the `one-time code:` label.
+fn extract_device_code(clean: &str) -> Option<String> {
+    let label = clean.find("one-time code:")?;
+    let rest = &clean[label + "one-time code:".len()..];
+    let token = rest.trim_start();
+    // Take the first run of non-whitespace chars as the candidate code.
+    let candidate = token.split_whitespace().next()?;
+    if is_valid_device_code(candidate) {
+        Some(candidate.to_string())
+    } else {
+        None
+    }
+}
+
+/// A device code is `XXXX-XXXX` (or longer segments separated by a single
+/// dash): letters/digits, a dash, letters/digits.
+fn is_valid_device_code(candidate: &str) -> bool {
+    let Some((left, right)) = candidate.split_once('-') else {
+        return false;
+    };
+    !left.is_empty()
+        && !right.is_empty()
+        && segment_is_alphanumeric(left)
+        && segment_is_alphanumeric(right)
+}
+
+/// True when every char in the segment is an ASCII letter or digit. Extracted
+/// so the closure form does not trip clippy's `redundant_closure` lint (the
+/// `char::is_ascii_alphanumeric` method takes `&self`, which is incompatible
+/// with `Iterator::all`'s `Fn(Item)` bound).
+fn segment_is_alphanumeric(segment: &str) -> bool {
+    segment.chars().all(|c| c.is_ascii_alphanumeric())
+}
+
+/// Extract the verification URL from the `Open this URL ... : <url>` line.
+fn extract_verification_url(clean: &str) -> Option<String> {
+    // Find the github.com device URL anywhere in the output.
+    let url_start = clean.find("https://github.com/login/device")?;
+    let rest = &clean[url_start..];
+    // URL ends at the first whitespace.
+    let url = rest
+        .split_whitespace()
+        .next()
+        .unwrap_or(rest)
+        .trim_end_matches('.');
+    Some(url.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_ansi_removes_color_codes() {
+        let input = "\x1b[33m!\x1b[0m hello \x1b[1mworld\x1b[0m";
+        assert_eq!(strip_ansi(input), "! hello world");
+    }
+
+    #[test]
+    fn is_valid_device_code_accepts_standard_shape() {
+        assert!(is_valid_device_code("7701-C5F6"));
+        assert!(is_valid_device_code("ABCD-1234"));
+    }
+
+    #[test]
+    fn is_valid_device_code_rejects_garbage() {
+        assert!(!is_valid_device_code("not-a-code"));
+        assert!(!is_valid_device_code("1234"));
+        assert!(!is_valid_device_code("-1234"));
+        assert!(!is_valid_device_code("1234-"));
+    }
+}

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -26,7 +26,7 @@ use repo_merge::parse_repo_merge_methods;
 mod auth_device;
 pub use auth_device::{
     AUTH_SCOPES, DeviceCode, build_auth_login_args, build_auth_login_env,
-    is_not_authenticated_error, parse_device_code,
+    is_not_authenticated_error, parse_device_code, redact_device_codes,
 };
 mod viewer;
 pub use viewer::{build_assign_issue_args, build_viewer_login_args, parse_viewer_login};

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -23,13 +23,11 @@ pub use create_issue::{CreatedIssue, parse_created_issue_json};
 pub use issue_lifecycle::{build_close_issue_args, build_delete_issue_args};
 use repo_merge::parse_repo_merge_methods;
 
-/// In-app device-code auth remediation boundary (issue #244).
 mod auth_device;
 pub use auth_device::{
     AUTH_SCOPES, DeviceCode, build_auth_login_args, build_auth_login_env,
     is_not_authenticated_error, parse_device_code,
 };
-
 mod viewer;
 pub use viewer::{build_assign_issue_args, build_viewer_login_args, parse_viewer_login};
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -23,6 +23,13 @@ pub use create_issue::{CreatedIssue, parse_created_issue_json};
 pub use issue_lifecycle::{build_close_issue_args, build_delete_issue_args};
 use repo_merge::parse_repo_merge_methods;
 
+/// In-app device-code auth remediation boundary (issue #244).
+mod auth_device;
+pub use auth_device::{
+    AUTH_SCOPES, DeviceCode, build_auth_login_args, build_auth_login_env,
+    is_not_authenticated_error, parse_device_code,
+};
+
 mod viewer;
 pub use viewer::{build_assign_issue_args, build_viewer_login_args, parse_viewer_login};
 

--- a/src/github/parse.rs
+++ b/src/github/parse.rs
@@ -34,11 +34,7 @@ pub fn categorize_error(exit_code: i32, stderr: &str) -> GhError {
         return GhError::RateLimited;
     }
 
-    if stderr_lower.contains("401")
-        || stderr_lower.contains("not logged in")
-        || stderr_lower.contains("authentication")
-        || stderr_lower.contains("not authenticated")
-    {
+    if not_authenticated_matcher(&stderr_lower) {
         return GhError::NotAuthenticated(stderr.to_string());
     }
 
@@ -52,6 +48,21 @@ pub fn categorize_error(exit_code: i32, stderr: &str) -> GhError {
     }
 
     GhError::ApiError(stderr.to_string())
+}
+
+/// The single source of truth for recognizing a `gh` authentication failure
+/// from a lowercased error/stderr string. Shared by [`categorize_error`]'s
+/// `NotAuthenticated` arm and [`crate::github::is_not_authenticated_error`]
+/// so the dispatch-layer auth-remediation trigger cannot drift from the
+/// error categorizer (issue #244).
+///
+/// @must_use
+#[must_use]
+pub(super) fn not_authenticated_matcher(stderr_lower: &str) -> bool {
+    stderr_lower.contains("401")
+        || stderr_lower.contains("not logged in")
+        || stderr_lower.contains("authentication")
+        || stderr_lower.contains("not authenticated")
 }
 
 /// Parse JSON output from `gh issue list --json` into Issue vector.

--- a/src/github/tests/auth_device.rs
+++ b/src/github/tests/auth_device.rs
@@ -1,0 +1,144 @@
+//! Tests for the in-app device-code auth remediation boundary (issue #244).
+//!
+//! These cover the PURE helpers only: scope list, argv assembly, environment,
+//! and stderr parsing of `gh auth login --web` output. The subprocess spawn
+//! itself is exercised end-to-end via the tmux scenario.
+
+use crate::github::{
+    AUTH_SCOPES, DeviceCode, build_auth_login_args, build_auth_login_env,
+    is_not_authenticated_error, parse_device_code,
+};
+
+#[test]
+fn auth_scopes_are_exactly_the_documented_set() {
+    assert_eq!(AUTH_SCOPES, ["repo", "read:org", "gist"]);
+}
+
+#[test]
+fn build_auth_login_args_assembles_noninteractive_web_flow() {
+    let args = build_auth_login_args(AUTH_SCOPES);
+    assert_eq!(
+        args,
+        [
+            "auth",
+            "login",
+            "--hostname",
+            "github.com",
+            "--git-protocol",
+            "https",
+            "--web",
+            "--scopes",
+            "repo",
+            "--scopes",
+            "read:org",
+            "--scopes",
+            "gist",
+        ]
+        .map(String::from)
+    );
+}
+
+#[test]
+fn build_auth_login_args_superset_scopes_preserved() {
+    // If requirements change, the builder must forward exactly what it is given
+    // so the granted scopes stay auditable from the call site.
+    let args = build_auth_login_args(&["repo", "read:org", "gist", "workflow"]);
+    assert_eq!(
+        args.iter().filter(|a| *a == "--scopes").count(),
+        4,
+        "one --scopes flag per requested scope"
+    );
+    assert!(args.contains(&"--web".to_string()));
+}
+
+#[test]
+fn build_auth_login_env_sets_no_op_browser() {
+    let env = build_auth_login_env();
+    assert!(
+        env.iter()
+            .any(|(k, v)| *k == "GH_BROWSER" && *v == "/bin/true"),
+        "GH_BROWSER must be a no-op so gh does not spawn a browser on a headless/remote host"
+    );
+}
+
+#[test]
+fn parse_device_code_extracts_code_and_url_from_real_stderr() {
+    // Real `gh auth login --web` non-interactive stderr (see plan findings).
+    let stderr = "! First copy your one-time code: 7701-C5F6\n\
+                  Open this URL to continue in your web browser: https://github.com/login/device\n";
+    let parsed = parse_device_code(stderr).unwrap_or_else(|| panic!("must parse real gh stderr"));
+    assert_eq!(parsed.code, "7701-C5F6");
+    assert_eq!(parsed.verification_url, "https://github.com/login/device");
+}
+
+#[test]
+fn parse_device_code_strips_ansi_color_escapes() {
+    // gh colorizes stderr when it believes it is a TTY; the parser must cope.
+    let stderr = "\x1b[33m!\x1b[0m First copy your one-time code: \x1b[1mABCD-1234\x1b[0m\n\
+                  \x1b[1mOpen this URL\x1b[0m to continue in your web browser: https://github.com/login/device\n";
+    let parsed =
+        parse_device_code(stderr).unwrap_or_else(|| panic!("must parse ANSI-colored stderr"));
+    assert_eq!(parsed.code, "ABCD-1234");
+    assert_eq!(parsed.verification_url, "https://github.com/login/device");
+}
+
+#[test]
+fn parse_device_code_returns_none_without_a_code() {
+    let stderr = "some unrelated gh output\n";
+    assert!(parse_device_code(stderr).is_none());
+}
+
+#[test]
+fn parse_device_code_returns_none_for_malformed_code() {
+    // A code without the XXXX-XXXX shape is not a device code.
+    let stderr = "! First copy your one-time code: not-a-code\n";
+    assert!(parse_device_code(stderr).is_none());
+}
+
+#[test]
+fn parse_device_code_extracts_url_even_when_embeded_in_sentence() {
+    let stderr = "! First copy your one-time code: 1234-5678\n\
+                  Open this URL to continue in your web browser: https://github.com/login/device/abc123\n";
+    let parsed = parse_device_code(stderr).unwrap_or_else(|| panic!("must parse"));
+    assert_eq!(parsed.code, "1234-5678");
+    assert_eq!(
+        parsed.verification_url,
+        "https://github.com/login/device/abc123"
+    );
+}
+
+#[test]
+fn device_code_is_debug_and_eq() {
+    // Sanity-check the derive so it can live in ModalState (Debug, Clone, PartialEq, Eq).
+    let a = DeviceCode {
+        code: "0000-0000".to_string(),
+        verification_url: "https://github.com/login/device".to_string(),
+    };
+    let b = a.clone();
+    assert_eq!(a, b);
+    let _ = format!("{a:?}");
+}
+
+#[test]
+fn is_not_authenticated_error_detects_gh_messages() {
+    // Mirrors the substrings categorize_error() uses for NotAuthenticated,
+    // so detection stays the single source of truth.
+    assert!(is_not_authenticated_error(
+        "gh is not authenticated. Run: gh auth login"
+    ));
+    assert!(is_not_authenticated_error(
+        "You are not logged into any GitHub hosts."
+    ));
+    assert!(is_not_authenticated_error("authentication required"));
+    assert!(is_not_authenticated_error("HTTP 401: unauthorized"));
+}
+
+#[test]
+fn is_not_authenticated_error_rejects_unrelated_errors() {
+    assert!(!is_not_authenticated_error(
+        "network error: could not resolve host"
+    ));
+    assert!(!is_not_authenticated_error("HTTP 403: forbidden"));
+    assert!(!is_not_authenticated_error("rate limit exceeded"));
+    assert!(!is_not_authenticated_error("some API error"));
+}

--- a/src/github/tests/auth_device.rs
+++ b/src/github/tests/auth_device.rs
@@ -6,7 +6,7 @@
 
 use crate::github::{
     AUTH_SCOPES, DeviceCode, build_auth_login_args, build_auth_login_env,
-    is_not_authenticated_error, parse_device_code,
+    is_not_authenticated_error, parse_device_code, redact_device_codes,
 };
 
 #[test]
@@ -96,7 +96,7 @@ fn parse_device_code_returns_none_for_malformed_code() {
 }
 
 #[test]
-fn parse_device_code_extracts_url_even_when_embeded_in_sentence() {
+fn parse_device_code_extracts_url_even_when_embedded_in_sentence() {
     let stderr = "! First copy your one-time code: 1234-5678\n\
                   Open this URL to continue in your web browser: https://github.com/login/device/abc123\n";
     let parsed = parse_device_code(stderr).unwrap_or_else(|| panic!("must parse"));
@@ -141,4 +141,44 @@ fn is_not_authenticated_error_rejects_unrelated_errors() {
     assert!(!is_not_authenticated_error("HTTP 403: forbidden"));
     assert!(!is_not_authenticated_error("rate limit exceeded"));
     assert!(!is_not_authenticated_error("some API error"));
+}
+
+#[test]
+fn redact_device_codes_replaces_code_shape() {
+    assert_eq!(
+        redact_device_codes("error: code WDJB-MJHT has expired"),
+        "error: code <redacted> has expired"
+    );
+}
+
+#[test]
+fn redact_device_codes_leaves_non_code_text_intact() {
+    assert_eq!(
+        redact_device_codes("the device code expired"),
+        "the device code expired"
+    );
+    // A 9-char token without the dash is not a code.
+    assert_eq!(redact_device_codes("abcdefghi"), "abcdefghi");
+}
+
+#[test]
+fn redact_device_codes_respects_word_boundaries() {
+    // A code embedded in a longer alphanumeric token is NOT redacted.
+    assert_eq!(
+        redact_device_codes("token=ABCD-EFGH1234"),
+        "token=ABCD-EFGH1234"
+    );
+    // But a standalone code at a word boundary is.
+    assert_eq!(
+        redact_device_codes("code ABCD-EFGH done"),
+        "code <redacted> done"
+    );
+}
+
+#[test]
+fn redact_device_codes_handles_multiple_codes() {
+    assert_eq!(
+        redact_device_codes("ABCD-EFGH then WXYZ-1234"),
+        "<redacted> then <redacted>"
+    );
 }

--- a/src/github/tests/mod.rs
+++ b/src/github/tests/mod.rs
@@ -1,2 +1,3 @@
 mod actions;
+mod auth_device;
 mod issues;

--- a/src/input.rs
+++ b/src/input.rs
@@ -19,6 +19,8 @@ pub enum InputMode {
     Confirm,
     /// Theme picker overlay.
     ThemePicker,
+    /// In-app device-code auth dialog (issue #244).
+    Auth,
     /// @plan PLAN-20260329-ISSUES-MODE.P03
     /// @requirement REQ-ISS-002
     IssuesNormal,
@@ -86,6 +88,7 @@ fn modal_input_mode(modal: &ModalState) -> Option<InputMode> {
         | ModalState::PreflightPrompt { .. }
         | ModalState::ConfirmIssueDirtyCopy { .. }
         | ModalState::ConfirmIssueOriginMismatch { .. } => Some(InputMode::Confirm),
+        ModalState::Auth { .. } => Some(InputMode::Auth),
         ModalState::None => None,
     }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -646,6 +646,23 @@ pub enum SystemMessage {
     Quit,
     ClearError,
     ClearWarning,
+    /// Open the in-app device-code auth dialog (issue #244).
+    OpenAuthDialog,
+    /// One-time code + verification URL parsed from `gh auth login` stderr.
+    AuthCodeReceived {
+        code: String,
+        url: String,
+    },
+    /// Device-code flow succeeded.
+    AuthSucceeded,
+    /// Device-code flow failed (transient — retry offered).
+    AuthFailed {
+        error: String,
+    },
+    /// User cancelled the auth dialog.
+    AuthCancelled,
+    /// User requested a retry of the auth flow.
+    AuthRetry,
 }
 
 /// Top-level typed message routed by the bus.
@@ -809,6 +826,12 @@ message_names!(SystemMessage {
     Self::Quit => "Quit",
     Self::ClearError => "ClearError",
     Self::ClearWarning => "ClearWarning",
+    Self::OpenAuthDialog => "OpenAuthDialog",
+    Self::AuthCodeReceived { .. } => "AuthCodeReceived",
+    Self::AuthSucceeded => "AuthSucceeded",
+    Self::AuthFailed { .. } => "AuthFailed",
+    Self::AuthCancelled => "AuthCancelled",
+    Self::AuthRetry => "AuthRetry",
 });
 
 message_names!(IssuesMessage {

--- a/src/messages/event_conversion.rs
+++ b/src/messages/event_conversion.rs
@@ -114,27 +114,6 @@ impl AppMessage {
     /// within the clippy line budget without a complexity suppression.
     fn from_non_ui_nav_event(event: AppEvent) -> Self {
         match event {
-            AppEvent::OpenNewRepository => {
-                Self::RepositoryAgent(RepositoryAgentMessage::OpenNewRepository)
-            }
-            AppEvent::OpenEditRepository(id) => {
-                Self::RepositoryAgent(RepositoryAgentMessage::OpenEditRepository(id))
-            }
-            AppEvent::OpenDeleteRepository(id) => {
-                Self::RepositoryAgent(RepositoryAgentMessage::OpenDeleteRepository(id))
-            }
-            AppEvent::OpenNewAgent(id) => {
-                Self::RepositoryAgent(RepositoryAgentMessage::OpenNewAgent(id))
-            }
-            AppEvent::OpenEditAgent(id) => {
-                Self::RepositoryAgent(RepositoryAgentMessage::OpenEditAgent(id))
-            }
-            AppEvent::OpenDeleteAgent(id) => {
-                Self::RepositoryAgent(RepositoryAgentMessage::OpenDeleteAgent(id))
-            }
-            AppEvent::ToggleDeleteWorkDir => {
-                Self::RepositoryAgent(RepositoryAgentMessage::ToggleDeleteWorkDir)
-            }
             AppEvent::KillAgent(id) => Self::Runtime(RuntimeMessage::KillAgent(id)),
             AppEvent::RelaunchAgent(id) => Self::Runtime(RuntimeMessage::RelaunchAgent(id)),
             AppEvent::RestartAgent(id) => Self::Runtime(RuntimeMessage::RestartAgent(id)),
@@ -168,7 +147,44 @@ impl AppMessage {
             AppEvent::Quit => Self::System(SystemMessage::Quit),
             AppEvent::ClearError => Self::System(SystemMessage::ClearError),
             AppEvent::ClearWarning => Self::System(SystemMessage::ClearWarning),
-            // Catch-all delegates issues/PRs/actions events.
+            // Auth remediation events route to the System channel (issue #244).
+            AppEvent::OpenAuthDialog => Self::System(SystemMessage::OpenAuthDialog),
+            AppEvent::AuthCodeReceived { code, url } => {
+                Self::System(SystemMessage::AuthCodeReceived { code, url })
+            }
+            AppEvent::AuthSucceeded => Self::System(SystemMessage::AuthSucceeded),
+            AppEvent::AuthFailed { error } => Self::System(SystemMessage::AuthFailed { error }),
+            AppEvent::AuthCancelled => Self::System(SystemMessage::AuthCancelled),
+            AppEvent::AuthRetry => Self::System(SystemMessage::AuthRetry),
+            // Catch-all: repository/agent events, then issues/PRs/actions.
+            other => Self::from_repository_agent_event(other),
+        }
+    }
+
+    /// Convert repository/agent [`AppEvent`] variants into the typed message bus.
+    fn from_repository_agent_event(event: AppEvent) -> Self {
+        match event {
+            AppEvent::OpenNewRepository => {
+                Self::RepositoryAgent(RepositoryAgentMessage::OpenNewRepository)
+            }
+            AppEvent::OpenEditRepository(id) => {
+                Self::RepositoryAgent(RepositoryAgentMessage::OpenEditRepository(id))
+            }
+            AppEvent::OpenDeleteRepository(id) => {
+                Self::RepositoryAgent(RepositoryAgentMessage::OpenDeleteRepository(id))
+            }
+            AppEvent::OpenNewAgent(id) => {
+                Self::RepositoryAgent(RepositoryAgentMessage::OpenNewAgent(id))
+            }
+            AppEvent::OpenEditAgent(id) => {
+                Self::RepositoryAgent(RepositoryAgentMessage::OpenEditAgent(id))
+            }
+            AppEvent::OpenDeleteAgent(id) => {
+                Self::RepositoryAgent(RepositoryAgentMessage::OpenDeleteAgent(id))
+            }
+            AppEvent::ToggleDeleteWorkDir => {
+                Self::RepositoryAgent(RepositoryAgentMessage::ToggleDeleteWorkDir)
+            }
             other => Self::from_issues_event(other),
         }
     }
@@ -474,6 +490,12 @@ impl From<SystemMessage> for AppEvent {
             SystemMessage::Quit => Self::Quit,
             SystemMessage::ClearError => Self::ClearError,
             SystemMessage::ClearWarning => Self::ClearWarning,
+            SystemMessage::OpenAuthDialog => Self::OpenAuthDialog,
+            SystemMessage::AuthCodeReceived { code, url } => Self::AuthCodeReceived { code, url },
+            SystemMessage::AuthSucceeded => Self::AuthSucceeded,
+            SystemMessage::AuthFailed { error } => Self::AuthFailed { error },
+            SystemMessage::AuthCancelled => Self::AuthCancelled,
+            SystemMessage::AuthRetry => Self::AuthRetry,
         }
     }
 }

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -756,6 +756,7 @@ fn is_blocking_modal_open(state: &AppState) -> bool {
             | ModalState::ConfirmIssueOriginMismatch { .. }
             | ModalState::ThemePicker { .. }
             | ModalState::WorkflowDispatch { .. }
+            | ModalState::Auth { .. }
     )
 }
 
@@ -774,7 +775,8 @@ fn active_overlay_for(state: &AppState) -> jefe::selection::OverlayPane {
         | jefe::state::ModalState::ConfirmKillAgent { .. }
         | jefe::state::ModalState::PreflightPrompt { .. }
         | jefe::state::ModalState::ConfirmIssueDirtyCopy { .. }
-        | jefe::state::ModalState::ConfirmIssueOriginMismatch { .. } => {
+        | jefe::state::ModalState::ConfirmIssueOriginMismatch { .. }
+        | jefe::state::ModalState::Auth { .. } => {
             return OverlayPane::ConfirmModal;
         }
         // Explicit match (not wildcard) so new ModalState variants force a

--- a/src/runtime/gh_auth.rs
+++ b/src/runtime/gh_auth.rs
@@ -1,0 +1,129 @@
+//! One-shot `gh auth login --web` subprocess driver for the in-app device-code
+//! auth remediation dialog (issue #244).
+//!
+//! This is NOT a tmux/PTY session — it is a single short-lived subprocess owned
+//! by the runtime layer (the runtime layer owns process orchestration per
+//! `dev-docs/standards/persistence-and-runtime.md`). It runs `gh auth login`
+//! non-interactively (stdin closed so `gh`'s `CanPrompt()` is false → no
+//! "Press Enter" prompt; `GH_BROWSER=/bin/true` so it never spawns a browser),
+//! captures stderr, parses the one-time code + URL, and reports exit status.
+//!
+//! The caller (dispatch layer) runs this off the UI thread via
+//! `spawn_gh_task_with_panic` and delivers `AuthCodeReceived` / `AuthSucceeded`
+//! / `AuthFailed` events back to the state layer.
+
+use std::process::{Command, Stdio};
+
+use crate::github::{
+    AUTH_SCOPES, DeviceCode, GhError, build_auth_login_args, build_auth_login_env,
+    parse_device_code,
+};
+
+/// The outcome of running the device-code auth flow.
+///
+/// `code` is `Some` when `gh` emitted a parseable one-time code before
+/// exiting. `exit_success` is true when `gh` exited 0 (token stored). Both
+/// can be true (success after the user authorized); `code` can also be `Some`
+/// with `exit_success == false` (the code was shown but then expired or the
+/// user denied — `gh` exits non-zero).
+#[derive(Debug, Clone)]
+pub struct AuthRunResult {
+    /// The parsed one-time code + verification URL, if `gh` emitted them.
+    pub code: Option<DeviceCode>,
+    /// Whether `gh auth login` exited 0 (success / token stored).
+    pub exit_success: bool,
+    /// Raw captured stderr (for diagnostics on failure).
+    pub stderr: String,
+}
+
+/// Run the non-interactive device-code auth flow.
+///
+/// Blocks until `gh auth login --web` exits. Intended to be called inside
+/// `smol::unblock` / `spawn_gh_task_with_panic` so it never blocks the UI.
+///
+/// Errors: returns `GhError::NotInstalled` if `gh` is not on PATH, else
+/// `GhError::NetworkError` for spawn failures. Subprocess non-zero exit is NOT
+/// an `Err` — it is reported via `AuthRunResult::exit_success` so the caller
+/// can surface a retryable failure in-dialog.
+pub fn run_device_auth() -> Result<AuthRunResult, GhError> {
+    let args = build_auth_login_args(AUTH_SCOPES);
+    let env = build_auth_login_env();
+
+    let mut command = Command::new("gh");
+    command.args(&args);
+    for (key, value) in &env {
+        command.env(key, value);
+    }
+    // stdin closed so gh takes its non-interactive path (no "Press Enter").
+    command.stdin(Stdio::null());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    let child = command.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            GhError::NotInstalled
+        } else {
+            GhError::NetworkError(e.to_string())
+        }
+    })?;
+
+    // `wait_with_output` drains stdout and stderr concurrently while waiting,
+    // avoiding the pipe-buffer deadlock that reading one pipe to EOF before
+    // the other can cause on large child output.
+    let output = child
+        .wait_with_output()
+        .map_err(|e| GhError::NetworkError(e.to_string()))?;
+    let exit_success = output.status.success();
+
+    let stderr_buf = String::from_utf8_lossy(&output.stderr).to_string();
+    let stdout_buf = String::from_utf8_lossy(&output.stdout).to_string();
+
+    // gh writes the device code to stderr; fall back to scanning stdout too
+    // (defensive — gh's stream choice has changed across versions).
+    let combined = if stderr_buf.is_empty() {
+        stdout_buf
+    } else {
+        stderr_buf.clone()
+    };
+    let code = parse_device_code(&combined);
+
+    Ok(AuthRunResult {
+        code,
+        exit_success,
+        stderr: stderr_buf,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_run_result_holds_code_and_status() {
+        let result = AuthRunResult {
+            code: Some(DeviceCode {
+                code: "1234-5678".to_string(),
+                verification_url: "https://github.com/login/device".to_string(),
+            }),
+            exit_success: true,
+            stderr: "! First copy your one-time code: 1234-5678".to_string(),
+        };
+        assert!(result.exit_success);
+        let code = result
+            .code
+            .as_ref()
+            .unwrap_or_else(|| panic!("code must be present on success"));
+        assert_eq!(code.code, "1234-5678");
+    }
+
+    #[test]
+    fn auth_run_result_allows_failure_without_code() {
+        let result = AuthRunResult {
+            code: None,
+            exit_success: false,
+            stderr: "error: could not connect".to_string(),
+        };
+        assert!(!result.exit_success);
+        assert!(result.code.is_none());
+    }
+}

--- a/src/runtime/gh_auth.rs
+++ b/src/runtime/gh_auth.rs
@@ -79,10 +79,13 @@ pub fn run_device_auth() -> Result<AuthRunResult, GhError> {
     let stderr_thread = spawn_pipe_reader(child.stderr.take());
     let stdout_thread = spawn_pipe_reader(child.stdout.take());
 
-    let exit_success = wait_with_deadline(&mut child)?.success();
-
+    // On timeout `wait_with_deadline` kills the child, so the reader threads
+    // return promptly once their pipes close. Join them on BOTH paths so we
+    // never leak detached reader threads on an error (issue #244 OCR review).
+    let exit_status = wait_with_deadline(&mut child);
     let stderr_buf = stderr_thread.join().unwrap_or_default();
     let stdout_buf = stdout_thread.join().unwrap_or_default();
+    let exit_success = exit_status?.success();
 
     // gh writes the device code to stderr; fall back to scanning stdout too
     // (defensive — gh's stream choice has changed across versions).

--- a/src/runtime/gh_auth.rs
+++ b/src/runtime/gh_auth.rs
@@ -12,12 +12,21 @@
 //! `spawn_gh_task_with_panic` and delivers `AuthCodeReceived` / `AuthSucceeded`
 //! / `AuthFailed` events back to the state layer.
 
+use std::io::Read;
 use std::process::{Command, Stdio};
+use std::time::Duration;
 
 use crate::github::{
     AUTH_SCOPES, DeviceCode, GhError, build_auth_login_args, build_auth_login_env,
     parse_device_code,
 };
+
+/// Upper bound on how long `run_device_auth` will wait for `gh auth login --web`
+/// to exit before killing the child and surfacing a retryable error. Generous
+/// by design: it only bounds a hung subprocess (interactive-prompt leak,
+/// network stall, CLI bug) — `gh`'s own device-code flow expires server-side
+/// well before this and the user is authorizing in parallel (issue #244).
+const DEVICE_AUTH_WAIT_DEADLINE: Duration = Duration::from_secs(300);
 
 /// The outcome of running the device-code auth flow.
 ///
@@ -46,12 +55,9 @@ pub struct AuthRunResult {
 /// an `Err` — it is reported via `AuthRunResult::exit_success` so the caller
 /// can surface a retryable failure in-dialog.
 pub fn run_device_auth() -> Result<AuthRunResult, GhError> {
-    let args = build_auth_login_args(AUTH_SCOPES);
-    let env = build_auth_login_env();
-
     let mut command = Command::new("gh");
-    command.args(&args);
-    for (key, value) in &env {
+    command.args(build_auth_login_args(AUTH_SCOPES));
+    for (key, value) in &build_auth_login_env() {
         command.env(key, value);
     }
     // stdin closed so gh takes its non-interactive path (no "Press Enter").
@@ -59,7 +65,7 @@ pub fn run_device_auth() -> Result<AuthRunResult, GhError> {
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
 
-    let child = command.spawn().map_err(|e| {
+    let mut child = command.spawn().map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
             GhError::NotInstalled
         } else {
@@ -67,31 +73,72 @@ pub fn run_device_auth() -> Result<AuthRunResult, GhError> {
         }
     })?;
 
-    // `wait_with_output` drains stdout and stderr concurrently while waiting,
-    // avoiding the pipe-buffer deadlock that reading one pipe to EOF before
-    // the other can cause on large child output.
-    let output = child
-        .wait_with_output()
-        .map_err(|e| GhError::NetworkError(e.to_string()))?;
-    let exit_success = output.status.success();
+    // Drain stdout/stderr on reader threads so neither pipe can fill its kernel
+    // buffer and deadlock the child, while the main thread polls `try_wait`
+    // against a deadline (see `wait_with_deadline`).
+    let stderr_thread = spawn_pipe_reader(child.stderr.take());
+    let stdout_thread = spawn_pipe_reader(child.stdout.take());
 
-    let stderr_buf = String::from_utf8_lossy(&output.stderr).to_string();
-    let stdout_buf = String::from_utf8_lossy(&output.stdout).to_string();
+    let exit_success = wait_with_deadline(&mut child)?.success();
+
+    let stderr_buf = stderr_thread.join().unwrap_or_default();
+    let stdout_buf = stdout_thread.join().unwrap_or_default();
 
     // gh writes the device code to stderr; fall back to scanning stdout too
     // (defensive — gh's stream choice has changed across versions).
-    let combined = if stderr_buf.is_empty() {
-        stdout_buf
+    let combined: &str = if stderr_buf.is_empty() {
+        &stdout_buf
     } else {
-        stderr_buf.clone()
+        &stderr_buf
     };
-    let code = parse_device_code(&combined);
+    let code = parse_device_code(combined);
 
     Ok(AuthRunResult {
         code,
         exit_success,
         stderr: stderr_buf,
     })
+}
+
+/// Spawn a thread that drains a piped child stream to a `String`. Returns an
+/// empty-string thread if the pipe was not captured. Reading on a dedicated
+/// thread (one per pipe) prevents a pipe-buffer deadlock when the child writes
+/// more than the kernel buffer to one stream while we wait on the other.
+fn spawn_pipe_reader<R: Read + Send + 'static>(pipe: Option<R>) -> std::thread::JoinHandle<String> {
+    std::thread::spawn(move || {
+        pipe.map(|mut s| {
+            let mut buf = String::new();
+            let _ = s.read_to_string(&mut buf);
+            buf
+        })
+        .unwrap_or_default()
+    })
+}
+
+/// Poll `child.try_wait()` against `DEVICE_AUTH_WAIT_DEADLINE`. On expiry, kill
+/// the child and return a retryable `GhError::NetworkError` so the dispatch
+/// layer surfaces the failure in-dialog instead of blocking the worker thread
+/// forever (issue #244 OCR review: hang-safety).
+fn wait_with_deadline(
+    child: &mut std::process::Child,
+) -> Result<std::process::ExitStatus, GhError> {
+    let deadline = std::time::Instant::now() + DEVICE_AUTH_WAIT_DEADLINE;
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| GhError::NetworkError(e.to_string()))?
+        {
+            return Ok(status);
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            return Err(GhError::NetworkError(format!(
+                "gh auth login did not finish within {} seconds",
+                DEVICE_AUTH_WAIT_DEADLINE.as_secs()
+            )));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
 }
 
 #[cfg(test)]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -12,6 +12,8 @@ mod attach_scheduler;
 mod capabilities;
 mod commands;
 mod errors;
+/// One-shot `gh auth login --web` device-code subprocess driver (issue #244).
+mod gh_auth;
 mod liveness;
 mod manager;
 mod pane_capture;
@@ -26,6 +28,7 @@ pub use capabilities::{
     validate_code_puppy_launch,
 };
 pub use errors::RuntimeError;
+pub use gh_auth::{AuthRunResult, run_device_auth};
 pub use liveness::{check_remote_session_alive, check_session_alive, pid_alive};
 pub use manager::{LivenessCheck, RuntimeManager, TmuxRuntimeManager};
 pub use preflight::{

--- a/src/state/auth_ops.rs
+++ b/src/state/auth_ops.rs
@@ -82,6 +82,9 @@ impl AppState {
     fn auth_retry(&mut self) {
         if let ModalState::Auth { state } = &mut self.modal {
             state.phase = AuthDialogPhase::AwaitingCode;
+            // Clear any stale top-level error so the retried flow starts clean
+            // (issue #244 OCR review).
+            self.error_message = None;
         }
     }
 

--- a/src/state/auth_ops.rs
+++ b/src/state/auth_ops.rs
@@ -1,0 +1,94 @@
+//! In-app device-code auth dialog state-machine transitions (issue #244).
+//!
+//! These methods are the deterministic reducer for `ModalState::Auth` /
+//! `AuthDialogState`. They perform NO I/O. The runtime layer owns the
+//! `gh auth login --web` subprocess; the dispatch layer delivers the events.
+//!
+//! State machine:
+//!
+//! ```text
+//! Idle --OpenAuthDialog--> AwaitingCode
+//! AwaitingCode --AuthCodeReceived--> Confirming{code,url}
+//! AwaitingCode --AuthFailed--> Failed{error,can_retry=true}
+//! Confirming --AuthSucceeded--> (modal closed)
+//! Confirming --AuthFailed--> Failed{error,can_retry=true}
+//! Failed --AuthRetry--> AwaitingCode
+//! * (auth) --AuthCancelled--> (modal closed, actionable error_message set)
+//! ```
+//!
+//! Stray events that arrive when no auth modal is open are ignored (the modal
+//! may have been closed by success/cancel while a late subprocess event was
+//! in flight).
+
+use crate::messages::SystemMessage;
+
+use super::AppState;
+use super::types::{AuthDialogPhase, AuthDialogState, ModalState};
+
+/// The actionable message shown when the user cancels the auth dialog. It
+/// still tells them how to authenticate manually, so cancellation is never a
+/// dead end.
+const AUTH_CANCELLED_MESSAGE: &str =
+    "GitHub authentication cancelled. Run `gh auth login` in a terminal to authenticate manually.";
+
+impl AppState {
+    /// Apply a [`SystemMessage`] auth variant to the auth dialog state machine.
+    pub(super) fn apply_auth_message(&mut self, message: SystemMessage) {
+        match message {
+            SystemMessage::OpenAuthDialog => self.open_auth_dialog(),
+            SystemMessage::AuthCodeReceived { code, url } => self.auth_code_received(code, url),
+            SystemMessage::AuthSucceeded => self.auth_succeeded(),
+            SystemMessage::AuthFailed { error } => self.auth_failed(error),
+            SystemMessage::AuthCancelled => self.auth_cancelled(),
+            SystemMessage::AuthRetry => self.auth_retry(),
+            // Non-auth system messages are handled by the caller.
+            SystemMessage::Quit | SystemMessage::ClearError | SystemMessage::ClearWarning => {}
+        }
+    }
+
+    fn open_auth_dialog(&mut self) {
+        // Defense-in-depth: never replace an existing modal from underneath
+        // the user. The dispatch layer only opens auth when no other modal is
+        // active, but the reducer guards independently.
+        if !matches!(self.modal, ModalState::None) {
+            return;
+        }
+        self.modal = ModalState::Auth {
+            state: AuthDialogState::awaiting_code(),
+        };
+    }
+
+    fn auth_code_received(&mut self, code: String, url: String) {
+        if let ModalState::Auth { state } = &mut self.modal {
+            state.phase = AuthDialogPhase::Confirming { code, url };
+        }
+    }
+
+    fn auth_succeeded(&mut self) {
+        if matches!(self.modal, ModalState::Auth { .. }) {
+            self.modal = ModalState::None;
+        }
+    }
+
+    fn auth_failed(&mut self, error: String) {
+        if let ModalState::Auth { state } = &mut self.modal {
+            state.phase = AuthDialogPhase::Failed {
+                error,
+                can_retry: true,
+            };
+        }
+    }
+
+    fn auth_retry(&mut self) {
+        if let ModalState::Auth { state } = &mut self.modal {
+            state.phase = AuthDialogPhase::AwaitingCode;
+        }
+    }
+
+    fn auth_cancelled(&mut self) {
+        if matches!(self.modal, ModalState::Auth { .. }) {
+            self.modal = ModalState::None;
+            self.error_message = Some(AUTH_CANCELLED_MESSAGE.to_string());
+        }
+    }
+}

--- a/src/state/auth_ops_tests.rs
+++ b/src/state/auth_ops_tests.rs
@@ -222,3 +222,22 @@ fn auth_dialog_phase_debug_redacts_device_code() {
         "Debug should keep the non-secret URL, got: {debug}"
     );
 }
+
+#[test]
+fn auth_dialog_phase_debug_redacts_code_in_failed_error() {
+    // Defense-in-depth: even if a code-shaped string reaches the Failed error
+    // text, the Debug impl must scrub it (issue #244 OCR review).
+    let phase = AuthDialogPhase::Failed {
+        error: "code 7701-C5F6 expired".to_string(),
+        can_retry: true,
+    };
+    let debug = format!("{phase:?}");
+    assert!(
+        !debug.contains("7701-C5F6"),
+        "Failed Debug must not leak a code-shaped substring, got: {debug}"
+    );
+    assert!(
+        debug.contains("<redacted>"),
+        "Failed Debug should mark the redacted code, got: {debug}"
+    );
+}

--- a/src/state/auth_ops_tests.rs
+++ b/src/state/auth_ops_tests.rs
@@ -77,6 +77,15 @@ fn auth_retry_from_failed_returns_to_awaiting_code() {
 }
 
 #[test]
+fn auth_retry_clears_stale_error_message() {
+    // A retried flow should start with a clean error slate (issue #244 OCR).
+    let mut state = AppState::default().apply(AppEvent::OpenAuthDialog);
+    state.error_message = Some("stale".to_string());
+    let next = state.apply(AppEvent::AuthRetry);
+    assert_eq!(next.error_message, None);
+}
+
+#[test]
 fn auth_succeeded_from_confirming_closes_modal() {
     let state =
         AppState::default()

--- a/src/state/auth_ops_tests.rs
+++ b/src/state/auth_ops_tests.rs
@@ -1,0 +1,200 @@
+//! State-machine tests for the in-app device-code auth dialog (issue #244).
+//!
+//! These exercise the deterministic reducer transitions on
+//! `ModalState::Auth` / `AuthDialogState` only — no I/O, no runtime.
+
+use super::AppState;
+use super::events::AppEvent;
+use super::types::{AuthDialogPhase, AuthDialogState, ModalState};
+
+#[test]
+fn open_auth_dialog_from_no_modal_sets_awaiting_code() {
+    let state = AppState::default();
+    assert!(matches!(state.modal, ModalState::None));
+
+    let next = state.apply(AppEvent::OpenAuthDialog);
+    match &next.modal {
+        ModalState::Auth { state } => assert!(
+            matches!(state.phase, AuthDialogPhase::AwaitingCode),
+            "must be AwaitingCode after OpenAuthDialog"
+        ),
+        other => panic!("expected Auth modal, got {other:?}"),
+    }
+}
+
+#[test]
+fn auth_code_received_transitions_to_confirming_with_code_and_url() {
+    let state = AppState::default().apply(AppEvent::OpenAuthDialog);
+    let next = state.apply(AppEvent::AuthCodeReceived {
+        code: "7701-C5F6".to_string(),
+        url: "https://github.com/login/device".to_string(),
+    });
+    match &next.modal {
+        ModalState::Auth { state } => match &state.phase {
+            AuthDialogPhase::Confirming { code, url } => {
+                assert_eq!(code, "7701-C5F6");
+                assert_eq!(url, "https://github.com/login/device");
+            }
+            other => panic!("expected Confirming, got {other:?}"),
+        },
+        other => panic!("expected Auth modal, got {other:?}"),
+    }
+}
+
+#[test]
+fn auth_failed_from_awaiting_transitions_to_failed_with_retry() {
+    let state = AppState::default().apply(AppEvent::OpenAuthDialog);
+    let next = state.apply(AppEvent::AuthFailed {
+        error: "the device code expired".to_string(),
+    });
+    match &next.modal {
+        ModalState::Auth { state } => match &state.phase {
+            AuthDialogPhase::Failed { error, can_retry } => {
+                assert_eq!(error, "the device code expired");
+                assert!(*can_retry, "transient failures must offer retry");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        },
+        other => panic!("expected Auth modal, got {other:?}"),
+    }
+}
+
+#[test]
+fn auth_retry_from_failed_returns_to_awaiting_code() {
+    let state = AppState::default()
+        .apply(AppEvent::OpenAuthDialog)
+        .apply(AppEvent::AuthFailed {
+            error: "network".to_string(),
+        });
+    let next = state.apply(AppEvent::AuthRetry);
+    match &next.modal {
+        ModalState::Auth { state } => assert!(
+            matches!(state.phase, AuthDialogPhase::AwaitingCode),
+            "retry must return to AwaitingCode"
+        ),
+        other => panic!("expected Auth modal, got {other:?}"),
+    }
+}
+
+#[test]
+fn auth_succeeded_from_confirming_closes_modal() {
+    let state =
+        AppState::default()
+            .apply(AppEvent::OpenAuthDialog)
+            .apply(AppEvent::AuthCodeReceived {
+                code: "1234-5678".to_string(),
+                url: "https://github.com/login/device".to_string(),
+            });
+    let next = state.apply(AppEvent::AuthSucceeded);
+    assert!(
+        matches!(next.modal, ModalState::None),
+        "success must close the modal"
+    );
+}
+
+#[test]
+fn auth_failed_from_confirming_transitions_to_failed_with_retry() {
+    // The code was shown (Confirming) but then expired or was denied while gh
+    // was still running (gh exits non-zero). The dialog must NOT stick in
+    // Confirming — it must surface a retryable failure (issue #244 review #1).
+    let state =
+        AppState::default()
+            .apply(AppEvent::OpenAuthDialog)
+            .apply(AppEvent::AuthCodeReceived {
+                code: "1234-5678".to_string(),
+                url: "https://github.com/login/device".to_string(),
+            });
+    let next = state.apply(AppEvent::AuthFailed {
+        error: "the device code has expired".to_string(),
+    });
+    match &next.modal {
+        ModalState::Auth { state } => match &state.phase {
+            AuthDialogPhase::Failed { error, can_retry } => {
+                assert_eq!(error, "the device code has expired");
+                assert!(*can_retry, "expiry after display must offer retry");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        },
+        other => panic!("expected Auth modal, got {other:?}"),
+    }
+}
+
+#[test]
+fn auth_cancelled_closes_modal_and_sets_actionable_message() {
+    let state = AppState::default().apply(AppEvent::OpenAuthDialog);
+    let next = state.apply(AppEvent::AuthCancelled);
+    assert!(
+        matches!(next.modal, ModalState::None),
+        "cancel must close the modal"
+    );
+    let msg = next
+        .error_message
+        .as_deref()
+        .unwrap_or_else(|| panic!("cancel must set an actionable error_message"));
+    assert!(
+        msg.to_lowercase().contains("cancel"),
+        "error_message must mention cancellation, got: {msg}"
+    );
+    assert!(
+        msg.to_lowercase().contains("gh auth login"),
+        "error_message must still tell the user how to authenticate manually, got: {msg}"
+    );
+}
+
+#[test]
+fn auth_failed_then_succeeded_closes_modal() {
+    // Expired code → retry → new code → success.
+    let state = AppState::default()
+        .apply(AppEvent::OpenAuthDialog)
+        .apply(AppEvent::AuthFailed {
+            error: "expired".to_string(),
+        })
+        .apply(AppEvent::AuthRetry)
+        .apply(AppEvent::AuthCodeReceived {
+            code: "ABCD-EFGH".to_string(),
+            url: "https://github.com/login/device".to_string(),
+        });
+    let next = state.apply(AppEvent::AuthSucceeded);
+    assert!(matches!(next.modal, ModalState::None));
+}
+
+#[test]
+fn open_auth_dialog_does_not_clobber_existing_form_modal() {
+    // A form modal (e.g. NewRepository) must not be replaced by the auth
+    // dialog from underneath the user. The dispatch layer is responsible for
+    // only opening auth when no other modal is active; the reducer defends by
+    // ignoring OpenAuthDialog when a non-None modal is already open.
+    let state = AppState {
+        modal: ModalState::Help,
+        ..AppState::default()
+    };
+    let next = state.apply(AppEvent::OpenAuthDialog);
+    assert!(
+        matches!(next.modal, ModalState::Help),
+        "OpenAuthDialog must not replace an existing modal"
+    );
+}
+
+#[test]
+fn auth_code_received_ignored_when_no_auth_modal() {
+    // Stray late-arriving code events must not corrupt state when the modal
+    // has already been closed.
+    let state = AppState::default();
+    let next = state.apply(AppEvent::AuthCodeReceived {
+        code: "0000-0000".to_string(),
+        url: "https://github.com/login/device".to_string(),
+    });
+    assert!(matches!(next.modal, ModalState::None));
+}
+
+#[test]
+fn auth_succeeded_ignored_when_no_auth_modal() {
+    let next = AppState::default().apply(AppEvent::AuthSucceeded);
+    assert!(matches!(next.modal, ModalState::None));
+}
+
+#[test]
+fn auth_dialog_state_default_is_idle() {
+    let state = AuthDialogState::default();
+    assert!(matches!(state.phase, AuthDialogPhase::Idle));
+}

--- a/src/state/auth_ops_tests.rs
+++ b/src/state/auth_ops_tests.rs
@@ -198,3 +198,27 @@ fn auth_dialog_state_default_is_idle() {
     let state = AuthDialogState::default();
     assert!(matches!(state.phase, AuthDialogPhase::Idle));
 }
+
+#[test]
+fn auth_dialog_phase_debug_redacts_device_code() {
+    // The one-time code is a short-lived bearer credential; it must never
+    // leak through Debug output (logs / crash reports / snapshots). The
+    // verification URL is not secret and may appear (issue #244 OCR review).
+    let phase = AuthDialogPhase::Confirming {
+        code: "7701-C5F6".to_string(),
+        url: "https://github.com/login/device".to_string(),
+    };
+    let debug = format!("{phase:?}");
+    assert!(
+        !debug.contains("7701-C5F6"),
+        "Debug must not leak the device code, got: {debug}"
+    );
+    assert!(
+        debug.contains("<redacted>"),
+        "Debug should mark the redacted field, got: {debug}"
+    );
+    assert!(
+        debug.contains("github.com/login/device"),
+        "Debug should keep the non-secret URL, got: {debug}"
+    );
+}

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -101,6 +101,25 @@ pub enum AppEvent {
     ClearError,
     ClearWarning,
 
+    // In-app device-code auth remediation (issue #244)
+    /// Open the auth dialog and start the device-code flow.
+    OpenAuthDialog,
+    /// The one-time code + verification URL were parsed from `gh` stderr.
+    AuthCodeReceived {
+        code: String,
+        url: String,
+    },
+    /// The device-code flow completed successfully (token stored by `gh`).
+    AuthSucceeded,
+    /// The device-code flow failed (network, code expiry, denied).
+    AuthFailed {
+        error: String,
+    },
+    /// The user cancelled the auth dialog (Esc).
+    AuthCancelled,
+    /// The user requested a retry from the Failed phase.
+    AuthRetry,
+
     // Terminal scrollback (issue #198)
     /// Scroll the terminal viewport up (back in history) by one line.
     TerminalScrollUp,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -25,6 +25,8 @@ mod issues_load_ops;
 mod issues_mutation_ops;
 mod issues_ops;
 mod modal_ops;
+// In-app device-code auth dialog state machine (issue #244).
+mod auth_ops;
 // Per-repository user-preference snapshot/restore operations (issue #163).
 mod preferences_ops;
 // @plan PLAN-20260624-PR-MODE.P03
@@ -738,6 +740,7 @@ impl AppState {
             SystemMessage::ClearError => self.error_message = None,
             SystemMessage::ClearWarning => self.warning_message = None,
             SystemMessage::Quit => {}
+            auth => self.apply_auth_message(auth),
         }
     }
 
@@ -843,6 +846,11 @@ impl AppState {
 #[cfg(test)]
 #[path = "issues_tests.rs"]
 mod issues_tests;
+
+// In-app device-code auth dialog state-machine tests (issue #244).
+#[cfg(test)]
+#[path = "auth_ops_tests.rs"]
+mod auth_ops_tests;
 
 #[cfg(test)]
 #[path = "confirm_focus_tests.rs"]

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -97,11 +97,16 @@ impl std::fmt::Debug for AuthDialogPhase {
                 .field("code", &"<redacted>")
                 .field("url", url)
                 .finish(),
-            Self::Failed { error, can_retry } => f
-                .debug_struct("AuthDialogPhase::Failed")
-                .field("error", error)
-                .field("can_retry", can_retry)
-                .finish(),
+            Self::Failed { error, can_retry } => {
+                // Defense-in-depth: the dispatch layer already scrubs the code
+                // shape before storing, but redact again here so a future caller
+                // cannot leak a one-time code via a Debug print (issue #244).
+                let redacted = crate::github::redact_device_codes(error);
+                f.debug_struct("AuthDialogPhase::Failed")
+                    .field("error", &redacted)
+                    .field("can_retry", can_retry)
+                    .finish()
+            }
             Self::Cancelled => f.write_str("AuthDialogPhase::Cancelled"),
         }
     }

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -67,7 +67,11 @@ pub enum ConfirmFocus {
 /// The dialog drives `gh auth login --web` non-interactively; these phases
 /// track where the flow is so the UI is render-only and the reducer stays
 /// deterministic.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `Debug` is implemented manually to redact the one-time device code: it is
+/// a short-lived bearer credential while valid, so it must never leak through
+/// `AppState` debug logs, crash reports, or test snapshots.
+#[derive(Clone, PartialEq, Eq)]
 pub enum AuthDialogPhase {
     /// Dialog not shown (modal closed).
     Idle,
@@ -81,6 +85,26 @@ pub enum AuthDialogPhase {
     Failed { error: String, can_retry: bool },
     /// The user cancelled (Esc); the modal is being dismissed.
     Cancelled,
+}
+
+impl std::fmt::Debug for AuthDialogPhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Idle => f.write_str("AuthDialogPhase::Idle"),
+            Self::AwaitingCode => f.write_str("AuthDialogPhase::AwaitingCode"),
+            Self::Confirming { url, .. } => f
+                .debug_struct("AuthDialogPhase::Confirming")
+                .field("code", &"<redacted>")
+                .field("url", url)
+                .finish(),
+            Self::Failed { error, can_retry } => f
+                .debug_struct("AuthDialogPhase::Failed")
+                .field("error", error)
+                .field("can_retry", can_retry)
+                .finish(),
+            Self::Cancelled => f.write_str("AuthDialogPhase::Cancelled"),
+        }
+    }
 }
 
 /// State carried by [`ModalState::Auth`].

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -62,6 +62,54 @@ pub enum ConfirmFocus {
     Confirm,
 }
 
+/// Phase of the in-app device-code auth dialog state machine (issue #244).
+///
+/// The dialog drives `gh auth login --web` non-interactively; these phases
+/// track where the flow is so the UI is render-only and the reducer stays
+/// deterministic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthDialogPhase {
+    /// Dialog not shown (modal closed).
+    Idle,
+    /// `gh auth login` subprocess spawned; waiting for the one-time code to
+    /// be parsed from its stderr.
+    AwaitingCode,
+    /// Code + URL have been parsed and shown to the user; the subprocess is
+    /// polling until the user authorizes in a browser.
+    Confirming { code: String, url: String },
+    /// A transient failure occurred (network, code expiry); a retry is offered.
+    Failed { error: String, can_retry: bool },
+    /// The user cancelled (Esc); the modal is being dismissed.
+    Cancelled,
+}
+
+/// State carried by [`ModalState::Auth`].
+///
+/// Runtime-only — never persisted (auth is an interactive, ephemeral flow).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthDialogState {
+    pub phase: AuthDialogPhase,
+}
+
+impl Default for AuthDialogState {
+    fn default() -> Self {
+        Self {
+            phase: AuthDialogPhase::Idle,
+        }
+    }
+}
+
+impl AuthDialogState {
+    /// Construct a fresh dialog in the [`AuthDialogPhase::AwaitingCode`]
+    /// phase — the entry point when the auth flow starts.
+    #[must_use]
+    pub fn awaiting_code() -> Self {
+        Self {
+            phase: AuthDialogPhase::AwaitingCode,
+        }
+    }
+}
+
 /// Modal/form state variants.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum ModalState {
@@ -177,6 +225,11 @@ pub enum ModalState {
         fields: WorkflowDispatchFormFields,
         focus: WorkflowDispatchFormFocus,
         cursor: WorkflowDispatchFormCursor,
+    },
+    /// In-app device-code auth remediation dialog (issue #244). Render-only
+    /// data: the runtime layer owns the `gh auth login --web` subprocess.
+    Auth {
+        state: AuthDialogState,
     },
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,7 +15,7 @@ pub mod util;
 
 // Re-export commonly used types
 pub use components::{KeybindBar, Preview, SelectableList, Sidebar, StatusBar, TerminalView};
-pub use modals::{ConfirmModal, HelpModal};
+pub use modals::{AuthModal, ConfirmModal, HelpModal};
 pub use screens::{
     ActionsScreen, Dashboard, NewAgentForm, NewRepositoryForm, SplitScreen, ThemePickerScreen,
     WorkflowDispatchForm,

--- a/src/ui/modals/auth.rs
+++ b/src/ui/modals/auth.rs
@@ -67,9 +67,12 @@ fn confirming_lines(code: &str, url: &str) -> Vec<AuthDialogLine> {
 
 /// Build the comma-separated scopes string from the single source of truth
 /// (`AUTH_SCOPES`) so the consent text cannot drift from what the subprocess
-/// actually requests (issue #244 OCR review).
-fn scopes_display() -> String {
-    AUTH_SCOPES.join(", ")
+/// actually requests (issue #244 OCR review). Cached in a `OnceLock` because
+/// the scopes are static and the string is rebuilt on every render while the
+/// dialog is in the `Confirming` phase.
+fn scopes_display() -> &'static str {
+    static SCOPES: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    SCOPES.get_or_init(|| AUTH_SCOPES.join(", "))
 }
 
 fn failed_lines(error: &str, can_retry: bool) -> Vec<AuthDialogLine> {
@@ -233,6 +236,6 @@ mod tests {
     #[test]
     fn scopes_display_derives_from_auth_scopes() {
         // The consent text must come from AUTH_SCOPES, not a hardcoded copy.
-        assert_eq!(scopes_display(), AUTH_SCOPES.join(", "));
+        assert_eq!(scopes_display(), AUTH_SCOPES.join(", ").as_str());
     }
 }

--- a/src/ui/modals/auth.rs
+++ b/src/ui/modals/auth.rs
@@ -1,0 +1,204 @@
+//! In-app device-code auth remediation modal (issue #244).
+//!
+//! Follows the pure-views pattern: `auth_dialog_view` is an iocraft-free,
+//! side-effect-free projection that turns an `AuthDialogState` into a fixed
+//! list of display lines. The `AuthModal` iocraft component only renders that
+//! projection.
+//!
+//! @plan PLAN-20260712-AUTH-DIALOG.P04
+
+use iocraft::prelude::*;
+
+use crate::selection::{SelectablePane, TextSelection};
+use crate::state::{AuthDialogPhase, AuthDialogState};
+use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
+use crate::ui::components::selectable_line;
+
+/// The fixed title of the auth dialog.
+pub const AUTH_MODAL_TITLE: &str = "Authenticate with GitHub";
+
+/// A single display line in the auth dialog projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthDialogLine {
+    pub text: String,
+}
+
+/// The pure projection of the auth dialog: a fixed list of display lines
+/// derived solely from the dialog state. No iocraft types, no `Color`, no
+/// runtime — trivially unit-testable.
+#[must_use]
+pub fn auth_dialog_view(state: &AuthDialogState) -> Vec<AuthDialogLine> {
+    match &state.phase {
+        AuthDialogPhase::Idle | AuthDialogPhase::AwaitingCode => awaiting_code_lines(),
+        AuthDialogPhase::Confirming { code, url } => confirming_lines(code, url),
+        AuthDialogPhase::Failed { error, can_retry } => failed_lines(error, *can_retry),
+        AuthDialogPhase::Cancelled => vec![AuthDialogLine {
+            text: String::from("Cancelling..."),
+        }],
+    }
+}
+
+fn line(text: impl Into<String>) -> AuthDialogLine {
+    AuthDialogLine { text: text.into() }
+}
+
+fn awaiting_code_lines() -> Vec<AuthDialogLine> {
+    vec![
+        line(AUTH_MODAL_TITLE),
+        line(String::new()),
+        line("Starting the GitHub device-code flow..."),
+        line("A one-time code will appear here shortly."),
+        line("Press Esc to cancel."),
+    ]
+}
+
+fn confirming_lines(code: &str, url: &str) -> Vec<AuthDialogLine> {
+    vec![
+        line(AUTH_MODAL_TITLE),
+        line(String::new()),
+        line(format!("One-time code: {code}")),
+        line(format!("Open this URL: {url}")),
+        line("Enter the code in your browser to authorize Jefe."),
+        line("Scopes requested: repo, read:org, gist"),
+        line("Waiting for authorization... Press Esc to cancel."),
+    ]
+}
+
+fn failed_lines(error: &str, can_retry: bool) -> Vec<AuthDialogLine> {
+    let retry_hint = if can_retry {
+        "Press r or Enter to retry. Press Esc to cancel."
+    } else {
+        "Press Esc to cancel."
+    };
+    vec![
+        line(AUTH_MODAL_TITLE),
+        line(String::new()),
+        line(format!("Authentication failed: {error}")),
+        line(retry_hint),
+    ]
+}
+
+/// Props for the auth modal.
+#[derive(Default, Props)]
+pub struct AuthModalProps {
+    pub state: AuthDialogState,
+    pub colors: ThemeColors,
+    pub selection: Option<TextSelection>,
+}
+
+/// Auth remediation modal — render-only.
+#[component]
+pub fn AuthModal(props: &AuthModalProps) -> impl Into<AnyElement<'static>> {
+    let rc = ResolvedColors::from_theme(Some(&props.colors));
+    let sel = SelectionColors::from_resolved(&rc);
+    let pane = SelectablePane::ConfirmModal;
+    let selection = props.selection;
+
+    let view = auth_dialog_view(&props.state);
+    let lines: Vec<AnyElement<'static>> = view
+        .iter()
+        .enumerate()
+        .map(|(idx, line)| selectable_line(&line.text, idx, selection, pane, rc.fg, sel))
+        .collect();
+
+    // Padding (2) plus the projected line count, clamped to a sane height.
+    // `u32::try_from` avoids the truncation cast lint; the line count is tiny
+    // so the fallback is never hit in practice.
+    let line_count = u32::try_from(lines.len().max(1)).unwrap_or(50);
+    let height = line_count + 2;
+
+    element! {
+        Box(
+            flex_direction: FlexDirection::Column,
+            width: 64u32,
+            height: height,
+            border_style: BorderStyle::Round,
+            border_color: rc.border_focused,
+            background_color: rc.bg,
+            padding: 1u32,
+        ) {
+            #(lines)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AuthDialogPhase;
+
+    fn phase(p: AuthDialogPhase) -> AuthDialogState {
+        AuthDialogState { phase: p }
+    }
+
+    #[test]
+    fn awaiting_code_view_has_title_and_cancel_hint() {
+        let view = auth_dialog_view(&phase(AuthDialogPhase::AwaitingCode));
+        let texts: Vec<&str> = view.iter().map(|l| l.text.as_str()).collect();
+        assert_eq!(texts.first(), Some(&AUTH_MODAL_TITLE));
+        assert!(
+            texts.iter().any(|t| t.contains("Esc")),
+            "must tell the user how to cancel: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn confirming_view_shows_code_and_url_and_scopes() {
+        let view = auth_dialog_view(&phase(AuthDialogPhase::Confirming {
+            code: "7701-C5F6".to_string(),
+            url: "https://github.com/login/device".to_string(),
+        }));
+        let joined = view
+            .iter()
+            .map(|l| l.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(joined.contains("7701-C5F6"), "must show the code");
+        assert!(
+            joined.contains("https://github.com/login/device"),
+            "must show the URL"
+        );
+        assert!(
+            joined.contains("repo, read:org, gist"),
+            "must disclose the requested scopes for informed consent"
+        );
+    }
+
+    #[test]
+    fn failed_view_shows_error_and_retry_hint() {
+        let view = auth_dialog_view(&phase(AuthDialogPhase::Failed {
+            error: "the device code expired".to_string(),
+            can_retry: true,
+        }));
+        let joined = view
+            .iter()
+            .map(|l| l.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(joined.contains("the device code expired"));
+        assert!(joined.contains("retry"), "must offer retry when can_retry");
+    }
+
+    #[test]
+    fn failed_view_no_retry_omits_retry_hint() {
+        let view = auth_dialog_view(&phase(AuthDialogPhase::Failed {
+            error: "denied".to_string(),
+            can_retry: false,
+        }));
+        let joined = view
+            .iter()
+            .map(|l| l.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(!joined.contains("retry"));
+        assert!(joined.contains("Esc"));
+    }
+
+    #[test]
+    fn idle_view_matches_awaiting() {
+        // Idle is the pre-open default; it renders the same waiting screen.
+        let idle = auth_dialog_view(&phase(AuthDialogPhase::Idle));
+        let awaiting = auth_dialog_view(&phase(AuthDialogPhase::AwaitingCode));
+        assert_eq!(idle, awaiting);
+    }
+}

--- a/src/ui/modals/auth.rs
+++ b/src/ui/modals/auth.rs
@@ -33,7 +33,7 @@ pub fn auth_dialog_view(state: &AuthDialogState) -> Vec<AuthDialogLine> {
         AuthDialogPhase::Confirming { code, url } => confirming_lines(code, url),
         AuthDialogPhase::Failed { error, can_retry } => failed_lines(error, *can_retry),
         AuthDialogPhase::Cancelled => vec![AuthDialogLine {
-            text: String::from("Cancelling..."),
+            text: String::from("Cancelled."),
         }],
     }
 }

--- a/src/ui/modals/auth.rs
+++ b/src/ui/modals/auth.rs
@@ -9,6 +9,7 @@
 
 use iocraft::prelude::*;
 
+use crate::github::AUTH_SCOPES;
 use crate::selection::{SelectablePane, TextSelection};
 use crate::state::{AuthDialogPhase, AuthDialogState};
 use crate::theme::{ResolvedColors, SelectionColors, ThemeColors};
@@ -59,9 +60,16 @@ fn confirming_lines(code: &str, url: &str) -> Vec<AuthDialogLine> {
         line(format!("One-time code: {code}")),
         line(format!("Open this URL: {url}")),
         line("Enter the code in your browser to authorize Jefe."),
-        line("Scopes requested: repo, read:org, gist"),
+        line(format!("Scopes requested: {}", scopes_display())),
         line("Waiting for authorization... Press Esc to cancel."),
     ]
+}
+
+/// Build the comma-separated scopes string from the single source of truth
+/// (`AUTH_SCOPES`) so the consent text cannot drift from what the subprocess
+/// actually requests (issue #244 OCR review).
+fn scopes_display() -> String {
+    AUTH_SCOPES.join(", ")
 }
 
 fn failed_lines(error: &str, can_retry: bool) -> Vec<AuthDialogLine> {
@@ -110,7 +118,10 @@ pub fn AuthModal(props: &AuthModalProps) -> impl Into<AnyElement<'static>> {
     element! {
         Box(
             flex_direction: FlexDirection::Column,
-            width: 64u32,
+            // Wide enough for the device URL + a session id (the URL line is
+            // the longest projected line). Bumped from 64 after OCR review
+            // noted a ~50-char URL plus surrounding text could truncate.
+            width: 72u32,
             height: height,
             border_style: BorderStyle::Round,
             border_color: rc.border_focused,
@@ -200,5 +211,28 @@ mod tests {
         let idle = auth_dialog_view(&phase(AuthDialogPhase::Idle));
         let awaiting = auth_dialog_view(&phase(AuthDialogPhase::AwaitingCode));
         assert_eq!(idle, awaiting);
+    }
+
+    #[test]
+    fn cancelled_view_announces_completion() {
+        // The Cancelled phase is a completed state, so the text must read as
+        // done, not in-progress (issue #244 OCR review).
+        let view = auth_dialog_view(&phase(AuthDialogPhase::Cancelled));
+        let joined = view
+            .iter()
+            .map(|l| l.text.as_str())
+            .collect::<Vec<_>>()
+            .join(
+                "
+",
+            );
+        assert!(joined.contains("Cancelled."), "got: {joined}");
+        assert!(!joined.contains("Cancelling..."));
+    }
+
+    #[test]
+    fn scopes_display_derives_from_auth_scopes() {
+        // The consent text must come from AUTH_SCOPES, not a hardcoded copy.
+        assert_eq!(scopes_display(), AUTH_SCOPES.join(", "));
     }
 }

--- a/src/ui/modals/mod.rs
+++ b/src/ui/modals/mod.rs
@@ -6,6 +6,10 @@
 mod confirm;
 mod help;
 
+// In-app device-code auth remediation modal (issue #244).
+mod auth;
+
+pub use auth::{AUTH_MODAL_TITLE, AuthModal, AuthModalProps};
 pub use confirm::{ConfirmModal, ConfirmModalProps};
 pub use help::{
     HELP_CHROME_ROWS, HELP_MODAL_WIDTH, HELP_TITLE, HelpModal, HelpModalProps, help_content_lines,

--- a/src/ui/orchestration.rs
+++ b/src/ui/orchestration.rs
@@ -9,7 +9,7 @@ use crate::state::{AppState, ConfirmFocus, ModalState, ScreenMode};
 use crate::theme::ThemeColors;
 use crate::ui::screens::{ActionsScreen, IssuesScreen, PullRequestsScreen, ThemePickerScreen};
 use crate::ui::{
-    ConfirmModal, Dashboard, HelpModal, NewAgentForm, NewRepositoryForm, SplitScreen,
+    AuthModal, ConfirmModal, Dashboard, HelpModal, NewAgentForm, NewRepositoryForm, SplitScreen,
     WorkflowDispatchForm,
 };
 
@@ -324,6 +324,25 @@ pub fn build_modal_element(
             }
             .into_any()
         }),
+        // In-app device-code auth remediation dialog (issue #244). Render-only:
+        // receives the dialog state as plain data.
+        ModalState::Auth { state } => Some(auth_modal_element(state, colors, snapshot)),
         _ => None,
     }
+}
+
+/// Build the render-only auth remediation modal element (issue #244).
+fn auth_modal_element(
+    state: &crate::state::AuthDialogState,
+    colors: &ThemeColors,
+    snapshot: &AppState,
+) -> AnyElement<'static> {
+    element! {
+        AuthModal(
+            state: state.clone(),
+            colors: colors.clone(),
+            selection: snapshot.selection,
+        )
+    }
+    .into_any()
 }


### PR DESCRIPTION
## Summary

Closes #244.

When a GitHub operation failed because `gh` was not authenticated, Jefe only surfaced a static "run `gh auth login`" error that forced the user out of the TUI. The detection layer (`categorize_error` -> `GhError::NotAuthenticated`) was already in place and tested; what was missing was the remediation UX. This PR adds an in-app modal that drives the OAuth device-code flow itself, so the user never has to leave Jefe.

## What it does

- On a `NotAuthenticated` failure across the issues/PRs/actions list and detail paths, the dispatch layer opens `ModalState::Auth` instead of (or in addition to) the bare error string.
- The runtime layer spawns `gh auth login --web --hostname github.com --git-protocol https --scopes repo --scopes read:org --scopes gist` **non-interactively**: stdin is closed so `gh`'s `CanPrompt()` is false (no "Press Enter" prompt), and `GH_BROWSER=/bin/true` so `gh` never spawns a browser on a headless/remote host. The user opens the verification URL on whatever device they choose.
- The one-time code and verification URL are parsed from `gh`'s stderr (ANSI-tolerant) and rendered by a render-only modal (`AuthModal` consuming the pure `auth_dialog_view` projection).
- The state machine transitions: `idle -> awaiting-code -> confirming -> success | failed (retryable) | cancelled`. Esc cancels; `r`/Enter retries from the `Failed` phase. Success closes the modal and returns the user to the operation that was blocked.

## Architecture (module boundaries respected)

| Concern | Owner | Files |
|---|---|---|
| Pure scopes/args/env/parser + shared detector | github boundary | `src/github/auth_device.rs`, `src/github/parse.rs` (`not_authenticated_matcher`) |
| State machine + reducer | state layer | `src/state/auth_ops.rs`, `src/state/types.rs`, `src/state/events.rs` |
| Subprocess spawn | runtime layer | `src/runtime/gh_auth.rs` (one-shot subprocess, NOT a PTY session) |
| Message routing | messages | `src/messages.rs`, `src/messages/event_conversion.rs` (SystemMessage channel) |
| Dispatch trigger + flow spawn | app_input | `src/app_input/auth_remediation.rs` + the 5 `persist_*_failed`/detail sites |
| Key handling | app_input | `src/app_input/modal_handlers.rs` (`handle_mode_auth_key`); routing in `app_shell.rs`, `input.rs`, `mouse_routing.rs` |
| Render-only modal | UI | `src/ui/modals/auth.rs` (pure `auth_dialog_view` + thin `AuthModal`); wired in `ui/orchestration.rs` |

`categorize_error`/`check_auth()` remain the single source of truth for detection — the dispatch predicate reuses a shared `not_authenticated_matcher` so it cannot drift from the categorizer.

## Testing (TDD, no mock theater)

- `github_tests::auth_device` — scope list is exactly `["repo","read:org","gist"]`; argv assembly; env (`GH_BROWSER=/bin/true`); stderr parser against real `gh` output (incl. ANSI); malformed/missing code cases.
- `state::auth_ops_tests` — every state-machine transition, including `Confirming --AuthFailed--> Failed (retryable)` (the expiry-after-display case) and stray-event guards.
- `app_input::auth_remediation` — the dispatch predicate (auth candidate only when `NotAuthenticated` and no modal is open).
- `runtime::gh_auth` — `AuthRunResult` shape.
- `ui::modals::auth` — pure projection lines for each phase (title, code, URL, scope disclosure, retry hint).
- `dev-docs/tmux-scenarios/auth-dialog.json` — manual TUI scenario (not a CI gate; requires an unauthenticated `gh` + real browser). Documented in `dev-docs/testing/tmux-harness.md`.

The subprocess spawn is intentionally a thin wrapper over `std::process::Command` (uses `wait_with_output` to drain stdout/stderr concurrently and avoid pipe-buffer deadlock); its correctness is proven by the parser + args/env tests + the e2e scenario.

## Review remediation

A pre-PR review caught one correctness defect: when the one-time code was shown but then expired or was denied (`gh` exits non-zero), no `AuthFailed` fired and the dialog stuck in `Confirming`. Fixed by surfacing `AuthFailed` on any non-zero exit after the flow started, with a `Confirming --AuthFailed--> Failed (retryable)` state test. Also: detection deduplicated into a shared matcher; `wait_with_output` replaces sequential pipe reads; the orphaned-`gh`-on-cancel behavior is documented (bounded by `gh`'s server-side device-code expiry).

## Verification

`make ci-check` passes: `cargo fmt --check`, clippy allow/source-size policy, clippy `-D warnings` (both gates), coverage **72.91%** (floor 30), `cargo build --workspace --all-features --locked`, and `cargo test --workspace --all-features --locked` (2374 tests, 0 failures).

## Notes / known limitations

- Esc closes the modal but does not kill the background `gh` subprocess (its `Child` handle is not retained across the dispatch seam). This is accepted for v1: with stdin null + `GH_BROWSER=/bin/true`, `gh` exits on its own when the device code expires (~15 min server-side) or the user authorizes elsewhere. The leak is bounded and inert.
- The TUI scenario is manual (not CI) because it requires an unauthenticated `gh` and a real browser authorization to complete the flow.