### PR TITLE
Require native Windows psmux CI (#256)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,27 +153,30 @@ jobs:
       JEFE_REQUIRE_PSMUX: "1"
       RUST_BACKTRACE: full
       RUST_TEST_THREADS: "1"
+      PSMUX_VERSION: "3.3.6"
+      PSMUX_SHA256: a56a890ea0829567818b9a368f16dcbd39c087f27328573df17c10dd39618947
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           target: x86_64-pc-windows-msvc
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-targets: false
           shared-key: windows-msvc
       - name: Initialize Windows diagnostics
         shell: pwsh
         run: New-Item -ItemType Directory -Force target/windows-ci | Out-Null
-      - name: Install pinned psmux 3.3.6
+      - name: Install pinned psmux
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $url = 'https://github.com/psmux/psmux/releases/download/v3.3.6/psmux-v3.3.6-windows-x64.zip'
-          $expected = 'a56a890ea0829567818b9a368f16dcbd39c087f27328573df17c10dd39618947'
-          $archive = Join-Path $env:RUNNER_TEMP 'psmux-v3.3.6-windows-x64.zip'
-          $install = Join-Path $env:RUNNER_TOOL_CACHE 'psmux\3.3.6\x64'
+          $archiveName = "psmux-v$env:PSMUX_VERSION-windows-x64.zip"
+          $url = "https://github.com/psmux/psmux/releases/download/v$env:PSMUX_VERSION/$archiveName"
+          $expected = $env:PSMUX_SHA256
+          $archive = Join-Path $env:RUNNER_TEMP $archiveName
+          $install = Join-Path $env:RUNNER_TOOL_CACHE "psmux/$env:PSMUX_VERSION/x64"
           Invoke-WebRequest -Uri $url -OutFile $archive
           $actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
           if ($actual -ne $expected) {
@@ -198,8 +201,9 @@ jobs:
           if ($status -ne 0) {
             exit $status
           }
-          if ($version -notmatch '3\.3\.6') {
-            throw "expected qualified psmux 3.3.6, got: $version"
+          $versionText = ($version | Out-String).Trim()
+          if ($versionText -ne "tmux $env:PSMUX_VERSION") {
+            throw "expected qualified psmux $env:PSMUX_VERSION, got: $versionText"
           }
       - name: Check formatting
         shell: pwsh
@@ -236,10 +240,10 @@ jobs:
         run: |
           $config = Join-Path $env:RUNNER_TEMP 'jefe windows ci config'
           $working = Join-Path $env:RUNNER_TEMP 'jefe windows ci working directory'
-          $artifacts = Join-Path $env:GITHUB_WORKSPACE 'target\tmux-harness\windows-startup'
+          $artifacts = Join-Path $env:GITHUB_WORKSPACE 'target/tmux-harness/windows-startup'
           New-Item -ItemType Directory -Force $config, $working, $artifacts | Out-Null
-          $harness = Join-Path $env:GITHUB_WORKSPACE 'target\debug\jefe-tmux-harness.exe'
-          $jefe = Join-Path $env:GITHUB_WORKSPACE 'target\debug\jefe.exe'
+          $harness = Join-Path $env:GITHUB_WORKSPACE 'target/debug/jefe-tmux-harness.exe'
+          $jefe = Join-Path $env:GITHUB_WORKSPACE 'target/debug/jefe.exe'
           & $harness `
             --scenario dev-docs/tmux-scenarios/startup-quit.json `
             --jefe-bin $jefe `
@@ -270,7 +274,7 @@ jobs:
           exit 0
       - name: Upload native Windows diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: native-windows-psmux-artifacts
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,143 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-features --locked
 
+  windows_native:
+    name: Native Windows (MSVC + psmux)
+    runs-on: windows-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    env:
+      CLIPPY_CONF_DIR: .github/clippy
+      JEFE_REQUIRE_PSMUX: "1"
+      RUST_BACKTRACE: full
+      RUST_TEST_THREADS: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: x86_64-pc-windows-msvc
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+          shared-key: windows-msvc
+      - name: Initialize Windows diagnostics
+        shell: pwsh
+        run: New-Item -ItemType Directory -Force target/windows-ci | Out-Null
+      - name: Install pinned psmux 3.3.6
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $url = 'https://github.com/psmux/psmux/releases/download/v3.3.6/psmux-v3.3.6-windows-x64.zip'
+          $expected = 'a56a890ea0829567818b9a368f16dcbd39c087f27328573df17c10dd39618947'
+          $archive = Join-Path $env:RUNNER_TEMP 'psmux-v3.3.6-windows-x64.zip'
+          $install = Join-Path $env:RUNNER_TOOL_CACHE 'psmux\3.3.6\x64'
+          Invoke-WebRequest -Uri $url -OutFile $archive
+          $actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne $expected) {
+            throw "psmux archive checksum mismatch: expected $expected, got $actual"
+          }
+          New-Item -ItemType Directory -Force $install | Out-Null
+          Expand-Archive -Path $archive -DestinationPath $install -Force
+          $executable = Get-ChildItem -Path $install -Filter psmux.exe -Recurse |
+            Select-Object -First 1
+          if ($null -eq $executable) {
+            throw "psmux.exe was not present in the verified archive"
+          }
+          $executable.DirectoryName | Out-File -FilePath $env:GITHUB_PATH -Append
+          "JEFE_PSMUX_BIN=$($executable.FullName)" |
+            Out-File -FilePath $env:GITHUB_ENV -Append
+      - name: Verify psmux version
+        shell: pwsh
+        run: |
+          $version = & $env:JEFE_PSMUX_BIN -V 2>&1
+          $status = $LASTEXITCODE
+          $version | Tee-Object -FilePath target/windows-ci/psmux-version.txt
+          if ($status -ne 0) {
+            exit $status
+          }
+          if ($version -notmatch '3\.3\.6') {
+            throw "expected qualified psmux 3.3.6, got: $version"
+          }
+      - name: Check formatting
+        shell: pwsh
+        run: |
+          cargo fmt --all --check 2>&1 |
+            Tee-Object -FilePath target/windows-ci/cargo-fmt.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Run strict Clippy
+        shell: pwsh
+        run: |
+          cargo clippy --workspace --all-targets --all-features -- -D warnings 2>&1 |
+            Tee-Object -FilePath target/windows-ci/cargo-clippy.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Build locked all-feature workspace
+        shell: pwsh
+        run: |
+          cargo build --workspace --all-features --locked 2>&1 |
+            Tee-Object -FilePath target/windows-ci/cargo-build.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Test locked all-feature workspace
+        shell: pwsh
+        run: |
+          cargo test --workspace --all-features --locked 2>&1 |
+            Tee-Object -FilePath target/windows-ci/cargo-test.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Run real psmux command-surface smoke suite
+        shell: pwsh
+        run: |
+          cargo test --features psmux-smoke --test psmux_smoke -- --nocapture 2>&1 |
+            Tee-Object -FilePath target/windows-ci/psmux-smoke.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Run deterministic startup and quit TUI scenario
+        shell: pwsh
+        run: |
+          $config = Join-Path $env:RUNNER_TEMP 'jefe windows ci config'
+          $working = Join-Path $env:RUNNER_TEMP 'jefe windows ci working directory'
+          $artifacts = Join-Path $env:GITHUB_WORKSPACE 'target\tmux-harness\windows-startup'
+          New-Item -ItemType Directory -Force $config, $working, $artifacts | Out-Null
+          $harness = Join-Path $env:GITHUB_WORKSPACE 'target\debug\jefe-tmux-harness.exe'
+          $jefe = Join-Path $env:GITHUB_WORKSPACE 'target\debug\jefe.exe'
+          & $harness `
+            --scenario dev-docs/tmux-scenarios/startup-quit.json `
+            --jefe-bin $jefe `
+            --config $config `
+            --working-dir $working `
+            --session "jefe-ci-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT" `
+            --out-dir $artifacts 2>&1 |
+            Tee-Object -FilePath target/windows-ci/tui-startup.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Record remaining owned psmux sessions
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $remaining = 'target/windows-ci/remaining-sessions.txt'
+          'No harness namespace was recorded.' | Out-File $remaining
+          $details = 'target/tmux-harness/windows-startup/multiplexer.txt'
+          if (Test-Path $details) {
+            $match = Select-String -Path $details -Pattern '^namespace: (.+)$'
+            if ($null -ne $match) {
+              $namespace = $match.Matches[0].Groups[1].Value
+              $output = & $env:JEFE_PSMUX_BIN -f NUL -L $namespace list-sessions 2>&1
+              $status = $LASTEXITCODE
+              @("namespace: $namespace", "status: $status") + $output |
+                Out-File $remaining
+            }
+          }
+          exit 0
+      - name: Upload native Windows diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-windows-psmux-artifacts
+          path: |
+            target/windows-ci
+            target/psmux-smoke
+            target/tmux-harness
+          if-no-files-found: warn
+
   tui_smoke:
     name: Optional TUI smoke (tmux)
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,51 @@ clippy-allow policy, source-file-size policy, clippy complexity gates, the 30%
 line-coverage gate, a workspace build, and the full test suite. See
 [Testing and Quality](dev-docs/standards/testing-and-quality.md) for every job.
 
+## Reproduce the native Windows CI gate
+
+Run the Windows gate from native PowerShell with the x86-64 MSVC toolchain. Do
+not use WSL, Cygwin, MSYS2, Git Bash, Docker, or another Unix compatibility
+layer for this qualification.
+
+CI pins psmux 3.3.6 from the official release archive
+`psmux-v3.3.6-windows-x64.zip` and verifies SHA-256
+`a56a890ea0829567818b9a368f16dcbd39c087f27328573df17c10dd39618947` before
+extracting it. Local contributors may install the same qualified release with:
+
+```powershell
+winget install --id marlocarlo.psmux --version 3.3.6 --exact
+psmux -V
+```
+
+Set `JEFE_PSMUX_BIN` if `psmux.exe` is not on `PATH`, then run the same required
+commands as CI:
+
+```powershell
+$env:JEFE_REQUIRE_PSMUX = '1'
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo build --workspace --all-features --locked
+cargo test --workspace --all-features --locked
+cargo test --features psmux-smoke --test psmux_smoke -- --nocapture
+
+$workspace = (Get-Location).Path
+$config = Join-Path $workspace 'target/windows local/config with spaces'
+$working = Join-Path $workspace 'target/windows local/working with spaces'
+$artifacts = Join-Path $workspace 'target/tmux-harness/windows-local'
+New-Item -ItemType Directory -Force $config, $working, $artifacts | Out-Null
+& (Join-Path $workspace 'target/debug/jefe-tmux-harness.exe') `
+  --scenario (Join-Path $workspace 'dev-docs/tmux-scenarios/startup-quit.json') `
+  --jefe-bin (Join-Path $workspace 'target/debug/jefe.exe') `
+  --config $config `
+  --working-dir $working `
+  --session 'jefe-windows-local' `
+  --out-dir $artifacts
+```
+
+The smoke suite and harness own unique psmux namespaces and only issue
+namespace-scoped cleanup. Failure diagnostics are written beneath
+`target/psmux-smoke` and `target/tmux-harness`.
+
 ## Branch and PR conventions
 
 - **One issue branch per issue** (e.g. `issue42`), branched from `main`.

--- a/src/app_input/issues_dispatch.rs
+++ b/src/app_input/issues_dispatch.rs
@@ -125,10 +125,10 @@ pub(super) fn load_issue_detail_for_selection(app_state: &mut AppStateHandle, ct
         move |mut app_state, ctx| {
             let event = detail_load_event(&ctx, params);
             // Offer the in-app auth dialog when gh is unauthenticated (issue #244).
-            if let AppEvent::IssueDetailLoadFailed { error, .. } = &event {
-                if super::auth_remediation::offer_auth_remediation(&mut app_state, &ctx, error) {
-                    return;
-                }
+            if let AppEvent::IssueDetailLoadFailed { error, .. } = &event
+                && super::auth_remediation::offer_auth_remediation(&mut app_state, &ctx, error)
+            {
+                return;
             }
             apply_and_persist(&mut app_state, &ctx, event);
         },

--- a/src/app_input/prs_dispatch.rs
+++ b/src/app_input/prs_dispatch.rs
@@ -115,10 +115,10 @@ pub(super) fn load_pr_detail_for_selection(app_state: &mut AppStateHandle, ctx: 
         move |mut app_state, ctx| {
             let event = pr_detail_load_event(&ctx, &params);
             // Offer the in-app auth dialog when gh is unauthenticated (issue #244).
-            if let AppEvent::PrDetailLoadFailed { error, .. } = &event {
-                if super::auth_remediation::offer_auth_remediation(&mut app_state, &ctx, error) {
-                    return;
-                }
+            if let AppEvent::PrDetailLoadFailed { error, .. } = &event
+                && super::auth_remediation::offer_auth_remediation(&mut app_state, &ctx, error)
+            {
+                return;
             }
             apply_and_persist(&mut app_state, &ctx, event);
         },

--- a/src/app_input/reclone_safety.rs
+++ b/src/app_input/reclone_safety.rs
@@ -159,6 +159,7 @@ mod tests {
         // On non-Unix there are no symlinks to create; skip.
     }
 
+    #[cfg(unix)]
     fn rand_label() -> String {
         use std::sync::atomic::{AtomicU64, Ordering};
         use std::time::{SystemTime, UNIX_EPOCH};
@@ -170,10 +171,12 @@ mod tests {
         format!("{nanos}-{seq}")
     }
 
+    #[cfg(unix)]
     trait TestResultStringExt {
         fn error_or_panic(self, context: &str) -> String;
     }
 
+    #[cfg(unix)]
     impl TestResultStringExt for Result<(), String> {
         fn error_or_panic(self, context: &str) -> String {
             match self {
@@ -183,10 +186,12 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     trait TestOptionExt<T> {
         fn value_or_panic(self, context: &str) -> T;
     }
 
+    #[cfg(unix)]
     impl<T> TestOptionExt<T> for Option<T> {
         fn value_or_panic(self, context: &str) -> T {
             match self {
@@ -196,10 +201,12 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     trait TestIoResultExt<T> {
         fn value_or_panic(self, context: &str) -> T;
     }
 
+    #[cfg(unix)]
     impl<T> TestIoResultExt<T> for std::io::Result<T> {
         fn value_or_panic(self, context: &str) -> T {
             match self {

--- a/src/harness/runner.rs
+++ b/src/harness/runner.rs
@@ -23,7 +23,10 @@ use super::step::Step;
 use super::tmux_driver::{TmuxDriver, TmuxDriverError, TmuxSession, TmuxStartRequest};
 use tracing::warn;
 
+#[cfg(not(windows))]
 const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(windows)]
+const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Result of a scenario run.

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -504,6 +504,7 @@ fn unique_session(label: &str) -> String {
 /// runtime kill can actually succeed, seeds a state.json with a Running agent
 /// bound to that session, then drives the real jefe binary through the
 /// kill → still-visible → navigate → filtered → quit flow.
+#[cfg(unix)]
 #[test]
 fn guarded_real_jefe_sticky_kill_scenario() {
     let Some(jefe_binary) = guarded_jefe_binary("sticky kill test") else {
@@ -540,6 +541,7 @@ fn guarded_real_jefe_sticky_kill_scenario() {
 
 /// Seed a config directory with a state.json containing a single Running agent
 /// bound to the given tmux session name (issue #116 scenario fixture).
+#[cfg(unix)]
 fn seed_sticky_agent_state(config_dir: &std::path::Path, agent_session: &str) {
     use crate::domain::{
         Agent, AgentId, AgentStatus, DEFAULT_SANDBOX_FLAGS, LaunchSignature,
@@ -605,6 +607,7 @@ fn seed_sticky_agent_state(config_dir: &std::path::Path, agent_session: &str) {
 }
 
 /// Run the issue #116 sticky-kill TUI scenario against the real jefe binary.
+#[cfg(unix)]
 fn run_sticky_scenario(jefe_binary: &std::path::Path, config_dir: &std::path::Path) -> RunSummary {
     let scenario = scenario(
         r#"[
@@ -639,6 +642,7 @@ fn run_sticky_scenario(jefe_binary: &std::path::Path, config_dir: &std::path::Pa
 /// Pre-create a tmux session running `sleep <seconds>` on jefe's dedicated
 /// socket so jefe's session-exists check (which targets the private socket)
 /// finds it. Returns `true` on success.
+#[cfg(unix)]
 fn create_sleep_session_on_jefe_socket(session_name: &str, seconds: u64) -> bool {
     let jefe_socket = crate::runtime::jefe_tmux_socket_path();
     match std::process::Command::new("tmux")
@@ -674,6 +678,7 @@ fn create_sleep_session_on_jefe_socket(session_name: &str, seconds: u64) -> bool
 }
 
 /// Capture pane text for a session on jefe's dedicated socket.
+#[cfg(unix)]
 fn capture_jefe_pane(session_name: &str) -> Option<String> {
     let jefe_socket = crate::runtime::jefe_tmux_socket_path();
     let output = std::process::Command::new("tmux")
@@ -697,10 +702,12 @@ fn capture_jefe_pane(session_name: &str) -> Option<String> {
 
 /// RAII guard that kills a pre-created tmux session on drop, ensuring cleanup
 /// even if the test panics mid-scenario.
+#[cfg(unix)]
 struct TmuxSessionCleanup {
     session_name: String,
 }
 
+#[cfg(unix)]
 impl Drop for TmuxSessionCleanup {
     fn drop(&mut self) {
         // Best-effort kill on both jefe's dedicated socket and the default
@@ -727,6 +734,7 @@ impl Drop for TmuxSessionCleanup {
 /// a state.json with a Running agent bound to that session, then drives the
 /// real jefe binary through the restart flow: active-only → Tab to Agents →
 /// Ctrl-r → expect agent still visible and running → quit.
+#[cfg(unix)]
 #[test]
 fn guarded_real_jefe_restart_scenario() {
     let Some(jefe_binary) = guarded_jefe_binary("restart test") else {
@@ -782,6 +790,7 @@ fn guarded_real_jefe_restart_scenario() {
 
 /// Seed a config directory with a state.json containing a single Running agent
 /// bound to the given tmux session name (issue #117 scenario fixture).
+#[cfg(unix)]
 fn seed_restart_agent_state(config_dir: &std::path::Path, agent_session: &str) {
     use crate::domain::{
         Agent, AgentId, AgentStatus, DEFAULT_SANDBOX_FLAGS, LaunchSignature,
@@ -853,6 +862,7 @@ fn seed_restart_agent_state(config_dir: &std::path::Path, agent_session: &str) {
 }
 
 /// Run the issue #117 restart TUI scenario against the real jefe binary.
+#[cfg(unix)]
 fn run_restart_scenario(jefe_binary: &std::path::Path, config_dir: &std::path::Path) -> RunSummary {
     let scenario = scenario(
         r#"[

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -963,6 +963,6 @@ pub fn send_keys(session_name: &str, keys: &str) -> Result<(), RuntimeError> {
 #[path = "commands_tests.rs"]
 mod tests;
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 #[path = "prefix_passthrough_tests.rs"]
 mod prefix_passthrough_tests;

--- a/src/runtime/commands_tests.rs
+++ b/src/runtime/commands_tests.rs
@@ -4,6 +4,7 @@
 use super::*;
 use crate::domain::SandboxEngine;
 use crate::runtime::pane_capture::{capture_pane_history_args, parse_pane_pid};
+#[cfg(unix)]
 use std::time::Duration;
 
 fn base_signature() -> LaunchSignature {
@@ -182,6 +183,7 @@ fn remote_tmux_command_wraps_run_as_user_once() {
 /// [`run_command_capture_with_timeout`] branch with a sub-second injectable
 /// deadline against a portable `sleep` probe, so the test is fast and hermetic
 /// (no `python3` dependency) (#173).
+#[cfg(unix)]
 #[test]
 fn remote_execution_timeout_returns_clear_error() {
     // `sleep` is specified by POSIX and present on every CI platform jefe

--- a/src/runtime/liveness.rs
+++ b/src/runtime/liveness.rs
@@ -9,17 +9,17 @@ use crate::runtime::commands::{
     remote_tmux_command, run_remote_ssh, shell_escape_single, tmux_command,
 };
 
-/// Check if a process with the given PID is alive via `kill -0`.
+/// Check if a process with the given PID is alive.
 ///
 /// This **complements**, not replaces, [`check_session_alive`]. When the jefe
-/// tmux server has died but the `llxprt` worker was reparented to launchd
-/// (ppid=1) and is still running, `check_session_alive` reports false (no
-/// tmux session) while `pid_alive` reports true — letting jefe recognize the
-/// worker is recoverable rather than marking the agent Dead.
+/// multiplexer server has died but the worker is still running,
+/// `check_session_alive` reports false while `pid_alive` reports true — letting
+/// jefe recognize the worker is recoverable rather than marking the agent Dead.
 ///
-/// Uses a shell-out to `kill -0` (resolved via PATH) because the project
-/// forbids `unsafe` code and the `libc`/`nix`/`sysinfo` crates. Local-only:
-/// remote agents must stay on the tmux/SSH-only path.
+/// Uses `kill -0` on Unix and filtered `tasklist` output on Windows because the
+/// project forbids `unsafe` code and the `libc`/`nix`/`sysinfo` crates. A spawn
+/// failure is fail-open on both platforms to avoid marking a potentially live
+/// worker Dead. Local-only: remote agents stay on the tmux/SSH-only path.
 #[must_use]
 pub fn pid_alive(pid: u32) -> bool {
     pid_alive_on_platform(pid)

--- a/src/runtime/liveness.rs
+++ b/src/runtime/liveness.rs
@@ -22,6 +22,11 @@ use crate::runtime::commands::{
 /// remote agents must stay on the tmux/SSH-only path.
 #[must_use]
 pub fn pid_alive(pid: u32) -> bool {
+    pid_alive_on_platform(pid)
+}
+
+#[cfg(unix)]
+fn pid_alive_on_platform(pid: u32) -> bool {
     match std::process::Command::new("kill")
         .arg("-0")
         .arg(pid.to_string())
@@ -36,6 +41,34 @@ pub fn pid_alive(pid: u32) -> bool {
             true
         }
     }
+}
+
+#[cfg(windows)]
+fn pid_alive_on_platform(pid: u32) -> bool {
+    let filter = format!("PID eq {pid}");
+    match std::process::Command::new("tasklist")
+        .args(["/FI", &filter, "/FO", "CSV", "/NH"])
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            let expected = format!("\",\"{pid}\",");
+            String::from_utf8_lossy(&output.stdout).contains(&expected)
+        }
+        Ok(_) => false,
+        Err(e) => {
+            tracing::warn!(error = %e, pid, "failed to spawn tasklist; assuming worker alive");
+            true
+        }
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn pid_alive_on_platform(pid: u32) -> bool {
+    tracing::warn!(
+        pid,
+        "PID liveness is unsupported on this platform; assuming worker alive"
+    );
+    true
 }
 
 /// Check if a tmux session exists and has at least one non-dead pane.

--- a/src/runtime/socket.rs
+++ b/src/runtime/socket.rs
@@ -213,7 +213,7 @@ pub fn jefe_tmux_socket_path() -> &'static std::path::Path {
     SOCKET_PATH.get_or_init(|| ensure_dir_or_fallback(resolve_socket_path()))
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 

--- a/tests/core/message_bus_contracts.rs
+++ b/tests/core/message_bus_contracts.rs
@@ -248,6 +248,7 @@ fn issue_self_assignment_failed_round_trips_through_message_bus() {
     assert_eq!(error, "repo restricts assignees");
 }
 
+#[cfg(unix)]
 #[test]
 fn architecture_boundary_script_passes_in_ci_tests() {
     let output = std::process::Command::new("bash")

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -3,6 +3,7 @@
 //! @plan PLAN-20260216-FIRSTVERSION-V1.P04
 //! @requirement REQ-TECH-002
 
+#[cfg(unix)]
 mod clippy_allow_policy;
 mod domain_state_contracts;
 mod message_bus_contracts;

--- a/tests/core/tmux_harness_docs_contracts.rs
+++ b/tests/core/tmux_harness_docs_contracts.rs
@@ -41,6 +41,36 @@ fn tmux_harness_guide_documents_native_windows_psmux_contract() {
     }
 }
 
+#[test]
+fn native_windows_ci_gates_psmux_and_startup_scenario() {
+    let workflow = read_repo_text(".github/workflows/ci.yml");
+    for required in [
+        "runs-on: windows-latest",
+        "target: x86_64-pc-windows-msvc",
+        "cargo fmt --all --check",
+        "cargo clippy --workspace --all-targets --all-features -- -D warnings",
+        "cargo build --workspace --all-features --locked",
+        "cargo test --workspace --all-features --locked",
+        "cargo test --features psmux-smoke --test psmux_smoke -- --nocapture",
+        "dev-docs/tmux-scenarios/startup-quit.json",
+        "JEFE_REQUIRE_PSMUX: \"1\"",
+        "timeout-minutes:",
+        "target/psmux-smoke",
+        "target/tmux-harness",
+    ] {
+        assert!(
+            workflow.contains(required),
+            "native Windows CI must include {required:?}"
+        );
+    }
+    assert!(
+        workflow.contains("psmux-v3.3.6-windows-x64.zip")
+            && workflow
+                .contains("a56a890ea0829567818b9a368f16dcbd39c087f27328573df17c10dd39618947"),
+        "native Windows CI must pin and checksum the qualified psmux release"
+    );
+}
+
 /// @requirement REQ-TMUX-HARNESS-005
 /// @pseudocode component-002 lines 1-6
 #[test]

--- a/tests/core/tmux_harness_docs_contracts.rs
+++ b/tests/core/tmux_harness_docs_contracts.rs
@@ -54,6 +54,7 @@ fn native_windows_ci_gates_psmux_and_startup_scenario() {
         "cargo test --features psmux-smoke --test psmux_smoke -- --nocapture",
         "dev-docs/tmux-scenarios/startup-quit.json",
         "JEFE_REQUIRE_PSMUX: \"1\"",
+        "PSMUX_VERSION: \"3.3.6\"",
         "timeout-minutes:",
         "target/psmux-smoke",
         "target/tmux-harness",
@@ -64,7 +65,8 @@ fn native_windows_ci_gates_psmux_and_startup_scenario() {
         );
     }
     assert!(
-        workflow.contains("psmux-v3.3.6-windows-x64.zip")
+        workflow.contains("psmux-v$env:PSMUX_VERSION-windows-x64.zip")
+            && workflow.contains("releases/download/v$env:PSMUX_VERSION/$archiveName")
             && workflow
                 .contains("a56a890ea0829567818b9a368f16dcbd39c087f27328573df17c10dd39618947"),
         "native Windows CI must pin and checksum the qualified psmux release"


### PR DESCRIPTION
## Summary

- add a required native Windows x86-64 MSVC CI job without changing the existing Unix jobs
- download psmux 3.3.6 from its official release, verify the pinned SHA-256, and fail if its version is unavailable or incompatible
- run formatting, strict Clippy, locked all-feature build/tests, the real psmux command-surface smoke suite, and the deterministic startup/quit TUI scenario
- exercise absolute Windows configuration and working paths containing spaces
- retain Rust logs, psmux version, command transcripts, screen/scrollback captures, and remaining owned-namespace session diagnostics as artifacts
- document exact native PowerShell reproduction commands
- make existing Unix-only shell, socket, and tmux-attach contracts explicit so the required Windows workspace command runs without compatibility layers
- add native Windows PID liveness through `tasklist` instead of silently failing open when `kill -0` is unavailable

## Test-first evidence

RED:

- added `native_windows_ci_gates_psmux_and_startup_scenario`
- demonstrated it failed because `.github/workflows/ci.yml` had no `runs-on: windows-latest` gate

GREEN:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` (with the repository CI Clippy configuration)
- `cargo build --workspace --all-features --locked`
- `cargo test --workspace --all-features --locked` with `JEFE_REQUIRE_PSMUX=1` and serialized real-process tests
- `cargo test --features psmux-smoke --test psmux_smoke -- --nocapture` (4 passed)
- native `startup-quit.json` scenario through psmux using absolute paths containing spaces (7 steps passed)
- `git diff --check`

## Safety

All real psmux tests use unique owned namespaces. Cleanup remains namespace-scoped; this change does not invoke bare `psmux kill-server` or contact unrelated user sessions. The Windows job uses native PowerShell only—no WSL, Cygwin, MSYS2, Git Bash, Docker, or Unix shell compatibility layer.

Closes #256
