### PR TITLE
Port the TUI harness to native Windows psmux (#255)

### DIFF
--- a/dev-docs/testing/tmux-harness.md
+++ b/dev-docs/testing/tmux-harness.md
@@ -1,16 +1,19 @@
-# Tmux-backed TUI harness
+# Multiplexer-backed TUI harness
 
-The tmux harness runs `jefe` inside a real terminal session and drives it with
+The harness runs `jefe` inside a real terminal session and drives it with
 keyboard input. It exists for deterministic end-to-end checks of behavior that is
 hard to validate with reducer or component tests alone: focus changes, terminal
 geometry, alternate-screen rendering, scrollback, process exit, and failure
 artifacts.
 
+Unix uses upstream tmux. Native Windows uses psmux and Windows ConPTY while
+sharing the same typed scenario schema, matchers, runner, and artifact model.
+
 The harness is intentionally split by side-effect boundary:
 
 1. **Scenario model and macro expansion** parse JSON into typed Rust structs.
 2. **Screen and scrollback matchers** evaluate captured text without I/O.
-3. **Tmux driver** owns all `tmux -f /dev/null` process calls.
+3. **Multiplexer driver** owns upstream tmux or native psmux process calls.
 4. **Runner/orchestrator** composes the pure layers with the driver seam,
    bounded polling, and artifact capture.
 5. **CLI and scenarios** provide local/manual entry points and opt-in smoke
@@ -106,6 +109,37 @@ cargo run --bin jefe-tmux-harness -- \
 To debug a failing scenario, add `--keep-session` and inspect the named tmux
 session printed by the scenario file or CLI defaults.
 
+### Native Windows with psmux
+
+Install psmux 3.3.6 or newer, then run the same scenario JSON from PowerShell:
+
+```powershell
+cargo build --workspace --all-features --locked
+$root = (Get-Location).Path
+cargo run --bin jefe-tmux-harness -- `
+  --scenario "$root\dev-docs\tmux-scenarios\startup-quit.json" `
+  --jefe-bin "$root\target\debug\jefe.exe" `
+  --config "$root\target\tmux harness Ω\config" `
+  --out-dir "$root\target\tmux harness Ω\startup-quit"
+```
+
+Set `JEFE_PSMUX_BIN` when psmux is not on `PATH`. Each invocation creates a
+unique `psmux -L <namespace>` namespace. Cleanup calls `kill-server` only with
+that owned `-L` namespace; the harness never invokes bare `psmux kill-server`.
+Use `--keep-session` to retain the isolated namespace. The CLI prints the
+session and the path to `multiplexer.txt`, which records the executable,
+qualified version, and namespace needed for safe inspection:
+
+```powershell
+psmux -L <namespace> list-sessions
+psmux -L <namespace> capture-pane -p -S -200 -t <session>
+psmux -L <namespace> kill-server
+```
+
+Missing or older psmux versions produce an actionable error identifying the
+executable, minimum version, and `JEFE_PSMUX_BIN` override. Native-Windows
+claims do not use WSL, Cygwin, MSYS2, Git Bash, Docker, or Unix shell wrappers.
+
 ## Artifact layout
 
 When an artifact directory is supplied, the runner may write:
@@ -114,6 +148,7 @@ When an artifact directory is supplied, the runner may write:
 - `final-scrollback.txt`: final scrollback capture on failure.
 - `error.txt`: structured failure context including step index, step kind, and
   reason.
+- `multiplexer.txt`: multiplexer executable/version and isolated namespace.
 - `<label>.screen.txt`: named captures from `capture` steps.
 - `<label>.history.txt`: named scrollback samples from `historySample` steps.
 

--- a/src/bin/jefe-tmux-harness.rs
+++ b/src/bin/jefe-tmux-harness.rs
@@ -47,6 +47,18 @@ fn run(args: CliArgs) -> ExitCode {
     match request.and_then(|req| run_tmux_scenario(&scenario, &req, args.out_dir.as_deref())) {
         Ok(summary) => {
             write_stdout(&format!("ok: {} steps\n", summary.steps_run));
+            if args.keep_session || scenario.config.keep_session {
+                write_stdout(&format!("retained session: {}\n", args.session));
+                if let Some(details) = summary.multiplexer_details {
+                    write_stdout(&details);
+                }
+                if let Some(directory) = summary.artifact_dir {
+                    write_stdout(&format!(
+                        "multiplexer details: {}\n",
+                        directory.join("multiplexer.txt").display()
+                    ));
+                }
+            }
             ExitCode::SUCCESS
         }
         Err(err) => {

--- a/src/bin/jefe-tmux-harness.rs
+++ b/src/bin/jefe-tmux-harness.rs
@@ -54,7 +54,7 @@ fn run(args: CliArgs) -> ExitCode {
                 }
                 if let Some(directory) = summary.artifact_dir {
                     write_stdout(&format!(
-                        "multiplexer details: {}\n",
+                        "multiplexer details file: {}\n",
                         directory.join("multiplexer.txt").display()
                     ));
                 }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -18,6 +18,8 @@ pub mod expand;
 pub mod macro_def;
 pub mod matchers;
 pub mod parser;
+#[cfg(windows)]
+mod psmux_process;
 pub mod runner;
 pub mod scenario;
 pub mod step;

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -21,6 +21,10 @@ pub mod parser;
 pub mod runner;
 pub mod scenario;
 pub mod step;
+#[cfg(windows)]
+#[path = "psmux_driver.rs"]
+pub mod tmux_driver;
+#[cfg(not(windows))]
 pub mod tmux_driver;
 
 pub use capture::{PaneStatus, PaneStatusParseError, ScreenCapture, ScrollbackSample};

--- a/src/harness/psmux_driver.rs
+++ b/src/harness/psmux_driver.rs
@@ -547,7 +547,11 @@ fn unique_namespace() -> String {
 }
 
 fn format_command(executable: &Path, namespace: &str, args: &[String]) -> String {
-    format!("{} -L {namespace} {}", executable.display(), args.join(" "))
+    format!(
+        "{} -f NUL -L {namespace} {}",
+        executable.display(),
+        args.join(" ")
+    )
 }
 
 fn output_lines(bytes: &[u8]) -> Vec<String> {

--- a/src/harness/psmux_driver.rs
+++ b/src/harness/psmux_driver.rs
@@ -162,7 +162,15 @@ impl TmuxDriver {
         request.validate()?;
         self.qualified_version()?;
         let args = new_session_args(request);
-        self.run_owned(&args, Some(&request.working_dir))?;
+        if let Err(error) = self.run_owned(&args, Some(&request.working_dir)) {
+            return match ignore_absent_cleanup(self.kill_owned_namespace()) {
+                Ok(()) => Err(error),
+                Err(cleanup) => Err(TmuxDriverError::Cleanup {
+                    session: error.to_string(),
+                    namespace: cleanup.to_string(),
+                }),
+            };
+        }
         if let Err(error) = self.configure_session(request) {
             return match self.kill_owned_namespace() {
                 Ok(()) => Err(error),
@@ -470,15 +478,24 @@ fn invalid_request(reason: &str) -> TmuxDriverError {
 
 fn ignore_absent_cleanup(result: Result<(), TmuxDriverError>) -> Result<(), TmuxDriverError> {
     match result {
-        Err(TmuxDriverError::Failed { stderr, .. })
-            if stderr.to_ascii_lowercase().contains("no server running")
-                || stderr.to_ascii_lowercase().contains("no sessions")
-                || stderr.to_ascii_lowercase().contains("can't find session") =>
+        Err(TmuxDriverError::Failed { command, stderr })
+            if is_cleanup_command(&command) && is_absent_cleanup_error(&stderr) =>
         {
             Ok(())
         }
         other => other,
     }
+}
+
+fn is_cleanup_command(command: &str) -> bool {
+    command.contains(" kill-session ") || command.ends_with(" kill-server")
+}
+
+fn is_absent_cleanup_error(stderr: &str) -> bool {
+    let stderr = stderr.to_ascii_lowercase();
+    stderr.contains("no server running")
+        || stderr.contains("no sessions")
+        || stderr.contains("can't find session")
 }
 
 fn parse_version_part(part: Option<&str>, name: &str, source: &str) -> Result<u32, String> {

--- a/src/harness/psmux_driver.rs
+++ b/src/harness/psmux_driver.rs
@@ -179,8 +179,9 @@ impl TmuxDriver {
         if session.keep_session {
             return Ok(());
         }
-        let _ = self.run(&["kill-session", "-t", &session.name]);
-        self.kill_owned_namespace()
+        let session_cleanup = self.run(&["kill-session", "-t", &session.name]);
+        let namespace_cleanup = self.kill_owned_namespace();
+        namespace_cleanup.and(session_cleanup)
     }
 
     pub fn send_line(&self, session: &TmuxSession, line: &str) -> Result<(), TmuxDriverError> {

--- a/src/harness/psmux_driver.rs
+++ b/src/harness/psmux_driver.rs
@@ -181,7 +181,15 @@ impl TmuxDriver {
         }
         let session_cleanup = self.run(&["kill-session", "-t", &session.name]);
         let namespace_cleanup = self.kill_owned_namespace();
-        namespace_cleanup.and(session_cleanup)
+        match (session_cleanup, namespace_cleanup) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(session), Ok(())) => Err(session),
+            (Ok(()), Err(namespace)) => Err(namespace),
+            (Err(session), Err(namespace)) => Err(TmuxDriverError::Cleanup {
+                session: session.to_string(),
+                namespace: namespace.to_string(),
+            }),
+        }
     }
 
     pub fn send_line(&self, session: &TmuxSession, line: &str) -> Result<(), TmuxDriverError> {
@@ -369,6 +377,7 @@ pub enum TmuxDriverError {
     Timeout { command: String },
     Failed { command: String, stderr: String },
     Parse { command: String, value: String },
+    Cleanup { session: String, namespace: String },
     PaneStatus(PaneStatusParseError),
 }
 
@@ -398,6 +407,10 @@ impl std::fmt::Display for TmuxDriverError {
             Self::Parse { command, value } => {
                 write!(formatter, "failed to parse {command} output: '{value}'")
             }
+            Self::Cleanup { session, namespace } => write!(
+                formatter,
+                "psmux cleanup failed: session cleanup: {session}; namespace cleanup: {namespace}"
+            ),
             Self::PaneStatus(error) => write!(formatter, "{error}"),
         }
     }

--- a/src/harness/psmux_driver.rs
+++ b/src/harness/psmux_driver.rs
@@ -319,10 +319,7 @@ impl TmuxDriver {
     }
 
     fn kill_owned_namespace(&self) -> Result<(), TmuxDriverError> {
-        match self.run(&["kill-server"]) {
-            Ok(()) | Err(TmuxDriverError::Failed { .. }) => Ok(()),
-            Err(error) => Err(error),
-        }
+        self.run(&["kill-server"])
     }
 
     fn run(&self, args: &[&str]) -> Result<(), TmuxDriverError> {
@@ -345,7 +342,10 @@ impl TmuxDriver {
         let command_name = format_command(&self.executable, &self.namespace, args);
         let mut command = Command::new(&self.executable);
         command.arg("-L").arg(&self.namespace).args(args);
-        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
         for variable in TMUX_ENV_VARS_TO_SCRUB {
             command.env_remove(variable);
         }

--- a/src/harness/psmux_driver.rs
+++ b/src/harness/psmux_driver.rs
@@ -1,0 +1,564 @@
+//! Native-Windows psmux driver boundary for the shared TUI harness.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use super::capture::{PaneStatus, PaneStatusParseError, ScreenCapture, ScrollbackSample};
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
+const MINIMUM_PSMUX_VERSION: PsmuxVersion = PsmuxVersion::new(3, 3, 6);
+const PANE_DEAD_FORMAT: &str = "#{pane_dead}";
+const HISTORY_SIZE_FORMAT: &str = "#{history_size}";
+const TMUX_ENV_VARS_TO_SCRUB: &[&str] = &["TMUX", "TMUX_PANE", "TMUX_TMPDIR"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TmuxStartRequest {
+    pub session_name: String,
+    pub command: Vec<String>,
+    pub working_dir: PathBuf,
+    pub cols: u16,
+    pub rows: u16,
+    pub history_limit: u32,
+    pub keep_session: bool,
+}
+
+impl TmuxStartRequest {
+    pub fn command(
+        session_name: impl Into<String>,
+        command: Vec<String>,
+        working_dir: impl Into<PathBuf>,
+        cols: u16,
+        rows: u16,
+        history_limit: u32,
+    ) -> Result<Self, TmuxDriverError> {
+        let request = Self {
+            session_name: session_name.into(),
+            command,
+            working_dir: working_dir.into(),
+            cols,
+            rows,
+            history_limit,
+            keep_session: false,
+        };
+        request.validate()?;
+        Ok(request)
+    }
+
+    pub fn jefe(
+        session_name: impl Into<String>,
+        jefe_binary: impl Into<PathBuf>,
+        config_dir: impl Into<PathBuf>,
+        working_dir: impl Into<PathBuf>,
+        dims: TmuxPaneSize,
+    ) -> Result<Self, TmuxDriverError> {
+        let command = vec![
+            jefe_binary.into().to_string_lossy().into_owned(),
+            "--config".to_string(),
+            config_dir.into().to_string_lossy().into_owned(),
+        ];
+        Self::command(
+            session_name,
+            command,
+            working_dir,
+            dims.cols,
+            dims.rows,
+            dims.history_limit,
+        )
+    }
+
+    #[must_use]
+    pub fn with_keep_session(mut self, keep_session: bool) -> Self {
+        self.keep_session = keep_session;
+        self
+    }
+
+    fn validate(&self) -> Result<(), TmuxDriverError> {
+        if self.session_name.trim().is_empty() {
+            return Err(invalid_request("session name must not be empty"));
+        }
+        if self.command.is_empty() || self.command.iter().any(String::is_empty) {
+            return Err(invalid_request("command must contain non-empty argv"));
+        }
+        if self.cols == 0 || self.rows == 0 || self.history_limit == 0 {
+            return Err(invalid_request(
+                "cols, rows, and history limit must be non-zero",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TmuxPaneSize {
+    pub cols: u16,
+    pub rows: u16,
+    pub history_limit: u32,
+}
+
+impl TmuxPaneSize {
+    #[must_use]
+    pub const fn new(cols: u16, rows: u16, history_limit: u32) -> Self {
+        Self {
+            cols,
+            rows,
+            history_limit,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TmuxSession {
+    pub name: String,
+    pub cols: u16,
+    pub rows: u16,
+    pub keep_session: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct TmuxDriver {
+    executable: PathBuf,
+    namespace: String,
+}
+
+impl Default for TmuxDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TmuxDriver {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            executable: std::env::var_os("JEFE_PSMUX_BIN")
+                .map_or_else(|| PathBuf::from("psmux"), PathBuf::from),
+            namespace: unique_namespace(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_available(&self) -> bool {
+        self.qualified_version().is_ok()
+    }
+
+    #[must_use]
+    pub fn diagnostics(&self) -> String {
+        let version = self
+            .version_output()
+            .unwrap_or_else(|error| format!("unavailable ({error})"));
+        format!(
+            "multiplexer: psmux\nexecutable: {}\npsmux version: {version}\nnamespace: {}\n",
+            self.executable.display(),
+            self.namespace
+        )
+    }
+
+    pub fn start_session(
+        &self,
+        request: &TmuxStartRequest,
+    ) -> Result<TmuxSession, TmuxDriverError> {
+        request.validate()?;
+        self.qualified_version()?;
+        let args = new_session_args(request);
+        self.run_owned(&args, Some(&request.working_dir))?;
+        if let Err(error) = self.configure_session(request) {
+            let _ = self.kill_owned_namespace();
+            return Err(error);
+        }
+        Ok(TmuxSession {
+            name: request.session_name.clone(),
+            cols: request.cols,
+            rows: request.rows,
+            keep_session: request.keep_session,
+        })
+    }
+
+    pub fn cleanup_session(&self, session: &TmuxSession) -> Result<(), TmuxDriverError> {
+        if session.keep_session {
+            return Ok(());
+        }
+        let _ = self.run(&["kill-session", "-t", &session.name]);
+        self.kill_owned_namespace()
+    }
+
+    pub fn send_line(&self, session: &TmuxSession, line: &str) -> Result<(), TmuxDriverError> {
+        self.run(&["send-keys", "-l", "-t", &session.name, "--", line])?;
+        self.send_key(session, "Enter")
+    }
+
+    pub fn send_key(&self, session: &TmuxSession, key: &str) -> Result<(), TmuxDriverError> {
+        if key.is_empty() {
+            return Err(invalid_request("key must not be empty"));
+        }
+        self.run(&["send-keys", "-t", &session.name, key])
+    }
+
+    pub fn send_keys(&self, session: &TmuxSession, keys: &[String]) -> Result<(), TmuxDriverError> {
+        if keys.iter().any(String::is_empty) {
+            return Err(invalid_request("keys must not contain empty entries"));
+        }
+        let mut args = vec![
+            "send-keys".to_string(),
+            "-t".to_string(),
+            session.name.clone(),
+            "--".to_string(),
+        ];
+        args.extend(keys.iter().cloned());
+        self.run_owned(&args, None).map(|_| ())
+    }
+
+    pub fn capture_screen(&self, session: &TmuxSession) -> Result<ScreenCapture, TmuxDriverError> {
+        let output = self.capture(&["capture-pane", "-p", "-t", &session.name])?;
+        Ok(ScreenCapture::new(
+            session.rows,
+            session.cols,
+            output_lines(&output.stdout),
+        ))
+    }
+
+    pub fn capture_scrollback(
+        &self,
+        session: &TmuxSession,
+        lines: u32,
+    ) -> Result<ScrollbackSample, TmuxDriverError> {
+        let history_size = self.history_size(session)?;
+        let start = format!("-{}", lines.max(1));
+        let output = self.capture(&["capture-pane", "-p", "-S", &start, "-t", &session.name])?;
+        Ok(ScrollbackSample::new(
+            history_size,
+            output_lines(&output.stdout),
+        ))
+    }
+
+    pub fn pane_status(&self, session: &TmuxSession) -> Result<PaneStatus, TmuxDriverError> {
+        let output = self.display_message(session, PANE_DEAD_FORMAT)?;
+        PaneStatus::parse_tmux_pane_dead(&output).map_err(TmuxDriverError::PaneStatus)
+    }
+
+    pub fn history_size(&self, session: &TmuxSession) -> Result<u64, TmuxDriverError> {
+        let output = self.display_message(session, HISTORY_SIZE_FORMAT)?;
+        output
+            .trim()
+            .parse::<u64>()
+            .map_err(|_| TmuxDriverError::Parse {
+                command: "display-message history_size".to_string(),
+                value: output.trim().to_string(),
+            })
+    }
+
+    pub fn copy_mode(&self, session: &TmuxSession, enabled: bool) -> Result<(), TmuxDriverError> {
+        if enabled {
+            self.run(&["copy-mode", "-t", &session.name])
+        } else {
+            self.run(&["send-keys", "-t", &session.name, "q"])
+        }
+    }
+
+    fn configure_session(&self, request: &TmuxStartRequest) -> Result<(), TmuxDriverError> {
+        self.run(&[
+            "set-option",
+            "-t",
+            &request.session_name,
+            "remain-on-exit",
+            "on",
+        ])?;
+        self.run(&[
+            "set-option",
+            "-wt",
+            &request.session_name,
+            "history-limit",
+            &request.history_limit.to_string(),
+        ])
+    }
+
+    fn display_message(
+        &self,
+        session: &TmuxSession,
+        format: &str,
+    ) -> Result<String, TmuxDriverError> {
+        let output = self.capture(&["display-message", "-p", "-t", &session.name, format])?;
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    fn qualified_version(&self) -> Result<PsmuxVersion, TmuxDriverError> {
+        let text = self.version_output()?;
+        let version =
+            PsmuxVersion::parse(&text).map_err(|reason| TmuxDriverError::Incompatible {
+                executable: self.executable.clone(),
+                reason,
+            })?;
+        if version < MINIMUM_PSMUX_VERSION {
+            return Err(TmuxDriverError::Incompatible {
+                executable: self.executable.clone(),
+                reason: format!(
+                    "found {version}; minimum supported version is {MINIMUM_PSMUX_VERSION}"
+                ),
+            });
+        }
+        Ok(version)
+    }
+
+    fn version_output(&self) -> Result<String, TmuxDriverError> {
+        let output = Command::new(&self.executable)
+            .arg("-V")
+            .output()
+            .map_err(|error| TmuxDriverError::Unavailable {
+                executable: self.executable.clone(),
+                reason: error.to_string(),
+            })?;
+        if !output.status.success() {
+            return Err(TmuxDriverError::Unavailable {
+                executable: self.executable.clone(),
+                reason: format_output(&output),
+            });
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    fn kill_owned_namespace(&self) -> Result<(), TmuxDriverError> {
+        match self.run(&["kill-server"]) {
+            Ok(()) | Err(TmuxDriverError::Failed { .. }) => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn run(&self, args: &[&str]) -> Result<(), TmuxDriverError> {
+        let owned = args
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect::<Vec<_>>();
+        self.run_owned(&owned, None).map(|_| ())
+    }
+
+    fn capture(&self, args: &[&str]) -> Result<Output, TmuxDriverError> {
+        let owned = args
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect::<Vec<_>>();
+        self.run_owned(&owned, None)
+    }
+
+    fn run_owned(&self, args: &[String], cwd: Option<&Path>) -> Result<Output, TmuxDriverError> {
+        let command_name = format_command(&self.executable, &self.namespace, args);
+        let mut command = Command::new(&self.executable);
+        command.arg("-L").arg(&self.namespace).args(args);
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        for variable in TMUX_ENV_VARS_TO_SCRUB {
+            command.env_remove(variable);
+        }
+        if let Some(directory) = cwd {
+            command.current_dir(directory);
+        }
+        let child = command.spawn().map_err(|error| TmuxDriverError::Spawn {
+            command: command_name.clone(),
+            reason: error.to_string(),
+        })?;
+        wait_for_command(child, &command_name)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TmuxDriverError {
+    InvalidRequest(String),
+    Unavailable { executable: PathBuf, reason: String },
+    Incompatible { executable: PathBuf, reason: String },
+    Spawn { command: String, reason: String },
+    Timeout { command: String },
+    Failed { command: String, stderr: String },
+    Parse { command: String, value: String },
+    PaneStatus(PaneStatusParseError),
+}
+
+impl std::fmt::Display for TmuxDriverError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidRequest(reason) => {
+                write!(formatter, "invalid psmux driver request: {reason}")
+            }
+            Self::Unavailable { executable, reason } => write!(
+                formatter,
+                "psmux is unavailable at '{}': {reason}; install marlocarlo.psmux >= {MINIMUM_PSMUX_VERSION} or set JEFE_PSMUX_BIN",
+                executable.display()
+            ),
+            Self::Incompatible { executable, reason } => write!(
+                formatter,
+                "incompatible psmux at '{}': {reason}",
+                executable.display()
+            ),
+            Self::Spawn { command, reason } => {
+                write!(formatter, "failed to spawn {command}: {reason}")
+            }
+            Self::Timeout { command } => write!(formatter, "psmux command timed out: {command}"),
+            Self::Failed { command, stderr } => {
+                write!(formatter, "psmux command failed ({command}): {stderr}")
+            }
+            Self::Parse { command, value } => {
+                write!(formatter, "failed to parse {command} output: '{value}'")
+            }
+            Self::PaneStatus(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for TmuxDriverError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct PsmuxVersion {
+    major: u32,
+    minor: u32,
+    patch: u32,
+}
+
+impl PsmuxVersion {
+    const fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    fn parse(value: &str) -> Result<Self, String> {
+        let token = value
+            .split_whitespace()
+            .find(|part| part.chars().next().is_some_and(|ch| ch.is_ascii_digit()))
+            .ok_or_else(|| format!("version output contains no numeric token: {value:?}"))?;
+        let mut parts = token.split('.');
+        let major = parse_version_part(parts.next(), "major", value)?;
+        let minor = parse_version_part(parts.next(), "minor", value)?;
+        let patch = parse_version_part(parts.next(), "patch", value)?;
+        Ok(Self::new(major, minor, patch))
+    }
+}
+
+impl std::fmt::Display for PsmuxVersion {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+fn invalid_request(reason: &str) -> TmuxDriverError {
+    TmuxDriverError::InvalidRequest(reason.to_string())
+}
+
+fn parse_version_part(part: Option<&str>, name: &str, source: &str) -> Result<u32, String> {
+    let value =
+        part.ok_or_else(|| format!("version output has no {name} component: {source:?}"))?;
+    value
+        .trim_matches(|character: char| !character.is_ascii_digit())
+        .parse::<u32>()
+        .map_err(|error| format!("invalid {name} version component in {source:?}: {error}"))
+}
+
+fn new_session_args(request: &TmuxStartRequest) -> Vec<String> {
+    let mut args = vec![
+        "new-session".to_string(),
+        "-d".to_string(),
+        "-s".to_string(),
+        request.session_name.clone(),
+        "-x".to_string(),
+        request.cols.to_string(),
+        "-y".to_string(),
+        request.rows.to_string(),
+        "-c".to_string(),
+        request.working_dir.to_string_lossy().into_owned(),
+    ];
+    args.push(windows_command_line(&request.command));
+    args
+}
+
+fn windows_command_line(arguments: &[String]) -> String {
+    let quoted = arguments
+        .iter()
+        .map(|argument| powershell_quote(argument))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("& {quoted}")
+}
+
+fn powershell_quote(argument: &str) -> String {
+    format!("'{}'", argument.replace('\'', "''"))
+}
+
+fn unique_namespace() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let sequence = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("jefe-harness-{}-{nanos:x}-{sequence:x}", std::process::id())
+}
+
+fn format_command(executable: &Path, namespace: &str, args: &[String]) -> String {
+    format!("{} -L {namespace} {}", executable.display(), args.join(" "))
+}
+
+fn wait_for_command(
+    mut child: std::process::Child,
+    command_name: &str,
+) -> Result<Output, TmuxDriverError> {
+    let deadline = Instant::now() + COMMAND_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return collect_output(child, command_name),
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(TmuxDriverError::Timeout {
+                    command: command_name.to_string(),
+                });
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(25)),
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(TmuxDriverError::Spawn {
+                    command: command_name.to_string(),
+                    reason: error.to_string(),
+                });
+            }
+        }
+    }
+}
+
+fn collect_output(
+    child: std::process::Child,
+    command_name: &str,
+) -> Result<Output, TmuxDriverError> {
+    let output = child
+        .wait_with_output()
+        .map_err(|error| TmuxDriverError::Spawn {
+            command: command_name.to_string(),
+            reason: error.to_string(),
+        })?;
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(TmuxDriverError::Failed {
+            command: command_name.to_string(),
+            stderr: format_output(&output),
+        })
+    }
+}
+
+fn format_output(output: &Output) -> String {
+    format!(
+        "status: {}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout).trim(),
+        String::from_utf8_lossy(&output.stderr).trim()
+    )
+}
+
+fn output_lines(bytes: &[u8]) -> Vec<String> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .map(std::borrow::ToOwned::to_owned)
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "psmux_driver_tests.rs"]
+mod tests;

--- a/src/harness/psmux_driver.rs
+++ b/src/harness/psmux_driver.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use super::capture::{PaneStatus, PaneStatusParseError, ScreenCapture, ScrollbackSample};
 
@@ -206,7 +206,7 @@ impl TmuxDriver {
         if key.is_empty() {
             return Err(invalid_request("key must not be empty"));
         }
-        self.run(&["send-keys", "-t", &session.name, key])
+        self.run(&["send-keys", "-t", &session.name, "--", key])
     }
 
     pub fn send_keys(&self, session: &TmuxSession, keys: &[String]) -> Result<(), TmuxDriverError> {
@@ -325,7 +325,7 @@ impl TmuxDriver {
         if !output.status.success() {
             return Err(TmuxDriverError::Unavailable {
                 executable: self.executable.clone(),
-                reason: format_output(&output),
+                reason: super::psmux_process::format_output(&output),
             });
         }
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
@@ -354,7 +354,12 @@ impl TmuxDriver {
     fn run_owned(&self, args: &[String], cwd: Option<&Path>) -> Result<Output, TmuxDriverError> {
         let command_name = format_command(&self.executable, &self.namespace, args);
         let mut command = Command::new(&self.executable);
-        command.arg("-L").arg(&self.namespace).args(args);
+        command
+            .arg("-f")
+            .arg("NUL")
+            .arg("-L")
+            .arg(&self.namespace)
+            .args(args);
         command
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
@@ -369,7 +374,7 @@ impl TmuxDriver {
             command: command_name.clone(),
             reason: error.to_string(),
         })?;
-        wait_for_command(child, &command_name)
+        super::psmux_process::wait_for_command(child, &command_name, COMMAND_TIMEOUT)
     }
 }
 
@@ -512,63 +517,6 @@ fn unique_namespace() -> String {
 
 fn format_command(executable: &Path, namespace: &str, args: &[String]) -> String {
     format!("{} -L {namespace} {}", executable.display(), args.join(" "))
-}
-
-fn wait_for_command(
-    mut child: std::process::Child,
-    command_name: &str,
-) -> Result<Output, TmuxDriverError> {
-    let deadline = Instant::now() + COMMAND_TIMEOUT;
-    loop {
-        match child.try_wait() {
-            Ok(Some(_)) => return collect_output(child, command_name),
-            Ok(None) if Instant::now() >= deadline => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(TmuxDriverError::Timeout {
-                    command: command_name.to_string(),
-                });
-            }
-            Ok(None) => std::thread::sleep(Duration::from_millis(25)),
-            Err(error) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(TmuxDriverError::Spawn {
-                    command: command_name.to_string(),
-                    reason: error.to_string(),
-                });
-            }
-        }
-    }
-}
-
-fn collect_output(
-    child: std::process::Child,
-    command_name: &str,
-) -> Result<Output, TmuxDriverError> {
-    let output = child
-        .wait_with_output()
-        .map_err(|error| TmuxDriverError::Spawn {
-            command: command_name.to_string(),
-            reason: error.to_string(),
-        })?;
-    if output.status.success() {
-        Ok(output)
-    } else {
-        Err(TmuxDriverError::Failed {
-            command: command_name.to_string(),
-            stderr: format_output(&output),
-        })
-    }
-}
-
-fn format_output(output: &Output) -> String {
-    format!(
-        "status: {}\nstdout: {}\nstderr: {}",
-        output.status,
-        String::from_utf8_lossy(&output.stdout).trim(),
-        String::from_utf8_lossy(&output.stderr).trim()
-    )
 }
 
 fn output_lines(bytes: &[u8]) -> Vec<String> {

--- a/src/harness/psmux_driver.rs
+++ b/src/harness/psmux_driver.rs
@@ -184,8 +184,9 @@ impl TmuxDriver {
         if session.keep_session {
             return Ok(());
         }
-        let session_cleanup = self.run(&["kill-session", "-t", &session.name]);
-        let namespace_cleanup = self.kill_owned_namespace();
+        let session_cleanup =
+            ignore_absent_cleanup(self.run(&["kill-session", "-t", &session.name]));
+        let namespace_cleanup = ignore_absent_cleanup(self.kill_owned_namespace());
         match (session_cleanup, namespace_cleanup) {
             (Ok(()), Ok(())) => Ok(()),
             (Err(session), Ok(())) => Err(session),
@@ -465,6 +466,19 @@ impl std::fmt::Display for PsmuxVersion {
 
 fn invalid_request(reason: &str) -> TmuxDriverError {
     TmuxDriverError::InvalidRequest(reason.to_string())
+}
+
+fn ignore_absent_cleanup(result: Result<(), TmuxDriverError>) -> Result<(), TmuxDriverError> {
+    match result {
+        Err(TmuxDriverError::Failed { stderr, .. })
+            if stderr.to_ascii_lowercase().contains("no server running")
+                || stderr.to_ascii_lowercase().contains("no sessions")
+                || stderr.to_ascii_lowercase().contains("can't find session") =>
+        {
+            Ok(())
+        }
+        other => other,
+    }
 }
 
 fn parse_version_part(part: Option<&str>, name: &str, source: &str) -> Result<u32, String> {

--- a/src/harness/psmux_driver.rs
+++ b/src/harness/psmux_driver.rs
@@ -164,8 +164,13 @@ impl TmuxDriver {
         let args = new_session_args(request);
         self.run_owned(&args, Some(&request.working_dir))?;
         if let Err(error) = self.configure_session(request) {
-            let _ = self.kill_owned_namespace();
-            return Err(error);
+            return match self.kill_owned_namespace() {
+                Ok(()) => Err(error),
+                Err(cleanup) => Err(TmuxDriverError::Cleanup {
+                    session: error.to_string(),
+                    namespace: cleanup.to_string(),
+                }),
+            };
         }
         Ok(TmuxSession {
             name: request.session_name.clone(),

--- a/src/harness/psmux_driver_tests.rs
+++ b/src/harness/psmux_driver_tests.rs
@@ -62,11 +62,9 @@ fn real_psmux_runs_a_stable_native_process_when_available() {
     let session = driver
         .start_session(&request)
         .unwrap_or_else(|error| panic!("psmux session should start: {error}"));
-    let screen = driver
-        .capture_screen(&session)
-        .unwrap_or_else(|error| panic!("screen should capture: {error}"));
+    let capture = driver.capture_screen(&session);
+    let cleanup = driver.cleanup_session(&session);
+    cleanup.unwrap_or_else(|error| panic!("owned namespace should clean up: {error}"));
+    let screen = capture.unwrap_or_else(|error| panic!("screen should capture: {error}"));
     assert_eq!((screen.cols, screen.rows), (100, 32));
-    driver
-        .cleanup_session(&session)
-        .unwrap_or_else(|error| panic!("owned namespace should clean up: {error}"));
 }

--- a/src/harness/psmux_driver_tests.rs
+++ b/src/harness/psmux_driver_tests.rs
@@ -7,7 +7,7 @@ fn windows_launch_plan_uses_platform_shell_without_a_unix_wrapper() {
         vec![
             "C:\\Program Files\\Jefe Ω\\jefe.exe".to_string(),
             "--config".to_string(),
-            "C:\\config dir Ω".to_string(),
+            "C:\\config dir O'Brien Ω".to_string(),
         ],
         "C:\\working dir Ω",
         100,
@@ -20,7 +20,7 @@ fn windows_launch_plan_uses_platform_shell_without_a_unix_wrapper() {
     let launch = args.last().map_or("", String::as_str);
     assert_eq!(
         launch,
-        "& 'C:\\Program Files\\Jefe Ω\\jefe.exe' '--config' 'C:\\config dir Ω'"
+        "& 'C:\\Program Files\\Jefe Ω\\jefe.exe' '--config' 'C:\\config dir O''Brien Ω'"
     );
     assert!(!launch.contains("unset ") && !launch.contains("exec "));
 }

--- a/src/harness/psmux_driver_tests.rs
+++ b/src/harness/psmux_driver_tests.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+#[test]
+fn windows_launch_plan_uses_platform_shell_without_a_unix_wrapper() {
+    let request = TmuxStartRequest::command(
+        "demo",
+        vec![
+            "C:\\Program Files\\Jefe Ω\\jefe.exe".to_string(),
+            "--config".to_string(),
+            "C:\\config dir Ω".to_string(),
+        ],
+        "C:\\working dir Ω",
+        100,
+        32,
+        2_000,
+    )
+    .unwrap_or_else(|error| panic!("request should be valid: {error}"));
+
+    let args = new_session_args(&request);
+    let launch = args.last().map_or("", String::as_str);
+    assert_eq!(
+        launch,
+        "& 'C:\\Program Files\\Jefe Ω\\jefe.exe' '--config' 'C:\\config dir Ω'"
+    );
+    assert!(!launch.contains("unset ") && !launch.contains("exec "));
+}
+
+#[test]
+fn every_driver_gets_a_unique_owned_namespace() {
+    let first = TmuxDriver::new();
+    let second = TmuxDriver::new();
+    assert_ne!(first.namespace, second.namespace);
+    assert!(first.diagnostics().contains("namespace: jefe-harness-"));
+}
+
+#[test]
+fn qualified_psmux_version_is_parsed() {
+    assert_eq!(PsmuxVersion::parse("tmux 3.3.6"), Ok(MINIMUM_PSMUX_VERSION));
+    assert!(PsmuxVersion::parse("psmux unknown").is_err());
+}
+
+#[test]
+fn real_psmux_runs_a_stable_native_process_when_available() {
+    let driver = TmuxDriver::new();
+    if !driver.is_available() {
+        return;
+    }
+    let request = TmuxStartRequest::command(
+        "driver-real",
+        vec![
+            "powershell.exe".to_string(),
+            "-NoProfile".to_string(),
+            "-Command".to_string(),
+            "Start-Sleep -Seconds 5".to_string(),
+        ],
+        std::env::current_dir().unwrap_or_else(|error| panic!("current directory: {error}")),
+        100,
+        32,
+        2_000,
+    )
+    .unwrap_or_else(|error| panic!("request should be valid: {error}"));
+    let session = driver
+        .start_session(&request)
+        .unwrap_or_else(|error| panic!("psmux session should start: {error}"));
+    let screen = driver
+        .capture_screen(&session)
+        .unwrap_or_else(|error| panic!("screen should capture: {error}"));
+    assert_eq!((screen.cols, screen.rows), (100, 32));
+    driver
+        .cleanup_session(&session)
+        .unwrap_or_else(|error| panic!("owned namespace should clean up: {error}"));
+}

--- a/src/harness/psmux_process.rs
+++ b/src/harness/psmux_process.rs
@@ -1,0 +1,103 @@
+//! Bounded native process collection for the Windows psmux boundary.
+
+use std::io::Read;
+use std::process::{Child, ExitStatus, Output};
+use std::time::{Duration, Instant};
+
+use super::tmux_driver::TmuxDriverError;
+
+type PipeReader = std::thread::JoinHandle<std::io::Result<Vec<u8>>>;
+
+pub(super) fn wait_for_command(
+    mut child: Child,
+    command_name: &str,
+    timeout: Duration,
+) -> Result<Output, TmuxDriverError> {
+    let stdout = child.stdout.take().map(spawn_pipe_reader);
+    let stderr = child.stderr.take().map(spawn_pipe_reader);
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                drain_pipe(stdout);
+                drain_pipe(stderr);
+                return Err(TmuxDriverError::Timeout {
+                    command: command_name.to_string(),
+                });
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(25)),
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                drain_pipe(stdout);
+                drain_pipe(stderr);
+                return Err(spawn_error(command_name, error.to_string()));
+            }
+        }
+    };
+    collect_output(status, stdout, stderr, command_name)
+}
+
+fn spawn_pipe_reader<R: Read + Send + 'static>(mut pipe: R) -> PipeReader {
+    std::thread::spawn(move || {
+        let mut output = Vec::new();
+        pipe.read_to_end(&mut output)?;
+        Ok(output)
+    })
+}
+
+fn drain_pipe(reader: Option<PipeReader>) {
+    if let Some(reader) = reader {
+        let _ = reader.join();
+    }
+}
+
+fn collect_output(
+    status: ExitStatus,
+    stdout: Option<PipeReader>,
+    stderr: Option<PipeReader>,
+    command_name: &str,
+) -> Result<Output, TmuxDriverError> {
+    let output = Output {
+        status,
+        stdout: join_pipe(stdout, command_name)?,
+        stderr: join_pipe(stderr, command_name)?,
+    };
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(TmuxDriverError::Failed {
+            command: command_name.to_string(),
+            stderr: format_output(&output),
+        })
+    }
+}
+
+fn join_pipe(reader: Option<PipeReader>, command_name: &str) -> Result<Vec<u8>, TmuxDriverError> {
+    let Some(reader) = reader else {
+        return Ok(Vec::new());
+    };
+    reader
+        .join()
+        .map_err(|_| spawn_error(command_name, "output reader panicked".to_string()))?
+        .map_err(|error| spawn_error(command_name, error.to_string()))
+}
+
+fn spawn_error(command_name: &str, reason: String) -> TmuxDriverError {
+    TmuxDriverError::Spawn {
+        command: command_name.to_string(),
+        reason,
+    }
+}
+
+pub(super) fn format_output(output: &Output) -> String {
+    format!(
+        "status: {}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout).trim(),
+        String::from_utf8_lossy(&output.stderr).trim()
+    )
+}

--- a/src/harness/runner.rs
+++ b/src/harness/runner.rs
@@ -35,6 +35,7 @@ pub struct RunSummary {
     pub steps_run: usize,
     pub artifact_dir: Option<PathBuf>,
     pub soft_failures: Vec<RunnerFailure>,
+    pub multiplexer_details: Option<String>,
 }
 
 /// Structured failure details for a step.
@@ -204,11 +205,29 @@ pub fn run_tmux_scenario(
     let effective_request = request
         .clone()
         .with_keep_session(request.keep_session || expanded.config.keep_session);
-    let session = tmux
-        .start_session(&effective_request)
-        .map_err(|err| RunnerError::Driver(err.to_string()))?;
+    let effective_artifact_dir = artifact_dir
+        .map(Path::to_path_buf)
+        .or_else(|| expanded.config.out_dir.clone());
+    if let Some(directory) = &effective_artifact_dir {
+        write_text(directory.join("multiplexer.txt"), &tmux.diagnostics())?;
+    }
+    let session = match tmux.start_session(&effective_request) {
+        Ok(session) => session,
+        Err(error) => {
+            if let Some(directory) = &effective_artifact_dir {
+                let _ = write_text(
+                    directory.join("error.txt"),
+                    &format!("startup error: {error}"),
+                );
+            }
+            return Err(RunnerError::Driver(error.to_string()));
+        }
+    };
     let mut driver = TmuxHarnessDriver::new(tmux.clone(), session.clone());
-    let result = run_expanded_scenario(&expanded, &mut driver, artifact_dir);
+    let mut result = run_expanded_scenario(&expanded, &mut driver, artifact_dir);
+    if let Ok(summary) = &mut result {
+        summary.multiplexer_details = Some(tmux.diagnostics());
+    }
     let cleanup = tmux.cleanup_session(&session);
     match (result, cleanup) {
         (Ok(summary), Ok(())) => Ok(summary),
@@ -252,6 +271,7 @@ fn run_steps<D: HarnessDriver>(
         steps_run: steps.len(),
         artifact_dir: context.artifact_dir.clone(),
         soft_failures: context.soft_failures.clone(),
+        multiplexer_details: None,
     })
 }
 

--- a/src/harness/runner.rs
+++ b/src/harness/runner.rs
@@ -214,12 +214,7 @@ pub fn run_tmux_scenario(
     let session = match tmux.start_session(&effective_request) {
         Ok(session) => session,
         Err(error) => {
-            if let Some(directory) = &effective_artifact_dir {
-                let _ = write_text(
-                    directory.join("error.txt"),
-                    &format!("startup error: {error}"),
-                );
-            }
+            write_startup_failure_artifact(effective_artifact_dir.as_ref(), &error);
             return Err(RunnerError::Driver(error.to_string()));
         }
     };
@@ -565,6 +560,18 @@ fn write_text(path: PathBuf, text: &str) -> Result<(), RunnerError> {
         path,
         reason: err.to_string(),
     })
+}
+
+fn write_startup_failure_artifact(directory: Option<&PathBuf>, error: &TmuxDriverError) {
+    if let Some(directory) = directory {
+        let artifact = write_text(
+            directory.join("error.txt"),
+            &format!("startup error: {error}"),
+        );
+        if let Err(artifact_error) = artifact {
+            warn!(%artifact_error, "failed to write harness startup failure artifact");
+        }
+    }
 }
 
 fn driver_call<E: std::fmt::Display>(result: Result<(), E>) -> Result<(), RunnerError> {

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -232,12 +232,12 @@ fn capture_name_is_sanitized_inside_artifact_dir() {
 #[test]
 fn scenario_config_out_dir_is_used_when_no_explicit_artifact_dir_is_passed() {
     let artifact_dir = tempfile::tempdir().value_or_panic("tempdir");
+    let out_dir = artifact_dir.path().to_string_lossy().replace('\\', "\\\\");
     let json = format!(
         r#"{{
-            "config": {{ "cols": 80, "rows": 24, "out_dir": "{}" }},
+            "config": {{ "cols": 80, "rows": 24, "out_dir": "{out_dir}" }},
             "steps": [ {{ "capture": "screen" }} ]
         }}"#,
-        artifact_dir.path().display()
     );
     let scenario = parse_scenario(&json).value_or_panic("scenario should parse");
     let mut driver = FakeDriver::default().with_screens(&["from config"]);
@@ -485,7 +485,7 @@ fn jefe_binary_path() -> Option<PathBuf> {
     let current = std::env::current_exe().ok()?;
     let deps_dir = current.parent()?;
     let debug_dir = deps_dir.parent()?;
-    let candidate = debug_dir.join("jefe");
+    let candidate = debug_dir.join(format!("jefe{}", std::env::consts::EXE_SUFFIX));
     candidate.exists().then_some(candidate)
 }
 

--- a/src/harness/tmux_driver.rs
+++ b/src/harness/tmux_driver.rs
@@ -215,6 +215,19 @@ impl TmuxDriver {
             .is_ok_and(|out| out.status.success())
     }
 
+    /// Describe the isolated multiplexer used by this harness run.
+    #[must_use]
+    pub fn diagnostics(&self) -> String {
+        let version = tmux_command().arg("-V").output().map_or_else(
+            |error| format!("unavailable ({error})"),
+            |output| String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        );
+        format!(
+            "multiplexer: tmux\ntmux version: {version}\nnamespace: {}\n",
+            harness_socket_name()
+        )
+    }
+
     /// Start a detached tmux session.
     ///
     /// # Errors

--- a/src/harness/tmux_driver.rs
+++ b/src/harness/tmux_driver.rs
@@ -218,10 +218,20 @@ impl TmuxDriver {
     /// Describe the isolated multiplexer used by this harness run.
     #[must_use]
     pub fn diagnostics(&self) -> String {
-        let version = tmux_command().arg("-V").output().map_or_else(
-            |error| format!("unavailable ({error})"),
-            |output| String::from_utf8_lossy(&output.stdout).trim().to_string(),
-        );
+        let version = match tmux_command().arg("-V").output() {
+            Ok(output) if output.status.success() => {
+                String::from_utf8_lossy(&output.stdout).trim().to_string()
+            }
+            Ok(output) => {
+                let details = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                if details.is_empty() {
+                    format!("unavailable ({})", output.status)
+                } else {
+                    format!("unavailable ({details})")
+                }
+            }
+            Err(error) => format!("unavailable ({error})"),
+        };
         format!(
             "multiplexer: tmux\ntmux version: {version}\nnamespace: {}\n",
             harness_socket_name()

--- a/tests/core/tmux_harness_docs_contracts.rs
+++ b/tests/core/tmux_harness_docs_contracts.rs
@@ -25,6 +25,22 @@ fn dev_docs_index_links_to_tmux_harness_guide() {
 }
 
 /// @plan PLAN-20260629-TMUX-HARNESS.P05
+#[test]
+fn tmux_harness_guide_documents_native_windows_psmux_contract() {
+    let guide = read_repo_text("dev-docs/testing/tmux-harness.md");
+    for required in [
+        "Native Windows with psmux",
+        "psmux 3.3.6",
+        "JEFE_PSMUX_BIN",
+        "unique `psmux -L <namespace>`",
+        "multiplexer.txt",
+        "never invokes bare `psmux kill-server`",
+        "WSL, Cygwin, MSYS2, Git Bash, Docker",
+    ] {
+        assert!(guide.contains(required), "guide must document {required:?}");
+    }
+}
+
 /// @requirement REQ-TMUX-HARNESS-005
 /// @pseudocode component-002 lines 1-6
 #[test]


### PR DESCRIPTION
## Summary

- select upstream tmux on Unix and native psmux/ConPTY on Windows behind the existing harness driver API
- create a unique psmux `-L` namespace for every harness run and clean up only that owned namespace
- qualify psmux 3.3.6+, scrub inherited tmux variables, and launch Windows commands through native PowerShell quoting that preserves spaces and Unicode
- preserve the shared typed scenario model, macro expansion, matchers, bounded polling, isolated config, and deterministic artifacts
- persist multiplexer executable/version/namespace details before startup and report retained namespaces directly from the CLI
- document native Windows execution, missing/incompatible psmux diagnostics, and safe retained-namespace debugging

## Test-first evidence

### RED

The unmodified `dev-docs/tmux-scenarios/startup-quit.json` was run on native Windows with config and artifact paths containing spaces and Unicode. Before implementation it failed before session startup because the harness invoked the Unix-oriented tmux path:

```text
scenario failed: driver error: tmux command failed (tmux -f /dev/null -L jefe-harness-13724 has-session -t jefe-harness-cli)
```

### GREEN

The same unmodified scenario now runs against real psmux 3.3.6 and real `jefe.exe`:

```text
ok: 7 steps
```

The successful run used paths such as `target\issue255 final Ω\config` and `target\issue255 final Ω\artifacts`.

## Safety and diagnostics

- every run receives a unique `jefe-harness-<pid>-<time>-<sequence>` namespace
- cleanup always invokes `kill-server` with the owned `-L` namespace; no bare psmux cleanup is used
- `--keep-session` reports the session, executable, psmux version, namespace, and artifact path
- startup failures write `multiplexer.txt` and `error.txt` before a session exists
- `JEFE_PSMUX_BIN` supports explicit executable discovery
- missing or incompatible psmux errors identify the executable, minimum version, and override
- native-Windows compatibility does not depend on WSL, Cygwin, MSYS2, Git Bash, Docker, or Unix shell wrappers

## Verification

Passed locally on native Windows:

- `cargo fmt --all --check`
- strict Clippy for the modified library and `jefe-tmux-harness` binary (`duration_suboptimal_units` suppressed locally because Rust 1.97 recommends an API unavailable under the repository's Rust 1.75 MSRV)
- `cargo check --workspace --all-features`
- `cargo build --workspace --all-features --locked`
- all harness tests: 71 passed
- native psmux driver tests: 4 passed, including a real-process startup/capture/scoped-cleanup test
- tmux harness documentation contracts: 3 passed
- unmodified `startup-quit.json` against real psmux/ConPTY: 7 steps passed
- explicit missing-psmux startup-failure artifact verification
- explicit retained-namespace reporting and scoped cleanup verification
- `git diff --check`

The complete Windows workspace test command also executes pre-existing Unix-specific runtime/socket/prefix suites. Those continue to fail on Windows independently of this change; the issue-specific harness, docs, build, and real psmux checks above pass. Linux CI remains the authoritative full-workspace gate.

Closes #255
