### PR TITLE
Accept tmux release suffixes during preflight (Fixes #283)

### DIFF
--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -746,7 +746,7 @@ fn parse_final_version_part(part: &str, source: &str) -> Result<u32, Multiplexer
             && suffix
                 .bytes()
                 .next()
-                .is_some_and(|byte| byte.is_ascii_alphabetic()));
+                .is_some_and(|byte| byte.is_ascii_lowercase()));
     if digits.is_empty() || !valid_suffix {
         return Err(malformed_version(source));
     }

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -88,15 +88,29 @@ impl MultiplexerVersion {
                 path: None,
                 output: output.to_owned(),
             })?;
-        let mut parts = token.split('.');
-        let major = parse_version_part(parts.next(), output)?;
-        let minor = parse_version_part(parts.next(), output)?;
-        let patch = parts
-            .next()
-            .map_or(Ok(0), |part| parse_version_part(Some(part), output))?;
-        if parts.next().is_some() {
+        let mut components = token.split('.');
+        let major_raw = components.next().ok_or_else(|| malformed_version(output))?;
+        let major = parse_strict_version_part(major_raw, output)?;
+        let minor_raw = components.next();
+        let patch_raw = components.next();
+        // After consuming up to three components, no trailing component may remain.
+        if components.next().is_some() {
             return Err(malformed_version(output));
         }
+        // The major component is always strict. Only the final present component
+        // may carry a single alphabetic release letter (e.g. Homebrew `tmux 3.7b`).
+        let (minor, patch) = match (minor_raw, patch_raw) {
+            (Some(minor_raw), None) => {
+                let minor = parse_final_version_part(minor_raw, output)?;
+                (minor, 0)
+            }
+            (Some(minor_raw), Some(patch_raw)) => {
+                let minor = parse_strict_version_part(minor_raw, output)?;
+                let patch = parse_final_version_part(patch_raw, output)?;
+                (minor, patch)
+            }
+            (None, _) => return Err(malformed_version(output)),
+        };
         Ok(Self::new(major, minor, patch))
     }
 }
@@ -709,14 +723,34 @@ fn stable_jefe_namespace() -> String {
     format!("jefe-{hash:016x}")
 }
 
-fn parse_version_part(part: Option<&str>, source: &str) -> Result<u32, MultiplexerError> {
-    let Some(part) = part else {
-        return Err(malformed_version(source));
-    };
+fn parse_strict_version_part(part: &str, source: &str) -> Result<u32, MultiplexerError> {
     if part.is_empty() || !part.bytes().all(|byte| byte.is_ascii_digit()) {
         return Err(malformed_version(source));
     }
     part.parse::<u32>().map_err(|_| malformed_version(source))
+}
+
+/// Parse the final present version component, permitting an optional single
+/// trailing ASCII alphabetic release letter (e.g. Homebrew `tmux 3.7b`).
+///
+/// The letter carries no semantic weight beyond release identification; it is
+/// discarded so that `3.7b` resolves to `3.7.0` and `3.3.6a` to `3.3.6`.
+fn parse_final_version_part(part: &str, source: &str) -> Result<u32, MultiplexerError> {
+    let digits_end = part
+        .bytes()
+        .position(|byte| !byte.is_ascii_digit())
+        .unwrap_or(part.len());
+    let (digits, suffix) = part.split_at(digits_end);
+    let valid_suffix = suffix.is_empty()
+        || (suffix.len() == 1
+            && suffix
+                .bytes()
+                .next()
+                .is_some_and(|byte| byte.is_ascii_alphabetic()));
+    if digits.is_empty() || !valid_suffix {
+        return Err(malformed_version(source));
+    }
+    digits.parse::<u32>().map_err(|_| malformed_version(source))
 }
 
 fn malformed_version(source: &str) -> MultiplexerError {

--- a/src/runtime/multiplexer_tests.rs
+++ b/src/runtime/multiplexer_tests.rs
@@ -100,6 +100,7 @@ fn version_parser_accepts_final_release_letter_suffix() {
         "tmux 3.7a.6",
         "tmux 3.7.b",
         "tmux 3.7ab",
+        "tmux 3.7B",
         "tmux 3.7-rc1",
         "tmux 3.7.6.1",
     ] {

--- a/src/runtime/multiplexer_tests.rs
+++ b/src/runtime/multiplexer_tests.rs
@@ -82,6 +82,53 @@ fn version_parser_accepts_tmux_compatible_psmux_output() {
 }
 
 #[test]
+fn version_parser_accepts_final_release_letter_suffix() {
+    // macOS/Homebrew tmux emits `tmux 3.7b`; the trailing release letter must
+    // not block session creation preflight (issue #283).
+    assert_eq!(
+        MultiplexerVersion::parse("tmux 3.7b"),
+        Ok(MultiplexerVersion::new(3, 7, 0))
+    );
+    assert_eq!(
+        MultiplexerVersion::parse("tmux 3.3.6a\r\n"),
+        Ok(MultiplexerVersion::new(3, 3, 6))
+    );
+    // The suffix is permitted only on the final present component; everything
+    // else stays strict.
+    for malformed in [
+        "tmux 3a.7",
+        "tmux 3.7a.6",
+        "tmux 3.7.b",
+        "tmux 3.7ab",
+        "tmux 3.7-rc1",
+        "tmux 3.7.6.1",
+    ] {
+        assert!(
+            matches!(
+                MultiplexerVersion::parse(malformed),
+                Err(MultiplexerError::MalformedVersion { .. })
+            ),
+            "version should be rejected: {malformed:?}"
+        );
+    }
+}
+
+#[test]
+fn probe_classification_accepts_homebrew_tmux_release_letter() {
+    let observation = ProbeObservation::Output {
+        platform: LocalPlatform::Unix,
+        path: PathBuf::from("/opt/homebrew/bin/tmux"),
+        status_success: true,
+        stdout: "tmux 3.7b\n".to_owned(),
+        stderr: String::new(),
+    };
+    assert_eq!(
+        classify_probe(observation),
+        Ok(MultiplexerVersion::new(3, 7, 0))
+    );
+}
+
+#[test]
 fn probe_classification_distinguishes_required_failure_modes() {
     let path = PathBuf::from("C:/Program Files/psmux/psmux.exe");
     assert!(matches!(


### PR DESCRIPTION
## Summary

- accept upstream tmux release-letter versions such as 3.7b during local multiplexer preflight
- keep non-final version components strict and reject malformed or ambiguous version strings
- preserve native Windows psmux selection, launch planning, and minimum-version enforcement
- add parser and preflight-classification regressions for Homebrew tmux output

## Root cause

Homebrew tmux 3.7b reports its version as:

    tmux 3.7b

The shared version parser required every component to contain digits only. Local session creation runs multiplexer preflight before new-session, so parsing failed before Jefe could create a tmux session or persist a runtime binding.

## Test evidence

RED before production changes:

- the new release-suffix parser test failed
- the new preflight-classification test failed
- the existing guarded real-multiplexer test failed against /opt/homebrew/bin/tmux with MalformedVersion for tmux 3.7b

GREEN after the fix:

- cargo test --lib multiplexer_tests: 12 passed
- make quick-check: passed
- make ci-check: passed, including formatting, strict clippy and complexity gates, coverage, build, unit/integration tests, and doctests
- Open Code Review: no comments

## Windows safety

No Windows-specific executable resolution, psmux selection, namespace arguments, launch-plan transport, command wrapping, or cfg(windows) code changed. Existing Windows-policy tests continue to pass. Numeric minimum-version comparison remains unchanged.

Fixes #283
