### PR TITLE
Route local runtime through native multiplexers (#257)

### DIFF
--- a/src/runtime/attach.rs
+++ b/src/runtime/attach.rs
@@ -517,20 +517,23 @@ fn ensure_wrap_slot(wraps: &mut Vec<bool>, rows: usize) {
     }
 }
 
-fn attach_command(session_name: &str, ssh_command: Option<&str>) -> CommandBuilder {
+fn attach_command(
+    session_name: &str,
+    ssh_command: Option<&str>,
+) -> Result<CommandBuilder, RuntimeError> {
     let mut cmd = if let Some(ssh_command) = ssh_command {
         let mut cmd = CommandBuilder::new("sh");
         cmd.arg("-lc");
         cmd.arg(ssh_command);
         cmd
     } else {
-        // Reuse `commands::tmux_base_args()` which encodes exactly
-        // `-f /dev/null -S <jefe-socket>`, reducing drift versus the rest of
-        // jefe's tmux command construction. The remote (SSH) branch is
-        // intentionally left without `-S` because remote tmux runs on the
-        // remote host under its own (possibly shared) socket.
-        let mut cmd = CommandBuilder::new("tmux");
-        for arg in super::commands::tmux_base_args() {
+        // Local attachment uses the same resolved executable and isolation
+        // policy as every other runtime command. The remote SSH branch remains
+        // an intentionally Unix command executed on the remote host.
+        let plan =
+            super::multiplexer::MultiplexerPlan::current().map_err(RuntimeError::Multiplexer)?;
+        let mut cmd = CommandBuilder::new(plan.executable());
+        for arg in plan.base_args() {
             cmd.arg(arg);
         }
         cmd.arg("attach-session");
@@ -539,7 +542,7 @@ fn attach_command(session_name: &str, ssh_command: Option<&str>) -> CommandBuild
         cmd
     };
     cmd.env("TERM", "xterm-256color");
-    cmd
+    Ok(cmd)
 }
 
 fn open_pty(rows: u16, cols: u16) -> Result<PtyPair, RuntimeError> {
@@ -579,7 +582,7 @@ impl AttachedViewer {
         debug!(session_name = %session_name, rows, cols, remote = ssh_command.is_some(), "AttachedViewer::spawn start");
 
         let pty_pair = open_pty(rows, cols)?;
-        let cmd = attach_command(session_name, ssh_command);
+        let cmd = attach_command(session_name, ssh_command)?;
 
         let child = pty_pair
             .slave

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -901,16 +901,12 @@ pub fn create_session(
 
 /// Check if a tmux session exists.
 #[allow(dead_code)]
-pub fn session_exists(session_name: &str) -> bool {
-    let Ok(mut command) = tmux_command() else {
-        return false;
-    };
-    let output = command.args(["has-session", "-t", session_name]).output();
-
-    match output {
-        Ok(out) => out.status.success(),
-        Err(_) => false,
-    }
+pub fn session_exists(session_name: &str) -> Result<bool, RuntimeError> {
+    let output = tmux_command()?
+        .args(["has-session", "-t", session_name])
+        .output()
+        .map_err(|error| RuntimeError::CapabilityProbeFailed(error.to_string()))?;
+    Ok(output.status.success())
 }
 
 pub fn remote_session_exists(

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -4,6 +4,7 @@
 //! @requirement REQ-TECH-004
 //! @pseudocode component-002 lines 01-06
 
+use std::ffi::{OsStr, OsString};
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 use std::time::{Duration, Instant};
@@ -13,8 +14,8 @@ use tracing::debug;
 use crate::domain::{AgentKind, LaunchSignature};
 
 use super::errors::RuntimeError;
+use super::multiplexer::{MultiplexerCapability, MultiplexerPlan};
 use super::preflight::sandbox_ssh_agent_warning;
-use super::socket::jefe_tmux_socket_path;
 
 const REMOTE_SSH_COMMAND_TIMEOUT: Duration = Duration::from_secs(20);
 
@@ -46,38 +47,14 @@ fn tmux_scrub_env_args() -> Vec<String> {
     args
 }
 
-/// The fixed base arguments every jefe local tmux command starts with:
-/// `-f /dev/null` (skip user config) and `-S <jefe-socket>` (dedicated socket).
+/// Resolve the local platform multiplexer and construct its isolated command.
 ///
-/// Factored out so tests can inspect the base arg composition deterministically
-/// without spawning tmux.
-#[must_use]
-pub fn tmux_base_args() -> Vec<String> {
-    let socket = jefe_tmux_socket_path();
-    vec![
-        "-f".to_owned(),
-        "/dev/null".to_owned(),
-        "-S".to_owned(),
-        socket.to_string_lossy().into_owned(),
-    ]
-}
-
-/// Build a local tmux `Command` that skips user config (`-f /dev/null`) and
-/// targets jefe's *private* socket (`-S <jefe-socket>`).
-///
-/// Jefe sets all tmux options programmatically, so loading `~/.tmux.conf` is
-/// unnecessary and can cause errors (e.g., pane-scoped options in the user
-/// config fail with "no current pane" when the server starts headlessly).
-///
-/// The dedicated socket (`-S`) isolates jefe's sessions from any unrelated user
-/// tmux sessions that share the default socket. This prevents jefe from
-/// destroying unrelated sessions and means jefe is unaffected when the shared
-/// default server dies (e.g. an OS reboot of the default tmux server).
-pub fn tmux_command() -> Command {
-    let mut cmd = Command::new("tmux");
-    let base = tmux_base_args();
-    cmd.args(&base);
-    cmd
+/// Unix preserves upstream tmux's `/dev/null` configuration and private socket.
+/// Native Windows selects qualified psmux with `NUL` and a private namespace.
+pub fn tmux_command() -> Result<Command, RuntimeError> {
+    MultiplexerPlan::current()
+        .map(|plan| plan.command())
+        .map_err(RuntimeError::Multiplexer)
 }
 
 // Re-export the pane capture / introspection helpers that production callers
@@ -87,7 +64,7 @@ pub fn tmux_command() -> Command {
 pub use super::pane_capture::{capture_pane_history, capture_pane_lines, pane_pid};
 
 fn tmux_cmd_status(args: &[&str], cwd: Option<&str>) -> Result<(), String> {
-    let mut cmd = tmux_command();
+    let mut cmd = tmux_command().map_err(|error| error.to_string())?;
     cmd.args(args);
     if let Some(dir) = cwd {
         cmd.current_dir(dir);
@@ -240,9 +217,10 @@ pub fn enforce_clipboard_passthrough(session_name: &str) {
         None,
     );
 
-    if let Ok(output) = tmux_command()
-        .args(["list-panes", "-t", session_name, "-F", PANE_FORMAT])
-        .output()
+    if let Ok(mut command) = tmux_command()
+        && let Ok(output) = command
+            .args(["list-panes", "-t", session_name, "-F", PANE_FORMAT])
+            .output()
         && output.status.success()
     {
         let panes = String::from_utf8_lossy(&output.stdout);
@@ -751,8 +729,13 @@ fn local_launch_plan(signature: &LaunchSignature) -> LocalLaunchPlan {
     }
 }
 
-fn local_launch_command(session_name: &str, work_dir: &Path, plan: &LocalLaunchPlan) -> Command {
-    let mut cmd = tmux_command();
+fn local_launch_command(
+    session_name: &str,
+    work_dir: &Path,
+    launch: &LocalLaunchPlan,
+) -> Result<Command, RuntimeError> {
+    let multiplexer = MultiplexerPlan::current().map_err(RuntimeError::Multiplexer)?;
+    let mut cmd = multiplexer.command();
     cmd.arg("new-session")
         .arg("-d")
         .arg("-s")
@@ -760,23 +743,29 @@ fn local_launch_command(session_name: &str, work_dir: &Path, plan: &LocalLaunchP
         .arg("-c")
         .arg(work_dir);
 
-    // Wrap the pane command in `env -u TMUX -u TMUX_PANE -u TMUX_TMPDIR …` so
-    // the llxprt child (and any tool it spawns) cannot reach jefe's private
-    // tmux server via a bare `tmux` (#171). tmux's server populates the pane
-    // env, so the scrub MUST live in the pane command rather than jefe's own
-    // process env. The argv is built by the pure [`local_pane_command_args`]
-    // helper so it is directly unit-testable.
-    for arg in local_pane_command_args(plan) {
+    let pane_args = launch.args.iter().map(OsString::from).collect::<Vec<_>>();
+    let environment = launch
+        .env
+        .iter()
+        .map(|(key, value)| (OsString::from(key), OsString::from(value)))
+        .collect::<Vec<_>>();
+    for arg in multiplexer
+        .pane_command_args(
+            OsStr::new(launch.agent_kind.binary_name()),
+            &pane_args,
+            &environment,
+        )
+        .map_err(RuntimeError::Multiplexer)?
+    {
         cmd.arg(arg);
     }
-    cmd
+    Ok(cmd)
 }
 
-/// Build the pane-command argv for a local agent session: the `env -u` scrub
-/// prefix, any `KEY=VALUE` env assignments, then `llxprt` and its launch args.
-///
-/// Factored out of [`local_launch_command`] so the scrub is unit-testable
-/// without spawning tmux or introspecting a `Command` (#171).
+/// Build the Unix pane-command argv for remote shell construction and
+/// regression tests. Local runtime launch uses `MultiplexerPlan::pane_command_args`
+/// so native Windows never receives this Unix `env -u` prefix.
+#[cfg(test)]
 fn local_pane_command_args(plan: &LocalLaunchPlan) -> Vec<String> {
     let mut args = tmux_scrub_env_args();
     for (key, value) in &plan.env {
@@ -813,23 +802,33 @@ fn finalize_local_session(session_name: &str, warning: Option<String>) {
     }
 }
 
+enum LocalCreateFailure {
+    Runtime(RuntimeError),
+    Command(String),
+}
+
 fn try_local_create_session(
     session_name: &str,
     work_dir: &Path,
     signature: &LaunchSignature,
     attempt: u8,
-) -> Result<(), String> {
+) -> Result<(), LocalCreateFailure> {
     let plan = local_launch_plan(signature);
-    let mut cmd = local_launch_command(session_name, work_dir, &plan);
-    debug!(session_name = %session_name, attempt, "create_session invoking tmux new-session");
+    let mut cmd =
+        local_launch_command(session_name, work_dir, &plan).map_err(LocalCreateFailure::Runtime)?;
+    debug!(session_name = %session_name, attempt, "create_session invoking local multiplexer new-session");
 
-    let output = cmd.output().map_err(|e| format!("tmux new-session: {e}"))?;
+    let output = cmd
+        .output()
+        .map_err(|error| LocalCreateFailure::Command(error.to_string()))?;
     if output.status.success() {
-        debug!(session_name = %session_name, attempt, "create_session tmux new-session succeeded");
+        debug!(session_name = %session_name, attempt, "create_session local multiplexer new-session succeeded");
         finalize_local_session(session_name, plan.warning);
         Ok(())
     } else {
-        Err(String::from_utf8_lossy(&output.stderr).to_string())
+        Err(LocalCreateFailure::Command(
+            String::from_utf8_lossy(&output.stderr).into_owned(),
+        ))
     }
 }
 
@@ -869,33 +868,44 @@ pub fn create_session(
         return create_remote_session(session_name, work_dir, signature);
     }
 
+    MultiplexerPlan::current()
+        .and_then(|plan| {
+            plan.preflight(&[
+                MultiplexerCapability::AttachSession,
+                MultiplexerCapability::PaneCapture,
+            ])
+        })
+        .map_err(RuntimeError::Multiplexer)?;
+
     let _ = kill_session(session_name);
     match try_local_create_session(session_name, work_dir, signature, 0) {
         Ok(()) => return Ok(()),
-        Err(stderr) if is_tmux_fork_broken(&stderr) => {
-            debug!(session_name = %session_name, attempt = 0, stderr = %stderr, "create_session retrying after tmux fork failure");
-            // Scoped recovery: kill only this one target session on the
-            // jefe-private socket, then retry. We must NOT call `tmux
-            // kill-server` here — that would nuke every jefe session (and,
-            // before the dedicated socket, every unrelated user session too)
-            // over a transient per-session fork error.
+        Err(LocalCreateFailure::Runtime(error)) => return Err(error),
+        Err(LocalCreateFailure::Command(stderr)) if is_tmux_fork_broken(&stderr) => {
+            debug!(session_name = %session_name, attempt = 0, stderr = %stderr, "create_session retrying after multiplexer fork failure");
+            // Scoped recovery: kill only this one target session in Jefe's
+            // private isolation handle. Never terminate the whole server.
             let _ = kill_session(session_name);
         }
-        Err(stderr) => return Err(local_spawn_error(session_name, 0, stderr)),
+        Err(LocalCreateFailure::Command(stderr)) => {
+            return Err(local_spawn_error(session_name, 0, stderr));
+        }
     }
 
     match try_local_create_session(session_name, work_dir, signature, 1) {
         Ok(()) => Ok(()),
-        Err(stderr) => Err(local_spawn_error(session_name, 1, stderr)),
+        Err(LocalCreateFailure::Runtime(error)) => Err(error),
+        Err(LocalCreateFailure::Command(stderr)) => Err(local_spawn_error(session_name, 1, stderr)),
     }
 }
 
 /// Check if a tmux session exists.
 #[allow(dead_code)]
 pub fn session_exists(session_name: &str) -> bool {
-    let output = tmux_command()
-        .args(["has-session", "-t", session_name])
-        .output();
+    let Ok(mut command) = tmux_command() else {
+        return false;
+    };
+    let output = command.args(["has-session", "-t", session_name]).output();
 
     match output {
         Ok(out) => out.status.success(),
@@ -916,7 +926,7 @@ pub fn remote_session_exists(
 ///
 /// @pseudocode component-002 lines 24-25
 pub fn kill_session(session_name: &str) -> Result<(), RuntimeError> {
-    let output = tmux_command()
+    let output = tmux_command()?
         .args(["kill-session", "-t", session_name])
         .output()
         .map_err(|e| RuntimeError::KillFailed(format!("tmux kill-session: {e}")))?;
@@ -944,7 +954,7 @@ pub fn kill_remote_session(
 /// Send keys to a tmux session (for testing/automation).
 #[allow(dead_code)]
 pub fn send_keys(session_name: &str, keys: &str) -> Result<(), RuntimeError> {
-    let output = tmux_command()
+    let output = tmux_command()?
         .args(["send-keys", "-t", session_name, keys, "Enter"])
         .output()
         .map_err(|e| RuntimeError::WriteFailed(format!("tmux send-keys: {e}")))?;

--- a/src/runtime/commands_tests.rs
+++ b/src/runtime/commands_tests.rs
@@ -526,18 +526,25 @@ fn sandbox_flags_env_value_is_raw_for_tmux_argv() {
 }
 
 #[test]
-fn tmux_base_args_include_config_skip_and_dedicated_socket() {
-    let args = tmux_base_args();
-    let socket = crate::runtime::jefe_tmux_socket_path();
-    assert_eq!(
-        args,
-        vec![
-            "-f".to_owned(),
-            "/dev/null".to_owned(),
-            "-S".to_owned(),
-            socket.to_string_lossy().into_owned(),
-        ]
-    );
+fn local_multiplexer_plan_uses_platform_isolation() {
+    let plan = MultiplexerPlan::current()
+        .unwrap_or_else(|error| panic!("local multiplexer plan should resolve: {error}"));
+    if cfg!(windows) {
+        assert!(plan.base_args().iter().any(|arg| arg == "-L"));
+        assert!(!plan.base_args().iter().any(|arg| arg == "/dev/null"));
+        assert!(!plan.base_args().iter().any(|arg| arg == "-S"));
+    } else {
+        let socket = crate::runtime::jefe_tmux_socket_path();
+        assert_eq!(
+            plan.base_args(),
+            [
+                std::ffi::OsString::from("-f"),
+                std::ffi::OsString::from("/dev/null"),
+                std::ffi::OsString::from("-S"),
+                socket.as_os_str().to_owned(),
+            ]
+        );
+    }
 }
 
 #[test]

--- a/src/runtime/errors.rs
+++ b/src/runtime/errors.rs
@@ -5,6 +5,8 @@
 
 use crate::domain::AgentId;
 
+use super::multiplexer::MultiplexerError;
+
 /// Errors from runtime operations.
 #[derive(Debug, Clone)]
 pub enum RuntimeError {
@@ -14,6 +16,8 @@ pub enum RuntimeError {
     AttachFailed(String),
     /// Failed to spawn session.
     SpawnFailed(String),
+    /// Local multiplexer dependency or policy failure.
+    Multiplexer(MultiplexerError),
     /// Failed to execute remote SSH session lifecycle command.
     RemoteExecutionFailed(String),
     /// A runtime capability probe could not execute successfully.
@@ -40,6 +44,7 @@ impl std::fmt::Display for RuntimeError {
             Self::SessionNotFound(name) => write!(f, "session not found: {name}"),
             Self::AttachFailed(msg) => write!(f, "attach failed: {msg}"),
             Self::SpawnFailed(msg) => write!(f, "spawn failed: {msg}"),
+            Self::Multiplexer(error) => write!(f, "multiplexer dependency failed: {error}"),
             Self::RemoteExecutionFailed(msg) => write!(f, "remote execution failed: {msg}"),
             Self::CapabilityProbeFailed(msg) => write!(f, "capability probe failed: {msg}"),
             Self::CapabilityCheckFailed(msg) => write!(f, "capability check failed: {msg}"),

--- a/src/runtime/liveness.rs
+++ b/src/runtime/liveness.rs
@@ -76,9 +76,10 @@ fn pid_alive_on_platform(pid: u32) -> bool {
 /// @pseudocode component-002 lines 33-35
 #[must_use]
 pub fn check_session_alive(session_name: &str) -> bool {
-    let has_session = tmux_command()
-        .args(["has-session", "-t", session_name])
-        .output();
+    let Ok(mut command) = tmux_command() else {
+        return false;
+    };
+    let has_session = command.args(["has-session", "-t", session_name]).output();
 
     let Ok(out) = has_session else {
         return false;
@@ -87,7 +88,10 @@ pub fn check_session_alive(session_name: &str) -> bool {
         return false;
     }
 
-    let panes = tmux_command()
+    let Ok(mut command) = tmux_command() else {
+        return false;
+    };
+    let panes = command
         .args(["list-panes", "-t", session_name, "-F", "#{pane_dead}"])
         .output();
 
@@ -151,7 +155,10 @@ pub fn check_remote_session_alive(remote: &RemoteRepositorySettings, session_nam
 /// List all jefe-managed tmux sessions.
 #[allow(dead_code)]
 pub fn list_jefe_sessions() -> Vec<String> {
-    let output = tmux_command()
+    let Ok(mut command) = tmux_command() else {
+        return Vec::new();
+    };
+    let output = command
         .args(["list-sessions", "-F", "#{session_name}"])
         .output();
 
@@ -171,9 +178,10 @@ pub fn list_jefe_sessions() -> Vec<String> {
 /// Kill a tmux session.
 #[allow(dead_code)]
 pub fn kill_session(session_name: &str) -> bool {
-    let output = tmux_command()
-        .args(["kill-session", "-t", session_name])
-        .output();
+    let Ok(mut command) = tmux_command() else {
+        return false;
+    };
+    let output = command.args(["kill-session", "-t", session_name]).output();
 
     match output {
         Ok(out) => out.status.success(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -16,6 +16,7 @@ mod errors;
 mod gh_auth;
 mod liveness;
 mod manager;
+mod multiplexer;
 mod pane_capture;
 mod preflight;
 mod session;
@@ -31,6 +32,10 @@ pub use errors::RuntimeError;
 pub use gh_auth::{AuthRunResult, run_device_auth};
 pub use liveness::{check_remote_session_alive, check_session_alive, pid_alive};
 pub use manager::{LivenessCheck, RuntimeManager, TmuxRuntimeManager};
+pub use multiplexer::{
+    LocalPlatform, MultiplexerCapability, MultiplexerError, MultiplexerIsolation, MultiplexerPlan,
+    MultiplexerVersion, ProbeObservation, classify_probe,
+};
 pub use preflight::{
     PreflightAction, PreflightIssue, execute_preflight_action, platform_engine_diagnostic,
     sandbox_preflight, sandbox_ssh_agent_warning,
@@ -38,6 +43,10 @@ pub use preflight::{
 pub use session::{RuntimeSession, TerminalCell, TerminalCellStyle, TerminalSnapshot};
 pub use socket::jefe_tmux_socket_path;
 pub use stub_manager::StubRuntimeManager;
+
+#[cfg(test)]
+#[path = "multiplexer_tests.rs"]
+mod multiplexer_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -89,7 +89,9 @@ impl MultiplexerVersion {
         let mut parts = token.split('.');
         let major = parse_version_part(parts.next(), output)?;
         let minor = parse_version_part(parts.next(), output)?;
-        let patch = parse_version_part(parts.next(), output)?;
+        let patch = parts
+            .next()
+            .map_or(Ok(0), |part| parse_version_part(Some(part), output))?;
         Ok(Self::new(major, minor, patch))
     }
 }

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -343,6 +343,8 @@ pub enum MultiplexerError {
     InvalidNamespace { namespace: String },
     /// A Windows shell command argument cannot be represented as Unicode.
     NonUnicodeArgument { value: OsString },
+    /// An environment variable name cannot be represented safely in PowerShell.
+    InvalidEnvironmentVariable { name: OsString },
 }
 
 impl std::fmt::Display for MultiplexerError {
@@ -399,6 +401,11 @@ impl std::fmt::Display for MultiplexerError {
                 formatter,
                 "Windows psmux shell argument is not valid Unicode: {}",
                 Path::new(value).display()
+            ),
+            Self::InvalidEnvironmentVariable { name } => write!(
+                formatter,
+                "invalid Windows environment variable name: {}",
+                Path::new(name).display()
             ),
         }
     }
@@ -479,7 +486,7 @@ fn windows_pane_command_args(
     for (key, value) in environment {
         commands.push(format!(
             "$env:{}={}",
-            unicode_argument(key)?,
+            environment_variable_name(key)?,
             powershell_quote(unicode_argument(value)?)
         ));
     }
@@ -500,6 +507,21 @@ fn unicode_argument(value: &OsStr) -> Result<&str, MultiplexerError> {
         })
 }
 
+fn environment_variable_name(value: &OsStr) -> Result<&str, MultiplexerError> {
+    let name = unicode_argument(value)?;
+    let mut bytes = name.bytes();
+    let valid = bytes
+        .next()
+        .is_some_and(|byte| byte == b'_' || byte.is_ascii_alphabetic())
+        && bytes.all(|byte| byte == b'_' || byte.is_ascii_alphanumeric());
+    if valid {
+        Ok(name)
+    } else {
+        Err(MultiplexerError::InvalidEnvironmentVariable {
+            name: value.to_owned(),
+        })
+    }
+}
 fn powershell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -173,7 +173,7 @@ impl MultiplexerPlan {
         environment: &[(OsString, OsString)],
     ) -> Result<Vec<OsString>, MultiplexerError> {
         match self.platform {
-            LocalPlatform::Unix => Ok(unix_pane_command_args(program, args, environment)),
+            LocalPlatform::Unix => unix_pane_command_args(program, args, environment),
             LocalPlatform::Windows => {
                 windows_pane_command_args(program, args, environment).map(|line| vec![line])
             }
@@ -458,13 +458,14 @@ fn unix_pane_command_args(
     program: &OsStr,
     args: &[OsString],
     environment: &[(OsString, OsString)],
-) -> Vec<OsString> {
+) -> Result<Vec<OsString>, MultiplexerError> {
     let mut command = vec![OsString::from("env")];
     for variable in ["TMUX", "TMUX_PANE", "TMUX_TMPDIR"] {
         command.push(OsString::from("-u"));
         command.push(OsString::from(variable));
     }
     for (key, value) in environment {
+        environment_variable_name(key)?;
         let mut assignment = key.clone();
         assignment.push("=");
         assignment.push(value);
@@ -472,7 +473,7 @@ fn unix_pane_command_args(
     }
     command.push(program.to_owned());
     command.extend(args.iter().cloned());
-    command
+    Ok(command)
 }
 
 fn windows_pane_command_args(

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -1,0 +1,677 @@
+//! Platform-aware local multiplexer resolution, isolation, and dependency probing.
+//!
+//! Unix uses upstream tmux on Jefe's private socket. Native Windows uses psmux
+//! on a private `-L` namespace. Remote SSH command construction intentionally
+//! remains in `runtime::commands` and does not use this local policy.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const MINIMUM_PSMUX_VERSION: MultiplexerVersion = MultiplexerVersion::new(3, 3, 6);
+const WINDOWS_INSTALL_GUIDANCE: &str =
+    "install psmux 3.3.6 or newer with `winget install marlocarlo.psmux`, then restart Jefe";
+const UNIX_INSTALL_GUIDANCE: &str =
+    "install upstream tmux with your operating system package manager";
+
+/// Local operating-system policy used to select a multiplexer implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalPlatform {
+    /// Upstream tmux with Unix-domain-socket isolation.
+    Unix,
+    /// Native psmux with named-namespace isolation.
+    Windows,
+}
+
+impl LocalPlatform {
+    /// Return the policy for the current compilation target.
+    #[must_use]
+    pub const fn current() -> Self {
+        if cfg!(windows) {
+            Self::Windows
+        } else {
+            Self::Unix
+        }
+    }
+}
+
+/// Isolation handle owned by Jefe's local multiplexer runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MultiplexerIsolation {
+    /// Private upstream-tmux Unix socket.
+    Socket(PathBuf),
+    /// Private native-psmux namespace.
+    Namespace(String),
+}
+
+/// Multiplexer behavior that callers may require before launching a session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MultiplexerCapability {
+    /// Isolation via an explicitly named psmux namespace.
+    NamespaceIsolation,
+    /// Isolation via an explicit upstream-tmux socket.
+    SocketIsolation,
+    /// Interactive client attachment.
+    AttachSession,
+    /// Pane capture and introspection.
+    PaneCapture,
+}
+
+/// Parsed tmux-compatible semantic version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MultiplexerVersion {
+    major: u32,
+    minor: u32,
+    patch: u32,
+}
+
+impl MultiplexerVersion {
+    /// Construct a parsed version.
+    #[must_use]
+    pub const fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    /// Parse output such as `tmux 3.3.6`.
+    pub fn parse(output: &str) -> Result<Self, MultiplexerError> {
+        let token = output
+            .split_whitespace()
+            .find(|part| part.chars().next().is_some_and(|ch| ch.is_ascii_digit()))
+            .ok_or_else(|| MultiplexerError::MalformedVersion {
+                path: None,
+                output: output.to_owned(),
+            })?;
+        let mut parts = token.split('.');
+        let major = parse_version_part(parts.next(), output)?;
+        let minor = parse_version_part(parts.next(), output)?;
+        let patch = parse_version_part(parts.next(), output)?;
+        Ok(Self::new(major, minor, patch))
+    }
+}
+
+impl std::fmt::Display for MultiplexerVersion {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// Pure, fully resolved local multiplexer command policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MultiplexerPlan {
+    platform: LocalPlatform,
+    executable: PathBuf,
+    isolation: MultiplexerIsolation,
+    base_args: Vec<OsString>,
+}
+
+impl MultiplexerPlan {
+    /// Validate and construct a plan for an explicit platform and isolation.
+    pub fn for_platform(
+        platform: LocalPlatform,
+        executable: PathBuf,
+        isolation: MultiplexerIsolation,
+    ) -> Result<Self, MultiplexerError> {
+        validate_executable(platform, &executable)?;
+        let base_args = base_args(platform, &isolation)?;
+        Ok(Self {
+            platform,
+            executable,
+            isolation,
+            base_args,
+        })
+    }
+
+    /// Resolve the current platform's executable and stable production isolation handle.
+    pub fn current() -> Result<Self, MultiplexerError> {
+        Self::resolved(false)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_for_test() -> Result<Self, MultiplexerError> {
+        Self::resolved(true)
+    }
+
+    fn resolved(unique: bool) -> Result<Self, MultiplexerError> {
+        let platform = LocalPlatform::current();
+        let executable = resolve_executable(platform)?;
+        let isolation = match platform {
+            LocalPlatform::Unix => {
+                MultiplexerIsolation::Socket(super::socket::jefe_tmux_socket_path().to_path_buf())
+            }
+            LocalPlatform::Windows if unique => {
+                MultiplexerIsolation::Namespace(unique_test_namespace())
+            }
+            LocalPlatform::Windows => MultiplexerIsolation::Namespace(stable_jefe_namespace()),
+        };
+        Self::for_platform(platform, executable, isolation)
+    }
+
+    /// Return the resolved executable without converting it to UTF-8.
+    #[must_use]
+    pub fn executable(&self) -> &Path {
+        &self.executable
+    }
+
+    /// Return the platform-correct arguments prepended to every local command.
+    #[must_use]
+    pub fn base_args(&self) -> &[OsString] {
+        &self.base_args
+    }
+
+    /// Build the platform-correct pane command passed to a new session.
+    pub fn pane_command_args(
+        &self,
+        program: &OsStr,
+        args: &[OsString],
+        environment: &[(OsString, OsString)],
+    ) -> Result<Vec<OsString>, MultiplexerError> {
+        match self.platform {
+            LocalPlatform::Unix => Ok(unix_pane_command_args(program, args, environment)),
+            LocalPlatform::Windows => {
+                windows_pane_command_args(program, args, environment).map(|line| vec![line])
+            }
+        }
+    }
+
+    /// Return the private isolation handle.
+    #[must_use]
+    pub const fn isolation(&self) -> &MultiplexerIsolation {
+        &self.isolation
+    }
+
+    /// Return whether this plan supports a required operation.
+    #[must_use]
+    pub const fn supports(&self, capability: MultiplexerCapability) -> bool {
+        match (self.platform, capability) {
+            (LocalPlatform::Unix, MultiplexerCapability::NamespaceIsolation)
+            | (LocalPlatform::Windows, MultiplexerCapability::SocketIsolation) => false,
+            (_, MultiplexerCapability::AttachSession | MultiplexerCapability::PaneCapture)
+            | (LocalPlatform::Unix, MultiplexerCapability::SocketIsolation)
+            | (LocalPlatform::Windows, MultiplexerCapability::NamespaceIsolation) => true,
+        }
+    }
+
+    /// Build a process command carrying this plan's executable and base args.
+    #[must_use]
+    pub fn command(&self) -> Command {
+        let mut command = Command::new(&self.executable);
+        command.args(&self.base_args);
+        command
+    }
+
+    /// Probe the executable and enforce version and capability policy.
+    pub fn preflight(
+        &self,
+        required: &[MultiplexerCapability],
+    ) -> Result<MultiplexerVersion, MultiplexerError> {
+        let output =
+            self.command()
+                .arg("-V")
+                .output()
+                .map_err(|error| MultiplexerError::LaunchFailed {
+                    path: self.executable.clone(),
+                    reason: error.to_string(),
+                    guidance: guidance(self.platform),
+                })?;
+        let version = classify_probe(output_observation(self.platform, &self.executable, output))?;
+        for capability in required {
+            if !self.supports(*capability) {
+                return Err(MultiplexerError::RequiredCapabilityUnavailable {
+                    path: self.executable.clone(),
+                    version,
+                    capability: *capability,
+                });
+            }
+        }
+        Ok(version)
+    }
+}
+
+/// Captured input to the pure dependency-probe classifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeObservation {
+    /// No acceptable executable was found.
+    Missing {
+        platform: LocalPlatform,
+        path: PathBuf,
+    },
+    /// The executable could not be started.
+    LaunchFailed {
+        platform: LocalPlatform,
+        path: PathBuf,
+        reason: String,
+    },
+    /// The executable completed and produced output.
+    Output {
+        platform: LocalPlatform,
+        path: PathBuf,
+        status_success: bool,
+        stdout: String,
+        stderr: String,
+    },
+    /// A parsed executable lacks a caller-required capability.
+    CapabilityMissing {
+        platform: LocalPlatform,
+        path: PathBuf,
+        version: MultiplexerVersion,
+        capability: MultiplexerCapability,
+    },
+}
+
+/// Classify dependency observations into a qualified version or typed error.
+pub fn classify_probe(
+    observation: ProbeObservation,
+) -> Result<MultiplexerVersion, MultiplexerError> {
+    match observation {
+        ProbeObservation::Missing { platform, path } => Err(MultiplexerError::MissingExecutable {
+            path,
+            guidance: guidance(platform),
+        }),
+        ProbeObservation::LaunchFailed {
+            platform,
+            path,
+            reason,
+        } => Err(MultiplexerError::LaunchFailed {
+            path,
+            reason,
+            guidance: guidance(platform),
+        }),
+        ProbeObservation::CapabilityMissing {
+            platform: _,
+            path,
+            version,
+            capability,
+        } => Err(MultiplexerError::RequiredCapabilityUnavailable {
+            path,
+            version,
+            capability,
+        }),
+        ProbeObservation::Output {
+            platform,
+            path,
+            status_success,
+            stdout,
+            stderr,
+        } => classify_output(platform, path, status_success, stdout, stderr),
+    }
+}
+
+/// Typed failures from local multiplexer resolution and dependency preflight.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MultiplexerError {
+    /// No supported executable was found.
+    MissingExecutable {
+        path: PathBuf,
+        guidance: &'static str,
+    },
+    /// A compatibility-environment executable was rejected.
+    RejectedExecutable { path: PathBuf, reason: &'static str },
+    /// The executable could not be launched.
+    LaunchFailed {
+        path: PathBuf,
+        reason: String,
+        guidance: &'static str,
+    },
+    /// Version output was not tmux-compatible.
+    MalformedVersion {
+        path: Option<PathBuf>,
+        output: String,
+    },
+    /// The executable version is below the supported minimum.
+    UnsupportedVersion {
+        path: PathBuf,
+        detected: MultiplexerVersion,
+        minimum: MultiplexerVersion,
+        guidance: &'static str,
+    },
+    /// A required command capability is unavailable.
+    RequiredCapabilityUnavailable {
+        path: PathBuf,
+        version: MultiplexerVersion,
+        capability: MultiplexerCapability,
+    },
+    /// The selected isolation handle does not match the platform policy.
+    InvalidIsolation { platform: LocalPlatform },
+    /// A psmux namespace contains unsupported characters or length.
+    InvalidNamespace { namespace: String },
+    /// A Windows shell command argument cannot be represented as Unicode.
+    NonUnicodeArgument { value: OsString },
+}
+
+impl std::fmt::Display for MultiplexerError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingExecutable { path, guidance } => write!(
+                formatter,
+                "multiplexer executable '{}' was not found; {guidance}",
+                path.display()
+            ),
+            Self::RejectedExecutable { path, reason } => write!(
+                formatter,
+                "rejected multiplexer executable '{}': {reason}",
+                path.display()
+            ),
+            Self::LaunchFailed {
+                path,
+                reason,
+                guidance,
+            } => write!(
+                formatter,
+                "failed to launch multiplexer '{}': {reason}; {guidance}",
+                path.display()
+            ),
+            Self::MalformedVersion { path, output } => {
+                format_malformed_version(formatter, path.as_deref(), output)
+            }
+            Self::UnsupportedVersion {
+                path,
+                detected,
+                minimum,
+                guidance,
+            } => write!(
+                formatter,
+                "unsupported multiplexer version {detected} at '{}'; minimum is {minimum}; {guidance}",
+                path.display()
+            ),
+            Self::RequiredCapabilityUnavailable {
+                path,
+                version,
+                capability,
+            } => write!(
+                formatter,
+                "multiplexer '{}' version {version} lacks required capability {capability:?}",
+                path.display()
+            ),
+            Self::InvalidIsolation { platform } => {
+                write!(formatter, "invalid multiplexer isolation for {platform:?}")
+            }
+            Self::InvalidNamespace { namespace } => {
+                write!(formatter, "invalid private psmux namespace {namespace:?}")
+            }
+            Self::NonUnicodeArgument { value } => write!(
+                formatter,
+                "Windows psmux shell argument is not valid Unicode: {}",
+                Path::new(value).display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for MultiplexerError {}
+
+fn format_malformed_version(
+    formatter: &mut std::fmt::Formatter<'_>,
+    path: Option<&Path>,
+    output: &str,
+) -> std::fmt::Result {
+    match path {
+        Some(path) => write!(
+            formatter,
+            "malformed multiplexer version output from '{}': {output:?}",
+            path.display()
+        ),
+        None => write!(
+            formatter,
+            "malformed multiplexer version output: {output:?}"
+        ),
+    }
+}
+/// Return deterministic executable names considered for a platform.
+#[must_use]
+pub fn executable_candidates(platform: LocalPlatform) -> Vec<OsString> {
+    match platform {
+        LocalPlatform::Unix => vec![OsString::from("tmux")],
+        LocalPlatform::Windows => vec![OsString::from("psmux.exe"), OsString::from("psmux")],
+    }
+}
+
+/// Validate a psmux namespace accepted by Jefe's private-isolation policy.
+pub fn validate_namespace(namespace: &str) -> Result<(), MultiplexerError> {
+    let valid = (8..=80).contains(&namespace.len())
+        && namespace
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-');
+    if valid {
+        Ok(())
+    } else {
+        Err(MultiplexerError::InvalidNamespace {
+            namespace: namespace.to_owned(),
+        })
+    }
+}
+
+fn unix_pane_command_args(
+    program: &OsStr,
+    args: &[OsString],
+    environment: &[(OsString, OsString)],
+) -> Vec<OsString> {
+    let mut command = vec![OsString::from("env")];
+    for variable in ["TMUX", "TMUX_PANE", "TMUX_TMPDIR"] {
+        command.push(OsString::from("-u"));
+        command.push(OsString::from(variable));
+    }
+    for (key, value) in environment {
+        let mut assignment = key.clone();
+        assignment.push("=");
+        assignment.push(value);
+        command.push(assignment);
+    }
+    command.push(program.to_owned());
+    command.extend(args.iter().cloned());
+    command
+}
+
+fn windows_pane_command_args(
+    program: &OsStr,
+    args: &[OsString],
+    environment: &[(OsString, OsString)],
+) -> Result<OsString, MultiplexerError> {
+    let mut commands = ["TMUX", "TMUX_PANE", "TMUX_TMPDIR"]
+        .map(|variable| format!("$env:{variable}=$null"))
+        .to_vec();
+    for (key, value) in environment {
+        commands.push(format!(
+            "$env:{}={}",
+            unicode_argument(key)?,
+            powershell_quote(unicode_argument(value)?)
+        ));
+    }
+    let mut launch = format!("& {}", powershell_quote(unicode_argument(program)?));
+    for argument in args {
+        launch.push(' ');
+        launch.push_str(&powershell_quote(unicode_argument(argument)?));
+    }
+    commands.push(launch);
+    Ok(OsString::from(commands.join("; ")))
+}
+
+fn unicode_argument(value: &OsStr) -> Result<&str, MultiplexerError> {
+    value
+        .to_str()
+        .ok_or_else(|| MultiplexerError::NonUnicodeArgument {
+            value: value.to_owned(),
+        })
+}
+
+fn powershell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn base_args(
+    platform: LocalPlatform,
+    isolation: &MultiplexerIsolation,
+) -> Result<Vec<OsString>, MultiplexerError> {
+    match (platform, isolation) {
+        (LocalPlatform::Unix, MultiplexerIsolation::Socket(socket)) => Ok(vec![
+            OsString::from("-f"),
+            OsString::from("/dev/null"),
+            OsString::from("-S"),
+            socket.as_os_str().to_owned(),
+        ]),
+        (LocalPlatform::Windows, MultiplexerIsolation::Namespace(namespace)) => {
+            validate_namespace(namespace)?;
+            Ok(vec![
+                OsString::from("-f"),
+                OsString::from("NUL"),
+                OsString::from("-L"),
+                OsString::from(namespace),
+            ])
+        }
+        _ => Err(MultiplexerError::InvalidIsolation { platform }),
+    }
+}
+
+fn validate_executable(platform: LocalPlatform, executable: &Path) -> Result<(), MultiplexerError> {
+    if platform != LocalPlatform::Windows {
+        return Ok(());
+    }
+    let filename = executable
+        .file_name()
+        .and_then(OsStr::to_str)
+        .map(str::to_ascii_lowercase);
+    let compatibility_path = executable.components().any(|component| {
+        component.as_os_str().to_str().is_some_and(|value| {
+            matches!(
+                value.to_ascii_lowercase().as_str(),
+                "wsl" | "cygwin" | "cygwin64" | "msys" | "msys2" | "msys64" | "git"
+            )
+        })
+    });
+    if compatibility_path
+        || !filename
+            .as_deref()
+            .is_some_and(|name| matches!(name, "psmux" | "psmux.exe"))
+    {
+        return Err(MultiplexerError::RejectedExecutable {
+            path: executable.to_path_buf(),
+            reason: "native Windows requires official psmux; WSL, Cygwin, MSYS2, and Git Bash tmux are unsupported",
+        });
+    }
+    Ok(())
+}
+
+fn resolve_executable(platform: LocalPlatform) -> Result<PathBuf, MultiplexerError> {
+    let override_name = match platform {
+        LocalPlatform::Unix => "JEFE_TMUX_BIN",
+        LocalPlatform::Windows => "JEFE_PSMUX_BIN",
+    };
+    if let Some(explicit) = std::env::var_os(override_name).filter(|value| !value.is_empty()) {
+        let path = PathBuf::from(explicit);
+        validate_executable(platform, &path)?;
+        return Ok(path);
+    }
+    for candidate in executable_candidates(platform) {
+        if let Some(path) = find_on_path(&candidate) {
+            validate_executable(platform, &path)?;
+            return Ok(path);
+        }
+    }
+    let path = PathBuf::from(&executable_candidates(platform)[0]);
+    Err(MultiplexerError::MissingExecutable {
+        path,
+        guidance: guidance(platform),
+    })
+}
+
+fn find_on_path(candidate: &OsStr) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for directory in std::env::split_paths(&path) {
+        let candidate_path = directory.join(candidate);
+        if candidate_path.is_file() {
+            return Some(candidate_path);
+        }
+    }
+    None
+}
+
+fn unique_test_namespace() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let sequence = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("jefe-test-{}-{sequence:x}", std::process::id())
+}
+
+fn stable_jefe_namespace() -> String {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for value in [
+        std::env::var_os("USERNAME"),
+        std::env::current_exe().ok().map(PathBuf::into_os_string),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        for byte in value.as_encoded_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    format!("jefe-{hash:016x}")
+}
+
+fn parse_version_part(part: Option<&str>, source: &str) -> Result<u32, MultiplexerError> {
+    let Some(part) = part else {
+        return Err(MultiplexerError::MalformedVersion {
+            path: None,
+            output: source.to_owned(),
+        });
+    };
+    part.trim_matches(|ch: char| !ch.is_ascii_digit())
+        .parse::<u32>()
+        .map_err(|_| MultiplexerError::MalformedVersion {
+            path: None,
+            output: source.to_owned(),
+        })
+}
+
+fn output_observation(platform: LocalPlatform, path: &Path, output: Output) -> ProbeObservation {
+    ProbeObservation::Output {
+        platform,
+        path: path.to_path_buf(),
+        status_success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    }
+}
+
+fn classify_output(
+    platform: LocalPlatform,
+    path: PathBuf,
+    status_success: bool,
+    stdout: String,
+    stderr: String,
+) -> Result<MultiplexerVersion, MultiplexerError> {
+    if !status_success {
+        return Err(MultiplexerError::LaunchFailed {
+            path,
+            reason: stderr,
+            guidance: guidance(platform),
+        });
+    }
+    let version = MultiplexerVersion::parse(&stdout).map_err(|error| match error {
+        MultiplexerError::MalformedVersion { output, .. } => MultiplexerError::MalformedVersion {
+            path: Some(path.clone()),
+            output,
+        },
+        other => other,
+    })?;
+    if platform == LocalPlatform::Windows && version < MINIMUM_PSMUX_VERSION {
+        return Err(MultiplexerError::UnsupportedVersion {
+            path,
+            detected: version,
+            minimum: MINIMUM_PSMUX_VERSION,
+            guidance: WINDOWS_INSTALL_GUIDANCE,
+        });
+    }
+    Ok(version)
+}
+
+const fn guidance(platform: LocalPlatform) -> &'static str {
+    match platform {
+        LocalPlatform::Unix => UNIX_INSTALL_GUIDANCE,
+        LocalPlatform::Windows => WINDOWS_INSTALL_GUIDANCE,
+    }
+}

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -92,6 +92,9 @@ impl MultiplexerVersion {
         let patch = parts
             .next()
             .map_or(Ok(0), |part| parse_version_part(Some(part), output))?;
+        if parts.next().is_some() {
+            return Err(malformed_version(output));
+        }
         Ok(Self::new(major, minor, patch))
     }
 }
@@ -639,17 +642,19 @@ fn stable_jefe_namespace() -> String {
 
 fn parse_version_part(part: Option<&str>, source: &str) -> Result<u32, MultiplexerError> {
     let Some(part) = part else {
-        return Err(MultiplexerError::MalformedVersion {
-            path: None,
-            output: source.to_owned(),
-        });
+        return Err(malformed_version(source));
     };
-    part.trim_matches(|ch: char| !ch.is_ascii_digit())
-        .parse::<u32>()
-        .map_err(|_| MultiplexerError::MalformedVersion {
-            path: None,
-            output: source.to_owned(),
-        })
+    if part.is_empty() || !part.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(malformed_version(source));
+    }
+    part.parse::<u32>().map_err(|_| malformed_version(source))
+}
+
+fn malformed_version(source: &str) -> MultiplexerError {
+    MultiplexerError::MalformedVersion {
+        path: None,
+        output: source.to_owned(),
+    }
 }
 
 fn output_observation(platform: LocalPlatform, path: &Path, output: Output) -> ProbeObservation {

--- a/src/runtime/multiplexer_tests.rs
+++ b/src/runtime/multiplexer_tests.rs
@@ -25,7 +25,7 @@ fn platform_policy_builds_unix_socket_and_windows_namespace_arguments() {
 
     let windows = MultiplexerPlan::for_platform(
         LocalPlatform::Windows,
-        PathBuf::from(r"C:\Program Files\psmux\psmux.exe"),
+        PathBuf::from("C:/Program Files/psmux/psmux.exe"),
         MultiplexerIsolation::Namespace("jefe-0123456789abcdef".to_owned()),
     )
     .unwrap_or_else(|error| panic!("windows plan should be valid: {error}"));
@@ -69,6 +69,10 @@ fn version_parser_accepts_tmux_compatible_psmux_output() {
         MultiplexerVersion::parse("tmux 3.3.6\r\n"),
         Ok(MultiplexerVersion::new(3, 3, 6))
     );
+    assert_eq!(
+        MultiplexerVersion::parse("tmux 3.4\n"),
+        Ok(MultiplexerVersion::new(3, 4, 0))
+    );
     assert!(matches!(
         MultiplexerVersion::parse("psmux unknown"),
         Err(MultiplexerError::MalformedVersion { .. })
@@ -77,7 +81,7 @@ fn version_parser_accepts_tmux_compatible_psmux_output() {
 
 #[test]
 fn probe_classification_distinguishes_required_failure_modes() {
-    let path = PathBuf::from(r"C:\Program Files\psmux\psmux.exe");
+    let path = PathBuf::from("C:/Program Files/psmux/psmux.exe");
     assert!(matches!(
         classify_probe(ProbeObservation::Missing {
             platform: LocalPlatform::Windows,
@@ -138,7 +142,7 @@ fn windows_rejects_shadowed_compatibility_environment_executables() {
 fn windows_pane_command_uses_powershell_without_unix_env_wrapper() {
     let plan = MultiplexerPlan::for_platform(
         LocalPlatform::Windows,
-        PathBuf::from(r"C:\Program Files\psmux\psmux.exe"),
+        PathBuf::from("C:/Program Files/psmux/psmux.exe"),
         MultiplexerIsolation::Namespace("jefe-0123456789abcdef".to_owned()),
     )
     .unwrap_or_else(|error| panic!("windows plan should be valid: {error}"));
@@ -196,7 +200,7 @@ fn guarded_real_multiplexer_preflight_qualifies_the_current_dependency() {
 
 #[test]
 fn path_arguments_remain_os_strings_without_lossy_conversion() {
-    let executable = PathBuf::from(r"C:\Program Files\psmux Ω\psmux.exe");
+    let executable = PathBuf::from("C:/Program Files/psmux Ω/psmux.exe");
     let plan = MultiplexerPlan::for_platform(
         LocalPlatform::Windows,
         executable.clone(),

--- a/src/runtime/multiplexer_tests.rs
+++ b/src/runtime/multiplexer_tests.rs
@@ -1,0 +1,208 @@
+//! Behavioral contracts for the platform-aware local multiplexer policy.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+
+use super::multiplexer::{
+    LocalPlatform, MultiplexerCapability, MultiplexerError, MultiplexerIsolation, MultiplexerPlan,
+    MultiplexerVersion, ProbeObservation, classify_probe, executable_candidates,
+    validate_namespace,
+};
+
+#[test]
+fn platform_policy_builds_unix_socket_and_windows_namespace_arguments() {
+    let unix = MultiplexerPlan::for_platform(
+        LocalPlatform::Unix,
+        PathBuf::from("/usr/bin/tmux"),
+        MultiplexerIsolation::Socket(PathBuf::from("/tmp/jefe.sock")),
+    )
+    .unwrap_or_else(|error| panic!("unix plan should be valid: {error}"));
+    assert_eq!(unix.executable(), Path::new("/usr/bin/tmux"));
+    assert_eq!(
+        unix.base_args(),
+        ["-f", "/dev/null", "-S", "/tmp/jefe.sock"].map(OsString::from)
+    );
+
+    let windows = MultiplexerPlan::for_platform(
+        LocalPlatform::Windows,
+        PathBuf::from(r"C:\Program Files\psmux\psmux.exe"),
+        MultiplexerIsolation::Namespace("jefe-0123456789abcdef".to_owned()),
+    )
+    .unwrap_or_else(|error| panic!("windows plan should be valid: {error}"));
+    assert_eq!(
+        windows.base_args(),
+        ["-f", "NUL", "-L", "jefe-0123456789abcdef"].map(OsString::from)
+    );
+    assert!(!windows.base_args().iter().any(|arg| arg == "/dev/null"));
+    assert!(!windows.base_args().iter().any(|arg| arg == "-S"));
+}
+
+#[test]
+fn executable_candidates_never_fall_back_to_compatibility_tmux_on_windows() {
+    assert_eq!(
+        executable_candidates(LocalPlatform::Windows),
+        [OsString::from("psmux.exe"), OsString::from("psmux")]
+    );
+    assert_eq!(
+        executable_candidates(LocalPlatform::Unix),
+        [OsString::from("tmux")]
+    );
+}
+
+#[test]
+fn namespace_validation_accepts_private_ascii_and_rejects_unsafe_values() {
+    assert!(validate_namespace("jefe-0123456789abcdef").is_ok());
+    for invalid in ["", "jefe space", "../jefe", "jefe/other", "jefe_Ω"] {
+        assert!(
+            matches!(
+                validate_namespace(invalid),
+                Err(MultiplexerError::InvalidNamespace { .. })
+            ),
+            "namespace should be rejected: {invalid:?}"
+        );
+    }
+}
+
+#[test]
+fn version_parser_accepts_tmux_compatible_psmux_output() {
+    assert_eq!(
+        MultiplexerVersion::parse("tmux 3.3.6\r\n"),
+        Ok(MultiplexerVersion::new(3, 3, 6))
+    );
+    assert!(matches!(
+        MultiplexerVersion::parse("psmux unknown"),
+        Err(MultiplexerError::MalformedVersion { .. })
+    ));
+}
+
+#[test]
+fn probe_classification_distinguishes_required_failure_modes() {
+    let path = PathBuf::from(r"C:\Program Files\psmux\psmux.exe");
+    assert!(matches!(
+        classify_probe(ProbeObservation::Missing {
+            platform: LocalPlatform::Windows,
+            path: path.clone(),
+        }),
+        Err(MultiplexerError::MissingExecutable { .. })
+    ));
+    assert!(matches!(
+        classify_probe(ProbeObservation::LaunchFailed {
+            platform: LocalPlatform::Windows,
+            path: path.clone(),
+            reason: "denied".to_owned(),
+        }),
+        Err(MultiplexerError::LaunchFailed { .. })
+    ));
+    assert!(matches!(
+        classify_probe(ProbeObservation::Output {
+            platform: LocalPlatform::Windows,
+            path: path.clone(),
+            status_success: true,
+            stdout: "tmux 3.3.5".to_owned(),
+            stderr: String::new(),
+        }),
+        Err(MultiplexerError::UnsupportedVersion { .. })
+    ));
+    assert!(matches!(
+        classify_probe(ProbeObservation::CapabilityMissing {
+            platform: LocalPlatform::Windows,
+            path,
+            version: MultiplexerVersion::new(3, 3, 6),
+            capability: MultiplexerCapability::NamespaceIsolation,
+        }),
+        Err(MultiplexerError::RequiredCapabilityUnavailable { .. })
+    ));
+}
+
+#[test]
+fn windows_rejects_shadowed_compatibility_environment_executables() {
+    for path in [
+        r"C:\Windows\System32\wsl.exe",
+        r"C:\cygwin64\bin\tmux.exe",
+        r"C:\Program Files\Git\usr\bin\tmux.exe",
+        r"C:\msys64\usr\bin\tmux.exe",
+    ] {
+        let error = MultiplexerPlan::for_platform(
+            LocalPlatform::Windows,
+            PathBuf::from(path),
+            MultiplexerIsolation::Namespace("jefe-0123456789abcdef".to_owned()),
+        );
+        assert!(
+            matches!(error, Err(MultiplexerError::RejectedExecutable { .. })),
+            "compatibility executable must be rejected: {path}"
+        );
+    }
+}
+
+#[test]
+fn windows_pane_command_uses_powershell_without_unix_env_wrapper() {
+    let plan = MultiplexerPlan::for_platform(
+        LocalPlatform::Windows,
+        PathBuf::from(r"C:\Program Files\psmux\psmux.exe"),
+        MultiplexerIsolation::Namespace("jefe-0123456789abcdef".to_owned()),
+    )
+    .unwrap_or_else(|error| panic!("windows plan should be valid: {error}"));
+    let pane = plan
+        .pane_command_args(
+            OsStr::new(r"C:\Program Files\LLxprt Ω\llxprt.exe"),
+            &[OsString::from("--profile"), OsString::from("O'Brien")],
+            &[(OsString::from("LLXPRT_DEBUG"), OsString::from("api"))],
+        )
+        .unwrap_or_else(|error| panic!("Windows pane command should build: {error}"));
+    assert_eq!(pane.len(), 1);
+    let line = pane[0].to_string_lossy();
+    assert!(line.contains("$env:TMUX=$null"));
+    assert!(line.contains("$env:TMUX_PANE=$null"));
+    assert!(line.contains("$env:TMUX_TMPDIR=$null"));
+    assert!(line.contains("& 'C:\\Program Files\\LLxprt Ω\\llxprt.exe'"));
+    assert!(line.contains("'O''Brien'"));
+    assert!(!line.contains("env -u"));
+}
+
+#[test]
+fn production_namespace_is_stable_while_test_namespaces_are_distinct() {
+    if !cfg!(windows) {
+        return;
+    }
+    let production_first = MultiplexerPlan::current()
+        .unwrap_or_else(|error| panic!("first production plan should resolve: {error}"));
+    let production_second = MultiplexerPlan::current()
+        .unwrap_or_else(|error| panic!("second production plan should resolve: {error}"));
+    assert_eq!(production_first.isolation(), production_second.isolation());
+
+    let first = MultiplexerPlan::current_for_test()
+        .unwrap_or_else(|error| panic!("first test plan should resolve: {error}"));
+    let second = MultiplexerPlan::current_for_test()
+        .unwrap_or_else(|error| panic!("second test plan should resolve: {error}"));
+    assert_ne!(first.isolation(), second.isolation());
+}
+
+#[test]
+fn guarded_real_multiplexer_preflight_qualifies_the_current_dependency() {
+    let plan = match MultiplexerPlan::current_for_test() {
+        Ok(plan) => plan,
+        Err(_) if std::env::var("JEFE_REQUIRE_PSMUX").as_deref() != Ok("1") => return,
+        Err(error) => panic!("required multiplexer should resolve: {error}"),
+    };
+    let result = plan.preflight(&[
+        MultiplexerCapability::AttachSession,
+        MultiplexerCapability::PaneCapture,
+    ]);
+    assert!(
+        result.is_ok(),
+        "real multiplexer preflight failed: {result:?}"
+    );
+}
+
+#[test]
+fn path_arguments_remain_os_strings_without_lossy_conversion() {
+    let executable = PathBuf::from(r"C:\Program Files\psmux Ω\psmux.exe");
+    let plan = MultiplexerPlan::for_platform(
+        LocalPlatform::Windows,
+        executable.clone(),
+        MultiplexerIsolation::Namespace("jefe-0123456789abcdef".to_owned()),
+    )
+    .unwrap_or_else(|error| panic!("unicode executable path should be valid: {error}"));
+    assert_eq!(plan.executable().as_os_str(), executable.as_os_str());
+    assert!(plan.base_args().iter().all(|arg| arg != OsStr::new("-S")));
+}

--- a/src/runtime/multiplexer_tests.rs
+++ b/src/runtime/multiplexer_tests.rs
@@ -196,8 +196,11 @@ fn production_namespace_is_stable_while_test_namespaces_are_distinct() {
     if !cfg!(windows) {
         return;
     }
-    let production_first = MultiplexerPlan::current()
-        .unwrap_or_else(|error| panic!("first production plan should resolve: {error}"));
+    let production_first = match MultiplexerPlan::current() {
+        Ok(plan) => plan,
+        Err(_) if std::env::var("JEFE_REQUIRE_PSMUX").as_deref() != Ok("1") => return,
+        Err(error) => panic!("required production plan should resolve: {error}"),
+    };
     let production_second = MultiplexerPlan::current()
         .unwrap_or_else(|error| panic!("second production plan should resolve: {error}"));
     assert_eq!(production_first.isolation(), production_second.isolation());

--- a/src/runtime/multiplexer_tests.rs
+++ b/src/runtime/multiplexer_tests.rs
@@ -161,6 +161,19 @@ fn windows_pane_command_uses_powershell_without_unix_env_wrapper() {
     assert!(line.contains("& 'C:\\Program Files\\LLxprt Ω\\llxprt.exe'"));
     assert!(line.contains("'O''Brien'"));
     assert!(!line.contains("env -u"));
+
+    let malicious = plan.pane_command_args(
+        OsStr::new("llxprt.exe"),
+        &[],
+        &[(
+            OsString::from("SAFE; Write-Error owned"),
+            OsString::from("value"),
+        )],
+    );
+    assert!(matches!(
+        malicious,
+        Err(MultiplexerError::InvalidEnvironmentVariable { .. })
+    ));
 }
 
 #[test]

--- a/src/runtime/multiplexer_tests.rs
+++ b/src/runtime/multiplexer_tests.rs
@@ -73,10 +73,12 @@ fn version_parser_accepts_tmux_compatible_psmux_output() {
         MultiplexerVersion::parse("tmux 3.4\n"),
         Ok(MultiplexerVersion::new(3, 4, 0))
     );
-    assert!(matches!(
-        MultiplexerVersion::parse("psmux unknown"),
-        Err(MultiplexerError::MalformedVersion { .. })
-    ));
+    for malformed in ["psmux unknown", "tmux 3a.3b.6", "tmux 3..6", "tmux 3.3.6.1"] {
+        assert!(matches!(
+            MultiplexerVersion::parse(malformed),
+            Err(MultiplexerError::MalformedVersion { .. })
+        ));
+    }
 }
 
 #[test]

--- a/src/runtime/multiplexer_tests.rs
+++ b/src/runtime/multiplexer_tests.rs
@@ -174,6 +174,21 @@ fn windows_pane_command_uses_powershell_without_unix_env_wrapper() {
         malicious,
         Err(MultiplexerError::InvalidEnvironmentVariable { .. })
     ));
+
+    let unix = MultiplexerPlan::for_platform(
+        LocalPlatform::Unix,
+        PathBuf::from("/usr/bin/tmux"),
+        MultiplexerIsolation::Socket(PathBuf::from("/tmp/jefe.sock")),
+    )
+    .unwrap_or_else(|error| panic!("Unix plan should be valid: {error}"));
+    assert!(matches!(
+        unix.pane_command_args(
+            OsStr::new("llxprt"),
+            &[],
+            &[(OsString::from("SAFE; owned"), OsString::from("value"))],
+        ),
+        Err(MultiplexerError::InvalidEnvironmentVariable { .. })
+    ));
 }
 
 #[test]

--- a/src/runtime/pane_capture.rs
+++ b/src/runtime/pane_capture.rs
@@ -9,6 +9,7 @@ use super::commands::tmux_command;
 /// Capture pane output for a session as plain text lines.
 pub fn capture_pane_lines(session_name: &str) -> Option<Vec<String>> {
     let output = tmux_command()
+        .ok()?
         .args(["capture-pane", "-p", "-t", session_name])
         .output()
         .ok()?;
@@ -65,7 +66,7 @@ pub fn capture_pane_history_args(session_name: &str, history_lines: usize) -> Ve
 pub fn capture_pane_history(session_name: &str, history_lines: usize) -> Option<Vec<String>> {
     let argv = capture_pane_history_args(session_name, history_lines);
     let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
-    let output = tmux_command().args(&argv_refs).output().ok()?;
+    let output = tmux_command().ok()?.args(&argv_refs).output().ok()?;
     if !output.status.success() {
         return None;
     }
@@ -101,6 +102,7 @@ pub fn parse_pane_pid(stdout: &str) -> Option<u32> {
 #[must_use]
 pub fn pane_pid(session_name: &str) -> Option<u32> {
     let output = tmux_command()
+        .ok()?
         .args(["list-panes", "-t", session_name, "-F", "#{pane_pid}"])
         .output()
         .ok()?;


### PR DESCRIPTION
## Summary

- centralize local multiplexer executable resolution, isolation arguments, dependency probing, capability checks, and typed failures
- preserve upstream tmux with `-f /dev/null -S <private socket>` on Unix while selecting qualified native psmux with `-f NUL -L <private namespace>` on Windows
- route local session creation, attachment, liveness, pane capture, and cleanup through the shared platform policy while leaving remote Linux tmux-over-SSH syntax unchanged
- preserve Unicode and space-containing paths as native OS strings and use safely quoted native PowerShell pane commands on Windows
- use a stable collision-resistant production namespace, distinct test namespaces, and session-scoped cleanup only

## Test-first evidence

RED: introduced behavioral multiplexer policy tests before the module existed; the focused test failed because `src/runtime/multiplexer.rs` was missing.

GREEN/REFACTOR:

- table-driven platform argument, executable, namespace, version, capability, failure-classification, Unicode/path, and PowerShell quoting tests
- guarded real native psmux dependency preflight
- full library suite with `JEFE_REQUIRE_PSMUX=1`: 1650 passed
- remote launch regression confirms Linux tmux-over-SSH syntax remains separate
- independent review remediated host-dependent classification, lossy path checks, typed error propagation, malformed-version path reporting, and unique test namespaces

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::duration_suboptimal_units`
- `cargo build --workspace --all-features --locked`
- `cargo test --workspace --all-features --locked`
- `git diff --check`

The local Clippy exception is limited to two pre-existing `Duration::from_secs(300)` constants that preserve the repository's Rust 1.75 MSRV; issue #257 adds no lint suppression.

Closes #257
