### PR TITLE
Support native Windows SSH for remote Linux agents (Fixes #263)

### DIFF
--- a/dev-docs/tmux-scenarios/windows-remote-linux-config.json
+++ b/dev-docs/tmux-scenarios/windows-remote-linux-config.json
@@ -1,0 +1,29 @@
+{
+  "config": {
+    "cols": 120,
+    "rows": 40,
+    "history_limit": 2000,
+    "initial_wait_ms": 100,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "key": "N" },
+    { "waitFor": "New Repository" },
+    { "key": "Tab" },
+    { "key": "Tab" },
+    { "key": "Tab" },
+    { "key": "Tab" },
+    { "key": "Tab" },
+    { "key": "Tab" },
+    { "key": "Tab" },
+    { "key": "Space" },
+    { "expect": "SSH Port" },
+    { "expect": "Identity File" },
+    { "expect": "SSH Options" },
+    { "capture": "windows-remote-linux-config" },
+    { "key": "Escape" },
+    { "line": "qqq" },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/project-plans/issue263-plan.md
+++ b/project-plans/issue263-plan.md
@@ -1,0 +1,46 @@
+# Issue #263 plan: native Windows SSH transport for remote Linux agents
+
+## Goal
+
+Preserve controlled remote Unix command semantics while making every local SSH
+process invocation explicit, shell-free, Windows-safe, typed, and diagnosable.
+
+## RED
+
+1. Add the repository-form TUI scenario first and prove SSH port, identity file,
+   and option fields are absent.
+2. Add domain/persistence tests for port, Unicode/space identity paths, and
+   validated SSH options with backward-compatible defaults.
+3. Add transport planning tests proving the resolved OpenSSH executable and each
+   host/port/identity/option/remote-command value remain distinct argv entries.
+4. Add failure-classification tests for missing executable, host-key failure,
+   authentication failure, timeout, cancellation, missing remote tmux/runtime,
+   and generic remote-command failure without exposing commands or credentials.
+5. Add attach planning tests proving Windows remote attachment never invokes a
+   local Unix shell and local psmux namespaces never enter remote argv.
+6. Add a guarded disposable real-SSH test configured entirely by environment;
+   skip with a diagnostic when no fixture is configured and clean only the
+   run-owned remote session/path.
+
+## GREEN
+
+1. Extend `RemoteRepositorySettings` and repository forms with typed port,
+   identity-file path, and validated options while preserving legacy state.
+2. Extend `local_command` with explicit Windows OpenSSH resolution and an
+   optional `JEFE_SSH_BIN` override.
+3. Introduce one shared SSH transport planner/executor used by runtime,
+   availability probes, prompt transfer, and remote repository preparation.
+4. Keep remote Linux scripts as controlled single remote-command arguments;
+   remove local `sh -lc` from remote attachment by spawning OpenSSH directly
+   through `portable-pty`.
+5. Return typed, actionable, redacted transport errors and retain bounded process
+   teardown.
+
+## REFACTOR and review
+
+- Remove duplicated SSH argv construction and direct `Command::new("ssh")`.
+- Audit LLxprt/Code Puppy discovery, preparation, launch, liveness, attach,
+  detach, kill, and cleanup through the shared boundary.
+- Confirm Unix behavior, quoting, effective-user wrapping, and upstream tmux
+  semantics are unchanged.
+- Run focused tests, the guarded fixture when configured, and all CI gates.

--- a/src/app_input/availability.rs
+++ b/src/app_input/availability.rs
@@ -216,6 +216,7 @@ mod tests {
             host: "build.example.com".to_owned(),
             run_as_user: "acoliver".to_owned(),
             setup_env_default: true,
+            ..RemoteRepositorySettings::default()
         };
         // CodePuppy is NOT installed locally.
         let available = &[AgentKind::Llxprt];
@@ -235,6 +236,7 @@ mod tests {
             host: "build.example.com".to_owned(),
             run_as_user: String::new(),
             setup_env_default: false,
+            ..RemoteRepositorySettings::default()
         };
         let available = &[][..];
         assert!(
@@ -254,6 +256,7 @@ mod tests {
             host: String::new(),
             run_as_user: String::new(),
             setup_env_default: false,
+            ..RemoteRepositorySettings::default()
         };
         let available = &[AgentKind::CodePuppy, AgentKind::Llxprt];
         let result = require_local_kind_available(AgentKind::CodePuppy, &remote, available);
@@ -269,6 +272,7 @@ mod tests {
             host: "build.example.com".to_owned(),
             run_as_user: String::new(),
             setup_env_default: false,
+            ..RemoteRepositorySettings::default()
         };
         let available = &[AgentKind::CodePuppy];
         let result = require_local_kind_available(AgentKind::CodePuppy, &remote, available);
@@ -285,6 +289,7 @@ mod tests {
             host: "build.example.com".to_owned(),
             run_as_user: String::new(),
             setup_env_default: false,
+            ..RemoteRepositorySettings::default()
         };
         let available = &[AgentKind::Llxprt];
         let result = require_local_kind_available(AgentKind::CodePuppy, &remote, available);

--- a/src/app_input/issue_prep_remote.rs
+++ b/src/app_input/issue_prep_remote.rs
@@ -6,7 +6,6 @@
 //! (command planning without execution), and the shared SSH helper functions.
 
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 use jefe::domain::RemoteRepositorySettings;
 
@@ -287,25 +286,15 @@ impl RemotePrepPlanner {
 
     /// Build the `ssh -T` argv for a remote command.
     fn ssh_argv(&self, remote_command: &str) -> Vec<String> {
-        vec![
-            "-o".to_owned(),
-            "BatchMode=yes".to_owned(),
-            "-o".to_owned(),
-            "ConnectTimeout=10".to_owned(),
-            // -T: disable PTY allocation for noninteractive prep/file
-            // transfer. This is distinct from the -tt used for tmux
-            // operations in runtime::commands.
-            "-T".to_owned(),
-            // `--` ends option parsing (defense in depth; identity
-            // validation is the primary guard).
-            "--".to_owned(),
-            format!(
-                "{}@{}",
-                self.remote.login_user.trim(),
-                self.remote.host.trim()
-            ),
-            remote_command.to_owned(),
-        ]
+        jefe::ssh::SshPlan::arguments(
+            &self.remote,
+            remote_command,
+            jefe::ssh::SshMode::NonInteractive,
+        )
+        .unwrap_or_else(|error| panic!("plan remote prep SSH: {error}"))
+        .into_iter()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect()
     }
 }
 
@@ -779,11 +768,7 @@ impl RemotePrepRunner {
         if output.status.success() {
             Ok(())
         } else {
-            Err(remote_failure_message(
-                &self.remote,
-                remote_command,
-                &output,
-            ))
+            Err(remote_failure_message(&self.remote, &output))
         }
     }
 
@@ -793,40 +778,17 @@ impl RemotePrepRunner {
         if output.status.success() {
             Ok(String::from_utf8_lossy(&output.stdout).into_owned())
         } else {
-            Err(remote_failure_message(
-                &self.remote,
-                remote_command,
-                &output,
-            ))
+            Err(remote_failure_message(&self.remote, &output))
         }
     }
 
     /// Run a remote command with prompt bytes piped via stdin.
     fn run_remote_stdin(&self, remote_command: &str, stdin_bytes: &[u8]) -> Result<(), String> {
-        use std::io::Write;
-        let mut child = self
-            .ssh_command(remote_command)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| format!("failed to spawn ssh: {e}"))?;
-        if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(stdin_bytes)
-                .map_err(|e| format!("failed to write prompt via stdin: {e}"))?;
-        }
-        let output = child
-            .wait_with_output()
-            .map_err(|e| format!("ssh failed: {e}"))?;
+        let output = self.execute_ssh(remote_command, Some(stdin_bytes))?;
         if output.status.success() {
             Ok(())
         } else {
-            Err(remote_failure_message(
-                &self.remote,
-                remote_command,
-                &output,
-            ))
+            Err(remote_failure_message(&self.remote, &output))
         }
     }
 
@@ -835,30 +797,22 @@ impl RemotePrepRunner {
     /// exit status is returned as `Ok(output)` so callers can distinguish
     /// predicate results from transport failures.
     fn run_remote_capture_raw(&self, remote_command: &str) -> Result<std::process::Output, String> {
-        self.ssh_command(remote_command)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .map_err(|e| {
-                format!(
-                    "SSH transport failure to {}@{}: {e}",
-                    self.remote.login_user.trim(),
-                    self.remote.host.trim()
-                )
-            })
+        self.execute_ssh(remote_command, None)
     }
 
-    /// Build the `ssh -T` command for a remote script.
-    fn ssh_command(&self, remote_command: &str) -> Command {
-        let mut cmd = Command::new("ssh");
-        cmd.args(["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "-T", "--"]);
-        cmd.arg(format!(
-            "{}@{}",
-            self.remote.login_user.trim(),
-            self.remote.host.trim()
-        ));
-        cmd.arg(remote_command);
-        cmd
+    fn execute_ssh(
+        &self,
+        remote_command: &str,
+        stdin: Option<&[u8]>,
+    ) -> Result<std::process::Output, String> {
+        jefe::ssh::SshPlan::new(
+            &self.remote,
+            remote_command,
+            jefe::ssh::SshMode::NonInteractive,
+        )
+        .map_err(|error| error.to_string())?
+        .execute(stdin, jefe::ssh::SSH_OPERATION_TIMEOUT, None)
+        .map_err(|error| error.to_string())
     }
 }
 
@@ -897,20 +851,14 @@ fn wrap_effective_user(remote: &RemoteRepositorySettings, command: &str) -> Stri
 /// Format a remote command failure message from a captured output.
 fn remote_failure_message(
     remote: &RemoteRepositorySettings,
-    command: &str,
     output: &std::process::Output,
 ) -> String {
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    let detail = if !stderr.is_empty() {
-        stderr
-    } else if !stdout.is_empty() {
-        stdout
-    } else {
-        format!("exit status {}", output.status)
-    };
+    let failure = jefe::ssh::classify_failure(
+        output.status.code(),
+        &String::from_utf8_lossy(&output.stderr),
+    );
     format!(
-        "remote prep on {}@{} failed ({command}): {detail}",
+        "remote prep on {}@{} failed: {failure}",
         remote.login_user.trim(),
         remote.host.trim(),
     )

--- a/src/app_input/issue_prep_remote_tests.rs
+++ b/src/app_input/issue_prep_remote_tests.rs
@@ -48,6 +48,7 @@ fn remote_settings() -> RemoteRepositorySettings {
         host: "build.example.com".to_owned(),
         run_as_user: "acoliver".to_owned(),
         setup_env_default: false,
+        ..RemoteRepositorySettings::default()
     }
 }
 
@@ -80,6 +81,7 @@ fn local_target_when_enabled_but_host_missing() {
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RemoteRepositorySettings::default()
     };
     assert_eq!(WorkTarget::from_remote(&remote), WorkTarget::Local);
 }

--- a/src/app_input/modal_handlers.rs
+++ b/src/app_input/modal_handlers.rs
@@ -546,14 +546,7 @@ fn validate_form_kind_available(app_state: &mut AppStateHandle) -> bool {
     let selection = match &state.modal {
         ModalState::NewRepository { fields, .. } | ModalState::EditRepository { fields, .. } => {
             let kind = AgentKind::from_form_value(&fields.default_agent_kind).unwrap_or_default();
-            let remote = RemoteRepositorySettings {
-                enabled: fields.remote_enabled,
-                login_user: fields.login_user.clone(),
-                host: fields.host.clone(),
-                run_as_user: fields.run_as_user.clone(),
-                setup_env_default: fields.setup_env_default,
-            };
-            (kind, remote)
+            jefe::state::AppState::remote_settings_from_fields(fields).map(|remote| (kind, remote))
         }
         ModalState::NewAgent {
             repository_id,
@@ -566,7 +559,7 @@ fn validate_form_kind_available(app_state: &mut AppStateHandle) -> bool {
                 .map_or_else(RemoteRepositorySettings::default, |repo| {
                     repo.remote.clone()
                 });
-            (kind, remote)
+            Ok((kind, remote))
         }
         ModalState::EditAgent { id, fields, .. } => {
             let kind = AgentKind::from_form_value(&fields.agent_kind).unwrap_or_default();
@@ -575,12 +568,18 @@ fn validate_form_kind_available(app_state: &mut AppStateHandle) -> bool {
                 .map_or_else(RemoteRepositorySettings::default, |repo| {
                     repo.remote.clone()
                 });
-            (kind, remote)
+            Ok((kind, remote))
         }
         _ => return true,
     };
     drop(state);
-    let (kind, remote) = selection;
+    let (kind, remote) = match selection {
+        Ok(selection) => selection,
+        Err(error) => {
+            app_state.write().error_message = Some(error);
+            return false;
+        }
+    };
 
     super::availability::local_kind_available_or_error(app_state, kind, &remote)
 }

--- a/src/app_input/remote_probe.rs
+++ b/src/app_input/remote_probe.rs
@@ -43,9 +43,7 @@
 //! with a transport/auth/infrastructure message and **never triggers a
 //! clone**.
 
-use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 use jefe::domain::{AgentKind, RemoteRepositorySettings};
 
@@ -121,33 +119,17 @@ pub(super) fn classify_probe_output(
     stdout: &str,
     stderr: &str,
 ) -> RemoteProbeResult {
-    match exit_code {
-        Some(0) => {
-            let trimmed = stdout.trim();
-            if trimmed == SENTINEL_OK {
-                RemoteProbeResult::Available
-            } else if trimmed == SENTINEL_NO {
-                RemoteProbeResult::NotAvailable
-            } else {
-                // Exit 0 but output is not exactly one sentinel — protocol
-                // mismatch, banner/prefix/suffix, both sentinels, or
-                // truncated output. Treat as infrastructure error (never
-                // clone).
-                RemoteProbeResult::Error(format!(
-                    "remote probe returned unexpected output (expected exactly one sentinel): \
-                     stdout={stdout:?} stderr={stderr:?}"
-                ))
-            }
-        }
-        Some(255) => RemoteProbeResult::Error(format!(
-            "SSH transport/auth/host failure (exit 255): {}",
-            stderr.trim()
-        )),
-        Some(code) => RemoteProbeResult::Error(format!(
-            "remote probe failed (exit {code}): {}",
-            stderr.trim()
-        )),
-        None => RemoteProbeResult::Error("remote probe terminated by signal".to_owned()),
+    if exit_code != Some(0) {
+        return RemoteProbeResult::Error(
+            jefe::ssh::classify_failure(exit_code, stderr).to_string(),
+        );
+    }
+    match stdout.trim() {
+        SENTINEL_OK => RemoteProbeResult::Available,
+        SENTINEL_NO => RemoteProbeResult::NotAvailable,
+        _ => RemoteProbeResult::Error(
+            "remote probe returned unexpected output; verify remote shell startup files".to_owned(),
+        ),
     }
 }
 
@@ -184,14 +166,24 @@ pub(super) fn classify_probe_output(
 /// LLxprt path-local `[ -x <work_dir>/node_modules/.bin/llxprt ]` check,
 /// which safely fails when the directory is absent.
 #[must_use]
+#[cfg(test)]
 pub(super) fn plan_remote_probe(
     remote: &RemoteRepositorySettings,
     work_dir: &Path,
     kind: AgentKind,
 ) -> Vec<String> {
+    ssh_arguments_as_strings(remote, &remote_probe_command(remote, work_dir, kind))
+        .unwrap_or_else(|error| panic!("plan remote probe: {error}"))
+}
+
+fn remote_probe_command(
+    remote: &RemoteRepositorySettings,
+    work_dir: &Path,
+    kind: AgentKind,
+) -> String {
     let inner = probe_inner_command(kind, work_dir);
     let effective = effective_user(remote);
-    let command = if effective == remote.login_user.trim() {
+    if effective == remote.login_user.trim() {
         inner
     } else {
         format!(
@@ -199,44 +191,20 @@ pub(super) fn plan_remote_probe(
             shell_escape(&effective),
             shell_escape(&inner),
         )
-    };
-    // Defense in depth: validate SSH identity before constructing the
-    // Runtime defense-in-depth: validate SSH identity before constructing the
-    // destination. The authoritative validation is at form/persistence
-    // boundaries (domain::target::validate_remote), but every SSH command
-    // site re-checks at runtime (not just debug builds) so stale data can
-    // never reach the shell. The `--` separator below is the final structural
-    // guard.
-    let user = remote.login_user.trim();
-    let host = remote.host.trim();
-    assert!(
-        jefe::domain::target::is_valid_ssh_identity(user)
-            && jefe::domain::target::is_valid_ssh_identity(host),
-        "SSH identity fields must be validated before reaching plan_remote_probe"
-    );
-    vec![
-        "-o".to_owned(),
-        "BatchMode=yes".to_owned(),
-        "-o".to_owned(),
-        "ConnectTimeout=10".to_owned(),
-        // Auto-accept the host key on first connect (TOFU) and verify it on
-        // subsequent connections. Without this, OpenSSH prompts interactively
-        // to accept an unknown host key — but these probes run non-interactively
-        // (no PTY), so the prompt would hang indefinitely.
-        "-o".to_owned(),
-        "StrictHostKeyChecking=accept-new".to_owned(),
-        "-o".to_owned(),
-        "ServerAliveInterval=5".to_owned(),
-        "-o".to_owned(),
-        "ServerAliveCountMax=3".to_owned(),
-        "-T".to_owned(),
-        // `--` ends option parsing so a destination starting with '-' cannot
-        // be misinterpreted as an ssh option (defense in depth; validation
-        // is the primary guard).
-        "--".to_owned(),
-        format!("{user}@{host}"),
-        command,
-    ]
+    }
+}
+
+fn ssh_arguments_as_strings(
+    remote: &RemoteRepositorySettings,
+    remote_command: &str,
+) -> Result<Vec<String>, String> {
+    jefe::ssh::SshPlan::arguments(remote, remote_command, jefe::ssh::SshMode::NonInteractive)
+        .map(|args| {
+            args.into_iter()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect()
+        })
+        .map_err(|error| error.to_string())
 }
 
 /// Build the inner shell command for the sentinel-based availability probe.
@@ -318,21 +286,22 @@ pub(super) fn execute_remote_probe(
     work_dir: &Path,
     kind: AgentKind,
 ) -> RemoteProbeResult {
-    let argv = plan_remote_probe(remote, work_dir, kind);
-    let mut cmd = Command::new("ssh");
-    cmd.args(&argv);
-    cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::piped());
-    let output = match cmd.output() {
+    let command = remote_probe_command(remote, work_dir, kind);
+    let plan = match jefe::ssh::SshPlan::new(remote, &command, jefe::ssh::SshMode::NonInteractive) {
+        Ok(plan) => plan,
+        Err(error) => return RemoteProbeResult::Error(error.to_string()),
+    };
+    let output = match plan.execute(None, jefe::ssh::SSH_OPERATION_TIMEOUT, None) {
         Ok(output) => output,
-        Err(error) => {
-            return RemoteProbeResult::Error(format!(
-                "failed to spawn ssh for remote probe: {error}"
-            ));
-        }
+        Err(error) => return RemoteProbeResult::Error(error.to_string()),
     };
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() {
+        return RemoteProbeResult::Error(
+            jefe::ssh::classify_failure(output.status.code(), &stderr).to_string(),
+        );
+    }
     classify_probe_output(output.status.code(), &stdout, &stderr)
 }
 
@@ -490,25 +459,7 @@ pub(super) fn plan_remote_prompt_write(
             shell_escape(&inner),
         )
     };
-    let ssh_argv = vec![
-        "-o".to_owned(),
-        "BatchMode=yes".to_owned(),
-        "-o".to_owned(),
-        "ConnectTimeout=10".to_owned(),
-        // Non-interactive host-key policy and post-connect keepalive (see
-        // plan_remote_probe for rationale).
-        "-o".to_owned(),
-        "StrictHostKeyChecking=accept-new".to_owned(),
-        "-o".to_owned(),
-        "ServerAliveInterval=5".to_owned(),
-        "-o".to_owned(),
-        "ServerAliveCountMax=3".to_owned(),
-        "-T".to_owned(),
-        // `--` ends option parsing (defense in depth; validation is primary).
-        "--".to_owned(),
-        format!("{}@{}", remote.login_user.trim(), remote.host.trim()),
-        command,
-    ];
+    let ssh_argv = ssh_arguments_as_strings(remote, &command)?;
     // Adversarial content safety: prompt bytes are in stdin, NOT argv.
     // Compare whole tokens to avoid false positives when a short prompt is a
     // coincidental substring of a fixed ssh option (e.g. "yes" ⊂ "BatchMode=yes").
@@ -573,40 +524,28 @@ pub(super) fn write_remote_prompt(
     relative_path: &str,
     prompt: &str,
 ) -> Result<(), String> {
-    let plan = plan_remote_prompt_write(remote, work_dir, relative_path, prompt)?;
-    let mut child = Command::new("ssh");
-    child.args(&plan.ssh_argv);
-    child.stdin(Stdio::piped());
-    child.stdout(Stdio::piped());
-    child.stderr(Stdio::piped());
-    let mut child = child
-        .spawn()
-        .map_err(|e| format!("failed to spawn ssh for prompt write: {e}"))?;
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(plan.stdin_prompt.as_bytes())
-            .map_err(|e| format!("failed to write prompt via stdin: {e}"))?;
-    }
-    let output = child
-        .wait_with_output()
-        .map_err(|e| format!("ssh prompt write failed: {e}"))?;
+    let planned_write = plan_remote_prompt_write(remote, work_dir, relative_path, prompt)?;
+    let remote_command = planned_write
+        .ssh_argv
+        .last()
+        .ok_or_else(|| "remote prompt write plan has no command".to_owned())?;
+    let plan = jefe::ssh::SshPlan::new(remote, remote_command, jefe::ssh::SshMode::NonInteractive)
+        .map_err(|error| error.to_string())?;
+    let output = plan
+        .execute(
+            Some(planned_write.stdin_prompt.as_bytes()),
+            jefe::ssh::SSH_OPERATION_TIMEOUT,
+            None,
+        )
+        .map_err(|error| error.to_string())?;
     if output.status.success() {
         Ok(())
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-        let detail = if !stderr.is_empty() {
-            stderr
-        } else if !stdout.is_empty() {
-            stdout
-        } else {
-            format!("exit status {}", output.status)
-        };
-        Err(format!(
-            "remote prompt write on {}@{} failed ({relative_path}): {detail}",
-            remote.login_user.trim(),
-            remote.host.trim(),
-        ))
+        Err(jefe::ssh::classify_failure(
+            output.status.code(),
+            &String::from_utf8_lossy(&output.stderr),
+        )
+        .to_string())
     }
 }
 

--- a/src/app_input/remote_probe.rs
+++ b/src/app_input/remote_probe.rs
@@ -113,6 +113,10 @@ pub(super) fn effective_user(remote: &RemoteRepositorySettings) -> String {
 /// - `exit_code == 0` with any prefix/suffix/both sentinels/malformed output
 ///   → `Error` (protocol mismatch, banner injection, or truncated output).
 /// - Any other nonzero exit → `Error`.
+///
+/// Live execution classifies transport failures through `SshPlan::execute`
+/// before calling this function. Accepting raw non-success outcomes here keeps
+/// this pure boundary classifier complete and directly testable.
 #[must_use]
 pub(super) fn classify_probe_output(
     exit_code: Option<i32>,
@@ -418,6 +422,8 @@ pub(super) const PR_PROMPT_RELATIVE_PATH: &str = ".jefe/pr-prompt.md";
 pub(super) struct PlannedPromptWrite {
     /// The full `ssh -T` argv (everything after the `ssh` binary).
     pub ssh_argv: Vec<String>,
+    /// The controlled Unix command sent to the remote host.
+    remote_command: String,
     /// The relative prompt path targeted (e.g. `.jefe/pr-prompt.md`).
     pub relative_path: String,
     /// Prompt bytes that would be transferred via stdin.
@@ -468,6 +474,7 @@ pub(super) fn plan_remote_prompt_write(
     }
     Ok(PlannedPromptWrite {
         ssh_argv,
+        remote_command: command,
         relative_path: relative_path.to_owned(),
         stdin_prompt: prompt.to_owned(),
     })
@@ -525,12 +532,12 @@ pub(super) fn write_remote_prompt(
     prompt: &str,
 ) -> Result<(), String> {
     let planned_write = plan_remote_prompt_write(remote, work_dir, relative_path, prompt)?;
-    let remote_command = planned_write
-        .ssh_argv
-        .last()
-        .ok_or_else(|| "remote prompt write plan has no command".to_owned())?;
-    let plan = jefe::ssh::SshPlan::new(remote, remote_command, jefe::ssh::SshMode::NonInteractive)
-        .map_err(|error| error.to_string())?;
+    let plan = jefe::ssh::SshPlan::new(
+        remote,
+        &planned_write.remote_command,
+        jefe::ssh::SshMode::NonInteractive,
+    )
+    .map_err(|error| error.to_string())?;
     let output = plan
         .execute(
             Some(planned_write.stdin_prompt.as_bytes()),

--- a/src/app_input/remote_probe_tests.rs
+++ b/src/app_input/remote_probe_tests.rs
@@ -45,6 +45,7 @@ fn valid_remote() -> RemoteRepositorySettings {
         host: "build.example.com".to_owned(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RemoteRepositorySettings::default()
     }
 }
 
@@ -55,6 +56,7 @@ fn remote_with_run_as() -> RemoteRepositorySettings {
         host: "build.example.com".to_owned(),
         run_as_user: "acoliver".to_owned(),
         setup_env_default: false,
+        ..RemoteRepositorySettings::default()
     }
 }
 
@@ -212,6 +214,7 @@ fn effective_user_trims_whitespace() {
         host: "host".to_owned(),
         run_as_user: "  acoliver  ".to_owned(),
         setup_env_default: false,
+        ..RemoteRepositorySettings::default()
     };
     assert_eq!(effective_user(&remote), "acoliver");
 }

--- a/src/app_input/target_resolution.rs
+++ b/src/app_input/target_resolution.rs
@@ -66,6 +66,7 @@ mod tests {
             host: host.to_owned(),
             run_as_user: String::new(),
             setup_env_default: false,
+            ..RemoteRepositorySettings::default()
         }
     }
 

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -112,6 +112,12 @@ pub struct RemoteRepositorySettings {
     #[serde(default)]
     pub host: String,
     #[serde(default)]
+    pub port: Option<u16>,
+    #[serde(default)]
+    pub identity_file: PathBuf,
+    #[serde(default)]
+    pub options: Vec<String>,
+    #[serde(default)]
     pub run_as_user: String,
     #[serde(default)]
     pub setup_env_default: bool,

--- a/src/domain/target.rs
+++ b/src/domain/target.rs
@@ -123,6 +123,7 @@ pub fn validate_ssh_option(option: &str) -> Result<(), String> {
         && !matches!(
             normalized.as_str(),
             "proxycommand"
+                | "proxyjump"
                 | "localcommand"
                 | "permitlocalcommand"
                 | "include"
@@ -411,6 +412,12 @@ mod tests {
         let mut good = remote(true, "ubuntu", "build.example.com");
         good.run_as_user = "deploy".to_owned();
         assert!(validate_remote(&good).is_ok());
+    }
+    #[test]
+    fn validate_remote_rejects_proxyjump_option() {
+        let mut bad = remote(true, "ubuntu", "build.example.com");
+        bad.options = vec!["ProxyJump=gateway.example.com".to_owned()];
+        assert!(validate_remote(&bad).is_err());
     }
 
     #[test]

--- a/src/domain/target.rs
+++ b/src/domain/target.rs
@@ -105,6 +105,44 @@ pub fn ssh_identity_validation_message() -> String {
         .to_owned()
 }
 
+/// Validate a user-supplied OpenSSH `-o` value.
+///
+/// Options must be one shell-free `name=value` argument. Settings that can
+/// execute a local command or override Jefe-owned connection structure are
+/// rejected so custom options cannot bypass the typed host, port, identity,
+/// timeout, host-key, and non-interactive policies.
+pub fn validate_ssh_option(option: &str) -> Result<(), String> {
+    let Some((name, value)) = option.split_once('=') else {
+        return Err("SSH options must use name=value syntax".to_owned());
+    };
+    let normalized = name.to_ascii_lowercase();
+    let valid_name = !name.is_empty()
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-')
+        && !matches!(
+            normalized.as_str(),
+            "proxycommand"
+                | "localcommand"
+                | "permitlocalcommand"
+                | "include"
+                | "match"
+                | "hostname"
+                | "port"
+                | "user"
+                | "identityfile"
+                | "batchmode"
+                | "connecttimeout"
+                | "stricthostkeychecking"
+                | "serveraliveinterval"
+                | "serveralivecountmax"
+        );
+    if !valid_name || value.is_empty() || value.chars().any(char::is_control) {
+        return Err(format!("SSH option {name:?} is not permitted"));
+    }
+    Ok(())
+}
+
 /// Validate remote settings for form submission.
 ///
 /// Returns `Ok(())` when the settings are either disabled or a complete remote
@@ -128,6 +166,12 @@ pub fn validate_remote(remote: &RemoteRepositorySettings) -> Result<(), String> 
     if !remote.run_as_user.trim().is_empty() && !is_valid_ssh_identity(&remote.run_as_user) {
         return Err(ssh_identity_validation_message());
     }
+    if remote.port == Some(0) {
+        return Err("SSH port must be between 1 and 65535".to_owned());
+    }
+    for option in &remote.options {
+        validate_ssh_option(option)?;
+    }
     Ok(())
 }
 
@@ -142,7 +186,22 @@ mod tests {
             host: host.to_owned(),
             run_as_user: String::new(),
             setup_env_default: false,
+            ..RemoteRepositorySettings::default()
         }
+    }
+
+    #[test]
+    fn validate_remote_rejects_zero_port_and_transport_owned_options() {
+        let mut settings = remote(true, "ubuntu", "host");
+        settings.port = Some(0);
+        assert!(validate_remote(&settings).is_err());
+
+        settings.port = Some(22);
+        settings.options = vec!["Port=2200".to_owned()];
+        assert!(validate_remote(&settings).is_err());
+
+        settings.options = vec!["Compression=yes".to_owned()];
+        assert_eq!(validate_remote(&settings), Ok(()));
     }
 
     #[test]

--- a/src/domain/target.rs
+++ b/src/domain/target.rs
@@ -110,7 +110,7 @@ pub fn ssh_identity_validation_message() -> String {
 /// Options must be one shell-free `name=value` argument. Only options that do
 /// not alter Jefe-owned destination, authentication, host-key, forwarding,
 /// connection-sharing, command, timeout, or terminal policies are accepted.
-pub fn validate_ssh_option(option: &str) -> Result<(), String> {
+fn validate_ssh_option(option: &str) -> Result<(), String> {
     const ALLOWED_OPTIONS: &[&str] = &[
         "compression",
         "ipqos",

--- a/src/domain/target.rs
+++ b/src/domain/target.rs
@@ -107,39 +107,35 @@ pub fn ssh_identity_validation_message() -> String {
 
 /// Validate a user-supplied OpenSSH `-o` value.
 ///
-/// Options must be one shell-free `name=value` argument. Settings that can
-/// execute a local command or override Jefe-owned connection structure are
-/// rejected so custom options cannot bypass the typed host, port, identity,
-/// timeout, host-key, and non-interactive policies.
+/// Options must be one shell-free `name=value` argument. Only options that do
+/// not alter Jefe-owned destination, authentication, host-key, forwarding,
+/// connection-sharing, command, timeout, or terminal policies are accepted.
 pub fn validate_ssh_option(option: &str) -> Result<(), String> {
+    const ALLOWED_OPTIONS: &[&str] = &[
+        "compression",
+        "ipqos",
+        "loglevel",
+        "logverbose",
+        "rekeylimit",
+        "tcpkeepalive",
+    ];
+
     let Some((name, value)) = option.split_once('=') else {
         return Err("SSH options must use name=value syntax".to_owned());
     };
-    let normalized = name.to_ascii_lowercase();
-    let valid_name = !name.is_empty()
-        && name
+    if name.is_empty()
+        || !name
             .chars()
             .all(|ch| ch.is_ascii_alphanumeric() || ch == '-')
-        && !matches!(
-            normalized.as_str(),
-            "proxycommand"
-                | "proxyjump"
-                | "localcommand"
-                | "permitlocalcommand"
-                | "include"
-                | "match"
-                | "hostname"
-                | "port"
-                | "user"
-                | "identityfile"
-                | "batchmode"
-                | "connecttimeout"
-                | "stricthostkeychecking"
-                | "serveraliveinterval"
-                | "serveralivecountmax"
-        );
-    if !valid_name || value.is_empty() || value.chars().any(char::is_control) {
+        || !ALLOWED_OPTIONS.contains(&name.to_ascii_lowercase().as_str())
+    {
         return Err(format!("SSH option {name:?} is not permitted"));
+    }
+    if value.is_empty() {
+        return Err(format!("SSH option {name:?} requires a value"));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(format!("SSH option {name:?} contains control characters"));
     }
     Ok(())
 }
@@ -418,6 +414,38 @@ mod tests {
         let mut bad = remote(true, "ubuntu", "build.example.com");
         bad.options = vec!["ProxyJump=gateway.example.com".to_owned()];
         assert!(validate_remote(&bad).is_err());
+    }
+
+    #[test]
+    fn validate_remote_allows_only_non_policy_ssh_options() {
+        let mut good = remote(true, "ubuntu", "build.example.com");
+        good.options = vec!["Compression=yes".to_owned(), "LogLevel=ERROR".to_owned()];
+        assert!(validate_remote(&good).is_ok());
+
+        for option in [
+            "UserKnownHostsFile=NUL",
+            "ForwardAgent=yes",
+            "CertificateFile=client-cert.pub",
+            "PasswordAuthentication=yes",
+            "ControlMaster=auto",
+            "RequestTTY=force",
+        ] {
+            let mut bad = good.clone();
+            bad.options = vec![option.to_owned()];
+            assert!(validate_remote(&bad).is_err(), "accepted {option}");
+        }
+    }
+
+    #[test]
+    fn ssh_option_validation_distinguishes_value_errors() {
+        assert_eq!(
+            validate_ssh_option("Compression="),
+            Err("SSH option \"Compression\" requires a value".to_owned())
+        );
+        assert_eq!(
+            validate_ssh_option("Compression=yes\n"),
+            Err("SSH option \"Compression\" contains control characters".to_owned())
+        );
     }
 
     #[test]

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -486,9 +486,8 @@ fn guarded_real_jefe_qqq_quits() {
     let scenario = scenario_with_wait_timeout(
         r#"[
             { "waitFor": "LLxprt Jefe" },
-            { "key": "q" },
-            { "key": "q" },
-            { "key": "q" },
+            { "wait": 500 },
+            { "line": "qqq" },
             { "waitForExit": 3000 }
         ]"#,
         30_000,
@@ -505,7 +504,7 @@ fn guarded_real_jefe_qqq_quits() {
 
     let summary = run_tmux_scenario(&scenario, &request, None).value_or_panic("qqq quit scenario");
 
-    assert_eq!(summary.steps_run, 5);
+    assert_eq!(summary.steps_run, 4);
 }
 
 fn jefe_binary_path() -> Option<PathBuf> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ pub mod runtime;
 /// Pure, iocraft-free mouse-selection model (pane geometry + text extraction).
 pub mod selection;
 pub mod services;
+/// Native-host OpenSSH planning and typed failure classification.
+pub mod ssh;
 pub mod startup;
 pub mod state;
 /// Pure multiline text-box viewport projection (iocraft-free).

--- a/src/local_command.rs
+++ b/src/local_command.rs
@@ -14,6 +14,8 @@ pub enum LocalTool {
     Git,
     /// GitHub command-line client.
     Gh,
+    /// OpenSSH command-line client.
+    Ssh,
 }
 
 impl LocalTool {
@@ -21,6 +23,7 @@ impl LocalTool {
         match self {
             Self::Git => "git",
             Self::Gh => "gh",
+            Self::Ssh => "ssh",
         }
     }
 
@@ -28,6 +31,7 @@ impl LocalTool {
         match self {
             Self::Git => "JEFE_GIT_BIN",
             Self::Gh => "JEFE_GH_BIN",
+            Self::Ssh => "JEFE_SSH_BIN",
         }
     }
 }
@@ -236,5 +240,24 @@ mod tests {
                 tool: LocalTool::Gh
             })
         ));
+    }
+
+    #[test]
+    fn windows_resolves_openssh_from_unicode_path() {
+        let root = tempfile::Builder::new()
+            .prefix("jefe OpenSSH Ω ")
+            .tempdir()
+            .unwrap_or_else(|error| panic!("create OpenSSH fixture: {error}"));
+        let executable = root.path().join("ssh.EXE");
+        std::fs::write(&executable, b"fixture")
+            .unwrap_or_else(|error| panic!("write OpenSSH fixture: {error}"));
+        let resolved = resolve_in(
+            LocalTool::Ssh,
+            ToolPlatform::Windows,
+            &[root.path().to_path_buf()],
+            Some(OsString::from(".EXE")),
+            None,
+        );
+        assert_eq!(resolved, Ok(executable));
     }
 }

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -695,6 +695,9 @@ impl PersistenceManager for FilePersistenceManager {
 }
 
 #[cfg(test)]
+mod remote_ssh_tests;
+
+#[cfg(test)]
 mod runtime_binding_tests;
 
 #[cfg(test)]

--- a/src/persistence/remote_ssh_tests.rs
+++ b/src/persistence/remote_ssh_tests.rs
@@ -1,0 +1,40 @@
+//! Persistence compatibility tests for remote OpenSSH settings.
+
+use crate::domain::RemoteRepositorySettings;
+
+trait TestResultExt<T> {
+    fn value_or_panic(self, context: &str) -> T;
+}
+
+impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
+    fn value_or_panic(self, context: &str) -> T {
+        match self {
+            Ok(value) => value,
+            Err(error) => panic!("{context}: {error:?}"),
+        }
+    }
+}
+
+#[test]
+fn remote_ssh_settings_round_trip_and_legacy_defaults_are_compatible() {
+    let configured = RemoteRepositorySettings {
+        enabled: true,
+        login_user: "ubuntu".to_owned(),
+        host: "linux.example".to_owned(),
+        port: Some(2222),
+        identity_file: std::path::PathBuf::from(r"C:\Keys Ω\agent key"),
+        options: vec!["Compression=yes".to_owned()],
+        ..RemoteRepositorySettings::default()
+    };
+    let encoded = serde_json::to_string(&configured).value_or_panic("serialize SSH settings");
+    let decoded: RemoteRepositorySettings =
+        serde_json::from_str(&encoded).value_or_panic("deserialize SSH settings");
+    assert_eq!(decoded, configured);
+
+    let legacy = r#"{"enabled":true,"login_user":"ubuntu","host":"linux.example","run_as_user":"","setup_env_default":false}"#;
+    let decoded: RemoteRepositorySettings =
+        serde_json::from_str(legacy).value_or_panic("deserialize legacy SSH settings");
+    assert_eq!(decoded.port, None);
+    assert!(decoded.identity_file.as_os_str().is_empty());
+    assert!(decoded.options.is_empty());
+}

--- a/src/runtime/attach.rs
+++ b/src/runtime/attach.rs
@@ -470,13 +470,14 @@ fn ensure_wrap_slot(wraps: &mut Vec<bool>, rows: usize) {
 
 fn attach_command(
     session_name: &str,
-    ssh_command: Option<&str>,
+    ssh_plan: Option<&crate::ssh::SshPlan>,
     multiplexer_plan: Option<&super::multiplexer::MultiplexerPlan>,
 ) -> Result<CommandBuilder, RuntimeError> {
-    let mut cmd = if let Some(ssh_command) = ssh_command {
-        let mut cmd = CommandBuilder::new("sh");
-        cmd.arg("-lc");
-        cmd.arg(ssh_command);
+    let mut cmd = if let Some(ssh_plan) = ssh_plan {
+        let mut cmd = CommandBuilder::new(ssh_plan.executable());
+        for arg in ssh_plan.args() {
+            cmd.arg(arg);
+        }
         cmd
     } else {
         // Local attachment uses the same resolved executable and isolation
@@ -538,22 +539,22 @@ impl AttachedViewer {
         session_name: &str,
         rows: u16,
         cols: u16,
-        ssh_command: &str,
+        ssh_plan: &crate::ssh::SshPlan,
     ) -> Result<Self, RuntimeError> {
-        Self::spawn_command(session_name, rows, cols, Some(ssh_command), None)
+        Self::spawn_command(session_name, rows, cols, Some(ssh_plan), None)
     }
 
     fn spawn_command(
         session_name: &str,
         rows: u16,
         cols: u16,
-        ssh_command: Option<&str>,
+        ssh_plan: Option<&crate::ssh::SshPlan>,
         multiplexer_plan: Option<&super::multiplexer::MultiplexerPlan>,
     ) -> Result<Self, RuntimeError> {
-        debug!(session_name = %session_name, rows, cols, remote = ssh_command.is_some(), "AttachedViewer::spawn start");
+        debug!(session_name = %session_name, rows, cols, remote = ssh_plan.is_some(), "AttachedViewer::spawn start");
 
         let pty_pair = open_pty(rows, cols)?;
-        let cmd = attach_command(session_name, ssh_command, multiplexer_plan)?;
+        let cmd = attach_command(session_name, ssh_plan, multiplexer_plan)?;
 
         let child = pty_pair
             .slave

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -335,51 +335,6 @@ fn run_command_capture_with_timeout(
     }
 }
 
-fn remote_ssh_args(
-    remote: &crate::domain::RemoteRepositorySettings,
-    remote_command: &str,
-) -> Vec<String> {
-    // Runtime defense-in-depth: validate SSH identity fields before
-    // constructing the destination. The authoritative validation happens at
-    // form/persistence boundaries via domain::target::validate_remote, but
-    // every SSH command site re-checks at runtime (not just debug builds) so
-    // a stale or unvalidated RemoteRepositorySettings can never reach the
-    // shell. The `--` separator below is the final structural guard: it ends
-    // option parsing so a destination starting with '-' cannot be parsed as
-    // an ssh option even if validation were bypassed.
-    let user = remote.login_user.trim();
-    let host = remote.host.trim();
-    assert!(
-        crate::domain::target::is_valid_ssh_identity(user)
-            && crate::domain::target::is_valid_ssh_identity(host),
-        "SSH identity fields must be validated before reaching remote_ssh_args"
-    );
-    vec![
-        "-o".to_owned(),
-        "BatchMode=yes".to_owned(),
-        "-o".to_owned(),
-        "ConnectTimeout=10".to_owned(),
-        // Auto-accept the host key on first connect (TOFU) and verify it on
-        // subsequent connections so SSH never hangs waiting for interactive
-        // acceptance in the non-PTY runtime path.
-        "-o".to_owned(),
-        "StrictHostKeyChecking=accept-new".to_owned(),
-        // Post-connect keepalive so a hung remote command is detected within
-        // ~15s instead of blocking indefinitely.
-        "-o".to_owned(),
-        "ServerAliveInterval=5".to_owned(),
-        "-o".to_owned(),
-        "ServerAliveCountMax=3".to_owned(),
-        "-tt".to_owned(),
-        // `--` ends option parsing so a destination starting with '-' cannot
-        // be misinterpreted as an ssh option (defense in depth; validation
-        // is the primary guard).
-        "--".to_owned(),
-        format!("{user}@{host}"),
-        remote_command.to_owned(),
-    ]
-}
-
 pub fn remote_tmux_command(
     remote: &crate::domain::RemoteRepositorySettings,
     inner_command: &str,
@@ -416,10 +371,10 @@ fn remote_kill_session_command(
     )
 }
 
-pub fn build_remote_attach_command(
+pub fn build_remote_attach_plan(
     remote: &crate::domain::RemoteRepositorySettings,
     session_name: &str,
-) -> String {
+) -> Result<crate::ssh::SshPlan, RuntimeError> {
     let remote_command = remote_tmux_command(
         remote,
         &format!(
@@ -427,21 +382,18 @@ pub fn build_remote_attach_command(
             shell_escape_single(session_name)
         ),
     );
-    let ssh_args = remote_ssh_args(remote, &remote_command);
-    format!("exec ssh {}", shell_join(&ssh_args))
+    crate::ssh::SshPlan::new(remote, &remote_command, crate::ssh::SshMode::Terminal)
+        .map_err(|error| RuntimeError::RemoteExecutionFailed(error.to_string()))
 }
 
 pub fn run_remote_ssh(
     remote: &crate::domain::RemoteRepositorySettings,
     remote_command: &str,
 ) -> Result<Output, RuntimeError> {
-    let ssh_args = remote_ssh_args(remote, remote_command);
-    let mut cmd = Command::new("ssh");
-    cmd.args(&ssh_args);
-    run_command_capture(
-        cmd,
-        &format!("ssh {}@{}", remote.login_user.trim(), remote.host.trim()),
-    )
+    let plan = crate::ssh::SshPlan::new(remote, remote_command, crate::ssh::SshMode::Terminal)
+        .map_err(|error| RuntimeError::RemoteExecutionFailed(error.to_string()))?;
+    plan.execute(None, crate::ssh::SSH_OPERATION_TIMEOUT, None)
+        .map_err(|error| RuntimeError::RemoteExecutionFailed(error.to_string()))
 }
 
 fn ensure_remote_success(
@@ -452,22 +404,12 @@ fn ensure_remote_success(
     if output.status.success() {
         Ok(output)
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-        let detail = if !stderr.is_empty() {
-            stderr
-        } else if !stdout.is_empty() {
-            stdout
-        } else {
-            format!(
-                "remote command failed on {}@{} with status {}",
-                remote.login_user.trim(),
-                remote.host.trim(),
-                output.status
-            )
-        };
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let failure = crate::ssh::classify_failure(output.status.code(), &stderr);
         Err(RuntimeError::RemoteExecutionFailed(format!(
-            "{action}: {detail}"
+            "{action} on {}@{}: {failure}",
+            remote.login_user.trim(),
+            remote.host.trim()
         )))
     }
 }

--- a/src/runtime/commands_tests.rs
+++ b/src/runtime/commands_tests.rs
@@ -6,6 +6,37 @@ use crate::domain::SandboxEngine;
 use crate::runtime::pane_capture::{capture_pane_history_args, parse_pane_pid};
 #[cfg(unix)]
 use std::time::Duration;
+#[test]
+fn remote_attach_plan_uses_direct_ssh_and_excludes_local_psmux_namespace() {
+    let remote = crate::domain::RemoteRepositorySettings {
+        enabled: true,
+        login_user: "ubuntu".to_owned(),
+        host: "linux.example".to_owned(),
+        port: Some(2222),
+        identity_file: std::path::PathBuf::from(r"C:\Keys Ω\agent key"),
+        options: vec!["Compression=yes".to_owned()],
+        ..crate::domain::RemoteRepositorySettings::default()
+    };
+    let plan = crate::ssh::SshPlan::with_executable(
+        std::path::PathBuf::from(r"C:\Program Files\OpenSSH\ssh.exe"),
+        &remote,
+        &remote_tmux_command(&remote, "tmux attach-session -t 'remote-agent'"),
+        crate::ssh::SshMode::Terminal,
+    )
+    .unwrap_or_else(|error| panic!("plan remote attach: {error}"));
+    assert_eq!(
+        plan.executable(),
+        std::path::Path::new(r"C:\Program Files\OpenSSH\ssh.exe")
+    );
+    assert!(plan.args().contains(&std::ffi::OsString::from("-tt")));
+    let remote_command = plan.args().last().map_or_else(
+        || panic!("remote attach plan should contain a command"),
+        |argument| argument.to_string_lossy(),
+    );
+    assert!(remote_command.contains("tmux attach-session"));
+    assert!(!remote_command.contains("psmux"));
+    assert!(!remote_command.contains("JEFE_PSMUX"));
+}
 
 fn base_signature() -> LaunchSignature {
     LaunchSignature {
@@ -169,6 +200,7 @@ fn remote_tmux_command_wraps_run_as_user_once() {
         host: "example.com".to_owned(),
         run_as_user: "acoliver".to_owned(),
         setup_env_default: false,
+        ..crate::domain::RemoteRepositorySettings::default()
     };
 
     let command = remote_tmux_command(&remote, "tmux has-session -t 'demo'");
@@ -307,6 +339,7 @@ fn remote_disable_prefix_command_targets_session_with_both_options() {
         host: "example.com".to_owned(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..crate::domain::RemoteRepositorySettings::default()
     };
 
     let command = remote_disable_prefix_command(&remote, "jefe-agent-prefix");
@@ -343,6 +376,7 @@ fn remote_disable_prefix_command_wraps_through_run_as_user() {
         host: "example.com".to_owned(),
         run_as_user: "acoliver".to_owned(),
         setup_env_default: false,
+        ..crate::domain::RemoteRepositorySettings::default()
     };
 
     let command = remote_disable_prefix_command(&remote, "s");

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -637,8 +637,8 @@ impl RuntimeManager for TmuxRuntimeManager {
             // Spawn new viewer
             debug!(agent_id = %agent_id.0, session_name = %session_name, "attach: spawning AttachedViewer");
             let viewer = if let Some(remote) = remote_settings {
-                let ssh_command = commands::build_remote_attach_command(&remote, &session_name);
-                AttachedViewer::spawn_remote(&session_name, self.rows, self.cols, &ssh_command)?
+                let ssh_plan = commands::build_remote_attach_plan(&remote, &session_name)?;
+                AttachedViewer::spawn_remote(&session_name, self.rows, self.cols, &ssh_plan)?
             } else {
                 AttachedViewer::spawn(&session_name, self.rows, self.cols)?
             };

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -39,6 +39,7 @@ pub use capabilities::{
     AgentRuntimeCapabilities, ModelDiscovery, code_puppy_help_supports_yolo, static_capabilities,
     validate_code_puppy_launch,
 };
+pub use commands::build_remote_attach_plan;
 #[cfg(feature = "psmux-smoke")]
 pub use commands::configure_prefix_for_passthrough_with_plan;
 pub use errors::RuntimeError;

--- a/src/services/tests.rs
+++ b/src/services/tests.rs
@@ -26,6 +26,7 @@ fn remote_repository() -> Repository {
             host: "example.com".to_owned(),
             run_as_user: "acoliver".to_owned(),
             setup_env_default: false,
+            ..RemoteRepositorySettings::default()
         },
         ..local_repository()
     }

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -7,7 +7,7 @@
 
 use std::ffi::OsString;
 use std::fmt;
-use std::io::Read;
+use std::io::{Error as IoError, ErrorKind, Read};
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
 use std::sync::Arc;
@@ -196,7 +196,7 @@ fn execute_command(
 ) -> Result<Output, SshError> {
     let mut child = command
         .spawn()
-        .map_err(|error| SshError::Spawn(error.to_string()))?;
+        .map_err(|error| SshError::Spawn(SshIoError::new(error)))?;
     let stdout = take_pipe(child.stdout.take(), &mut child, "stdout")?;
     let stderr = take_pipe(child.stderr.take(), &mut child, "stderr")?;
     let stdout_reader = read_pipe(stdout);
@@ -232,7 +232,7 @@ fn execute_command(
                     stdout_reader,
                     stderr_reader,
                     stdin_writer,
-                    SshError::Io(error.to_string()),
+                    SshError::Io(SshIoError::new(error)),
                 ));
             }
         }
@@ -256,7 +256,9 @@ fn take_pipe<T>(
 ) -> Result<T, SshError> {
     pipe.ok_or_else(|| {
         terminate_child(child);
-        SshError::Io(format!("OpenSSH {name} pipe was unavailable"))
+        SshError::Io(SshIoError::message(format!(
+            "OpenSSH {name} pipe was unavailable"
+        )))
     })
 }
 
@@ -289,8 +291,12 @@ fn join_reader(
 ) -> Result<Vec<u8>, SshError> {
     reader
         .join()
-        .map_err(|_| SshError::Io("OpenSSH output reader terminated unexpectedly".to_owned()))?
-        .map_err(|error| SshError::Io(error.to_string()))
+        .map_err(|_| {
+            SshError::Io(SshIoError::message(
+                "OpenSSH output reader terminated unexpectedly",
+            ))
+        })?
+        .map_err(|error| SshError::Io(SshIoError::new(error)))
 }
 
 fn join_writer(
@@ -301,8 +307,12 @@ fn join_writer(
     };
     writer
         .join()
-        .map_err(|_| SshError::Io("OpenSSH input writer terminated unexpectedly".to_owned()))?
-        .map_err(|error| SshError::Io(error.to_string()))
+        .map_err(|_| {
+            SshError::Io(SshIoError::message(
+                "OpenSSH input writer terminated unexpectedly",
+            ))
+        })?
+        .map_err(|error| SshError::Io(SshIoError::new(error)))
 }
 
 fn stop_execution(
@@ -324,6 +334,68 @@ fn terminate_child(child: &mut std::process::Child) {
     let _ = child.wait();
 }
 
+/// Preserved local process error with programmatic OS classification.
+#[derive(Clone)]
+pub struct SshIoError {
+    source: Arc<IoError>,
+}
+
+impl SshIoError {
+    fn new(source: IoError) -> Self {
+        Self {
+            source: Arc::new(source),
+        }
+    }
+
+    fn message(message: impl Into<String>) -> Self {
+        Self::new(IoError::other(message.into()))
+    }
+
+    /// Return the standard I/O error category.
+    #[must_use]
+    pub fn kind(&self) -> ErrorKind {
+        self.source.kind()
+    }
+
+    /// Return the platform error code when one is available.
+    #[must_use]
+    pub fn raw_os_error(&self) -> Option<i32> {
+        self.source.raw_os_error()
+    }
+}
+
+impl fmt::Debug for SshIoError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SshIoError")
+            .field("kind", &self.kind())
+            .field("raw_os_error", &self.raw_os_error())
+            .finish()
+    }
+}
+
+impl fmt::Display for SshIoError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.source.fmt(formatter)
+    }
+}
+
+impl PartialEq for SshIoError {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind() == other.kind()
+            && self.raw_os_error() == other.raw_os_error()
+            && self.source.to_string() == other.source.to_string()
+    }
+}
+
+impl Eq for SshIoError {}
+
+impl std::error::Error for SshIoError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
 /// Typed SSH planning and execution failure.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SshError {
@@ -332,9 +404,9 @@ pub enum SshError {
     /// Connection settings are incomplete or unsafe.
     InvalidSettings(String),
     /// OpenSSH could not be started.
-    Spawn(String),
+    Spawn(SshIoError),
     /// Local process I/O failed.
-    Io(String),
+    Io(SshIoError),
     /// The remote host key could not be verified.
     HostKey,
     /// Authentication failed.
@@ -385,7 +457,22 @@ impl fmt::Display for SshError {
     }
 }
 
-impl std::error::Error for SshError {}
+impl std::error::Error for SshError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::LocalTool(error) => Some(error),
+            Self::Spawn(error) | Self::Io(error) => Some(error),
+            Self::InvalidSettings(_)
+            | Self::HostKey
+            | Self::Authentication
+            | Self::Timeout
+            | Self::Cancelled
+            | Self::MissingRemoteTmux
+            | Self::MissingRemoteRuntime
+            | Self::RemoteCommand { .. } => None,
+        }
+    }
+}
 
 /// Classify redacted OpenSSH diagnostics into actionable failure categories.
 #[must_use]
@@ -514,6 +601,20 @@ mod tests {
                 .to_string()
                 .contains("secret")
         );
+    }
+
+    #[test]
+    fn spawn_errors_preserve_io_kind_and_source() {
+        let plan = SshPlan {
+            executable: std::env::temp_dir().join("jefe-definitely-missing-ssh-executable"),
+            args: Vec::new(),
+        };
+        let result = plan.execute(None, Duration::from_secs(1), None);
+        let Err(SshError::Spawn(error)) = result else {
+            panic!("expected typed OpenSSH spawn failure");
+        };
+        assert_eq!(error.kind(), ErrorKind::NotFound);
+        assert!(std::error::Error::source(&error).is_some());
     }
 
     #[test]

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,0 +1,531 @@
+//! Native-host OpenSSH planning, execution, and failure classification.
+//!
+//! Local executable and argv construction is kept separate from controlled
+//! Unix command strings executed by the remote Linux shell. Every non-PTY SSH
+//! operation uses the same bounded executor; interactive attachment consumes
+//! the same validated plan through `portable-pty`.
+
+use std::ffi::OsString;
+use std::fmt;
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use crate::domain::RemoteRepositorySettings;
+use crate::local_command::{self, LocalTool, LocalToolError};
+
+/// Maximum duration for a non-interactive SSH operation.
+pub const SSH_OPERATION_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Whether the remote operation requires a terminal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SshMode {
+    /// Disable PTY allocation for probes and file operations.
+    NonInteractive,
+    /// Force PTY allocation for tmux attachment and lifecycle commands.
+    Terminal,
+}
+
+/// Cooperative cancellation signal for a running non-interactive SSH process.
+#[derive(Clone, Debug, Default)]
+pub struct SshCancellation {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl SshCancellation {
+    /// Request cancellation. The executor kills and reaps the SSH child.
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+}
+
+/// A validated, shell-free local OpenSSH invocation.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SshPlan {
+    executable: PathBuf,
+    args: Vec<OsString>,
+}
+
+impl fmt::Debug for SshPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SshPlan")
+            .field("executable", &"<redacted>")
+            .field("argument_count", &self.args.len())
+            .finish()
+    }
+}
+
+impl SshPlan {
+    /// Plan an OpenSSH invocation using the configured local executable.
+    pub fn new(
+        remote: &RemoteRepositorySettings,
+        remote_command: &str,
+        mode: SshMode,
+    ) -> Result<Self, SshError> {
+        let executable = local_command::resolve(LocalTool::Ssh).map_err(SshError::LocalTool)?;
+        Self::with_executable(executable, remote, remote_command, mode)
+    }
+
+    /// Plan an invocation with an explicitly supplied executable.
+    pub fn with_executable(
+        executable: PathBuf,
+        remote: &RemoteRepositorySettings,
+        remote_command: &str,
+        mode: SshMode,
+    ) -> Result<Self, SshError> {
+        Ok(Self {
+            executable,
+            args: Self::arguments(remote, remote_command, mode)?,
+        })
+    }
+
+    /// Build validated OpenSSH arguments without resolving an executable.
+    pub fn arguments(
+        remote: &RemoteRepositorySettings,
+        remote_command: &str,
+        mode: SshMode,
+    ) -> Result<Vec<OsString>, SshError> {
+        crate::domain::target::validate_remote(remote).map_err(SshError::InvalidSettings)?;
+        if !remote.enabled {
+            return Err(SshError::InvalidSettings(
+                "remote SSH transport is disabled".to_owned(),
+            ));
+        }
+        if remote_command.is_empty() {
+            return Err(SshError::InvalidSettings(
+                "remote command must not be empty".to_owned(),
+            ));
+        }
+        let mut args = common_args(remote);
+        args.push(OsString::from(match mode {
+            SshMode::NonInteractive => "-T",
+            SshMode::Terminal => "-tt",
+        }));
+        args.push(OsString::from("--"));
+        args.push(OsString::from(format!(
+            "{}@{}",
+            remote.login_user.trim(),
+            remote.host.trim()
+        )));
+        args.push(OsString::from(remote_command));
+        Ok(args)
+    }
+
+    /// Return the resolved local OpenSSH executable.
+    #[must_use]
+    pub fn executable(&self) -> &std::path::Path {
+        &self.executable
+    }
+
+    /// Return the exact OpenSSH argv entries.
+    #[must_use]
+    pub fn args(&self) -> &[OsString] {
+        &self.args
+    }
+
+    /// Construct a process command without a local shell.
+    #[must_use]
+    pub fn command(&self) -> Command {
+        let mut command = Command::new(&self.executable);
+        command.args(&self.args);
+        command
+    }
+
+    /// Execute a bounded non-interactive plan with optional stdin and cancellation.
+    pub fn execute(
+        &self,
+        stdin: Option<&[u8]>,
+        timeout: Duration,
+        cancellation: Option<&SshCancellation>,
+    ) -> Result<Output, SshError> {
+        if cancellation.is_some_and(SshCancellation::is_cancelled) {
+            return Err(SshError::Cancelled);
+        }
+        let mut command = self.command();
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        if stdin.is_some() {
+            command.stdin(Stdio::piped());
+        } else {
+            command.stdin(Stdio::null());
+        }
+        execute_command(command, stdin, timeout, cancellation)
+    }
+}
+
+fn common_args(remote: &RemoteRepositorySettings) -> Vec<OsString> {
+    let mut args = vec![
+        OsString::from("-o"),
+        OsString::from("BatchMode=yes"),
+        OsString::from("-o"),
+        OsString::from("ConnectTimeout=10"),
+        OsString::from("-o"),
+        OsString::from("StrictHostKeyChecking=accept-new"),
+        OsString::from("-o"),
+        OsString::from("ServerAliveInterval=5"),
+        OsString::from("-o"),
+        OsString::from("ServerAliveCountMax=3"),
+    ];
+    if let Some(port) = remote.port {
+        args.extend([OsString::from("-p"), OsString::from(port.to_string())]);
+    }
+    if !remote.identity_file.as_os_str().is_empty() {
+        args.extend([
+            OsString::from("-i"),
+            remote.identity_file.as_os_str().to_owned(),
+        ]);
+    }
+    for option in &remote.options {
+        args.extend([OsString::from("-o"), OsString::from(option)]);
+    }
+    args
+}
+
+fn execute_command(
+    mut command: Command,
+    stdin: Option<&[u8]>,
+    timeout: Duration,
+    cancellation: Option<&SshCancellation>,
+) -> Result<Output, SshError> {
+    let mut child = command
+        .spawn()
+        .map_err(|error| SshError::Spawn(error.to_string()))?;
+    let stdout = take_pipe(child.stdout.take(), &mut child, "stdout")?;
+    let stderr = take_pipe(child.stderr.take(), &mut child, "stderr")?;
+    let stdout_reader = read_pipe(stdout);
+    let stderr_reader = read_pipe(stderr);
+    let stdin_writer = start_stdin_writer(stdin, &mut child)?;
+    let deadline = Instant::now() + timeout;
+
+    let status = loop {
+        if cancellation.is_some_and(SshCancellation::is_cancelled) {
+            return Err(stop_execution(
+                &mut child,
+                stdout_reader,
+                stderr_reader,
+                stdin_writer,
+                SshError::Cancelled,
+            ));
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() >= deadline => {
+                return Err(stop_execution(
+                    &mut child,
+                    stdout_reader,
+                    stderr_reader,
+                    stdin_writer,
+                    SshError::Timeout,
+                ));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(25)),
+            Err(error) => {
+                return Err(stop_execution(
+                    &mut child,
+                    stdout_reader,
+                    stderr_reader,
+                    stdin_writer,
+                    SshError::Io(error.to_string()),
+                ));
+            }
+        }
+    };
+
+    let stdout = join_reader(stdout_reader);
+    let stderr = join_reader(stderr_reader);
+    let stdin = join_writer(stdin_writer);
+    stdin?;
+    Ok(Output {
+        status,
+        stdout: stdout?,
+        stderr: stderr?,
+    })
+}
+
+fn take_pipe<T>(
+    pipe: Option<T>,
+    child: &mut std::process::Child,
+    name: &str,
+) -> Result<T, SshError> {
+    pipe.ok_or_else(|| {
+        terminate_child(child);
+        SshError::Io(format!("OpenSSH {name} pipe was unavailable"))
+    })
+}
+
+fn start_stdin_writer(
+    stdin: Option<&[u8]>,
+    child: &mut std::process::Child,
+) -> Result<Option<std::thread::JoinHandle<std::io::Result<()>>>, SshError> {
+    use std::io::Write;
+
+    let Some(bytes) = stdin else {
+        return Ok(None);
+    };
+    let mut pipe = take_pipe(child.stdin.take(), child, "stdin")?;
+    let bytes = bytes.to_vec();
+    Ok(Some(std::thread::spawn(move || pipe.write_all(&bytes))))
+}
+
+fn read_pipe(
+    mut pipe: impl Read + Send + 'static,
+) -> std::thread::JoinHandle<std::io::Result<Vec<u8>>> {
+    std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        pipe.read_to_end(&mut bytes)?;
+        Ok(bytes)
+    })
+}
+
+fn join_reader(
+    reader: std::thread::JoinHandle<std::io::Result<Vec<u8>>>,
+) -> Result<Vec<u8>, SshError> {
+    reader
+        .join()
+        .map_err(|_| SshError::Io("OpenSSH output reader terminated unexpectedly".to_owned()))?
+        .map_err(|error| SshError::Io(error.to_string()))
+}
+
+fn join_writer(
+    writer: Option<std::thread::JoinHandle<std::io::Result<()>>>,
+) -> Result<(), SshError> {
+    let Some(writer) = writer else {
+        return Ok(());
+    };
+    writer
+        .join()
+        .map_err(|_| SshError::Io("OpenSSH input writer terminated unexpectedly".to_owned()))?
+        .map_err(|error| SshError::Io(error.to_string()))
+}
+
+fn stop_execution(
+    child: &mut std::process::Child,
+    stdout: std::thread::JoinHandle<std::io::Result<Vec<u8>>>,
+    stderr: std::thread::JoinHandle<std::io::Result<Vec<u8>>>,
+    stdin: Option<std::thread::JoinHandle<std::io::Result<()>>>,
+    error: SshError,
+) -> SshError {
+    terminate_child(child);
+    let _ = join_writer(stdin);
+    let _ = join_reader(stdout);
+    let _ = join_reader(stderr);
+    error
+}
+
+fn terminate_child(child: &mut std::process::Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Typed SSH planning and execution failure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SshError {
+    /// Local OpenSSH could not be resolved.
+    LocalTool(LocalToolError),
+    /// Connection settings are incomplete or unsafe.
+    InvalidSettings(String),
+    /// OpenSSH could not be started.
+    Spawn(String),
+    /// Local process I/O failed.
+    Io(String),
+    /// The remote host key could not be verified.
+    HostKey,
+    /// Authentication failed.
+    Authentication,
+    /// The operation exceeded its deadline.
+    Timeout,
+    /// The process was cancelled.
+    Cancelled,
+    /// Remote tmux is unavailable.
+    MissingRemoteTmux,
+    /// The selected agent runtime is unavailable remotely.
+    MissingRemoteRuntime,
+    /// A remote operation failed without exposing its payload.
+    RemoteCommand { status: Option<i32> },
+}
+
+impl fmt::Display for SshError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LocalTool(error) => write!(formatter, "OpenSSH unavailable: {error}"),
+            Self::InvalidSettings(error) => write!(formatter, "invalid SSH settings: {error}"),
+            Self::Spawn(error) => write!(formatter, "could not start OpenSSH: {error}"),
+            Self::Io(error) => write!(formatter, "OpenSSH process I/O failed: {error}"),
+            Self::HostKey => write!(
+                formatter,
+                "SSH host-key verification failed; verify known_hosts"
+            ),
+            Self::Authentication => write!(
+                formatter,
+                "SSH authentication failed; verify the configured identity"
+            ),
+            Self::Timeout => write!(formatter, "SSH operation timed out"),
+            Self::Cancelled => write!(formatter, "SSH operation was cancelled"),
+            Self::MissingRemoteTmux => {
+                write!(formatter, "remote tmux is not installed or unavailable")
+            }
+            Self::MissingRemoteRuntime => write!(
+                formatter,
+                "remote agent runtime is not installed or unavailable"
+            ),
+            Self::RemoteCommand { status } => {
+                write!(
+                    formatter,
+                    "remote SSH operation failed with status {status:?}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for SshError {}
+
+/// Classify redacted OpenSSH diagnostics into actionable failure categories.
+#[must_use]
+pub fn classify_failure(status: Option<i32>, stderr: &str) -> SshError {
+    let diagnostic = stderr.to_ascii_lowercase();
+    if status.is_none() {
+        SshError::Cancelled
+    } else if diagnostic.contains("host key verification failed")
+        || diagnostic.contains("remote host identification has changed")
+    {
+        SshError::HostKey
+    } else if diagnostic.contains("permission denied")
+        || diagnostic.contains("authentication failed")
+    {
+        SshError::Authentication
+    } else if diagnostic.contains("timed out") || diagnostic.contains("connection timeout") {
+        SshError::Timeout
+    } else if diagnostic.contains("tmux: command not found")
+        || diagnostic.contains("tmux: not found")
+    {
+        SshError::MissingRemoteTmux
+    } else if diagnostic.contains("code-puppy: not found")
+        || diagnostic.contains("llxprt: not found")
+    {
+        SshError::MissingRemoteRuntime
+    } else {
+        SshError::RemoteCommand { status }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn remote() -> RemoteRepositorySettings {
+        RemoteRepositorySettings {
+            enabled: true,
+            login_user: "ubuntu".to_owned(),
+            host: "linux.example".to_owned(),
+            port: Some(2222),
+            identity_file: PathBuf::from(r"C:\Keys Ω\agent key"),
+            options: vec!["Compression=yes".to_owned()],
+            ..RemoteRepositorySettings::default()
+        }
+    }
+
+    #[test]
+    fn plan_preserves_windows_paths_and_remote_command_as_distinct_arguments() {
+        let plan = SshPlan::with_executable(
+            PathBuf::from(r"C:\Program Files\OpenSSH\ssh.exe"),
+            &remote(),
+            "tmux attach-session -t 'agent Ω'",
+            SshMode::Terminal,
+        )
+        .unwrap_or_else(|error| panic!("plan SSH: {error}"));
+        assert_eq!(
+            plan.executable(),
+            std::path::Path::new(r"C:\Program Files\OpenSSH\ssh.exe")
+        );
+        assert!(
+            plan.args()
+                .contains(&OsString::from(r"C:\Keys Ω\agent key"))
+        );
+        assert!(plan.args().contains(&OsString::from("2222")));
+        assert_eq!(
+            plan.args().last(),
+            Some(&OsString::from("tmux attach-session -t 'agent Ω'"))
+        );
+    }
+
+    #[test]
+    fn unsafe_local_command_options_are_rejected() {
+        let mut settings = remote();
+        settings.options = vec!["ProxyCommand=steal-secret".to_owned()];
+        let result = SshPlan::with_executable(
+            PathBuf::from("ssh"),
+            &settings,
+            "true",
+            SshMode::NonInteractive,
+        );
+        assert!(matches!(result, Err(SshError::InvalidSettings(_))));
+    }
+
+    #[test]
+    fn plans_reject_disabled_transport_and_empty_remote_commands() {
+        let mut settings = remote();
+        settings.enabled = false;
+        let disabled = SshPlan::arguments(&settings, "true", SshMode::NonInteractive);
+        assert!(matches!(disabled, Err(SshError::InvalidSettings(_))));
+
+        settings.enabled = true;
+        let empty = SshPlan::arguments(&settings, "", SshMode::NonInteractive);
+        assert!(matches!(empty, Err(SshError::InvalidSettings(_))));
+    }
+
+    #[test]
+    fn plan_debug_output_redacts_executable_and_command_payload() {
+        let plan = SshPlan::with_executable(
+            PathBuf::from(r"C:\Program Files\OpenSSH\ssh.exe"),
+            &remote(),
+            "token=secret",
+            SshMode::NonInteractive,
+        )
+        .unwrap_or_else(|error| panic!("plan SSH: {error}"));
+        let diagnostic = format!("{plan:?}");
+        assert!(!diagnostic.contains("OpenSSH"));
+        assert!(!diagnostic.contains("secret"));
+    }
+
+    #[test]
+    fn failures_are_typed_and_do_not_retain_sensitive_payloads() {
+        assert_eq!(
+            classify_failure(Some(255), "Host key verification failed."),
+            SshError::HostKey
+        );
+        assert_eq!(
+            classify_failure(Some(255), "Permission denied (publickey)."),
+            SshError::Authentication
+        );
+        assert_eq!(
+            classify_failure(None, "secret command"),
+            SshError::Cancelled
+        );
+        assert!(
+            !classify_failure(Some(17), "token=secret")
+                .to_string()
+                .contains("secret")
+        );
+    }
+
+    #[test]
+    fn cancellation_is_typed_before_process_execution() {
+        let cancellation = SshCancellation::default();
+        cancellation.cancel();
+        let plan = SshPlan {
+            executable: std::env::current_exe()
+                .unwrap_or_else(|error| panic!("resolve test executable: {error}")),
+            args: Vec::new(),
+        };
+        let result = plan.execute(None, Duration::from_secs(1), Some(&cancellation));
+        assert_eq!(result, Err(SshError::Cancelled));
+    }
+}

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -38,11 +38,11 @@ pub struct SshCancellation {
 impl SshCancellation {
     /// Request cancellation. The executor kills and reaps the SSH child.
     pub fn cancel(&self) {
-        self.cancelled.store(true, Ordering::Release);
+        self.cancelled.store(true, Ordering::Relaxed);
     }
 
     fn is_cancelled(&self) -> bool {
-        self.cancelled.load(Ordering::Acquire)
+        self.cancelled.load(Ordering::Relaxed)
     }
 }
 

--- a/src/state/form_build.rs
+++ b/src/state/form_build.rs
@@ -58,15 +58,49 @@ impl AppState {
         resolve_agent_work_dir(repository, value)
     }
 
-    pub(super) fn remote_settings_from_fields(
+    /// Parse and validate SSH settings from repository form fields.
+    pub fn remote_settings_from_fields(
         fields: &RepositoryFormFields,
-    ) -> RemoteRepositorySettings {
-        RemoteRepositorySettings {
+    ) -> Result<RemoteRepositorySettings, String> {
+        let port = match fields.ssh_port.trim() {
+            "" => None,
+            value => {
+                let port = value
+                    .parse::<u16>()
+                    .map_err(|_| "SSH port must be between 1 and 65535".to_owned())?;
+                if port == 0 {
+                    return Err("SSH port must be between 1 and 65535".to_owned());
+                }
+                Some(port)
+            }
+        };
+        let settings = RemoteRepositorySettings {
             enabled: fields.remote_enabled,
             login_user: fields.login_user.trim().to_owned(),
             host: fields.host.trim().to_owned(),
+            port,
+            identity_file: std::path::PathBuf::from(fields.identity_file.trim()),
+            options: fields
+                .ssh_options
+                .split_whitespace()
+                .map(str::to_owned)
+                .collect(),
             run_as_user: fields.run_as_user.trim().to_owned(),
             setup_env_default: fields.setup_env_default,
+        };
+        crate::domain::target::validate_remote(&settings)?;
+        Ok(settings)
+    }
+
+    fn validated_remote_settings(
+        fields: &RepositoryFormFields,
+    ) -> Option<RemoteRepositorySettings> {
+        match Self::remote_settings_from_fields(fields) {
+            Ok(settings) => Some(settings),
+            Err(error) => {
+                warn!(error = %error, "rejecting repository create: invalid remote config");
+                None
+            }
         }
     }
 
@@ -100,15 +134,7 @@ impl AppState {
             return None;
         }
 
-        // Reject an enabled-but-incomplete remote config visibly: the user
-        // must provide both login_user and host when remote is enabled.
-        // This prevents silently persisting a config that would later be
-        // treated as local or rejected at launch time.
-        let remote_settings = Self::remote_settings_from_fields(fields);
-        if let Err(error) = crate::domain::target::validate_remote(&remote_settings) {
-            warn!(error = %error, "rejecting repository create: incomplete remote config");
-            return None;
-        }
+        let remote_settings = Self::validated_remote_settings(fields)?;
 
         let trimmed_base_dir = fields.base_dir.trim();
         let base_dir = if trimmed_base_dir.is_empty() {
@@ -173,12 +199,13 @@ impl AppState {
             return false;
         }
 
-        // Reject an enabled-but-incomplete remote config visibly.
-        let remote_settings = Self::remote_settings_from_fields(fields);
-        if let Err(error) = crate::domain::target::validate_remote(&remote_settings) {
-            warn!(error = %error, "rejecting repository update: incomplete remote config");
-            return false;
-        }
+        let remote_settings = match Self::remote_settings_from_fields(fields) {
+            Ok(settings) => settings,
+            Err(error) => {
+                warn!(error = %error, "rejecting repository update: invalid remote config");
+                return false;
+            }
+        };
 
         trimmed_name.clone_into(&mut repo.name);
         repo.slug = slug;

--- a/src/state/form_build.rs
+++ b/src/state/form_build.rs
@@ -62,17 +62,21 @@ impl AppState {
     pub fn remote_settings_from_fields(
         fields: &RepositoryFormFields,
     ) -> Result<RemoteRepositorySettings, String> {
-        let port = match fields.ssh_port.trim() {
-            "" => None,
-            value => {
-                let port = value
-                    .parse::<u16>()
-                    .map_err(|_| "SSH port must be between 1 and 65535".to_owned())?;
-                if port == 0 {
-                    return Err("SSH port must be between 1 and 65535".to_owned());
+        let port = if fields.remote_enabled {
+            match fields.ssh_port.trim() {
+                "" => None,
+                value => {
+                    let port = value
+                        .parse::<u16>()
+                        .map_err(|_| "SSH port must be between 1 and 65535".to_owned())?;
+                    if port == 0 {
+                        return Err("SSH port must be between 1 and 65535".to_owned());
+                    }
+                    Some(port)
                 }
-                Some(port)
             }
+        } else {
+            None
         };
         let settings = RemoteRepositorySettings {
             enabled: fields.remote_enabled,

--- a/src/state/form_cursor.rs
+++ b/src/state/form_cursor.rs
@@ -45,6 +45,16 @@ pub(super) fn handle_repository_field_char(
         RepositoryFormFocus::Host => {
             cursor.host = insert_char_at(&mut fields.host, cursor.host, c);
         }
+        RepositoryFormFocus::SshPort => {
+            cursor.ssh_port = insert_char_at(&mut fields.ssh_port, cursor.ssh_port, c);
+        }
+        RepositoryFormFocus::IdentityFile => {
+            cursor.identity_file =
+                insert_char_at(&mut fields.identity_file, cursor.identity_file, c);
+        }
+        RepositoryFormFocus::SshOptions => {
+            cursor.ssh_options = insert_char_at(&mut fields.ssh_options, cursor.ssh_options, c);
+        }
         RepositoryFormFocus::RunAsUser => {
             cursor.run_as_user = insert_char_at(&mut fields.run_as_user, cursor.run_as_user, c);
         }
@@ -91,6 +101,15 @@ pub(super) fn move_repository_field_cursor_right(
             cursor.login_user = move_cursor_right(&fields.login_user, cursor.login_user);
         }
         RepositoryFormFocus::Host => cursor.host = move_cursor_right(&fields.host, cursor.host),
+        RepositoryFormFocus::SshPort => {
+            cursor.ssh_port = move_cursor_right(&fields.ssh_port, cursor.ssh_port);
+        }
+        RepositoryFormFocus::IdentityFile => {
+            cursor.identity_file = move_cursor_right(&fields.identity_file, cursor.identity_file);
+        }
+        RepositoryFormFocus::SshOptions => {
+            cursor.ssh_options = move_cursor_right(&fields.ssh_options, cursor.ssh_options);
+        }
         RepositoryFormFocus::RunAsUser => {
             cursor.run_as_user = move_cursor_right(&fields.run_as_user, cursor.run_as_user);
         }
@@ -174,6 +193,13 @@ pub(super) fn move_repository_field_cursor_left(
         }
         RepositoryFormFocus::LoginUser => cursor.login_user = move_cursor_left(cursor.login_user),
         RepositoryFormFocus::Host => cursor.host = move_cursor_left(cursor.host),
+        RepositoryFormFocus::SshPort => cursor.ssh_port = move_cursor_left(cursor.ssh_port),
+        RepositoryFormFocus::IdentityFile => {
+            cursor.identity_file = move_cursor_left(cursor.identity_file);
+        }
+        RepositoryFormFocus::SshOptions => {
+            cursor.ssh_options = move_cursor_left(cursor.ssh_options);
+        }
         RepositoryFormFocus::RunAsUser => cursor.run_as_user = move_cursor_left(cursor.run_as_user),
     }
 }

--- a/src/state/form_ops.rs
+++ b/src/state/form_ops.rs
@@ -255,6 +255,17 @@ impl AppState {
             RepositoryFormFocus::Host => {
                 cursor.host = delete_char_before(&mut fields.host, cursor.host);
             }
+            RepositoryFormFocus::SshPort => {
+                cursor.ssh_port = delete_char_before(&mut fields.ssh_port, cursor.ssh_port);
+            }
+            RepositoryFormFocus::IdentityFile => {
+                cursor.identity_file =
+                    delete_char_before(&mut fields.identity_file, cursor.identity_file);
+            }
+            RepositoryFormFocus::SshOptions => {
+                cursor.ssh_options =
+                    delete_char_before(&mut fields.ssh_options, cursor.ssh_options);
+            }
             RepositoryFormFocus::RunAsUser => {
                 cursor.run_as_user =
                     delete_char_before(&mut fields.run_as_user, cursor.run_as_user);
@@ -300,6 +311,15 @@ impl AppState {
             }
             RepositoryFormFocus::Host => {
                 delete_char_at(&mut fields.host, cursor.host);
+            }
+            RepositoryFormFocus::SshPort => {
+                delete_char_at(&mut fields.ssh_port, cursor.ssh_port);
+            }
+            RepositoryFormFocus::IdentityFile => {
+                delete_char_at(&mut fields.identity_file, cursor.identity_file);
+            }
+            RepositoryFormFocus::SshOptions => {
+                delete_char_at(&mut fields.ssh_options, cursor.ssh_options);
             }
             RepositoryFormFocus::RunAsUser => {
                 delete_char_at(&mut fields.run_as_user, cursor.run_as_user);

--- a/src/state/form_ops_tests.rs
+++ b/src/state/form_ops_tests.rs
@@ -226,6 +226,7 @@ fn remote_repository_creation_preserves_remote_base_dir_without_local_expansion(
         host: "170.9.234.179".to_owned(),
         run_as_user: "acoliver".to_owned(),
         setup_env_default: true,
+        ..RepositoryFormFields::default()
     };
 
     let Some(repository) = AppState::create_repository_from_fields(&fields) else {
@@ -258,6 +259,7 @@ fn repository_name_that_normalizes_to_empty_slug_is_rejected() {
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RepositoryFormFields::default()
     };
 
     assert!(AppState::create_repository_from_fields(&fields).is_none());
@@ -408,7 +410,10 @@ fn repository_checkbox_toggle_updates_remote_fields() {
     state = state.apply(AppEvent::FormNextField); // LoginUser → Host
     state = state.apply(AppEvent::FormChar('1'));
     state = state.apply(AppEvent::FormChar('.'));
-    state = state.apply(AppEvent::FormNextField); // Host → RunAsUser
+    state = state.apply(AppEvent::FormNextField); // Host → SshPort
+    state = state.apply(AppEvent::FormNextField); // SshPort → IdentityFile
+    state = state.apply(AppEvent::FormNextField); // IdentityFile → SshOptions
+    state = state.apply(AppEvent::FormNextField); // SshOptions → RunAsUser
     state = state.apply(AppEvent::FormChar('a'));
     state = state.apply(AppEvent::FormNextField); // RunAsUser → SetupEnvDefault
     state = state.apply(AppEvent::FormToggleCheckbox); // toggle setup_env_default
@@ -447,6 +452,7 @@ fn create_repository_rejects_invalid_github_repo_without_slash() {
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RepositoryFormFields::default()
     };
     assert!(AppState::create_repository_from_fields(&fields).is_none());
 }
@@ -466,6 +472,7 @@ fn create_repository_rejects_github_repo_with_extra_slash() {
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RepositoryFormFields::default()
     };
     assert!(AppState::create_repository_from_fields(&fields).is_none());
 }
@@ -485,6 +492,7 @@ fn create_repository_rejects_github_repo_missing_owner() {
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RepositoryFormFields::default()
     };
     assert!(AppState::create_repository_from_fields(&fields).is_none());
 }
@@ -504,6 +512,7 @@ fn create_repository_rejects_github_repo_missing_repo_name() {
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RepositoryFormFields::default()
     };
     assert!(AppState::create_repository_from_fields(&fields).is_none());
 }
@@ -523,6 +532,7 @@ fn create_repository_accepts_empty_github_repo() {
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RepositoryFormFields::default()
     };
     assert!(AppState::create_repository_from_fields(&fields).is_some());
 }
@@ -542,6 +552,7 @@ fn create_repository_accepts_well_formed_github_repo() {
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RepositoryFormFields::default()
     };
     let Some(repo) = AppState::create_repository_from_fields(&fields) else {
         panic!("valid repo");
@@ -563,6 +574,7 @@ fn create_repository_rejects_github_repo_with_internal_whitespace_in_owner() {
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RepositoryFormFields::default()
     };
     assert!(AppState::create_repository_from_fields(&fields).is_none());
 }
@@ -583,6 +595,7 @@ fn create_repository_rejects_github_repo_with_whitespace_around_slash() {
             host: String::new(),
             run_as_user: String::new(),
             setup_env_default: false,
+            ..RepositoryFormFields::default()
         };
         assert!(
             AppState::create_repository_from_fields(&fields).is_none(),
@@ -607,6 +620,7 @@ fn create_repository_rejects_github_repo_with_at_sign() {
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RepositoryFormFields::default()
     };
     assert!(AppState::create_repository_from_fields(&fields).is_none());
 }
@@ -626,6 +640,7 @@ fn create_repository_accepts_github_repo_with_surrounding_whitespace_and_trims_i
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RepositoryFormFields::default()
     };
     let Some(repo) = AppState::create_repository_from_fields(&fields) else {
         panic!("valid repo with surrounding whitespace");
@@ -650,6 +665,7 @@ fn update_repository_rejects_invalid_github_repo_keeping_existing() {
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RepositoryFormFields::default()
     };
     assert!(!AppState::update_repository_from_fields(&mut repo, &fields));
     // Existing value preserved because update was rejected.
@@ -673,6 +689,7 @@ fn update_repository_accepts_well_formed_github_repo_after_invalid_rejection() {
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RepositoryFormFields::default()
     };
     assert!(!AppState::update_repository_from_fields(
         &mut repo, &invalid
@@ -780,12 +797,56 @@ fn issue266_valid_fields() -> RepositoryFormFields {
         github_issue_pr_repo: String::new(),
         remote_enabled: false,
         login_user: String::new(),
+
         host: String::new(),
         run_as_user: String::new(),
         setup_env_default: false,
+        ..RepositoryFormFields::default()
     }
 }
 
+#[test]
+fn remote_repository_form_preserves_validated_ssh_transport_fields() {
+    let fields = RepositoryFormFields {
+        name: "Remote SSH".to_owned(),
+        remote_enabled: true,
+        login_user: "ubuntu".to_owned(),
+        host: "linux.example".to_owned(),
+        ssh_port: "2222".to_owned(),
+        identity_file: r"C:\Keys Ω\agent key".to_owned(),
+        ssh_options: "Compression=yes LogLevel=ERROR".to_owned(),
+        ..RepositoryFormFields::default()
+    };
+    let Some(repository) = AppState::create_repository_from_fields(&fields) else {
+        panic!("valid SSH fields should create a repository");
+    };
+    assert_eq!(repository.remote.port, Some(2222));
+    assert_eq!(
+        repository.remote.identity_file,
+        std::path::PathBuf::from(r"C:\Keys Ω\agent key")
+    );
+    assert_eq!(
+        repository.remote.options,
+        vec!["Compression=yes", "LogLevel=ERROR"]
+    );
+}
+
+#[test]
+fn remote_repository_form_rejects_invalid_port_and_unsafe_option() {
+    let mut fields = RepositoryFormFields {
+        name: "Remote SSH".to_owned(),
+        remote_enabled: true,
+        login_user: "ubuntu".to_owned(),
+        host: "linux.example".to_owned(),
+        ssh_port: "not-a-port".to_owned(),
+        ..RepositoryFormFields::default()
+    };
+    assert!(AppState::create_repository_from_fields(&fields).is_none());
+
+    fields.ssh_port = "22".to_owned();
+    fields.ssh_options = "ProxyCommand=credential-helper".to_owned();
+    assert!(AppState::create_repository_from_fields(&fields).is_none());
+}
 /// A blank `github_issue_pr_repo` is accepted (preserves existing behavior).
 #[test]
 fn create_repository_accepts_blank_issue_pr_repo() {

--- a/src/state/form_ops_tests.rs
+++ b/src/state/form_ops_tests.rs
@@ -847,6 +847,20 @@ fn remote_repository_form_rejects_invalid_port_and_unsafe_option() {
     fields.ssh_options = "ProxyCommand=credential-helper".to_owned();
     assert!(AppState::create_repository_from_fields(&fields).is_none());
 }
+
+#[test]
+fn local_repository_ignores_stale_invalid_ssh_port() {
+    let fields = RepositoryFormFields {
+        name: "Local Repository".to_owned(),
+        remote_enabled: false,
+        ssh_port: "not-a-port".to_owned(),
+        ..RepositoryFormFields::default()
+    };
+    let Some(repository) = AppState::create_repository_from_fields(&fields) else {
+        panic!("disabled remote settings must not block a local repository");
+    };
+    assert_eq!(repository.remote.port, None);
+}
 /// A blank `github_issue_pr_repo` is accepted (preserves existing behavior).
 #[test]
 fn create_repository_accepts_blank_issue_pr_repo() {

--- a/src/state/form_types.rs
+++ b/src/state/form_types.rs
@@ -121,6 +121,9 @@ pub struct RepositoryFormFields {
     pub remote_enabled: bool,
     pub login_user: String,
     pub host: String,
+    pub ssh_port: String,
+    pub identity_file: String,
+    pub ssh_options: String,
     pub run_as_user: String,
     pub setup_env_default: bool,
 }
@@ -136,6 +139,9 @@ pub struct RepositoryFormCursor {
     pub github_issue_pr_repo: usize,
     pub login_user: usize,
     pub host: usize,
+    pub ssh_port: usize,
+    pub identity_file: usize,
+    pub ssh_options: usize,
     pub run_as_user: usize,
 }
 
@@ -153,6 +159,9 @@ pub enum RepositoryFormFocus {
     RemoteEnabled,
     LoginUser,
     Host,
+    SshPort,
+    IdentityFile,
+    SshOptions,
     RunAsUser,
     SetupEnvDefault,
 }
@@ -171,7 +180,10 @@ impl RepositoryFormFocus {
             Self::IssuePrRepo => Self::RemoteEnabled,
             Self::RemoteEnabled => Self::LoginUser,
             Self::LoginUser => Self::Host,
-            Self::Host => Self::RunAsUser,
+            Self::Host => Self::SshPort,
+            Self::SshPort => Self::IdentityFile,
+            Self::IdentityFile => Self::SshOptions,
+            Self::SshOptions => Self::RunAsUser,
             Self::RunAsUser => Self::SetupEnvDefault,
             Self::SetupEnvDefault => Self::Name,
         }
@@ -191,7 +203,10 @@ impl RepositoryFormFocus {
             Self::RemoteEnabled => Self::IssuePrRepo,
             Self::LoginUser => Self::RemoteEnabled,
             Self::Host => Self::LoginUser,
-            Self::RunAsUser => Self::Host,
+            Self::SshPort => Self::Host,
+            Self::IdentityFile => Self::SshPort,
+            Self::SshOptions => Self::IdentityFile,
+            Self::RunAsUser => Self::SshOptions,
             Self::SetupEnvDefault => Self::RunAsUser,
         }
     }

--- a/src/state/modal_ops.rs
+++ b/src/state/modal_ops.rs
@@ -121,6 +121,12 @@ impl AppState {
                 remote_enabled: r.remote.enabled,
                 login_user: r.remote.login_user.clone(),
                 host: r.remote.host.clone(),
+                ssh_port: r
+                    .remote
+                    .port
+                    .map_or_else(String::new, |port| port.to_string()),
+                identity_file: r.remote.identity_file.to_string_lossy().into_owned(),
+                ssh_options: r.remote.options.join(" "),
                 run_as_user: r.remote.run_as_user.clone(),
                 setup_env_default: r.remote.setup_env_default,
             })
@@ -136,6 +142,9 @@ impl AppState {
                 github_issue_pr_repo: fields.github_issue_pr_repo.chars().count(),
                 login_user: fields.login_user.chars().count(),
                 host: fields.host.chars().count(),
+                ssh_port: fields.ssh_port.chars().count(),
+                identity_file: fields.identity_file.chars().count(),
+                ssh_options: fields.ssh_options.chars().count(),
                 run_as_user: fields.run_as_user.chars().count(),
             },
             fields,

--- a/src/state/state_ops.rs
+++ b/src/state/state_ops.rs
@@ -128,6 +128,7 @@ mod tests {
             host: "192.0.2.10".into(),
             run_as_user: "acoliver".into(),
             setup_env_default: true,
+            ..RemoteRepositorySettings::default()
         };
 
         let mut agent = Agent::new(

--- a/src/ui/screens/new_repository.rs
+++ b/src/ui/screens/new_repository.rs
@@ -250,14 +250,38 @@ pub fn NewRepositoryForm(props: &NewRepositoryFormProps) -> impl Into<AnyElement
     ));
 
     // Content lines 7-9: remote fields.
-    let remote_labels = ["Login User", "Host / IP", "Run As User"];
-    let remote_values = [&fields.login_user, &fields.host, &fields.run_as_user];
+    let remote_labels = [
+        "Login User",
+        "Host / IP",
+        "SSH Port",
+        "Identity File",
+        "SSH Options",
+        "Run As User",
+    ];
+    let remote_values = [
+        &fields.login_user,
+        &fields.host,
+        &fields.ssh_port,
+        &fields.identity_file,
+        &fields.ssh_options,
+        &fields.run_as_user,
+    ];
     let remote_focuses = [
         RepositoryFormFocus::LoginUser,
         RepositoryFormFocus::Host,
+        RepositoryFormFocus::SshPort,
+        RepositoryFormFocus::IdentityFile,
+        RepositoryFormFocus::SshOptions,
         RepositoryFormFocus::RunAsUser,
     ];
-    let remote_cursors = [cursor.login_user, cursor.host, cursor.run_as_user];
+    let remote_cursors = [
+        cursor.login_user,
+        cursor.host,
+        cursor.ssh_port,
+        cursor.identity_file,
+        cursor.ssh_options,
+        cursor.run_as_user,
+    ];
     for (((label, value), field_focus), field_cursor) in remote_labels
         .iter()
         .zip(remote_values.iter())

--- a/src/ui/screens/new_repository.rs
+++ b/src/ui/screens/new_repository.rs
@@ -255,7 +255,7 @@ pub fn NewRepositoryForm(props: &NewRepositoryFormProps) -> impl Into<AnyElement
         "Host / IP",
         "SSH Port",
         "Identity File",
-        "SSH Options",
+        "SSH Options (space-separated)",
         "Run As User",
     ];
     let remote_values = [

--- a/tests/runtime/mod.rs
+++ b/tests/runtime/mod.rs
@@ -2,5 +2,6 @@
 //!
 //! @plan PLAN-20260216-FIRSTVERSION-V1.P07
 
+mod remote_ssh_fixture;
 mod runtime_lifecycle;
 mod terminal_focus_routing;

--- a/tests/runtime/remote_ssh_fixture.rs
+++ b/tests/runtime/remote_ssh_fixture.rs
@@ -1,0 +1,121 @@
+//! Guarded behavioral coverage for a disposable remote Linux SSH fixture.
+//!
+//! The test is inert unless `JEFE_REAL_SSH_HOST` and `JEFE_REAL_SSH_USER` are
+//! configured. It creates one uniquely named upstream tmux session and one
+//! uniquely named remote path, attaches through Jefe's shell-free plan, and
+//! cleans only those run-owned resources.
+
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use jefe::domain::RemoteRepositorySettings;
+use jefe::ssh::{SSH_OPERATION_TIMEOUT, SshCancellation, SshMode, SshPlan};
+
+struct RemoteFixtureGuard {
+    settings: RemoteRepositorySettings,
+    session: String,
+    path: String,
+}
+
+impl RemoteFixtureGuard {
+    fn execute(&self, command: &str) -> Result<std::process::Output, jefe::ssh::SshError> {
+        SshPlan::new(&self.settings, command, SshMode::NonInteractive)?.execute(
+            None,
+            SSH_OPERATION_TIMEOUT,
+            None,
+        )
+    }
+}
+
+impl Drop for RemoteFixtureGuard {
+    fn drop(&mut self) {
+        let command = format!(
+            "tmux kill-session -t '{}' >/dev/null 2>&1 || :; rm -rf -- '{}'",
+            self.session, self.path
+        );
+        let _ = self.execute(&command);
+    }
+}
+
+fn configured_fixture() -> Result<Option<RemoteRepositorySettings>, String> {
+    let Ok(host) = std::env::var("JEFE_REAL_SSH_HOST") else {
+        return Ok(None);
+    };
+    let Ok(login_user) = std::env::var("JEFE_REAL_SSH_USER") else {
+        return Ok(None);
+    };
+    let port = match std::env::var("JEFE_REAL_SSH_PORT") {
+        Ok(value) => Some(
+            value
+                .parse::<u16>()
+                .map_err(|error| format!("invalid JEFE_REAL_SSH_PORT: {error}"))?,
+        ),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(error) => return Err(format!("invalid JEFE_REAL_SSH_PORT: {error}")),
+    };
+    let identity_file = std::env::var_os("JEFE_REAL_SSH_IDENTITY")
+        .map(PathBuf::from)
+        .unwrap_or_default();
+    Ok(Some(RemoteRepositorySettings {
+        enabled: true,
+        login_user,
+        host,
+        port,
+        identity_file,
+        ..RemoteRepositorySettings::default()
+    }))
+}
+
+#[test]
+fn guarded_windows_real_ssh_launches_attaches_and_cleans_owned_resources() {
+    if !cfg!(windows) {
+        tracing::info!("skipping Windows real-SSH fixture test on a non-Windows host");
+        return;
+    }
+    let configured =
+        configured_fixture().unwrap_or_else(|error| panic!("configure real-SSH fixture: {error}"));
+    let Some(settings) = configured else {
+        tracing::info!(
+            "skipping real-SSH fixture test; configure JEFE_REAL_SSH_HOST and JEFE_REAL_SSH_USER"
+        );
+        return;
+    };
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let session = format!("jefe-ssh-test-{}-{nonce}", std::process::id());
+    let path = format!("/tmp/{session}");
+    let guard = RemoteFixtureGuard {
+        settings,
+        session: session.clone(),
+        path: path.clone(),
+    };
+
+    let launch = format!(
+        "set -e; mkdir -p '{path}'; tmux new-session -d -s '{session}' \"printf 'JEFE_REMOTE_READY\\n'; exec sleep 120\""
+    );
+    let output = guard
+        .execute(&launch)
+        .unwrap_or_else(|error| panic!("launch deterministic remote agent: {error}"));
+    assert!(output.status.success());
+
+    let attach = jefe::runtime::build_remote_attach_plan(&guard.settings, &session)
+        .unwrap_or_else(|error| panic!("plan remote attach: {error}"));
+    let cancellation = SshCancellation::default();
+    let cancellation_signal = cancellation.clone();
+    let cancel_thread = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(500));
+        cancellation_signal.cancel();
+    });
+    let attached = attach.execute(None, Duration::from_secs(5), Some(&cancellation));
+    cancel_thread
+        .join()
+        .unwrap_or_else(|_| panic!("join attach cancellation thread"));
+    assert!(matches!(attached, Err(jefe::ssh::SshError::Cancelled)));
+
+    let verify = guard
+        .execute(&format!("tmux capture-pane -pt '{session}'"))
+        .unwrap_or_else(|error| panic!("capture remote fixture pane: {error}"));
+    assert!(verify.status.success());
+    assert!(String::from_utf8_lossy(&verify.stdout).contains("JEFE_REMOTE_READY"));
+}

--- a/tests/runtime/remote_ssh_fixture.rs
+++ b/tests/runtime/remote_ssh_fixture.rs
@@ -33,7 +33,9 @@ impl Drop for RemoteFixtureGuard {
             "tmux kill-session -t '{}' >/dev/null 2>&1 || :; rm -rf -- '{}'",
             self.session, self.path
         );
-        let _ = self.execute(&command);
+        if let Err(error) = self.execute(&command) {
+            tracing::error!(%error, "failed to clean the owned real-SSH fixture");
+        }
     }
 }
 
@@ -64,6 +66,22 @@ fn configured_fixture() -> Result<Option<RemoteRepositorySettings>, String> {
         identity_file,
         ..RemoteRepositorySettings::default()
     }))
+}
+
+fn wait_for_attached_client(guard: &RemoteFixtureGuard, session: &str) -> Result<(), String> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let command = format!("tmux list-clients -t '{session}' -F '#{{client_name}}'");
+        match guard.execute(&command) {
+            Ok(output) if output.status.success() && !output.stdout.is_empty() => return Ok(()),
+            Ok(_) | Err(_) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Ok(_) | Err(_) => {
+                return Err("remote tmux client did not attach before deadline".to_owned());
+            }
+        }
+    }
 }
 
 #[test]
@@ -102,15 +120,16 @@ fn guarded_windows_real_ssh_launches_attaches_and_cleans_owned_resources() {
     let attach = jefe::runtime::build_remote_attach_plan(&guard.settings, &session)
         .unwrap_or_else(|error| panic!("plan remote attach: {error}"));
     let cancellation = SshCancellation::default();
-    let cancellation_signal = cancellation.clone();
-    let cancel_thread = std::thread::spawn(move || {
-        std::thread::sleep(Duration::from_millis(500));
-        cancellation_signal.cancel();
+    let attach_cancellation = cancellation.clone();
+    let attach_thread = std::thread::spawn(move || {
+        attach.execute(None, Duration::from_secs(10), Some(&attach_cancellation))
     });
-    let attached = attach.execute(None, Duration::from_secs(5), Some(&cancellation));
-    cancel_thread
+    wait_for_attached_client(&guard, &session)
+        .unwrap_or_else(|error| panic!("observe remote tmux attachment: {error}"));
+    cancellation.cancel();
+    let attached = attach_thread
         .join()
-        .unwrap_or_else(|_| panic!("join attach cancellation thread"));
+        .unwrap_or_else(|_| panic!("join remote attach thread"));
     assert!(matches!(attached, Err(jefe::ssh::SshError::Cancelled)));
 
     let verify = guard

--- a/tests/ui/forms_and_modals.rs
+++ b/tests/ui/forms_and_modals.rs
@@ -322,6 +322,9 @@ fn repository_form_toggles_remote_fields() {
     state = state.apply(AppEvent::FormNextField); // Host
     state = state.apply(AppEvent::FormChar('1'));
     state = state.apply(AppEvent::FormChar('0'));
+    state = state.apply(AppEvent::FormNextField); // SshPort
+    state = state.apply(AppEvent::FormNextField); // IdentityFile
+    state = state.apply(AppEvent::FormNextField); // SshOptions
     state = state.apply(AppEvent::FormNextField); // RunAsUser
     state = state.apply(AppEvent::FormChar('m'));
     state = state.apply(AppEvent::FormNextField); // SetupEnvDefault


### PR DESCRIPTION
## Summary

- add a shared, shell-free OpenSSH planner/executor for every remote probe, preparation, lifecycle, and attachment path
- resolve native Windows OpenSSH explicitly, preserving ports, Unicode/space-containing identity paths, validated options, and controlled remote Unix command quoting as distinct argv entries
- expose remote SSH settings in repository forms with validated persistence and backward-compatible defaults
- classify transport failures into actionable redacted errors and bound subprocess timeout, cancellation, and cleanup behavior
- add command-planning, form, persistence, direct-attach namespace, TUI scenario, and guarded disposable real-SSH coverage

## Security and platform boundaries

- does not invoke `sh`, WSL, Cygwin, MSYS2, or Git Bash for local SSH execution
- keeps local psmux namespaces out of remote upstream tmux commands
- rejects command-executing and Jefe-owned SSH option overrides
- does not include remote command payloads, prompt bytes, identity material, or raw remote output in surfaced transport errors

## Verification

- `cargo fmt --all --check`
- exact stable strict clippy with `CLIPPY_CONF_DIR=.github/clippy`
- dedicated complexity clippy gate
- clippy policy and source-file-size policy equivalents on native Windows
- `cargo build --workspace --all-features --locked`
- `cargo test --workspace --all-features --locked` (1963 lib, 666 bin, 241 integration, psmux and doctests all passed)
- coverage gate: 70.53% lines, required minimum 30%
- Windows remote repository-form TUI scenario passed
- guarded real-SSH fixture skips unless `JEFE_REAL_SSH_HOST` and `JEFE_REAL_SSH_USER` are configured

Fixes #263