### PR TITLE
Use workflow filename (not full path) for Actions runs API endpoint (Fixes #206)

### DIFF
--- a/project-plans/issue206-plan.md
+++ b/project-plans/issue206-plan.md
@@ -1,0 +1,78 @@
+# Issue #206 — Actions workflow filter returns no runs (full path sent to API)
+
+## Root cause (verified empirically)
+
+`build_runs_api_path` in `src/github/actions.rs` builds the filtered runs endpoint
+using `percent_encode_path(&filter.workflow_path)`. `percent_encode_path` deliberately
+keeps `/` unescaped, so for `workflow_path = ".github/workflows/ocr-review.yml"` the
+produced URL path is:
+
+    repos/{owner}/{repo}/actions/workflows/.github/workflows/ocr-review.yml/runs?...
+
+The literal slashes split the path into extra segments, so GitHub routes it as a
+different resource and returns **HTTP 404 "Not Found"** (confirmed: `gh api` exits 1,
+stderr `gh: Not Found (HTTP 404)`). The reducer's `fail_runs_load` then sets
+`actions_state.error` and leaves `runs` empty, producing the observed "no runs".
+
+The GitHub REST API `actions/workflows/{workflow_id_or_filename}/runs` endpoint
+accepts the **bare workflow filename** (e.g. `ocr-review.yml`) — verified it returns
+200 with 376 runs for the OCR Review workflow.
+
+The "message flashes at the top" is the 404 error banner rendered from
+`actions_state.error` while the empty list renders "No workflow runs match filters".
+Fixing the filename eliminates the 404, so the flash disappears. The error-handling
+plumbing (`fail_runs_load` / `complete_runs_load` clearing `error`) is already sound
+and persists errors until a successful reload — no separate flash bug to fix.
+
+## Scope (single file: `src/github/actions.rs`)
+
+### Production change — `build_runs_api_path`
+
+Extract the **bare filename** (last path segment of `filter.workflow_path`) and use
+that as the `{filename}` path segment. Keep `workflow_path` semantics everywhere else
+(state, cycling, committed filter) unchanged — only the API path construction changes.
+
+Add a small pure helper `workflow_filename(path: &str) -> &str` that returns the
+substring after the last `/` (or the whole string if there is no `/`). Use it inside
+`build_runs_api_path` so the encoded segment is the filename only.
+
+The `percent_encode_path` helper no longer needs to keep `/` verbatim for the workflow
+segment (since we now pass only the filename), but it is also used nowhere else and
+MUST NOT be loosened/tightened in a way that affects correctness — keep its behavior,
+just feed it the filename. (The `/` passthrough becomes dead for this call site but is
+harmless; leave the function as-is to avoid scope creep.)
+
+### Test changes — same file's `#[cfg(test)] mod tests`
+
+1. **Update** `build_runs_api_path_uses_workflow_path_not_name`: this test currently
+   asserts the buggy behavior (`path.contains(".github/workflows/ci.yml")`). Change it
+   to assert the FIX: the API path contains `/workflows/ci.yml/runs` (bare filename)
+   and does NOT contain `.github/` or an encoded `%2F`. Rename to
+   `build_runs_api_path_uses_workflow_filename_not_full_path` for clarity.
+
+2. **Add** `build_runs_api_path_uses_filename_for_nested_workflow_path`: with
+   `workflow_path = ".github/workflows/ocr-review.yml"`, assert the path contains
+   `ocr-review.yml` and does NOT contain `.github` or `workflows/ocr-review.yml`
+   (i.e. only the last segment is used).
+
+3. **Add** `build_runs_api_path_filename_without_directory_separator`: when
+   `workflow_path` has no `/` (defensive: a workflow path that is already just a
+   filename), the whole value is used unchanged.
+
+4. Keep existing `build_runs_api_path_no_workflow_filter` and
+   `build_runs_api_path_with_status_filter` passing unchanged.
+
+### Out of scope
+- No state-layer changes (`workflow_path` stays the full path for cycling/matching).
+- No UI/error-banner changes (the 404 is eliminated at the source).
+- No changes to `percent_encode_path`/`percent_encode_query` behavior.
+
+## TDD sequence
+1. RED: update test (1) and add tests (2), (3) first; `cargo test build_runs_api_path`
+   fails because the current code emits the full path.
+2. GREEN: add `workflow_filename` helper and use it in `build_runs_api_path`; tests pass.
+3. REFACTOR: keep the helper next to `percent_encode_path` with a doc comment explaining
+   the GitHub API requires the filename, not the full path.
+
+## Verification
+`make ci-check` (fmt --check, clippy `-D warnings`, coverage >=30, build, test).

--- a/src/github/actions.rs
+++ b/src/github/actions.rs
@@ -7,15 +7,14 @@ use std::fmt::Write;
 use std::process::Command;
 
 /// Percent-encode a value for use in a URL path segment (RFC 3986). Keeps
-/// unreserved characters (`A-Za-z0-9-._~`) verbatim; encodes everything else.
-/// Callers pass a bare workflow filename (see [`workflow_filename`]), so `/`
-/// passthrough is retained only for robustness, not because path segments
-/// contain slashes.
+/// unreserved characters (`A-Za-z0-9-._~`) verbatim; encodes everything else,
+/// including `/` (as `%2F`) so a stray full path can never silently leak
+/// slashes into a single path segment and reproduce the #206 404.
 fn percent_encode_path(value: &str) -> String {
     let mut out = String::with_capacity(value.len());
     for &b in value.as_bytes() {
         match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
                 out.push(b as char);
             }
             _ => {
@@ -418,6 +417,22 @@ impl GhClient {
 mod tests {
     use super::*;
     use crate::domain::ActionsFilter;
+
+    /// `percent_encode_path` must encode `/` as `%2F` so a stray full path
+    /// passed without going through `workflow_filename` can never silently
+    /// leak slashes into a single path segment (the #206 404 regression).
+    #[test]
+    fn percent_encode_path_encodes_slash() {
+        let encoded = percent_encode_path(".github/workflows/ci.yml");
+        assert!(
+            encoded.contains("%2F"),
+            "slash must be percent-encoded, got: {encoded}"
+        );
+        assert!(
+            !encoded.contains('/'),
+            "no literal slash may remain, got: {encoded}"
+        );
+    }
 
     /// The API path must use the workflow FILENAME (last path segment), not
     /// the full `.github/workflows/ci.yml` path. The GitHub REST endpoint

--- a/src/github/actions.rs
+++ b/src/github/actions.rs
@@ -6,10 +6,14 @@ use crate::domain::{
 use std::fmt::Write;
 use std::process::Command;
 
-/// Percent-encode a value for use in a URL path segment (RFC 3986). Keeps
-/// unreserved characters (`A-Za-z0-9-._~`) verbatim; encodes everything else,
-/// including `/` (as `%2F`) so a stray full path can never silently leak
-/// slashes into a single path segment and reproduce the #206 404.
+/// Percent-encode a SINGLE URL path segment (RFC 3986). Keeps unreserved
+/// characters (`A-Za-z0-9-._~`) verbatim; encodes everything else, including
+/// `/` (as `%2F`) so a stray full path can never silently leak slashes into
+/// one segment and reproduce the #206 404.
+///
+/// This is intentionally segment-only: it does NOT preserve `/` as a path
+/// separator. Callers building multi-segment paths must join already-encoded
+/// segments with literal `/` themselves; do not pass a composite path here.
 fn percent_encode_path(value: &str) -> String {
     let mut out = String::with_capacity(value.len());
     for &b in value.as_bytes() {

--- a/src/github/actions.rs
+++ b/src/github/actions.rs
@@ -294,6 +294,11 @@ fn run_gh<S: AsRef<std::ffi::OsStr>>(args: &[S]) -> Result<String, GhError> {
 /// REST API rejects the full `.github/workflows/...` path (literal slashes
 /// route to a different resource, returning HTTP 404) and also rejects the
 /// `workflow` display name with HTTP 404.
+///
+/// The sentinel ("all") and emptiness checks run against the normalized
+/// filename, so non-canonical inputs (`"all/"`, `"/"`, `"///"`, `""`) all
+/// fall through to the generic `actions/runs` endpoint rather than producing
+/// a malformed workflow-specific URL.
 #[must_use]
 pub fn build_runs_api_path(
     owner: &str,
@@ -302,9 +307,14 @@ pub fn build_runs_api_path(
     page: u32,
     per_page: u32,
 ) -> String {
-    let workflow_enc = percent_encode_path(workflow_filename(&filter.workflow_path));
+    // Normalize once: the sentinel ("all") and emptiness checks run against
+    // the SAME value used in the path segment, so "all/", "/", "///", and ""
+    // all route to the generic runs endpoint instead of producing malformed
+    // workflow-specific URLs like /workflows/all/runs or /workflows//runs.
+    let workflow_id = workflow_filename(&filter.workflow_path);
+    let workflow_enc = percent_encode_path(workflow_id);
     let status_enc = percent_encode_query(&filter.status);
-    let mut api_path = if filter.workflow_path != "all" && !filter.workflow_path.is_empty() {
+    let mut api_path = if workflow_id != "all" && !workflow_id.is_empty() {
         format!(
             "repos/{owner}/{repo}/actions/workflows/{workflow_enc}/runs?page={page}&per_page={per_page}"
         )
@@ -535,6 +545,29 @@ mod tests {
             path.ends_with("/actions/runs?page=1&per_page=30"),
             "expected generic runs endpoint, got: {path}"
         );
+    }
+
+    /// Non-canonical "all" / empty inputs must fall through to the generic
+    /// runs endpoint, not a malformed workflow-specific URL. The sentinel is
+    /// checked against the normalized filename, so "all/" and "///" resolve
+    /// to "all" / "" respectively.
+    #[test]
+    fn build_runs_api_path_non_canonical_all_routes_to_generic_endpoint() {
+        for raw in ["all/", "/", "///", ""] {
+            let filter = ActionsFilter {
+                workflow_path: raw.to_string(),
+                ..ActionsFilter::default()
+            };
+            let path = build_runs_api_path("owner", "repo", &filter, 1, 30);
+            assert!(
+                path.ends_with("/actions/runs?page=1&per_page=30"),
+                "raw {raw:?} must route to the generic runs endpoint, got: {path}"
+            );
+            assert!(
+                !path.contains("/workflows/"),
+                "raw {raw:?} must not produce a workflow-specific URL, got: {path}"
+            );
+        }
     }
 
     /// Status filter is appended as a query parameter.

--- a/src/github/actions.rs
+++ b/src/github/actions.rs
@@ -7,8 +7,10 @@ use std::fmt::Write;
 use std::process::Command;
 
 /// Percent-encode a value for use in a URL path segment (RFC 3986). Keeps
-/// unreserved characters (`A-Za-z0-9-._~`) and `/` (workflow filter may be a
-/// `.github/workflows/ci.yml` path) verbatim; encodes everything else.
+/// unreserved characters (`A-Za-z0-9-._~`) verbatim; encodes everything else.
+/// Callers pass a bare workflow filename (see [`workflow_filename`]), so `/`
+/// passthrough is retained only for robustness, not because path segments
+/// contain slashes.
 fn percent_encode_path(value: &str) -> String {
     let mut out = String::with_capacity(value.len());
     for &b in value.as_bytes() {
@@ -22,6 +24,20 @@ fn percent_encode_path(value: &str) -> String {
         }
     }
     out
+}
+
+/// Return the bare workflow filename (last path segment) of a workflow
+/// file path. The GitHub REST API
+/// `repos/{owner}/{repo}/actions/workflows/{workflow_id_or_filename}/runs`
+/// endpoint accepts the workflow's filename (e.g. `ci.yml`) but NOT the
+/// full `.github/workflows/ci.yml` path — literal slashes in the path
+/// segment make the API route to a different resource and return 404.
+#[must_use]
+fn workflow_filename(path: &str) -> &str {
+    match path.rsplit_once('/') {
+        Some((_, name)) => name,
+        None => path,
+    }
 }
 
 /// Percent-encode a value for use in a URL query component (RFC 3986). Keeps
@@ -263,9 +279,13 @@ fn run_gh<S: AsRef<std::ffi::OsStr>>(args: &[S]) -> Result<String, GhError> {
 
 /// Build the GitHub API path for listing workflow runs with filters.
 ///
-/// Pure function extracted from `list_runs` for unit testability — verifies
-/// the workflow filter uses `workflow_path` (file path) not `workflow` (display
-/// name), since the API rejects display names with HTTP 404.
+/// Pure function extracted from `list_runs` for unit testability. When a
+/// workflow filter is set, only the bare **filename** of `workflow_path`
+/// (its last `/`-separated segment, via [`workflow_filename`]) is sent as
+/// the `actions/workflows/{filename}/runs` endpoint segment — the GitHub
+/// REST API rejects the full `.github/workflows/...` path (literal slashes
+/// route to a different resource, returning HTTP 404) and also rejects the
+/// `workflow` display name with HTTP 404.
 #[must_use]
 pub fn build_runs_api_path(
     owner: &str,
@@ -274,7 +294,7 @@ pub fn build_runs_api_path(
     page: u32,
     per_page: u32,
 ) -> String {
-    let workflow_enc = percent_encode_path(&filter.workflow_path);
+    let workflow_enc = percent_encode_path(workflow_filename(&filter.workflow_path));
     let status_enc = percent_encode_query(&filter.status);
     let mut api_path = if filter.workflow_path != "all" && !filter.workflow_path.is_empty() {
         format!(
@@ -399,10 +419,13 @@ mod tests {
     use super::*;
     use crate::domain::ActionsFilter;
 
-    /// The API path must use the workflow FILE PATH, not the display name.
-    /// Using the display name would produce HTTP 404 (BUG 2).
+    /// The API path must use the workflow FILENAME (last path segment), not
+    /// the full `.github/workflows/ci.yml` path. The GitHub REST endpoint
+    /// `actions/workflows/{workflow_id_or_filename}/runs` rejects the full
+    /// path with HTTP 404 because the literal slashes split the path into
+    /// wrong segments.
     #[test]
-    fn build_runs_api_path_uses_workflow_path_not_name() {
+    fn build_runs_api_path_uses_workflow_filename_not_full_path() {
         let filter = ActionsFilter {
             workflow: "CI".to_string(),
             workflow_path: ".github/workflows/ci.yml".to_string(),
@@ -410,12 +433,55 @@ mod tests {
         };
         let path = build_runs_api_path("owner", "repo", &filter, 1, 30);
         assert!(
-            path.contains(".github/workflows/ci.yml"),
-            "API path must contain the workflow file path, got: {path}"
+            path.contains("/workflows/ci.yml/runs"),
+            "API path must contain the bare workflow filename, got: {path}"
+        );
+        assert!(
+            !path.contains(".github/"),
+            "API path must NOT leak the full directory path, got: {path}"
+        );
+        assert!(
+            !path.contains("%2F"),
+            "API path must NOT contain encoded slashes, got: {path}"
         );
         assert!(
             !path.contains("/workflows/CI/"),
             "API path must NOT contain the display name, got: {path}"
+        );
+    }
+
+    /// A nested workflow path like `.github/workflows/ocr-review.yml` must
+    /// resolve to the bare filename `ocr-review.yml` in the API path segment.
+    #[test]
+    fn build_runs_api_path_uses_filename_for_nested_workflow_path() {
+        let filter = ActionsFilter {
+            workflow: "OCR Review".to_string(),
+            workflow_path: ".github/workflows/ocr-review.yml".to_string(),
+            ..ActionsFilter::default()
+        };
+        let path = build_runs_api_path("owner", "repo", &filter, 1, 30);
+        // Exact contract: only the bare filename appears as the workflow
+        // segment; the `.github/workflows/` prefix must not leak into the URL.
+        assert_eq!(
+            path, "repos/owner/repo/actions/workflows/ocr-review.yml/runs?page=1&per_page=30",
+            "API path must use the bare workflow filename, got: {path}"
+        );
+    }
+
+    /// A workflow path that is already just a filename (no directory
+    /// separator) must be used unchanged. Defensive: guards against future
+    /// state changes where the path may be normalized to a bare filename.
+    #[test]
+    fn build_runs_api_path_filename_without_directory_separator() {
+        let filter = ActionsFilter {
+            workflow: "CI".to_string(),
+            workflow_path: "ci.yml".to_string(),
+            ..ActionsFilter::default()
+        };
+        let path = build_runs_api_path("owner", "repo", &filter, 1, 30);
+        assert!(
+            path.contains("/workflows/ci.yml/runs"),
+            "API path must contain the bare filename, got: {path}"
         );
     }
 

--- a/src/github/actions.rs
+++ b/src/github/actions.rs
@@ -31,11 +31,16 @@ fn percent_encode_path(value: &str) -> String {
 /// endpoint accepts the workflow's filename (e.g. `ci.yml`) but NOT the
 /// full `.github/workflows/ci.yml` path — literal slashes in the path
 /// segment make the API route to a different resource and return 404.
+///
+/// Trailing slashes are trimmed first so a non-canonical path like
+/// `.github/workflows/ci.yml/` resolves to `ci.yml` rather than an empty
+/// segment (which would produce a malformed `/workflows//runs` URL).
 #[must_use]
 fn workflow_filename(path: &str) -> &str {
-    match path.rsplit_once('/') {
+    let trimmed = path.trim_end_matches('/');
+    match trimmed.rsplit_once('/') {
         Some((_, name)) => name,
-        None => path,
+        None => trimmed,
     }
 }
 
@@ -431,6 +436,22 @@ mod tests {
         assert!(
             !encoded.contains('/'),
             "no literal slash may remain, got: {encoded}"
+        );
+    }
+
+    /// A non-canonical trailing slash must not collapse the filename to an
+    /// empty segment (which would yield a malformed `/workflows//runs` URL).
+    #[test]
+    fn build_runs_api_path_trailing_slash_still_uses_filename() {
+        let filter = ActionsFilter {
+            workflow: "CI".to_string(),
+            workflow_path: ".github/workflows/ci.yml/".to_string(),
+            ..ActionsFilter::default()
+        };
+        let path = build_runs_api_path("owner", "repo", &filter, 1, 30);
+        assert_eq!(
+            path, "repos/owner/repo/actions/workflows/ci.yml/runs?page=1&per_page=30",
+            "trailing slash must be trimmed before extracting the filename, got: {path}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the Actions-mode workflow filter returning no runs (and a transient error banner) because the full workflow file path was sent to the GitHub REST API instead of the bare workflow filename.

Fixes #206

## Root cause (verified empirically)

`build_runs_api_path` in `src/github/actions.rs` built the filtered runs endpoint by percent-encoding `filter.workflow_path` (the full path, e.g. `.github/workflows/ocr-review.yml`). The `percent_encode_path` helper kept `/` unescaped, so the resulting URL path was:

    repos/{owner}/{repo}/actions/workflows/.github/workflows/ocr-review.yml/runs?...

The literal slashes split the path into wrong segments, and GitHub routed it to a different resource, returning **HTTP 404 "Not Found"**. The reducer's `fail_runs_load` then set `actions_state.error` and left `runs` empty — producing the observed "no runs" plus the flashing 404 error banner.

Confirmed against the live API:
- `gh api repos/.../actions/workflows/.github/workflows/ocr-review.yml/runs` → **404** (exit 1, `gh: Not Found (HTTP 404)`)
- `gh api repos/.../actions/workflows/ocr-review.yml/runs` → **200**, 376 runs

The GitHub REST endpoint `actions/workflows/{workflow_id_or_filename}/runs` accepts the **bare workflow filename** (last path segment), not the full `.github/workflows/...` path.

## The "message flashes at the top"

The flash is the 404 error banner rendered from `actions_state.error` while the empty list renders "No workflow runs match filters". Fixing the filename eliminates the 404 at the source, so the flash disappears. The error-handling plumbing (`fail_runs_load` / `complete_runs_load` clearing `error` on a successful reload) is already sound and persists errors until a successful reload — no separate UI/state bug to fix.

## Changes (single file: `src/github/actions.rs`)

- **New pure helper** `workflow_filename(path: &str) -> &str` — returns the last `/`-separated segment of a workflow file path (the bare filename the API requires).
- **`build_runs_api_path`** now encodes `workflow_filename(&filter.workflow_path)` instead of the full path. The `workflow_path` field is unchanged everywhere else (state, cycling, committed filter) — it still holds the full path for matching/cycling; only the API path construction changes.
- **`percent_encode_path`** now encodes `/` as `%2F` (previously passed `/` through verbatim). The passthrough became dead code after the filename extraction, but leaving it would let a future caller that bypasses `workflow_filename` silently leak slashes into a path segment and reproduce the 404. Encoding `/` closes that regression vector.
- **Tests** (TDD: RED → GREEN):
  - Updated `build_runs_api_path_uses_workflow_filename_not_full_path` (was `..._uses_workflow_path_not_name`, which asserted the buggy behavior) — now asserts the bare filename is used, the full `.github/` path does not leak, and no `%2F` appears.
  - Added `build_runs_api_path_uses_filename_for_nested_workflow_path` — exact-equality assertion for the `.github/workflows/ocr-review.yml` → `ocr-review.yml` case from the issue.
  - Added `build_runs_api_path_filename_without_directory_separator` — defensive: a path with no `/` is used unchanged.
  - Added `percent_encode_path_encodes_slash` — guards the encoder against a future `/`-passthrough regression.

## Verification

- `cargo fmt --all --check` — pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — pass
- `cargo build --workspace --all-features --locked` — pass
- `cargo test --workspace --all-features --locked` — 1603 lib tests pass
- `scripts/check-architecture.sh`, `scripts/check-clippy-allows.sh`, `scripts/check-source-file-size.sh` — pass
- Reviewed by `rustreviewer` (APPROVE) and `ocr` / Open Code Review (one medium finding addressed: the dead `/` passthrough).

## Pre-existing test note

`harness::runner::tests::guarded_real_jefe_sticky_kill_scenario` fails identically on `main` (commit a1b33cf) in the local environment — it is a tmux-backed TUI scenario about dead-agent sticky visibility, unrelated to this Actions-mode URL fix. It is environment-sensitive (spawns the real binary in a tmux session); this change touches only pure URL construction in `src/github/actions.rs` and cannot affect agent-lifecycle rendering.

## Scope

Minimal, confined to `src/github/actions.rs`. No state-layer, UI, or persistence changes. No `unwrap`/`expect` in production, no `unsafe`, no lint suppression, no complexity-threshold changes.
