### PR TITLE
Bound CodeRabbit review demand (Fixes #311)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: "en-US"
+reviews:
+  review_status: true
+  review_details: true
+  review_progress: true
+  auto_review:
+    enabled: false
+    drafts: false
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 2
+    ignore_title_keywords:
+      - "[WIP]"
+      - "DO NOT MERGE"
+      - "[skip review]"
+    labels:
+      - "review-ready"
+      - "!wip"
+      - "!do-not-review"
+  path_instructions:
+    - path: "**/*.rs"
+      instructions: |
+        Apply Jefe's Rust standards. Prefer explicit domain types; use Option for
+        absence and Result with typed errors for fallible operations. Require no
+        unwrap or expect in production paths and no unsafe code. Check Unix,
+        macOS, and native Windows behavior where process, path, terminal, or
+        runtime boundaries are changed.
+    - path: "src/**/*.rs"
+      instructions: |
+        Preserve the documented ownership boundaries and unidirectional data
+        flow. Keep state transitions deterministic and side effects at runtime,
+        persistence, GitHub, or other boundary modules. Check cancellation,
+        stale-result, cleanup, and durability behavior for external work.
+    - path: "tests/**/*.rs"
+      instructions: |
+        Review changed tests and behavioral coverage as first-class code. Tests
+        should prove observable success and failure behavior without relying on
+        arbitrary sleeps, mock call counts, host load, or panic-driven setup.
+    - path: ".github/workflows/**/*.yml"
+      instructions: |
+        Treat untrusted pull request code and configuration as hostile when
+        secrets or elevated permissions are available. Require least-privilege
+        permissions, commit-pinned actions, explicit exact-head validation, and
+        no weakening of format, lint, coverage, build, test, or review gates.
+    - path: ".github/workflows/**/*.yaml"
+      instructions: |
+        Treat untrusted pull request code and configuration as hostile when
+        secrets or elevated permissions are available. Require least-privilege
+        permissions, commit-pinned actions, explicit exact-head validation, and
+        no weakening of format, lint, coverage, build, test, or review gates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,15 @@ namespace-scoped cleanup. Failure diagnostics are written beneath
   merge.
 - Squash-merge or rebase-merge to `main`. Delete the feature branch after merge.
 
+## Code review demand
+
+Keep active work in a draft PR (or use the documented WIP markers), run the
+required exact-head local gate, and push that verified head before marking the
+PR ready and adding the `review-ready` label. The
+[CodeRabbit review-demand policy](dev-docs/code-review-demand.md) defines the
+explicit trigger, automatic-review limits, deliberate manual reruns,
+reviewed-head coverage, and immutable measurement events.
+
 ## Standards
 
 The authoritative standards live under [`dev-docs/standards/`](dev-docs/standards/):

--- a/dev-docs/code-review-demand.md
+++ b/dev-docs/code-review-demand.md
@@ -1,0 +1,168 @@
+# CodeRabbit review-demand policy
+
+Jefe uses the root [`.coderabbit.yaml`](../.coderabbit.yaml) as its authoritative
+repository-level CodeRabbit configuration. Organization or workspace global
+overrides can take precedence. On a pull request, use
+`@coderabbitai configuration` to inspect the resolved values and the source of
+each value rather than assuming the root file won.
+
+This policy controls when Jefe asks for a review and how it measures the
+result. It does not alter the vendor's organization-level allowance, guarantee
+zero throttling, or replace the separately owned cross-repository measurement
+ledger.
+
+## Deliberate ready-for-review lifecycle
+
+1. Keep the pull request in draft while implementation, refactoring, or known
+   remediation is still in progress. If draft state is unavailable, keep
+   `[WIP]`, `DO NOT MERGE`, or `[skip review]` in the title, or apply the `wip`
+   or `do-not-review` label.
+2. Complete the issue's acceptance evidence and run the repository's required
+   exact-head local gate. For Jefe this is normally `make ci-check`.
+3. Push the verified commit and confirm that the pull request's current head SHA
+   is the commit that passed the gate.
+4. Remove every WIP title marker or exclusion label, mark the pull request ready,
+   and add the `review-ready` label. Add that label only after the implementation
+   and required local evidence are ready for external review. The positive label
+   is the explicit vendor-documented trigger for the first automatic review.
+5. Treat the automatic review as coverage of the head CodeRabbit reports, not
+   automatically as coverage of every later push. After remediation, rerun the
+   required local gate, push the final commit, and compare the current head SHA
+   with the most recent successfully reviewed head SHA.
+
+Automatic review is disabled until the positive `review-ready` label opts the
+pull request in. After opt-in, automatic incremental review remains enabled but
+pauses after two reviewed commits. Two is the vendor-documented early-pause
+range for active branches and preserves follow-up review without reviewing
+every small push. Drafts, title markers, and negative labels override the ready
+label so active development does not consume review allowance.
+
+Do not infer coverage from the absence of a throttle message. A review is
+covered only when a successful completion identifies the relevant reviewed head
+SHA.
+
+## Manual review requests and allowance cost
+
+Both manual commands cost one PR review from the allowance when the review runs:
+
+- `@coderabbitai review` requests an incremental review of commits added since
+  the last review. Use it after the automatic pause when uncovered commits are
+  ready for a focused pass.
+- `@coderabbitai full review` requests a complete review from scratch. Reserve
+  it for a broad architectural rewrite, a large rebase or conflict resolution,
+  or a case where the prior review boundary is uncertain. It is not a routine
+  retry command.
+
+Do not request a review when the reviewed head already equals the current head
+SHA. Do not send repeated commands after a throttle response. Preserve the
+response as evidence, finish any other required review gates, and issue one
+deliberate request only when uncovered work remains and allowance is available.
+A manual request supplements the two-commit automatic cap; it does not prove
+that the request completed or that the requested head was reviewed.
+
+## Immutable measurement events
+
+The publication repository owns the cross-repository measurement ledger and it
+is not available in this repository. When that ledger is available to Jefe
+automation, append the events below. Until then, retain GitHub comments, check
+runs, reviews, and throttle responses as source evidence; do not create a
+mutable local counter as a substitute.
+
+All ledger entries are append-only. Every entry includes a schema version,
+unique event ID, repository and pull-request identity, UTC observation time,
+the source URL or source event identity, and the effective resolved
+configuration fingerprint or the literal value `unknown`. Events that observe
+review eligibility also include an eligibility snapshot and reason, such as
+ready, draft, title-excluded, label-excluded, or otherwise ineligible.
+Corrections append a replacement or invalidation event that references the
+prior event; they never rewrite it. Request and outcome events remain separate
+so a request cannot be mutated into a successful completion.
+
+### `review_requested`
+
+Append for every automatic or manual request, including a request later
+throttled or failed. Include:
+
+- a unique request ID;
+- automatic, manual incremental, or manual full trigger;
+- requester or automation identity;
+- requested head SHA and base SHA;
+- request timestamp; and
+- the ready-state eligibility snapshot that authorized the request.
+
+### `review_completed`
+
+Append only when the vendor reports successful completion. Include the request
+ID, completion timestamp, reviewed head SHA, review identity or URL, and review
+kind. Never copy the requested head SHA into the reviewed head field without a
+completion artifact that identifies that head.
+
+### `review_throttled`
+
+Append when the request or review receives an explicit allowance/rate-limit
+response. Include the request ID, requested head SHA, response timestamp,
+vendor response classification, and source URL or immutable message identity.
+A throttle event is not a completion event.
+
+### `review_coverage_observed`
+
+Append at ready-for-review, after each completion or throttle response, after a
+push, and at the terminal PR state. Include the current head SHA, the most
+recent successfully reviewed head SHA (or null), the completion event ID used
+as evidence (or null), an exact-head-covered boolean, and the eligibility
+snapshot at observation. For cohorting, the terminal state is `merged` or
+`closed`; include that state and its terminal timestamp.
+
+Create one terminal denominator record per PR whose lifecycle contains at least
+one qualifying ready/opt-in observation. Once qualified, the PR remains in the
+cohort even if `review-ready` is later removed, the PR returns to draft, or an
+exclusion marker is added. Multiple ready/unready cycles still produce one
+terminal denominator record; immutable observations preserve each transition.
+This captures stale coverage without inflating the metric by dropping previously
+eligible PRs or assuming coverage from a missing throttle message.
+
+Collectors must be idempotent on source identity. Duplicate ingestion may point
+to the same source event but must not double-count a request, completion, or
+throttle.
+
+## Complete rolling-window evaluation
+
+Define the Monday 00:00 UTC measurement cutoff `T` and publish at publication
+time `P = T + 7d`, after the seven-day outcome-settling period. The report's
+ingestion as-of boundary is `P`. Compare the adjacent complete current window
+`[T-28d, T)` with the prior window `[T-56d, T-28d)`. Never tune from a partial
+window. Requests join a window by request timestamp; their linked completion or
+throttle outcomes may arrive through `P`. Terminal coverage observations join
+by terminal timestamp. Events arriving after `P` remain append-only and produce
+a referenced correction in the next publication.
+
+Evaluate throttle rate and exact-head review coverage together:
+
+- **Throttle rate:** requests in the window with a linked `review_throttled`
+  event divided by all distinct `review_requested` requests in the window.
+- **Exact-head review coverage:** eligible ready PR terminal observations whose
+  current head SHA equals a successfully reviewed head SHA, divided by all
+  eligible ready PR terminal observations in the window.
+
+Also report automatic, manual incremental, and manual full requests separately
+so manual retries cannot hide demand. Publish event counts and missing-evidence
+counts with each ratio. Report a zero denominator as `not applicable`, never as
+zero percent. Late-arriving events remain append-only and are identified as a
+correction in the next publication rather than rewriting a prior result.
+
+Group results by the effective resolved configuration fingerprint. A window
+with mixed or `unknown` fingerprints is non-comparable for tuning and must be
+published as such. A lower throttle rate does not justify a change if exact-head
+coverage fell, and a higher coverage rate does not justify unbounded requests.
+
+Do not change the two-commit cap, ready-label behavior, or WIP controls inside a
+measured window. A future tuning change must cite both adjacent complete windows
+for both metrics, record the configuration commit and resolved fingerprint, and
+take effect after the next cutoff. Missing throttle messages never count as
+successful reviews.
+
+## Vendor references
+
+- [CodeRabbit configuration schema](https://coderabbit.ai/integrations/schema.v2.json)
+- [Automatic review controls](https://docs.coderabbit.ai/configuration/auto-review)
+- [Code review commands](https://docs.coderabbit.ai/reference/review-commands)

--- a/project-plans/issue311-plan.md
+++ b/project-plans/issue311-plan.md
@@ -181,6 +181,9 @@ Its SHA-256 was
   qualifying ready/opt-in observation and deduplicated repeated readiness cycles.
 - **In-scope—Fix:** Required the initial configuration to omit `path_filters`
   entirely and asserted every configured WIP title marker.
+- **In-scope—Fix:** Made repository read failures name the missing path, parsed
+  YAML keys and path entries without fixed quotes/indentation, and constrained
+  documentation assertions to their owning Markdown sections.
 
 ## Deferred findings and follow-ups
 

--- a/project-plans/issue311-plan.md
+++ b/project-plans/issue311-plan.md
@@ -1,0 +1,187 @@
+# Issue #311 Implementation Plan: Bound CodeRabbit review demand
+
+## Issue
+
+GitHub #311 — Add root CodeRabbit demand controls and throttle coverage
+visibility.
+
+The issue and its only comment were fetched on 2026-07-15. The comment is the
+CodeRabbit issue-planner prompt and adds no acceptance requirements.
+
+## Research and decisions
+
+- The current CodeRabbit v2 schema is
+  `https://coderabbit.ai/integrations/schema.v2.json` (JSON Schema draft
+  2020-12).
+- Current automatic-review documentation says draft PRs are skipped with
+  `reviews.auto_review.drafts: false`, title keywords are case-insensitive
+  exclusions, and `auto_pause_after_reviewed_commits` values of 1 or 2 are the
+  recommended early pause for active branches.
+- Current command documentation says `@coderabbitai review` is incremental,
+  `@coderabbitai full review` starts from scratch, and each command consumes
+  one PR review from the allowance when it runs.
+- The root configuration is authoritative for this repository, subject to the
+  vendor's documented higher-priority organization/workspace global overrides.
+  Contributors can use `@coderabbitai configuration` to inspect the resolved
+  source of each setting.
+- Jefe has no local or vendored cross-repository measurement ledger. This
+  change defines the immutable events and activation rule but does not invent a
+  competing ledger. Until the external ledger is available, GitHub review
+  comments, checks, and throttle responses remain source evidence rather than
+  mutable local counters.
+- No `.github/` change is planned. The issue authorizes root CodeRabbit
+  configuration and contributor documentation, but not a CI/workflow change.
+- This is repository policy, not user-visible TUI behavior; a TUI harness
+  scenario would not exercise it and is out of scope.
+
+## Acceptance matrix
+
+| Row | Actor / launch path | Input and boundary cases | Observable success | Observable failure / diagnostic | Side effects and compatibility | Behavioral evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| A1 | CodeRabbit loads root configuration for a PR | Non-draft PR; draft PR; ready PR with `[WIP]`, `DO NOT MERGE`, or `[skip review]` title; `review-ready`, `wip`, or `do-not-review` label | Adding `review-ready` explicitly triggers review after verification; drafts and marked WIP PRs do not review | CodeRabbit review status/configuration response identifies the resolved setting | No change to organization allowance; global overrides can supersede repository YAML | Structural contract test asserts the nested opt-in controls; current vendor schema validates YAML |
+| A2 | CodeRabbit receives pushes after an initial eligible review | One or more follow-up commits, including rapid pushes | Incremental review remains enabled and auto-pauses after two reviewed commits | CodeRabbit pause/status message is evidence; absence of throttle is not coverage proof | Counter semantics remain vendor-owned; cap starts at two | Contract test asserts `auto_incremental_review: true` and cap `2` |
+| A3 | Reviewer deliberately requests another pass | Uncovered commits; broad rewrite; no commits since reviewed head; paused review | Incremental command is used for uncovered commits; full command only for broad/uncertain coverage; no duplicate exact-head request | Manual command response or throttle response is recorded as evidence | Every successful manual incremental or full command costs one allowance review | Documentation contract test asserts commands, cost, and exact-head guard |
+| A4 | Contributor opens and advances a PR | Active work; local verification failure; exact-head verification success; final push after review | Work is kept draft/WIP; `review-ready` is added only after required local gates pass; final head's coverage is checked | PR review status/checks show pending, skipped, throttled, or stale reviewed head | Existing branch/PR and exact-head delivery rules remain authoritative | Documentation contract test asserts the explicit ready-label lifecycle |
+| A5 | CodeRabbit reviews Rust production and test changes | `src/**/*.rs`, Rust tests under `src/` and `tests/`, generated/build output | Source and tests remain eligible; Rust instructions distinguish absence from typed fallible errors, forbid production unwrap/expect, preserve deterministic state, and require behavioral coverage | Missing file feedback is visible in review details; schema validation catches malformed entries | No broad Rust source/test exclusions or TypeScript-derived filters | Structural contract test rejects Rust-scope exclusions and asserts scoped Rust guidance |
+| A6 | CodeRabbit reviews Jefe workflow changes | `.github/workflows/**/*.yml` or `.yaml` | Review focuses on untrusted PR boundaries, least privilege, pinned actions, secret handling, and exact-head gates | Review comments identify workflow safety concerns | Guidance only; no workflow file changes | Contract test asserts workflow path guidance |
+| A7 | Measurement automation appends review lifecycle evidence once the external ledger is available | Automatic/manual request; completion; throttle; current and reviewed head observations | Append-only request, completion, throttle, and coverage events share request/PR/head identities; late events do not overwrite history | Missing/invalid events remain visible as an incomplete ledger sequence | No local mutable counters and no inference that no throttle means coverage | Documentation contract test asserts immutable event types and fields |
+| A8 | Maintainer evaluates whether to tune demand controls | Complete and incomplete rolling windows; throttle without coverage; coverage without throttle; mixed or unknown configuration | Adjacent complete 28-day windows are compared after a fixed settling period; throttle rate and exact-head coverage are evaluated by resolved configuration | Partial, mixed, or unknown-configuration windows are non-comparable and zero denominators are not applicable | No mid-window tuning; no promise of zero throttling | Documentation contract test asserts cohort timestamps, adjacent windows, settling, and metric handling |
+
+## Non-goals
+
+- Do not change CodeRabbit organization/workspace allowance or promise zero
+  throttling.
+- Do not disable incremental review.
+- Do not exclude production source or tests merely to lower demand.
+- Do not treat the absence of a throttle message as proof of reviewed coverage.
+- Do not add a local substitute for the separately owned publication ledger.
+- Do not modify GitHub Actions, the PR template, dependencies, runtime code, or
+  TUI behavior.
+- Do not copy TypeScript, JavaScript, Node, mobile, or generated-file filters
+  from vendor examples.
+
+## Vertical slices
+
+### Slice 1 — Executable repository-policy contract
+
+- **Rows:** A1–A8.
+- **Owner/boundary:** Repository integration test over version-controlled
+  configuration and contributor policy.
+- **Allowed file:** `tests/coderabbit_policy.rs`.
+- **RED:** The test fails because `.coderabbit.yaml` and the demand policy do
+  not exist.
+- **GREEN:** The test verifies explicit review controls, preserved source/test
+  scope, repository-specific path instructions, manual allowance semantics,
+  immutable event definitions, and complete-window tuning rules.
+- **Verification:**
+  `cargo test --test coderabbit_policy -- --nocapture`.
+
+### Slice 2 — Root demand controls
+
+- **Rows:** A1, A2, A5, A6.
+- **Owner/boundary:** CodeRabbit's repository-root configuration.
+- **Allowed file:** `.coderabbit.yaml`.
+- **GREEN:** Root YAML requires a positive `review-ready` opt-in, excludes
+  drafts/WIP, keeps incremental review enabled, pauses after two reviewed
+  commits, avoids Rust source/test exclusions, and supplies Rust/Jefe workflow
+  path instructions.
+- **External validation:** Convert YAML to JSON with Ruby's standard `yaml` and
+  `json` libraries, then validate against a freshly fetched current v2 schema
+  using AJV draft 2020 mode. Record schema URL and SHA-256 in verification
+  evidence; do not vendor generated schema output.
+
+### Slice 3 — Deliberate review lifecycle and measurement policy
+
+- **Rows:** A3, A4, A7, A8.
+- **Owner/boundary:** Contributor process documentation.
+- **Allowed files:** `dev-docs/code-review-demand.md`, `CONTRIBUTING.md`.
+- **GREEN:** Contributors have an explicit draft-to-ready-label lifecycle,
+  manual rerun cost/use policy, exact-head coverage check, append-only ledger
+  event contract, and reproducible adjacent rolling-window comparison rule.
+- **Verification:** Focused contract test plus link validation by inspection.
+
+## Expected files
+
+| File | Acceptance rows | Purpose |
+| --- | --- | --- |
+| `project-plans/issue311-plan.md` | All | Decision-complete plan, scope ledger, and evidence |
+| `tests/coderabbit_policy.rs` | All | Behavioral repository-policy contract |
+| `.coderabbit.yaml` | A1, A2, A5, A6 | Authoritative vendor configuration |
+| `dev-docs/code-review-demand.md` | A3, A4, A7, A8 | Team and automation lifecycle policy |
+| `CONTRIBUTING.md` | A4 | Contributor entry-point link and concise ready rule |
+
+## Scope ledger
+
+| Item | Status | Decision |
+| --- | --- | --- |
+| Root CodeRabbit configuration | Accepted | Direct issue requirement |
+| Repository policy integration test | Accepted | TDD evidence for config/documentation behavior |
+| Contributor demand/measurement guide | Accepted | Direct issue requirement |
+| Contributor-guide link | Accepted | Makes deliberate behavior discoverable |
+| Repository `review-ready` label | Accepted | Required external trigger for the configured explicit opt-in lifecycle |
+| GitHub Actions or PR-template enforcement | Excluded | `.github/` changes require separate explicit approval and are unnecessary for acceptance |
+| Cross-repository ledger implementation | Excluded | Separately owned publication infrastructure is not present |
+| Runtime or TUI changes/scenarios | Excluded | No user-visible application behavior changes |
+| Dependency changes | Excluded | One-off schema validation uses available tools without manifest changes |
+
+## Review counters
+
+- Local Open Code Review runs before PR: 1 / 2.
+- Open Code Review runs after PR: 0 / 2.
+- Rust reviewer runs: 2.
+
+## Verification evidence
+
+The current vendor schema was fetched from the documented URL on 2026-07-15.
+Its SHA-256 was
+`d57478bfb748dbdf5d0509367f90d9c7fac65d8436639cfbec1cbeec77bf4b30`.
+
+| Candidate head | Command / review | Result |
+| --- | --- | --- |
+| Worktree before implementation | `cargo test --test coderabbit_policy -- --nocapture` (RED) | Expected failure: all four tests reported missing config/policy files |
+| Worktree before review fixes | `cargo test --test coderabbit_policy -- --nocapture` | Passed: 4 tests |
+| Worktree before review fixes | Current CodeRabbit v2 JSON Schema validation via AJV draft 2020 | Passed: converted `.coderabbit.yaml` is valid |
+| Worktree before review fixes | `make quick-check` | Passed |
+| Worktree before review fixes | `make ci-check` with current rustup toolchain first on `PATH` | Passed; stale Homebrew Clippy 1.92 was shadowing rustup Clippy 1.97 |
+| Worktree before review fixes | rustreviewer | Five actionable findings; all addressed in the current candidate |
+| Worktree after strengthened contracts | `cargo test --test coderabbit_policy -- --nocapture` (RED) | Expected failure: explicit trigger, scoped Rust guidance, and reproducible measurement semantics were absent |
+| Current candidate | Open Code Review | One medium finding fixed; one false finding rejected because `path_filters` is an optional section intentionally inspected for future exclusions; one parser-dependency suggestion rejected as an unapproved dependency expansion |
+| Current candidate | `cargo test --test coderabbit_policy -- --nocapture` | Passed: 5 tests |
+| Current candidate | Current CodeRabbit v2 JSON Schema validation via AJV draft 2020 | Passed |
+| Current candidate | `make ci-check` with current rustup toolchain first on `PATH` | Passed after all review fixes |
+| Current candidate | Live repository label lookup | `review-ready`, `wip`, and `do-not-review` exist with documented descriptions |
+
+## Review finding triage
+
+- **Blocker—Fix:** Replaced implicit ready behavior with the documented positive
+  `review-ready` label trigger and disabled global automatic review.
+- **In-scope—Fix:** Defined cohort timestamps, adjacent windows, settling,
+  effective configuration fingerprints, eligibility snapshots, terminal states,
+  zero denominators, late events, and non-comparable mixed configurations.
+- **In-scope—Fix:** Strengthened tests to inspect nested YAML sections and
+  path-scoped guidance, added descriptive assertions, and limited path-filter
+  rejection to Rust production/test exclusions without adding a dependency.
+- **In-scope—Fix:** Replaced bare `WIP` substring matching with `[WIP]`.
+- **In-scope—Fix:** Clarified that `Option` models absence while `Result` with a
+  typed error models fallible operations.
+- **In-scope—Fix:** Changed Rust-scope filter matching to complete path
+  components and added positive/negative regression cases.
+- **Reject:** OCR interpreted the deliberate optional `path_filters` inspection
+  as a typo for `path_instructions`; the test separately inspects path
+  instructions and must guard future exclusions even though the current section
+  is absent.
+- **Reject:** A general YAML parser would add an unapproved dependency. The
+  narrow section reader is paired with current-schema AJV validation and tests
+  only repository-owned formatting.
+- **Blocker—Fix:** Created the live `review-ready`, `wip`, and `do-not-review`
+  repository labels required by the documented lifecycle.
+- **In-scope—Fix:** Defined measurement cutoff `T`, publication `P = T + 7d`,
+  the as-of boundary, and post-publication corrections.
+- **In-scope—Fix:** Made terminal coverage membership depend on any historical
+  qualifying ready/opt-in observation and deduplicated repeated readiness cycles.
+- **In-scope—Fix:** Required the initial configuration to omit `path_filters`
+  entirely and asserted every configured WIP title marker.
+
+## Deferred findings and follow-ups
+
+None.

--- a/tests/coderabbit_policy.rs
+++ b/tests/coderabbit_policy.rs
@@ -6,16 +6,32 @@
 use std::{fs, io, path::Path};
 
 fn repository_text(relative_path: &str) -> io::Result<String> {
-    fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path))
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path);
+    fs::read_to_string(&path).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("could not read {}: {error}", path.display()),
+        )
+    })
 }
 
 fn leading_spaces(line: &str) -> usize {
     line.bytes().take_while(|byte| *byte == b' ').count()
 }
 
-fn yaml_section<'a>(text: &'a str, header: &str, indent: usize) -> Vec<&'a str> {
+fn is_yaml_key(line: &str, key: &str, indent: usize) -> bool {
+    if leading_spaces(line) != indent {
+        return false;
+    }
+    line.trim()
+        .strip_prefix(key)
+        .and_then(|suffix| suffix.strip_prefix(':'))
+        .is_some_and(|suffix| suffix.trim().is_empty() || suffix.trim_start().starts_with('#'))
+}
+
+fn yaml_section<'a>(text: &'a str, key: &str, indent: usize) -> Vec<&'a str> {
     let lines = text.lines().collect::<Vec<_>>();
-    let Some(start) = lines.iter().position(|line| *line == header) else {
+    let Some(start) = lines.iter().position(|line| is_yaml_key(line, key, indent)) else {
         return Vec::new();
     };
 
@@ -30,8 +46,27 @@ fn section_contains(section: &[&str], setting: &str) -> bool {
     section.iter().any(|line| line.trim() == setting)
 }
 
+fn yaml_list_scalar<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    let item = line.trim().strip_prefix("- ")?;
+    let value = item.strip_prefix(key)?.strip_prefix(':')?.trim();
+    Some(value.trim_matches(['\'', '"']))
+}
+
 fn path_instruction<'a>(config: &'a str, path: &str) -> Vec<&'a str> {
-    yaml_section(config, &format!("    - path: \"{path}\""), 4)
+    let lines = config.lines().collect::<Vec<_>>();
+    let Some(start) = lines
+        .iter()
+        .position(|line| yaml_list_scalar(line, "path") == Some(path))
+    else {
+        return Vec::new();
+    };
+    let indent = leading_spaces(lines[start]);
+
+    lines
+        .into_iter()
+        .skip(start + 1)
+        .take_while(|line| line.trim().is_empty() || leading_spaces(line) > indent)
+        .collect()
 }
 
 fn excludes_rust_scope(filter: &str) -> bool {
@@ -53,10 +88,28 @@ fn excludes_rust_scope(filter: &str) -> bool {
     })
 }
 
+fn markdown_section(text: &str, heading: &str) -> String {
+    let header = format!("## {heading}");
+    let lines = text.lines().collect::<Vec<_>>();
+    let Some(start) = lines.iter().position(|line| line.trim() == header) else {
+        return String::new();
+    };
+
+    lines
+        .into_iter()
+        .skip(start + 1)
+        .take_while(|line| !line.starts_with("## "))
+        .collect::<Vec<_>>()
+        .join(" ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 #[test]
 fn automatic_reviews_are_ready_only_and_bounded() -> io::Result<()> {
     let config = repository_text(".coderabbit.yaml")?;
-    let auto_review = yaml_section(&config, "  auto_review:", 2);
+    let auto_review = yaml_section(&config, "auto_review", 2);
 
     assert!(
         section_contains(&auto_review, "enabled: false"),
@@ -122,7 +175,7 @@ fn rust_scope_filter_detection_uses_complete_path_components() {
 #[test]
 fn review_scope_includes_rust_source_tests_and_jefe_workflows() -> io::Result<()> {
     let config = repository_text(".coderabbit.yaml")?;
-    let path_filters = yaml_section(&config, "  path_filters:", 2);
+    let path_filters = yaml_section(&config, "path_filters", 2);
 
     assert!(
         path_filters.is_empty(),
@@ -162,7 +215,8 @@ fn review_scope_includes_rust_source_tests_and_jefe_workflows() -> io::Result<()
 #[test]
 fn contributor_policy_defines_deliberate_review_lifecycle() -> io::Result<()> {
     let policy = repository_text("dev-docs/code-review-demand.md")?;
-    let normalized_policy = policy.split_whitespace().collect::<Vec<_>>().join(" ");
+    let lifecycle = markdown_section(&policy, "Deliberate ready-for-review lifecycle");
+    let manual_requests = markdown_section(&policy, "Manual review requests and allowance cost");
     let contributor_guide = repository_text("CONTRIBUTING.md")?;
 
     assert!(
@@ -170,32 +224,32 @@ fn contributor_policy_defines_deliberate_review_lifecycle() -> io::Result<()> {
         "the contributor entry point must link to the demand policy"
     );
     assert!(
-        normalized_policy.contains("Keep the pull request in draft"),
+        lifecycle.contains("Keep the pull request in draft"),
         "active implementation must remain draft"
     );
     assert!(
-        normalized_policy.contains("add the `review-ready` label"),
+        lifecycle.contains("add the `review-ready` label"),
         "ready review must use the configured explicit trigger"
     );
     assert!(
-        normalized_policy.contains("current head SHA"),
+        lifecycle.contains("current head SHA"),
         "readiness and coverage must be tied to the exact head"
     );
     assert!(
-        normalized_policy.contains("`@coderabbitai review`")
-            && normalized_policy.contains("`@coderabbitai full review`"),
-        "both manual review commands must be documented"
+        manual_requests.contains("`@coderabbitai review`")
+            && manual_requests.contains("`@coderabbitai full review`"),
+        "both manual review commands must be documented in the manual-request section"
     );
     assert!(
-        normalized_policy.contains("cost one PR review from the allowance"),
+        manual_requests.contains("cost one PR review from the allowance"),
         "manual review allowance cost must be explicit"
     );
     assert!(
-        normalized_policy.contains("Do not request a review when the reviewed head"),
+        manual_requests.contains("Do not request a review when the reviewed head"),
         "duplicate exact-head requests must be prohibited"
     );
     assert!(
-        normalized_policy.contains("Do not infer coverage from the absence of a throttle"),
+        lifecycle.contains("Do not infer coverage from the absence of a throttle"),
         "missing throttle evidence must not imply coverage"
     );
 
@@ -205,7 +259,8 @@ fn contributor_policy_defines_deliberate_review_lifecycle() -> io::Result<()> {
 #[test]
 fn measurement_policy_requires_reproducible_complete_windows() -> io::Result<()> {
     let policy = repository_text("dev-docs/code-review-demand.md")?;
-    let normalized_policy = policy.split_whitespace().collect::<Vec<_>>().join(" ");
+    let events = markdown_section(&policy, "Immutable measurement events");
+    let windows = markdown_section(&policy, "Complete rolling-window evaluation");
 
     for event_type in [
         "`review_requested`",
@@ -214,49 +269,48 @@ fn measurement_policy_requires_reproducible_complete_windows() -> io::Result<()>
         "`review_coverage_observed`",
     ] {
         assert!(
-            normalized_policy.contains(event_type),
+            events.contains(event_type),
             "measurement policy is missing event type {event_type}"
         );
     }
     assert!(
-        normalized_policy.contains("append-only"),
+        events.contains("append-only"),
         "measurement events must remain immutable"
     );
     assert!(
-        normalized_policy.contains("resolved configuration fingerprint")
-            && normalized_policy.contains("eligibility snapshot"),
+        events.contains("resolved configuration fingerprint")
+            && events.contains("eligibility snapshot"),
         "events must preserve effective configuration and eligibility evidence"
     );
     assert!(
-        normalized_policy.contains("terminal state is `merged` or `closed`"),
+        events.contains("terminal state is `merged` or `closed`"),
         "coverage cohort terminal states must be defined"
     );
     assert!(
-        normalized_policy.contains("qualifying ready/opt-in observation")
-            && normalized_policy.contains("remains in the cohort"),
+        events.contains("qualifying ready/opt-in observation")
+            && events.contains("remains in the cohort"),
         "terminal coverage cohort membership must survive later ready-state changes"
     );
     assert!(
-        normalized_policy.contains("[T-28d, T)") && normalized_policy.contains("[T-56d, T-28d)"),
+        windows.contains("[T-28d, T)") && windows.contains("[T-56d, T-28d)"),
         "adjacent complete rolling windows must be explicit"
     );
     assert!(
-        normalized_policy.contains("measurement cutoff `T`")
-            && normalized_policy.contains("publication time `P = T + 7d`")
-            && normalized_policy.contains("as-of boundary is `P`"),
+        windows.contains("measurement cutoff `T`")
+            && windows.contains("publication time `P = T + 7d`")
+            && windows.contains("as-of boundary is `P`"),
         "window outcomes need explicit cutoff, publication, and as-of boundaries"
     );
     assert!(
-        normalized_policy.contains("zero denominator")
-            && normalized_policy.contains("non-comparable"),
+        windows.contains("zero denominator") && windows.contains("non-comparable"),
         "undefined ratios and mixed configurations need deterministic handling"
     );
     assert!(
-        normalized_policy.contains("throttle rate and exact-head review coverage"),
+        windows.contains("throttle rate and exact-head review coverage"),
         "demand and coverage metrics must be evaluated together"
     );
     assert!(
-        normalized_policy.contains("Never tune from a partial window"),
+        windows.contains("Never tune from a partial window"),
         "partial windows must not drive tuning"
     );
 

--- a/tests/coderabbit_policy.rs
+++ b/tests/coderabbit_policy.rs
@@ -1,0 +1,264 @@
+//! Repository-level contract tests for CodeRabbit demand controls.
+//!
+//! These tests keep the root vendor configuration and the contributor-facing
+//! review lifecycle aligned with Jefe's review-demand policy.
+
+use std::{fs, io, path::Path};
+
+fn repository_text(relative_path: &str) -> io::Result<String> {
+    fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path))
+}
+
+fn leading_spaces(line: &str) -> usize {
+    line.bytes().take_while(|byte| *byte == b' ').count()
+}
+
+fn yaml_section<'a>(text: &'a str, header: &str, indent: usize) -> Vec<&'a str> {
+    let lines = text.lines().collect::<Vec<_>>();
+    let Some(start) = lines.iter().position(|line| *line == header) else {
+        return Vec::new();
+    };
+
+    lines
+        .into_iter()
+        .skip(start + 1)
+        .take_while(|line| line.trim().is_empty() || leading_spaces(line) > indent)
+        .collect()
+}
+
+fn section_contains(section: &[&str], setting: &str) -> bool {
+    section.iter().any(|line| line.trim() == setting)
+}
+
+fn path_instruction<'a>(config: &'a str, path: &str) -> Vec<&'a str> {
+    yaml_section(config, &format!("    - path: \"{path}\""), 4)
+}
+
+fn excludes_rust_scope(filter: &str) -> bool {
+    let pattern = filter
+        .trim()
+        .trim_start_matches("- ")
+        .trim_matches(['\'', '"']);
+    let excluded = pattern.strip_prefix('!');
+
+    excluded.is_some_and(|path| {
+        path == "*.rs"
+            || path == "**/*.rs"
+            || path == "src"
+            || path.starts_with("src/")
+            || path == "tests"
+            || path.starts_with("tests/")
+            || path.contains("/src/")
+            || path.contains("/tests/")
+    })
+}
+
+#[test]
+fn automatic_reviews_are_ready_only_and_bounded() -> io::Result<()> {
+    let config = repository_text(".coderabbit.yaml")?;
+    let auto_review = yaml_section(&config, "  auto_review:", 2);
+
+    assert!(
+        section_contains(&auto_review, "enabled: false"),
+        "automatic review must require an explicit ready trigger"
+    );
+    assert!(
+        section_contains(&auto_review, "drafts: false"),
+        "draft pull requests must remain excluded"
+    );
+    assert!(
+        section_contains(&auto_review, "auto_incremental_review: true"),
+        "incremental review must remain enabled after opt-in"
+    );
+    assert!(
+        section_contains(&auto_review, "auto_pause_after_reviewed_commits: 2"),
+        "automatic incremental review must pause after two reviewed commits"
+    );
+    for marker in ["- \"[WIP]\"", "- \"DO NOT MERGE\"", "- \"[skip review]\""] {
+        assert!(
+            section_contains(&auto_review, marker),
+            "ready-only review is missing title exclusion {marker}"
+        );
+    }
+    assert!(
+        section_contains(&auto_review, "- \"review-ready\""),
+        "the review-ready label must trigger opt-in review"
+    );
+    assert!(
+        section_contains(&auto_review, "- \"!wip\"")
+            && section_contains(&auto_review, "- \"!do-not-review\""),
+        "WIP exclusion labels must override the positive ready label"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rust_scope_filter_detection_uses_complete_path_components() {
+    for protected in [
+        "- \"!src/**\"",
+        "- \"!tests/**\"",
+        "- \"!**/src/**\"",
+        "- \"!**/tests/**\"",
+        "- \"!**/*.rs\"",
+    ] {
+        assert!(
+            excludes_rust_scope(protected),
+            "protected Rust scope exclusion was not detected: {protected}"
+        );
+    }
+    for unrelated in [
+        "- \"!not-src/**\"",
+        "- \"!tests-helper/**\"",
+        "- \"!target/**\"",
+    ] {
+        assert!(
+            !excludes_rust_scope(unrelated),
+            "unrelated exclusion was misclassified as Rust scope: {unrelated}"
+        );
+    }
+}
+
+#[test]
+fn review_scope_includes_rust_source_tests_and_jefe_workflows() -> io::Result<()> {
+    let config = repository_text(".coderabbit.yaml")?;
+    let path_filters = yaml_section(&config, "  path_filters:", 2);
+
+    assert!(
+        path_filters.is_empty(),
+        "the initial demand policy must not add path filters; future filters require deliberate contract review"
+    );
+
+    let rust = path_instruction(&config, "**/*.rs").join(" ");
+    let source = path_instruction(&config, "src/**/*.rs").join(" ");
+    let tests = path_instruction(&config, "tests/**/*.rs").join(" ");
+    let short_extension_workflows =
+        path_instruction(&config, ".github/workflows/**/*.yml").join(" ");
+    let long_extension_workflows =
+        path_instruction(&config, ".github/workflows/**/*.yaml").join(" ");
+
+    assert!(
+        rust.contains("use Option for")
+            && rust.contains("absence and Result with typed errors for fallible operations"),
+        "Rust guidance must distinguish absence from fallible operations"
+    );
+    assert!(
+        source.contains("state transitions deterministic"),
+        "production guidance must preserve Jefe ownership boundaries"
+    );
+    assert!(
+        tests.contains("changed tests and behavioral coverage"),
+        "test guidance must preserve first-class review coverage"
+    );
+    assert!(
+        short_extension_workflows.contains("untrusted pull request code")
+            && long_extension_workflows.contains("untrusted pull request code"),
+        "both GitHub workflow extensions must receive Jefe safety guidance"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn contributor_policy_defines_deliberate_review_lifecycle() -> io::Result<()> {
+    let policy = repository_text("dev-docs/code-review-demand.md")?;
+    let normalized_policy = policy.split_whitespace().collect::<Vec<_>>().join(" ");
+    let contributor_guide = repository_text("CONTRIBUTING.md")?;
+
+    assert!(
+        contributor_guide.contains("CodeRabbit review-demand policy"),
+        "the contributor entry point must link to the demand policy"
+    );
+    assert!(
+        normalized_policy.contains("Keep the pull request in draft"),
+        "active implementation must remain draft"
+    );
+    assert!(
+        normalized_policy.contains("add the `review-ready` label"),
+        "ready review must use the configured explicit trigger"
+    );
+    assert!(
+        normalized_policy.contains("current head SHA"),
+        "readiness and coverage must be tied to the exact head"
+    );
+    assert!(
+        normalized_policy.contains("`@coderabbitai review`")
+            && normalized_policy.contains("`@coderabbitai full review`"),
+        "both manual review commands must be documented"
+    );
+    assert!(
+        normalized_policy.contains("cost one PR review from the allowance"),
+        "manual review allowance cost must be explicit"
+    );
+    assert!(
+        normalized_policy.contains("Do not request a review when the reviewed head"),
+        "duplicate exact-head requests must be prohibited"
+    );
+    assert!(
+        normalized_policy.contains("Do not infer coverage from the absence of a throttle"),
+        "missing throttle evidence must not imply coverage"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn measurement_policy_requires_reproducible_complete_windows() -> io::Result<()> {
+    let policy = repository_text("dev-docs/code-review-demand.md")?;
+    let normalized_policy = policy.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    for event_type in [
+        "`review_requested`",
+        "`review_completed`",
+        "`review_throttled`",
+        "`review_coverage_observed`",
+    ] {
+        assert!(
+            normalized_policy.contains(event_type),
+            "measurement policy is missing event type {event_type}"
+        );
+    }
+    assert!(
+        normalized_policy.contains("append-only"),
+        "measurement events must remain immutable"
+    );
+    assert!(
+        normalized_policy.contains("resolved configuration fingerprint")
+            && normalized_policy.contains("eligibility snapshot"),
+        "events must preserve effective configuration and eligibility evidence"
+    );
+    assert!(
+        normalized_policy.contains("terminal state is `merged` or `closed`"),
+        "coverage cohort terminal states must be defined"
+    );
+    assert!(
+        normalized_policy.contains("qualifying ready/opt-in observation")
+            && normalized_policy.contains("remains in the cohort"),
+        "terminal coverage cohort membership must survive later ready-state changes"
+    );
+    assert!(
+        normalized_policy.contains("[T-28d, T)") && normalized_policy.contains("[T-56d, T-28d)"),
+        "adjacent complete rolling windows must be explicit"
+    );
+    assert!(
+        normalized_policy.contains("measurement cutoff `T`")
+            && normalized_policy.contains("publication time `P = T + 7d`")
+            && normalized_policy.contains("as-of boundary is `P`"),
+        "window outcomes need explicit cutoff, publication, and as-of boundaries"
+    );
+    assert!(
+        normalized_policy.contains("zero denominator")
+            && normalized_policy.contains("non-comparable"),
+        "undefined ratios and mixed configurations need deterministic handling"
+    );
+    assert!(
+        normalized_policy.contains("throttle rate and exact-head review coverage"),
+        "demand and coverage metrics must be evaluated together"
+    );
+    assert!(
+        normalized_policy.contains("Never tune from a partial window"),
+        "partial windows must not drive tuning"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- add the authoritative root CodeRabbit v2 configuration with explicit review-ready label opt-in
- skip drafts and WIP-marked pull requests while keeping incremental review enabled and pausing after two reviewed commits
- preserve Rust production/test review scope and add Jefe-specific Rust and workflow guidance
- document manual review allowance cost, exact-head readiness, immutable measurement events, and reproducible adjacent rolling-window evaluation
- add repository-policy contract tests and create the review-ready, wip, and do-not-review repository labels

Fixes #311

## Acceptance evidence

- current CodeRabbit v2 schema validation passed with AJV draft 2020; fetched schema SHA-256: d57478bfb748dbdf5d0509367f90d9c7fac65d8436639cfbec1cbeec77bf4b30
- focused policy contract: 5 passed
- complete local gate: make ci-check passed with the current rustup stable toolchain
- rustreviewer findings were implemented and re-verified
- local Open Code Review finding was implemented; two incorrect/scope-expanding suggestions were explicitly rejected in the issue plan
- live repository labels verified: review-ready, wip, do-not-review

## Testing notes

    cargo test --test coderabbit_policy -- --nocapture
    PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" make ci-check

TUI harness coverage is not applicable because this change affects repository review policy only; no runtime or UI behavior changes.

## Scope

Five files, 679 added lines. No dependency, workflow, PR-template, runtime, TUI, lint-threshold, coverage-threshold, suppression, or source-exclusion changes.
