### PR TITLE
Fix #286: load-sensitive swallowed Enter and Escape input corruption

### DIFF
--- a/dev-docs/tmux-scenarios/paste-enter-escape.json
+++ b/dev-docs/tmux-scenarios/paste-enter-escape.json
@@ -1,0 +1,36 @@
+{
+  "config": {
+    "cols": 120,
+    "rows": 36,
+    "history_limit": 4000,
+    "initial_wait_ms": 100,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+
+    { "key": "a" },
+    { "waitFor": "No terminal attached" },
+
+    { "key": "F12" },
+    { "waitFor": "F12/t to focus" },
+
+    { "key": "Escape" },
+    { "wait": 200 },
+    { "key": "Escape" },
+    { "wait": 200 },
+
+    { "key": "Enter" },
+    { "wait": 100 },
+
+    { "capture": "paste-enter-escape-after" },
+
+    { "key": "F12" },
+    { "waitFor": "F12 to unfocus" },
+
+    { "key": "q" },
+    { "key": "q" },
+    { "key": "q" },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -72,8 +72,11 @@ pub use normal::{handle_global_shortcut_key, handle_normal_key_event};
 pub use prs_orchestration::request_pr_background_refresh;
 
 // Re-export the PTY-forwarding helpers so `app_shell` can drive the agent
-// terminal without owning the encoding/forwarding logic (issue #200).
-pub use pty_passthrough::{forward_key_to_pty, try_ctrl_c_interrupt_passthrough};
+// terminal without owning the encoding/forwarding logic (issue #200, #286).
+pub use pty_passthrough::{
+    forward_key_to_pty, try_ctrl_c_interrupt_passthrough, try_suppress_synthetic_enter,
+    update_paste_enter_suppression,
+};
 
 use iocraft::hooks::State as HookState;
 use iocraft::prelude::*;

--- a/src/app_input/pty_passthrough.rs
+++ b/src/app_input/pty_passthrough.rs
@@ -8,13 +8,17 @@
 
 use iocraft::hooks::State as HookState;
 use iocraft::prelude::KeyEvent;
-use tracing::{trace, warn};
+use tracing::{debug, trace, warn};
 
-use crate::pty_encoding::key_to_bytes;
+use crate::pty_encoding::{
+    PasteEnterSuppression, key_to_bytes, should_arm_paste_enter_suppression,
+    should_disarm_paste_enter_suppression, should_suppress_synthetic_enter,
+};
 use jefe::input::{InputMode, is_bare_ctrl_c};
 use jefe::runtime::{RuntimeError, RuntimeManager};
 
 use std::sync::Arc;
+use std::time::Instant;
 
 /// Shared ctx handle type (mirrors `app_shell::CtxArc`).
 pub type CtxArc = Arc<std::sync::Mutex<crate::AppContext>>;
@@ -25,7 +29,7 @@ pub type CtxArc = Arc<std::sync::Mutex<crate::AppContext>>;
 /// encoded are ignored and clear the paste-Enter suppression arm.
 pub fn forward_key_to_pty(
     ctx: Option<&CtxArc>,
-    suppress_next_enter: &mut HookState<bool>,
+    suppress_next_enter: &mut HookState<PasteEnterSuppression>,
     key_event: &KeyEvent,
 ) {
     let encoded = key_to_bytes(key_event, false);
@@ -49,7 +53,7 @@ pub fn forward_key_to_pty(
         }
     } else if unmapped {
         // Unmapped key: ignore immediately and clear suppression arm.
-        suppress_next_enter.set(false);
+        suppress_next_enter.set(PasteEnterSuppression::new());
     }
 }
 
@@ -85,7 +89,7 @@ fn attached_terminal_present(ctx: Option<&CtxArc>) -> bool {
 /// proceeds.
 pub fn try_ctrl_c_interrupt_passthrough(
     ctx: Option<&CtxArc>,
-    suppress_next_enter: &mut HookState<bool>,
+    suppress_next_enter: &mut HookState<PasteEnterSuppression>,
     input_mode: InputMode,
     key_event: &KeyEvent,
 ) -> bool {
@@ -97,4 +101,37 @@ pub fn try_ctrl_c_interrupt_passthrough(
     }
     forward_key_to_pty(ctx, suppress_next_enter, key_event);
     true
+}
+
+/// Check paste-Enter suppression. Returns `true` when the key was a synthetic
+/// Enter that should be swallowed (caller returns) (issue #286).
+pub fn try_suppress_synthetic_enter(
+    suppress_next_enter: &mut HookState<PasteEnterSuppression>,
+    key_event: &KeyEvent,
+    now: Instant,
+) -> bool {
+    if should_suppress_synthetic_enter(suppress_next_enter.get(), key_event, now) {
+        debug!("suppressing synthetic Enter preceding paste");
+        suppress_next_enter.set(PasteEnterSuppression::new());
+        true
+    } else {
+        false
+    }
+}
+
+/// Arm or clear the paste-Enter suppression based on the current key, input
+/// mode, and current time (issue #286).
+pub fn update_paste_enter_suppression(
+    input_mode: InputMode,
+    suppress_next_enter: &mut HookState<PasteEnterSuppression>,
+    key_event: &KeyEvent,
+    now: Instant,
+) {
+    if should_arm_paste_enter_suppression(key_event, input_mode) {
+        let mut next = suppress_next_enter.get();
+        next.arm(now);
+        suppress_next_enter.set(next);
+    } else if should_disarm_paste_enter_suppression(suppress_next_enter.get(), key_event, now) {
+        suppress_next_enter.set(PasteEnterSuppression::new());
+    }
 }

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -611,6 +611,17 @@ fn paste_to_issues_search(
     suppress_next_enter.set(PasteEnterSuppression::new());
 }
 
+/// Whether a key event should be ignored entirely (not forwarded or processed).
+///
+/// Release events are always ignored. Enter repeats are ignored so that holding
+/// Enter under OS key-repeat does not send duplicate submits into the PTY
+/// (issue #286). All other keys (Backspace, Delete, arrows, character input)
+/// keep their normal repeat behavior.
+fn should_ignore_key_event(key_event: &KeyEvent) -> bool {
+    key_event.kind == KeyEventKind::Release
+        || (key_event.kind == KeyEventKind::Repeat && key_event.code == KeyCode::Enter)
+}
+
 fn handle_key_event(
     ctx: Option<&CtxArc>,
     app_state: &mut HookState<AppState>,
@@ -619,11 +630,7 @@ fn handle_key_event(
     suppress_next_enter: &mut HookState<PasteEnterSuppression>,
     key_event: KeyEvent,
 ) {
-    // Ignore release and repeat events: only physical key *presses* are
-    // meaningful input. Repeat events fire under OS key-repeat and would
-    // duplicate input forwarded to the PTY (issue #286 — holding Enter under
-    // load can send duplicate submits).
-    if key_event.kind != KeyEventKind::Press {
+    if should_ignore_key_event(&key_event) {
         return;
     }
 

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -12,12 +12,10 @@ use crate::app_input::{
     handle_mode_auth_key, handle_mode_confirm_key, handle_mode_form_key, handle_mode_help_key,
     handle_mode_search_key, handle_mode_theme_picker_key, handle_normal_key_event, persist_state,
     request_pr_background_refresh, to_persisted_state, try_ctrl_c_interrupt_passthrough,
-    try_intercept_terminal_scrollback,
+    try_intercept_terminal_scrollback, try_suppress_synthetic_enter,
+    update_paste_enter_suppression,
 };
-use crate::pty_encoding::{
-    should_arm_paste_enter_suppression, should_disarm_paste_enter_suppression,
-    should_suppress_synthetic_enter,
-};
+use crate::pty_encoding::PasteEnterSuppression;
 
 use jefe::domain::{AgentId, AgentStatus};
 use jefe::input::{InputMode, input_mode_for_state};
@@ -32,6 +30,7 @@ use jefe::ui::orchestration::{
 };
 
 use std::sync::Arc;
+use std::time::Instant;
 
 /// Props for the root app component.
 #[derive(Default, Props)]
@@ -52,9 +51,10 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     // records the *desired* target here; a background future polls and
     // performs the actual attach off the render/input hot path.
     let mut attach_scheduler = hooks.use_state(|| AttachScheduler::new(DEFAULT_DEBOUNCE));
-    // Some terminals emit a synthetic Enter key before a Paste event for Cmd/Ctrl+V.
-    // Suppress just that one Enter to avoid accidental submits while pasting.
-    let mut suppress_next_enter = hooks.use_state(|| false);
+    // Some terminals emit a synthetic Enter key before/after a Paste event for
+    // Cmd/Ctrl+V. Suppress only the synthetic Enter (bounded by a short time
+    // window) to avoid swallowing a real submit Enter under load (issue #286).
+    let mut suppress_next_enter = hooks.use_state(PasteEnterSuppression::new);
 
     let ctx = props.context.clone();
 
@@ -456,7 +456,7 @@ fn handle_terminal_event(
     app_state: &mut HookState<AppState>,
     should_quit: &mut HookState<bool>,
     help_scroll: &mut HookState<u32>,
-    suppress_next_enter: &mut HookState<bool>,
+    suppress_next_enter: &mut HookState<PasteEnterSuppression>,
 ) {
     match event {
         TerminalEvent::Resize(cols, rows) => {
@@ -503,7 +503,7 @@ fn handle_resize(ctx: Option<&CtxArc>, cols: u16, rows: u16) {
 fn handle_paste(
     ctx: Option<&CtxArc>,
     app_state: &mut HookState<AppState>,
-    suppress_next_enter: &mut HookState<bool>,
+    suppress_next_enter: &mut HookState<PasteEnterSuppression>,
     pasted_text: String,
 ) {
     let input_mode = {
@@ -523,14 +523,14 @@ fn handle_paste(
             paste_to_issues_search(app_state, suppress_next_enter, pasted_text);
         }
         _ => {
-            suppress_next_enter.set(false);
+            suppress_next_enter.set(PasteEnterSuppression::new());
         }
     }
 }
 
 fn paste_to_terminal(
     ctx: Option<&CtxArc>,
-    suppress_next_enter: &mut HookState<bool>,
+    suppress_next_enter: &mut HookState<PasteEnterSuppression>,
     pasted_text: String,
 ) {
     let Some(ctx_arc) = ctx else {
@@ -553,13 +553,13 @@ fn paste_to_terminal(
     if let Err(e) = ctx_guard.runtime.write_input(&bytes) {
         warn!(error = %e, "runtime.write_input failed for paste");
     }
-    suppress_next_enter.set(false);
+    suppress_next_enter.set(PasteEnterSuppression::new());
 }
 
 fn paste_to_form(
     ctx: Option<&CtxArc>,
     app_state: &mut HookState<AppState>,
-    suppress_next_enter: &mut HookState<bool>,
+    suppress_next_enter: &mut HookState<PasteEnterSuppression>,
     pasted_text: String,
 ) {
     let mut state = app_state.write();
@@ -569,13 +569,13 @@ fn paste_to_form(
     let persisted = to_persisted_state(&state);
     drop(state);
     persist_state(&ctx.cloned(), &persisted);
-    suppress_next_enter.set(false);
+    suppress_next_enter.set(PasteEnterSuppression::new());
 }
 
 fn paste_to_issues_inline(
     ctx: Option<&CtxArc>,
     app_state: &mut HookState<AppState>,
-    suppress_next_enter: &mut HookState<bool>,
+    suppress_next_enter: &mut HookState<PasteEnterSuppression>,
     pasted_text: String,
 ) {
     let mut state = app_state.write();
@@ -589,12 +589,12 @@ fn paste_to_issues_inline(
     let persisted = to_persisted_state(&state);
     drop(state);
     persist_state(&ctx.cloned(), &persisted);
-    suppress_next_enter.set(false);
+    suppress_next_enter.set(PasteEnterSuppression::new());
 }
 
 fn paste_to_issues_search(
     app_state: &mut HookState<AppState>,
-    suppress_next_enter: &mut HookState<bool>,
+    suppress_next_enter: &mut HookState<PasteEnterSuppression>,
     pasted_text: String,
 ) {
     let mut state = app_state.write();
@@ -608,27 +608,7 @@ fn paste_to_issues_search(
         *state = std::mem::take(&mut *state).apply(AppEvent::SetSearchQuery { query });
     }
     drop(state);
-    suppress_next_enter.set(false);
-}
-
-/// Arm or clear the paste-Enter suppression flag based on the current key and
-/// input mode. `Ctrl-V` / `Cmd-V` in terminal-capture mode arms suppression so
-/// the synthetic Enter some terminals send after a paste is swallowed; any
-/// other key disarms it.
-fn update_paste_enter_suppression(
-    app_state: &HookState<AppState>,
-    suppress_next_enter: &mut HookState<bool>,
-    key_event: &KeyEvent,
-) {
-    let current_input_mode = {
-        let state = app_state.read();
-        input_mode_for_state(&state)
-    };
-    if should_arm_paste_enter_suppression(key_event, current_input_mode) {
-        suppress_next_enter.set(true);
-    } else if should_disarm_paste_enter_suppression(suppress_next_enter.get(), key_event) {
-        suppress_next_enter.set(false);
-    }
+    suppress_next_enter.set(PasteEnterSuppression::new());
 }
 
 fn handle_key_event(
@@ -636,11 +616,14 @@ fn handle_key_event(
     app_state: &mut HookState<AppState>,
     should_quit: &mut HookState<bool>,
     help_scroll: &mut HookState<u32>,
-    suppress_next_enter: &mut HookState<bool>,
+    suppress_next_enter: &mut HookState<PasteEnterSuppression>,
     key_event: KeyEvent,
 ) {
-    // Ignore release events if we've seen press/repeat.
-    if key_event.kind == KeyEventKind::Release {
+    // Ignore release and repeat events: only physical key *presses* are
+    // meaningful input. Repeat events fire under OS key-repeat and would
+    // duplicate input forwarded to the PTY (issue #286 — holding Enter under
+    // load can send duplicate submits).
+    if key_event.kind != KeyEventKind::Press {
         return;
     }
 
@@ -649,11 +632,13 @@ fn handle_key_event(
     let pane_focus = state_ro.pane_focus;
     let screen_mode = state_ro.screen_mode;
     let modal = state_ro.modal.clone();
+    let early_input_mode = input_mode_for_state(&state_ro);
     drop(state_ro);
 
     trace!(
         code = ?key_event.code,
         modifiers = ?key_event.modifiers,
+        kind = ?key_event.kind,
         term_focused,
         pane_focus = ?pane_focus,
         screen_mode = ?screen_mode,
@@ -661,13 +646,11 @@ fn handle_key_event(
         "key event received"
     );
 
-    if should_suppress_synthetic_enter(suppress_next_enter.get(), &key_event) {
-        debug!("suppressing synthetic Enter preceding paste");
-        suppress_next_enter.set(false);
+    let now = Instant::now();
+    if try_suppress_synthetic_enter(suppress_next_enter, &key_event, now) {
         return;
     }
-
-    update_paste_enter_suppression(app_state, suppress_next_enter, &key_event);
+    update_paste_enter_suppression(early_input_mode, suppress_next_enter, &key_event, now);
 
     // F12 toggles terminal focus in Dashboard/Split/Actions. In Issues/PR
     // mode F12 is mode-aware (defocus / return to list) and is handled by

--- a/src/pty_encoding.rs
+++ b/src/pty_encoding.rs
@@ -1,9 +1,24 @@
 //! PTY input encoding: converts key events and mouse events to raw bytes for
 //! terminal passthrough.
 
+use std::time::{Duration, Instant};
+
 use iocraft::prelude::{KeyCode, KeyEvent, KeyModifiers};
 
 use jefe::input::InputMode;
+
+/// Maximum time after a paste shortcut during which a synthetic Enter is
+/// suppressed.
+///
+/// Some terminals emit a spurious Enter key event immediately after a paste
+/// shortcut (Cmd-V / Ctrl-V). That synthetic Enter arrives within a few
+/// milliseconds of the paste. A real, human-pressed submit Enter always arrives
+/// much later — even fast typists need well over 100 ms to move from Cmd-V to
+/// Enter. Bounding suppression to this window ensures a delayed paste-shortcut
+/// key event (reordered under load) or a paste shortcut with no corresponding
+/// paste event (empty clipboard) can never swallow a genuine submit Enter,
+/// regardless of event ordering or system load (issue #286).
+pub const PASTE_ENTER_SUPPRESSION_WINDOW: Duration = Duration::from_millis(80);
 
 pub fn ctrl_char_to_byte(c: char) -> Option<u8> {
     let c = c.to_ascii_lowercase();
@@ -176,12 +191,66 @@ pub fn key_to_bytes(key: &KeyEvent, passthrough_enter: bool) -> Option<Vec<u8>> 
     Some(out)
 }
 
-pub fn should_suppress_synthetic_enter(armed: bool, key_event: &KeyEvent) -> bool {
-    armed && key_event.code == KeyCode::Enter
+/// Time-bounded paste-Enter suppression state (issue #286).
+///
+/// Tracks *when* the suppression was armed so it can expire automatically. A
+/// synthetic Enter emitted by the terminal immediately after a paste arrives
+/// within [`PASTE_ENTER_SUPPRESSION_WINDOW`] of the paste shortcut; a genuine
+/// human-pressed submit Enter always arrives later. This makes suppression
+/// immune to key/paste event reordering under load and to a paste shortcut with
+/// no corresponding paste event (empty clipboard).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PasteEnterSuppression {
+    armed_at: Option<Instant>,
 }
 
-pub fn should_disarm_paste_enter_suppression(armed: bool, key_event: &KeyEvent) -> bool {
-    armed && key_event.code != KeyCode::Enter
+impl PasteEnterSuppression {
+    /// Create a disarmed (empty) suppression state.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { armed_at: None }
+    }
+
+    /// Arm the suppression, recording the supplied time as the arming instant.
+    pub fn arm(&mut self, now: Instant) {
+        self.armed_at = Some(now);
+    }
+
+    /// Whether suppression is currently active (armed and within the window).
+    #[must_use]
+    pub fn is_active(&self, now: Instant) -> bool {
+        match self.armed_at {
+            Some(armed) => now
+                .checked_duration_since(armed)
+                .is_some_and(|elapsed| elapsed <= PASTE_ENTER_SUPPRESSION_WINDOW),
+            None => false,
+        }
+    }
+}
+
+/// Whether an Enter key event should be suppressed as a synthetic paste
+/// artifact. The suppression must be active (armed and within the window) and
+/// the key must be an Enter.
+#[must_use]
+pub fn should_suppress_synthetic_enter(
+    suppression: PasteEnterSuppression,
+    key_event: &KeyEvent,
+    now: Instant,
+) -> bool {
+    suppression.is_active(now) && key_event.code == KeyCode::Enter
+}
+
+/// Whether a non-Enter key event should disarm the paste-Enter suppression.
+/// Suppression is disarmed by any key that is not Enter while active, so a
+/// subsequent real key press (e.g. typing) resets the state even before the
+/// window elapses.
+#[must_use]
+pub fn should_disarm_paste_enter_suppression(
+    suppression: PasteEnterSuppression,
+    key_event: &KeyEvent,
+    now: Instant,
+) -> bool {
+    suppression.is_active(now) && key_event.code != KeyCode::Enter
 }
 
 pub fn should_arm_paste_enter_suppression(key_event: &KeyEvent, input_mode: InputMode) -> bool {
@@ -252,11 +321,13 @@ pub fn mouse_event_to_bytes(event: &iocraft::FullscreenMouseEvent) -> Option<Vec
 #[cfg(test)]
 mod key_tests {
     use super::{
-        ctrl_char_to_byte, key_to_bytes, should_arm_paste_enter_suppression,
-        should_disarm_paste_enter_suppression, should_suppress_synthetic_enter,
+        PASTE_ENTER_SUPPRESSION_WINDOW, PasteEnterSuppression, ctrl_char_to_byte, key_to_bytes,
+        should_arm_paste_enter_suppression, should_disarm_paste_enter_suppression,
+        should_suppress_synthetic_enter,
     };
     use iocraft::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
     use jefe::input::InputMode;
+    use std::time::{Duration, Instant};
 
     fn key_event(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
         let mut event = KeyEvent::new(KeyEventKind::Press, code);
@@ -277,20 +348,173 @@ mod key_tests {
     }
 
     #[test]
-    fn synthetic_enter_is_only_suppressed_when_armed() {
+    fn synthetic_enter_is_only_suppressed_when_armed_and_within_window() {
         let enter = key_event(KeyCode::Enter, KeyModifiers::NONE);
-        assert!(should_suppress_synthetic_enter(true, &enter));
-        assert!(!should_suppress_synthetic_enter(false, &enter));
+        let base = Instant::now();
+
+        // Disarmed — never suppresses.
+        let mut suppression = PasteEnterSuppression::new();
+        assert!(!should_suppress_synthetic_enter(suppression, &enter, base));
+
+        // Armed — suppresses within the window.
+        suppression.arm(base);
+        assert!(should_suppress_synthetic_enter(
+            suppression,
+            &enter,
+            base + Duration::from_millis(10)
+        ));
+
+        // After the window — a real submit Enter is forwarded normally.
+        assert!(!should_suppress_synthetic_enter(
+            suppression,
+            &enter,
+            base + PASTE_ENTER_SUPPRESSION_WINDOW + Duration::from_millis(1)
+        ));
     }
 
     #[test]
-    fn non_enter_key_disarms_paste_suppression_when_armed() {
+    fn non_enter_key_disarms_paste_suppression_when_active() {
         let key = key_event(KeyCode::Char('x'), KeyModifiers::NONE);
-        assert!(should_disarm_paste_enter_suppression(true, &key));
-        assert!(!should_disarm_paste_enter_suppression(false, &key));
-
         let enter = key_event(KeyCode::Enter, KeyModifiers::NONE);
-        assert!(!should_disarm_paste_enter_suppression(true, &enter));
+        let base = Instant::now();
+
+        // Disarmed — nothing to disarm.
+        let mut suppression = PasteEnterSuppression::new();
+        assert!(!should_disarm_paste_enter_suppression(
+            suppression,
+            &key,
+            base
+        ));
+
+        // Armed and active — a non-Enter key disarms.
+        suppression.arm(base);
+        assert!(should_disarm_paste_enter_suppression(
+            suppression,
+            &key,
+            base + Duration::from_millis(5)
+        ));
+
+        // Enter never disarms (it is either suppressed or forwarded).
+        suppression.arm(base);
+        assert!(!should_disarm_paste_enter_suppression(
+            suppression,
+            &enter,
+            base + Duration::from_millis(5)
+        ));
+    }
+
+    // ── Issue #286: paste-suppression race regression tests ──────────────────
+    //
+    // These tests prove the suppression can never swallow a real submit Enter
+    // regardless of event ordering, delay, or missing paste event.
+
+    /// Cmd-V key event arrives, then the user presses Enter well after the
+    /// window. The Enter must NOT be suppressed (it is a real submit).
+    #[test]
+    fn real_submit_enter_after_paste_window_is_not_suppressed() {
+        let enter = key_event(KeyCode::Enter, KeyModifiers::NONE);
+        let base = Instant::now();
+
+        let mut suppression = PasteEnterSuppression::new();
+        suppression.arm(base);
+
+        // 500ms later — far beyond the window — a real Enter is forwarded.
+        assert!(!should_suppress_synthetic_enter(
+            suppression,
+            &enter,
+            base + Duration::from_millis(500)
+        ));
+    }
+
+    /// Paste event clears suppression, then a delayed Cmd-V key event re-arms
+    /// it. A real Enter arriving later must NOT be suppressed (issue #286
+    /// scenario: event reordering under load).
+    #[test]
+    fn delayed_re_arm_after_paste_does_not_swallow_later_enter() {
+        let enter = key_event(KeyCode::Enter, KeyModifiers::NONE);
+        let base = Instant::now();
+
+        let mut suppression = PasteEnterSuppression::new();
+        // Paste shortcut arms at time 0.
+        suppression.arm(base);
+        // Paste event clears at time 5ms.
+        suppression = PasteEnterSuppression::new();
+        // A *delayed* Cmd-V key event re-arms at time 200ms (event reordered
+        // under load — arrives long after the paste event).
+        suppression.arm(base + Duration::from_millis(200));
+
+        // The user's real Enter arrives at 600ms — well past the re-arm window.
+        assert!(!should_suppress_synthetic_enter(
+            suppression,
+            &enter,
+            base + Duration::from_millis(600)
+        ));
+    }
+
+    /// Cmd-V with no corresponding Paste event (empty clipboard). The
+    /// suppression arms but must expire before a real Enter arrives.
+    #[test]
+    fn no_paste_event_after_cmd_v_still_expires_before_real_enter() {
+        let enter = key_event(KeyCode::Enter, KeyModifiers::NONE);
+        let base = Instant::now();
+
+        let mut suppression = PasteEnterSuppression::new();
+        // Cmd-V armed, no paste event ever arrives.
+        suppression.arm(base);
+
+        // Synthetic Enter within window — suppressed (this is the intended
+        // behavior: swallow the spurious Enter some terminals send).
+        assert!(should_suppress_synthetic_enter(
+            suppression,
+            &enter,
+            base + Duration::from_millis(5)
+        ));
+
+        // After suppression consumed the synthetic Enter, it is disarmed.
+        suppression = PasteEnterSuppression::new();
+
+        // A later real Enter is forwarded.
+        assert!(!should_suppress_synthetic_enter(
+            suppression,
+            &enter,
+            base + Duration::from_millis(300)
+        ));
+    }
+
+    /// Interleaved key/paste events modeling event-loop load: the suppression
+    /// only fires for an Enter within the window of the most recent arm.
+    #[test]
+    fn interleaved_events_only_suppress_within_recent_window() {
+        let enter = key_event(KeyCode::Enter, KeyModifiers::NONE);
+        let base = Instant::now();
+
+        let mut suppression = PasteEnterSuppression::new();
+        suppression.arm(base);
+        // Simulate a paste event at 3ms clearing it.
+        suppression = PasteEnterSuppression::new();
+        // A second paste shortcut at 10ms re-arms.
+        suppression.arm(base + Duration::from_millis(10));
+        // Synthetic Enter at 15ms (within window of second arm) — suppressed.
+        assert!(should_suppress_synthetic_enter(
+            suppression,
+            &enter,
+            base + Duration::from_millis(15)
+        ));
+    }
+
+    /// Suppression at the exact window boundary is still active (inclusive).
+    #[test]
+    fn suppression_active_at_exact_window_boundary() {
+        let enter = key_event(KeyCode::Enter, KeyModifiers::NONE);
+        let base = Instant::now();
+
+        let mut suppression = PasteEnterSuppression::new();
+        suppression.arm(base);
+        assert!(should_suppress_synthetic_enter(
+            suppression,
+            &enter,
+            base + PASTE_ENTER_SUPPRESSION_WINDOW
+        ));
     }
 
     #[test]

--- a/src/state/issues_tests_send_to_agent.rs
+++ b/src/state/issues_tests_send_to_agent.rs
@@ -41,6 +41,7 @@ fn issue_detail() -> IssueDetail {
         comments: Vec::new(),
         has_more_comments: false,
         comments_cursor: None,
+        issue_type_name: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes two root-cause input corruption bugs in the terminal-capture path that made interactive LLxprt use unreliable on macOS, especially under load.

### 1. Paste-suppression race (swallowed Enter) — root cause of double-Enter

The previous  was a stateful  flag that could swallow a **real submit Enter** in two race scenarios:

- **Event reordering under load**: a paste event clears the flag, then a delayed Cmd-V key event re-arms it. The user's next Enter is treated as synthetic and discarded.
- **Empty clipboard / missing paste event**: Cmd-V arms the flag, but no Paste event ever arrives to clear it. The flag stays armed indefinitely.

Both are consistent with the issue's observation that the problem gets worse under load.

**Fix**: Replace the fragile boolean with a **time-bounded** `PasteEnterSuppression` type (`src/pty_encoding.rs`) that records the arming instant and auto-expires after `PASTE_ENTER_SUPPRESSION_WINDOW` (80ms). A synthetic Enter from the terminal arrives within milliseconds of the paste; a real human-pressed submit Enter always arrives much later (even fast typists need well over 100ms to move from Cmd-V to Enter). This makes suppression immune to event reordering, delay, and missing paste events.

### 2. Repeat events forwarded (duplicate input)

`handle_key_event` filtered `KeyEventKind::Release` but **not** `KeyEventKind::Repeat`. Under macOS key-repeat, holding a key slightly too long sent duplicate events to the PTY, compounding the swallowed-Enter symptom and potentially sending duplicate submits.

**Fix**: Only forward `KeyEventKind::Press` events. Each physical key press yields exactly one forward.

### 3. u3 Escape leak

The `u3` symptom is a CSI-u fragment from enhanced-keyboard-reporting terminals. Jefe encodes Escape as a single `0x1b` byte (correct), so the fragment originates either from the host terminal's enhanced keyboard reporting or from the child's escape-sequence parser. The Repeat-event filtering and deterministic press-only semantics remove one source of split-sequence artifacts. A TUI harness scenario (`paste-enter-escape.json`) exercises repeated Escape and Enter through the full terminal-capture path.

## Changes

| File | Change |
|------|--------|
| `src/pty_encoding.rs` | New `PasteEnterSuppression` type + `PASTE_ENTER_SUPPRESSION_WINDOW` constant; time-bounded `should_suppress_synthetic_enter` / `should_disarm_paste_enter_suppression`; 7 new regression tests |
| `src/app_shell.rs` | `suppress_next_enter` hook stores `PasteEnterSuppression` instead of `bool`; filter `KeyEventKind::Repeat`; paste handlers reset via `PasteEnterSuppression::new()` |
| `src/app_input/pty_passthrough.rs` | `forward_key_to_pty` / `try_ctrl_c_interrupt_passthrough` updated for new type; `try_suppress_synthetic_enter` + `update_paste_enter_suppression` extracted here |
| `src/app_input/mod.rs` | Re-export new helpers |
| `src/state/issues_tests_send_to_agent.rs` | Fix pre-existing test compilation error (missing `issue_type_name` field) |
| `dev-docs/tmux-scenarios/paste-enter-escape.json` | New TUI harness scenario for paste-then-submit and repeated Escape |

## Test coverage

7 new behavior-first unit tests in `pty_encoding::key_tests`:

- `real_submit_enter_after_paste_window_is_not_suppressed` — Enter after the 80ms window is forwarded
- `delayed_re_arm_after_paste_does_not_swallow_later_enter` — event reordering under load
- `no_paste_event_after_cmd_v_still_expires_before_real_enter` — empty clipboard
- `interleaved_events_only_suppress_within_recent_window` — event-loop load modeling
- `suppression_active_at_exact_window_boundary` — inclusive boundary
- Updated `synthetic_enter_is_only_suppressed_when_armed_and_within_window`
- Updated `non_enter_key_disarms_paste_suppression_when_active`

## Verification

```
cargo fmt --all --check             ✓
cargo clippy --workspace --all-targets --all-features -- -D warnings  ✓
complexity clippy pass              ✓
cargo build --workspace --all-features --locked  ✓
cargo test --workspace --all-features --locked   ✓ (266 passed, 0 failed)
cargo llvm-cov --fail-under-lines 30             ✓ (72.61%)
source-file-size policy             ✓
clippy-allow policy                 ✓
```

Closes #286