### PR TITLE
Add first-class Actions job inspection (Fixes #194)

### DIFF
--- a/dev-docs/testing/tmux-harness.md
+++ b/dev-docs/testing/tmux-harness.md
@@ -186,10 +186,13 @@ manual/opt-in and also skips when `tmux` cannot be installed or found.
 - [`scratch-pr-mode.json`](../tmux-scenarios/scratch-pr-mode.json): manual
   scratch scenario for PR-mode screen validation. It is intentionally not a CI
   gate because repository/GitHub configuration can vary by developer machine.
-- [`actions-mode.json`](../tmux-scenarios/actions-mode.json): launches the app,
-  enters Actions mode (`g`), verifies the runs-list pane renders, navigates
-  down, then exits and quits. Intentionally not a CI gate — it requires a
-  configured repository and may vary by developer machine.
+- [`actions-mode.json`](../tmux-scenarios/actions-mode.json): uses the fail-closed
+  `scripts/issue194-gh-shim.sh` fixture to load a real run, enters job detail,
+  verifies jobs are collapsed by default, expands success and failure steps
+  with their status glyphs, collapses with `Esc`, navigates job focus, and backs
+  out to the run list. Run it end to end with
+  `scripts/issue194-run-scenario.sh`; the runner seeds isolated state and audits
+  that production performs only the expected read-only `gh` operations.
 - [`code-puppy-chord-passthrough.json`](../tmux-scenarios/code-puppy-chord-passthrough.json):
   manual scenario that focuses an agent terminal and sends the Code Puppy
   shell-control chords (`Ctrl-X Ctrl-B`, `Ctrl-X Ctrl-X`, `Ctrl-C`) through

--- a/dev-docs/tmux-scenarios/actions-mode.json
+++ b/dev-docs/tmux-scenarios/actions-mode.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "cols": 100,
-    "rows": 32,
+    "rows": 24,
     "history_limit": 2000,
     "initial_wait_ms": 100,
     "assert_mode": "strict"
@@ -9,15 +9,30 @@
   "steps": [
     { "waitFor": "LLxprt Jefe" },
     { "key": "g" },
-    { "waitFor": "WORKFLOW RUNS" },
-    { "expect": "navigate" },
-    { "capture": "actions-mode-entered" },
-    { "key": "Down" },
-    { "wait": 100 },
-    { "capture": "actions-mode-navigated" },
+    { "waitFor": "Inspectable Actions fixture" },
+    { "expect": "Enter detail" },
+    { "key": "Enter" },
+    { "waitFor": "Jobs:" },
+    { "expect": "> ▸ ✓ build-linux-with-a-long-job-name" },
+    { "waitForNot": "Checkout fixture source" },
+    { "key": "Right" },
+    { "waitFor": "Checkout fixture source" },
+    { "expect": "✓ [1] Checkout fixture source" },
     { "key": "Escape" },
-    { "waitForNot": "WORKFLOW RUNS" },
-    { "key": "q" },
+    { "waitForNot": "Checkout fixture source" },
+    { "expect": "> ▸ ✓ build-linux-with-a-long-job-name" },
+    { "key": "Down" },
+    { "expect": "> ▸ ✗ test-suite-with-a-long-job-name" },
+    { "key": "Enter" },
+    { "waitFor": "Run failing fixture tests" },
+    { "expect": "✗ [1] Run failing fixture tests" },
+    { "key": "Escape" },
+    { "waitForNot": "Run failing fixture tests" },
+    { "key": "Escape" },
+    { "expect": "Inspectable Actions fixture" },
+    { "key": "Escape" },
+    { "waitForNot": "Workflow Runs" },
+    { "keys": ["q", "q", "q"] },
     { "waitForExit": 3000 }
   ]
 }

--- a/project-plans/issue194-plan.md
+++ b/project-plans/issue194-plan.md
@@ -1,0 +1,64 @@
+# Issue 194: Inspectable GitHub Actions jobs
+
+## Problem and contract
+
+Actions run details must expose jobs as a compact, keyboard-navigable inline
+sub-focus. Jobs begin collapsed. The focused job is visibly distinct, and its
+steps retain their status glyphs when expanded.
+
+The deterministic input contract is:
+
+- `Enter` on a selected run moves focus from `RunList` to `Detail`.
+- `Up`/`Down` in `Detail` moves the focused job and keeps its row in view.
+- `Enter`/`Right` expands the focused job and never collapses it.
+- `Left` collapses the focused job and otherwise remains in `Detail`.
+- `Esc` in `Detail` collapses the focused job when expanded; when already
+  collapsed, it returns focus to `RunList`. `Esc` from `RunList` exits Actions.
+- Run changes and detail reloads clear expansions; accepted detail loads focus
+  the first job, if present.
+
+## Architecture
+
+Use the existing inline job sub-focus in `ActionsState` rather than a fourth
+pane. The reducer owns focus, expansion, collapse, and scroll-following. The
+Actions pure view projects the focused job and computes its rendered line. The
+UI only renders the projection and emits typed intent. Runtime, GitHub, and
+persistence boundaries remain unchanged.
+
+The expand operation receives a dedicated `ActionsMessage::ExpandJob` and
+`AppEvent::ActionsExpandJob`; using the existing toggle would violate the
+expand-only key contract. Collapse remains a separate typed intent.
+
+A fourth pane is rejected because it would duplicate run-detail context, require
+new layout and selection geometry, and diverge from the established PR-thread
+inline inspection model without adding behavior required by this issue.
+
+## Test-first sequence
+
+1. Update the fixed-geometry Actions TUI scenario first. It asserts the new
+   `Enter detail` hint and proves `Tab` into Detail followed by `Esc` refocuses
+   the run list instead of exiting Actions.
+2. Add key-resolution tests for RunList `Enter`, Detail expand-only keys,
+   collapse keys, and contextual `Esc` behavior.
+3. Add reducer tests for idempotent expand, collapse/refocus semantics, default
+   collapse, and job-navigation scroll-following across collapsed and expanded
+   predecessors.
+4. Add pure projection/UI tests proving the focused job row is identified,
+   visible after windowing, and rendered with a stable focus marker while
+   per-step success/failure glyphs remain intact.
+5. Add message conversion/classification contract tests for the new expand-only
+   intent.
+6. Implement the smallest production changes through AppEvent -> ActionsMessage
+   -> reducer -> pure projection -> UI, then refactor only where needed to meet
+   complexity and source-size gates.
+7. Run targeted tests, `cargo fmt --all`, `make quick-check`, and `make ci-check`.
+
+## Invariants and edge cases
+
+- No detail or no jobs: expand/collapse/navigation are safe no-ops; Detail Esc
+  refocuses RunList.
+- A stale focused index is clamped before projection or transition.
+- A zero-row viewport does not underflow and renders no content.
+- Expanding/collapsing clamps the stored scroll offset after line-count changes.
+- Job navigation follows rendered job-row positions, including step rows from
+  expanded preceding jobs.

--- a/scripts/issue194-gh-shim.sh
+++ b/scripts/issue194-gh-shim.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AUDIT="${GH_SHIM_AUDIT:?GH_SHIM_AUDIT is required}"
+printf '%s\n' "$*" >> "$AUDIT"
+
+case "$*" in
+  "api repos/owner/actions-fixture/actions/runs"\?"page=1&per_page=30")
+    cat <<'JSON'
+{"total_count":1,"workflow_runs":[{"id":19401,"name":"CI","display_title":"Inspectable Actions fixture","head_branch":"issue194","head_sha":"abc194","run_number":194,"event":"push","status":"completed","conclusion":"failure","created_at":"2026-07-14T00:00:00Z","updated_at":"2026-07-14T00:01:00Z"}]}
+JSON
+    ;;
+  "api repos/owner/actions-fixture/actions/workflows --jq .workflows")
+    cat <<'JSON'
+[{"id":194,"name":"CI","path":".github/workflows/ci.yml","state":"active"}]
+JSON
+    ;;
+  "run view --repo owner/actions-fixture 19401 --json attempt,conclusion,createdAt,databaseId,displayTitle,event,headBranch,headSha,name,number,startedAt,status,updatedAt,url,workflowDatabaseId,workflowName")
+    cat <<'JSON'
+{"databaseId":19401,"name":"Inspectable Actions fixture","headBranch":"issue194","headSha":"abc194","number":194,"event":"push","status":"completed","conclusion":"failure","workflowName":"CI","createdAt":"2026-07-14T00:00:00Z","updatedAt":"2026-07-14T00:01:00Z"}
+JSON
+    ;;
+  "run view --repo owner/actions-fixture 19401 --json jobs --jq .jobs")
+    cat <<'JSON'
+[{"databaseId":19411,"name":"build-linux-with-a-long-job-name","status":"completed","conclusion":"success","steps":[{"name":"Checkout fixture source","status":"completed","conclusion":"success","number":1},{"name":"Compile fixture application","status":"completed","conclusion":"success","number":2}]},{"databaseId":19412,"name":"test-suite-with-a-long-job-name","status":"completed","conclusion":"failure","steps":[{"name":"Run failing fixture tests","status":"completed","conclusion":"failure","number":1}]},{"databaseId":19413,"name":"publish-artifacts","status":"completed","conclusion":"skipped","steps":[]}]
+JSON
+    ;;
+  *)
+    printf 'REJECTED %s
+' "$*" >> "$AUDIT"
+    printf 'REJECTED unexpected gh argv: ' >&2
+    printf '%q ' "$@" >&2
+    printf '\n' >&2
+    exit 64
+    ;;
+esac

--- a/scripts/issue194-run-scenario.sh
+++ b/scripts/issue194-run-scenario.sh
@@ -17,7 +17,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-for command_name in cargo tmux; do
+for command_name in cargo python3 tmux; do
   command -v "$command_name" >/dev/null || { echo "FATAL: $command_name is required" >&2; exit 1; }
 done
 
@@ -27,22 +27,41 @@ schema_version = 1
 theme = "green-screen"
 override_agent_theme = false
 EOF
-cat > "$CONFIG/state.json" <<EOF
-{
-  "schema_version": 1,
-  "repositories": [{
-    "id": "issue194-repo", "name": "actions-fixture", "slug": "actions-fixture",
-    "base_dir": "$REPO", "default_profile": "", "default_code_puppy_model": "",
-    "github_repo": "owner/actions-fixture",
-    "remote": {"enabled": false, "host": "", "user": "", "port": null},
-    "issue_base_prompt": "", "default_agent_kind": "llxprt", "agent_ids": []
-  }],
-  "agents": [], "selected_repository_index": 0, "selected_agent_index": null,
-  "hide_idle_repositories": false, "last_selected_agent_by_repo": [],
-  "pane_focus": "", "terminal_focused": false, "user_preferences": {}
+python3 - "$REPO" "$CONFIG/state.json" <<'PY'
+import json
+import sys
+
+repo, output = sys.argv[1:]
+state = {
+    "schema_version": 1,
+    "repositories": [{
+        "id": "issue194-repo",
+        "name": "actions-fixture",
+        "slug": "actions-fixture",
+        "base_dir": repo,
+        "default_profile": "",
+        "default_code_puppy_model": "",
+        "github_repo": "owner/actions-fixture",
+        "remote": {"enabled": False, "host": "", "user": "", "port": None},
+        "issue_base_prompt": "",
+        "default_agent_kind": "llxprt",
+        "agent_ids": [],
+    }],
+    "agents": [],
+    "selected_repository_index": 0,
+    "selected_agent_index": None,
+    "hide_idle_repositories": False,
+    "last_selected_agent_by_repo": [],
+    "pane_focus": "",
+    "terminal_focused": False,
+    "user_preferences": {},
 }
-EOF
-cp "$ROOT/scripts/issue194-gh-shim.sh" "$SHIM_BIN/gh"
+with open(output, "w", encoding="utf-8") as stream:
+    json.dump(state, stream)
+PY
+SHIM_SOURCE="$ROOT/scripts/issue194-gh-shim.sh"
+[[ -s "$SHIM_SOURCE" ]] || { echo "FATAL: missing or empty gh shim: $SHIM_SOURCE" >&2; exit 1; }
+cp "$SHIM_SOURCE" "$SHIM_BIN/gh"
 chmod +x "$SHIM_BIN/gh"
 
 (cd "$ROOT" && cargo build --locked --bin jefe --bin jefe-tmux-harness)

--- a/scripts/issue194-run-scenario.sh
+++ b/scripts/issue194-run-scenario.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+ARTIFACT="$ROOT/target/tmux-harness/issue194-$$"
+CONFIG="$ARTIFACT/config"
+SHIM_BIN="$ARTIFACT/bin"
+REPO="$ARTIFACT/repo"
+AUDIT="$ARTIFACT/gh-audit.log"
+SESSION="jefe-issue194-$$"
+
+cleanup() {
+  if tmux has-session -t "$SESSION" 2>/dev/null; then
+    tmux kill-session -t "$SESSION" || echo "WARN: failed to stop tmux session $SESSION" >&2
+  fi
+  rm -rf "$ARTIFACT"
+}
+trap cleanup EXIT
+
+for command_name in cargo tmux; do
+  command -v "$command_name" >/dev/null || { echo "FATAL: $command_name is required" >&2; exit 1; }
+done
+
+mkdir -p "$CONFIG" "$SHIM_BIN" "$REPO"
+cat > "$CONFIG/settings.toml" <<'EOF'
+schema_version = 1
+theme = "green-screen"
+override_agent_theme = false
+EOF
+cat > "$CONFIG/state.json" <<EOF
+{
+  "schema_version": 1,
+  "repositories": [{
+    "id": "issue194-repo", "name": "actions-fixture", "slug": "actions-fixture",
+    "base_dir": "$REPO", "default_profile": "", "default_code_puppy_model": "",
+    "github_repo": "owner/actions-fixture",
+    "remote": {"enabled": false, "host": "", "user": "", "port": null},
+    "issue_base_prompt": "", "default_agent_kind": "llxprt", "agent_ids": []
+  }],
+  "agents": [], "selected_repository_index": 0, "selected_agent_index": null,
+  "hide_idle_repositories": false, "last_selected_agent_by_repo": [],
+  "pane_focus": "", "terminal_focused": false, "user_preferences": {}
+}
+EOF
+cp "$ROOT/scripts/issue194-gh-shim.sh" "$SHIM_BIN/gh"
+chmod +x "$SHIM_BIN/gh"
+
+(cd "$ROOT" && cargo build --locked --bin jefe --bin jefe-tmux-harness)
+env PATH="$SHIM_BIN:$PATH" GH_SHIM_AUDIT="$AUDIT" \
+  "$ROOT/target/debug/jefe-tmux-harness" \
+  --scenario "$ROOT/dev-docs/tmux-scenarios/actions-mode.json" \
+  --jefe-bin "$ROOT/target/debug/jefe" \
+  --config "$CONFIG" --out-dir "$ARTIFACT" --session "$SESSION"
+
+[[ -s "$AUDIT" ]] || { echo "FATAL: gh shim was not invoked" >&2; exit 1; }
+if grep -q REJECTED "$AUDIT"; then cat "$AUDIT" >&2; exit 1; fi
+for expected in "actions/runs?page=1&per_page=30" "actions/workflows" "run view --repo owner/actions-fixture 19401" "--json jobs --jq .jobs"; do
+  grep -F -- "$expected" "$AUDIT" >/dev/null || { echo "FATAL: missing audit operation: $expected" >&2; cat "$AUDIT" >&2; exit 1; }
+done
+printf 'PASS: issue 194 Actions scenario and read-only gh audit\n'

--- a/src/actions_detail_view.rs
+++ b/src/actions_detail_view.rs
@@ -45,6 +45,9 @@ impl ActionsDetailProjection {
     }
 
     /// Clamp an offset and reveal the focused job within the display viewport.
+    ///
+    /// A zero-height viewport retains a bounded document-row anchor so a later
+    /// resize can reveal the same focused job without losing its position.
     #[must_use]
     pub fn reveal_focused_job(&self, offset: usize, viewport_rows: usize) -> usize {
         let max = self.max_scroll_offset(viewport_rows);
@@ -150,9 +153,19 @@ fn status_glyph(
     match status {
         WorkflowRunStatus::Completed => match conclusion {
             Some(WorkflowRunConclusion::Success) => "\u{2713}",
-            Some(WorkflowRunConclusion::Failure) => "\u{2717}",
-            Some(WorkflowRunConclusion::Cancelled | WorkflowRunConclusion::Skipped) => "\u{2298}",
-            _ => "?",
+            Some(
+                WorkflowRunConclusion::Failure
+                | WorkflowRunConclusion::TimedOut
+                | WorkflowRunConclusion::ActionRequired
+                | WorkflowRunConclusion::StartupFailure,
+            ) => "\u{2717}",
+            Some(
+                WorkflowRunConclusion::Cancelled
+                | WorkflowRunConclusion::Skipped
+                | WorkflowRunConclusion::Stale
+                | WorkflowRunConclusion::Neutral,
+            ) => "\u{2298}",
+            Some(WorkflowRunConclusion::Unknown) | None => "?",
         },
         WorkflowRunStatus::InProgress => "~",
         WorkflowRunStatus::Queued

--- a/src/actions_detail_view.rs
+++ b/src/actions_detail_view.rs
@@ -1,0 +1,286 @@
+//! Pure Actions job-detail geometry and wrapped display-row projection.
+//!
+//! This module is the single iocraft-free source of truth for job focus
+//! normalization, status text, wrapping, scroll bounds, and focus reveal.
+
+use std::collections::HashSet;
+use std::hash::BuildHasher;
+
+use crate::domain::{WorkflowRunConclusion, WorkflowRunDetail, WorkflowRunStatus};
+use crate::layout::ActionsDetailGeometry;
+use crate::text_wrap::wrap_text;
+
+/// One wrapped row rendered in the Actions detail document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActionsDetailRow {
+    /// Plain text rendered for this display row.
+    pub text: String,
+    /// Job owning this row when it is part of a job heading.
+    pub job_index: Option<usize>,
+}
+
+/// Complete wrapped Actions detail projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActionsDetailProjection {
+    /// Display rows in document order.
+    pub rows: Vec<ActionsDetailRow>,
+    /// Normalized job focus used by both renderer and reducer transitions.
+    pub focused_job_index: Option<usize>,
+}
+
+impl ActionsDetailProjection {
+    /// Return the first display row occupied by the focused job heading.
+    #[must_use]
+    pub fn focused_job_row(&self) -> Option<usize> {
+        let focused = self.focused_job_index?;
+        self.rows
+            .iter()
+            .position(|row| row.job_index == Some(focused))
+    }
+
+    /// Return the greatest valid display-row scroll offset.
+    #[must_use]
+    pub fn max_scroll_offset(&self, viewport_rows: usize) -> usize {
+        self.rows.len().saturating_sub(viewport_rows)
+    }
+
+    /// Clamp an offset and reveal the focused job within the display viewport.
+    #[must_use]
+    pub fn reveal_focused_job(&self, offset: usize, viewport_rows: usize) -> usize {
+        let max = self.max_scroll_offset(viewport_rows);
+        let current = offset.min(max);
+        let Some(row) = self.focused_job_row() else {
+            return current;
+        };
+        if viewport_rows == 0 || row < current {
+            return row.min(max);
+        }
+        if row >= current.saturating_add(viewport_rows) {
+            return row.saturating_add(1).saturating_sub(viewport_rows).min(max);
+        }
+        current
+    }
+
+    /// Join projected display rows into the pre-wrapped renderer document.
+    #[must_use]
+    pub fn content(&self) -> String {
+        self.rows
+            .iter()
+            .map(|row| row.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+/// Normalize a possibly stale job index against the loaded detail.
+#[must_use]
+pub fn normalize_job_focus(
+    detail: &WorkflowRunDetail,
+    focused_job_index: Option<usize>,
+) -> Option<usize> {
+    let last = detail.jobs.len().checked_sub(1)?;
+    Some(focused_job_index.unwrap_or(0).min(last))
+}
+
+/// Project a run detail into the exact wrapped rows consumed by the renderer.
+#[must_use]
+pub fn project_actions_detail<S: BuildHasher>(
+    detail: &WorkflowRunDetail,
+    expanded_jobs: &HashSet<u64, S>,
+    focused_job_index: Option<usize>,
+    geometry: ActionsDetailGeometry,
+) -> ActionsDetailProjection {
+    let focused_job_index = normalize_job_focus(detail, focused_job_index);
+    let mut rows = Vec::new();
+    push_wrapped_row(&mut rows, String::new(), None, geometry.content_width);
+    push_wrapped_row(&mut rows, "Jobs:".to_string(), None, geometry.content_width);
+    for (job_index, job) in detail.jobs.iter().enumerate() {
+        let expanded = expanded_jobs.contains(&job.id);
+        let marker = if focused_job_index == Some(job_index) {
+            ">"
+        } else {
+            " "
+        };
+        let indicator = if expanded { "\u{25BE}" } else { "\u{25B8}" };
+        let glyph = status_glyph(job.status, job.conclusion);
+        push_wrapped_row(
+            &mut rows,
+            format!("{marker} {indicator} {glyph} {}", job.name),
+            Some(job_index),
+            geometry.content_width,
+        );
+        if expanded {
+            for step in &job.steps {
+                let glyph = status_glyph(step.status, step.conclusion);
+                push_wrapped_row(
+                    &mut rows,
+                    format!("  {glyph} [{}] {}", step.number, step.name),
+                    None,
+                    geometry.content_width,
+                );
+            }
+        }
+    }
+    ActionsDetailProjection {
+        rows,
+        focused_job_index,
+    }
+}
+
+fn push_wrapped_row(
+    rows: &mut Vec<ActionsDetailRow>,
+    text: String,
+    job_index: Option<usize>,
+    width: usize,
+) {
+    rows.extend(
+        wrap_text(&text, width)
+            .into_iter()
+            .map(|row| ActionsDetailRow {
+                text: row.text,
+                job_index,
+            }),
+    );
+}
+
+fn status_glyph(
+    status: WorkflowRunStatus,
+    conclusion: Option<WorkflowRunConclusion>,
+) -> &'static str {
+    match status {
+        WorkflowRunStatus::Completed => match conclusion {
+            Some(WorkflowRunConclusion::Success) => "\u{2713}",
+            Some(WorkflowRunConclusion::Failure) => "\u{2717}",
+            Some(WorkflowRunConclusion::Cancelled | WorkflowRunConclusion::Skipped) => "\u{2298}",
+            _ => "?",
+        },
+        WorkflowRunStatus::InProgress => "~",
+        WorkflowRunStatus::Queued
+        | WorkflowRunStatus::Requested
+        | WorkflowRunStatus::Waiting
+        | WorkflowRunStatus::Pending => ".",
+        WorkflowRunStatus::Unknown => "?",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{WorkflowRun, WorkflowRunJob, WorkflowRunStep};
+
+    fn run() -> WorkflowRun {
+        WorkflowRun {
+            id: 1,
+            name: "run".to_string(),
+            head_branch: "main".to_string(),
+            head_sha: "abc".to_string(),
+            run_number: 1,
+            event: "push".to_string(),
+            status: WorkflowRunStatus::Completed,
+            conclusion: Some(WorkflowRunConclusion::Success),
+            workflow_name: "CI".to_string(),
+            created_at: "now".to_string(),
+            updated_at: "now".to_string(),
+        }
+    }
+
+    fn job(id: u64, name: &str, step_name: &str) -> WorkflowRunJob {
+        WorkflowRunJob {
+            id,
+            name: name.to_string(),
+            status: WorkflowRunStatus::Completed,
+            conclusion: Some(if id == 2 {
+                WorkflowRunConclusion::Failure
+            } else {
+                WorkflowRunConclusion::Success
+            }),
+            steps: vec![WorkflowRunStep {
+                name: step_name.to_string(),
+                status: WorkflowRunStatus::Completed,
+                conclusion: Some(if id == 2 {
+                    WorkflowRunConclusion::Failure
+                } else {
+                    WorkflowRunConclusion::Success
+                }),
+                number: 1,
+            }],
+        }
+    }
+
+    fn detail() -> WorkflowRunDetail {
+        WorkflowRunDetail {
+            run: run(),
+            jobs: vec![
+                job(
+                    1,
+                    "a very long build job heading",
+                    "a very long checkout step name",
+                ),
+                job(2, "test", "failing tests"),
+                job(3, "final deployment job", "publish"),
+            ],
+        }
+    }
+
+    fn geometry(width: usize, rows: usize) -> ActionsDetailGeometry {
+        ActionsDetailGeometry {
+            viewport_rows: rows,
+            content_width: width,
+        }
+    }
+
+    #[test]
+    fn narrow_projection_wraps_job_and_step_and_preserves_status_glyphs() {
+        let detail = detail();
+        let expanded = HashSet::from([1, 2]);
+        let view = project_actions_detail(&detail, &expanded, Some(1), geometry(10, 4));
+
+        assert!(
+            view.rows.len() > 10,
+            "long job and step text must add display rows"
+        );
+        assert_eq!(view.focused_job_index, Some(1));
+        assert!(view.content().contains('\u{2713}'));
+        assert!(view.content().contains('\u{2717}'));
+        assert!(view.rows.iter().all(|row| row.text.chars().count() <= 10));
+    }
+
+    #[test]
+    fn final_job_reveal_uses_wrapped_predecessor_rows_and_valid_bounds() {
+        let detail = detail();
+        let expanded = HashSet::from([1, 2]);
+        let view = project_actions_detail(&detail, &expanded, Some(2), geometry(9, 3));
+        let offset = view.reveal_focused_job(0, 3);
+        let focused = view.focused_job_row().unwrap_or_default();
+
+        assert!(focused >= offset && focused < offset + 3);
+        assert!(offset <= view.max_scroll_offset(3));
+        assert!(
+            focused > 6,
+            "wrapped long job and step rows must shift the final job"
+        );
+    }
+
+    #[test]
+    fn zero_width_and_zero_viewport_keep_projection_and_bounds_total() {
+        let detail = detail();
+        let view = project_actions_detail(&detail, &HashSet::new(), Some(99), geometry(0, 0));
+
+        assert_eq!(view.focused_job_index, Some(2));
+        assert!(view.rows.iter().all(|row| row.text.is_empty()));
+        assert!(view.reveal_focused_job(usize::MAX, 0) <= view.max_scroll_offset(0));
+    }
+
+    #[test]
+    fn empty_jobs_normalize_focus_to_none() {
+        let detail = WorkflowRunDetail {
+            run: run(),
+            jobs: Vec::new(),
+        };
+        let view = project_actions_detail(&detail, &HashSet::new(), Some(9), geometry(5, 2));
+
+        assert_eq!(view.focused_job_index, None);
+        assert_eq!(view.focused_job_row(), None);
+        assert_eq!(view.rows.len(), 2);
+    }
+}

--- a/src/actions_view.rs
+++ b/src/actions_view.rs
@@ -1,12 +1,10 @@
-//! Pure GitHub Actions list and detail viewport projections.
+//! Pure GitHub Actions run-list viewport projection.
 //!
-//! This module is iocraft-free and side-effect-free: it maps the actions state
-//! (runs, selected index, details, scrolling offset) plus viewport heights
-//! into windowed display projections. This makes the scrolling math and layout
-//! logic fully unit-testable without a terminal.
+//! This iocraft-free module maps loaded runs and list geometry into a stable
+//! selection-following window. Job-detail projection lives in
+//! [`crate::actions_detail_view`].
 
-use crate::domain::{WorkflowRun, WorkflowRunConclusion, WorkflowRunDetail, WorkflowRunStatus};
-use std::collections::HashSet;
+use crate::domain::{WorkflowRun, WorkflowRunConclusion, WorkflowRunStatus};
 
 /// A single run in the projected runs list view.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,51 +45,17 @@ pub fn project_runs_list(
             total_runs_count: 0,
         };
     }
-
-    // Clamp selected index defensively (it may briefly exceed len during async
-    // updates, and slicing with an out-of-bounds index would panic).
     let selected_idx = selected_run_index.unwrap_or(0).min(runs.len() - 1);
-    // The window's start must leave room for a full viewport below it when the
-    // list is long enough. Using `runs.len() - 1` as the cap lets the window
-    // slide all the way to the last item, which can show fewer than
-    // `list_viewport_height` runs even when a full page would fit. Cap at
-    // `runs.len() - list_viewport_height` (saturating) so the window fills the
-    // viewport whenever possible; when the list is shorter than the viewport,
-    // this saturates to 0 (show everything from the top).
     let max_first_visible = runs.len().saturating_sub(list_viewport_height);
     let first_visible_run = selected_idx
         .saturating_sub(list_viewport_height / 2)
         .min(max_first_visible);
-
     let end = (first_visible_run + list_viewport_height).min(runs.len());
-    let visible_slice = if first_visible_run >= runs.len() {
-        &[]
-    } else {
-        &runs[first_visible_run..end]
-    };
-
-    let visible_runs = visible_slice
+    let visible_runs = runs[first_visible_run..end]
         .iter()
         .enumerate()
-        .map(|(i, r)| {
-            let actual_idx = first_visible_run + i;
-            ProjectedRun {
-                id: r.id,
-                name: r.name.clone(),
-                head_branch: r.head_branch.clone(),
-                head_sha: r.head_sha.clone(),
-                run_number: r.run_number,
-                event: r.event.clone(),
-                workflow_name: r.workflow_name.clone(),
-                created_at: r.created_at.clone(),
-                updated_at: r.updated_at.clone(),
-                status: r.status,
-                conclusion: r.conclusion,
-                is_selected: selected_run_index == Some(actual_idx),
-            }
-        })
+        .map(|(offset, run)| projected_run(run, first_visible_run + offset, selected_run_index))
         .collect();
-
     ActionsRunListView {
         visible_runs,
         first_visible_run_index: first_visible_run,
@@ -99,139 +63,28 @@ pub fn project_runs_list(
     }
 }
 
-/// Count the total rendered content lines for a workflow run detail.
-///
-/// This is the pure line-count helper used by the scroll-clamp logic in
-/// `actions_ops.rs`. When a job is collapsed (not in `expanded_jobs`), only
-/// its JobRow line is counted; when expanded, its StepRows are also counted.
-/// Always counts: 1 header + 1 section title + 1 line per job.
-#[must_use]
-pub fn detail_line_count<S: ::std::hash::BuildHasher>(
-    detail: &WorkflowRunDetail,
-    expanded_jobs: &HashSet<u64, S>,
-) -> usize {
-    let mut count = 2; // Header + "Jobs:" section title
-    for job in &detail.jobs {
-        count += 1; // JobRow
-        if expanded_jobs.contains(&job.id) {
-            count += job.steps.len(); // StepRows (only when expanded)
-        }
-    }
-    count
-}
-
-/// A structured line in the projected run details view.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DetailLine {
-    Header {
-        workflow_name: String,
-        event: String,
-        head_branch: String,
-        head_sha: String,
-        created_at: String,
-        updated_at: String,
-    },
-    SectionTitle {
-        title: String,
-    },
-    JobRow {
-        job_id: u64,
-        name: String,
-        status: crate::domain::WorkflowRunStatus,
-        conclusion: Option<crate::domain::WorkflowRunConclusion>,
-        expanded: bool,
-    },
-    StepRow {
-        number: u32,
-        name: String,
-        status: crate::domain::WorkflowRunStatus,
-        conclusion: Option<crate::domain::WorkflowRunConclusion>,
-    },
-}
-
-/// The projected window of run details (jobs/steps).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ActionsDetailView {
-    pub visible_lines: Vec<DetailLine>,
-    pub total_lines_count: usize,
-}
-
-/// Project the workflow run details into a scroll-windowed view.
-///
-/// Jobs not in `expanded_jobs` render as a single JobRow; expanded jobs also
-/// render their StepRows. The JobRow carries an `expanded` flag so the
-/// renderer can show the `\u{25B8}`/`\u{25BE}` indicator.
-#[must_use]
-pub fn project_detail_view<S: ::std::hash::BuildHasher>(
-    detail: &WorkflowRunDetail,
-    detail_scroll_offset: usize,
-    detail_viewport_height: usize,
-    expanded_jobs: &HashSet<u64, S>,
-) -> ActionsDetailView {
-    let mut lines = Vec::new();
-
-    lines.push(DetailLine::Header {
-        workflow_name: detail.run.workflow_name.clone(),
-        event: detail.run.event.clone(),
-        head_branch: detail.run.head_branch.clone(),
-        head_sha: detail.run.head_sha.clone(),
-        created_at: detail.run.created_at.clone(),
-        updated_at: detail.run.updated_at.clone(),
-    });
-
-    lines.push(DetailLine::SectionTitle {
-        title: "Jobs:".to_string(),
-    });
-
-    for job in &detail.jobs {
-        let is_expanded = expanded_jobs.contains(&job.id);
-        lines.push(DetailLine::JobRow {
-            job_id: job.id,
-            name: job.name.clone(),
-            status: job.status,
-            conclusion: job.conclusion,
-            expanded: is_expanded,
-        });
-
-        if is_expanded {
-            for step in &job.steps {
-                lines.push(DetailLine::StepRow {
-                    number: step.number,
-                    name: step.name.clone(),
-                    status: step.status,
-                    conclusion: step.conclusion,
-                });
-            }
-        }
-    }
-
-    let total_lines_count = lines.len();
-    let start = detail_scroll_offset.min(total_lines_count.saturating_sub(1));
-    let visible_lines = if lines.is_empty() {
-        Vec::new()
-    } else {
-        lines
-            .into_iter()
-            .skip(start)
-            .take(detail_viewport_height)
-            .collect()
-    };
-
-    ActionsDetailView {
-        visible_lines,
-        total_lines_count,
+fn projected_run(run: &WorkflowRun, index: usize, selected: Option<usize>) -> ProjectedRun {
+    ProjectedRun {
+        id: run.id,
+        name: run.name.clone(),
+        head_branch: run.head_branch.clone(),
+        head_sha: run.head_sha.clone(),
+        run_number: run.run_number,
+        event: run.event.clone(),
+        workflow_name: run.workflow_name.clone(),
+        created_at: run.created_at.clone(),
+        updated_at: run.updated_at.clone(),
+        status: run.status,
+        conclusion: run.conclusion,
+        is_selected: selected == Some(index),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{
-        WorkflowRun, WorkflowRunConclusion, WorkflowRunDetail, WorkflowRunJob, WorkflowRunStatus,
-        WorkflowRunStep,
-    };
 
-    fn make_run(id: u64) -> WorkflowRun {
+    fn run(id: u64) -> WorkflowRun {
         WorkflowRun {
             id,
             name: format!("run {id}"),
@@ -248,417 +101,48 @@ mod tests {
     }
 
     #[test]
-    fn test_project_runs_list_scrolling() {
-        let runs: Vec<WorkflowRun> = (0..10).map(make_run).collect();
+    fn selection_is_centered_when_possible() {
+        let runs: Vec<_> = (0..10).map(run).collect();
+        let view = project_runs_list(&runs, Some(5), 3);
 
-        // 3 viewport size, selected index 5 (middle)
-        let projection = project_runs_list(&runs, Some(5), 3);
-        assert_eq!(projection.first_visible_run_index, 4);
-        assert_eq!(projection.visible_runs.len(), 3);
-        assert_eq!(projection.visible_runs[0].id, 4);
-        assert_eq!(projection.visible_runs[1].id, 5);
-        assert!(projection.visible_runs[1].is_selected);
-        assert_eq!(projection.visible_runs[2].id, 6);
+        assert_eq!(view.first_visible_run_index, 4);
+        assert_eq!(view.visible_runs.len(), 3);
+        assert!(view.visible_runs[1].is_selected);
     }
 
     #[test]
-    fn test_project_runs_list_empty_no_panic() {
-        let projection = project_runs_list(&[], None, 5);
-        assert!(projection.visible_runs.is_empty());
-        assert_eq!(projection.first_visible_run_index, 0);
-        assert_eq!(projection.total_runs_count, 0);
+    fn final_page_stays_full() {
+        let runs: Vec<_> = (0..7).map(run).collect();
+        let view = project_runs_list(&runs, Some(6), 5);
+
+        assert_eq!(view.first_visible_run_index, 2);
+        assert_eq!(view.visible_runs.len(), 5);
+        assert!(view.visible_runs.last().is_some_and(|run| run.id == 6));
     }
 
     #[test]
-    fn test_project_runs_list_zero_height_viewport() {
-        let runs: Vec<WorkflowRun> = (0..5).map(make_run).collect();
-        let projection = project_runs_list(&runs, Some(2), 0);
-        // Zero-height viewport: no visible runs but no panic.
-        assert!(projection.visible_runs.is_empty());
-        assert_eq!(projection.total_runs_count, 5);
+    fn empty_and_zero_height_are_total() {
+        assert!(project_runs_list(&[], None, 5).visible_runs.is_empty());
+        let runs: Vec<_> = (0..3).map(run).collect();
+        assert!(project_runs_list(&runs, Some(2), 0).visible_runs.is_empty());
     }
 
     #[test]
-    fn test_project_runs_list_stale_selected_eq_len_no_panic() {
-        let runs: Vec<WorkflowRun> = vec![make_run(0), make_run(1), make_run(2)];
-        // selected_run_index == runs.len() (3 == 3) — stale, must not panic.
-        let projection = project_runs_list(&runs, Some(3), 5);
-        assert_eq!(projection.total_runs_count, 3);
-        // The clamped index should be 2 (len-1), not 3.
-        assert!(
-            projection.visible_runs.iter().all(|r| r.id <= 2),
-            "clamped selection must not exceed last index"
-        );
+    fn short_list_stays_visible_from_the_top() {
+        let runs: Vec<_> = (0..2).map(run).collect();
+        let view = project_runs_list(&runs, Some(1), 5);
+
+        assert_eq!(view.first_visible_run_index, 0);
+        assert_eq!(view.visible_runs.len(), 2);
+        assert!(view.visible_runs[1].is_selected);
     }
 
     #[test]
-    fn test_project_runs_list_stale_selected_greatly_exceeds_len_no_panic() {
-        let runs: Vec<WorkflowRun> = vec![make_run(0), make_run(1)];
-        // selected_run_index >> runs.len() — extremely stale, must not panic.
-        let projection = project_runs_list(&runs, Some(999), 3);
-        assert_eq!(projection.total_runs_count, 2);
-        assert!(
-            projection.visible_runs.iter().all(|r| r.id <= 1),
-            "greatly-exceeding selection must clamp to valid range"
-        );
-    }
+    fn stale_selection_clamps_window_without_marking_invalid_row() {
+        let runs: Vec<_> = (0..3).map(run).collect();
+        let view = project_runs_list(&runs, Some(99), 2);
 
-    #[test]
-    fn test_project_runs_list_final_partial_page() {
-        let runs: Vec<WorkflowRun> = (0..7).map(make_run).collect();
-        // Select the last run (index 6) with a 5-row viewport. The window
-        // start is clamped to len-viewport = 7-5 = 2 so a full 5-row page fits
-        // (runs 2..7) rather than sliding to show only a partial tail.
-        let projection = project_runs_list(&runs, Some(6), 5);
-        assert_eq!(
-            projection.first_visible_run_index, 2,
-            "window start must leave room for a full viewport"
-        );
-        assert_eq!(
-            projection.visible_runs.len(),
-            5,
-            "a full page must fit when the list is longer than the viewport"
-        );
-        assert_eq!(projection.total_runs_count, 7);
-        // The selected (last) run should be visible.
-        assert!(
-            projection.visible_runs.last().is_some_and(|r| r.id == 6),
-            "final page must include the last run"
-        );
-    }
-
-    #[test]
-    fn test_project_runs_list_short_list_shows_all_from_top() {
-        // When the list is shorter than the viewport, the window start
-        // saturates to 0 and everything is shown from the top.
-        let runs: Vec<WorkflowRun> = vec![make_run(0), make_run(1)];
-        let projection = project_runs_list(&runs, Some(1), 5);
-        assert_eq!(projection.first_visible_run_index, 0);
-        assert_eq!(projection.visible_runs.len(), 2);
-    }
-
-    #[test]
-    fn test_project_detail_view_scrolling_and_clamp() {
-        let detail = WorkflowRunDetail {
-            run: make_run(0),
-            jobs: vec![WorkflowRunJob {
-                id: 0,
-                name: "build".to_string(),
-                status: WorkflowRunStatus::Completed,
-                conclusion: Some(WorkflowRunConclusion::Success),
-                steps: vec![
-                    WorkflowRunStep {
-                        name: "checkout".to_string(),
-                        status: WorkflowRunStatus::Completed,
-                        conclusion: Some(WorkflowRunConclusion::Success),
-                        number: 1,
-                    },
-                    WorkflowRunStep {
-                        name: "compile".to_string(),
-                        status: WorkflowRunStatus::Completed,
-                        conclusion: Some(WorkflowRunConclusion::Success),
-                        number: 2,
-                    },
-                ],
-            }],
-        };
-        // All jobs expanded for backward-compat with the original test.
-        let expanded: HashSet<u64> = HashSet::from([0u64]);
-        // 2 (header + section title) + 1 job + 2 steps = 5 lines.
-        assert_eq!(detail_line_count(&detail, &expanded), 5);
-
-        // Normal windowed projection from offset 0 with viewport 3 -> first 3.
-        let view = project_detail_view(&detail, 0, 3, &expanded);
-        assert_eq!(view.total_lines_count, 5);
-        assert_eq!(view.visible_lines.len(), 3);
-
-        // Offset 1 with viewport 3 -> lines 1..4 (3 lines).
-        let view = project_detail_view(&detail, 1, 3, &expanded);
-        assert_eq!(view.visible_lines.len(), 3);
-
-        // Offset past end clamps to last line (4), showing 1 line.
-        let view = project_detail_view(&detail, 999, 3, &expanded);
-        assert_eq!(view.visible_lines.len(), 1);
-    }
-
-    #[test]
-    fn test_project_detail_view_zero_viewport() {
-        let detail = WorkflowRunDetail {
-            run: make_run(0),
-            jobs: Vec::new(),
-        };
-        let expanded = HashSet::new();
-        // Zero-height viewport: no visible lines but no panic.
-        let view = project_detail_view(&detail, 0, 0, &expanded);
-        assert_eq!(view.total_lines_count, 2);
-        assert!(view.visible_lines.is_empty());
-    }
-
-    #[test]
-    fn test_project_detail_view_line_order() {
-        let detail = WorkflowRunDetail {
-            run: make_run(0),
-            jobs: vec![WorkflowRunJob {
-                id: 0,
-                name: "build".to_string(),
-                status: WorkflowRunStatus::Completed,
-                conclusion: Some(WorkflowRunConclusion::Success),
-                steps: vec![WorkflowRunStep {
-                    name: "checkout".to_string(),
-                    status: WorkflowRunStatus::Completed,
-                    conclusion: Some(WorkflowRunConclusion::Success),
-                    number: 1,
-                }],
-            }],
-        };
-        let expanded: HashSet<u64> = HashSet::from([0u64]);
-        // Header -> SectionTitle -> JobRow -> StepRow
-        let view = project_detail_view(&detail, 0, 10, &expanded);
-        assert_eq!(view.visible_lines.len(), 4);
-        assert!(matches!(view.visible_lines[0], DetailLine::Header { .. }));
-        assert!(matches!(
-            view.visible_lines[1],
-            DetailLine::SectionTitle { .. }
-        ));
-        assert!(matches!(view.visible_lines[2], DetailLine::JobRow { .. }));
-        assert!(matches!(view.visible_lines[3], DetailLine::StepRow { .. }));
-    }
-
-    #[test]
-    fn test_detail_line_count_zero_jobs() {
-        let detail = WorkflowRunDetail {
-            run: make_run(0),
-            jobs: Vec::new(),
-        };
-        let expanded = HashSet::new();
-        // 1 header + 1 section title + 0 jobs = 2
-        assert_eq!(detail_line_count(&detail, &expanded), 2);
-    }
-
-    #[test]
-    fn test_detail_line_count_one_job_zero_steps() {
-        let detail = WorkflowRunDetail {
-            run: make_run(0),
-            jobs: vec![WorkflowRunJob {
-                id: 0,
-                name: "build".to_string(),
-                status: WorkflowRunStatus::Completed,
-                conclusion: None,
-                steps: Vec::new(),
-            }],
-        };
-        let expanded = HashSet::new();
-        // 2 + 1 job + 0 steps = 3
-        assert_eq!(detail_line_count(&detail, &expanded), 3);
-    }
-
-    #[test]
-    fn test_detail_line_count_multiple_jobs_and_steps() {
-        let detail = WorkflowRunDetail {
-            run: make_run(0),
-            jobs: vec![
-                WorkflowRunJob {
-                    id: 0,
-                    name: "build".to_string(),
-                    status: WorkflowRunStatus::Completed,
-                    conclusion: Some(WorkflowRunConclusion::Success),
-                    steps: vec![
-                        WorkflowRunStep {
-                            name: "checkout".to_string(),
-                            status: WorkflowRunStatus::Completed,
-                            conclusion: Some(WorkflowRunConclusion::Success),
-                            number: 1,
-                        },
-                        WorkflowRunStep {
-                            name: "compile".to_string(),
-                            status: WorkflowRunStatus::Completed,
-                            conclusion: Some(WorkflowRunConclusion::Success),
-                            number: 2,
-                        },
-                    ],
-                },
-                WorkflowRunJob {
-                    id: 1,
-                    name: "test".to_string(),
-                    status: WorkflowRunStatus::Completed,
-                    conclusion: Some(WorkflowRunConclusion::Success),
-                    steps: vec![WorkflowRunStep {
-                        name: "unit-tests".to_string(),
-                        status: WorkflowRunStatus::Completed,
-                        conclusion: Some(WorkflowRunConclusion::Success),
-                        number: 1,
-                    }],
-                },
-            ],
-        };
-        let expanded: HashSet<u64> = [0u64, 1u64].into_iter().collect();
-        // 2 (header+title) + 1 job + 2 steps + 1 job + 1 step = 7
-        assert_eq!(detail_line_count(&detail, &expanded), 7);
-    }
-
-    // ---- BUG 5: expand/collapse ----
-
-    #[test]
-    fn detail_line_count_all_collapsed() {
-        let detail = WorkflowRunDetail {
-            run: make_run(0),
-            jobs: vec![
-                WorkflowRunJob {
-                    id: 10,
-                    name: "build".to_string(),
-                    status: WorkflowRunStatus::Completed,
-                    conclusion: Some(WorkflowRunConclusion::Success),
-                    steps: vec![
-                        WorkflowRunStep {
-                            name: "checkout".to_string(),
-                            status: WorkflowRunStatus::Completed,
-                            conclusion: Some(WorkflowRunConclusion::Success),
-                            number: 1,
-                        },
-                        WorkflowRunStep {
-                            name: "compile".to_string(),
-                            status: WorkflowRunStatus::Completed,
-                            conclusion: Some(WorkflowRunConclusion::Success),
-                            number: 2,
-                        },
-                    ],
-                },
-                WorkflowRunJob {
-                    id: 20,
-                    name: "test".to_string(),
-                    status: WorkflowRunStatus::Completed,
-                    conclusion: Some(WorkflowRunConclusion::Success),
-                    steps: vec![WorkflowRunStep {
-                        name: "unit-tests".to_string(),
-                        status: WorkflowRunStatus::Completed,
-                        conclusion: Some(WorkflowRunConclusion::Success),
-                        number: 1,
-                    }],
-                },
-            ],
-        };
-        let expanded = HashSet::new();
-        // 2 (header+title) + 2 jobs (collapsed, no steps) = 4
-        assert_eq!(
-            detail_line_count(&detail, &expanded),
-            2 + 2,
-            "all collapsed: 2 + num_jobs"
-        );
-    }
-
-    #[test]
-    fn detail_line_count_one_job_expanded() {
-        let detail = WorkflowRunDetail {
-            run: make_run(0),
-            jobs: vec![
-                WorkflowRunJob {
-                    id: 10,
-                    name: "build".to_string(),
-                    status: WorkflowRunStatus::Completed,
-                    conclusion: Some(WorkflowRunConclusion::Success),
-                    steps: vec![
-                        WorkflowRunStep {
-                            name: "checkout".to_string(),
-                            status: WorkflowRunStatus::Completed,
-                            conclusion: Some(WorkflowRunConclusion::Success),
-                            number: 1,
-                        },
-                        WorkflowRunStep {
-                            name: "compile".to_string(),
-                            status: WorkflowRunStatus::Completed,
-                            conclusion: Some(WorkflowRunConclusion::Success),
-                            number: 2,
-                        },
-                    ],
-                },
-                WorkflowRunJob {
-                    id: 20,
-                    name: "test".to_string(),
-                    status: WorkflowRunStatus::Completed,
-                    conclusion: Some(WorkflowRunConclusion::Success),
-                    steps: vec![WorkflowRunStep {
-                        name: "unit-tests".to_string(),
-                        status: WorkflowRunStatus::Completed,
-                        conclusion: Some(WorkflowRunConclusion::Success),
-                        number: 1,
-                    }],
-                },
-            ],
-        };
-        let expanded: HashSet<u64> = HashSet::from([10u64]);
-        // 2 + 2 jobs + 2 steps in expanded job 10 = 6
-        assert_eq!(
-            detail_line_count(&detail, &expanded),
-            2 + 2 + 2,
-            "one expanded: 2 + num_jobs + steps_in_expanded_job"
-        );
-    }
-
-    #[test]
-    fn project_detail_view_collapsed_omits_steps() {
-        let detail = WorkflowRunDetail {
-            run: make_run(0),
-            jobs: vec![WorkflowRunJob {
-                id: 10,
-                name: "build".to_string(),
-                status: WorkflowRunStatus::Completed,
-                conclusion: Some(WorkflowRunConclusion::Success),
-                steps: vec![WorkflowRunStep {
-                    name: "checkout".to_string(),
-                    status: WorkflowRunStatus::Completed,
-                    conclusion: Some(WorkflowRunConclusion::Success),
-                    number: 1,
-                }],
-            }],
-        };
-        let expanded = HashSet::new();
-        let view = project_detail_view(&detail, 0, 10, &expanded);
-        // Header + SectionTitle + 1 JobRow (no steps) = 3 lines.
-        assert_eq!(view.visible_lines.len(), 3);
-        // The JobRow must exist but no StepRow.
-        assert!(matches!(view.visible_lines[2], DetailLine::JobRow { .. }));
-        assert!(
-            !view
-                .visible_lines
-                .iter()
-                .any(|l| matches!(l, DetailLine::StepRow { .. })),
-            "collapsed job must not emit StepRows"
-        );
-        // The JobRow must carry expanded: false.
-        assert!(matches!(
-            view.visible_lines[2],
-            DetailLine::JobRow {
-                expanded: false,
-                ..
-            }
-        ));
-    }
-
-    #[test]
-    fn project_detail_view_expanded_includes_steps() {
-        let detail = WorkflowRunDetail {
-            run: make_run(0),
-            jobs: vec![WorkflowRunJob {
-                id: 10,
-                name: "build".to_string(),
-                status: WorkflowRunStatus::Completed,
-                conclusion: Some(WorkflowRunConclusion::Success),
-                steps: vec![WorkflowRunStep {
-                    name: "checkout".to_string(),
-                    status: WorkflowRunStatus::Completed,
-                    conclusion: Some(WorkflowRunConclusion::Success),
-                    number: 1,
-                }],
-            }],
-        };
-        let expanded: HashSet<u64> = HashSet::from([10u64]);
-        let view = project_detail_view(&detail, 0, 10, &expanded);
-        // Header + SectionTitle + 1 JobRow + 1 StepRow = 4 lines.
-        assert_eq!(view.visible_lines.len(), 4);
-        assert!(matches!(
-            view.visible_lines[2],
-            DetailLine::JobRow { expanded: true, .. }
-        ));
-        assert!(matches!(view.visible_lines[3], DetailLine::StepRow { .. }));
+        assert_eq!(view.first_visible_run_index, 1);
+        assert!(view.visible_runs.iter().all(|run| !run.is_selected));
     }
 }

--- a/src/app_input/actions.rs
+++ b/src/app_input/actions.rs
@@ -69,7 +69,9 @@ fn resolve_filter_key_event(state: &AppState, key_event: &KeyEvent) -> Option<Ap
 
 fn resolve_global_actions_key_event(state: &AppState, key_event: &KeyEvent) -> Option<AppEvent> {
     match key_event.code {
-        KeyCode::Esc => Some(AppEvent::ExitActionsMode),
+        KeyCode::Esc if state.actions_state.focus != ActionsFocus::Detail => {
+            Some(AppEvent::ExitActionsMode)
+        }
         KeyCode::Char('r') => Some(AppEvent::ActionsReload),
         KeyCode::Char('f') => Some(AppEvent::ActionsOpenFilterControls),
         KeyCode::Char('/') => Some(AppEvent::ActionsFocusSearchInput),
@@ -111,6 +113,7 @@ fn resolve_focus_key_event(state: &AppState, key_event: &KeyEvent) -> Option<App
             KeyCode::PageDown => Some(AppEvent::ActionsNavigatePageDown),
             KeyCode::Home => Some(AppEvent::ActionsNavigateHome),
             KeyCode::End => Some(AppEvent::ActionsNavigateEnd),
+            KeyCode::Enter => Some(AppEvent::ActionsEnter),
             KeyCode::Left => Some(AppEvent::ActionsCycleFocusReverse),
             KeyCode::Right | KeyCode::Tab => Some(AppEvent::ActionsCycleFocus),
             _ => None,
@@ -120,8 +123,9 @@ fn resolve_focus_key_event(state: &AppState, key_event: &KeyEvent) -> Option<App
             KeyCode::Down => Some(AppEvent::ActionsNavigateJobDown),
             KeyCode::PageUp => Some(AppEvent::ActionsScrollDetailUp),
             KeyCode::PageDown => Some(AppEvent::ActionsScrollDetailDown),
-            KeyCode::Enter | KeyCode::Right => Some(AppEvent::ActionsToggleJobExpand),
+            KeyCode::Enter | KeyCode::Right => Some(AppEvent::ActionsExpandJob),
             KeyCode::Left => Some(AppEvent::ActionsCollapseJob),
+            KeyCode::Esc => Some(AppEvent::ActionsDetailEscape),
             KeyCode::Tab => Some(AppEvent::ActionsCycleFocus),
             _ => None,
         },
@@ -168,6 +172,56 @@ mod tests {
         assert!(matches!(
             resolve_actions_key_event(&state, &clear_all),
             Some(AppEvent::ActionsClearDraftFilter)
+        ));
+    }
+
+    #[test]
+    fn run_list_enter_opens_detail() {
+        let mut state = AppState::default();
+        state.actions_state.focus = ActionsFocus::RunList;
+
+        assert!(matches!(
+            resolve_actions_key_event(&state, &key(KeyCode::Enter)),
+            Some(AppEvent::ActionsEnter)
+        ));
+    }
+
+    #[test]
+    fn detail_enter_and_right_are_expand_only_intents() {
+        let mut state = AppState::default();
+        state.actions_state.focus = ActionsFocus::Detail;
+
+        for code in [KeyCode::Enter, KeyCode::Right] {
+            assert!(matches!(
+                resolve_actions_key_event(&state, &key(code)),
+                Some(AppEvent::ActionsExpandJob)
+            ));
+        }
+    }
+
+    #[test]
+    fn detail_left_collapses_and_escape_uses_contextual_detail_intent() {
+        let mut state = AppState::default();
+        state.actions_state.focus = ActionsFocus::Detail;
+
+        assert!(matches!(
+            resolve_actions_key_event(&state, &key(KeyCode::Left)),
+            Some(AppEvent::ActionsCollapseJob)
+        ));
+        assert!(matches!(
+            resolve_actions_key_event(&state, &key(KeyCode::Esc)),
+            Some(AppEvent::ActionsDetailEscape)
+        ));
+    }
+
+    #[test]
+    fn run_list_escape_still_exits_actions_mode() {
+        let mut state = AppState::default();
+        state.actions_state.focus = ActionsFocus::RunList;
+
+        assert!(matches!(
+            resolve_actions_key_event(&state, &key(KeyCode::Esc)),
+            Some(AppEvent::ExitActionsMode)
         ));
     }
 }

--- a/src/app_input/actions_orchestration.rs
+++ b/src/app_input/actions_orchestration.rs
@@ -66,12 +66,50 @@ fn dispatch_actions_navigation(
     }
 }
 
+/// Synchronize transient Actions geometry through the typed reducer pipeline.
+pub fn synchronize_actions_geometry(
+    app_state: &mut AppStateHandle,
+    term_cols: u16,
+    term_rows: u16,
+) {
+    let (error_visible, filter_open, current) = {
+        let state = app_state.read();
+        (
+            state.actions_state.error.is_some(),
+            state.actions_state.ui.filter_ui_open,
+            (
+                state.actions_state.detail_viewport_rows,
+                state.actions_state.detail_content_width,
+            ),
+        )
+    };
+    let geometry =
+        jefe::layout::actions_detail_geometry(term_cols, term_rows, error_visible, filter_open);
+    if current == (geometry.viewport_rows, geometry.content_width) {
+        return;
+    }
+    let event = AppEvent::ActionsSetDetailGeometry {
+        viewport_rows: geometry.viewport_rows,
+        content_width: geometry.content_width,
+    };
+    let mut state = app_state.write();
+    *state = std::mem::take(&mut *state).apply(event);
+}
+
+fn synchronize_current_actions_geometry(app_state: &mut AppStateHandle) {
+    let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((120, 40));
+    synchronize_actions_geometry(app_state, term_cols, term_rows);
+}
+
 /// Route an `ActionsMessage` to the appropriate dispatcher.
 pub(super) fn dispatch_actions_message(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
     message: ActionsMessage,
 ) {
+    if !matches!(message, ActionsMessage::SetDetailGeometry { .. }) {
+        synchronize_current_actions_geometry(app_state);
+    }
     match message {
         m @ (ActionsMessage::EnterMode
         | ActionsMessage::Reload
@@ -571,16 +609,15 @@ fn dispatch_run_detail_reload(app_state: &mut AppStateHandle, ctx: &SharedContex
         (repo_clone, run_id, request_id)
     };
 
-    {
-        let mut state = app_state.write();
-        state.actions_state.next_detail_request_id = request_id;
-        state.actions_state.detail_pending = Some(jefe::state::ActionsDetailPending {
+    apply_and_persist(
+        app_state,
+        ctx,
+        AppEvent::ActionsBeginDetailReload {
             scope_repo_id: repo.id.clone(),
             run_id,
             request_id,
-        });
-        state.actions_state.loading.detail = true;
-    }
+        },
+    );
 
     let (repo_id, repo_id_panic) = (repo.id.clone(), repo.id.clone());
     gh_async::spawn_gh_task_with_panic(

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -71,6 +71,7 @@ pub use normal::{handle_global_shortcut_key, handle_normal_key_event};
 
 // Re-export the background-refresh orchestration helper so `app_shell` can
 // import it from `app_input` (issue #128).
+pub use actions_orchestration::synchronize_actions_geometry;
 pub use prs_orchestration::request_pr_background_refresh;
 
 // Re-export the PTY-forwarding helpers so `app_shell` can drive the agent

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -11,9 +11,9 @@ use crate::app_input::{
     dispatch_app_event, forward_key_to_pty, handle_f12_toggle, handle_global_shortcut_key,
     handle_mode_auth_key, handle_mode_confirm_key, handle_mode_form_key, handle_mode_help_key,
     handle_mode_search_key, handle_mode_theme_picker_key, handle_normal_key_event, persist_state,
-    request_pr_background_refresh, to_persisted_state, try_ctrl_c_interrupt_passthrough,
-    try_intercept_terminal_scrollback, try_suppress_synthetic_enter,
-    update_paste_enter_suppression,
+    request_pr_background_refresh, synchronize_actions_geometry, to_persisted_state,
+    try_ctrl_c_interrupt_passthrough, try_intercept_terminal_scrollback,
+    try_suppress_synthetic_enter, update_paste_enter_suppression,
 };
 use crate::pty_encoding::PasteEnterSuppression;
 
@@ -460,6 +460,7 @@ fn handle_terminal_event(
     match event {
         TerminalEvent::Resize(cols, rows) => {
             crate::mouse_routing::clear_selection(app_state);
+            synchronize_actions_geometry(app_state, cols, rows);
             handle_resize(ctx, cols, rows);
         }
         TerminalEvent::FullscreenMouse(mouse_event) => {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -410,6 +410,33 @@ pub fn prs_detail_viewport_rows(
     issues_detail_viewport_rows(term_rows, error_visible, filter_controls_open)
 }
 
+/// Complete Actions detail geometry shared by state transitions and rendering.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ActionsDetailGeometry {
+    /// Wrapped display rows visible below the fixed metadata header.
+    pub viewport_rows: usize,
+    /// Character width used by the shared document wrapping projection.
+    pub content_width: usize,
+}
+
+/// Compute Actions detail geometry from terminal dimensions and visible bands.
+#[must_use]
+pub fn actions_detail_geometry(
+    term_cols: u16,
+    term_rows: u16,
+    error_visible: bool,
+    filter_controls_open: bool,
+) -> ActionsDetailGeometry {
+    ActionsDetailGeometry {
+        viewport_rows: prs_detail_viewport_rows(
+            usize::from(term_rows),
+            error_visible,
+            filter_controls_open,
+        ),
+        content_width: usize::from(prs_detail_content_width(term_cols)),
+    }
+}
+
 /// Compute inner content width for issue-list title lines.
 #[must_use]
 pub fn issue_list_content_width(term_cols: u16) -> u16 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //! @plan PLAN-20260216-FIRSTVERSION-V1.P09
 //! @requirement REQ-TECH-001
 
+pub mod actions_detail_view;
 pub mod actions_view;
 pub mod agent_detection;
 pub mod cli;

--- a/src/messages/actions.rs
+++ b/src/messages/actions.rs
@@ -13,11 +13,23 @@ pub enum ActionsMessage {
     Enter,
     CycleFocus,
     CycleFocusReverse,
+    /// Synchronize the renderer's exact wrapped detail geometry.
+    SetDetailGeometry {
+        viewport_rows: usize,
+        content_width: usize,
+    },
     ScrollDetail(ScrollDir),
-    ToggleJobExpand,
+    ExpandJob,
     CollapseJob,
+    DetailEscape,
     NavigateJob(crate::messages::NavDir),
 
+    /// Begin a correlated run-detail reload and clear stale inspection state.
+    BeginDetailReload {
+        scope_repo_id: RepositoryId,
+        run_id: u64,
+        request_id: u64,
+    },
     RunsLoaded {
         scope_repo_id: RepositoryId,
         filter: Box<ActionsFilter>,
@@ -124,10 +136,13 @@ impl ActionsMessage {
             Self::Enter => "ActionsListEnter",
             Self::CycleFocus => "ActionsCycleFocus",
             Self::CycleFocusReverse => "ActionsCycleFocusReverse",
+            Self::SetDetailGeometry { .. } => "ActionsSetDetailGeometry",
             Self::ScrollDetail(_) => "ActionsScrollDetail",
-            Self::ToggleJobExpand => "ActionsToggleJobExpand",
+            Self::ExpandJob => "ActionsExpandJob",
             Self::CollapseJob => "ActionsCollapseJob",
+            Self::DetailEscape => "ActionsDetailEscape",
             Self::NavigateJob(_) => "ActionsNavigateJob",
+            Self::BeginDetailReload { .. } => "ActionsBeginDetailReload",
             Self::RunsLoaded { .. } => "ActionsRunsLoaded",
             Self::RunsLoadFailed { .. } => "ActionsRunsLoadFailed",
             Self::RunsPageLoaded { .. } => "ActionsRunsPageLoaded",

--- a/src/messages/actions_conversion.rs
+++ b/src/messages/actions_conversion.rs
@@ -118,13 +118,7 @@ impl ActionsMessage {
             Self::OpenWorkflowDispatch(workflow) => AppEvent::OpenWorkflowDispatch(workflow),
             Self::CloseWorkflowDispatch => AppEvent::CloseWorkflowDispatch,
             Self::WorkflowDispatchSubmitted { .. } => Self::into_dispatch_submitted(self),
-            Self::WorkflowDispatchSuccess {
-                scope_repo_id,
-                request_id,
-            } => AppEvent::WorkflowDispatchSuccess {
-                scope_repo_id,
-                request_id,
-            },
+            message @ Self::WorkflowDispatchSuccess { .. } => message.into_dispatch_success(),
             Self::WorkflowDispatchFailed { .. } => Self::into_dispatch_failed(self),
         }
     }
@@ -197,7 +191,6 @@ impl ActionsMessage {
             } => AppEvent::ActionsBeginDetailReload {
                 scope_repo_id,
                 run_id,
-
                 request_id,
             },
             _ => unreachable!(),
@@ -210,6 +203,19 @@ impl ActionsMessage {
                 scope_repo_id,
                 request_id,
             } => Self::WorkflowDispatchSuccess {
+                scope_repo_id,
+                request_id,
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    fn into_dispatch_success(self) -> AppEvent {
+        match self {
+            Self::WorkflowDispatchSuccess {
+                scope_repo_id,
+                request_id,
+            } => AppEvent::WorkflowDispatchSuccess {
                 scope_repo_id,
                 request_id,
             },

--- a/src/messages/actions_conversion.rs
+++ b/src/messages/actions_conversion.rs
@@ -23,12 +23,17 @@ impl ActionsMessage {
             AppEvent::ActionsEnter => Self::Enter,
             AppEvent::ActionsCycleFocus => Self::CycleFocus,
             AppEvent::ActionsCycleFocusReverse => Self::CycleFocusReverse,
+            event @ AppEvent::ActionsSetDetailGeometry { .. } => Self::from_detail_geometry(event),
             AppEvent::ActionsScrollDetailUp => Self::ScrollDetail(ScrollDir::Up),
             AppEvent::ActionsScrollDetailDown => Self::ScrollDetail(ScrollDir::Down),
-            AppEvent::ActionsToggleJobExpand => Self::ToggleJobExpand,
+            AppEvent::ActionsExpandJob => Self::ExpandJob,
             AppEvent::ActionsCollapseJob => Self::CollapseJob,
+            AppEvent::ActionsDetailEscape => Self::DetailEscape,
             AppEvent::ActionsNavigateJobUp => Self::NavigateJob(NavDir::Up),
             AppEvent::ActionsNavigateJobDown => Self::NavigateJob(NavDir::Down),
+            event @ AppEvent::ActionsBeginDetailReload { .. } => {
+                Self::from_begin_detail_reload(event)
+            }
             AppEvent::ActionsRunsLoaded { .. } => Self::from_runs_loaded(event),
             AppEvent::ActionsRunsLoadFailed { .. } => Self::from_runs_failed(event),
             AppEvent::ActionsRunsPageLoaded { .. } => Self::from_runs_page_loaded(event),
@@ -56,13 +61,7 @@ impl ActionsMessage {
             AppEvent::OpenWorkflowDispatch(workflow) => Self::OpenWorkflowDispatch(workflow),
             AppEvent::CloseWorkflowDispatch => Self::CloseWorkflowDispatch,
             AppEvent::WorkflowDispatchSubmitted { .. } => Self::from_dispatch_submitted(event),
-            AppEvent::WorkflowDispatchSuccess {
-                scope_repo_id,
-                request_id,
-            } => Self::WorkflowDispatchSuccess {
-                scope_repo_id,
-                request_id,
-            },
+            event @ AppEvent::WorkflowDispatchSuccess { .. } => Self::from_dispatch_success(event),
             AppEvent::WorkflowDispatchFailed { .. } => Self::from_dispatch_failed(event),
             _ => unreachable!("unhandled event for ActionsMessage: {:?}", event),
         }
@@ -79,9 +78,11 @@ impl ActionsMessage {
             Self::Enter => AppEvent::ActionsEnter,
             Self::CycleFocus => AppEvent::ActionsCycleFocus,
             Self::CycleFocusReverse => AppEvent::ActionsCycleFocusReverse,
+            message @ Self::SetDetailGeometry { .. } => message.into_detail_geometry(),
             Self::ScrollDetail(dir) => Self::map_detail_scroll(dir),
-            Self::ToggleJobExpand => AppEvent::ActionsToggleJobExpand,
+            Self::ExpandJob => AppEvent::ActionsExpandJob,
             Self::CollapseJob => AppEvent::ActionsCollapseJob,
+            Self::DetailEscape => AppEvent::ActionsDetailEscape,
             Self::NavigateJob(dir) => match dir {
                 NavDir::Up => AppEvent::ActionsNavigateJobUp,
                 // Job navigation is vertical only; treat any non-Up direction
@@ -89,6 +90,7 @@ impl ActionsMessage {
                 // total without duplicating the Up arm body.
                 _ => AppEvent::ActionsNavigateJobDown,
             },
+            message @ Self::BeginDetailReload { .. } => message.into_begin_detail_reload(),
             Self::RunsLoaded { .. } => Self::into_runs_loaded(self),
             Self::RunsLoadFailed { .. } => Self::into_runs_failed(self),
             Self::RunsPageLoaded { .. } => Self::into_runs_page_loaded(self),
@@ -142,6 +144,76 @@ impl ActionsMessage {
         match dir {
             ScrollDir::Up | ScrollDir::PageUp => AppEvent::ActionsScrollDetailUp,
             ScrollDir::Down | ScrollDir::PageDown => AppEvent::ActionsScrollDetailDown,
+        }
+    }
+
+    fn from_detail_geometry(event: AppEvent) -> Self {
+        match event {
+            AppEvent::ActionsSetDetailGeometry {
+                viewport_rows,
+                content_width,
+            } => Self::SetDetailGeometry {
+                viewport_rows,
+                content_width,
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    fn from_begin_detail_reload(event: AppEvent) -> Self {
+        match event {
+            AppEvent::ActionsBeginDetailReload {
+                scope_repo_id,
+                run_id,
+                request_id,
+            } => Self::BeginDetailReload {
+                scope_repo_id,
+                run_id,
+                request_id,
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    fn into_detail_geometry(self) -> AppEvent {
+        match self {
+            Self::SetDetailGeometry {
+                viewport_rows,
+                content_width,
+            } => AppEvent::ActionsSetDetailGeometry {
+                viewport_rows,
+                content_width,
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    fn into_begin_detail_reload(self) -> AppEvent {
+        match self {
+            Self::BeginDetailReload {
+                scope_repo_id,
+                run_id,
+                request_id,
+            } => AppEvent::ActionsBeginDetailReload {
+                scope_repo_id,
+                run_id,
+
+                request_id,
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    fn from_dispatch_success(event: AppEvent) -> Self {
+        match event {
+            AppEvent::WorkflowDispatchSuccess {
+                scope_repo_id,
+                request_id,
+            } => Self::WorkflowDispatchSuccess {
+                scope_repo_id,
+                request_id,
+            },
+            _ => unreachable!(),
         }
     }
 

--- a/src/messages/event_conversion.rs
+++ b/src/messages/event_conversion.rs
@@ -224,12 +224,15 @@ impl AppMessage {
                 | AppEvent::ActionsEnter
                 | AppEvent::ActionsCycleFocus
                 | AppEvent::ActionsCycleFocusReverse
+                | AppEvent::ActionsSetDetailGeometry { .. }
                 | AppEvent::ActionsScrollDetailUp
                 | AppEvent::ActionsScrollDetailDown
-                | AppEvent::ActionsToggleJobExpand
+                | AppEvent::ActionsExpandJob
                 | AppEvent::ActionsCollapseJob
+                | AppEvent::ActionsDetailEscape
                 | AppEvent::ActionsNavigateJobUp
                 | AppEvent::ActionsNavigateJobDown
+                | AppEvent::ActionsBeginDetailReload { .. }
                 | AppEvent::ActionsRunsLoaded { .. }
                 | AppEvent::ActionsRunsLoadFailed { .. }
                 | AppEvent::ActionsRunsPageLoaded { .. }

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -958,7 +958,7 @@ fn scroll_detail_pane(
     }
     {
         let mut state = app_state.write();
-        refresh_detail_viewport_rows(&mut state, pane, rows);
+        refresh_detail_viewport_rows(&mut state, pane, cols, rows);
     }
     let (current, max) = {
         let state = app_state.read();

--- a/src/mouse_routing_banner_tests.rs
+++ b/src/mouse_routing_banner_tests.rs
@@ -68,11 +68,17 @@ fn no_banner_keeps_issues_workspace_at_row_one_for_mouse_routing() {
 /// workspace (issue #265).
 #[test]
 fn notice_only_banner_reduces_issues_detail_viewport_rows() {
+    let term_cols: u16 = 120;
     let term_rows: u16 = 40;
 
     // Baseline: no banner.
     let mut state_none = AppState::default();
-    refresh_detail_viewport_rows(&mut state_none, SelectablePane::IssueDetail, term_rows);
+    refresh_detail_viewport_rows(
+        &mut state_none,
+        SelectablePane::IssueDetail,
+        term_cols,
+        term_rows,
+    );
     let rows_none = state_none.issues_state.detail_viewport_rows;
 
     // Notice-only banner.
@@ -83,7 +89,12 @@ fn notice_only_banner_reduces_issues_detail_viewport_rows() {
         },
         ..AppState::default()
     };
-    refresh_detail_viewport_rows(&mut state_notice, SelectablePane::IssueDetail, term_rows);
+    refresh_detail_viewport_rows(
+        &mut state_notice,
+        SelectablePane::IssueDetail,
+        term_cols,
+        term_rows,
+    );
     let rows_notice = state_notice.issues_state.detail_viewport_rows;
 
     // Error-only banner (reference).
@@ -94,7 +105,12 @@ fn notice_only_banner_reduces_issues_detail_viewport_rows() {
         },
         ..AppState::default()
     };
-    refresh_detail_viewport_rows(&mut state_error, SelectablePane::IssueDetail, term_rows);
+    refresh_detail_viewport_rows(
+        &mut state_error,
+        SelectablePane::IssueDetail,
+        term_cols,
+        term_rows,
+    );
     let rows_error = state_error.issues_state.detail_viewport_rows;
 
     assert_eq!(

--- a/src/mouse_routing_detail.rs
+++ b/src/mouse_routing_detail.rs
@@ -6,13 +6,14 @@ use jefe::state::AppState;
 pub(super) fn refresh_detail_viewport_rows(
     state: &mut AppState,
     pane: SelectablePane,
+    term_cols: u16,
     term_rows: u16,
 ) {
-    let term_rows = usize::from(term_rows);
+    let term_rows_usize = usize::from(term_rows);
     match pane {
         SelectablePane::IssueDetail => {
             state.issues_state.detail_viewport_rows = jefe::layout::issues_detail_viewport_rows(
-                term_rows,
+                term_rows_usize,
                 jefe::layout::issues_banner_visible(
                     state.issues_state.error.as_deref(),
                     state.issues_state.draft_notice.as_deref(),
@@ -22,17 +23,20 @@ pub(super) fn refresh_detail_viewport_rows(
         }
         SelectablePane::PrDetail => {
             state.prs_state.detail_viewport_rows = jefe::layout::prs_detail_viewport_rows(
-                term_rows,
+                term_rows_usize,
                 state.prs_state.error.is_some(),
                 state.prs_state.filter_ui.controls_open,
             );
         }
         SelectablePane::ActionsDetail => {
-            state.actions_state.detail_viewport_rows = jefe::layout::prs_detail_viewport_rows(
+            let geometry = jefe::layout::actions_detail_geometry(
+                term_cols,
                 term_rows,
                 state.actions_state.error.is_some(),
                 state.actions_state.ui.filter_ui_open,
             );
+            state.actions_state.detail_viewport_rows = geometry.viewport_rows;
+            state.actions_state.detail_content_width = geometry.content_width;
         }
         _ => {}
     }

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -22,7 +22,7 @@ use crate::issue_detail_content::build_detail_content;
 use crate::pr_detail_content::build_pr_detail_content;
 use crate::runtime::TerminalSnapshot;
 use crate::selection::SelectablePane;
-use crate::state::AppState;
+use crate::state::{AppState, ScreenMode};
 use crate::ui::components::issue_detail::issue_detail_header_view;
 use crate::ui::components::issue_list::{IssueListLayout, issue_list_visible_rows};
 use crate::ui::components::pr_detail::pr_detail_header_view;
@@ -373,7 +373,13 @@ fn status_bar_lines(state: &AppState) -> PaneContent {
 /// Keybind bar line that matches the rendered hint text for the active screen
 /// mode, reusing the pure [`keybind_hints_for`] projection.
 fn keybind_bar_lines(state: &AppState) -> PaneContent {
-    let hints = crate::ui::components::keybind_bar::keybind_hints_for(state.screen_mode, false);
+    let actions_focus =
+        (state.screen_mode == ScreenMode::DashboardActions).then_some(state.actions_state.focus);
+    let hints = crate::ui::components::keybind_bar::keybind_hints_for(
+        state.screen_mode,
+        false,
+        actions_focus,
+    );
     PaneContent::new(SelectablePane::KeybindBar, vec![hints.to_string()])
 }
 

--- a/src/state/actions_job_ops.rs
+++ b/src/state/actions_job_ops.rs
@@ -76,9 +76,13 @@ impl AppState {
         viewport_rows: usize,
         content_width: usize,
     ) -> bool {
-        self.actions_state.detail_viewport_rows = viewport_rows;
-        self.actions_state.detail_content_width = content_width;
-        self.follow_focused_job();
+        if self.actions_state.detail_viewport_rows != viewport_rows
+            || self.actions_state.detail_content_width != content_width
+        {
+            self.actions_state.detail_viewport_rows = viewport_rows;
+            self.actions_state.detail_content_width = content_width;
+            self.follow_focused_job();
+        }
         true
     }
 
@@ -146,7 +150,12 @@ impl AppState {
         self.actions_state.focused_job_index = Some(match dir {
             NavDir::Up => current.saturating_sub(1),
             NavDir::Down => current.saturating_add(1).min(last),
-            _ => current,
+            NavDir::PageUp
+            | NavDir::PageDown
+            | NavDir::Home
+            | NavDir::End
+            | NavDir::Next
+            | NavDir::Prev => current,
         });
         self.follow_focused_job();
         true

--- a/src/state/actions_job_ops.rs
+++ b/src/state/actions_job_ops.rs
@@ -1,0 +1,154 @@
+//! Deterministic Actions job-inspection transitions and display-row bounds.
+//!
+//! Reducers in `actions_ops` delegate here so focus normalization, wrapping,
+//! expansion, and scroll-follow all consume one pure detail projection.
+
+use super::{ActionsFocus, AppState};
+use crate::actions_detail_view::{normalize_job_focus, project_actions_detail};
+use crate::layout::ActionsDetailGeometry;
+use crate::messages::{NavDir, ScrollDir};
+
+impl AppState {
+    /// Clear all inspection state immediately when a new run/list load begins.
+    pub(super) fn reset_actions_inspection(&mut self) {
+        self.actions_state.expanded_jobs.clear();
+        self.actions_state.focused_job_index = None;
+        self.actions_state.detail_scroll_offset = 0;
+    }
+
+    fn detail_geometry(&self) -> ActionsDetailGeometry {
+        ActionsDetailGeometry {
+            viewport_rows: self.actions_state.detail_viewport_rows,
+            content_width: self.actions_state.detail_content_width,
+        }
+    }
+
+    fn detail_projection(&self) -> Option<crate::actions_detail_view::ActionsDetailProjection> {
+        let detail = self.actions_state.run_detail.as_ref()?;
+        Some(project_actions_detail(
+            detail,
+            &self.actions_state.expanded_jobs,
+            self.actions_state.focused_job_index,
+            self.detail_geometry(),
+        ))
+    }
+
+    fn normalize_actions_job_focus(&mut self) {
+        self.actions_state.focused_job_index =
+            self.actions_state.run_detail.as_ref().and_then(|detail| {
+                normalize_job_focus(detail, self.actions_state.focused_job_index)
+            });
+    }
+
+    fn max_actions_detail_scroll_offset(&self) -> usize {
+        self.detail_projection().map_or(0, |projection| {
+            projection.max_scroll_offset(self.actions_state.detail_viewport_rows)
+        })
+    }
+
+    /// Public Actions detail bound used by mouse-wheel routing.
+    #[must_use]
+    pub fn actions_max_detail_scroll_offset(&self) -> usize {
+        self.max_actions_detail_scroll_offset()
+    }
+
+    fn clamp_actions_detail_scroll(&mut self) {
+        self.actions_state.detail_scroll_offset = self
+            .actions_state
+            .detail_scroll_offset
+            .min(self.max_actions_detail_scroll_offset());
+    }
+
+    fn follow_focused_job(&mut self) {
+        self.normalize_actions_job_focus();
+        let Some(projection) = self.detail_projection() else {
+            self.actions_state.detail_scroll_offset = 0;
+            return;
+        };
+        self.actions_state.detail_scroll_offset = projection.reveal_focused_job(
+            self.actions_state.detail_scroll_offset,
+            self.actions_state.detail_viewport_rows,
+        );
+    }
+
+    pub(super) fn set_actions_detail_geometry(
+        &mut self,
+        viewport_rows: usize,
+        content_width: usize,
+    ) -> bool {
+        self.actions_state.detail_viewport_rows = viewport_rows;
+        self.actions_state.detail_content_width = content_width;
+        self.follow_focused_job();
+        true
+    }
+
+    pub(super) fn handle_actions_detail_scroll(&mut self, dir: ScrollDir) -> bool {
+        let max = self.max_actions_detail_scroll_offset();
+        let current = self.actions_state.detail_scroll_offset.min(max);
+        self.actions_state.detail_scroll_offset = match dir {
+            ScrollDir::Up => current.saturating_sub(1),
+            ScrollDir::Down => current.saturating_add(1).min(max),
+            ScrollDir::PageUp => current.saturating_sub(super::VIEWPORT_PAGE_JUMP),
+            ScrollDir::PageDown => current.saturating_add(super::VIEWPORT_PAGE_JUMP).min(max),
+        };
+        true
+    }
+
+    fn focused_job_id(&mut self) -> Option<u64> {
+        self.normalize_actions_job_focus();
+        let index = self.actions_state.focused_job_index?;
+        self.actions_state
+            .run_detail
+            .as_ref()?
+            .jobs
+            .get(index)
+            .map(|job| job.id)
+    }
+
+    pub(super) fn expand_actions_job(&mut self) -> bool {
+        if let Some(job_id) = self.focused_job_id() {
+            self.actions_state.expanded_jobs.insert(job_id);
+            self.follow_focused_job();
+        }
+        true
+    }
+
+    pub(super) fn collapse_actions_job(&mut self) -> bool {
+        if let Some(job_id) = self.focused_job_id() {
+            self.actions_state.expanded_jobs.remove(&job_id);
+        }
+        self.follow_focused_job();
+        true
+    }
+
+    pub(super) fn handle_actions_detail_escape(&mut self) -> bool {
+        let collapsed = self
+            .focused_job_id()
+            .is_some_and(|job_id| self.actions_state.expanded_jobs.remove(&job_id));
+        if collapsed {
+            self.follow_focused_job();
+        } else {
+            self.actions_state.focus = ActionsFocus::RunList;
+            self.clamp_actions_detail_scroll();
+        }
+        true
+    }
+
+    pub(super) fn navigate_actions_job(&mut self, dir: NavDir) -> bool {
+        self.normalize_actions_job_focus();
+        let Some(detail) = self.actions_state.run_detail.as_ref() else {
+            return true;
+        };
+        let Some(current) = self.actions_state.focused_job_index else {
+            return true;
+        };
+        let last = detail.jobs.len().saturating_sub(1);
+        self.actions_state.focused_job_index = Some(match dir {
+            NavDir::Up => current.saturating_sub(1),
+            NavDir::Down => current.saturating_add(1).min(last),
+            _ => current,
+        });
+        self.follow_focused_job();
+        true
+    }
+}

--- a/src/state/actions_load_ops.rs
+++ b/src/state/actions_load_ops.rs
@@ -41,7 +41,7 @@ impl AppState {
         if matches!(outcome, AcceptOutcome::Applied | AcceptOutcome::Empty) {
             self.actions_state.error = None;
             self.actions_state.run_detail = None;
-            self.actions_state.detail_scroll_offset = 0;
+            self.reset_actions_inspection();
             self.actions_state.loading.detail = false;
             self.actions_state.detail_pending = None;
         }
@@ -121,7 +121,7 @@ impl AppState {
     pub(super) fn trigger_list_reload(&mut self) -> bool {
         self.actions_state.list.clear_items();
         self.actions_state.run_detail = None;
-        self.actions_state.detail_scroll_offset = 0;
+        self.reset_actions_inspection();
         self.actions_state.loading.detail = false;
         self.actions_state.detail_pending = None;
         if let Some(repo_id) = self.selected_repository().map(|r| r.id.clone()) {
@@ -132,6 +132,7 @@ impl AppState {
 
     /// Allocate a request id and begin a visible reload on the list.
     pub(super) fn begin_actions_reload(&mut self, repo_id: RepositoryId) {
+        self.reset_actions_inspection();
         let Ok(request_id) = self.actions_state.list.next_request_id() else {
             return;
         };

--- a/src/state/actions_ops.rs
+++ b/src/state/actions_ops.rs
@@ -40,8 +40,7 @@ impl AppState {
         self.actions_state.dispatch_pending = None;
         self.actions_state.detail_pending = None;
         self.actions_state.workflows_pending = None;
-        self.actions_state.expanded_jobs.clear();
-        self.actions_state.focused_job_index = None;
+        self.reset_actions_inspection();
         true
     }
 
@@ -106,12 +105,10 @@ impl AppState {
             crate::messages::NavDir::Next | crate::messages::NavDir::Prev => current,
         };
         self.actions_state.list.set_selected_index(Some(new_idx));
-        self.actions_state.detail_scroll_offset = 0;
+        self.reset_actions_inspection();
         self.actions_state.run_detail = None;
         self.actions_state.loading.detail = false;
         self.actions_state.detail_pending = None;
-        self.actions_state.expanded_jobs.clear();
-        self.actions_state.focused_job_index = None;
         true
     }
 
@@ -121,9 +118,7 @@ impl AppState {
     fn reset_actions_for_repo_change(&mut self) {
         self.actions_state.list.clear();
         self.actions_state.run_detail = None;
-        self.actions_state.detail_scroll_offset = 0;
-        self.actions_state.expanded_jobs.clear();
-        self.actions_state.focused_job_index = None;
+        self.reset_actions_inspection();
         self.actions_state.workflows.clear();
         self.actions_state.committed_filter = ActionsFilter::default();
         self.actions_state.draft_filter = ActionsFilter::default();
@@ -137,7 +132,7 @@ impl AppState {
 
     fn handle_enter(&mut self) -> bool {
         if matches!(self.actions_state.focus, ActionsFocus::RunList)
-            && self.actions_state.list.selected_index().is_some()
+            && self.actions_state.selected_run().is_some()
         {
             self.actions_state.focus = ActionsFocus::Detail;
         }
@@ -161,99 +156,22 @@ impl AppState {
         true
     }
 
-    /// Maximum scroll offset for the Actions detail pane, derived from the
-    /// detail's line count (mirroring `issues_ops.rs` clamping logic).
-    fn max_detail_scroll_offset(&self) -> usize {
-        let Some(detail) = &self.actions_state.run_detail else {
-            return 0;
-        };
-        let lines =
-            crate::actions_view::detail_line_count(detail, &self.actions_state.expanded_jobs);
-        let viewport = if self.actions_state.detail_viewport_rows == 0 {
-            crate::layout::detail_viewport_rows(40)
-        } else {
-            self.actions_state.detail_viewport_rows
-        };
-        lines.saturating_sub(viewport)
-    }
-
-    /// Public accessor for the Actions detail max scroll offset (used by mouse
-    /// routing to clamp wheel-scrolling).
-    #[must_use]
-    pub fn actions_max_detail_scroll_offset(&self) -> usize {
-        self.max_detail_scroll_offset()
-    }
-
-    fn handle_scroll_detail(&mut self, dir: crate::messages::ScrollDir) -> bool {
-        let max = self.max_detail_scroll_offset();
-        let current = self.actions_state.detail_scroll_offset.min(max);
-        match dir {
-            crate::messages::ScrollDir::Up => {
-                self.actions_state.detail_scroll_offset = current.saturating_sub(1);
-            }
-            crate::messages::ScrollDir::Down => {
-                self.actions_state.detail_scroll_offset = (current + 1).min(max);
-            }
-            crate::messages::ScrollDir::PageUp => {
-                self.actions_state.detail_scroll_offset =
-                    current.saturating_sub(super::VIEWPORT_PAGE_JUMP);
-            }
-            crate::messages::ScrollDir::PageDown => {
-                self.actions_state.detail_scroll_offset =
-                    (current + super::VIEWPORT_PAGE_JUMP).min(max);
-            }
-        }
-        true
-    }
-
-    /// Toggle the expand/collapse state of the currently focused job.
-    fn toggle_job_expand(&mut self) -> bool {
-        let Some(detail) = &self.actions_state.run_detail else {
-            return true;
-        };
-        let Some(idx) = self.actions_state.focused_job_index else {
-            return true;
-        };
-        let Some(job) = detail.jobs.get(idx) else {
-            return true;
-        };
-        if self.actions_state.expanded_jobs.contains(&job.id) {
-            self.actions_state.expanded_jobs.remove(&job.id);
-        } else {
-            self.actions_state.expanded_jobs.insert(job.id);
-        }
-        true
-    }
-
-    /// Collapse the currently focused job (Left/Esc in detail pane).
-    fn collapse_job(&mut self) -> bool {
-        let Some(detail) = &self.actions_state.run_detail else {
-            return true;
-        };
-        let Some(idx) = self.actions_state.focused_job_index else {
-            return true;
-        };
-        if let Some(job) = detail.jobs.get(idx) {
-            self.actions_state.expanded_jobs.remove(&job.id);
-        }
-        true
-    }
-
-    /// Move the focused job up/down within the detail pane.
-    fn navigate_job(&mut self, dir: crate::messages::NavDir) -> bool {
-        let Some(detail) = &self.actions_state.run_detail else {
-            return true;
-        };
-        if detail.jobs.is_empty() {
-            return true;
-        }
-        let current = self.actions_state.focused_job_index.unwrap_or(0);
-        let new_idx = match dir {
-            crate::messages::NavDir::Up => current.saturating_sub(1),
-            crate::messages::NavDir::Down => (current + 1).min(detail.jobs.len() - 1),
-            _ => current,
-        };
-        self.actions_state.focused_job_index = Some(new_idx);
+    fn begin_detail_reload(
+        &mut self,
+        scope_repo_id: RepositoryId,
+        run_id: u64,
+        request_id: u64,
+    ) -> bool {
+        self.reset_actions_inspection();
+        self.actions_state.error = None;
+        self.actions_state.run_detail = None;
+        self.actions_state.next_detail_request_id = request_id;
+        self.actions_state.detail_pending = Some(super::ActionsDetailPending {
+            scope_repo_id,
+            run_id,
+            request_id,
+        });
+        self.actions_state.loading.detail = true;
         true
     }
 
@@ -504,17 +422,25 @@ impl AppState {
             }
             ActionsMessage::Reload => {
                 self.actions_state.error = None;
-                true
+                self.trigger_list_reload()
             }
-            ActionsMessage::RefocusList => self.refocus_list(),
+            ActionsMessage::RefocusList => {
+                self.reset_actions_inspection();
+                self.refocus_list()
+            }
             ActionsMessage::Navigate(dir) => self.handle_navigation(*dir),
             ActionsMessage::Enter => self.handle_enter(),
             ActionsMessage::CycleFocus => self.cycle_focus(),
             ActionsMessage::CycleFocusReverse => self.cycle_focus_reverse(),
-            ActionsMessage::ScrollDetail(dir) => self.handle_scroll_detail(*dir),
-            ActionsMessage::ToggleJobExpand => self.toggle_job_expand(),
-            ActionsMessage::CollapseJob => self.collapse_job(),
-            ActionsMessage::NavigateJob(dir) => self.navigate_job(*dir),
+            ActionsMessage::SetDetailGeometry {
+                viewport_rows,
+                content_width,
+            } => self.set_actions_detail_geometry(*viewport_rows, *content_width),
+            ActionsMessage::ScrollDetail(dir) => self.handle_actions_detail_scroll(*dir),
+            ActionsMessage::ExpandJob => self.expand_actions_job(),
+            ActionsMessage::CollapseJob => self.collapse_actions_job(),
+            ActionsMessage::DetailEscape => self.handle_actions_detail_escape(),
+            ActionsMessage::NavigateJob(dir) => self.navigate_actions_job(*dir),
             _ => false,
         }
     }
@@ -594,6 +520,11 @@ impl AppState {
     /// Handle detail and workflow load/failure messages.
     fn handle_detail_message(&mut self, message: &ActionsMessage) -> bool {
         match message {
+            ActionsMessage::BeginDetailReload {
+                scope_repo_id,
+                run_id,
+                request_id,
+            } => self.begin_detail_reload(scope_repo_id.clone(), *run_id, *request_id),
             ActionsMessage::DetailLoaded {
                 scope_repo_id,
                 run_id,

--- a/src/state/actions_tests.rs
+++ b/src/state/actions_tests.rs
@@ -417,6 +417,18 @@ mod tests {
     }
 
     #[test]
+    fn run_list_enter_focuses_detail_when_a_run_is_selected() {
+        let mut state = create_test_state();
+        state.actions_state.list.items_mut().push(make_run(1));
+        state.actions_state.list.set_selected_index(Some(0));
+        state.actions_state.focus = ActionsFocus::RunList;
+
+        state.apply_actions_message(ActionsMessage::Enter);
+
+        assert_eq!(state.actions_state.focus, ActionsFocus::Detail);
+    }
+
+    #[test]
     fn load_detail_resets_expanded_jobs_and_focuses_first() {
         let mut state = create_test_state();
         state.actions_state.expanded_jobs.insert(999);
@@ -436,35 +448,38 @@ mod tests {
     }
 
     #[test]
-    fn toggle_job_expand_adds_and_removes() {
+    fn expand_job_is_idempotent() {
         let mut state = create_test_state();
         state.actions_state.run_detail = Some(make_detail_with_jobs());
         state.actions_state.focused_job_index = Some(0);
 
-        state.apply_actions_message(ActionsMessage::ToggleJobExpand);
-        assert!(state.actions_state.expanded_jobs.contains(&100));
+        state.apply_actions_message(ActionsMessage::ExpandJob);
+        state.apply_actions_message(ActionsMessage::ExpandJob);
 
-        state.apply_actions_message(ActionsMessage::ToggleJobExpand);
-        assert!(!state.actions_state.expanded_jobs.contains(&100));
+        assert!(state.actions_state.expanded_jobs.contains(&100));
     }
 
     #[test]
-    fn navigate_job_moves_focus() {
+    fn navigate_job_moves_focus_and_scroll_follows_rendered_row() {
         let mut state = create_test_state();
         state.actions_state.run_detail = Some(make_detail_with_jobs());
         state.actions_state.focused_job_index = Some(0);
+        state.actions_state.detail_viewport_rows = 2;
+        state.actions_state.expanded_jobs.insert(100);
 
         state.apply_actions_message(ActionsMessage::NavigateJob(NavDir::Down));
         assert_eq!(state.actions_state.focused_job_index, Some(1));
+        assert_eq!(
+            state.actions_state.detail_scroll_offset, 4,
+            "second job follows the two rendered steps of the expanded first job"
+        );
 
         state.apply_actions_message(ActionsMessage::NavigateJob(NavDir::Down));
         assert_eq!(state.actions_state.focused_job_index, Some(1));
 
         state.apply_actions_message(ActionsMessage::NavigateJob(NavDir::Up));
         assert_eq!(state.actions_state.focused_job_index, Some(0));
-
-        state.apply_actions_message(ActionsMessage::NavigateJob(NavDir::Up));
-        assert_eq!(state.actions_state.focused_job_index, Some(0));
+        assert_eq!(state.actions_state.detail_scroll_offset, 2);
     }
 
     #[test]
@@ -473,11 +488,26 @@ mod tests {
         state.actions_state.run_detail = Some(make_detail_with_jobs());
         state.actions_state.focused_job_index = Some(0);
 
-        state.apply_actions_message(ActionsMessage::ToggleJobExpand);
-        assert!(state.actions_state.expanded_jobs.contains(&100));
-
+        state.apply_actions_message(ActionsMessage::ExpandJob);
         state.apply_actions_message(ActionsMessage::CollapseJob);
+
         assert!(!state.actions_state.expanded_jobs.contains(&100));
+    }
+
+    #[test]
+    fn detail_escape_collapses_then_refocuses_run_list() {
+        let mut state = create_test_state();
+        state.actions_state.focus = ActionsFocus::Detail;
+        state.actions_state.run_detail = Some(make_detail_with_jobs());
+        state.actions_state.focused_job_index = Some(0);
+        state.actions_state.expanded_jobs.insert(100);
+
+        state.apply_actions_message(ActionsMessage::DetailEscape);
+        assert!(!state.actions_state.expanded_jobs.contains(&100));
+        assert_eq!(state.actions_state.focus, ActionsFocus::Detail);
+
+        state.apply_actions_message(ActionsMessage::DetailEscape);
+        assert_eq!(state.actions_state.focus, ActionsFocus::RunList);
     }
 
     // ---- NEW: load-more reducer tests (issue #202) ----

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -584,12 +584,22 @@ pub enum AppEvent {
     ActionsEnter,
     ActionsCycleFocus,
     ActionsCycleFocusReverse,
+    ActionsSetDetailGeometry {
+        viewport_rows: usize,
+        content_width: usize,
+    },
     ActionsScrollDetailUp,
     ActionsScrollDetailDown,
-    ActionsToggleJobExpand,
+    ActionsExpandJob,
     ActionsCollapseJob,
+    ActionsDetailEscape,
     ActionsNavigateJobUp,
     ActionsNavigateJobDown,
+    ActionsBeginDetailReload {
+        scope_repo_id: RepositoryId,
+        run_id: u64,
+        request_id: u64,
+    },
     ActionsRunsLoaded {
         scope_repo_id: RepositoryId,
         filter: Box<crate::domain::ActionsFilter>,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -6,6 +6,7 @@
 //!
 //! Pseudocode reference: component-001 lines 01-12
 
+mod actions_job_ops;
 mod actions_load_ops;
 #[cfg(test)]
 mod actions_load_tests;

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -594,7 +594,10 @@ pub struct ActionsState {
     pub error: Option<String>,
     pub focus: ActionsFocus,
     pub detail_scroll_offset: usize,
+    /// Last synchronized wrapped display-row viewport height.
     pub detail_viewport_rows: usize,
+    /// Last synchronized content width used by the Actions wrap projection.
+    pub detail_content_width: usize,
     /// Job ids that are expanded (showing their steps). Jobs not in this set
     /// are collapsed (JobRow only). Defaults to empty (all collapsed).
     pub expanded_jobs: std::collections::HashSet<u64>,
@@ -630,6 +633,13 @@ impl ActionsState {
     #[must_use]
     pub fn selected_run_index(&self) -> Option<usize> {
         self.list.selected_index()
+    }
+
+    /// The selected run when the stored index still names a loaded item.
+    #[must_use]
+    pub fn selected_run(&self) -> Option<&crate::domain::WorkflowRun> {
+        self.selected_run_index()
+            .and_then(|index| self.runs().get(index))
     }
 
     /// Whether the list is visibly loading (reload-visible or page pending).

--- a/src/ui/components/actions_detail.rs
+++ b/src/ui/components/actions_detail.rs
@@ -6,8 +6,9 @@
 //! (windowing, line building) lives in [`crate::actions_view`]; this module
 //! handles the header-rows + content-string + viewport-math glue.
 
-use crate::actions_view::{DetailLine, project_detail_view};
+use crate::actions_detail_view::project_actions_detail;
 use crate::domain::WorkflowRunDetail;
+use crate::layout::ActionsDetailGeometry;
 use crate::selection::{SelectablePane, TextSelection};
 use crate::theme::ThemeColors;
 
@@ -31,97 +32,18 @@ pub struct ActionsDetailProjectionInputs<'a> {
     pub detail: Option<&'a WorkflowRunDetail>,
     /// Scroll offset for the content viewport.
     pub scroll_offset: usize,
-    /// Detail pane height in rows, supplied by the screen.
-    pub viewport_rows: Option<u16>,
+    /// Exact detail display geometry supplied by the shared layout helper.
+    pub geometry: ActionsDetailGeometry,
     /// Whether this pane is focused.
     pub focused: bool,
-    /// Content width (terminal cols) for text wrapping.
-    pub content_width: usize,
     /// Theme colors.
     pub colors: ThemeColors,
     /// Active text selection, if any.
     pub selection: Option<TextSelection>,
+    /// Focused job index within the loaded detail.
+    pub focused_job_index: Option<usize>,
     /// Set of expanded job ids (collapsed = not in set).
     pub expanded_jobs: &'a std::collections::HashSet<u64>,
-}
-
-/// Map a job/step status+conclusion to a leading glyph.
-///
-/// Uses non-pictographic, width-stable symbols (NOT emoji):
-/// - `\u{2713}` (check mark) success
-/// - `\u{2717}` (ballot X) failure
-/// - `\u{2298}` (circled division) cancelled / skipped
-/// - `~` in-progress
-/// - `.` queued / pending
-/// - `?` unknown
-fn status_glyph(
-    status: crate::domain::WorkflowRunStatus,
-    conclusion: Option<crate::domain::WorkflowRunConclusion>,
-) -> &'static str {
-    match status {
-        crate::domain::WorkflowRunStatus::Completed => match conclusion {
-            Some(crate::domain::WorkflowRunConclusion::Success) => "\u{2713}",
-            Some(crate::domain::WorkflowRunConclusion::Failure) => "\u{2717}",
-            Some(
-                crate::domain::WorkflowRunConclusion::Cancelled
-                | crate::domain::WorkflowRunConclusion::Skipped,
-            ) => "\u{2298}",
-            _ => "?",
-        },
-        crate::domain::WorkflowRunStatus::InProgress => "~",
-        crate::domain::WorkflowRunStatus::Queued
-        | crate::domain::WorkflowRunStatus::Requested
-        | crate::domain::WorkflowRunStatus::Waiting
-        | crate::domain::WorkflowRunStatus::Pending => ".",
-        crate::domain::WorkflowRunStatus::Unknown => "?",
-    }
-}
-
-/// Render a [`DetailLine`] to its plain-text representation for the content
-/// string. Each line becomes one row in the scrollable viewport. Job and step
-/// lines use a leading status glyph instead of trailing text.
-fn line_text(line: &DetailLine) -> String {
-    match line {
-        DetailLine::Header {
-            workflow_name,
-            event,
-            head_branch,
-            head_sha,
-            created_at,
-            updated_at,
-        } => {
-            let _ = (
-                workflow_name,
-                event,
-                head_branch,
-                head_sha,
-                created_at,
-                updated_at,
-            );
-            String::new()
-        }
-        DetailLine::SectionTitle { title } => title.clone(),
-        DetailLine::JobRow {
-            name,
-            status,
-            conclusion,
-            expanded,
-            ..
-        } => {
-            let glyph = status_glyph(*status, *conclusion);
-            let indicator = if *expanded { "\u{25BE}" } else { "\u{25B8}" };
-            format!("{indicator} {glyph} {name}")
-        }
-        DetailLine::StepRow {
-            number,
-            name,
-            status,
-            conclusion,
-        } => {
-            let glyph = status_glyph(*status, *conclusion);
-            format!("  {glyph} [{number}] {name}")
-        }
-    }
 }
 
 /// Build the five fixed header rows for a loaded run detail.
@@ -156,46 +78,25 @@ fn build_header_rows(detail: &WorkflowRunDetail) -> Vec<DetailHeaderRow> {
     ]
 }
 
-/// Compute the scrollable viewport rows from the supplied pane height.
-///
-/// Mirrors the PR detail viewport math: subtract header rows + 2 (border +
-/// separator). Falls back to a default terminal height when none is supplied.
-fn detail_viewport_rows(available_height: Option<u16>) -> usize {
-    const DEFAULT_TERM_ROWS: usize = 40;
-    if let Some(height) = available_height {
-        (usize::from(height)).saturating_sub(ACTIONS_DETAIL_HEADER_ROWS + 2)
-    } else {
-        crate::layout::prs_detail_viewport_rows(DEFAULT_TERM_ROWS, false, false)
-    }
-}
-
 /// Pure projection of the Actions detail pane into a [`DetailPaneProps`].
 ///
-/// Builds header rows from the run metadata, flattens jobs/steps into a plain
-/// content string (newline-joined), and computes the scroll viewport rows.
-/// When no detail is loaded, a placeholder is shown.
+/// The shared Actions projection supplies already-wrapped display rows, so the
+/// generic renderer consumes the same row coordinates used by reducer bounds.
 #[must_use]
 pub fn actions_detail_props(inputs: ActionsDetailProjectionInputs<'_>) -> DetailPaneProps {
-    let scroll_rows = detail_viewport_rows(inputs.viewport_rows);
-
     let (header_rows, content) = if let Some(detail) = inputs.detail {
-        let rows = build_header_rows(detail);
-        let view = project_detail_view(
+        let projection = project_actions_detail(
             detail,
-            inputs.scroll_offset,
-            scroll_rows,
             inputs.expanded_jobs,
+            inputs.focused_job_index,
+            inputs.geometry,
         );
-        let text = view
-            .visible_lines
-            .iter()
-            .map(line_text)
-            .collect::<Vec<_>>()
-            .join("\n");
-        (rows, text)
+        (build_header_rows(detail), projection.content())
     } else {
-        let rows = build_placeholder_header_rows();
-        (rows, "Select a workflow run to view details.".to_string())
+        (
+            build_placeholder_header_rows(),
+            "Select a workflow run to view details.".to_string(),
+        )
     };
 
     DetailPaneProps {
@@ -203,9 +104,9 @@ pub fn actions_detail_props(inputs: ActionsDetailProjectionInputs<'_>) -> Detail
         content,
         content_cursor: None,
         scroll_offset: inputs.scroll_offset,
-        viewport_rows: scroll_rows,
+        viewport_rows: inputs.geometry.viewport_rows,
         content_line_offset: ACTIONS_DETAIL_HEADER_ROWS,
-        max_line_width: inputs.content_width,
+        max_line_width: inputs.geometry.content_width,
         focused: inputs.focused,
         pane: SelectablePane::ActionsDetail,
         colors: inputs.colors,
@@ -279,11 +180,14 @@ mod tests {
         let inputs = ActionsDetailProjectionInputs {
             detail: Some(&detail),
             scroll_offset: 0,
-            viewport_rows: Some(20),
+            geometry: ActionsDetailGeometry {
+                viewport_rows: 13,
+                content_width: 80,
+            },
             focused: true,
-            content_width: 80,
             colors: ThemeColors::default(),
             selection: None,
+            focused_job_index: Some(0),
             expanded_jobs: &expanded_all(),
         };
         let props = actions_detail_props(inputs);
@@ -301,11 +205,14 @@ mod tests {
         let inputs = ActionsDetailProjectionInputs {
             detail: None,
             scroll_offset: 0,
-            viewport_rows: Some(20),
+            geometry: ActionsDetailGeometry {
+                viewport_rows: 13,
+                content_width: 80,
+            },
             focused: false,
-            content_width: 80,
             colors: ThemeColors::default(),
             selection: None,
+            focused_job_index: Some(0),
             expanded_jobs: &expanded_none(),
         };
         let props = actions_detail_props(inputs);
@@ -319,11 +226,14 @@ mod tests {
         let inputs = ActionsDetailProjectionInputs {
             detail: Some(&detail),
             scroll_offset: 0,
-            viewport_rows: Some(20),
+            geometry: ActionsDetailGeometry {
+                viewport_rows: 13,
+                content_width: 80,
+            },
             focused: false,
-            content_width: 80,
             colors: ThemeColors::default(),
             selection: None,
+            focused_job_index: Some(0),
             expanded_jobs: &expanded_all(),
         };
         let props = actions_detail_props(inputs);
@@ -338,11 +248,14 @@ mod tests {
         let inputs = ActionsDetailProjectionInputs {
             detail: Some(&detail),
             scroll_offset: 0,
-            viewport_rows: Some(20),
+            geometry: ActionsDetailGeometry {
+                viewport_rows: 13,
+                content_width: 80,
+            },
             focused: false,
-            content_width: 80,
             colors: ThemeColors::default(),
             selection: None,
+            focused_job_index: Some(0),
             expanded_jobs: &expanded_all(),
         };
         let props = actions_detail_props(inputs);
@@ -363,11 +276,14 @@ mod tests {
         let inputs = ActionsDetailProjectionInputs {
             detail: Some(&detail),
             scroll_offset: 0,
-            viewport_rows: Some(20),
+            geometry: ActionsDetailGeometry {
+                viewport_rows: 13,
+                content_width: 80,
+            },
             focused: false,
-            content_width: 80,
             colors: ThemeColors::default(),
             selection: None,
+            focused_job_index: Some(0),
             expanded_jobs: &expanded_all(),
         };
         let props = actions_detail_props(inputs);
@@ -389,11 +305,14 @@ mod tests {
         let inputs = ActionsDetailProjectionInputs {
             detail: Some(&detail),
             scroll_offset: 0,
-            viewport_rows: Some(20),
+            geometry: ActionsDetailGeometry {
+                viewport_rows: 13,
+                content_width: 80,
+            },
             focused: false,
-            content_width: 80,
             colors: ThemeColors::default(),
             selection: None,
+            focused_job_index: Some(0),
             expanded_jobs: &expanded_all(),
         };
         let props = actions_detail_props(inputs);
@@ -404,31 +323,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn status_glyph_maps_all_conclusions() {
-        use crate::domain::WorkflowRunStatus as S;
-        assert_eq!(
-            status_glyph(S::Completed, Some(WorkflowRunConclusion::Success)),
-            "\u{2713}"
-        );
-        assert_eq!(
-            status_glyph(S::Completed, Some(WorkflowRunConclusion::Failure)),
-            "\u{2717}"
-        );
-        assert_eq!(
-            status_glyph(S::Completed, Some(WorkflowRunConclusion::Cancelled)),
-            "\u{2298}"
-        );
-        assert_eq!(
-            status_glyph(S::Completed, Some(WorkflowRunConclusion::Skipped)),
-            "\u{2298}"
-        );
-        assert_eq!(status_glyph(S::InProgress, None), "~");
-        assert_eq!(status_glyph(S::Queued, None), ".");
-        assert_eq!(status_glyph(S::Pending, None), ".");
-        assert_eq!(status_glyph(S::Unknown, None), "?");
-    }
-
     // ---- BUG 5: expand/collapse indicator ----
 
     #[test]
@@ -437,11 +331,14 @@ mod tests {
         let inputs = ActionsDetailProjectionInputs {
             detail: Some(&detail),
             scroll_offset: 0,
-            viewport_rows: Some(20),
+            geometry: ActionsDetailGeometry {
+                viewport_rows: 13,
+                content_width: 80,
+            },
             focused: false,
-            content_width: 80,
             colors: ThemeColors::default(),
             selection: None,
+            focused_job_index: Some(0),
             expanded_jobs: &expanded_none(),
         };
         let props = actions_detail_props(inputs);
@@ -462,11 +359,14 @@ mod tests {
         let inputs = ActionsDetailProjectionInputs {
             detail: Some(&detail),
             scroll_offset: 0,
-            viewport_rows: Some(20),
+            geometry: ActionsDetailGeometry {
+                viewport_rows: 13,
+                content_width: 80,
+            },
             focused: false,
-            content_width: 80,
             colors: ThemeColors::default(),
             selection: None,
+            focused_job_index: Some(0),
             expanded_jobs: &expanded_all(),
         };
         let props = actions_detail_props(inputs);
@@ -479,5 +379,29 @@ mod tests {
             props.content.contains("checkout"),
             "expanded job must show steps"
         );
+    }
+
+    #[test]
+    fn focused_job_renders_stable_marker_and_steps_keep_status_glyphs() {
+        let mut detail = make_detail();
+        detail.jobs[0].steps[0].conclusion = Some(WorkflowRunConclusion::Failure);
+        let inputs = ActionsDetailProjectionInputs {
+            detail: Some(&detail),
+            scroll_offset: 0,
+            geometry: ActionsDetailGeometry {
+                viewport_rows: 13,
+                content_width: 80,
+            },
+            focused: true,
+            colors: ThemeColors::default(),
+            selection: None,
+            focused_job_index: Some(0),
+            expanded_jobs: &expanded_all(),
+        };
+
+        let props = actions_detail_props(inputs);
+
+        assert!(props.content.contains("> \u{25BE} \u{2713} build"));
+        assert!(props.content.contains("  \u{2717} [1] checkout"));
     }
 }

--- a/src/ui/components/issue_lifecycle_render_tests.rs
+++ b/src/ui/components/issue_lifecycle_render_tests.rs
@@ -11,7 +11,7 @@ use crate::ui::components::keybind_bar::keybind_hints_for;
 
 #[test]
 fn issues_keybind_hint_includes_close_and_delete() {
-    let hints = keybind_hints_for(ScreenMode::DashboardIssues, false);
+    let hints = keybind_hints_for(ScreenMode::DashboardIssues, false, None);
     assert!(
         hints.contains("close"),
         "issues keybind hint should include close, got: {hints}"
@@ -24,7 +24,7 @@ fn issues_keybind_hint_includes_close_and_delete() {
 
 #[test]
 fn issues_keybind_hint_includes_capital_c_and_d() {
-    let hints = keybind_hints_for(ScreenMode::DashboardIssues, false);
+    let hints = keybind_hints_for(ScreenMode::DashboardIssues, false, None);
     assert!(
         hints.contains("C close"),
         "issues keybind hint should show 'C close', got: {hints}"

--- a/src/ui/components/keybind_bar.rs
+++ b/src/ui/components/keybind_bar.rs
@@ -6,7 +6,7 @@
 
 use iocraft::prelude::*;
 
-use crate::state::ScreenMode;
+use crate::state::{ActionsFocus, ScreenMode};
 use crate::theme::{ResolvedColors, ThemeColors};
 
 /// Props for the keybind bar component.
@@ -16,6 +16,8 @@ pub struct KeybindBarProps {
     pub screen_mode: ScreenMode,
     /// Whether terminal is focused.
     pub terminal_focused: bool,
+    /// Active Actions pane when Actions mode is rendered.
+    pub actions_focus: Option<ActionsFocus>,
     /// Theme colors.
     pub colors: ThemeColors,
 }
@@ -26,7 +28,11 @@ pub struct KeybindBarProps {
 /// @requirement REQ-PR-012
 /// @pseudocode component-001 lines 1-12
 #[must_use]
-pub fn keybind_hints_for(screen_mode: ScreenMode, terminal_focused: bool) -> &'static str {
+pub fn keybind_hints_for(
+    screen_mode: ScreenMode,
+    terminal_focused: bool,
+    actions_focus: Option<ActionsFocus>,
+) -> &'static str {
     if terminal_focused {
         return "F12 unfocus";
     }
@@ -43,9 +49,17 @@ pub fn keybind_hints_for(screen_mode: ScreenMode, terminal_focused: bool) -> &'s
         ScreenMode::DashboardPullRequests => {
             "^/v items | </> panes | Enter detail | f filter | / search | Tab detail focus (j/k) | p list | r reply | R resolve | S send-to-agent | c comment | o open | m merge | L labels A assignees M milestone T title W state | a exit | Esc back/exit"
         }
-        ScreenMode::DashboardActions => {
-            "^/v navigate | Tab cycle focus | f filter | / search | d dispatch | r refresh | Esc/q exit"
-        }
+        ScreenMode::DashboardActions => match actions_focus.unwrap_or(ActionsFocus::RunList) {
+            ActionsFocus::RepoList => {
+                "^/v repos | > runs | Tab pane | f filter | / search | d dispatch | r refresh | Esc exit"
+            }
+            ActionsFocus::RunList => {
+                "^/v runs | Enter detail | Tab pane | f filter | / search | d dispatch | r refresh | Esc exit"
+            }
+            ActionsFocus::Detail => {
+                "^/v jobs | Enter/Right expand | Left collapse | Esc collapse/back | PgUp/PgDn scroll | Tab pane | ? help"
+            }
+        },
     }
 }
 
@@ -54,7 +68,11 @@ pub fn keybind_hints_for(screen_mode: ScreenMode, terminal_focused: bool) -> &'s
 pub fn KeybindBar(props: &KeybindBarProps) -> impl Into<AnyElement<'static>> {
     let rc = ResolvedColors::from_theme(Some(&props.colors));
 
-    let hints = keybind_hints_for(props.screen_mode, props.terminal_focused);
+    let hints = keybind_hints_for(
+        props.screen_mode,
+        props.terminal_focused,
+        props.actions_focus,
+    );
 
     element! {
         Box(
@@ -65,5 +83,94 @@ pub fn KeybindBar(props: &KeybindBarProps) -> impl Into<AnyElement<'static>> {
         ) {
             Text(content: hints, color: rc.bg)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn actions_hints_are_focus_specific_and_fit_151_columns() {
+        let repos = keybind_hints_for(
+            ScreenMode::DashboardActions,
+            false,
+            Some(ActionsFocus::RepoList),
+        );
+        let list = keybind_hints_for(
+            ScreenMode::DashboardActions,
+            false,
+            Some(ActionsFocus::RunList),
+        );
+        let detail = keybind_hints_for(
+            ScreenMode::DashboardActions,
+            false,
+            Some(ActionsFocus::Detail),
+        );
+
+        for required in [
+            "Enter detail",
+            "f filter",
+            "/ search",
+            "d dispatch",
+            "r refresh",
+        ] {
+            assert!(list.contains(required));
+        }
+        assert!(repos.contains("^/v repos"));
+        assert!(repos.contains("> runs"));
+        assert!(detail.contains("Enter/Right expand"));
+        assert!(detail.contains("Esc collapse/back"));
+        assert!(repos.chars().count() <= 150);
+        assert!(list.chars().count() <= 150);
+        assert!(detail.chars().count() <= 150);
+    }
+
+    #[test]
+    fn actions_run_list_footer_renders_refresh_at_fixed_width() {
+        let mut element = element! {
+            Box(width: 151u32, height: 1u32) {
+                KeybindBar(
+                    screen_mode: ScreenMode::DashboardActions,
+                    terminal_focused: false,
+                    actions_focus: Some(ActionsFocus::RunList),
+                    colors: ThemeColors::default(),
+                )
+            }
+        };
+        let canvas = element.render(Some(151));
+        let mut output = Vec::new();
+        canvas
+            .write_ansi(&mut output)
+            .unwrap_or_else(|error| panic!("render keybind bar: {error}"));
+        let rendered = String::from_utf8_lossy(&output);
+
+        assert!(rendered.contains("f filter"));
+        assert!(rendered.contains("/ search"));
+        assert!(rendered.contains("d dispatch"));
+        assert!(rendered.contains("r refresh"));
+    }
+
+    #[test]
+    fn actions_detail_footer_renders_scroll_and_help_at_fixed_width() {
+        let mut element = element! {
+            Box(width: 151u32, height: 1u32) {
+                KeybindBar(
+                    screen_mode: ScreenMode::DashboardActions,
+                    terminal_focused: false,
+                    actions_focus: Some(ActionsFocus::Detail),
+                    colors: ThemeColors::default(),
+                )
+            }
+        };
+        let canvas = element.render(Some(151));
+        let mut output = Vec::new();
+        canvas
+            .write_ansi(&mut output)
+            .unwrap_or_else(|error| panic!("render keybind bar: {error}"));
+        let rendered = String::from_utf8_lossy(&output);
+
+        assert!(rendered.contains("PgUp/PgDn scroll"));
+        assert!(rendered.contains("? help"));
     }
 }

--- a/src/ui/components/keybind_bar.rs
+++ b/src/ui/components/keybind_bar.rs
@@ -49,14 +49,14 @@ pub fn keybind_hints_for(
         ScreenMode::DashboardPullRequests => {
             "^/v items | </> panes | Enter detail | f filter | / search | Tab detail focus (j/k) | p list | r reply | R resolve | S send-to-agent | c comment | o open | m merge | L labels A assignees M milestone T title W state | a exit | Esc back/exit"
         }
-        ScreenMode::DashboardActions => match actions_focus.unwrap_or(ActionsFocus::RunList) {
-            ActionsFocus::RepoList => {
+        ScreenMode::DashboardActions => match actions_focus {
+            Some(ActionsFocus::RepoList) => {
                 "^/v repos | > runs | Tab pane | f filter | / search | d dispatch | r refresh | Esc exit"
             }
-            ActionsFocus::RunList => {
+            Some(ActionsFocus::RunList) | None => {
                 "^/v runs | Enter detail | Tab pane | f filter | / search | d dispatch | r refresh | Esc exit"
             }
-            ActionsFocus::Detail => {
+            Some(ActionsFocus::Detail) => {
                 "^/v jobs | Enter/Right expand | Left collapse | Esc collapse/back | PgUp/PgDn scroll | Tab pane | ? help"
             }
         },
@@ -91,7 +91,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn actions_hints_are_focus_specific_and_fit_151_columns() {
+    fn actions_hints_are_focus_specific_and_fit_footer_width() {
         let repos = keybind_hints_for(
             ScreenMode::DashboardActions,
             false,

--- a/src/ui/components/pr_render_screen_tests.rs
+++ b/src/ui/components/pr_render_screen_tests.rs
@@ -208,7 +208,7 @@ fn test_pr_screen_renders_error_banner_when_error_present() {
 /// @pseudocode component-001 lines 1-12
 #[test]
 fn test_pr_keybind_bar_and_help_list_o_open_in_browser() {
-    let hints = keybind_hints_for(ScreenMode::DashboardPullRequests, false);
+    let hints = keybind_hints_for(ScreenMode::DashboardPullRequests, false, None);
     assert!(
         hints.contains("o open"),
         "PR-mode keybind bar must list 'o open', got: {hints}"
@@ -232,7 +232,7 @@ fn test_pr_keybind_bar_and_help_list_o_open_in_browser() {
 
     // terminal_focused short-circuit: the bar shows the unfocus hint instead.
     assert_eq!(
-        keybind_hints_for(ScreenMode::DashboardPullRequests, true),
+        keybind_hints_for(ScreenMode::DashboardPullRequests, true, None),
         "F12 unfocus",
         "focused-terminal keybind bar must short-circuit to 'F12 unfocus'"
     );
@@ -246,7 +246,7 @@ fn test_pr_keybind_bar_and_help_list_o_open_in_browser() {
 /// (issue #175): `L labels A assignees M milestone T title Y type W state`.
 #[test]
 fn test_issues_keybind_bar_lists_property_edit_shortcuts() {
-    let hints = keybind_hints_for(ScreenMode::DashboardIssues, false);
+    let hints = keybind_hints_for(ScreenMode::DashboardIssues, false, None);
     assert!(
         hints.contains("L labels"),
         "Issues keybind bar must list 'L labels' (issue #175), got: {hints}"
@@ -277,7 +277,7 @@ fn test_issues_keybind_bar_lists_property_edit_shortcuts() {
 /// (PRs don't have the Type property).
 #[test]
 fn test_pr_keybind_bar_has_no_type_shortcut() {
-    let hints = keybind_hints_for(ScreenMode::DashboardPullRequests, false);
+    let hints = keybind_hints_for(ScreenMode::DashboardPullRequests, false, None);
     assert!(
         !hints.contains("Y type"),
         "PR keybind bar must NOT list 'Y type' (PRs have no Type property), got: {hints}"

--- a/src/ui/modals/help.rs
+++ b/src/ui/modals/help.rs
@@ -49,6 +49,16 @@ pub fn help_content_lines() -> &'static [&'static str] {
         "  m           Merge (PR)",
         "  Tip: Tab/j/k to a review thread, then R resolve / r reply",
         "",
+        "Actions:",
+        "  Up/Down     Select repository, run, or focused job",
+        "  Enter       Open run detail / expand focused job",
+        "  Right/Left  Expand / collapse focused job",
+        "  Esc         Collapse job, back to runs, then exit Actions",
+        "  PgUp/PgDn   Scroll job detail",
+        "  Tab         Cycle repository, runs, and detail focus",
+        "  f /         Filter / search workflow runs",
+        "  d / r       Dispatch workflow / refresh runs",
+        "",
         "Dashboard:",
         "  n           New agent",
         "  N           New repository",
@@ -223,6 +233,15 @@ mod tests {
         assert!(joined.contains("Space       Grab/move/drop reorder"));
         assert!(joined.contains("v           Toggle active-only"));
         assert!(joined.contains("F9          Theme picker"));
+        for action in [
+            "Open run detail / expand focused job",
+            "Expand / collapse focused job",
+            "Collapse job, back to runs, then exit Actions",
+            "Filter / search workflow runs",
+            "Dispatch workflow / refresh runs",
+        ] {
+            assert!(joined.contains(action), "missing Actions help: {action}");
+        }
     }
 
     /// `help_viewport_rows` honors the preferred minimum on normal terminals and

--- a/src/ui/screens/actions.rs
+++ b/src/ui/screens/actions.rs
@@ -82,6 +82,7 @@ pub fn ActionsScreen(props: &ActionsScreenProps) -> impl Into<AnyElement<'static
     let expanded_jobs = state.map_or_else(std::collections::HashSet::new, |s| {
         s.actions_state.expanded_jobs.clone()
     });
+    let focused_job_index = state.and_then(|s| s.actions_state.focused_job_index);
 
     let has_filters = state.is_some_and(|s| {
         let f = &s.actions_state.committed_filter;
@@ -91,12 +92,16 @@ pub fn ActionsScreen(props: &ActionsScreenProps) -> impl Into<AnyElement<'static
     // Compute the rows/columns available to panes using the SAME shared helpers
     // the PRs screen uses — single source of truth for geometry.
     let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((120, 40));
-    let (list_pane_rows, detail_pane_height) =
+    let (list_pane_rows, _) =
         crate::layout::prs_pane_rows(usize::from(term_rows), error_message.is_some(), filter_open);
     let list_pane_rows = u16::try_from(list_pane_rows).unwrap_or(u16::MAX);
-    let detail_pane_height = u16::try_from(detail_pane_height).unwrap_or(u16::MAX);
+    let detail_geometry = crate::layout::actions_detail_geometry(
+        term_cols,
+        term_rows,
+        error_message.is_some(),
+        filter_open,
+    );
     let list_width = crate::layout::pr_list_content_width(term_cols);
-    let detail_content_width = crate::layout::prs_detail_content_width(term_cols) as usize;
     let sidebar_width = u32::from(crate::layout::prs_main_columns(term_cols).sidebar_width);
 
     // In Actions mode the sidebar focus is driven solely by ActionsFocus
@@ -205,11 +210,11 @@ pub fn ActionsScreen(props: &ActionsScreenProps) -> impl Into<AnyElement<'static
                             ActionsDetailProjectionInputs {
                                 detail: detail.as_ref(),
                                 scroll_offset: detail_scroll_offset,
-                                viewport_rows: Some(detail_pane_height),
+                                geometry: detail_geometry,
                                 focused: detail_focused,
-                                content_width: detail_content_width,
                                 colors: colors.clone(),
                                 selection,
+                                focused_job_index,
                                 expanded_jobs: &expanded_jobs,
                             },
                         ))])
@@ -221,6 +226,7 @@ pub fn ActionsScreen(props: &ActionsScreenProps) -> impl Into<AnyElement<'static
             KeybindBar(
                 screen_mode: state.map_or(ScreenMode::DashboardActions, |s| s.screen_mode),
                 terminal_focused: false,
+                actions_focus: Some(actions_focus),
                 colors: colors.clone(),
             )
         }

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -262,6 +262,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
             KeybindBar(
                 screen_mode: state.map_or(ScreenMode::Dashboard, |s| s.screen_mode),
                 terminal_focused: terminal_focused,
+                actions_focus: None,
                 colors: colors,
             )
         }

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -426,6 +426,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
             KeybindBar(
                 screen_mode: state.map_or(ScreenMode::DashboardIssues, |s| s.screen_mode),
                 terminal_focused: false,
+                actions_focus: None,
                 colors: colors.clone(),
             )
         }

--- a/src/ui/screens/pull_requests.rs
+++ b/src/ui/screens/pull_requests.rs
@@ -380,6 +380,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
             KeybindBar(
                 screen_mode: state.map_or(ScreenMode::DashboardPullRequests, |s| s.screen_mode),
                 terminal_focused: false,
+                actions_focus: None,
                 colors: colors.clone(),
             )
         }

--- a/src/ui/screens/split.rs
+++ b/src/ui/screens/split.rs
@@ -149,6 +149,7 @@ pub fn SplitScreen(props: &SplitScreenProps) -> impl Into<AnyElement<'static>> {
             KeybindBar(
                 screen_mode: ScreenMode::Split,
                 terminal_focused: false,
+                actions_focus: None,
                 colors: colors,
             )
         }

--- a/tests/core/message_bus_contracts.rs
+++ b/tests/core/message_bus_contracts.rs
@@ -70,6 +70,19 @@ fn app_events_route_to_domain_channels() {
 }
 
 #[test]
+fn actions_job_inspection_intents_route_to_actions_channel() {
+    for (event, name) in [
+        (AppEvent::ActionsExpandJob, "ActionsExpandJob"),
+        (AppEvent::ActionsCollapseJob, "ActionsCollapseJob"),
+        (AppEvent::ActionsDetailEscape, "ActionsDetailEscape"),
+    ] {
+        let route = AppMessage::from(event).route();
+        assert_eq!(route.domain, MessageDomain::Actions);
+        assert_eq!(route.name, name);
+    }
+}
+
+#[test]
 fn actions_page_results_route_to_actions_channel() {
     let loaded = AppEvent::ActionsRunsPageLoaded {
         scope_repo_id: RepositoryId("repo-1".into()),


### PR DESCRIPTION
## Summary
- adds inline job sub-focus to Actions run details with jobs collapsed by default
- makes Enter and Right expand-only while Left and Escape collapse before navigating back
- keeps focused jobs visible using wrapped-row geometry synchronized with the rendered viewport
- preserves leading success and failure glyphs for expanded steps
- resets inspection state across run changes and reloads
- adds focus-specific footer hints and complete Actions help

## Architecture
- keeps deeper inspection inline, matching PR thread expansion rather than adding a disruptive fourth pane
- centralizes pure wrapped-row projection in src/actions_detail_view.rs
- keeps job focus and expansion transitions in the state layer
- routes geometry and inspection intents through typed AppEvent and ActionsMessage conversions

## Test-first coverage
- added reducer, projection, input-routing, message-contract, footer-render, and geometry tests
- added a fail-closed read-only gh shim and real tmux scenario with success and failure jobs and steps
- scenario verifies default collapse, visible focus, Enter/Right expansion, step glyphs, Escape collapse, job navigation, and back navigation

## Verification
- make ci-check
- scripts/issue194-run-scenario.sh
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- Open Code Review and CodeRabbit CLI findings evaluated and remediated

Fixes #194