### PR TITLE
Fix #262: reconcile persistent Windows agent lifecycles

### DIFF
--- a/dev-docs/tmux-scenarios/windows-multi-agent-lifecycle.json
+++ b/dev-docs/tmux-scenarios/windows-multi-agent-lifecycle.json
@@ -28,6 +28,7 @@
     { "key": "Tab" },
     { "key": "Enter" },
     { "waitForNot": "Kill agent" },
+    { "waitForNot": "Puppy Four" },
     { "expect": "LLxprt Ω One" },
     { "expect": "Puppy Ω Two" },
     { "expect": "LLxprt Three" },

--- a/dev-docs/tmux-scenarios/windows-multi-agent-lifecycle.json
+++ b/dev-docs/tmux-scenarios/windows-multi-agent-lifecycle.json
@@ -1,0 +1,38 @@
+{
+  "config": {
+    "cols": 130,
+    "rows": 40,
+    "history_limit": 4000,
+    "initial_wait_ms": 200,
+    "wait_timeout_ms": 15000,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "waitFor": "LLxprt Ω One" },
+    { "expect": "Puppy Ω Two" },
+    { "expect": "LLxprt Three" },
+    { "expect": "Puppy Four" },
+    { "capture": "four-running-agents" },
+    { "key": "M-1" },
+    { "waitFor": "LLXPRT_ONE_READY" },
+    { "key": "M-2" },
+    { "waitFor": "PUPPY_TWO_READY" },
+    { "key": "M-3" },
+    { "waitFor": "LLXPRT_THREE_READY" },
+    { "key": "M-4" },
+    { "waitFor": "PUPPY_FOUR_READY" },
+    { "capture": "agent-switching" },
+    { "key": "C-k" },
+    { "waitFor": "Kill agent" },
+    { "key": "Tab" },
+    { "key": "Enter" },
+    { "waitForNot": "Kill agent" },
+    { "expect": "LLxprt Ω One" },
+    { "expect": "Puppy Ω Two" },
+    { "expect": "LLxprt Three" },
+    { "capture": "selected-agent-killed" },
+    { "key": "C-q" },
+    { "waitForExit": 5000 }
+  ]
+}

--- a/project-plans/issue262-plan.md
+++ b/project-plans/issue262-plan.md
@@ -1,0 +1,57 @@
+# Issue #262 plan: persistent Windows multi-agent lifecycle parity
+
+## Scope and existing foundation
+
+Issues #259–#261 already provide native psmux process identity, ConPTY attachment,
+agent executable resolution, and Windows-safe repository preparation. This issue
+closes lifecycle gaps rather than introducing a second runtime architecture.
+
+## RED
+
+1. Create the Windows TUI lifecycle scenario first. It assumes an isolated
+   configuration seeded with four deterministic agents (two LLxprt, two Code
+   Puppy), verifies switching and selected-agent kill, and initially fails before
+   fixture setup/state exists.
+2. Add pure startup-reconciliation tests covering explicit Running, Stopped,
+   Stale, Recoverable, and Inconsistent classifications from:
+   - live, missing, or unavailable psmux evidence;
+   - local versus remote runtime;
+   - coherent, legacy, or inconsistent persisted binding;
+   - alive, exited, inaccessible, reused-PID, malformed, and failed process probes.
+3. Add regression tests proving a live session with a mismatched persisted
+   session/signature is never reattached and a Windows identity without a
+   creation discriminator is malformed rather than accepted as alive.
+4. Add persistence tests for Unicode/spaces, both runtime kinds, launch flags,
+   process identity round-trip, and legacy identity omission.
+5. Add a real psmux integration test with four independently interactive
+   recording fixtures in two repositories. Prove scoped kill, attach-client
+   teardown, restart-style reattachment, dead-pane detection, and namespace
+   isolation. Guard real LLxprt/Code Puppy checks on installation.
+
+## GREEN
+
+1. Introduce explicit deterministic startup evidence/classification domain types
+   at the application orchestration seam; keep OS/psmux probing in runtime.
+2. Validate persisted runtime bindings against the stable derived session name,
+   current launch signature, and internally consistent PID identity before
+   reattachment.
+3. Map classifications conservatively:
+   - Running -> register/reattach;
+   - Recoverable -> preserve metadata without destructive action;
+   - Stopped/Stale/Inconsistent -> mark Dead and clear stale binding.
+4. Preserve remote tmux-only behavior and legacy Unix state where no process
+   identity was ever persisted.
+5. Complete deterministic fixture/harness setup without shell-only Windows
+   assumptions or global psmux cleanup.
+
+## REFACTOR and verification
+
+- Keep state classification pure and injectable; no mock-only lifecycle claims.
+- Keep kill/delete scoped to one stable AgentId and Jefe's private namespace.
+- Verify relaunch retains runtime kind, model/profile, work directory, flags,
+  sandbox, and continue/quick-resume semantics.
+- Review Windows reboot, process access denial, probe failure, partial launch,
+  malformed state, and concurrent agent behavior.
+- Run focused tests, format, strict Clippy, locked build/tests, and all CI gates.
+- Independently review the complete diff before commit, then monitor PR checks
+  and review threads to green.

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -76,6 +76,108 @@ fn normalize_persisted_sandbox_engines(state: &mut AppState) -> bool {
     );
     true
 }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionEvidence {
+    Alive,
+    Missing,
+    Unavailable,
+}
+
+impl From<jefe::runtime::SessionLiveness> for SessionEvidence {
+    fn from(value: jefe::runtime::SessionLiveness) -> Self {
+        match value {
+            jefe::runtime::SessionLiveness::Alive => Self::Alive,
+            jefe::runtime::SessionLiveness::Missing => Self::Missing,
+            jefe::runtime::SessionLiveness::Unavailable => Self::Unavailable,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BindingEvidence {
+    Coherent,
+    Legacy,
+    Inconsistent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartupClassification {
+    Running,
+    Stopped,
+    Stale,
+    Recoverable,
+    Inconsistent,
+}
+
+#[must_use]
+fn binding_evidence(
+    binding: Option<&jefe::domain::RuntimeBinding>,
+    agent_id: &AgentId,
+    signature: &LaunchSignature,
+) -> BindingEvidence {
+    let Some(binding) = binding else {
+        return BindingEvidence::Legacy;
+    };
+    if binding.session_name != RuntimeSession::session_name_for(agent_id)
+        || binding.launch_signature != *signature
+    {
+        return BindingEvidence::Inconsistent;
+    }
+    match (binding.pid, binding.process_identity) {
+        (Some(pid), Some(identity)) if pid != identity.pid => BindingEvidence::Inconsistent,
+        (Some(_) | None, None) => BindingEvidence::Legacy,
+        (None, Some(_)) => BindingEvidence::Inconsistent,
+        (Some(_), Some(_)) => BindingEvidence::Coherent,
+    }
+}
+
+#[must_use]
+fn classify_startup(
+    session: SessionEvidence,
+    binding: BindingEvidence,
+    remote: bool,
+    process: ProcessLiveness,
+) -> StartupClassification {
+    if binding == BindingEvidence::Inconsistent {
+        return StartupClassification::Inconsistent;
+    }
+    match session {
+        SessionEvidence::Alive => StartupClassification::Running,
+        SessionEvidence::Unavailable => StartupClassification::Recoverable,
+        SessionEvidence::Missing if remote => StartupClassification::Stopped,
+        SessionEvidence::Missing => match process {
+            ProcessLiveness::Alive => StartupClassification::Recoverable,
+            ProcessLiveness::Dead => StartupClassification::Stopped,
+            ProcessLiveness::ReusedPid => StartupClassification::Stale,
+            ProcessLiveness::MalformedIdentity => StartupClassification::Inconsistent,
+            ProcessLiveness::Inaccessible | ProcessLiveness::ProbeFailure => {
+                StartupClassification::Recoverable
+            }
+        },
+    }
+}
+
+fn classify_agent_startup(
+    agent: &Agent,
+    signature: &LaunchSignature,
+    runtime: &TmuxRuntimeManager,
+) -> StartupClassification {
+    let session = runtime
+        .session_liveness_for_signature(&agent.id, signature)
+        .into();
+    let binding = binding_evidence(agent.runtime_binding.as_ref(), &agent.id, signature);
+    let process = if signature.remote.enabled {
+        ProcessLiveness::MalformedIdentity
+    } else {
+        process_liveness(
+            agent
+                .runtime_binding
+                .as_ref()
+                .and_then(|value| value.process_identity),
+        )
+    };
+    classify_startup(session, binding, signature.remote.enabled, process)
+}
 
 /// Load persisted state and settings into `app_state` exactly once.
 ///
@@ -163,6 +265,7 @@ pub fn init_app_state(app_state: &mut HookState<AppState>, ctx: &SharedContext) 
 ///
 /// Factored out of [`reconcile_running_agents`] so the decision logic is
 /// unit-testable without spawning real tmux.
+#[cfg(test)]
 #[must_use]
 fn is_agent_dead(
     session_exists: bool,
@@ -189,7 +292,6 @@ fn is_agent_dead(
 ///
 /// Returns the collected dead agent IDs; does not mutate `state`.
 fn reconcile_running_agents(state: &AppState, runtime: &TmuxRuntimeManager) -> Vec<AgentId> {
-    let mut running_agents: Vec<(AgentId, LaunchSignature, Option<ProcessIdentity>)> = Vec::new();
     let mut dead_ids = Vec::new();
     for agent in state
         .agents
@@ -200,20 +302,14 @@ fn reconcile_running_agents(state: &AppState, runtime: &TmuxRuntimeManager) -> V
             dead_ids.push(agent.id.clone());
             continue;
         };
-
-        running_agents.push((
-            agent.id.clone(),
-            launch_signature_for_agent(agent, repository),
-            agent
-                .runtime_binding
-                .as_ref()
-                .and_then(|binding| binding.process_identity),
-        ));
-    }
-    for (agent_id, signature, process_identity) in running_agents {
-        let session_exists = runtime.session_exists_for_signature(&agent_id, &signature);
-        if is_agent_dead(session_exists, signature.remote.enabled, process_identity) {
-            dead_ids.push(agent_id);
+        let signature = launch_signature_for_agent(agent, repository);
+        if matches!(
+            classify_agent_startup(agent, &signature, runtime),
+            StartupClassification::Stopped
+                | StartupClassification::Stale
+                | StartupClassification::Inconsistent
+        ) {
+            dead_ids.push(agent.id.clone());
         }
     }
     dead_ids
@@ -246,6 +342,7 @@ fn apply_dead_reconciliations(
 /// Factored out of [`restore_runtime_sessions`] so the three-way restore
 /// decision is unit-testable without spawning real tmux. Mirrors
 /// [`is_agent_dead`] as the single source of truth for the dead-decision.
+#[cfg(test)]
 #[must_use]
 fn restore_dead_decision(
     session_exists: bool,
@@ -268,6 +365,7 @@ fn restore_dead_decision(
 }
 
 /// Decision outcome for restoring one Running agent's session.
+#[cfg(test)]
 #[derive(Debug, PartialEq, Eq)]
 enum RestoreDecision {
     /// Tmux session still exists → reattach/revive.
@@ -315,24 +413,15 @@ fn restore_one_agent(
     let binding = agent.runtime_binding.as_ref();
     let pid = binding.and_then(|value| value.pid);
     let process_identity = binding.and_then(|value| value.process_identity);
-    let session_exists = runtime.session_exists_for_signature(&agent.id, &signature);
 
-    match restore_dead_decision(session_exists, signature.remote.enabled, process_identity) {
-        RestoreDecision::Dead => RestoreOneOutcome::Dead,
-        // SkipOrphan agents remain Running in AppState but have NO entry in
-        // the TmuxRuntimeManager in-memory session map (by design — the
-        // persisted `runtime_binding.pid` is the liveness source of truth for
-        // orphans; active orphan reclaim/re-adoption is the deferred follow-up,
-        // issue #121 item 4).
-        RestoreDecision::SkipOrphan => RestoreOneOutcome::Skip,
-        RestoreDecision::Revive => {
+    match classify_agent_startup(agent, &signature, runtime) {
+        StartupClassification::Stopped
+        | StartupClassification::Stale
+        | StartupClassification::Inconsistent => RestoreOneOutcome::Dead,
+        StartupClassification::Recoverable => RestoreOneOutcome::Skip,
+        StartupClassification::Running => {
             match revive_agent_session(agent, &signature, runtime, runtime_warning) {
                 ReviveOutcome::Revived => {
-                    // A reattach does not respawn the worker, so fall back to
-                    // the previously-persisted PID if worker_pid transiently
-                    // returns None (e.g. a tmux list-panes hiccup right after
-                    // create). Without this, the revived agent's binding could
-                    // be persisted with pid: None, stripping the fallback.
                     let resolved_pid = runtime.worker_pid(&agent.id).or(pid);
                     let process_identity = runtime
                         .worker_process_identity(&agent.id)
@@ -632,6 +721,158 @@ mod tests {
         assert_eq!(
             restore_dead_decision(true, false, Some(me)),
             RestoreDecision::Revive
+        );
+    }
+
+    #[test]
+    fn startup_classification_covers_required_lifecycle_states() {
+        let coherent = BindingEvidence::Coherent;
+        assert_eq!(
+            classify_startup(
+                SessionEvidence::Alive,
+                coherent,
+                false,
+                ProcessLiveness::Dead
+            ),
+            StartupClassification::Running
+        );
+        assert_eq!(
+            classify_startup(
+                SessionEvidence::Missing,
+                coherent,
+                false,
+                ProcessLiveness::Dead
+            ),
+            StartupClassification::Stopped
+        );
+        assert_eq!(
+            classify_startup(
+                SessionEvidence::Missing,
+                coherent,
+                false,
+                ProcessLiveness::ReusedPid
+            ),
+            StartupClassification::Stale
+        );
+        assert_eq!(
+            classify_startup(
+                SessionEvidence::Missing,
+                coherent,
+                false,
+                ProcessLiveness::Alive
+            ),
+            StartupClassification::Recoverable
+        );
+        assert_eq!(
+            classify_startup(
+                SessionEvidence::Missing,
+                BindingEvidence::Inconsistent,
+                false,
+                ProcessLiveness::Alive
+            ),
+            StartupClassification::Inconsistent
+        );
+    }
+
+    #[test]
+    fn unavailable_runtime_probe_is_recoverable_not_phantom_dead() {
+        for liveness in [ProcessLiveness::Dead, ProcessLiveness::ProbeFailure] {
+            assert_eq!(
+                classify_startup(
+                    SessionEvidence::Unavailable,
+                    BindingEvidence::Coherent,
+                    false,
+                    liveness
+                ),
+                StartupClassification::Recoverable
+            );
+        }
+    }
+
+    #[test]
+    fn missing_remote_session_is_stopped_without_local_pid_fallback() {
+        assert_eq!(
+            classify_startup(
+                SessionEvidence::Missing,
+                BindingEvidence::Coherent,
+                true,
+                ProcessLiveness::Alive
+            ),
+            StartupClassification::Stopped
+        );
+    }
+
+    #[test]
+    fn malformed_or_inaccessible_process_identity_is_classified_conservatively() {
+        assert_eq!(
+            classify_startup(
+                SessionEvidence::Missing,
+                BindingEvidence::Coherent,
+                false,
+                ProcessLiveness::MalformedIdentity
+            ),
+            StartupClassification::Inconsistent
+        );
+        assert_eq!(
+            classify_startup(
+                SessionEvidence::Missing,
+                BindingEvidence::Coherent,
+                false,
+                ProcessLiveness::Inaccessible
+            ),
+            StartupClassification::Recoverable
+        );
+    }
+
+    #[test]
+    fn live_session_with_mismatched_binding_is_never_reattached() {
+        assert_eq!(
+            classify_startup(
+                SessionEvidence::Alive,
+                BindingEvidence::Inconsistent,
+                false,
+                ProcessLiveness::Alive
+            ),
+            StartupClassification::Inconsistent
+        );
+    }
+
+    #[test]
+    fn binding_evidence_rejects_wrong_session_signature_and_pid() {
+        let (agent, repository) = code_puppy_agent_and_repository();
+        let signature = launch_signature_for_agent(&agent, &repository);
+        let mut binding = jefe::domain::RuntimeBinding {
+            session_name: RuntimeSession::session_name_for(&agent.id),
+            launch_signature: signature.clone(),
+            attached: false,
+            last_seen: None,
+            pid: Some(41),
+            process_identity: Some(ProcessIdentity::new(41, 900)),
+        };
+        assert_eq!(
+            binding_evidence(Some(&binding), &agent.id, &signature),
+            BindingEvidence::Coherent
+        );
+        binding.session_name = "jefe-wrong-agent".to_owned();
+        assert_eq!(
+            binding_evidence(Some(&binding), &agent.id, &signature),
+            BindingEvidence::Inconsistent
+        );
+        binding.session_name = RuntimeSession::session_name_for(&agent.id);
+        binding.launch_signature.profile = "wrong-profile".to_owned();
+        assert_eq!(
+            binding_evidence(Some(&binding), &agent.id, &signature),
+            BindingEvidence::Inconsistent
+        );
+        binding.launch_signature = signature.clone();
+        binding.pid = Some(42);
+        assert_eq!(
+            binding_evidence(Some(&binding), &agent.id, &signature),
+            BindingEvidence::Inconsistent
+        );
+        assert_eq!(
+            binding_evidence(None, &agent.id, &signature),
+            BindingEvidence::Legacy
         );
     }
 }

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -141,6 +141,9 @@ fn classify_startup(
     if binding == BindingEvidence::Inconsistent {
         return StartupClassification::Inconsistent;
     }
+    if !remote && process == ProcessLiveness::ReusedPid {
+        return StartupClassification::Stale;
+    }
     match session {
         SessionEvidence::Alive => StartupClassification::Running,
         SessionEvidence::Unavailable => StartupClassification::Recoverable,
@@ -748,6 +751,15 @@ mod tests {
         assert_eq!(
             classify_startup(
                 SessionEvidence::Missing,
+                coherent,
+                false,
+                ProcessLiveness::ReusedPid
+            ),
+            StartupClassification::Stale
+        );
+        assert_eq!(
+            classify_startup(
+                SessionEvidence::Alive,
                 coherent,
                 false,
                 ProcessLiveness::ReusedPid

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -594,6 +594,7 @@ fn seed_sticky_agent_state(
         std::path::PathBuf::from("/tmp"),
     );
     agent.status = AgentStatus::Running;
+    agent.code_puppy_yolo = Some(false);
     agent.shortcut_slot = Some(1);
     agent.runtime_binding = Some(RuntimeBinding {
         session_name: agent_session.to_string(),

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -576,9 +576,14 @@ fn guarded_real_jefe_sticky_kill_scenario() {
 /// Seed a config directory with a state.json containing a single Running agent
 /// bound to the given tmux session name (issue #116 scenario fixture).
 #[cfg(unix)]
+type StickyAgentId = crate::domain::AgentId;
+#[cfg(unix)]
+type StickyConfigPath = std::path::Path;
+
+#[cfg(unix)]
 fn seed_sticky_agent_state(
-    config_dir: &std::path::Path,
-    agent_id: &crate::domain::AgentId,
+    config_dir: &StickyConfigPath,
+    agent_id: &StickyAgentId,
     agent_session: &str,
 ) {
     use crate::domain::{

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -545,7 +545,8 @@ fn guarded_real_jefe_sticky_kill_scenario() {
     };
 
     let unique = unique_session("stickyagent");
-    let agent_session = format!("jefe-stickyagent-{unique}");
+    let agent_id = crate::domain::AgentId(unique);
+    let agent_session = crate::runtime::RuntimeSession::session_name_for(&agent_id);
 
     // Pre-create a tmux session running sleep on jefe's dedicated socket so
     // jefe's session-exists check (which now targets the private socket) finds
@@ -566,7 +567,7 @@ fn guarded_real_jefe_sticky_kill_scenario() {
     };
 
     let config_dir = tempfile::tempdir().value_or_panic("isolated config tempdir");
-    seed_sticky_agent_state(config_dir.path(), &agent_session);
+    seed_sticky_agent_state(config_dir.path(), &agent_id, &agent_session);
 
     let summary = run_sticky_scenario(&jefe_binary, config_dir.path());
     assert_eq!(summary.steps_run, 13);
@@ -575,15 +576,19 @@ fn guarded_real_jefe_sticky_kill_scenario() {
 /// Seed a config directory with a state.json containing a single Running agent
 /// bound to the given tmux session name (issue #116 scenario fixture).
 #[cfg(unix)]
-fn seed_sticky_agent_state(config_dir: &std::path::Path, agent_session: &str) {
+fn seed_sticky_agent_state(
+    config_dir: &std::path::Path,
+    agent_id: &crate::domain::AgentId,
+    agent_session: &str,
+) {
     use crate::domain::{
-        Agent, AgentId, AgentStatus, DEFAULT_SANDBOX_FLAGS, LaunchSignature,
-        RemoteRepositorySettings, Repository, RepositoryId, RuntimeBinding, SandboxEngine,
+        Agent, AgentStatus, DEFAULT_SANDBOX_FLAGS, LaunchSignature, RemoteRepositorySettings,
+        Repository, RepositoryId, RuntimeBinding, SandboxEngine,
     };
     use crate::persistence::{FilePersistenceManager, PersistenceManager, PersistencePaths, State};
 
     let mut agent = Agent::new(
-        AgentId("stickyagent".into()),
+        agent_id.clone(),
         RepositoryId("testrepo".into()),
         "StickyAgent".into(),
         std::path::PathBuf::from("/tmp"),

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -599,7 +599,6 @@ fn seed_sticky_agent_state(
         std::path::PathBuf::from("/tmp"),
     );
     agent.status = AgentStatus::Running;
-    agent.code_puppy_yolo = Some(false);
     agent.shortcut_slot = Some(1);
     agent.runtime_binding = Some(RuntimeBinding {
         session_name: agent_session.to_string(),
@@ -607,7 +606,7 @@ fn seed_sticky_agent_state(
             work_dir: std::path::PathBuf::from("/tmp"),
             profile: String::new(),
             code_puppy_model: String::new(),
-            code_puppy_yolo: Some(false),
+            code_puppy_yolo: None,
             code_puppy_quick_resume: false,
             mode_flags: vec![],
             llxprt_debug: String::new(),

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -695,4 +695,7 @@ impl PersistenceManager for FilePersistenceManager {
 }
 
 #[cfg(test)]
+mod runtime_binding_tests;
+
+#[cfg(test)]
 mod tests;

--- a/src/persistence/runtime_binding_tests.rs
+++ b/src/persistence/runtime_binding_tests.rs
@@ -1,0 +1,97 @@
+//! Persistence contracts for multi-runtime restart metadata.
+
+use super::*;
+use crate::domain::{
+    Agent, AgentId, AgentKind, AgentStatus, LaunchSignature, ProcessIdentity,
+    RemoteRepositorySettings, Repository, RepositoryId, RuntimeBinding, SandboxEngine,
+};
+
+fn bound_runtime_agent(repository_id: &RepositoryId, index: u32, kind: AgentKind) -> Agent {
+    let id = AgentId(format!("agent-Ω-{index}"));
+    let work_dir = std::path::PathBuf::from(format!(r"C:\work dirs\agent Ω {index}"));
+    let mut agent = Agent::new(
+        id.clone(),
+        repository_id.clone(),
+        format!("Agent Ω {index}"),
+        work_dir.clone(),
+    );
+    agent.agent_kind = kind;
+    agent.status = AgentStatus::Running;
+    agent.profile = format!("profile-{index}");
+    agent.code_puppy_model = "model/Ω".to_owned();
+    agent.code_puppy_quick_resume = kind == AgentKind::CodePuppy;
+    agent.pass_continue = kind == AgentKind::Llxprt;
+    agent.runtime_binding = Some(runtime_binding(&agent, &id, work_dir, index, kind));
+    agent
+}
+
+fn runtime_binding(
+    agent: &Agent,
+    id: &AgentId,
+    work_dir: std::path::PathBuf,
+    index: u32,
+    kind: AgentKind,
+) -> RuntimeBinding {
+    let signature = LaunchSignature {
+        work_dir,
+        profile: agent.profile.clone(),
+        code_puppy_model: agent.code_puppy_model.clone(),
+        code_puppy_yolo: Some(true),
+        code_puppy_quick_resume: agent.code_puppy_quick_resume,
+        mode_flags: vec!["--flag Ω".to_owned()],
+        llxprt_debug: "runtime=trace".to_owned(),
+        pass_continue: agent.pass_continue,
+        sandbox_enabled: false,
+        sandbox_engine: SandboxEngine::Podman,
+        sandbox_flags: String::new(),
+        remote: RemoteRepositorySettings::default(),
+        agent_kind: kind,
+    };
+    RuntimeBinding {
+        session_name: crate::runtime::RuntimeSession::session_name_for(id),
+        launch_signature: signature,
+        attached: index == 0,
+        last_seen: Some(1_000 + u64::from(index)),
+        pid: Some(10_000 + index),
+        process_identity: Some(ProcessIdentity::new(
+            10_000 + index,
+            90_000 + u64::from(index),
+        )),
+    }
+}
+
+#[test]
+fn restart_roundtrip_preserves_unicode_multi_runtime_bindings() {
+    let repository_id = RepositoryId("repo-Ω spaces".to_owned());
+    let repository = Repository::new(
+        repository_id.clone(),
+        "Repository Ω With Spaces".to_owned(),
+        "repository-omega".to_owned(),
+        std::path::PathBuf::from(r"C:\work dirs\repository Ω"),
+    );
+    let state = State {
+        repositories: vec![repository],
+        agents: vec![
+            bound_runtime_agent(&repository_id, 0, AgentKind::Llxprt),
+            bound_runtime_agent(&repository_id, 1, AgentKind::CodePuppy),
+        ],
+        ..State::default_with_version()
+    };
+    let json = serde_json::to_vec(&state)
+        .unwrap_or_else(|error| panic!("serialize runtime state: {error}"));
+    let loaded: State = serde_json::from_slice(&json)
+        .unwrap_or_else(|error| panic!("deserialize runtime state: {error}"));
+
+    assert_eq!(loaded.repositories[0].name, "Repository Ω With Spaces");
+    assert_eq!(loaded.agents[0].agent_kind, AgentKind::Llxprt);
+    assert_eq!(loaded.agents[1].agent_kind, AgentKind::CodePuppy);
+    assert!(loaded.agents[0].pass_continue);
+    assert!(loaded.agents[1].code_puppy_quick_resume);
+    assert_eq!(
+        loaded.agents[1]
+            .runtime_binding
+            .as_ref()
+            .and_then(|binding| binding.process_identity),
+        Some(ProcessIdentity::new(10_001, 90_001))
+    );
+}

--- a/src/persistence/runtime_binding_tests.rs
+++ b/src/persistence/runtime_binding_tests.rs
@@ -77,6 +77,11 @@ fn restart_roundtrip_preserves_unicode_multi_runtime_bindings() {
         ],
         ..State::default_with_version()
     };
+    let expected_bindings = state
+        .agents
+        .iter()
+        .map(|agent| agent.runtime_binding.clone())
+        .collect::<Vec<_>>();
     let json = serde_json::to_vec(&state)
         .unwrap_or_else(|error| panic!("serialize runtime state: {error}"));
     let loaded: State = serde_json::from_slice(&json)
@@ -87,11 +92,14 @@ fn restart_roundtrip_preserves_unicode_multi_runtime_bindings() {
     assert_eq!(loaded.agents[1].agent_kind, AgentKind::CodePuppy);
     assert!(loaded.agents[0].pass_continue);
     assert!(loaded.agents[1].code_puppy_quick_resume);
-    assert_eq!(
-        loaded.agents[1]
-            .runtime_binding
-            .as_ref()
-            .and_then(|binding| binding.process_identity),
-        Some(ProcessIdentity::new(10_001, 90_001))
-    );
+    let loaded_bindings = loaded
+        .agents
+        .iter()
+        .map(|agent| agent.runtime_binding.as_ref())
+        .collect::<Vec<_>>();
+    let expected_json = serde_json::to_value(&expected_bindings)
+        .unwrap_or_else(|error| panic!("serialize expected bindings: {error}"));
+    let loaded_json = serde_json::to_value(&loaded_bindings)
+        .unwrap_or_else(|error| panic!("serialize loaded bindings: {error}"));
+    assert_eq!(loaded_json, expected_json);
 }

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -936,21 +936,16 @@ pub fn remote_session_exists(
 ) -> Result<bool, RuntimeError> {
     let command = remote_has_session_command(remote, session_name);
     let output = run_remote_ssh(remote, &command)?;
-    if output.status.success() {
-        return Ok(true);
+    match output.status.code() {
+        Some(0) => Ok(true),
+        Some(1) => Ok(false),
+        _ => Err(RuntimeError::CapabilityProbeFailed(format!(
+            "remote tmux session probe failed: {}",
+            output.status
+        ))),
     }
-    if output.status.code() == Some(1) {
-        return Ok(false);
-    }
-    Err(RuntimeError::CapabilityProbeFailed(format!(
-        "remote tmux session probe failed with status {}: {}",
-        output.status,
-        String::from_utf8_lossy(&output.stderr).trim()
-    )))
 }
-
 /// Kill a tmux session.
-///
 /// @pseudocode component-002 lines 24-25
 pub fn kill_session(session_name: &str) -> Result<(), RuntimeError> {
     let output = tmux_command()?

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -936,7 +936,17 @@ pub fn remote_session_exists(
 ) -> Result<bool, RuntimeError> {
     let command = remote_has_session_command(remote, session_name);
     let output = run_remote_ssh(remote, &command)?;
-    Ok(output.status.success())
+    if output.status.success() {
+        return Ok(true);
+    }
+    if output.status.code() == Some(1) {
+        return Ok(false);
+    }
+    Err(RuntimeError::CapabilityProbeFailed(format!(
+        "remote tmux session probe failed with status {}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr).trim()
+    )))
 }
 
 /// Kill a tmux session.

--- a/src/runtime/liveness.rs
+++ b/src/runtime/liveness.rs
@@ -102,18 +102,30 @@ pub fn session_liveness(session_name: &str) -> SessionLiveness {
     if !output.status.success() {
         return SessionLiveness::Missing;
     }
-    if parse_dead_pane_flags(&String::from_utf8_lossy(&output.stdout)) {
-        SessionLiveness::Alive
-    } else {
-        SessionLiveness::Missing
-    }
+    parse_dead_pane_flags(&String::from_utf8_lossy(&output.stdout))
 }
 
-fn parse_dead_pane_flags(output: &str) -> bool {
-    output
+fn parse_dead_pane_flags(output: &str) -> SessionLiveness {
+    let mut saw_dead = false;
+    for flag in output
         .lines()
         .map(str::trim)
-        .any(|flag| !flag.is_empty() && (flag == "0" || flag.eq_ignore_ascii_case("false")))
+        .filter(|flag| !flag.is_empty())
+    {
+        if flag == "0" || flag.eq_ignore_ascii_case("false") {
+            return SessionLiveness::Alive;
+        }
+        if flag == "1" || flag.eq_ignore_ascii_case("true") {
+            saw_dead = true;
+        } else {
+            return SessionLiveness::Unavailable;
+        }
+    }
+    if saw_dead {
+        SessionLiveness::Missing
+    } else {
+        SessionLiveness::Unavailable
+    }
 }
 
 /// Check if a tmux session exists and has at least one non-dead pane.
@@ -504,6 +516,17 @@ jefe-b
 ";
         let set = parse_alive_sessions(raw);
         assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn dead_pane_parser_preserves_tri_state() {
+        assert_eq!(parse_dead_pane_flags("0\n1\n"), SessionLiveness::Alive);
+        assert_eq!(parse_dead_pane_flags("1\ntrue\n"), SessionLiveness::Missing);
+        assert_eq!(parse_dead_pane_flags(""), SessionLiveness::Unavailable);
+        assert_eq!(
+            parse_dead_pane_flags("unexpected\n"),
+            SessionLiveness::Unavailable
+        );
     }
 
     // --- parse_pane_alive (pure) ---

--- a/src/runtime/liveness.rs
+++ b/src/runtime/liveness.rs
@@ -66,51 +66,62 @@ fn pid_alive_on_platform(pid: u32) -> bool {
     true
 }
 
+/// Result of probing one persistent multiplexer session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionLiveness {
+    /// The session exists and contains a non-dead pane.
+    Alive,
+    /// The session is absent or all of its panes have exited.
+    Missing,
+    /// The multiplexer command could not be started or queried.
+    Unavailable,
+}
+
+/// Probe whether a local session exists and contains a non-dead pane.
+#[must_use]
+pub fn session_liveness(session_name: &str) -> SessionLiveness {
+    let Ok(mut command) = tmux_command() else {
+        return SessionLiveness::Unavailable;
+    };
+    let Ok(output) = command.args(["has-session", "-t", session_name]).output() else {
+        return SessionLiveness::Unavailable;
+    };
+    if !output.status.success() {
+        return SessionLiveness::Missing;
+    }
+
+    let Ok(mut command) = tmux_command() else {
+        return SessionLiveness::Unavailable;
+    };
+    let Ok(output) = command
+        .args(["list-panes", "-t", session_name, "-F", "#{pane_dead}"])
+        .output()
+    else {
+        return SessionLiveness::Unavailable;
+    };
+    if !output.status.success() {
+        return SessionLiveness::Missing;
+    }
+    if parse_dead_pane_flags(&String::from_utf8_lossy(&output.stdout)) {
+        SessionLiveness::Alive
+    } else {
+        SessionLiveness::Missing
+    }
+}
+
+fn parse_dead_pane_flags(output: &str) -> bool {
+    output
+        .lines()
+        .map(str::trim)
+        .any(|flag| !flag.is_empty() && (flag == "0" || flag.eq_ignore_ascii_case("false")))
+}
+
 /// Check if a tmux session exists and has at least one non-dead pane.
 ///
 /// @pseudocode component-002 lines 33-35
 #[must_use]
 pub fn check_session_alive(session_name: &str) -> bool {
-    let Ok(mut command) = tmux_command() else {
-        return false;
-    };
-    let has_session = command.args(["has-session", "-t", session_name]).output();
-
-    let Ok(out) = has_session else {
-        return false;
-    };
-    if !out.status.success() {
-        return false;
-    }
-
-    let Ok(mut command) = tmux_command() else {
-        return false;
-    };
-    let panes = command
-        .args(["list-panes", "-t", session_name, "-F", "#{pane_dead}"])
-        .output();
-
-    let Ok(out) = panes else {
-        return false;
-    };
-    if !out.status.success() {
-        return false;
-    }
-
-    let stdout = String::from_utf8_lossy(&out.stdout);
-
-    for line in stdout.lines() {
-        let dead_flag = line.trim();
-        if dead_flag.is_empty() {
-            continue;
-        }
-
-        if dead_flag == "0" || dead_flag.eq_ignore_ascii_case("false") {
-            return true;
-        }
-    }
-
-    false
+    session_liveness(session_name) == SessionLiveness::Alive
 }
 
 /// Check if a remote tmux session exists and has at least one non-dead pane.

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -384,11 +384,25 @@ impl TmuxRuntimeManager {
         agent_id: &AgentId,
         signature: &LaunchSignature,
     ) -> bool {
+        self.session_liveness_for_signature(agent_id, signature) == liveness::SessionLiveness::Alive
+    }
+
+    /// Probe a persisted session without collapsing infrastructure failures into absence.
+    #[must_use]
+    pub fn session_liveness_for_signature(
+        &self,
+        agent_id: &AgentId,
+        signature: &LaunchSignature,
+    ) -> liveness::SessionLiveness {
         let session_name = RuntimeSession::session_name_for(agent_id);
         if signature.remote.enabled {
-            commands::remote_session_exists(&signature.remote, &session_name).unwrap_or(false)
+            match commands::remote_session_exists(&signature.remote, &session_name) {
+                Ok(true) => liveness::SessionLiveness::Alive,
+                Ok(false) => liveness::SessionLiveness::Missing,
+                Err(_) => liveness::SessionLiveness::Unavailable,
+            }
         } else {
-            liveness::check_session_alive(&session_name)
+            liveness::session_liveness(&session_name)
         }
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -44,8 +44,9 @@ pub use commands::configure_prefix_for_passthrough_with_plan;
 pub use errors::RuntimeError;
 pub use gh_auth::{AuthRunResult, run_device_auth};
 pub use liveness::{
-    alive_session_set, batch_liveness_check, check_remote_session_alive, check_session_alive,
-    parse_alive_sessions, parse_pane_alive, pid_alive, reconcile_dead_agents,
+    SessionLiveness, alive_session_set, batch_liveness_check, check_remote_session_alive,
+    check_session_alive, parse_alive_sessions, parse_pane_alive, pid_alive, reconcile_dead_agents,
+    session_liveness,
 };
 pub use manager::{LivenessCheck, RuntimeManager, TmuxRuntimeManager};
 pub use multiplexer::{

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -66,6 +66,7 @@ const fn classify_running(expected: ProcessIdentity, actual: ProcessIdentity) ->
     }
     match (expected.started_at, actual.started_at) {
         (Some(expected), Some(actual)) if expected != actual => ProcessLiveness::ReusedPid,
+        (None, Some(_)) => ProcessLiveness::MalformedIdentity,
         (Some(_), None) => ProcessLiveness::ProbeFailure,
         _ => ProcessLiveness::Alive,
     }

--- a/src/runtime/process_tests.rs
+++ b/src/runtime/process_tests.rs
@@ -43,6 +43,20 @@ fn classification_distinguishes_every_required_state() {
 }
 
 #[test]
+fn platform_identity_without_persisted_creation_time_is_malformed() {
+    let legacy = ProcessIdentity {
+        pid: 41,
+        started_at: None,
+    };
+    let observed = ProcessIdentity::new(41, 900);
+
+    assert_eq!(
+        classify_process_observation(Some(legacy), ProcessObservation::Running(observed)),
+        ProcessLiveness::MalformedIdentity
+    );
+}
+
+#[test]
 fn production_probe_observes_running_and_normal_exit() {
     let mut child = spawn_sleeping_fixture(Duration::from_millis(120));
     let identity = capture_process_identity(child.id())

--- a/tests/psmux_smoke.rs
+++ b/tests/psmux_smoke.rs
@@ -456,6 +456,59 @@ fn psmux_named_namespaces_are_isolated_and_cleanup_is_scoped() {
     }
 }
 
+#[test]
+fn psmux_four_recording_agents_remain_independent_and_scoped() {
+    let Some((executable, version_text)) = qualified_psmux() else {
+        return;
+    };
+    let mut namespace = namespace_or_panic(executable, "four-agents", &version_text);
+    let repo_one = tempfile::Builder::new()
+        .prefix("jefe repo Ω one ")
+        .tempdir()
+        .unwrap_or_else(|error| panic!("create first repository fixture: {error}"));
+    let repo_two = tempfile::Builder::new()
+        .prefix("jefe repo two ")
+        .tempdir()
+        .unwrap_or_else(|error| panic!("create second repository fixture: {error}"));
+    let agents = [
+        ("llxprt-one", repo_one.path(), "A", "PSMUX_BYTE_41"),
+        ("puppy-two", repo_one.path(), "B", "PSMUX_BYTE_42"),
+        ("llxprt-three", repo_two.path(), "C", "PSMUX_BYTE_43"),
+        ("puppy-four", repo_two.path(), "D", "PSMUX_BYTE_44"),
+    ];
+    for (session, work_dir, input, expected) in agents {
+        namespace
+            .run_os(&[
+                OsString::from("new-session"),
+                OsString::from("-d"),
+                OsString::from("-s"),
+                OsString::from(session),
+                OsString::from("-c"),
+                work_dir.as_os_str().to_owned(),
+                OsString::from(FIXTURE),
+            ])
+            .unwrap_or_else(|error| panic!("create {session}: {error}"));
+        namespace
+            .wait_for_capture(session, "PSMUX_SMOKE_READY")
+            .unwrap_or_else(|error| panic!("wait for {session}: {error}"));
+        namespace
+            .run(&["send-keys", "-l", "-t", session, "--", input])
+            .unwrap_or_else(|error| panic!("interact with {session}: {error}"));
+        namespace
+            .wait_for_capture(session, expected)
+            .unwrap_or_else(|error| panic!("verify {session}: {error}"));
+    }
+    namespace
+        .run(&["kill-session", "-t", "puppy-two"])
+        .unwrap_or_else(|error| panic!("kill selected agent: {error}"));
+    assert!(namespace.run(&["has-session", "-t", "puppy-two"]).is_err());
+    for survivor in ["llxprt-one", "llxprt-three", "puppy-four"] {
+        namespace
+            .run(&["has-session", "-t", survivor])
+            .unwrap_or_else(|error| panic!("selected kill affected {survivor}: {error}"));
+    }
+}
+
 fn exercise_command_surface(namespace: &mut PsmuxNamespace) -> Result<(), SmokeFailure> {
     let session = "jefe-smoke";
     let work_dir = tempfile::Builder::new()


### PR DESCRIPTION
## Summary

- classify persisted local agent startup as running, stopped, stale, recoverable, or inconsistent from typed psmux and process evidence
- refuse wrong-session, changed-launch-signature, and reused-PID restoration while preserving recoverable agents during transient probe failures
- preserve LLxprt Code and Code Puppy runtime bindings across Unicode/space-containing persistence round trips
- exercise four independent native psmux sessions and selected-session teardown, with a Windows multi-agent TUI scenario

## Test-first evidence

- added startup classification tests before introducing the classifier and observed the expected compile failure
- added a malformed process identity regression and observed `Alive` before changing it to `MalformedIdentity`
- created the Windows TUI lifecycle scenario first and observed its initial missing-fixture failure

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --all-features --locked`
- `cargo test --workspace --all-features --locked`
- real psmux four-agent smoke test on Windows
- native source-file hard-limit check

Fixes #262