### PR TITLE
Fix #259: use native process identity for Windows liveness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -680,6 +680,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-width 0.2.2",
+ "whoami",
+ "winsafe",
 ]
 
 [[package]]
@@ -690,11 +692,12 @@ checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -712,17 +715,16 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags 2.11.0",
  "libc",
 ]
 
@@ -794,7 +796,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -843,6 +845,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1663,6 +1683,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,10 +1710,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.108"
+name = "wasite"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1695,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1705,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1718,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -1757,6 +1795,29 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]
@@ -1886,6 +1947,12 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfff8264c3af1b0352006934e2265365ecb5a145aee88e770dc8b82e0456f4f"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ comrak = { version = "0.53", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winsafe = { version = "0.0.27", features = ["kernel"] }
-whoami = "=2.1.2"
+whoami = "2.1.2"
 
 [features]
 psmux-smoke = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,10 @@ lru = "0.12"
 # jefe's iocraft pipeline.
 comrak = { version = "0.53", default-features = false }
 
+[target.'cfg(windows)'.dependencies]
+winsafe = { version = "0.0.27", features = ["kernel"] }
+whoami = "=2.1.2"
+
 [features]
 psmux-smoke = []
 

--- a/project-plans/issue259-plan.md
+++ b/project-plans/issue259-plan.md
@@ -1,0 +1,33 @@
+# Issue #259 — Native process liveness and runtime identity
+
+## Behavioral goal
+
+Replace Windows command-line liveness and environment-derived namespace identity with typed platform services. Persist a process-instance discriminator so startup reconciliation cannot mistake a reused Windows PID for the original agent. Keep remote SSH/Unix probes unchanged.
+
+## Test-first sequence
+
+1. **RED — classification contracts**
+   - Add pure tests for alive, exited, inaccessible, reused PID, malformed persisted identity, and probe failure.
+   - Assert probe failure never classifies as alive.
+2. **RED — native process transitions**
+   - Spawn the Rust test executable as short- and long-lived child processes.
+   - Prove running, normal exit, and forced termination transitions through the production process service.
+3. **RED — namespace identity**
+   - Test deterministic namespace hashing, separation for distinct identities, privacy-safe output, and collision-resistant test suffixes.
+4. **GREEN — platform services**
+   - Add a runtime process service. Windows uses the safe `winsafe` wrapper around `OpenProcess`, `GetExitCodeProcess`, and `GetProcessTimes`; Unix retains supported local semantics.
+   - Add a Windows identity source using the maintained `whoami` crate and hash identity material before constructing psmux namespace names.
+5. **GREEN — persistence/reconciliation integration**
+   - Add a backward-compatible optional process identity to runtime bindings and sessions.
+   - Capture it with pane PID creation and use it during startup reconciliation.
+   - Preserve remote tmux/SSH liveness behavior exactly.
+6. **REFACTOR/VERIFY**
+   - Remove Windows `tasklist` and environment-username identity assumptions.
+   - Run focused tests, independent review, and the full CI verification suite.
+
+## Boundaries
+
+- Runtime owns native process and namespace side effects.
+- Domain owns serializable process-instance data.
+- Persistence remains backward compatible through `#[serde(default)]`.
+- No UI behavior changes; no TUI scenario is required.

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -210,9 +210,9 @@ fn reconcile_running_agents(state: &AppState, runtime: &TmuxRuntimeManager) -> V
                 .and_then(|binding| binding.process_identity),
         ));
     }
-    for (agent_id, signature, pid) in running_agents {
+    for (agent_id, signature, process_identity) in running_agents {
         let session_exists = runtime.session_exists_for_signature(&agent_id, &signature);
-        if is_agent_dead(session_exists, signature.remote.enabled, pid) {
+        if is_agent_dead(session_exists, signature.remote.enabled, process_identity) {
             dead_ids.push(agent_id);
         }
     }

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -333,13 +333,13 @@ fn restore_one_agent(
                     // returns None (e.g. a tmux list-panes hiccup right after
                     // create). Without this, the revived agent's binding could
                     // be persisted with pid: None, stripping the fallback.
-                    let pid = runtime.worker_pid(&agent.id).or(pid);
+                    let resolved_pid = runtime.worker_pid(&agent.id).or(pid);
                     let process_identity = runtime
                         .worker_process_identity(&agent.id)
                         .or(process_identity);
                     RestoreOneOutcome::Revived {
                         signature: Box::new(signature),
-                        pid,
+                        pid: resolved_pid,
                         process_identity,
                     }
                 }

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -4,12 +4,13 @@ use iocraft::hooks::State as HookState;
 use tracing::warn;
 
 use jefe::domain::{
-    Agent, AgentId, AgentStatus, LaunchSignature, PlatformCapabilities, SandboxEngine,
+    Agent, AgentId, AgentStatus, LaunchSignature, PlatformCapabilities, ProcessIdentity,
+    SandboxEngine,
 };
 use jefe::persistence::{PersistenceManager, Settings, State as PersistedState};
 use jefe::runtime::{
-    RuntimeError, RuntimeManager, RuntimeSession, TmuxRuntimeManager, pid_alive,
-    platform_engine_diagnostic,
+    ProcessLiveness, RuntimeError, RuntimeManager, RuntimeSession, TmuxRuntimeManager,
+    platform_engine_diagnostic, process_liveness,
 };
 use jefe::state::AppState;
 use jefe::theme::ThemeManager;
@@ -163,20 +164,18 @@ pub fn init_app_state(app_state: &mut HookState<AppState>, ctx: &SharedContext) 
 /// Factored out of [`reconcile_running_agents`] so the decision logic is
 /// unit-testable without spawning real tmux.
 #[must_use]
-fn is_agent_dead(session_exists: bool, remote_enabled: bool, pid: Option<u32>) -> bool {
+fn is_agent_dead(
+    session_exists: bool,
+    remote_enabled: bool,
+    process_identity: Option<ProcessIdentity>,
+) -> bool {
     if session_exists {
         return false;
     }
-    // Remote agents: no local PID fallback is available; dead if session gone.
     if remote_enabled {
         return true;
     }
-    // Local agents: consult the worker PID fallback. A live worker means the
-    // agent is recoverable, not dead.
-    match pid {
-        Some(pid) => !pid_alive(pid),
-        None => true,
-    }
+    !matches!(process_liveness(process_identity), ProcessLiveness::Alive)
 }
 
 /// Find Running agents whose tmux sessions no longer exist.
@@ -190,7 +189,7 @@ fn is_agent_dead(session_exists: bool, remote_enabled: bool, pid: Option<u32>) -
 ///
 /// Returns the collected dead agent IDs; does not mutate `state`.
 fn reconcile_running_agents(state: &AppState, runtime: &TmuxRuntimeManager) -> Vec<AgentId> {
-    let mut running_agents: Vec<(AgentId, LaunchSignature, Option<u32>)> = Vec::new();
+    let mut running_agents: Vec<(AgentId, LaunchSignature, Option<ProcessIdentity>)> = Vec::new();
     let mut dead_ids = Vec::new();
     for agent in state
         .agents
@@ -205,7 +204,10 @@ fn reconcile_running_agents(state: &AppState, runtime: &TmuxRuntimeManager) -> V
         running_agents.push((
             agent.id.clone(),
             launch_signature_for_agent(agent, repository),
-            agent.runtime_binding.as_ref().and_then(|b| b.pid),
+            agent
+                .runtime_binding
+                .as_ref()
+                .and_then(|binding| binding.process_identity),
         ));
     }
     for (agent_id, signature, pid) in running_agents {
@@ -248,7 +250,7 @@ fn apply_dead_reconciliations(
 fn restore_dead_decision(
     session_exists: bool,
     remote_enabled: bool,
-    pid: Option<u32>,
+    process_identity: Option<ProcessIdentity>,
 ) -> RestoreDecision {
     if session_exists {
         return RestoreDecision::Revive;
@@ -256,7 +258,7 @@ fn restore_dead_decision(
     // `session_exists` is always `false` here — the `true` case early-returns
     // as `Revive` above. The argument is threaded through for clarity and to
     // keep `is_agent_dead` self-documenting.
-    if is_agent_dead(session_exists, remote_enabled, pid) {
+    if is_agent_dead(session_exists, remote_enabled, process_identity) {
         return RestoreDecision::Dead;
     }
     // Session is gone but the local worker PID is still alive: keep the agent
@@ -283,6 +285,7 @@ enum RestoreOneOutcome {
     Revived {
         signature: Box<LaunchSignature>,
         pid: Option<u32>,
+        process_identity: Option<ProcessIdentity>,
     },
     /// Agent should be marked Dead (binding cleared).
     Dead,
@@ -309,10 +312,12 @@ fn restore_one_agent(
         return RestoreOneOutcome::Dead;
     };
     let signature = launch_signature_for_agent(agent, &repository);
-    let pid = agent.runtime_binding.as_ref().and_then(|b| b.pid);
+    let binding = agent.runtime_binding.as_ref();
+    let pid = binding.and_then(|value| value.pid);
+    let process_identity = binding.and_then(|value| value.process_identity);
     let session_exists = runtime.session_exists_for_signature(&agent.id, &signature);
 
-    match restore_dead_decision(session_exists, signature.remote.enabled, pid) {
+    match restore_dead_decision(session_exists, signature.remote.enabled, process_identity) {
         RestoreDecision::Dead => RestoreOneOutcome::Dead,
         // SkipOrphan agents remain Running in AppState but have NO entry in
         // the TmuxRuntimeManager in-memory session map (by design — the
@@ -329,9 +334,13 @@ fn restore_one_agent(
                     // create). Without this, the revived agent's binding could
                     // be persisted with pid: None, stripping the fallback.
                     let pid = runtime.worker_pid(&agent.id).or(pid);
+                    let process_identity = runtime
+                        .worker_process_identity(&agent.id)
+                        .or(process_identity);
                     RestoreOneOutcome::Revived {
                         signature: Box::new(signature),
                         pid,
+                        process_identity,
                     }
                 }
                 ReviveOutcome::Died => RestoreOneOutcome::Dead,
@@ -362,7 +371,12 @@ pub fn restore_runtime_sessions(app_state: &mut HookState<AppState>, ctx: &Share
         return;
     };
 
-    let mut revived_running: Vec<(AgentId, LaunchSignature, Option<u32>)> = Vec::new();
+    let mut revived_running: Vec<(
+        AgentId,
+        LaunchSignature,
+        Option<u32>,
+        Option<ProcessIdentity>,
+    )> = Vec::new();
     let mut newly_dead = Vec::new();
     let mut runtime_warning: Option<String> = None;
 
@@ -373,8 +387,12 @@ pub fn restore_runtime_sessions(app_state: &mut HookState<AppState>, ctx: &Share
             &mut ctx_guard.runtime,
             &mut runtime_warning,
         ) {
-            RestoreOneOutcome::Revived { signature, pid } => {
-                revived_running.push((agent.id.clone(), *signature, pid));
+            RestoreOneOutcome::Revived {
+                signature,
+                pid,
+                process_identity,
+            } => {
+                revived_running.push((agent.id.clone(), *signature, pid, process_identity));
             }
             RestoreOneOutcome::Dead => newly_dead.push(agent.id.clone()),
             RestoreOneOutcome::Skip => {}
@@ -430,11 +448,16 @@ fn revive_agent_session(
 /// Apply restored session results to app state and persist.
 fn apply_restored_state(
     state: &mut AppState,
-    revived_running: Vec<(AgentId, LaunchSignature, Option<u32>)>,
+    revived_running: Vec<(
+        AgentId,
+        LaunchSignature,
+        Option<u32>,
+        Option<ProcessIdentity>,
+    )>,
     newly_dead: Vec<AgentId>,
     runtime_warning: Option<String>,
 ) {
-    for (agent_id, signature, pid) in revived_running {
+    for (agent_id, signature, pid, process_identity) in revived_running {
         if let Some(agent) = state.agents.iter_mut().find(|agent| agent.id == agent_id) {
             agent.status = AgentStatus::Running;
             let session_name = RuntimeSession::session_name_for(&agent_id);
@@ -443,6 +466,7 @@ fn apply_restored_state(
                 launch_signature: signature,
                 attached: false,
                 last_seen: None,
+                process_identity,
                 pid,
             });
         }
@@ -465,6 +489,11 @@ fn apply_restored_state(
 mod tests {
     use super::*;
     use jefe::domain::{AgentKind, Repository, RepositoryId};
+
+    fn current_process_identity() -> ProcessIdentity {
+        jefe::runtime::capture_process_identity(std::process::id())
+            .unwrap_or_else(|error| panic!("capture current process identity: {error}"))
+    }
 
     fn code_puppy_agent_and_repository() -> (Agent, Repository) {
         let repository_id = RepositoryId("repo-model".to_owned());
@@ -508,7 +537,7 @@ mod tests {
     /// Session still exists → never dead, regardless of PID.
     #[test]
     fn is_agent_dead_false_when_session_exists() {
-        let me = std::process::id();
+        let me = current_process_identity();
         assert!(!is_agent_dead(true, false, Some(me)));
         assert!(!is_agent_dead(true, true, None));
     }
@@ -517,7 +546,7 @@ mod tests {
     /// keeps it Running for reclaim).
     #[test]
     fn is_agent_dead_false_when_local_worker_pid_alive() {
-        let me = std::process::id();
+        let me = current_process_identity();
         assert!(!is_agent_dead(false, false, Some(me)));
     }
 
@@ -527,7 +556,11 @@ mod tests {
         // 2_000_000_000 is within pid_t (i32) range but far above every
         // platform's pid_max (Linux ~4.19M, macOS ~99998), so kill -0
         // deterministically returns ESRCH (no such process).
-        assert!(is_agent_dead(false, false, Some(2_000_000_000)));
+        assert!(is_agent_dead(
+            false,
+            false,
+            Some(ProcessIdentity::new(2_000_000_000, 1))
+        ));
     }
 
     /// Local agent, session gone, no PID recorded → dead (no fallback info).
@@ -541,7 +574,7 @@ mod tests {
     fn is_agent_dead_true_when_remote_session_gone() {
         // Even with a live PID present, remote agents must not use the local
         // pid_alive check; they rely solely on the tmux/SSH session path.
-        let me = std::process::id();
+        let me = current_process_identity();
         assert!(is_agent_dead(false, true, Some(me)));
     }
 
@@ -553,7 +586,7 @@ mod tests {
     /// `init_app_state` correctly applied.
     #[test]
     fn restore_decision_skips_local_orphan_with_live_pid() {
-        let me = std::process::id();
+        let me = current_process_identity();
         assert_eq!(
             restore_dead_decision(false, false, Some(me)),
             RestoreDecision::SkipOrphan
@@ -564,7 +597,7 @@ mod tests {
     /// the remote host).
     #[test]
     fn restore_decision_dead_when_remote_no_session() {
-        let me = std::process::id();
+        let me = current_process_identity();
         assert_eq!(
             restore_dead_decision(false, true, Some(me)),
             RestoreDecision::Dead
@@ -587,7 +620,7 @@ mod tests {
         // platform's pid_max (Linux ~4.19M, macOS ~99998), so kill -0
         // deterministically returns ESRCH (no such process).
         assert_eq!(
-            restore_dead_decision(false, false, Some(2_000_000_000)),
+            restore_dead_decision(false, false, Some(ProcessIdentity::new(2_000_000_000, 1))),
             RestoreDecision::Dead
         );
     }
@@ -595,7 +628,7 @@ mod tests {
     /// Local agent with a live tmux session ⇒ Revive (reattach).
     #[test]
     fn restore_decision_revive_when_session_exists() {
-        let me = std::process::id();
+        let me = current_process_identity();
         assert_eq!(
             restore_dead_decision(true, false, Some(me)),
             RestoreDecision::Revive

--- a/src/app_input/agent_runtime.rs
+++ b/src/app_input/agent_runtime.rs
@@ -5,7 +5,7 @@
 //! shared runtime context for worker PIDs. They are shared by the launch,
 //! relaunch, kill, and issue/PR send paths in `app_input` and its child modules.
 
-use jefe::domain::{AgentId, AgentStatus, LaunchSignature};
+use jefe::domain::{AgentId, AgentStatus, LaunchSignature, ProcessIdentity};
 use jefe::state::AppState;
 
 use super::SharedContext;
@@ -24,6 +24,7 @@ pub(super) fn set_agent_runtime_binding(
     session_name: String,
     signature: LaunchSignature,
     pid: Option<u32>,
+    process_identity: Option<ProcessIdentity>,
 ) {
     if let Some(agent) = state.agents.iter_mut().find(|agent| &agent.id == agent_id) {
         agent.runtime_binding = Some(jefe::domain::RuntimeBinding {
@@ -31,6 +32,7 @@ pub(super) fn set_agent_runtime_binding(
             launch_signature: signature,
             attached: false,
             last_seen: None,
+            process_identity,
             pid,
         });
     }
@@ -60,10 +62,17 @@ pub(super) fn clear_agent_runtime_attachment(state: &mut AppState) {
 /// shared context. Returns `None` when the context is absent, the lock is
 /// poisoned, or the runtime has no PID recorded. Shared by the launch,
 /// relaunch, and issue/PR send paths.
-pub(super) fn worker_pid_for(ctx: &SharedContext, agent_id: &AgentId) -> Option<u32> {
-    ctx.as_ref()
-        .and_then(|arc| arc.lock().ok())
-        .and_then(|guard| guard.runtime.worker_pid(agent_id))
+pub(super) fn worker_process_for(
+    ctx: &SharedContext,
+    agent_id: &AgentId,
+) -> (Option<u32>, Option<ProcessIdentity>) {
+    let Some(guard) = ctx.as_ref().and_then(|arc| arc.lock().ok()) else {
+        return (None, None);
+    };
+    (
+        guard.runtime.worker_pid(agent_id),
+        guard.runtime.worker_process_identity(agent_id),
+    )
 }
 
 /// Resolve the worker PID to persist on a runtime binding, gated on launch
@@ -71,17 +80,21 @@ pub(super) fn worker_pid_for(ctx: &SharedContext, agent_id: &AgentId) -> Option<
 ///
 /// All launch/relaunch persistence paths share the same invariant: the PID
 /// must be queried from the runtime **before** the caller takes the
-/// `app_state` write lock, because `worker_pid_for` acquires the shared
+/// `app_state` write lock, because `worker_process_for` acquires the shared
 /// context mutex and `app_state-lock → ctx-lock` would be a lock-ordering
 /// hazard. Centralizing the success-gated query here guarantees that ordering
 /// is respected at every call site. On the failure path no binding is
 /// persisted, so the query is skipped.
-pub(super) fn pid_on_success(
+pub(super) fn process_on_success(
     ctx: &SharedContext,
     agent_id: &AgentId,
     success: bool,
-) -> Option<u32> {
-    success.then(|| worker_pid_for(ctx, agent_id)).flatten()
+) -> (Option<u32>, Option<ProcessIdentity>) {
+    if success {
+        worker_process_for(ctx, agent_id)
+    } else {
+        Default::default()
+    }
 }
 
 pub(super) fn mark_runtime_session_dead_if_present(state: &mut AppState, agent_id: &AgentId) {

--- a/src/app_input/app_input_tests.rs
+++ b/src/app_input/app_input_tests.rs
@@ -117,6 +117,7 @@ fn set_agent_runtime_binding_sets_session_and_signature() {
         String::from("jefe-agent-1"),
         signature.clone(),
         None,
+        None,
     );
 
     let binding = state
@@ -147,6 +148,7 @@ fn set_agent_runtime_binding_persists_pid() {
         String::from("jefe-agent-pid"),
         signature.clone(),
         Some(12345),
+        Some(jefe::domain::ProcessIdentity::new(12345, 67890)),
     );
 
     let binding = state
@@ -175,6 +177,7 @@ fn mark_and_clear_runtime_attachment_flags() {
         launch_signature: sample_signature(),
         attached: false,
         last_seen: None,
+        process_identity: None,
         pid: None,
     });
 
@@ -184,6 +187,7 @@ fn mark_and_clear_runtime_attachment_flags() {
         launch_signature: sample_signature(),
         attached: true,
         last_seen: None,
+        process_identity: None,
         pid: None,
     });
 
@@ -218,6 +222,7 @@ fn mark_runtime_session_dead_sets_dead_and_detaches() {
         launch_signature: sample_signature(),
         attached: true,
         last_seen: None,
+        process_identity: None,
         pid: None,
     });
 

--- a/src/app_input/issues_send.rs
+++ b/src/app_input/issues_send.rs
@@ -34,7 +34,7 @@ use super::issues_dispatch;
 use super::{
     AppStateHandle, REMOTE_ATTACH_SETTLE_DELAY, SharedContext, apply_and_persist,
     close_modal_and_persist, gh_async, github_client, launch_signature_for_agent, persist_state,
-    pid_on_success, preflight_or_prompt, to_persisted_state,
+    preflight_or_prompt, process_on_success, to_persisted_state,
 };
 
 pub(super) fn dispatch_agent_chooser_confirm(app_state: &mut AppStateHandle, ctx: &SharedContext) {
@@ -517,10 +517,16 @@ fn launch_issue_agent(
     // Resolve the worker PID for the persisted binding's PID-liveness
     // fallback, before taking the app-state write lock (lock-ordering
     // constraint). Skipped on the failure path (no binding persisted).
-    let pid = pid_on_success(ctx, &agent_id, launched);
+    let (pid, process_identity) = process_on_success(ctx, &agent_id, launched);
     let mut state = app_state.write();
     if launched {
-        persist_issue_agent_launch_success(&mut state, &agent_id, launch_sig, pid);
+        persist_issue_agent_launch_success(
+            &mut state,
+            &agent_id,
+            launch_sig,
+            pid,
+            process_identity,
+        );
     } else {
         *state = std::mem::take(&mut *state).apply(AppEvent::SendToAgentFailed {
             error: "Failed to launch agent".to_string(),
@@ -603,6 +609,7 @@ fn persist_issue_agent_launch_success(
     agent_id: &AgentId,
     launch_sig: LaunchSignature,
     pid: Option<u32>,
+    process_identity: Option<jefe::domain::ProcessIdentity>,
 ) {
     if let Some(agent) = state.agents.iter_mut().find(|agent| &agent.id == agent_id) {
         agent.status = jefe::domain::AgentStatus::Running;
@@ -612,6 +619,7 @@ fn persist_issue_agent_launch_success(
             launch_signature: launch_sig,
             attached: false,
             last_seen: None,
+            process_identity,
             pid,
         });
     }

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -50,8 +50,8 @@ mod remote_probe;
 mod target_resolution;
 use agent_runtime::{
     clear_agent_runtime_attachment, clear_runtime_warning, mark_agent_runtime_attached,
-    mark_runtime_session_dead_if_present, pid_on_success, set_agent_runtime_binding,
-    worker_pid_for,
+    mark_runtime_session_dead_if_present, process_on_success, set_agent_runtime_binding,
+    worker_process_for,
 };
 
 pub use modal_handlers::{
@@ -326,7 +326,7 @@ fn mark_launch_attached(
 ) {
     // Query the runtime for the worker PID before taking the app-state write
     // lock, so the persisted binding carries the PID-liveness fallback.
-    let pid = worker_pid_for(ctx, agent_id);
+    let (pid, process_identity) = worker_process_for(ctx, agent_id);
 
     let mut state = app_state.write();
     set_agent_runtime_binding(
@@ -335,6 +335,7 @@ fn mark_launch_attached(
         jefe::runtime::RuntimeSession::session_name_for(agent_id),
         signature.clone(),
         pid,
+        process_identity,
     );
     clear_agent_runtime_attachment(&mut state);
     mark_agent_runtime_attached(&mut state, agent_id, true);
@@ -812,14 +813,14 @@ fn persist_relaunch_result(
     relaunched: bool,
 ) {
     let relaunch_event = AppEvent::RelaunchAgent(agent_id.clone());
-    // Query the PID BEFORE taking the app-state write lock: worker_pid_for
+    // Query the PID BEFORE taking the app-state write lock: worker_process_for
     // acquires the ctx mutex, so app_state-lock → ctx-lock would be a
-    // lock-ordering hazard. `pid_on_success` skips the query on the failure
+    // lock-ordering hazard. `process_on_success` skips the query on the failure
     // path (no binding is persisted).
-    let pid = pid_on_success(ctx, &agent_id, relaunched);
+    let (pid, process_identity) = process_on_success(ctx, &agent_id, relaunched);
     let mut state = app_state.write();
     if relaunched {
-        persist_relaunch_success(&mut state, &agent_id, relaunch_event, pid);
+        persist_relaunch_success(&mut state, &agent_id, relaunch_event, pid, process_identity);
     } else {
         persist_relaunch_failure(&mut state, &agent_id, relaunch_event);
     }
@@ -833,6 +834,7 @@ fn persist_relaunch_success(
     agent_id: &AgentId,
     relaunch_event: AppEvent,
     pid: Option<u32>,
+    process_identity: Option<jefe::domain::ProcessIdentity>,
 ) {
     // Capture agent_kind before `apply` consumes the state snapshot, so the
     // SSH-agent warning can be gated: only LLxprt uses the sandbox subsystem,
@@ -846,6 +848,7 @@ fn persist_relaunch_success(
             jefe::runtime::RuntimeSession::session_name_for(&agent.id),
             signature,
             pid,
+            process_identity,
         );
     }
     *state = std::mem::take(state).apply(relaunch_event);

--- a/src/app_input/prs_orchestration.rs
+++ b/src/app_input/prs_orchestration.rs
@@ -19,8 +19,8 @@ use super::fresh_prompt::{FreshPromptKind, prepare_fresh_prompt_signature};
 use super::{
     AppStateHandle, REMOTE_ATTACH_SETTLE_DELAY, SharedContext, apply_and_persist,
     clear_agent_runtime_attachment, dispatch_app_event, gh_async, github_client,
-    launch_signature_for_agent, mark_agent_runtime_attached, persist_state, pid_on_success,
-    preflight_or_prompt, prs_comments_dispatch, prs_dispatch, prs_list_dispatch, prs_mutation,
+    launch_signature_for_agent, mark_agent_runtime_attached, persist_state, preflight_or_prompt,
+    process_on_success, prs_comments_dispatch, prs_dispatch, prs_list_dispatch, prs_mutation,
     to_persisted_state,
 };
 
@@ -629,10 +629,10 @@ fn launch_pr_agent(
     let launched = spawn_and_attach_fresh_for_pr(ctx, &agent_id, &work_dir, &launch_sig);
     // Resolve the worker PID before taking the app-state write lock
     // (lock-ordering constraint). Skipped on the failure path.
-    let pid = pid_on_success(ctx, &agent_id, launched);
+    let (pid, process_identity) = process_on_success(ctx, &agent_id, launched);
     let mut state = app_state.write();
     if launched {
-        persist_pr_agent_launch_success(&mut state, &agent_id, launch_sig, pid);
+        persist_pr_agent_launch_success(&mut state, &agent_id, launch_sig, pid, process_identity);
     } else {
         *state = std::mem::take(&mut *state).apply(AppEvent::PrSendToAgentFailed {
             error: "Failed to launch agent".to_string(),
@@ -700,6 +700,7 @@ fn persist_pr_agent_launch_success(
     agent_id: &AgentId,
     launch_sig: LaunchSignature,
     pid: Option<u32>,
+    process_identity: Option<jefe::domain::ProcessIdentity>,
 ) {
     if let Some(agent) = state.agents.iter_mut().find(|agent| &agent.id == agent_id) {
         agent.status = jefe::domain::AgentStatus::Running;
@@ -709,6 +710,7 @@ fn persist_pr_agent_launch_success(
             launch_signature: launch_sig,
             attached: false,
             last_seen: None,
+            process_identity,
             pid,
         });
     }

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -264,7 +264,7 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
         let mut app_state = app_state;
         async move {
             loop {
-                smol::Timer::after(std::time::Duration::from_mins(1)).await;
+                smol::Timer::after(std::time::Duration::from_secs(60)).await;
                 request_pr_background_refresh(&mut app_state, &ctx);
             }
         }

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -264,7 +264,7 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
         let mut app_state = app_state;
         async move {
             loop {
-                smol::Timer::after(std::time::Duration::from_secs(60)).await;
+                smol::Timer::after(std::time::Duration::from_mins(1)).await;
                 request_pr_background_refresh(&mut app_state, &ctx);
             }
         }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -757,6 +757,26 @@ pub struct Agent {
     pub runtime_binding: Option<RuntimeBinding>,
 }
 
+/// Stable identity of one operating-system process instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProcessIdentity {
+    pub pid: u32,
+    /// Platform process creation discriminator. Windows exposes this as the
+    /// process creation FILETIME; `None` supports legacy/Unix bindings.
+    #[serde(default)]
+    pub started_at: Option<u64>,
+}
+
+impl ProcessIdentity {
+    #[must_use]
+    pub const fn new(pid: u32, started_at: u64) -> Self {
+        Self {
+            pid,
+            started_at: Some(started_at),
+        }
+    }
+}
+
 /// Runtime session binding metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuntimeBinding {
@@ -776,6 +796,10 @@ pub struct RuntimeBinding {
     /// files that predate this field.
     #[serde(default)]
     pub pid: Option<u32>,
+    /// Process-instance identity captured with the PID. Older state files omit
+    /// this field and continue through the legacy PID-only migration path.
+    #[serde(default)]
+    pub process_identity: Option<ProcessIdentity>,
 }
 
 /// Launch signature for recreating runtime sessions.

--- a/src/domain/tests.rs
+++ b/src/domain/tests.rs
@@ -397,6 +397,7 @@ fn runtime_binding_deserializes_missing_pid_as_none() {
     let binding: RuntimeBinding =
         serde_json::from_value(value).value_or_panic("binding should deserialize");
     assert!(binding.pid.is_none());
+    assert!(binding.process_identity.is_none());
 }
 
 #[test]
@@ -421,12 +422,17 @@ fn runtime_binding_roundtrips_pid_when_present() {
         attached: false,
         last_seen: None,
         pid: Some(42_000),
+        process_identity: Some(ProcessIdentity::new(42_000, 123_456)),
     };
 
     let json = serde_json::to_value(&binding).value_or_panic("should serialize");
     let binding2: RuntimeBinding =
         serde_json::from_value(json).value_or_panic("should deserialize");
     assert_eq!(binding2.pid, Some(42_000));
+    assert_eq!(
+        binding2.process_identity,
+        Some(ProcessIdentity::new(42_000, 123_456))
+    );
 }
 
 // =============================================================================

--- a/src/git_info/mod.rs
+++ b/src/git_info/mod.rs
@@ -43,7 +43,7 @@ const BRANCH_TTL: Duration = Duration::from_secs(5);
 ///
 /// The origin URL changes very rarely (essentially never during a session),
 /// so this is much longer than the branch TTL.
-const ORIGIN_TTL: Duration = Duration::from_secs(300);
+const ORIGIN_TTL: Duration = Duration::from_mins(5);
 
 /// Resolved git display info for an agent's work directory.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/src/git_info/mod.rs
+++ b/src/git_info/mod.rs
@@ -43,7 +43,7 @@ const BRANCH_TTL: Duration = Duration::from_secs(5);
 ///
 /// The origin URL changes very rarely (essentially never during a session),
 /// so this is much longer than the branch TTL.
-const ORIGIN_TTL: Duration = Duration::from_mins(5);
+const ORIGIN_TTL: Duration = Duration::from_secs(5 * 60);
 
 /// Resolved git display info for an agent's work directory.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -798,7 +798,6 @@ fn seed_restart_agent_state(config_dir: &std::path::Path, agent_session: &str) {
         RemoteRepositorySettings, Repository, RepositoryId, RuntimeBinding, SandboxEngine,
     };
     use crate::persistence::{FilePersistenceManager, PersistenceManager, PersistencePaths, State};
-    // Derive the agent id from the session name so that
     // `RuntimeSession::session_name_for(agent_id)` reproduces `agent_session`
     // exactly. This keeps the pre-created (sleep) session name coherent with
     // the name jefe computes for the agent, so restart targets the SAME session

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -798,7 +798,6 @@ fn seed_restart_agent_state(config_dir: &std::path::Path, agent_session: &str) {
         RemoteRepositorySettings, Repository, RepositoryId, RuntimeBinding, SandboxEngine,
     };
     use crate::persistence::{FilePersistenceManager, PersistenceManager, PersistencePaths, State};
-
     // Derive the agent id from the session name so that
     // `RuntimeSession::session_name_for(agent_id)` reproduces `agent_session`
     // exactly. This keeps the pre-created (sleep) session name coherent with

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -576,6 +576,7 @@ fn seed_sticky_agent_state(config_dir: &std::path::Path, agent_session: &str) {
         },
         attached: false,
         last_seen: None,
+        process_identity: None,
         pid: None,
     });
 
@@ -831,6 +832,7 @@ fn seed_restart_agent_state(config_dir: &std::path::Path, agent_session: &str) {
         },
         attached: false,
         last_seen: None,
+        process_identity: None,
         pid: None,
     });
 

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -547,7 +547,7 @@ fn seed_sticky_agent_state(config_dir: &std::path::Path, agent_session: &str) {
         Agent, AgentId, AgentStatus, DEFAULT_SANDBOX_FLAGS, LaunchSignature,
         RemoteRepositorySettings, Repository, RepositoryId, RuntimeBinding, SandboxEngine,
     };
-    use crate::persistence::{FilePersistenceManager, PersistenceManager, PersistencePaths, State};
+    use crate::persistence::State;
 
     let mut agent = Agent::new(
         AgentId("stickyagent".into()),
@@ -851,14 +851,20 @@ fn seed_restart_agent_state(config_dir: &std::path::Path, agent_session: &str) {
         terminal_focused: false,
         user_preferences: crate::domain::UserPreferences::default(),
     };
+    save_seeded_state(config_dir, &persisted_state);
+}
+
+#[cfg(unix)]
+fn save_seeded_state(config_dir: &std::path::Path, state: &crate::persistence::State) {
+    use crate::persistence::{FilePersistenceManager, PersistenceManager, PersistencePaths};
+
     let paths = PersistencePaths {
         settings_path: config_dir.join("settings.toml"),
         state_path: config_dir.join("state.json"),
     };
-    let persistence = FilePersistenceManager::with_paths(paths);
-    persistence
-        .save_state(&persisted_state)
-        .unwrap_or_else(|e| panic!("save state: {e:?}"));
+    FilePersistenceManager::with_paths(paths)
+        .save_state(state)
+        .unwrap_or_else(|error| panic!("save state: {error:?}"));
 }
 
 /// Run the issue #117 restart TUI scenario against the real jefe binary.

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -547,7 +547,7 @@ fn seed_sticky_agent_state(config_dir: &std::path::Path, agent_session: &str) {
         Agent, AgentId, AgentStatus, DEFAULT_SANDBOX_FLAGS, LaunchSignature,
         RemoteRepositorySettings, Repository, RepositoryId, RuntimeBinding, SandboxEngine,
     };
-    use crate::persistence::State;
+    use crate::persistence::{FilePersistenceManager, PersistenceManager, PersistencePaths, State};
 
     let mut agent = Agent::new(
         AgentId("stickyagent".into()),
@@ -797,7 +797,7 @@ fn seed_restart_agent_state(config_dir: &std::path::Path, agent_session: &str) {
         Agent, AgentId, AgentStatus, DEFAULT_SANDBOX_FLAGS, LaunchSignature,
         RemoteRepositorySettings, Repository, RepositoryId, RuntimeBinding, SandboxEngine,
     };
-    use crate::persistence::{FilePersistenceManager, PersistenceManager, PersistencePaths, State};
+    use crate::persistence::State;
     // `RuntimeSession::session_name_for(agent_id)` reproduces `agent_session`
     // exactly. This keeps the pre-created (sleep) session name coherent with
     // the name jefe computes for the agent, so restart targets the SAME session

--- a/src/runtime/gh_auth.rs
+++ b/src/runtime/gh_auth.rs
@@ -26,7 +26,7 @@ use crate::github::{
 /// by design: it only bounds a hung subprocess (interactive-prompt leak,
 /// network stall, CLI bug) — `gh`'s own device-code flow expires server-side
 /// well before this and the user is authorizing in parallel (issue #244).
-const DEVICE_AUTH_WAIT_DEADLINE: Duration = Duration::from_secs(300);
+const DEVICE_AUTH_WAIT_DEADLINE: Duration = Duration::from_mins(5);
 
 /// The outcome of running the device-code auth flow.
 ///

--- a/src/runtime/gh_auth.rs
+++ b/src/runtime/gh_auth.rs
@@ -26,7 +26,7 @@ use crate::github::{
 /// by design: it only bounds a hung subprocess (interactive-prompt leak,
 /// network stall, CLI bug) — `gh`'s own device-code flow expires server-side
 /// well before this and the user is authorizing in parallel (issue #244).
-const DEVICE_AUTH_WAIT_DEADLINE: Duration = Duration::from_mins(5);
+const DEVICE_AUTH_WAIT_DEADLINE: Duration = Duration::from_secs(5 * 60);
 
 /// The outcome of running the device-code auth flow.
 ///

--- a/src/runtime/identity.rs
+++ b/src/runtime/identity.rs
@@ -1,0 +1,63 @@
+//! Privacy-conscious user identity for private multiplexer namespaces.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// Hash opaque identity bytes into a psmux-compatible namespace without
+/// exposing the identity material.
+#[must_use]
+pub fn namespace_for_identity(identity: &[u8]) -> String {
+    let mut hash = FNV_OFFSET;
+    for byte in identity {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    format!("jefe-{hash:016x}")
+}
+
+/// Return a collision-resistant namespace for isolated automation runs.
+#[must_use]
+pub fn unique_namespace_for_identity(identity: &[u8]) -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    format!(
+        "{}-{:x}-{nanos:x}-{counter:x}",
+        namespace_for_identity(identity),
+        std::process::id()
+    )
+}
+
+#[cfg(windows)]
+fn current_identity_material() -> Vec<u8> {
+    let account = whoami::username().unwrap_or_else(|_| "local-user".to_owned());
+    let host = whoami::hostname().unwrap_or_else(|_| "local".to_owned());
+    format!("{host}\0{account}").into_bytes()
+}
+
+#[cfg(not(windows))]
+fn current_identity_material() -> Vec<u8> {
+    std::env::var_os("USER")
+        .or_else(|| std::env::var_os("LOGNAME"))
+        .map_or_else(
+            || b"local-user".to_vec(),
+            |value| value.as_encoded_bytes().to_vec(),
+        )
+}
+
+/// Stable, privacy-safe namespace for the current user.
+#[must_use]
+pub fn stable_current_user_namespace() -> String {
+    namespace_for_identity(&current_identity_material())
+}
+
+/// Isolated namespace for the current test/run.
+#[must_use]
+pub fn unique_current_user_namespace() -> String {
+    unique_namespace_for_identity(&current_identity_material())
+}

--- a/src/runtime/identity.rs
+++ b/src/runtime/identity.rs
@@ -44,6 +44,7 @@ fn current_identity_material() -> Vec<u8> {
 fn current_identity_material() -> Vec<u8> {
     std::env::var_os("USER")
         .or_else(|| std::env::var_os("LOGNAME"))
+        .filter(|value| !value.is_empty())
         .map_or_else(
             || b"local-user".to_vec(),
             |value| value.as_encoded_bytes().to_vec(),

--- a/src/runtime/identity_tests.rs
+++ b/src/runtime/identity_tests.rs
@@ -1,0 +1,33 @@
+//! Behavioral contracts for privacy-conscious runtime namespace identity.
+
+use super::identity::{namespace_for_identity, unique_namespace_for_identity};
+
+#[test]
+fn namespace_is_deterministic_private_and_valid() {
+    let raw_identity = b"S-1-5-21-private-user-material";
+    let first = namespace_for_identity(raw_identity);
+    let second = namespace_for_identity(raw_identity);
+
+    assert_eq!(first, second);
+    assert!(first.starts_with("jefe-"));
+    assert!(
+        first
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    );
+    assert!(!first.contains("private"));
+    assert!(!first.contains("S-1-5"));
+}
+
+#[test]
+fn namespaces_separate_users_and_parallel_runs() {
+    let first_user = namespace_for_identity(b"user-one");
+    let second_user = namespace_for_identity(b"user-two");
+    assert_ne!(first_user, second_user);
+
+    let first_run = unique_namespace_for_identity(b"user-one");
+    let second_run = unique_namespace_for_identity(b"user-one");
+    assert_ne!(first_run, second_run);
+    assert!(first_run.starts_with(&first_user));
+    assert!(second_run.starts_with(&first_user));
+}

--- a/src/runtime/liveness.rs
+++ b/src/runtime/liveness.rs
@@ -16,10 +16,8 @@ use crate::runtime::commands::{
 /// `check_session_alive` reports false while `pid_alive` reports true — letting
 /// jefe recognize the worker is recoverable rather than marking the agent Dead.
 ///
-/// Uses `kill -0` on Unix and filtered `tasklist` output on Windows because the
-/// project forbids `unsafe` code and the `libc`/`nix`/`sysinfo` crates. A spawn
-/// failure is fail-open on both platforms to avoid marking a potentially live
-/// worker Dead. Local-only: remote agents stay on the tmux/SSH-only path.
+/// Uses `kill -0` on Unix and the native process-identity probe on Windows.
+/// Local-only: remote agents stay on the tmux/SSH-only path.
 #[must_use]
 pub fn pid_alive(pid: u32) -> bool {
     pid_alive_on_platform(pid)
@@ -45,21 +43,7 @@ fn pid_alive_on_platform(pid: u32) -> bool {
 
 #[cfg(windows)]
 fn pid_alive_on_platform(pid: u32) -> bool {
-    let filter = format!("PID eq {pid}");
-    match std::process::Command::new("tasklist")
-        .args(["/FI", &filter, "/FO", "CSV", "/NH"])
-        .output()
-    {
-        Ok(output) if output.status.success() => {
-            let expected = format!("\",\"{pid}\",");
-            String::from_utf8_lossy(&output.stdout).contains(&expected)
-        }
-        Ok(_) => false,
-        Err(e) => {
-            tracing::warn!(error = %e, pid, "failed to spawn tasklist; assuming worker alive");
-            true
-        }
-    }
+    super::process::capture_process_identity(pid).is_ok()
 }
 
 #[cfg(not(any(unix, windows)))]

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -428,6 +428,17 @@ impl TmuxRuntimeManager {
         self.sessions.get(agent_id).and_then(|s| s.pid)
     }
 
+    /// Return the stable worker process identity for restart reconciliation.
+    #[must_use]
+    pub fn worker_process_identity(
+        &self,
+        agent_id: &AgentId,
+    ) -> Option<crate::domain::ProcessIdentity> {
+        self.sessions
+            .get(agent_id)
+            .and_then(|session| session.process_identity)
+    }
+
     fn spawn_session_internal(
         &mut self,
         agent_id: &AgentId,
@@ -521,6 +532,8 @@ impl TmuxRuntimeManager {
         // Store/refresh session binding.
         let mut session = RuntimeSession::new(agent_id.clone(), session_name, signature.clone());
         session.pid = captured_pid;
+        session.process_identity =
+            captured_pid.and_then(|pid| super::process::capture_process_identity(pid).ok());
         self.sessions.insert(agent_id.clone(), session);
 
         // Remove from dead signatures if present.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -16,11 +16,13 @@ mod commands;
 mod errors;
 /// One-shot `gh auth login --web` device-code subprocess driver (issue #244).
 mod gh_auth;
+mod identity;
 mod liveness;
 mod manager;
 mod multiplexer;
 mod pane_capture;
 mod preflight;
+mod process;
 mod session;
 mod socket;
 mod stub_manager;
@@ -47,6 +49,10 @@ pub use preflight::{
     PreflightAction, PreflightIssue, execute_preflight_action, platform_engine_diagnostic,
     sandbox_preflight, sandbox_ssh_agent_warning,
 };
+pub use process::{
+    ProcessIdentityError, ProcessLiveness, ProcessObservation, capture_process_identity,
+    classify_process_observation, process_liveness,
+};
 pub use session::{RuntimeSession, TerminalCell, TerminalCellStyle, TerminalSnapshot};
 pub use socket::jefe_tmux_socket_path;
 pub use stub_manager::StubRuntimeManager;
@@ -54,6 +60,14 @@ pub use stub_manager::StubRuntimeManager;
 #[cfg(test)]
 #[path = "agent_executable_tests.rs"]
 mod agent_executable_tests;
+
+#[cfg(test)]
+#[path = "identity_tests.rs"]
+mod identity_tests;
+
+#[cfg(test)]
+#[path = "process_tests.rs"]
+mod process_tests;
 
 #[cfg(test)]
 #[path = "multiplexer_tests.rs"]

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -7,7 +7,6 @@
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::agent_executable::ResolvedAgentExecutable;
 use super::agent_launcher::{AgentLauncherError, INTERNAL_LAUNCH_ARGUMENT, write_launch_plan};
@@ -687,26 +686,11 @@ fn find_on_path(candidate: &OsStr) -> Option<PathBuf> {
 }
 
 fn unique_test_namespace() -> String {
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let sequence = COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("jefe-test-{}-{sequence:x}", std::process::id())
+    super::identity::unique_current_user_namespace()
 }
 
 fn stable_jefe_namespace() -> String {
-    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
-    for value in [
-        std::env::var_os("USERNAME"),
-        std::env::current_exe().ok().map(PathBuf::into_os_string),
-    ]
-    .into_iter()
-    .flatten()
-    {
-        for byte in value.as_encoded_bytes() {
-            hash ^= u64::from(*byte);
-            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
-        }
-    }
-    format!("jefe-{hash:016x}")
+    super::identity::stable_current_user_namespace()
 }
 
 fn parse_version_part(part: Option<&str>, source: &str) -> Result<u32, MultiplexerError> {

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -1,0 +1,156 @@
+//! Typed local process-instance liveness service.
+
+use crate::domain::ProcessIdentity;
+
+/// Platform observation before comparison with persisted identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessObservation {
+    Running(ProcessIdentity),
+    Exited,
+    Inaccessible,
+    ProbeFailed,
+}
+
+/// Complete process-liveness classification used by restart reconciliation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessLiveness {
+    Alive,
+    Dead,
+    Inaccessible,
+    ReusedPid,
+    MalformedIdentity,
+    ProbeFailure,
+}
+
+/// Failure to capture a valid running process identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessIdentityError {
+    classification: ProcessLiveness,
+}
+
+impl std::fmt::Display for ProcessIdentityError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "process identity unavailable: {:?}",
+            self.classification
+        )
+    }
+}
+
+impl std::error::Error for ProcessIdentityError {}
+
+/// Pure comparison of persisted process identity and a fresh platform probe.
+#[must_use]
+pub const fn classify_process_observation(
+    expected: Option<ProcessIdentity>,
+    observation: ProcessObservation,
+) -> ProcessLiveness {
+    let Some(expected) = expected else {
+        return ProcessLiveness::MalformedIdentity;
+    };
+    if expected.pid == 0 {
+        return ProcessLiveness::MalformedIdentity;
+    }
+    match observation {
+        ProcessObservation::Exited => ProcessLiveness::Dead,
+        ProcessObservation::Inaccessible => ProcessLiveness::Inaccessible,
+        ProcessObservation::ProbeFailed => ProcessLiveness::ProbeFailure,
+        ProcessObservation::Running(actual) => classify_running(expected, actual),
+    }
+}
+
+const fn classify_running(expected: ProcessIdentity, actual: ProcessIdentity) -> ProcessLiveness {
+    if expected.pid != actual.pid {
+        return ProcessLiveness::ReusedPid;
+    }
+    match (expected.started_at, actual.started_at) {
+        (Some(expected), Some(actual)) if expected != actual => ProcessLiveness::ReusedPid,
+        (Some(_), None) => ProcessLiveness::ProbeFailure,
+        _ => ProcessLiveness::Alive,
+    }
+}
+
+/// Capture the identity of a currently running process.
+pub fn capture_process_identity(pid: u32) -> Result<ProcessIdentity, ProcessIdentityError> {
+    match probe_process(pid) {
+        ProcessObservation::Running(identity) => Ok(identity),
+        observation => Err(ProcessIdentityError {
+            classification: classify_process_observation(
+                Some(ProcessIdentity {
+                    pid,
+                    started_at: None,
+                }),
+                observation,
+            ),
+        }),
+    }
+}
+
+/// Classify one persisted process instance against the local operating system.
+#[must_use]
+pub fn process_liveness(identity: Option<ProcessIdentity>) -> ProcessLiveness {
+    let Some(identity) = identity else {
+        return ProcessLiveness::MalformedIdentity;
+    };
+    classify_process_observation(Some(identity), probe_process(identity.pid))
+}
+
+#[cfg(windows)]
+fn probe_process(pid: u32) -> ProcessObservation {
+    use winsafe::{HPROCESS, co};
+
+    if pid == 0 {
+        return ProcessObservation::ProbeFailed;
+    }
+    let access = co::PROCESS::QUERY_LIMITED_INFORMATION | co::PROCESS::SYNCHRONIZE;
+    let process = match HPROCESS::OpenProcess(access, false, pid) {
+        Ok(process) => process,
+        Err(error) if error == co::ERROR::ACCESS_DENIED => {
+            return ProcessObservation::Inaccessible;
+        }
+        Err(error) if error == co::ERROR::INVALID_PARAMETER => {
+            return ProcessObservation::Exited;
+        }
+        Err(_) => return ProcessObservation::ProbeFailed,
+    };
+    match process.WaitForSingleObject(Some(0)) {
+        Ok(wait) if wait == co::WAIT::OBJECT_0 => ProcessObservation::Exited,
+        Ok(wait) if wait == co::WAIT::TIMEOUT => match process.GetProcessTimes() {
+            Ok((creation, _, _, _)) => ProcessObservation::Running(ProcessIdentity {
+                pid,
+                started_at: Some(
+                    (u64::from(creation.dwHighDateTime) << 32) | u64::from(creation.dwLowDateTime),
+                ),
+            }),
+            Err(error) if error == co::ERROR::ACCESS_DENIED => ProcessObservation::Inaccessible,
+            Err(_) => ProcessObservation::ProbeFailed,
+        },
+        Err(error) if error == co::ERROR::ACCESS_DENIED => ProcessObservation::Inaccessible,
+        Ok(_) | Err(_) => ProcessObservation::ProbeFailed,
+    }
+}
+
+#[cfg(unix)]
+fn probe_process(pid: u32) -> ProcessObservation {
+    if pid == 0 {
+        return ProcessObservation::ProbeFailed;
+    }
+    match std::process::Command::new("kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .status()
+    {
+        Ok(status) if status.success() => ProcessObservation::Running(ProcessIdentity {
+            pid,
+            started_at: None,
+        }),
+        Ok(_) => ProcessObservation::Exited,
+        Err(_) => ProcessObservation::ProbeFailed,
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn probe_process(_pid: u32) -> ProcessObservation {
+    ProcessObservation::ProbeFailed
+}

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -143,11 +143,27 @@ fn probe_process(pid: u32) -> ProcessObservation {
     {
         Ok(status) if status.success() => ProcessObservation::Running(ProcessIdentity {
             pid,
-            started_at: None,
+            started_at: unix_process_start_time(pid),
         }),
         Ok(_) => ProcessObservation::Exited,
         Err(_) => ProcessObservation::ProbeFailed,
     }
+}
+
+#[cfg(target_os = "linux")]
+fn unix_process_start_time(pid: u32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let command_end = stat.rfind(')')?;
+    stat.get(command_end + 2..)?
+        .split_whitespace()
+        .nth(19)?
+        .parse()
+        .ok()
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+const fn unix_process_start_time(_pid: u32) -> Option<u64> {
+    None
 }
 
 #[cfg(not(any(unix, windows)))]

--- a/src/runtime/process_tests.rs
+++ b/src/runtime/process_tests.rs
@@ -1,0 +1,101 @@
+//! Behavioral contracts for process-instance liveness.
+
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::Duration;
+
+use super::process::{
+    ProcessLiveness, ProcessObservation, capture_process_identity, classify_process_observation,
+    process_liveness,
+};
+use crate::domain::ProcessIdentity;
+
+#[test]
+fn classification_distinguishes_every_required_state() {
+    let expected = ProcessIdentity::new(41, 900);
+    assert_eq!(
+        classify_process_observation(Some(expected), ProcessObservation::Running(expected)),
+        ProcessLiveness::Alive
+    );
+    assert_eq!(
+        classify_process_observation(Some(expected), ProcessObservation::Exited),
+        ProcessLiveness::Dead
+    );
+    assert_eq!(
+        classify_process_observation(Some(expected), ProcessObservation::Inaccessible),
+        ProcessLiveness::Inaccessible
+    );
+    assert_eq!(
+        classify_process_observation(
+            Some(expected),
+            ProcessObservation::Running(ProcessIdentity::new(41, 901))
+        ),
+        ProcessLiveness::ReusedPid
+    );
+    assert_eq!(
+        classify_process_observation(None, ProcessObservation::Running(expected)),
+        ProcessLiveness::MalformedIdentity
+    );
+    assert_eq!(
+        classify_process_observation(Some(expected), ProcessObservation::ProbeFailed),
+        ProcessLiveness::ProbeFailure
+    );
+}
+
+#[test]
+fn production_probe_observes_running_and_normal_exit() {
+    let mut child = spawn_sleeping_fixture(Duration::from_millis(120));
+    let identity = capture_process_identity(child.id())
+        .unwrap_or_else(|error| panic!("capture child process identity: {error}"));
+    assert_eq!(process_liveness(Some(identity)), ProcessLiveness::Alive);
+    let status = child
+        .wait()
+        .unwrap_or_else(|error| panic!("wait for child fixture: {error}"));
+    assert!(status.success());
+    assert_eq!(process_liveness(Some(identity)), ProcessLiveness::Dead);
+}
+
+#[test]
+fn production_probe_observes_forced_termination() {
+    let mut child = spawn_sleeping_fixture(Duration::from_secs(10));
+    let identity = capture_process_identity(child.id())
+        .unwrap_or_else(|error| panic!("capture child process identity: {error}"));
+    child
+        .kill()
+        .unwrap_or_else(|error| panic!("terminate child fixture: {error}"));
+    let _status = child
+        .wait()
+        .unwrap_or_else(|error| panic!("reap child fixture: {error}"));
+    assert_eq!(process_liveness(Some(identity)), ProcessLiveness::Dead);
+}
+
+fn spawn_sleeping_fixture(duration: Duration) -> std::process::Child {
+    let executable =
+        std::env::current_exe().unwrap_or_else(|error| panic!("resolve test executable: {error}"));
+    Command::new(executable)
+        .args([
+            "--exact",
+            "runtime::process_tests::native_sleep_fixture",
+            "--nocapture",
+        ])
+        .env(
+            "JEFE_PROCESS_TEST_SLEEP_MS",
+            duration.as_millis().to_string(),
+        )
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|error| panic!("spawn process fixture: {error}"))
+}
+
+#[test]
+fn native_sleep_fixture() {
+    let Some(milliseconds) = std::env::var_os("JEFE_PROCESS_TEST_SLEEP_MS") else {
+        return;
+    };
+    let milliseconds = milliseconds
+        .to_string_lossy()
+        .parse::<u64>()
+        .unwrap_or_else(|error| panic!("parse fixture duration: {error}"));
+    thread::sleep(Duration::from_millis(milliseconds));
+}

--- a/src/runtime/process_tests.rs
+++ b/src/runtime/process_tests.rs
@@ -73,11 +73,7 @@ fn spawn_sleeping_fixture(duration: Duration) -> std::process::Child {
     let executable =
         std::env::current_exe().unwrap_or_else(|error| panic!("resolve test executable: {error}"));
     Command::new(executable)
-        .args([
-            "--exact",
-            "runtime::process_tests::native_sleep_fixture",
-            "--nocapture",
-        ])
+        .args(["--exact", "runtime::process_tests::native_sleep_fixture"])
         .env(
             "JEFE_PROCESS_TEST_SLEEP_MS",
             duration.as_millis().to_string(),

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -4,7 +4,7 @@
 //! @requirement REQ-TECH-004
 //! @pseudocode component-002 lines 01-06
 
-use crate::domain::{AgentId, LaunchSignature};
+use crate::domain::{AgentId, LaunchSignature, ProcessIdentity};
 
 /// Runtime session binding for an agent.
 ///
@@ -26,6 +26,8 @@ pub struct RuntimeSession {
     /// liveness fallback when the tmux session is gone but the worker process
     /// is still alive.
     pub pid: Option<u32>,
+    /// Stable process-instance identity used to reject PID reuse.
+    pub process_identity: Option<ProcessIdentity>,
 }
 
 impl RuntimeSession {
@@ -38,6 +40,7 @@ impl RuntimeSession {
             launch_signature,
             attached: false,
             pid: None,
+            process_identity: None,
         }
     }
 

--- a/tests/core/message_bus_contracts.rs
+++ b/tests/core/message_bus_contracts.rs
@@ -185,6 +185,7 @@ fn typed_kill_agent_clears_runtime_binding() {
         },
         attached: true,
         last_seen: None,
+        process_identity: None,
         pid: None,
     });
 


### PR DESCRIPTION
## Summary

- replace Windows PID-only/external-command liveness with a typed native process-instance probe
- persist process creation identity so restart reconciliation rejects reused PIDs and probe failures never fail open
- derive stable privacy-safe per-user psmux namespaces, with collision-resistant isolated-run suffixes
- preserve remote SSH/tmux behavior and legacy persisted-state deserialization

## Implementation

- added `ProcessIdentity`, `ProcessObservation`, and `ProcessLiveness` domain/runtime contracts
- use safe `winsafe` process handles, zero-time waits, and creation timestamps on Windows
- propagate the exact identity captured by the runtime manager through issue, PR, direct, relaunch, and startup restore persistence paths
- classify dead, inaccessible, reused, malformed, and failed probes distinctly; only `Alive` preserves an orphaned local worker
- removed the Windows `tasklist` fallback
- hash current-user identity material before using it in psmux namespace names

## Tests

- behavioral classification coverage for all typed outcomes
- real child-process running, normal-exit, and forced-termination coverage
- stable/private/distinct/unique namespace contracts
- startup restore and persistence compatibility coverage
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --all-features --locked`
- `cargo test --workspace --all-features --locked`

`make ci-check` could not be invoked locally because this Windows host has neither `make` nor `bash`; all mandated Cargo gates passed directly.

Fixes #259
