### PR TITLE
Restore mouse wheel/scrollbar/scroll-key scrolling for llxprt terminals (Fixes #245)

### DIFF
--- a/.jefe/pr-body-245.md
+++ b/.jefe/pr-body-245.md
@@ -1,0 +1,51 @@
+## Summary
+
+Fixes #245 — mouse-wheel scrolling, scrollbar dragging, and scroll-key input (PageUp/PageDown/Home/End) were broken when running llxprt-code inside a Jefe-managed terminal, after the copy/selection (#197 / PR #218) and Code Puppy scrollback (#198 / PR #219, #221) changes.
+
+All three input paths were unconditionally intercepted by Jefe's scrollback viewport / selection state machine regardless of agent kind, starving llxprt-code (a full TUI that handles its own scrolling via SGR mouse reporting) of the events it needed.
+
+## Root cause
+
+The scrollback/selection interception code used only `mouse_reporting_active` and `shift_held` to decide ownership. But **both** Code Puppy and llxprt-code advertise SGR mouse reporting, so that flag alone cannot distinguish them. The distinguishing predicate is `is_kennel_mode()`:
+
+- **Code Puppy (kennel)** uses Jefe's tmux-history scrollback viewport — that is the entire point of the #198 design. Jefe **should** intercept the wheel and scroll keys for these sessions.
+- **llxprt-code (non-kennel)** is a full TUI application with its own scrollback and mouse handling. It **must** receive wheel events, scrollbar drags, and scroll-key events directly over the PTY.
+
+The previous code intercepted all three input paths unconditionally, so llxprt-code never received them.
+
+## Fix
+
+Gate every scrollback/selection interception path on `is_kennel_mode()`. Non-kennel agents (llxprt) now receive their events natively; kennel (Code Puppy) behavior is preserved exactly (#197 + #198).
+
+### Layer changes
+
+- **input** (`src/input.rs`): `should_intercept_for_scrollback` gains a `kennel_mode` param and returns `None` for non-kennel agents, forwarding all scroll keys (PageUp/PageDown/Home/End/arrows) to the PTY. `app_input/mod.rs` reads `is_kennel_mode()` once and threads it through.
+- **mouse_routing** (`src/mouse_routing.rs`): the wheel pre-check in `route_terminal_gesture` is gated by a new pure helper `wheel_intercept_active_for_agent(kennel_mode, shift_held)` so non-kennel wheel events fall through to the gesture state machine, which forwards them to reporting children. The two per-event state reads are merged into a single lock acquisition.
+- **selection/gesture** (`src/selection/gesture.rs`): the pure gesture-ownership state machine gains a `kennel_mode` field on `GestureEvent` and a new `PtyOwned` gesture state. For a non-kennel reporting child, an unmodified left gesture (down/drag/up) forwards to the PTY immediately and latches `PtyOwned` — so **scrollbar drags and clicks** reach llxprt. Shift+drag still does Jefe text selection for both kinds. Kennel (Code Puppy) reporting left-gestures keep the #197 `Pending` behavior (drag = Jefe selection, pure click = PTY replay) **unchanged**. A non-left event (wheel/right/middle) while `PtyOwned` resets to Idle (nothing is buffered, so no flush is needed).
+
+### Behavioral contract
+
+| Agent | Wheel | Scrollbar drag (left) | Shift+drag | Scroll keys | Text selection |
+|---|---|---|---|---|---|
+| Code Puppy (kennel) | Jefe scrollback (#198) | Jefe selection (#197) | Jefe selection | Jefe scrollback | Yes |
+| llxprt (non-kennel) | Forwards to PTY | Forwards to PTY | Jefe selection | Forwards to PTY | Yes (shift+drag) |
+
+## Testing (TDD)
+
+- Pure truth-table tests for `wheel_intercept_active_for_agent` (kennel/shift/wheel/over-pane matrix).
+- 8 `should_intercept_for_scrollback` tests asserting non-kennel forwards all scroll keys to the PTY.
+- 8 gesture-state tests covering the non-kennel `PtyOwned` lifecycle: down/drag/up forward to PTY, shift still selects, non-reporting still selects, kennel still `Pending`, and wheel/other-button while `PtyOwned` resets to Idle.
+- A routing-layer integration assertion that a non-kennel wheel forwards to the PTY via the gesture machine.
+- A TUI scenario (`dev-docs/tmux-scenarios/llxprt-terminal-scroll.json`) documents the end-to-end PageUp path.
+
+All existing #197 (Code Puppy selection) and #198 (Code Puppy scrollback) tests are preserved and pass unchanged.
+
+## Verification
+
+- `cargo fmt --all --check` — pass
+- `CLIPPY_CONF_DIR=.github/clippy cargo clippy --workspace --all-targets --all-features -- -D warnings` — pass (zero warnings; no lint suppressions added)
+- `cargo build --workspace --all-features --locked` — pass
+- `cargo test --workspace --all-features --locked` — 1602 lib + 264 integration tests pass
+- Coverage: 72.29% (floor 30%)
+
+closes #245

--- a/dev-docs/tmux-scenarios/llxprt-terminal-scroll.json
+++ b/dev-docs/tmux-scenarios/llxprt-terminal-scroll.json
@@ -1,0 +1,32 @@
+{
+  "config": {
+    "cols": 100,
+    "rows": 24,
+    "history_limit": 2000,
+    "initial_wait_ms": 200,
+    "assert_mode": "soft"
+  },
+  "macros": {
+    "quit": {
+      "params": [],
+      "steps": [
+        { "key": "q" },
+        { "key": "q" },
+        { "key": "q" },
+        { "waitForExit": 3000 }
+      ]
+    }
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "key": "F12" },
+    { "wait": 300 },
+    { "line": "for i in $(seq 1 60); do printf 'line %d\\n' $i; done" },
+    { "wait": 500 },
+    { "historySample": "before-scroll" },
+    { "key": "PageUp" },
+    { "wait": 200 },
+    { "capture": "after-pageup" },
+    { "macro": "quit", "args": {} }
+  ]
+}

--- a/project-plans/issue245-plan.md
+++ b/project-plans/issue245-plan.md
@@ -1,0 +1,128 @@
+# Issue #245 — Mouse scrolling and scrollbar selection are broken in llxprt-code
+
+## Problem
+
+After the copy/selection (#197 / PR #218) and Code Puppy scrollback (#198 /
+PR #219, #221) changes, mouse-wheel scrolling and scrollbar interaction are
+broken when running **llxprt-code** inside a Jefe-managed terminal.
+
+### Observed
+- Mouse-wheel input no longer scrolls llxprt-code.
+- The scrollbar always triggers text selection instead of scrolling.
+
+### Expected (from the issue)
+- Mouse-wheel scrolls the llxprt-code terminal normally.
+- Scrollbar drag/click scrolls rather than initiating text selection.
+- Text selection remains available without intercepting ordinary scrolling.
+- **Both** Code Puppy's Jefe-managed scrollback **and** llxprt-code's native
+  scrolling must work.
+
+## Root cause
+
+`src/mouse_routing.rs::route_terminal_gesture` contains an **unconditional**
+wheel-interception pre-check (introduced by #198):
+
+```rust
+if !shift_held && is_wheel_event(mouse_event) && is_event_over_terminal_pane(mouse_event) {
+    refresh_terminal_scroll_geometry_from_ctx(ctx, app_state);
+    if let Some(scroll_evt) = wheel_to_terminal_scroll_event(mouse_event) {
+        let mut state = app_state.write();
+        *state = std::mem::take(&mut *state).apply(scroll_evt);
+    }
+    return true; // ALWAYS consumed by Jefe scrollback — never reaches the PTY
+}
+```
+
+This steals **every** non-shift wheel event over the focused terminal pane for
+Jefe's scrollback viewport, **regardless of agent kind**. The pure gesture
+state machine (`selection/gesture.rs::process_wheel`) already correctly
+forwards wheel events to a mouse-reporting child, but the router's pre-check
+short-circuits before the state machine ever sees the wheel event.
+
+### Why this breaks llxprt-code but not Code Puppy
+
+- **Code Puppy** (kennel / `AgentKind::CodePuppy`) is a line-oriented agent
+  whose tmux pane retains history. Issue #198 built a Jefe-side scrollback
+  viewport (capture-pane history + live snapshot) specifically for it. Jefe
+  **should** intercept the wheel for these sessions.
+- **llxprt-code** (`AgentKind::Llxprt`) is a full TUI application that
+  advertises SGR mouse reporting and handles its **own** scrolling — it has
+  its own scrollback and expects to receive wheel events over the PTY. Jefe
+  intercepting the wheel starves it.
+
+Both kinds set `mouse_reporting_active() == true`, so the reporting flag alone
+cannot distinguish them. The distinguishing predicate is `is_kennel_mode()`
+(selected agent is Code Puppy).
+
+A parallel unconditional intercept exists in the **keyboard** path:
+`app_input::try_intercept_terminal_scrollback` →
+`input::should_intercept_for_scrollback` intercepts PageUp/PageDown/Home/End
+for the Jefe scrollback in `InputMode::TerminalCapture` regardless of agent
+kind. This steals llxprt-code's keyboard scroll keys the same way.
+
+## Fix design
+
+Gate **both** the wheel and the keyboard scrollback interception on
+`is_kennel_mode()`. When the focused terminal belongs to a non-kennel agent
+(llxprt), the events flow through the existing gesture/forwarding path so the
+child receives them natively.
+
+### Layer responsibilities (respect existing boundaries)
+
+| Layer   | Change                                                                 |
+|---------|------------------------------------------------------------------------|
+| Input   | `should_intercept_for_scrollback` gains a `kennel_mode` param; returns `None` for non-kennel so keys forward to the PTY. Pure + unit-tested. |
+| App input | `try_intercept_terminal_scrollback` reads `is_kennel_mode()` once and threads it into the pure helper. |
+| Mouse routing | The wheel pre-check in `route_terminal_gesture` only intercepts when `is_kennel_mode()`; otherwise the wheel flows through the gesture state machine (which already forwards to reporting children). |
+| State   | No new state; reuses existing `is_kennel_mode()` selector. |
+
+No new AppState fields, no persistence changes, no UI changes.
+
+### Behavioral contract
+
+1. **Kennel (Code Puppy) + wheel over terminal** → Jefe scrollback viewport
+   moves (unchanged #198 behavior).
+2. **Non-kennel (llxprt) + wheel over terminal, reporting active** → wheel
+   forwards to the PTY (llxprt-code scrolls itself).
+3. **Non-kennel (llxprt) + wheel, NOT reporting** → falls through to app-level
+   detail scroll (unchanged).
+4. **Shift+wheel (any agent)** → host passthrough (unchanged #197 behavior).
+5. **Kennel (Code Puppy) + PageUp/PageDown/Home/End** → Jefe scrollback
+   (unchanged #198 behavior).
+6. **Non-kennel (llxprt) + PageUp/PageDown/Home/End** → forwarded to the PTY.
+7. Text selection (left-button drag / shift-drag) remains unchanged for both
+   agent kinds.
+
+## Test-first plan (RED → GREEN → REFACTOR)
+
+### Pure unit tests (state-machine / helper level)
+
+- `selection/gesture_tests.rs` already covers wheel-forward-to-reporting; no
+  change needed there (the state machine is already correct).
+- `input.rs` tests: extend `should_intercept_for_scrollback` tests to assert
+  that for `kennel_mode == false` the helper returns `None` for PageUp /
+  PageDown / Home / End / arrows (events must forward to the PTY). Keep the
+  existing `kennel_mode == true` assertions.
+- `mouse_routing_tests.rs`: add tests proving the wheel pre-check is gated on
+  kennel mode — for a non-kennel focused terminal the wheel is NOT consumed
+  by the Jefe scrollback (the scroll offset does not change). Use the
+  `focused_terminal_state(AgentKind::Llxprt)` helper.
+
+### Integration test
+
+- `tests/runtime/terminal_focus_routing.rs`: add a test asserting that for a
+  non-kennel reporting terminal, a wheel event produces a `ForwardToPty`
+  gesture action (the state machine path), and for a kennel terminal the
+  wheel is consumed by the scrollback (offset changes).
+
+### TUI harness scenario
+
+- Add `dev-docs/tmux-scenarios/llxprt-terminal-scroll.json`: focus the
+  terminal on an llxprt agent, produce output, send a wheel scroll, and
+  assert the child received it (via a capture / expect on scrolled content).
+  This proves the end-to-end path. (Soft assert mode, like the existing
+  scrollback scenario.)
+
+## Verification
+
+`make ci-check` (fmt, clippy gates, coverage ≥30, build, test).

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -464,8 +464,15 @@ pub fn try_intercept_terminal_scrollback(
     ctx: &SharedContext,
     key_event: &KeyEvent,
 ) -> bool {
-    let offset_is_some = app_state.read().terminal_history_offset.is_some();
-    let Some(scroll_evt) = jefe::input::should_intercept_for_scrollback(key_event, offset_is_some)
+    let (offset_is_some, kennel_mode) = {
+        let state = app_state.read();
+        (
+            state.terminal_history_offset.is_some(),
+            state.is_kennel_mode(),
+        )
+    };
+    let Some(scroll_evt) =
+        jefe::input::should_intercept_for_scrollback(key_event, offset_is_some, kennel_mode)
     else {
         return false;
     };

--- a/src/input.rs
+++ b/src/input.rs
@@ -229,6 +229,10 @@ pub fn route_search_key(key: &KeyEvent) -> SearchKeyRoute {
 ///   (`terminal_history_offset.is_some()`). When `true`, arrow keys also move
 ///   the viewport; when `false` (follow-tail), only PageUp/PageDown/Home
 ///   trigger scroll interception.
+/// - `kennel_mode`: Whether the focused terminal belongs to a kennel (Code
+///   Puppy) agent. When `false` (llxprt), ALL scroll keys are forwarded to
+///   the PTY so the child TUI's native scrolling is not stolen by Jefe's
+///   scrollback viewport (issue #245).
 ///
 /// Returns the `AppEvent` to dispatch, or `None` when the key should be
 /// forwarded to the PTY as normal terminal input.
@@ -255,7 +259,14 @@ pub fn route_search_key(key: &KeyEvent) -> SearchKeyRoute {
 pub fn should_intercept_for_scrollback(
     key_event: &KeyEvent,
     offset_is_some: bool,
+    kennel_mode: bool,
 ) -> Option<AppEvent> {
+    // Non-kennel agents (llxprt) handle their own scrolling — forward all
+    // scroll keys to the PTY so the child TUI's native scrollback works
+    // (issue #245).
+    if !kennel_mode {
+        return None;
+    }
     // Modifier chords always go to the PTY (so child TUI key bindings work).
     if key_event.modifiers != KeyModifiers::NONE {
         return None;
@@ -736,28 +747,35 @@ mod tests {
     }
 
     // ── should_intercept_for_scrollback (issue #198) ───────────────────────
+    //
+    // The `kennel_mode` parameter gates whether Jefe's scrollback viewport
+    // intercepts scroll keys (issue #245). Kennel agents (Code Puppy) use
+    // Jefe's scrollback; non-kennel agents (llxprt) handle their own
+    // scrolling. The tests below use `kennel_mode = true` to preserve the
+    // existing #198 behavior. Separate tests (at the end) assert the
+    // non-kennel forwarding contract.
 
     #[test]
     fn scrollback_pageup_intercepts_from_follow_tail() {
-        let evt = should_intercept_for_scrollback(&key(KeyCode::PageUp), false);
+        let evt = should_intercept_for_scrollback(&key(KeyCode::PageUp), false, true);
         assert!(matches!(evt, Some(AppEvent::TerminalScrollPageUp)));
     }
 
     #[test]
     fn scrollback_pagedown_intercepts_from_follow_tail() {
-        let evt = should_intercept_for_scrollback(&key(KeyCode::PageDown), false);
+        let evt = should_intercept_for_scrollback(&key(KeyCode::PageDown), false, true);
         assert!(matches!(evt, Some(AppEvent::TerminalScrollPageDown)));
     }
 
     #[test]
     fn scrollback_pageup_intercepts_when_scrolled_back() {
-        let evt = should_intercept_for_scrollback(&key(KeyCode::PageUp), true);
+        let evt = should_intercept_for_scrollback(&key(KeyCode::PageUp), true, true);
         assert!(matches!(evt, Some(AppEvent::TerminalScrollPageUp)));
     }
 
     #[test]
     fn scrollback_pagedown_intercepts_when_scrolled_back() {
-        let evt = should_intercept_for_scrollback(&key(KeyCode::PageDown), true);
+        let evt = should_intercept_for_scrollback(&key(KeyCode::PageDown), true, true);
         assert!(matches!(evt, Some(AppEvent::TerminalScrollPageDown)));
     }
 
@@ -765,22 +783,31 @@ mod tests {
 
     #[test]
     fn scrollback_ctrl_end_forwards_to_pty() {
-        let evt =
-            should_intercept_for_scrollback(&key_mods(KeyCode::End, KeyModifiers::CONTROL), true);
+        let evt = should_intercept_for_scrollback(
+            &key_mods(KeyCode::End, KeyModifiers::CONTROL),
+            true,
+            true,
+        );
         assert!(evt.is_none(), "Ctrl+End must be forwarded to the PTY");
     }
 
     #[test]
     fn scrollback_alt_pageup_forwards_to_pty() {
-        let evt =
-            should_intercept_for_scrollback(&key_mods(KeyCode::PageUp, KeyModifiers::ALT), false);
+        let evt = should_intercept_for_scrollback(
+            &key_mods(KeyCode::PageUp, KeyModifiers::ALT),
+            false,
+            true,
+        );
         assert!(evt.is_none(), "Alt+PageUp must be forwarded to the PTY");
     }
 
     #[test]
     fn scrollback_shift_pageup_forwards_to_pty() {
-        let evt =
-            should_intercept_for_scrollback(&key_mods(KeyCode::PageUp, KeyModifiers::SHIFT), false);
+        let evt = should_intercept_for_scrollback(
+            &key_mods(KeyCode::PageUp, KeyModifiers::SHIFT),
+            false,
+            true,
+        );
         assert!(evt.is_none(), "Shift+PageUp must be forwarded to the PTY");
     }
 
@@ -789,21 +816,28 @@ mod tests {
         let evt = should_intercept_for_scrollback(
             &key_mods(KeyCode::PageDown, KeyModifiers::CONTROL),
             false,
+            true,
         );
         assert!(evt.is_none(), "Ctrl+PageDown must be forwarded to the PTY");
     }
 
     #[test]
     fn scrollback_ctrl_home_forwards_to_pty() {
-        let evt =
-            should_intercept_for_scrollback(&key_mods(KeyCode::Home, KeyModifiers::CONTROL), true);
+        let evt = should_intercept_for_scrollback(
+            &key_mods(KeyCode::Home, KeyModifiers::CONTROL),
+            true,
+            true,
+        );
         assert!(evt.is_none(), "Ctrl+Home must be forwarded to the PTY");
     }
 
     #[test]
     fn scrollback_ctrl_up_forwards_to_pty_even_when_scrolled() {
-        let evt =
-            should_intercept_for_scrollback(&key_mods(KeyCode::Up, KeyModifiers::CONTROL), true);
+        let evt = should_intercept_for_scrollback(
+            &key_mods(KeyCode::Up, KeyModifiers::CONTROL),
+            true,
+            true,
+        );
         assert!(
             evt.is_none(),
             "Ctrl+Up must be forwarded to the PTY even when scrolled"
@@ -814,7 +848,7 @@ mod tests {
 
     #[test]
     fn scrollback_end_at_follow_tail_forwards_to_pty() {
-        let evt = should_intercept_for_scrollback(&key(KeyCode::End), false);
+        let evt = should_intercept_for_scrollback(&key(KeyCode::End), false, true);
         assert!(
             evt.is_none(),
             "End at follow-tail must be forwarded to the PTY"
@@ -823,7 +857,7 @@ mod tests {
 
     #[test]
     fn scrollback_end_while_scrolled_returns_follow_tail() {
-        let evt = should_intercept_for_scrollback(&key(KeyCode::End), true);
+        let evt = should_intercept_for_scrollback(&key(KeyCode::End), true, true);
         assert!(matches!(evt, Some(AppEvent::TerminalFollowTail)));
     }
 
@@ -831,7 +865,7 @@ mod tests {
 
     #[test]
     fn scrollback_home_intercepts_when_scrolled_back() {
-        let evt = should_intercept_for_scrollback(&key(KeyCode::Home), true);
+        let evt = should_intercept_for_scrollback(&key(KeyCode::Home), true, true);
         assert!(
             matches!(evt, Some(AppEvent::TerminalScrollToTop)),
             "Home must map to TerminalScrollToTop (scroll to top of history)"
@@ -840,7 +874,7 @@ mod tests {
 
     #[test]
     fn scrollback_home_intercepts_from_follow_tail() {
-        let evt = should_intercept_for_scrollback(&key(KeyCode::Home), false);
+        let evt = should_intercept_for_scrollback(&key(KeyCode::Home), false, true);
         assert!(
             matches!(evt, Some(AppEvent::TerminalScrollToTop)),
             "Home must intercept from follow-tail too (enter scrollback from anywhere)"
@@ -849,42 +883,112 @@ mod tests {
 
     #[test]
     fn scrollback_up_intercepts_when_scrolled_back() {
-        let evt = should_intercept_for_scrollback(&key(KeyCode::Up), true);
+        let evt = should_intercept_for_scrollback(&key(KeyCode::Up), true, true);
         assert!(matches!(evt, Some(AppEvent::TerminalScrollUp)));
     }
 
     #[test]
     fn scrollback_down_intercepts_when_scrolled_back() {
-        let evt = should_intercept_for_scrollback(&key(KeyCode::Down), true);
+        let evt = should_intercept_for_scrollback(&key(KeyCode::Down), true, true);
         assert!(matches!(evt, Some(AppEvent::TerminalScrollDown)));
     }
 
     #[test]
     fn scrollback_up_not_intercepted_when_following() {
         // When at follow-tail (offset None), Up goes to the PTY.
-        let evt = should_intercept_for_scrollback(&key(KeyCode::Up), false);
+        let evt = should_intercept_for_scrollback(&key(KeyCode::Up), false, true);
         assert!(evt.is_none());
     }
 
     #[test]
     fn scrollback_down_not_intercepted_when_following() {
-        let evt = should_intercept_for_scrollback(&key(KeyCode::Down), false);
+        let evt = should_intercept_for_scrollback(&key(KeyCode::Down), false, true);
         assert!(evt.is_none());
     }
 
     #[test]
     fn scrollback_regular_keys_not_intercepted() {
         // Regular character keys are never intercepted.
-        assert!(should_intercept_for_scrollback(&key(KeyCode::Char('a')), true).is_none());
-        assert!(should_intercept_for_scrollback(&key(KeyCode::Enter), true).is_none());
-        assert!(should_intercept_for_scrollback(&key(KeyCode::Tab), true).is_none());
-        assert!(should_intercept_for_scrollback(&key(KeyCode::Backspace), true).is_none());
+        assert!(should_intercept_for_scrollback(&key(KeyCode::Char('a')), true, true).is_none());
+        assert!(should_intercept_for_scrollback(&key(KeyCode::Enter), true, true).is_none());
+        assert!(should_intercept_for_scrollback(&key(KeyCode::Tab), true, true).is_none());
+        assert!(should_intercept_for_scrollback(&key(KeyCode::Backspace), true, true).is_none());
     }
 
     #[test]
     fn scrollback_left_right_not_intercepted() {
         // Left/Right go to the PTY even when scrolled back.
-        assert!(should_intercept_for_scrollback(&key(KeyCode::Left), true).is_none());
-        assert!(should_intercept_for_scrollback(&key(KeyCode::Right), true).is_none());
+        assert!(should_intercept_for_scrollback(&key(KeyCode::Left), true, true).is_none());
+        assert!(should_intercept_for_scrollback(&key(KeyCode::Right), true, true).is_none());
+    }
+
+    // ── Issue #245: non-kennel agents forward ALL scroll keys to the PTY ────
+    //
+    // When `kennel_mode == false` (llxprt), the helper must return `None`
+    // for every scroll key so the child TUI's native scrolling is not
+    // stolen by Jefe's scrollback viewport. This is true even when the
+    // viewport is scrolled back (`offset_is_some == true`).
+
+    #[test]
+    fn non_kennel_pageup_forwards_to_pty() {
+        let evt = should_intercept_for_scrollback(&key(KeyCode::PageUp), true, false);
+        assert!(evt.is_none(), "non-kennel PageUp must forward to the PTY");
+    }
+
+    #[test]
+    fn non_kennel_pagedown_forwards_to_pty() {
+        let evt = should_intercept_for_scrollback(&key(KeyCode::PageDown), true, false);
+        assert!(evt.is_none(), "non-kennel PageDown must forward to the PTY");
+    }
+
+    #[test]
+    fn non_kennel_home_forwards_to_pty() {
+        let evt = should_intercept_for_scrollback(&key(KeyCode::Home), true, false);
+        assert!(evt.is_none(), "non-kennel Home must forward to the PTY");
+    }
+
+    #[test]
+    fn non_kennel_end_forwards_to_pty_when_scrolled() {
+        let evt = should_intercept_for_scrollback(&key(KeyCode::End), true, false);
+        assert!(
+            evt.is_none(),
+            "non-kennel End must forward to the PTY even when scrolled back"
+        );
+    }
+
+    #[test]
+    fn non_kennel_up_forwards_to_pty_when_scrolled() {
+        let evt = should_intercept_for_scrollback(&key(KeyCode::Up), true, false);
+        assert!(
+            evt.is_none(),
+            "non-kennel Up must forward to the PTY even when scrolled back"
+        );
+    }
+
+    #[test]
+    fn non_kennel_down_forwards_to_pty_when_scrolled() {
+        let evt = should_intercept_for_scrollback(&key(KeyCode::Down), true, false);
+        assert!(
+            evt.is_none(),
+            "non-kennel Down must forward to the PTY even when scrolled back"
+        );
+    }
+
+    #[test]
+    fn non_kennel_pageup_forwards_from_follow_tail() {
+        let evt = should_intercept_for_scrollback(&key(KeyCode::PageUp), false, false);
+        assert!(
+            evt.is_none(),
+            "non-kennel PageUp must forward from follow-tail"
+        );
+    }
+
+    #[test]
+    fn non_kennel_pagedown_forwards_from_follow_tail() {
+        let evt = should_intercept_for_scrollback(&key(KeyCode::PageDown), false, false);
+        assert!(
+            evt.is_none(),
+            "non-kennel PageDown must forward from follow-tail"
+        );
     }
 }

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -199,7 +199,10 @@ fn route_terminal_gesture(
     shift_held: bool,
     mouse_reporting_active: bool,
 ) -> bool {
-    let gesture_state = app_state.read().terminal_gesture_state.clone();
+    let (gesture_state, kennel_mode) = {
+        let state = app_state.read();
+        (state.terminal_gesture_state.clone(), state.is_kennel_mode())
+    };
 
     let Some(event_kind) = gesture_event_kind(mouse_event.kind) else {
         // Unmapped event kind (e.g. plain move) — reset gesture state and let
@@ -208,13 +211,18 @@ fn route_terminal_gesture(
         return false;
     };
 
-    // Issue #198: wheel events over the focused terminal pane move the Jefe
-    // scrollback viewport BEFORE the gesture state machine or PTY forwarding.
-    // This is the crux of usable scrollback: wheel-up scrolls the Jefe
-    // viewport, not the child. Shift+wheel already bypassed above (host
-    // native scroll). Clicks/drags still flow through the gesture machine so
-    // reporting children stay interactive.
-    if !shift_held && is_wheel_event(mouse_event) && is_event_over_terminal_pane(mouse_event) {
+    // Issue #198 + #245: wheel events over the focused terminal pane move the
+    // Jefe scrollback viewport BEFORE the gesture state machine or PTY
+    // forwarding — but ONLY for kennel (Code Puppy) agents. Non-kennel agents
+    // (llxprt) handle their own scrolling via SGR mouse reporting, so their
+    // wheel events must fall through to the gesture state machine below which
+    // forwards them to the PTY (issue #245). Shift+wheel is host passthrough.
+    // Clicks/drags always flow through the gesture machine so reporting
+    // children stay interactive.
+    if wheel_intercept_active_for_agent(kennel_mode, shift_held)
+        && is_wheel_event(mouse_event)
+        && is_event_over_terminal_pane(mouse_event)
+    {
         // Refresh scroll geometry from runtime + layout BEFORE applying so
         // the reducer's clamp bounds match the rendered content (mirrors the
         // keyboard dispatch path). Runs at event time, never at render time.
@@ -232,6 +240,7 @@ fn route_terminal_gesture(
         col: mouse_event.column,
         row: mouse_event.row,
         mouse_reporting_active,
+        kennel_mode,
     };
     let resolver = |col: u16, row: u16| resolve_terminal_point(app_state, col, row);
 
@@ -395,6 +404,23 @@ fn is_event_over_terminal_pane(mouse_event: &iocraft::FullscreenMouseEvent) -> b
         && mouse_event.column <= col_end
         && mouse_event.row >= layout.pane_row0
         && mouse_event.row <= row_end
+}
+
+/// Whether Jefe's scrollback viewport should own wheel events for the focused
+/// terminal agent (issue #198 + #245).
+///
+/// Returns `true` only when the agent is a kennel (Code Puppy) session AND
+/// shift is not held (shift+wheel is host passthrough). Non-kennel agents
+/// (llxprt) handle their own scrolling via SGR mouse reporting, so the wheel
+/// must forward to the PTY through the gesture state machine (issue #245).
+///
+/// The wheel-vs-non-wheel and over-pane-vs-not checks are performed by the
+/// caller (via [`is_wheel_event`] and [`is_event_over_terminal_pane`], already
+/// unit-tested separately) so this helper stays focused on the agent-kind
+/// gating decision that #245 introduced.
+#[must_use]
+pub fn wheel_intercept_active_for_agent(kennel_mode: bool, shift_held: bool) -> bool {
+    kennel_mode && !shift_held
 }
 
 /// Map a wheel event to a terminal scroll AppEvent (issue #198).
@@ -959,3 +985,7 @@ fn scroll_detail_pane(
 #[cfg(test)]
 #[path = "mouse_routing_tests.rs"]
 mod mouse_routing_tests;
+
+#[cfg(test)]
+#[path = "mouse_routing_wheel_intercept_tests.rs"]
+mod mouse_routing_wheel_intercept_tests;

--- a/src/mouse_routing_tests.rs
+++ b/src/mouse_routing_tests.rs
@@ -265,6 +265,7 @@ fn reporting_click_replays_down_then_up_with_real_coords() {
         col: 5,
         row: 3,
         mouse_reporting_active: true,
+        kennel_mode: true,
     };
     let (action, pending) = GestureState::default().process(down, &resolver);
     assert!(matches!(action, GestureAction::Noop));
@@ -276,6 +277,7 @@ fn reporting_click_replays_down_then_up_with_real_coords() {
         col: 9,
         row: 7,
         mouse_reporting_active: true,
+        kennel_mode: true,
     };
     let (action, next) = pending.process(up, &resolver);
     let GestureAction::ForwardToPty(replays) = action else {
@@ -311,6 +313,7 @@ fn reporting_drag_begins_range_from_buffered_down() {
         col: 2,
         row: 4,
         mouse_reporting_active: true,
+        kennel_mode: true,
     };
     let (_, pending) = GestureState::default().process(down, &resolver);
     let drag = GestureEvent {
@@ -319,6 +322,7 @@ fn reporting_drag_begins_range_from_buffered_down() {
         col: 8,
         row: 4,
         mouse_reporting_active: true,
+        kennel_mode: true,
     };
     let (action, owned) = pending.process(drag, &resolver);
     match action {
@@ -347,6 +351,7 @@ fn stray_left_down_while_pending_flushes_buffered_down() {
         col: 3,
         row: 3,
         mouse_reporting_active: true,
+        kennel_mode: true,
     };
     let (_, pending) = GestureState::default().process(down, &resolver);
     let second_down = GestureEvent {
@@ -355,6 +360,7 @@ fn stray_left_down_while_pending_flushes_buffered_down() {
         col: 6,
         row: 6,
         mouse_reporting_active: true,
+        kennel_mode: true,
     };
     let (action, _) = pending.process(second_down, &resolver);
     let GestureAction::ForwardToPty(replays) = action else {
@@ -446,6 +452,7 @@ fn focused_terminal_drag_resolves_to_terminalview_selection_via_production_geome
         col: 30,
         row: 25,
         mouse_reporting_active: true,
+        kennel_mode: true,
     };
     let (down_action, down_gesture) = GestureState::default().process(down, &resolver);
     assert_eq!(
@@ -461,6 +468,7 @@ fn focused_terminal_drag_resolves_to_terminalview_selection_via_production_geome
         col: 35,
         row: 25,
         mouse_reporting_active: true,
+        kennel_mode: true,
     };
     let (drag_action, drag_gesture) = down_gesture.process(drag, &resolver);
     match drag_action {

--- a/src/mouse_routing_wheel_intercept_tests.rs
+++ b/src/mouse_routing_wheel_intercept_tests.rs
@@ -1,0 +1,110 @@
+//! Tests for the wheel-intercept agent-kind gating (issue #245).
+//!
+//! Extracted from `mouse_routing_tests.rs` to keep that file under the 1000-line
+//! size limit. These tests exercise the pure helper
+//! [`super::wheel_intercept_active_for_agent`] which encapsulates the decision
+//! of whether Jefe's scrollback viewport should own wheel events for the
+//! focused terminal agent. The wheel-vs-non-wheel and over-pane-vs-not checks
+//! are performed by the caller via `is_wheel_event` / `is_event_over_terminal_pane`
+//! (already unit-tested in `mouse_routing_tests.rs`), so this helper focuses on
+//! the agent-kind gating that #245 introduced.
+
+use super::wheel_intercept_active_for_agent;
+use jefe::selection::{
+    GestureAction, GestureEvent, GestureEventKind, GestureState, SelectablePane,
+};
+
+// ── wheel_intercept_active_for_agent truth table ─────────────────────────────
+//
+// The wheel-intercept pre-check in `route_terminal_gesture` must be gated on
+// `is_kennel_mode()`. Non-kennel agents (llxprt) handle their own scrolling
+// via SGR mouse reporting, so the wheel must fall through to the gesture state
+// machine which forwards it to the PTY. These tests exercise the pure helper
+// that encapsulates that agent-kind decision.
+
+#[test]
+fn wheel_intercept_active_for_kennel_no_shift() {
+    // Code Puppy scrollback: Jefe may intercept the wheel (subject to the
+    // caller's wheel + over-pane checks).
+    assert!(
+        wheel_intercept_active_for_agent(true, false),
+        "kennel + no shift must allow scrollback intercept"
+    );
+}
+
+#[test]
+fn wheel_intercept_inactive_for_non_kennel_no_shift() {
+    // THIS IS THE REGRESSION TEST (issue #245): llxprt is non-kennel, so the
+    // wheel must NOT be intercepted — it falls through to the gesture state
+    // machine which forwards it to the PTY via SGR mouse reporting.
+    assert!(
+        !wheel_intercept_active_for_agent(false, false),
+        "non-kennel + no shift must NOT intercept (llxprt owns scrolling)"
+    );
+}
+
+#[test]
+fn wheel_intercept_inactive_for_kennel_shift() {
+    // Shift+wheel is host passthrough — never intercepted, regardless of kind.
+    assert!(
+        !wheel_intercept_active_for_agent(true, true),
+        "kennel + shift must NOT intercept (host passthrough)"
+    );
+}
+
+#[test]
+fn wheel_intercept_inactive_for_non_kennel_shift() {
+    // Non-kennel + shift: doubly excluded (non-kennel AND shift passthrough).
+    assert!(
+        !wheel_intercept_active_for_agent(false, true),
+        "non-kennel + shift must NOT intercept"
+    );
+}
+
+/// Integration assertion (issue #245): for a non-kennel agent with mouse
+/// reporting active, the wheel is NOT intercepted by Jefe scrollback (the pure
+/// helper returns false), so it falls through to the gesture state machine
+/// which forwards it to the PTY. This proves the end-to-end routing contract:
+/// non-kennel wheel → helper says no → gesture machine forwards to PTY.
+///
+/// This mirrors the existing `wheel_forwards_when_mouse_reporting_active`
+/// test in `tests/runtime/terminal_focus_routing.rs` but adds the routing-layer
+/// gate assertion that was missing.
+#[test]
+fn non_kennel_wheel_not_intercepted_and_forwards_to_pty() {
+    use jefe::selection::SelectionPoint;
+
+    // The routing-layer gate: non-kennel + no shift → NOT intercepted. The
+    // wheel falls through to the gesture state machine.
+    assert!(
+        !wheel_intercept_active_for_agent(false, false),
+        "non-kennel wheel must NOT be intercepted by Jefe scrollback (issue #245)"
+    );
+
+    // The gesture state machine (the fallback path) forwards the wheel to the
+    // PTY when mouse reporting is active.
+    let wheel_event = GestureEvent {
+        kind: GestureEventKind::ScrollDown,
+        shift_held: false,
+        col: 5,
+        row: 5,
+        mouse_reporting_active: true,
+        kennel_mode: false,
+    };
+    let resolver = |col: u16, row: u16| -> Option<SelectionPoint> {
+        if col < 2 || row < 2 {
+            return None;
+        }
+        Some(SelectionPoint::new(SelectablePane::TerminalView, 0, 0))
+    };
+    let (action, _state) = GestureState::default().process(wheel_event, &resolver);
+    match action {
+        GestureAction::ForwardToPty(replays) => {
+            assert_eq!(replays.len(), 1);
+            assert_eq!(replays[0].kind, GestureEventKind::ScrollDown);
+        }
+        other => panic!(
+            "non-kennel reporting wheel must forward to PTY via gesture machine, got {other:?}"
+        ),
+    }
+}

--- a/src/mouse_routing_wheel_intercept_tests.rs
+++ b/src/mouse_routing_wheel_intercept_tests.rs
@@ -61,17 +61,25 @@ fn wheel_intercept_inactive_for_non_kennel_shift() {
     );
 }
 
-/// Integration assertion (issue #245): for a non-kennel agent with mouse
-/// reporting active, the wheel is NOT intercepted by Jefe scrollback (the pure
-/// helper returns false), so it falls through to the gesture state machine
-/// which forwards it to the PTY. This proves the end-to-end routing contract:
-/// non-kennel wheel → helper says no → gesture machine forwards to PTY.
+/// Composite assertion (issue #245) validating the two pure components that
+/// the production router (`route_terminal_gesture`) composes for a non-kennel
+/// wheel event:
 ///
-/// This mirrors the existing `wheel_forwards_when_mouse_reporting_active`
-/// test in `tests/runtime/terminal_focus_routing.rs` but adds the routing-layer
-/// gate assertion that was missing.
+/// 1. the routing-layer gate helper `wheel_intercept_active_for_agent` returns
+///    `false` for a non-kennel agent, so the router does NOT intercept the
+///    wheel for Jefe scrollback;
+/// 2. the gesture state machine (the fallback the router delegates to when the
+///    gate is false) forwards the wheel to the PTY when mouse reporting is
+///    active.
+///
+/// This validates the helper and the gesture machine in isolation. The router
+/// itself takes an iocraft `HookState<AppState>` that cannot be constructed
+/// outside a hook context, so it is not unit-testable here; the router's
+/// composition of these two pure components is instead covered by the truth
+/// table above and the existing `wheel_forwards_when_mouse_reporting_active`
+/// integration test in `tests/runtime/terminal_focus_routing.rs`.
 #[test]
-fn non_kennel_wheel_not_intercepted_and_forwards_to_pty() {
+fn non_kennel_wheel_gate_and_gesture_machine_forward_to_pty() {
     use jefe::selection::SelectionPoint;
 
     // The routing-layer gate: non-kennel + no shift → NOT intercepted. The

--- a/src/selection/gesture.rs
+++ b/src/selection/gesture.rs
@@ -8,11 +8,12 @@
 //!
 //! # Decision table (at left-down)
 //!
-//! | shift | reporting | owner decision                                               |
-//! |:-----:|:---------:|--------------------------------------------------------------|
-//! | yes   | any       | Jefe owns (shift means "I want a Jefe selection")            |
-//! | no    | no        | Jefe owns (selection over snapshot)                          |
-//! | no    | yes       | **pending** — buffer the down, decide on the next event     |
+//! | shift | reporting | kennel | owner decision                                              |
+//! |:-----:|:---------:|:------:|-------------------------------------------------------------|
+//! | yes   | any       | any    | Jefe owns (shift means "I want a Jefe selection")           |
+//! | no    | no        | any    | Jefe owns (selection over snapshot)                         |
+//! | no    | yes       | no     | **PTY owns** — forward down immediately, latch PtyOwned (#245) |
+//! | no    | yes       | yes    | **pending** — buffer the down, decide on the next event (#197) |
 //!
 //! # Pending resolution
 //!
@@ -28,6 +29,18 @@
 //! - A stray second **left-down** (rare with well-formed event sequences) →
 //!   flush the buffered down to the PTY first, then start the new gesture, so
 //!   the reporting app never loses a press.
+//!
+//! # PTY-owned resolution (non-kennel, issue #245)
+//!
+//! While **pty-owned** (non-kennel reporting child, non-shift left-down
+//! forwarded immediately):
+//! - A left-button **drag** → forward the drag to the PTY (scrollbar drag,
+//!   text selection in the child TUI, etc.).
+//! - Left-button **up** → forward the up to the PTY, then reset to idle.
+//! - Any **non-left-button** event (wheel/right/middle) or a stray second
+//!   **left-down** → reset to idle and process the event from idle (nothing is
+//!   buffered in PtyOwned — the down was already forwarded — so no flush is
+//!   needed).
 //!
 //! # Other gestures
 //!
@@ -76,6 +89,11 @@ pub struct GestureEvent {
     /// reads it once per event under a single lock acquisition (issue #197
     /// TOCTOU fix).
     pub mouse_reporting_active: bool,
+    /// Whether the agent is a kennel (Code Puppy) agent. Injected per-event by
+    /// the router so the state machine stays pure. Kennel agents use Jefe's
+    /// text selection over reporting terminals (issue #197); non-kennel agents
+    /// (llxprt) own their left-button mouse events over the PTY (issue #245).
+    pub kennel_mode: bool,
 }
 
 /// The action the router should take in response to an event.
@@ -154,6 +172,13 @@ pub enum GestureState {
         /// The anchor point (content coordinates).
         anchor: SelectionPoint,
     },
+    /// The PTY owns the gesture: a non-kennel reporting child's left-button
+    /// down was forwarded immediately, and subsequent drags/up are forwarded
+    /// too (issue #245: non-kennel scrollbar drags/clicks must reach the PTY,
+    /// not Jefe's text selection). Nothing is buffered — the down was already
+    /// forwarded — so a non-left event or stray left-down simply resets to
+    /// Idle.
+    PtyOwned,
 }
 
 impl GestureState {
@@ -168,6 +193,22 @@ impl GestureState {
     where
         R: Fn(u16, u16) -> Option<SelectionPoint>,
     {
+        // A non-left event (wheel/right/middle) or a stray second LeftDown
+        // while PtyOwned → reset to Idle and process the event from Idle.
+        // PtyOwned has nothing buffered (the down was already forwarded), so
+        // no flush is needed — unlike Pending (issue #245).
+        if matches!(self, Self::PtyOwned)
+            && matches!(
+                event.kind,
+                GestureEventKind::LeftDown
+                    | GestureEventKind::ScrollUp
+                    | GestureEventKind::ScrollDown
+                    | GestureEventKind::OtherButton
+            )
+        {
+            return Self::Idle.process(event, resolve_point);
+        }
+
         // Any non-drag left-button-terminating event while pending → flush:
         // replay the buffered down to the PTY, then process the current event
         // from idle. This prevents a reporting app from being starved of its
@@ -231,7 +272,23 @@ impl GestureState {
             };
         }
 
-        // Reporting child, non-shift → pending: buffer the down, decide later.
+        // Reporting child, non-shift:
+        // - Non-kennel (llxprt) → PTY owns: forward the down immediately and
+        //   latch PtyOwned so the whole gesture (scrollbar drag / click) reaches
+        //   the child (issue #245).
+        // - Kennel (Code Puppy) → pending: buffer the down, decide on the next
+        //   event (unchanged #197 behavior).
+        if !event.kennel_mode {
+            return (
+                GestureAction::ForwardToPty(vec![PtyReplay {
+                    col: event.col,
+                    row: event.row,
+                    kind: GestureEventKind::LeftDown,
+                }]),
+                Self::PtyOwned,
+            );
+        }
+
         (
             GestureAction::Noop,
             Self::Pending {
@@ -297,6 +354,17 @@ impl GestureState {
                 // Drag without a preceding down — ignore.
                 (GestureAction::Noop, Self::Idle)
             }
+            Self::PtyOwned => {
+                // PTY owns the gesture: forward the drag to the child.
+                (
+                    GestureAction::ForwardToPty(vec![PtyReplay {
+                        col: event.col,
+                        row: event.row,
+                        kind: GestureEventKind::LeftDrag,
+                    }]),
+                    Self::PtyOwned,
+                )
+            }
         }
     }
 
@@ -328,6 +396,17 @@ impl GestureState {
                 )
             }
             Self::Idle => (GestureAction::Noop, Self::Idle),
+            Self::PtyOwned => {
+                // PTY owns the gesture: forward the up to the child, then reset.
+                (
+                    GestureAction::ForwardToPty(vec![PtyReplay {
+                        col: event.col,
+                        row: event.row,
+                        kind: GestureEventKind::LeftUp,
+                    }]),
+                    Self::Idle,
+                )
+            }
         }
     }
 

--- a/src/selection/gesture_tests.rs
+++ b/src/selection/gesture_tests.rs
@@ -15,6 +15,7 @@ fn ev(kind: GestureEventKind, shift: bool, reporting: bool) -> GestureEvent {
         col: 10,
         row: 5,
         mouse_reporting_active: reporting,
+        kennel_mode: true,
     }
 }
 
@@ -25,6 +26,19 @@ fn ev_at(kind: GestureEventKind, shift: bool, reporting: bool, col: u16, row: u1
         col,
         row,
         mouse_reporting_active: reporting,
+        kennel_mode: true,
+    }
+}
+
+/// Like [`ev`] but with `kennel_mode` set to `false` (non-kennel / llxprt).
+fn ev_nk(kind: GestureEventKind, shift: bool, reporting: bool) -> GestureEvent {
+    GestureEvent {
+        kind,
+        shift_held: shift,
+        col: 10,
+        row: 5,
+        mouse_reporting_active: reporting,
+        kennel_mode: false,
     }
 }
 
@@ -338,4 +352,176 @@ fn pending_drag_with_unresolvable_anchor_forwards_buffered_down() {
         other => panic!("expected ForwardToPty of buffered down + drag, got {other:?}"),
     }
     assert_eq!(state, GestureState::Idle);
+}
+
+// ── Issue #245: non-kennel (llxprt) reporting left-button gestures go to PTY ──
+//
+// A non-kennel reporting child (llxprt TUI) must own its left-button events:
+// scrollbar drags, clicks, etc. are forwarded to the PTY immediately, NOT
+// claimed by Jefe's text selection. Shift+drag still does Jefe selection.
+// Kennel (Code Puppy) behavior is unchanged (#197).
+
+#[test]
+fn non_kennel_reporting_down_forwards_to_pty() {
+    let state = GestureState::default();
+    let (action, state) = state.process(ev_nk(GestureEventKind::LeftDown, false, true), &resolver);
+    match action {
+        GestureAction::ForwardToPty(replays) => {
+            assert_eq!(
+                replays.len(),
+                1,
+                "non-kennel reporting down must forward exactly one LeftDown"
+            );
+            assert_eq!(replays[0].kind, GestureEventKind::LeftDown);
+            assert_eq!((replays[0].col, replays[0].row), (10, 5));
+        }
+        other => panic!("non-kennel reporting down must ForwardToPty, got {other:?}"),
+    }
+    assert_eq!(
+        state,
+        GestureState::PtyOwned,
+        "non-kennel reporting down must latch PtyOwned"
+    );
+}
+
+#[test]
+fn non_kennel_reporting_drag_forwards_to_pty() {
+    // Chain through the real LeftDown so the test exercises the actual
+    // Idle → PtyOwned transition (not a hand-constructed PtyOwned).
+    let state = GestureState::default();
+    let (_, state) = state.process(ev_nk(GestureEventKind::LeftDown, false, true), &resolver);
+    assert_eq!(state, GestureState::PtyOwned);
+    let (action, state) = state.process(ev_nk(GestureEventKind::LeftDrag, false, true), &resolver);
+    match action {
+        GestureAction::ForwardToPty(replays) => {
+            assert_eq!(
+                replays.len(),
+                1,
+                "non-kennel reporting drag must forward exactly one LeftDrag"
+            );
+            assert_eq!(replays[0].kind, GestureEventKind::LeftDrag);
+        }
+        other => panic!("non-kennel reporting drag must ForwardToPty, got {other:?}"),
+    }
+    assert_eq!(
+        state,
+        GestureState::PtyOwned,
+        "drag while PtyOwned must stay PtyOwned"
+    );
+}
+
+#[test]
+fn non_kennel_reporting_up_forwards_to_pty_and_resets() {
+    // Chain through the real LeftDown so the test exercises the actual
+    // Idle → PtyOwned transition (not a hand-constructed PtyOwned).
+    let state = GestureState::default();
+    let (_, state) = state.process(ev_nk(GestureEventKind::LeftDown, false, true), &resolver);
+    assert_eq!(state, GestureState::PtyOwned);
+    let (action, state) = state.process(ev_nk(GestureEventKind::LeftUp, false, true), &resolver);
+    match action {
+        GestureAction::ForwardToPty(replays) => {
+            assert_eq!(
+                replays.len(),
+                1,
+                "non-kennel reporting up must forward exactly one LeftUp"
+            );
+            assert_eq!(replays[0].kind, GestureEventKind::LeftUp);
+        }
+        other => panic!("non-kennel reporting up must ForwardToPty, got {other:?}"),
+    }
+    assert_eq!(
+        state,
+        GestureState::Idle,
+        "up while PtyOwned must reset to Idle"
+    );
+}
+
+#[test]
+fn pty_owned_wheel_resets_to_idle_and_forwards() {
+    // A wheel/right/middle event while PtyOwned must reset to Idle and be
+    // processed from Idle (PtyOwned has nothing buffered — the down was
+    // already forwarded — so no flush is needed). For a reporting child the
+    // wheel forwards to the PTY (issue #245).
+    let state = GestureState::default();
+    let (_, state) = state.process(ev_nk(GestureEventKind::LeftDown, false, true), &resolver);
+    assert_eq!(state, GestureState::PtyOwned);
+    let (action, state) =
+        state.process(ev_nk(GestureEventKind::ScrollDown, false, true), &resolver);
+    match action {
+        GestureAction::ForwardToPty(replays) => {
+            assert_eq!(replays.len(), 1);
+            assert_eq!(replays[0].kind, GestureEventKind::ScrollDown);
+        }
+        other => panic!("wheel while PtyOwned must forward to PTY, got {other:?}"),
+    }
+    assert_eq!(
+        state,
+        GestureState::Idle,
+        "wheel while PtyOwned must reset to Idle"
+    );
+}
+
+#[test]
+fn pty_owned_other_button_resets_to_idle_and_forwards() {
+    // A right/middle-button event while PtyOwned must reset to Idle and
+    // forward to the reporting child (issue #245).
+    let state = GestureState::default();
+    let (_, state) = state.process(ev_nk(GestureEventKind::LeftDown, false, true), &resolver);
+    assert_eq!(state, GestureState::PtyOwned);
+    let (action, state) =
+        state.process(ev_nk(GestureEventKind::OtherButton, false, true), &resolver);
+    assert!(
+        matches!(action, GestureAction::ForwardToPty(_)),
+        "other-button while PtyOwned must forward to PTY, got {action:?}"
+    );
+    assert_eq!(
+        state,
+        GestureState::Idle,
+        "other-button while PtyOwned must reset to Idle"
+    );
+}
+
+#[test]
+fn non_kennel_shift_down_still_selects() {
+    let state = GestureState::default();
+    let (action, state) = state.process(ev_nk(GestureEventKind::LeftDown, true, true), &resolver);
+    assert!(
+        matches!(action, GestureAction::BeginSelection(_)),
+        "shift+down on non-kennel reporting must begin Jefe selection, got {action:?}"
+    );
+    assert!(
+        matches!(state, GestureState::JefeOwned { .. }),
+        "shift+down must latch JefeOwned even for non-kennel"
+    );
+}
+
+#[test]
+fn non_kennel_non_reporting_down_selects() {
+    let state = GestureState::default();
+    let (action, state) = state.process(ev_nk(GestureEventKind::LeftDown, false, false), &resolver);
+    assert!(
+        matches!(action, GestureAction::BeginSelection(_)),
+        "non-reporting non-kennel down must begin Jefe selection, got {action:?}"
+    );
+    assert!(
+        matches!(state, GestureState::JefeOwned { .. }),
+        "non-reporting non-kennel down must latch JefeOwned"
+    );
+}
+
+#[test]
+fn kennel_reporting_down_goes_pending() {
+    // Kennel (Code Puppy) behavior is UNCHANGED (#197): reporting + kennel +
+    // non-shift left-down → Pending (buffered), not PtyOwned.
+    let state = GestureState::default();
+    let (action, state) = state.process(ev(GestureEventKind::LeftDown, false, true), &resolver);
+    assert_eq!(
+        action,
+        GestureAction::Noop,
+        "kennel reporting down must buffer (Noop), not forward"
+    );
+    assert!(
+        matches!(state, GestureState::Pending { .. }),
+        "kennel reporting down must be Pending, got {state:?}"
+    );
 }

--- a/src/selection/gesture_tests.rs
+++ b/src/selection/gesture_tests.rs
@@ -470,10 +470,17 @@ fn pty_owned_other_button_resets_to_idle_and_forwards() {
     assert_eq!(state, GestureState::PtyOwned);
     let (action, state) =
         state.process(ev_nk(GestureEventKind::OtherButton, false, true), &resolver);
-    assert!(
-        matches!(action, GestureAction::ForwardToPty(_)),
-        "other-button while PtyOwned must forward to PTY, got {action:?}"
-    );
+    match action {
+        GestureAction::ForwardToPty(replays) => {
+            assert_eq!(
+                replays.len(),
+                1,
+                "other-button while PtyOwned must forward exactly one replay"
+            );
+            assert_eq!(replays[0].kind, GestureEventKind::OtherButton);
+        }
+        other => panic!("other-button while PtyOwned must forward to PTY, got {other:?}"),
+    }
     assert_eq!(
         state,
         GestureState::Idle,

--- a/tests/runtime/terminal_focus_routing.rs
+++ b/tests/runtime/terminal_focus_routing.rs
@@ -230,6 +230,7 @@ fn event(kind: GestureEventKind, shift: bool, reporting: bool) -> GestureEvent {
         col: 5,
         row: 5,
         mouse_reporting_active: reporting,
+        kennel_mode: true,
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #245 — mouse-wheel scrolling, scrollbar dragging, and scroll-key input (PageUp/PageDown/Home/End) were broken when running llxprt-code inside a Jefe-managed terminal, after the copy/selection (#197 / PR #218) and Code Puppy scrollback (#198 / PR #219, #221) changes.

All three input paths were unconditionally intercepted by Jefe's scrollback viewport / selection state machine regardless of agent kind, starving llxprt-code (a full TUI that handles its own scrolling via SGR mouse reporting) of the events it needed.

## Root cause

The scrollback/selection interception code used only `mouse_reporting_active` and `shift_held` to decide ownership. But **both** Code Puppy and llxprt-code advertise SGR mouse reporting, so that flag alone cannot distinguish them. The distinguishing predicate is `is_kennel_mode()`:

- **Code Puppy (kennel)** uses Jefe's tmux-history scrollback viewport — that is the entire point of the #198 design. Jefe **should** intercept the wheel and scroll keys for these sessions.
- **llxprt-code (non-kennel)** is a full TUI application with its own scrollback and mouse handling. It **must** receive wheel events, scrollbar drags, and scroll-key events directly over the PTY.

The previous code intercepted all three input paths unconditionally, so llxprt-code never received them.

## Fix

Gate every scrollback/selection interception path on `is_kennel_mode()`. Non-kennel agents (llxprt) now receive their events natively; kennel (Code Puppy) behavior is preserved exactly (#197 + #198).

### Layer changes

- **input** (`src/input.rs`): `should_intercept_for_scrollback` gains a `kennel_mode` param and returns `None` for non-kennel agents, forwarding all scroll keys (PageUp/PageDown/Home/End/arrows) to the PTY. `app_input/mod.rs` reads `is_kennel_mode()` once and threads it through.
- **mouse_routing** (`src/mouse_routing.rs`): the wheel pre-check in `route_terminal_gesture` is gated by a new pure helper `wheel_intercept_active_for_agent(kennel_mode, shift_held)` so non-kennel wheel events fall through to the gesture state machine, which forwards them to reporting children. The two per-event state reads are merged into a single lock acquisition.
- **selection/gesture** (`src/selection/gesture.rs`): the pure gesture-ownership state machine gains a `kennel_mode` field on `GestureEvent` and a new `PtyOwned` gesture state. For a non-kennel reporting child, an unmodified left gesture (down/drag/up) forwards to the PTY immediately and latches `PtyOwned` — so **scrollbar drags and clicks** reach llxprt. Shift+drag still does Jefe text selection for both kinds. Kennel (Code Puppy) reporting left-gestures keep the #197 `Pending` behavior (drag = Jefe selection, pure click = PTY replay) **unchanged**. A non-left event (wheel/right/middle) while `PtyOwned` resets to Idle (nothing is buffered, so no flush is needed).

### Behavioral contract

| Agent | Wheel | Scrollbar drag (left) | Shift+drag | Scroll keys | Text selection |
|---|---|---|---|---|---|
| Code Puppy (kennel) | Jefe scrollback (#198) | Jefe selection (#197) | Jefe selection | Jefe scrollback | Yes |
| llxprt (non-kennel) | Forwards to PTY | Forwards to PTY | Jefe selection | Forwards to PTY | Yes (shift+drag) |

## Testing (TDD)

- Pure truth-table tests for `wheel_intercept_active_for_agent` (kennel/shift/wheel/over-pane matrix).
- 8 `should_intercept_for_scrollback` tests asserting non-kennel forwards all scroll keys to the PTY.
- 8 gesture-state tests covering the non-kennel `PtyOwned` lifecycle: down/drag/up forward to PTY, shift still selects, non-reporting still selects, kennel still `Pending`, and wheel/other-button while `PtyOwned` resets to Idle.
- A routing-layer integration assertion that a non-kennel wheel forwards to the PTY via the gesture machine.
- A TUI scenario (`dev-docs/tmux-scenarios/llxprt-terminal-scroll.json`) documents the end-to-end PageUp path.

All existing #197 (Code Puppy selection) and #198 (Code Puppy scrollback) tests are preserved and pass unchanged.

## Verification

- `cargo fmt --all --check` — pass
- `CLIPPY_CONF_DIR=.github/clippy cargo clippy --workspace --all-targets --all-features -- -D warnings` — pass (zero warnings; no lint suppressions added)
- `cargo build --workspace --all-features --locked` — pass
- `cargo test --workspace --all-features --locked` — 1602 lib + 264 integration tests pass
- Coverage: 72.29% (floor 30%)

closes #245
