### PR TITLE
Add accessible shared PR filter controls

### DIFF
--- a/src/app_input/actions.rs
+++ b/src/app_input/actions.rs
@@ -46,7 +46,7 @@ fn resolve_search_key_event(state: &AppState, key_event: &KeyEvent) -> Option<Ap
 }
 
 fn resolve_filter_key_event(state: &AppState, key_event: &KeyEvent) -> Option<AppEvent> {
-    match resolve_filter_control_key(FilterEditorKind::Cycle, key_event)? {
+    match resolve_filter_control_key(FilterEditorKind::Choice, key_event)? {
         FilterControlCommand::Apply => Some(AppEvent::ActionsApplyFilter),
         FilterControlCommand::Cancel => Some(AppEvent::ActionsCloseFilterControls),
         FilterControlCommand::Next => Some(AppEvent::ActionsFilterNavigateNext),
@@ -63,7 +63,7 @@ fn resolve_filter_key_event(state: &AppState, key_event: &KeyEvent) -> Option<Ap
         FilterControlCommand::CycleNext | FilterControlCommand::CyclePrevious => {
             Some(AppEvent::ActionsCycleFilterStatus)
         }
-        FilterControlCommand::Append(_) | FilterControlCommand::Backspace => None,
+        _ => None,
     }
 }
 
@@ -147,6 +147,15 @@ mod tests {
             resolve_actions_key_event(&state, &key(KeyCode::Delete)),
             Some(AppEvent::ActionsUpdateDraftFilter {
                 field: ActionsFilterField::Workflow,
+                value
+            }) if value.is_empty()
+        ));
+
+        state.actions_state.ui.filter_field_index = 1;
+        assert!(matches!(
+            resolve_actions_key_event(&state, &key(KeyCode::Delete)),
+            Some(AppEvent::ActionsUpdateDraftFilter {
+                field: ActionsFilterField::Status,
                 value
             }) if value.is_empty()
         ));

--- a/src/app_input/actions.rs
+++ b/src/app_input/actions.rs
@@ -127,3 +127,35 @@ fn resolve_focus_key_event(state: &AppState, key_event: &KeyEvent) -> Option<App
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iocraft::prelude::KeyEventKind;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(KeyEventKind::Press, code)
+    }
+
+    #[test]
+    fn actions_filter_supports_advertised_clear_commands() {
+        let mut state = AppState::default();
+        state.actions_state.ui.filter_ui_open = true;
+        state.actions_state.ui.filter_field_index = 0;
+
+        assert!(matches!(
+            resolve_actions_key_event(&state, &key(KeyCode::Delete)),
+            Some(AppEvent::ActionsUpdateDraftFilter {
+                field: ActionsFilterField::Workflow,
+                value
+            }) if value.is_empty()
+        ));
+
+        let mut clear_all = key(KeyCode::Char('l'));
+        clear_all.modifiers = KeyModifiers::CONTROL;
+        assert!(matches!(
+            resolve_actions_key_event(&state, &clear_all),
+            Some(AppEvent::ActionsClearDraftFilter)
+        ));
+    }
+}

--- a/src/app_input/actions.rs
+++ b/src/app_input/actions.rs
@@ -53,10 +53,10 @@ fn resolve_filter_key_event(state: &AppState, key_event: &KeyEvent) -> Option<Ap
         FilterControlCommand::Previous => Some(AppEvent::ActionsFilterNavigatePrev),
         FilterControlCommand::ClearAll => Some(AppEvent::ActionsClearDraftFilter),
         FilterControlCommand::ClearCurrent => Some(AppEvent::ActionsUpdateDraftFilter {
-            field: if state.actions_state.ui.filter_field_index == 0 {
-                ActionsFilterField::Workflow
-            } else {
-                ActionsFilterField::Status
+            field: match state.actions_state.ui.filter_field_index {
+                0 => ActionsFilterField::Workflow,
+                1 => ActionsFilterField::Status,
+                _ => return None,
             },
             value: String::new(),
         }),
@@ -159,6 +159,9 @@ mod tests {
                 value
             }) if value.is_empty()
         ));
+
+        state.actions_state.ui.filter_field_index = 2;
+        assert!(resolve_actions_key_event(&state, &key(KeyCode::Delete)).is_none());
 
         let mut clear_all = key(KeyCode::Char('l'));
         clear_all.modifiers = KeyModifiers::CONTROL;

--- a/src/app_input/actions.rs
+++ b/src/app_input/actions.rs
@@ -1,5 +1,7 @@
 use iocraft::prelude::*;
-use jefe::state::{ActionsFocus, AppEvent, AppState};
+use jefe::state::{ActionsFilterField, ActionsFocus, AppEvent, AppState};
+
+use super::filter_controls::{FilterControlCommand, FilterEditorKind, resolve_filter_control_key};
 
 /// Pure key resolver for Actions mode.
 pub fn resolve_actions_key_event(state: &AppState, key_event: &KeyEvent) -> Option<AppEvent> {
@@ -43,14 +45,25 @@ fn resolve_search_key_event(state: &AppState, key_event: &KeyEvent) -> Option<Ap
     }
 }
 
-fn resolve_filter_key_event(_state: &AppState, key_event: &KeyEvent) -> Option<AppEvent> {
-    match key_event.code {
-        KeyCode::Esc => Some(AppEvent::ActionsCloseFilterControls),
-        KeyCode::Enter => Some(AppEvent::ActionsApplyFilter),
-        KeyCode::Tab => Some(AppEvent::ActionsFilterNavigateNext),
-        KeyCode::BackTab => Some(AppEvent::ActionsFilterNavigatePrev),
-        KeyCode::Up | KeyCode::Down => Some(AppEvent::ActionsCycleFilterStatus),
-        _ => None,
+fn resolve_filter_key_event(state: &AppState, key_event: &KeyEvent) -> Option<AppEvent> {
+    match resolve_filter_control_key(FilterEditorKind::Cycle, key_event)? {
+        FilterControlCommand::Apply => Some(AppEvent::ActionsApplyFilter),
+        FilterControlCommand::Cancel => Some(AppEvent::ActionsCloseFilterControls),
+        FilterControlCommand::Next => Some(AppEvent::ActionsFilterNavigateNext),
+        FilterControlCommand::Previous => Some(AppEvent::ActionsFilterNavigatePrev),
+        FilterControlCommand::ClearAll => Some(AppEvent::ActionsClearDraftFilter),
+        FilterControlCommand::ClearCurrent => Some(AppEvent::ActionsUpdateDraftFilter {
+            field: if state.actions_state.ui.filter_field_index == 0 {
+                ActionsFilterField::Workflow
+            } else {
+                ActionsFilterField::Status
+            },
+            value: String::new(),
+        }),
+        FilterControlCommand::CycleNext | FilterControlCommand::CyclePrevious => {
+            Some(AppEvent::ActionsCycleFilterStatus)
+        }
+        FilterControlCommand::Append(_) | FilterControlCommand::Backspace => None,
     }
 }
 

--- a/src/app_input/filter_controls.rs
+++ b/src/app_input/filter_controls.rs
@@ -1,6 +1,6 @@
 //! Shared keyboard behavior for filter controls.
 //!
-//! Domains describe the active editor kind, then translate the resulting
+//! Each domain describes its active editor kind, then translates the resulting
 //! command into their own events. State mutation and query semantics stay in
 //! the domain reducers instead of leaking into a universal filter framework.
 
@@ -110,6 +110,34 @@ mod tests {
         assert_eq!(
             resolve_filter_control_key(FilterEditorKind::Text, &release),
             None
+        );
+    }
+
+    #[test]
+    fn clear_all_and_choice_commands_are_resolved() {
+        let mut clear_all = key(KeyCode::Char('l'));
+        clear_all.modifiers = KeyModifiers::CONTROL;
+        assert_eq!(
+            resolve_filter_control_key(FilterEditorKind::Choice, &clear_all),
+            Some(FilterControlCommand::ClearAll)
+        );
+        assert_eq!(
+            resolve_filter_control_key(FilterEditorKind::Choice, &key(KeyCode::Right)),
+            Some(FilterControlCommand::CycleNext)
+        );
+        assert_eq!(
+            resolve_filter_control_key(FilterEditorKind::Choice, &key(KeyCode::Left)),
+            Some(FilterControlCommand::CyclePrevious)
+        );
+        assert_eq!(
+            resolve_filter_control_key(FilterEditorKind::Choice, &key(KeyCode::Backspace)),
+            Some(FilterControlCommand::Backspace)
+        );
+        let mut shifted = key(KeyCode::Char('X'));
+        shifted.modifiers = KeyModifiers::SHIFT;
+        assert_eq!(
+            resolve_filter_control_key(FilterEditorKind::Choice, &shifted),
+            Some(FilterControlCommand::Append('X'))
         );
     }
 

--- a/src/app_input/filter_controls.rs
+++ b/src/app_input/filter_controls.rs
@@ -4,7 +4,7 @@
 //! command into their own events. State mutation and query semantics stay in
 //! the domain reducers instead of leaking into a universal filter framework.
 
-use iocraft::prelude::{KeyCode, KeyEvent, KeyModifiers};
+use iocraft::prelude::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum FilterEditorKind {
@@ -31,6 +31,9 @@ pub(super) fn resolve_filter_control_key(
     editor: FilterEditorKind,
     key_event: &KeyEvent,
 ) -> Option<FilterControlCommand> {
+    if key_event.kind != KeyEventKind::Press {
+        return None;
+    }
     match key_event.code {
         KeyCode::Enter => Some(FilterControlCommand::Apply),
         KeyCode::Esc => Some(FilterControlCommand::Cancel),
@@ -95,6 +98,16 @@ mod tests {
         assert_eq!(
             resolve_filter_control_key(editor, &key(KeyCode::Delete)),
             Some(FilterControlCommand::ClearCurrent)
+        );
+    }
+
+    #[test]
+    fn ignores_non_press_events() {
+        let mut release = key(KeyCode::Enter);
+        release.kind = KeyEventKind::Release;
+        assert_eq!(
+            resolve_filter_control_key(FilterEditorKind::Text, &release),
+            None
         );
     }
 

--- a/src/app_input/filter_controls.rs
+++ b/src/app_input/filter_controls.rs
@@ -39,7 +39,9 @@ pub(super) fn resolve_filter_control_key(
         KeyCode::Esc => Some(FilterControlCommand::Cancel),
         KeyCode::Tab => Some(FilterControlCommand::Next),
         KeyCode::BackTab => Some(FilterControlCommand::Previous),
-        KeyCode::Delete => Some(FilterControlCommand::ClearCurrent),
+        KeyCode::Delete if editor != FilterEditorKind::Cycle => {
+            Some(FilterControlCommand::ClearCurrent)
+        }
         KeyCode::Char('l') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
             Some(FilterControlCommand::ClearAll)
         }

--- a/src/app_input/filter_controls.rs
+++ b/src/app_input/filter_controls.rs
@@ -1,0 +1,120 @@
+//! Shared keyboard behavior for filter controls.
+//!
+//! Domains describe the active editor kind, then translate the resulting
+//! command into their own events. State mutation and query semantics stay in
+//! the domain reducers instead of leaking into a universal filter framework.
+
+use iocraft::prelude::{KeyCode, KeyEvent, KeyModifiers};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum FilterEditorKind {
+    Cycle,
+    Text,
+    Choice,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum FilterControlCommand {
+    Apply,
+    Cancel,
+    Next,
+    Previous,
+    ClearCurrent,
+    ClearAll,
+    CycleNext,
+    CyclePrevious,
+    Append(char),
+    Backspace,
+}
+
+pub(super) fn resolve_filter_control_key(
+    editor: FilterEditorKind,
+    key_event: &KeyEvent,
+) -> Option<FilterControlCommand> {
+    match key_event.code {
+        KeyCode::Enter => Some(FilterControlCommand::Apply),
+        KeyCode::Esc => Some(FilterControlCommand::Cancel),
+        KeyCode::Tab => Some(FilterControlCommand::Next),
+        KeyCode::BackTab => Some(FilterControlCommand::Previous),
+        KeyCode::Delete => Some(FilterControlCommand::ClearCurrent),
+        KeyCode::Char('l') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(FilterControlCommand::ClearAll)
+        }
+        KeyCode::Left if editor != FilterEditorKind::Text => {
+            Some(FilterControlCommand::CyclePrevious)
+        }
+        KeyCode::Right | KeyCode::Up | KeyCode::Down if editor != FilterEditorKind::Text => {
+            Some(FilterControlCommand::CycleNext)
+        }
+        KeyCode::Char(' ') if editor == FilterEditorKind::Cycle => {
+            Some(FilterControlCommand::CycleNext)
+        }
+        KeyCode::Char(c)
+            if editor != FilterEditorKind::Cycle
+                && !key_event
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+        {
+            Some(FilterControlCommand::Append(c))
+        }
+        KeyCode::Backspace if editor != FilterEditorKind::Cycle => {
+            Some(FilterControlCommand::Backspace)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iocraft::prelude::KeyEventKind;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(KeyEventKind::Press, code)
+    }
+
+    #[test]
+    fn shared_lifecycle_and_navigation_keys_are_domain_neutral() {
+        let editor = FilterEditorKind::Text;
+        assert_eq!(
+            resolve_filter_control_key(editor, &key(KeyCode::Enter)),
+            Some(FilterControlCommand::Apply)
+        );
+        assert_eq!(
+            resolve_filter_control_key(editor, &key(KeyCode::Esc)),
+            Some(FilterControlCommand::Cancel)
+        );
+        assert_eq!(
+            resolve_filter_control_key(editor, &key(KeyCode::Tab)),
+            Some(FilterControlCommand::Next)
+        );
+        assert_eq!(
+            resolve_filter_control_key(editor, &key(KeyCode::BackTab)),
+            Some(FilterControlCommand::Previous)
+        );
+        assert_eq!(
+            resolve_filter_control_key(editor, &key(KeyCode::Delete)),
+            Some(FilterControlCommand::ClearCurrent)
+        );
+    }
+
+    #[test]
+    fn editor_kind_selects_cycle_or_text_behavior() {
+        assert_eq!(
+            resolve_filter_control_key(FilterEditorKind::Cycle, &key(KeyCode::Char(' '))),
+            Some(FilterControlCommand::CycleNext)
+        );
+        assert_eq!(
+            resolve_filter_control_key(FilterEditorKind::Choice, &key(KeyCode::Left)),
+            Some(FilterControlCommand::CyclePrevious)
+        );
+        assert_eq!(
+            resolve_filter_control_key(FilterEditorKind::Text, &key(KeyCode::Char('x'))),
+            Some(FilterControlCommand::Append('x'))
+        );
+        assert_eq!(
+            resolve_filter_control_key(FilterEditorKind::Text, &key(KeyCode::Backspace)),
+            Some(FilterControlCommand::Backspace)
+        );
+    }
+}

--- a/src/app_input/issues_filter.rs
+++ b/src/app_input/issues_filter.rs
@@ -32,6 +32,9 @@ pub(super) fn resolve_filter_key_event(state: &AppState, key_event: &KeyEvent) -
     {
         return Some(AppEvent::ExitIssuesMode);
     }
+    if matches!(key_event.code, KeyCode::Delete) && field_idx == 0 {
+        return active_field_clear_event(field_idx);
+    }
     let editor = if field_idx == 0 {
         FilterEditorKind::Cycle
     } else if is_choice_field(field_idx) {

--- a/src/app_input/issues_filter.rs
+++ b/src/app_input/issues_filter.rs
@@ -7,6 +7,8 @@ use std::collections::BTreeSet;
 use jefe::domain::{FILTER_CHOICE_ANY, FILTER_CHOICE_NONE};
 use jefe::state::{AppEvent, AppState, ISSUE_FILTER_FIELD_COUNT};
 
+use super::filter_controls::{FilterControlCommand, FilterEditorKind, resolve_filter_control_key};
+
 /// Filter field names indexed by `filter_field_index`.
 /// 0=state (cycle-only), 1..7 are text/choice fields.
 const FILTER_FIELD_NAMES: [&str; ISSUE_FILTER_FIELD_COUNT] = [
@@ -25,48 +27,36 @@ const FILTER_FIELD_NAMES: [&str; ISSUE_FILTER_FIELD_COUNT] = [
 pub(super) fn resolve_filter_key_event(state: &AppState, key_event: &KeyEvent) -> Option<AppEvent> {
     let field_idx = state.issues_state.filter_ui.field_index;
 
-    match key_event.code {
-        KeyCode::Enter => Some(AppEvent::ApplyFilter),
-        KeyCode::Esc => Some(AppEvent::CloseFilterControls),
-        KeyCode::Tab => Some(AppEvent::FilterNavigateNext),
-        KeyCode::BackTab => Some(AppEvent::FilterNavigatePrev),
-        KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-            Some(AppEvent::ExitIssuesMode)
-        }
-        KeyCode::Char('l') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-            Some(AppEvent::ClearDraftFilter)
-        }
-        KeyCode::Delete => active_field_clear_event(field_idx),
-        // Field-specific input
-        KeyCode::Left | KeyCode::Right | KeyCode::Char(' ') if field_idx == 0 => {
-            // State field: cycle through open/closed/all
+    if matches!(key_event.code, KeyCode::Char('c'))
+        && key_event.modifiers.contains(KeyModifiers::CONTROL)
+    {
+        return Some(AppEvent::ExitIssuesMode);
+    }
+    let editor = if field_idx == 0 {
+        FilterEditorKind::Cycle
+    } else if is_choice_field(field_idx) {
+        FilterEditorKind::Choice
+    } else {
+        FilterEditorKind::Text
+    };
+    match resolve_filter_control_key(editor, key_event)? {
+        FilterControlCommand::Apply => Some(AppEvent::ApplyFilter),
+        FilterControlCommand::Cancel => Some(AppEvent::CloseFilterControls),
+        FilterControlCommand::Next => Some(AppEvent::FilterNavigateNext),
+        FilterControlCommand::Previous => Some(AppEvent::FilterNavigatePrev),
+        FilterControlCommand::ClearAll => Some(AppEvent::ClearDraftFilter),
+        FilterControlCommand::ClearCurrent => active_field_clear_event(field_idx),
+        FilterControlCommand::CycleNext | FilterControlCommand::CyclePrevious if field_idx == 0 => {
             Some(AppEvent::CycleFilterState)
         }
-        KeyCode::Right if is_choice_field(field_idx) => {
+        FilterControlCommand::CycleNext => {
             choice_cycle_event(state, field_idx, ChoiceDirection::Next)
         }
-        KeyCode::Left if is_choice_field(field_idx) => {
+        FilterControlCommand::CyclePrevious => {
             choice_cycle_event(state, field_idx, ChoiceDirection::Previous)
         }
-        KeyCode::Char(c) if field_idx > 0 => {
-            let &field_name = FILTER_FIELD_NAMES.get(field_idx)?;
-            let mut value = current_filter_field_value(state, field_name);
-            value.push(c);
-            Some(AppEvent::UpdateDraftFilter {
-                field: field_name.to_string(),
-                value,
-            })
-        }
-        KeyCode::Backspace if field_idx > 0 => {
-            let &field_name = FILTER_FIELD_NAMES.get(field_idx)?;
-            let mut value = current_filter_field_value(state, field_name);
-            value.pop();
-            Some(AppEvent::UpdateDraftFilter {
-                field: field_name.to_string(),
-                value,
-            })
-        }
-        _ => None, // consumed, no leak
+        FilterControlCommand::Append(c) => update_text_event(state, field_idx, Some(c)),
+        FilterControlCommand::Backspace => update_text_event(state, field_idx, None),
     }
 }
 
@@ -90,6 +80,24 @@ fn active_field_clear_event(field_idx: usize) -> Option<AppEvent> {
     Some(AppEvent::UpdateDraftFilter {
         field: field_name.to_string(),
         value: String::new(),
+    })
+}
+
+fn update_text_event(
+    state: &AppState,
+    field_idx: usize,
+    character: Option<char>,
+) -> Option<AppEvent> {
+    let &field_name = FILTER_FIELD_NAMES.get(field_idx)?;
+    let mut value = current_filter_field_value(state, field_name);
+    if let Some(character) = character {
+        value.push(character);
+    } else {
+        value.pop();
+    }
+    Some(AppEvent::UpdateDraftFilter {
+        field: field_name.to_string(),
+        value,
     })
 }
 

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+mod filter_controls;
 mod issues;
 mod issues_dispatch;
 mod issues_filter;

--- a/src/app_input/prs.rs
+++ b/src/app_input/prs.rs
@@ -98,6 +98,7 @@ fn resolve_pr_global_key(state: &AppState, key_event: &KeyEvent) -> Option<AppEv
         KeyCode::Esc => Some(handle_esc_in_prs_mode(state, key_event)),
         KeyCode::Char('a') => Some(AppEvent::ExitPrsMode),
         KeyCode::Char('p' | 'P') => Some(AppEvent::RefocusPrList),
+        KeyCode::Char('f') => Some(AppEvent::PrOpenFilterControls),
         // Cross-mode navigation: `i` from PRs switches to Issues mode (issue #164).
         KeyCode::Char('i' | 'I') => Some(AppEvent::EnterIssuesMode),
         // F12 defocuses the terminal or returns to the PR list (issue #164).

--- a/src/app_input/prs_filter.rs
+++ b/src/app_input/prs_filter.rs
@@ -12,6 +12,8 @@ use iocraft::prelude::*;
 
 use jefe::state::{AppEvent, AppState};
 
+use super::filter_controls::{FilterControlCommand, FilterEditorKind, resolve_filter_control_key};
+
 /// The eight filter fields indexed by `filter_ui.field_index`.
 /// State field (index 0) is the default for Space cycling.
 const DRAFT_FIELD: usize = 1;
@@ -36,20 +38,26 @@ pub(super) fn handle_pr_filter_controls_key(
     key_event: &KeyEvent,
 ) -> Option<AppEvent> {
     let field_idx = state.prs_state.filter_ui.field_index;
-    match key_event.code {
-        KeyCode::Enter => Some(AppEvent::PrApplyFilter),
-        KeyCode::Esc => Some(AppEvent::PrCloseFilterControls),
-        KeyCode::Tab => Some(AppEvent::PrFilterNavigateNext),
-        KeyCode::BackTab => Some(AppEvent::PrFilterNavigatePrev),
-        KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-            Some(AppEvent::PrClearFilter)
+    let editor = if is_text_field(field_idx) {
+        FilterEditorKind::Text
+    } else {
+        FilterEditorKind::Cycle
+    };
+    match resolve_filter_control_key(editor, key_event)? {
+        FilterControlCommand::Apply => Some(AppEvent::PrApplyFilter),
+        FilterControlCommand::Cancel => Some(AppEvent::PrCloseFilterControls),
+        FilterControlCommand::Next => Some(AppEvent::PrFilterNavigateNext),
+        FilterControlCommand::Previous => Some(AppEvent::PrFilterNavigatePrev),
+        FilterControlCommand::ClearAll => Some(AppEvent::PrClearFilter),
+        FilterControlCommand::ClearCurrent if is_text_field(field_idx) => {
+            Some(text_clear_event(state, field_idx))
         }
-        KeyCode::Char(' ') if !is_text_field(field_idx) => Some(space_event_for_field(field_idx)),
-        KeyCode::Char(c) if is_text_field(field_idx) => Some(text_char_event(state, field_idx, c)),
-        KeyCode::Backspace if is_text_field(field_idx) => {
-            Some(text_backspace_event(state, field_idx))
+        FilterControlCommand::CycleNext | FilterControlCommand::CyclePrevious => {
+            Some(space_event_for_field(field_idx))
         }
-        _ => None,
+        FilterControlCommand::Append(c) => Some(text_char_event(state, field_idx, c)),
+        FilterControlCommand::Backspace => Some(text_backspace_event(state, field_idx)),
+        FilterControlCommand::ClearCurrent => None,
     }
 }
 
@@ -101,6 +109,14 @@ fn text_backspace_event(state: &AppState, field_idx: usize) -> AppEvent {
     let (field, mut value) = text_field_value(state, field_idx);
     value.pop();
     AppEvent::PrUpdateDraftFilter { field, value }
+}
+
+fn text_clear_event(state: &AppState, field_idx: usize) -> AppEvent {
+    let (field, _) = text_field_value(state, field_idx);
+    AppEvent::PrUpdateDraftFilter {
+        field,
+        value: String::new(),
+    }
 }
 
 /// Read the (field_name, current_value) for the active text field.

--- a/src/app_input/prs_integration_tests.rs
+++ b/src/app_input/prs_integration_tests.rs
@@ -262,11 +262,11 @@ fn it_filter_apply_reloads_and_updates_list() {
 
     // Open filter controls through the same key router users exercise.
     let event = prs::resolve_prs_key_event(&state, &key(KeyCode::Char('f')));
-    assert!(
-        matches!(event, Some(AppEvent::PrOpenFilterControls)),
-        "f must emit PrOpenFilterControls (got {event:?})"
-    );
-    state.apply_in_place(event.unwrap_or_else(|| panic!("f must emit an event")));
+    let event = match event {
+        Some(event @ AppEvent::PrOpenFilterControls) => event,
+        other => panic!("f must emit PrOpenFilterControls (got {other:?})"),
+    };
+    state.apply_in_place(event);
     assert!(state.prs_state.filter_ui.controls_open);
 
     // Cycle the review-decision draft filter via the REAL filter-controls handler.

--- a/src/app_input/prs_integration_tests.rs
+++ b/src/app_input/prs_integration_tests.rs
@@ -247,12 +247,9 @@ fn it_repo_nav_switches_scope_and_reloads() {
 /// applying the filter copies the draft to `committed_filter` and flags a list
 /// reload (`loading.list = true`) — the interactive filter path (#38/#40).
 ///
-/// Drives the REAL key handlers for the filter-controls sub-focus: `f` (open
-/// controls) via `resolve_prs_key_event` in the filter tier is not a direct
-/// key — instead we open via `PrOpenFilterControls`, then cycle a draft field
-/// via the REAL filter-controls key handler, and apply via the Enter key
-/// handler. Then delivers a `PrListLoaded` for the new filter and asserts the
-/// list updates.
+/// Drives the REAL key handlers for the complete filter path: `f` opens the
+/// controls, Space cycles a draft field, and Enter applies it. Then delivers a
+/// `PrListLoaded` for the new filter and asserts the list updates.
 ///
 /// @plan PLAN-20260624-PR-MODE.P15
 /// @requirement REQ-PR-008
@@ -263,8 +260,13 @@ fn it_filter_apply_reloads_and_updates_list() {
     let mut state = active_prs_state();
     state.prs_state.pr_focus = PrFocus::PrList;
 
-    // Open filter controls (the dispatch arm runs this reducer transition).
-    state.apply_in_place(AppEvent::PrOpenFilterControls);
+    // Open filter controls through the same key router users exercise.
+    let event = prs::resolve_prs_key_event(&state, &key(KeyCode::Char('f')));
+    assert!(
+        matches!(event, Some(AppEvent::PrOpenFilterControls)),
+        "f must emit PrOpenFilterControls (got {event:?})"
+    );
+    state.apply_in_place(event.unwrap_or_else(|| panic!("f must emit an event")));
     assert!(state.prs_state.filter_ui.controls_open);
 
     // Cycle the review-decision draft filter via the REAL filter-controls handler.

--- a/src/app_input/prs_key_tests.rs
+++ b/src/app_input/prs_key_tests.rs
@@ -422,6 +422,16 @@ fn test_filter_controls_tab_space_text_enter_clear_esc() {
     // Enter => apply.
     let enter = resolve_prs_key_event(&state, &key(KeyCode::Enter));
     assert!(matches!(enter, Some(AppEvent::PrApplyFilter)));
+
+    // Delete clears the active text field without applying the form.
+    let mut text_state = prs_state_with_filter_open(4);
+    text_state.prs_state.draft_filter.author = "octocat".to_string();
+    let delete = resolve_prs_key_event(&text_state, &key(KeyCode::Delete));
+    assert!(matches!(
+        delete,
+        Some(AppEvent::PrUpdateDraftFilter { field, value })
+            if field == "author" && value.is_empty()
+    ));
 }
 
 /// Filter field cycling wraps through all eight fields (state, draft,

--- a/src/state/prs_ops.rs
+++ b/src/state/prs_ops.rs
@@ -214,6 +214,8 @@ impl AppState {
                     .field_index
                     .min(PR_FILTER_FIELD_COUNT.saturating_sub(1));
                 self.prs_state.draft_filter = self.prs_state.committed_filter.clone();
+                self.prs_state.filter_ui.draft_labels_text =
+                    self.prs_state.committed_filter.labels.join(",");
                 true
             }
             AppEvent::PrCloseFilterControls => {

--- a/src/ui/components/filter_controls.rs
+++ b/src/ui/components/filter_controls.rs
@@ -117,9 +117,15 @@ pub fn issue_filter_fields(
 /// @requirement REQ-ISS-008
 #[must_use]
 pub fn issue_filter_action_hints() -> &'static [&'static str] {
+    shared_filter_action_hints()
+}
+
+/// Shared key hints for the common filter-control workflow.
+#[must_use]
+pub fn shared_filter_action_hints() -> &'static [&'static str] {
     &[
         "Tab next  ",
-        "←/→ choices  ",
+        "←/→ cycle  ",
         "Enter apply  ",
         "Delete field  ",
         "Ctrl-L clear all  ",
@@ -185,12 +191,7 @@ pub fn actions_filter_fields(
 /// scheme: Tab next field, Up/Down cycle value, Enter apply, Esc cancel).
 #[must_use]
 pub fn actions_filter_action_hints() -> &'static [&'static str] {
-    &[
-        "Tab next field  ",
-        "Up/Down cycle  ",
-        "Enter apply  ",
-        "Esc cancel",
-    ]
+    shared_filter_action_hints()
 }
 
 /// Build the full [`FilterBarProps`] for the Actions filter bar.

--- a/src/ui/components/pr_filter_controls.rs
+++ b/src/ui/components/pr_filter_controls.rs
@@ -14,6 +14,7 @@ use crate::domain::{ChecksFilter, PrFilter, PrFilterState, ReviewDecisionFilter}
 use crate::theme::ThemeColors;
 
 use super::filter_bar::{FilterBarProps, FilterFieldView};
+use super::filter_controls::shared_filter_action_hints;
 
 /// Row-1 prefix text before the first field (matches the pre-refactor
 /// `PrFilterControls` component exactly).
@@ -168,13 +169,7 @@ pub fn pr_filter_field_views(
 /// @requirement REQ-PR-008
 #[must_use]
 pub fn pr_filter_action_hints() -> &'static [&'static str] {
-    &[
-        "Tab next  ",
-        "Space cycle  ",
-        "Enter apply  ",
-        "Ctrl-c clear  ",
-        "Esc cancel",
-    ]
+    shared_filter_action_hints()
 }
 
 /// Build the full [`FilterBarProps`] for the PR filter bar.


### PR DESCRIPTION
## Summary

- wire `f` through the real Pull Requests keyboard router so the advertised filter command actually opens the existing PR controls
- introduce a small domain-neutral filter-control command resolver shared by Issues, Actions, and Pull Requests
- keep field values, reducer mutations, persistence, reloads, and query semantics in thin domain adapters rather than building a universal conditional framework
- standardize filter action hints and keyboard behavior for navigation, cycling, apply, current-field clearing, clear-all, and cancel
- restore the raw multi-label editing value from committed PR labels whenever controls open
- replace the PR integration test's direct reducer shortcut with the real `f` input path

## Supported PR filters

The accessible control exposes the existing end-to-end PR filter model:

- state: open, closed, merged, all
- draft/ready
- review decision
- checks status
- author
- assignee
- reviewer
- multiple labels

Free-text search remains available through the existing `/` search control and is combined with the committed filter by the existing GitHub query builder. Base branch, head branch, and milestone were deliberately not added: unlike the fields above, they are not represented by the existing `PrFilter` model/API path, and adding a mystery grab bag while refactoring shared behavior would expand persistence and query scope without evidence that the product needs it.

## Architecture

`app_input::filter_controls` owns only common key interpretation and emits domain-neutral commands. Each domain maps those commands to its own typed events. The existing generic `FilterBar` remains the renderer, and domain projections still provide field labels and values. This keeps the IoC boundary proportional: DRY behavior, no `if issues { ... } else if prs { ... }` monster, and no reducer trait framework.

## Test-first evidence

The existing PR integration test was first changed to open controls through `resolve_prs_key_event` with `f`. It failed with:

```text
f must emit PrOpenFilterControls (got None)
```

The implementation then made that real input path pass. Shared resolver unit tests cover lifecycle/navigation and cycle/text editor behavior; the complete existing Issues, Actions, PR filter, persistence, rendering, and query suites provide regression coverage.

## Verification

```text
make ci-check
```

Passed, including formatting, Clippy allow policy, source-length policy, standard and complexity Clippy, coverage threshold, locked all-feature build, full locked all-feature tests, harness tests, and doctests.

Closes #250
