### PR TITLE
Print PID and commit hash in the lower-right corner (Fixes #223)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,36 @@
+//! Build script: captures the short git commit hash at compile time.
+//!
+//! Sets `JEFE_GIT_COMMIT` so the running binary can display its build identity
+//! (issue #223). Falls back to "unknown" when git is unavailable or the build
+//! directory is not inside a git working tree (e.g. a tarball extraction).
+
+use std::process::Command;
+
+fn main() {
+    // Re-run when HEAD changes so the baked commit stays accurate.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs");
+
+    let commit = git_short_commit().unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=JEFE_GIT_COMMIT={commit}");
+}
+
+/// Run `git rev-parse --short HEAD` in the crate root, returning the trimmed
+/// short hash. Returns `None` if git is missing or the directory is not a
+/// working tree so the build never fails due to the identity lookup.
+fn git_short_commit() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -7,9 +7,13 @@
 use std::process::Command;
 
 fn main() {
-    // Re-run when HEAD changes so the baked commit stays accurate.
+    // `.git/HEAD` is a file (possibly a symbolic ref) whose contents change on
+    // branch switch and new commits, so Cargo re-runs this script and the
+    // baked commit stays accurate. Watching the `.git/refs` *directory* is a
+    // no-op (Cargo only watches files), and the branch name is not known at
+    // build time, so we rely on `.git/HEAD` alone — fast-forwards that do not
+    // touch any source file require a clean rebuild to refresh the hash.
     println!("cargo:rerun-if-changed=.git/HEAD");
-    println!("cargo:rerun-if-changed=.git/refs");
 
     let commit = git_short_commit().unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=JEFE_GIT_COMMIT={commit}");

--- a/dev-docs/tmux-scenarios/pid-commit-corner.json
+++ b/dev-docs/tmux-scenarios/pid-commit-corner.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "cols": 100,
+    "rows": 32,
+    "history_limit": 2000,
+    "initial_wait_ms": 100,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "expect": "No terminal attached" },
+    { "expect": "pid:" },
+    { "capture": "pid-commit-corner" },
+    { "key": "q" },
+    { "key": "q" },
+    { "key": "q" },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,4 +85,61 @@ mod github_tests_pr_threads;
 
 /// Current application version.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Short git commit hash baked in at build time (issue #223).
+///
+/// Falls back to `"unknown"` when the crate was built outside a git working
+/// tree (e.g. a tarball) so display code never has to branch on availability.
+pub const GIT_COMMIT: &str = match option_env!("JEFE_GIT_COMMIT") {
+    Some(commit) => commit,
+    None => "unknown",
+};
+
+/// Format the process-identity label shown in the lower-right corner so the
+/// running jefe can always be identified (issue #223).
+///
+/// The format is `pid:{pid} {commit}` — compact and greppable. The function is
+/// pure so render code and selection-copy projections share one source of
+/// truth and it can be unit-tested without a process or git working tree.
+#[must_use]
+pub fn process_identity_label(pid: u32, commit: &str) -> String {
+    format!("pid:{pid} {commit}")
+}
+
 pub mod harness;
+
+#[cfg(test)]
+mod identity_tests {
+    use super::*;
+
+    #[test]
+    fn label_formats_pid_and_commit() {
+        let label = process_identity_label(12_345, "abc1234");
+        assert_eq!(label, "pid:12345 abc1234");
+    }
+
+    #[test]
+    fn label_includes_pid_marker() {
+        let label = process_identity_label(1, "deadbeef");
+        assert!(
+            label.starts_with("pid:1 "),
+            "label must start with the pid marker: {label}"
+        );
+    }
+
+    #[test]
+    fn label_includes_commit() {
+        let label = process_identity_label(42, "feat0ab");
+        assert!(
+            label.ends_with(" feat0ab"),
+            "label must end with the commit hash: {label}"
+        );
+    }
+
+    #[test]
+    fn git_commit_is_non_empty() {
+        // The build script falls back to "unknown", so the constant is never
+        // empty regardless of whether the build runs inside a git tree.
+        assert!(!GIT_COMMIT.is_empty());
+    }
+}

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -397,7 +397,9 @@ fn status_bar_lines(state: &AppState) -> PaneContent {
 }
 
 /// Keybind bar line that matches the rendered hint text for the active screen
-/// mode, reusing the pure [`keybind_hints_for`] projection.
+/// mode, reusing the pure [`keybind_hints_for`] projection. The right-aligned
+/// process-identity label (pid + commit) is appended so mouse-selection copy
+/// captures it (issue #223).
 fn keybind_bar_lines(state: &AppState) -> PaneContent {
     let actions_focus =
         (state.screen_mode == ScreenMode::DashboardActions).then_some(state.actions_state.focus);
@@ -406,7 +408,12 @@ fn keybind_bar_lines(state: &AppState) -> PaneContent {
         false,
         actions_focus,
     );
-    PaneContent::new(SelectablePane::KeybindBar, vec![hints.to_string()])
+    let identity = crate::process_identity_label(std::process::id(), crate::GIT_COMMIT);
+    // The rendered bar uses SpaceBetween so the identity sits on the far
+    // right. For the flat selection text, append it with a separator so the
+    // full row is captureable in one string.
+    let line = format!("{hints}   {identity}");
+    PaneContent::new(SelectablePane::KeybindBar, vec![line])
 }
 
 // ── Issue #178: overlay content providers (delegated to submodules) ──────

--- a/src/selection/content_tests.rs
+++ b/src/selection/content_tests.rs
@@ -297,6 +297,13 @@ fn keybind_bar_lines_match_rendered_hints() {
     let content = pane_content_lines(SelectablePane::KeybindBar, &state, None, &[], 120, 40);
     assert_eq!(content.lines.len(), 1);
     assert!(content.lines[0].contains("navigate"));
+    // The process-identity label (pid + commit) must be present so mouse-copy
+    // captures it (issue #223).
+    assert!(
+        content.lines[0].contains("pid:"),
+        "keybind bar copy must include the pid marker: {}",
+        content.lines[0]
+    );
 }
 
 #[test]

--- a/src/ui/components/keybind_bar.rs
+++ b/src/ui/components/keybind_bar.rs
@@ -18,6 +18,9 @@ pub struct KeybindBarProps {
     pub terminal_focused: bool,
     /// Active Actions pane when Actions mode is rendered.
     pub actions_focus: Option<ActionsFocus>,
+    /// Process-identity label (pid + commit) shown in the lower-right corner
+    /// (issue #223).
+    pub identity_label: String,
     /// Theme colors.
     pub colors: ThemeColors,
 }
@@ -76,12 +79,19 @@ pub fn KeybindBar(props: &KeybindBarProps) -> impl Into<AnyElement<'static>> {
 
     element! {
         Box(
+            flex_direction: FlexDirection::Row,
             width: 100pct,
             height: 1u32,
             background_color: rc.fg,
+            justify_content: JustifyContent::SpaceBetween,
             padding_left: 1u32,
+            padding_right: 1u32,
         ) {
+            // Left: keybind hints
             Text(content: hints, color: rc.bg)
+
+            // Right: process identity (pid + commit) — issue #223
+            Text(content: props.identity_label.clone(), color: rc.bg)
         }
     }
 }
@@ -134,6 +144,7 @@ mod tests {
                     screen_mode: ScreenMode::DashboardActions,
                     terminal_focused: false,
                     actions_focus: Some(ActionsFocus::RunList),
+                    identity_label: "pid:1 abc".to_string(),
                     colors: ThemeColors::default(),
                 )
             }
@@ -159,6 +170,7 @@ mod tests {
                     screen_mode: ScreenMode::DashboardActions,
                     terminal_focused: false,
                     actions_focus: Some(ActionsFocus::Detail),
+                    identity_label: "pid:1 abc".to_string(),
                     colors: ThemeColors::default(),
                 )
             }
@@ -172,5 +184,37 @@ mod tests {
 
         assert!(rendered.contains("PgUp/PgDn scroll"));
         assert!(rendered.contains("? help"));
+    }
+
+    #[test]
+    fn keybind_bar_renders_identity_label_in_lower_right() {
+        let identity = "pid:99999 deadbeef".to_string();
+        // Use a width wide enough for the hints + identity in any screen mode.
+        let mut element = element! {
+            Box(width: 300u32, height: 1u32) {
+                KeybindBar(
+                    screen_mode: ScreenMode::Dashboard,
+                    terminal_focused: false,
+                    actions_focus: None,
+                    identity_label: identity.clone(),
+                    colors: ThemeColors::default(),
+                )
+            }
+        };
+        let canvas = element.render(Some(300));
+        let mut output = Vec::new();
+        canvas
+            .write_ansi(&mut output)
+            .unwrap_or_else(|error| panic!("render keybind bar: {error}"));
+        let rendered = String::from_utf8_lossy(&output);
+
+        assert!(
+            rendered.contains(&identity),
+            "keybind bar must render the identity label: {rendered}"
+        );
+        assert!(
+            rendered.contains("pid:"),
+            "keybind bar must show the pid marker: {rendered}"
+        );
     }
 }

--- a/src/ui/screens/actions.rs
+++ b/src/ui/screens/actions.rs
@@ -237,6 +237,7 @@ pub fn ActionsScreen(props: &ActionsScreenProps) -> impl Into<AnyElement<'static
                 screen_mode: state.map_or(ScreenMode::DashboardActions, |s| s.screen_mode),
                 terminal_focused: false,
                 actions_focus: Some(actions_focus),
+                identity_label: crate::process_identity_label(std::process::id(), crate::GIT_COMMIT),
                 colors: colors.clone(),
             )
         }

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -269,6 +269,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                 screen_mode: state.map_or(ScreenMode::Dashboard, |s| s.screen_mode),
                 terminal_focused: terminal_focused,
                 actions_focus: None,
+                identity_label: crate::process_identity_label(std::process::id(), crate::GIT_COMMIT),
                 colors: colors,
             )
         }

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -435,6 +435,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                 screen_mode: state.map_or(ScreenMode::DashboardIssues, |s| s.screen_mode),
                 terminal_focused: false,
                 actions_focus: None,
+                identity_label: crate::process_identity_label(std::process::id(), crate::GIT_COMMIT),
                 colors: colors.clone(),
             )
         }

--- a/src/ui/screens/pull_requests.rs
+++ b/src/ui/screens/pull_requests.rs
@@ -389,6 +389,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                 screen_mode: state.map_or(ScreenMode::DashboardPullRequests, |s| s.screen_mode),
                 terminal_focused: false,
                 actions_focus: None,
+                identity_label: crate::process_identity_label(std::process::id(), crate::GIT_COMMIT),
                 colors: colors.clone(),
             )
         }

--- a/src/ui/screens/split.rs
+++ b/src/ui/screens/split.rs
@@ -136,6 +136,7 @@ pub fn SplitScreen(props: &SplitScreenProps) -> impl Into<AnyElement<'static>> {
                 screen_mode: ScreenMode::Split,
                 terminal_focused: false,
                 actions_focus: None,
+                identity_label: crate::process_identity_label(std::process::id(), crate::GIT_COMMIT),
                 colors: colors,
             )
         }


### PR DESCRIPTION
## Summary

Prints the running jefe process PID and short git commit hash in the lower-right corner of the keybind bar on every screen, so a running jefe instance can always be uniquely identified (issue #223).

## Changes

- **build.rs** (new): captures the short git commit hash via `git rev-parse --short HEAD` at build time, exposing it as `JEFE_GIT_COMMIT`. Falls back to `unknown` when built outside a git tree (e.g. tarball) so display code never branches on availability.
- **src/lib.rs**: adds `pub const GIT_COMMIT` and a pure `process_identity_label(pid, commit) -> String` helper that formats `pid:{pid} {commit}`. The function is pure so render code and selection-copy projections share one source of truth.
- **src/ui/components/keybind_bar.rs**: adds `identity_label` prop and renders the bar as a `SpaceBetween` row (left = keybind hints, right = identity label).
- **src/ui/screens/{dashboard,issues,pull_requests,actions,split}.rs**: all five screens pass `process_identity_label(std::process::id(), GIT_COMMIT)` to the keybind bar.
- **src/selection/content.rs**: `keybind_bar_lines()` appends the identity label so mouse-selection copy captures it alongside the hints.
- **dev-docs/tmux-scenarios/pid-commit-corner.json** (new): TUI harness scenario that waits for the dashboard and expects the `pid:` marker on screen.

## Test plan

- Unit tests for `process_identity_label` format (`pid:12345 abc1234`).
- Render test verifying the keybind bar renders the identity label text.
- Selection-content test verifying copy includes the `pid:` marker.
- TUI scenario covering the visible label on the dashboard.
- Full verification suite passes locally: `cargo fmt --check`, `cargo clippy`, `cargo build --locked`, `cargo test --workspace`.

Closes #223
