### PR TITLE
Add dedicated errors panel with ring buffer and status bar indicator (Fixes #292)

### DIFF
--- a/dev-docs/tmux-scenarios/errors-mode.json
+++ b/dev-docs/tmux-scenarios/errors-mode.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "cols": 100,
+    "rows": 24,
+    "history_limit": 2000,
+    "initial_wait_ms": 100,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "key": "e" },
+    { "waitFor": "Errors" },
+    { "expect": "No errors recorded" },
+    { "expect": "Esc exit" },
+    { "key": "Escape" },
+    { "waitForNot": "No errors recorded" },
+    { "keys": ["q", "q", "q"] },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/project-plans/issue292-plan.md
+++ b/project-plans/issue292-plan.md
@@ -1,0 +1,77 @@
+# Issue #292 — Errors should have a dedicated component or panel
+
+## Issue summary
+
+Right now errors get printed above the selection panel, the layout shifts for
+a second, then it goes away. Instead:
+
+1. That an error happened should go to the title bar (where the WARN: ssh agent
+   socket currently shows) — show the last error there.
+2. A dedicated errors panel showing the last N errors.
+3. Works like issues/PRs/actions — list by title, detail on selection.
+4. Eager-loaded since errors are local, not remote.
+
+## Acceptance matrix
+
+| # | Actor / path | Input | Observable success | Failure / diagnostic | Test |
+|---|---|---|---|---|---|
+| A1 | Any code path that sets `error_message` | error string | `ErrorEntry` pushed to `errors_state` store, capped at N (50) | — | unit: push_error + cap |
+| A2 | Any code path that sets per-mode `error` (issues/prs/actions) | error string | `ErrorEntry` pushed to `errors_state` store | — | unit: per-mode error → store |
+| A3 | Status bar render | state with ≥1 error | center shows last error title (truncated) | — | unit + harness |
+| A4 | Status bar render | state with 0 errors | center shows normal repo/running stats | — | unit |
+| A5 | Status bar render | state with warning only (ssh) | center shows WARN (existing behavior) | — | existing tests |
+| A6 | Dashboard key `e`/`E` | Dashboard mode | Enters errors mode (ScreenMode::DashboardErrors) | — | unit: key → event |
+| A7 | Enter errors mode | from dashboard | screen_mode set, focus=list, errors_state.active=true, prior focus saved | — | unit: state transition |
+| A8 | Errors mode render | ≥1 error | List pane shows error titles, detail pane shows selected error detail | — | harness scenario |
+| A9 | Errors mode navigation | up/down in list | selected index moves, detail follows | — | unit |
+| A10 | Errors mode Esc | any focus | exits to dashboard, prior focus restored | — | unit |
+| A11 | Errors mode keybind bar | — | shows errors-mode hints | — | unit |
+
+## Non-goals
+
+- No persistence of error store (runtime-only, like issues/prs state).
+- No filtering or search for errors (all errors shown).
+- No mutation/editing of errors (read-only).
+- No warning capture (only errors, per the issue wording).
+- No replacing per-mode error banners in the existing issues/PRs/actions
+  screens (those are per-mode errors; the global store is additive).
+- No remote fetching (errors are local).
+
+## Vertical slices
+
+1. **Domain + State**: `ErrorEntry`, `ErrorStore`, `ErrorsState`, error capture
+   in the reducer's error-setting transitions.
+2. **Events + Messages**: `EnterErrorsMode`/`ExitErrorsMode`/navigation events,
+   `ErrorsMessage` conversion.
+3. **UI**: `ErrorsScreen` component, `ScreenMode::DashboardErrors`, keybind hint.
+4. **Title bar**: last-error display in the status bar.
+5. **Input**: `e`/`E` key from Dashboard to enter errors mode, Esc to exit.
+
+## Architecture layers
+
+- `src/domain/errors.rs` — ErrorEntry domain type
+- `src/state/errors_types.rs` — ErrorsState
+- `src/state/types.rs` — add errors_state field, ScreenMode variant
+- `src/state/errors_ops.rs` — reducer operations
+- `src/state/events.rs` — new events
+- `src/state/mod.rs` — wire up apply, error capture
+- `src/messages.rs` + `src/messages/errors_conversion.rs` — ErrorsMessage
+- `src/ui/screens/errors.rs` — ErrorsScreen
+- `src/ui/components/status_bar.rs` — last-error display
+- `src/ui/components/keybind_bar.rs` — errors-mode hints
+- `src/ui/orchestration.rs` — screen dispatch
+- `src/app_input/normal.rs` — `e`/`E` key handler
+- `src/selection/` — pane geometry for errors mode
+
+## Scope ledger
+
+(tracked during implementation)
+
+## Review counters
+
+- OCR pre-PR: 0/2
+- OCR post-PR: 0/2
+
+## Verification evidence
+
+(to be filled during implementation)

--- a/src/app_input/errors.rs
+++ b/src/app_input/errors.rs
@@ -35,8 +35,11 @@ pub(super) fn handle_errors_mode_key(
         KeyCode::Tab | KeyCode::Right => Some(AppEvent::ErrorsCycleFocus),
         // Left/Backtab: cycle focus reverse.
         KeyCode::BackTab | KeyCode::Left => Some(AppEvent::ErrorsCycleFocusReverse),
-        // Clear all errors.
-        KeyCode::Char('c') => Some(AppEvent::ErrorsClearAll),
+        // Ctrl-c: clear all errors (destructive — requires modifier like
+        // other destructive actions in this codebase).
+        KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(AppEvent::ErrorsClearAll)
+        }
         // Scroll detail (j/k as vim-like aliases).
         KeyCode::Char('j') if focus == ErrorsFocus::ErrorDetail => {
             Some(AppEvent::ErrorsScrollDetailDown)

--- a/src/app_input/errors.rs
+++ b/src/app_input/errors.rs
@@ -1,0 +1,55 @@
+//! Errors-mode key dispatch (issue #292).
+//!
+//! The error log has no async operations — all keys are synchronous navigation,
+//! focus, scroll, and clear. Esc exits to Dashboard (unless the detail pane is
+//! focused, in which case it refocuses the list first).
+
+use iocraft::prelude::*;
+
+use jefe::state::{AppEvent, AppState, ErrorsFocus};
+
+use super::{AppStateHandle, SharedContext};
+
+/// Entry point: handle a key in DashboardErrors screen mode.
+pub(super) fn handle_errors_mode_key(
+    app_state: &AppStateHandle,
+    _ctx: &SharedContext,
+    key_event: &KeyEvent,
+) -> Option<AppEvent> {
+    let focus = app_state.read().errors_state.focus;
+
+    match key_event.code {
+        // Esc: if detail is focused, refocus the list first; otherwise exit.
+        KeyCode::Esc if focus != ErrorsFocus::ErrorDetail => Some(AppEvent::ExitErrorsMode),
+        KeyCode::Esc => Some(AppEvent::RefocusErrorList),
+        // Navigation (works in all panes; repo nav when sidebar focused).
+        KeyCode::Up => Some(AppEvent::ErrorsNavigateUp),
+        KeyCode::Down => Some(AppEvent::ErrorsNavigateDown),
+        KeyCode::Home => Some(AppEvent::ErrorsNavigateHome),
+        KeyCode::End => Some(AppEvent::ErrorsNavigateEnd),
+        KeyCode::PageUp => Some(AppEvent::ErrorsScrollDetailUp),
+        KeyCode::PageDown => Some(AppEvent::ErrorsScrollDetailDown),
+        // Enter: list → detail focus.
+        KeyCode::Enter if focus == ErrorsFocus::ErrorList => Some(AppEvent::ErrorsEnter),
+        // Tab/Right: cycle focus forward.
+        KeyCode::Tab | KeyCode::Right => Some(AppEvent::ErrorsCycleFocus),
+        // Left/Backtab: cycle focus reverse.
+        KeyCode::BackTab | KeyCode::Left => Some(AppEvent::ErrorsCycleFocusReverse),
+        // Clear all errors.
+        KeyCode::Char('c') => Some(AppEvent::ErrorsClearAll),
+        // Scroll detail (j/k as vim-like aliases).
+        KeyCode::Char('j') if focus == ErrorsFocus::ErrorDetail => {
+            Some(AppEvent::ErrorsScrollDetailDown)
+        }
+        KeyCode::Char('k') if focus == ErrorsFocus::ErrorDetail => {
+            Some(AppEvent::ErrorsScrollDetailUp)
+        }
+        _ => None,
+    }
+}
+
+/// Read-only access to errors focus for the dispatch gate in normal.rs.
+#[allow(dead_code)]
+fn _errors_focus(state: &AppState) -> ErrorsFocus {
+    state.errors_state.focus
+}

--- a/src/app_input/errors.rs
+++ b/src/app_input/errors.rs
@@ -27,17 +27,17 @@ pub(super) fn handle_errors_mode_key(
         KeyCode::Down => Some(AppEvent::ErrorsNavigateDown),
         KeyCode::Home => Some(AppEvent::ErrorsNavigateHome),
         KeyCode::End => Some(AppEvent::ErrorsNavigateEnd),
-        KeyCode::PageUp => Some(AppEvent::ErrorsScrollDetailUp),
-        KeyCode::PageDown => Some(AppEvent::ErrorsScrollDetailDown),
+        KeyCode::PageUp => Some(AppEvent::ErrorsScrollDetailPageUp),
+        KeyCode::PageDown => Some(AppEvent::ErrorsScrollDetailPageDown),
         // Enter: list → detail focus.
         KeyCode::Enter if focus == ErrorsFocus::ErrorList => Some(AppEvent::ErrorsEnter),
         // Tab/Right: cycle focus forward.
         KeyCode::Tab | KeyCode::Right => Some(AppEvent::ErrorsCycleFocus),
         // Left/Backtab: cycle focus reverse.
         KeyCode::BackTab | KeyCode::Left => Some(AppEvent::ErrorsCycleFocusReverse),
-        // Ctrl-c: clear all errors (destructive — requires modifier like
-        // other destructive actions in this codebase).
-        KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+        // Ctrl-c/Ctrl-C: clear all errors (destructive — requires modifier
+        // like other destructive actions in this codebase).
+        KeyCode::Char('c' | 'C') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
             Some(AppEvent::ErrorsClearAll)
         }
         // Scroll detail (j/k as vim-like aliases).

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -46,6 +46,8 @@ mod prs_orchestration;
 
 mod actions;
 mod actions_orchestration;
+// Errors-mode key dispatch (issue #292).
+mod errors;
 // In-app device-code auth remediation dispatch (issue #244).
 mod auth_remediation;
 mod gh_async;

--- a/src/app_input/normal.rs
+++ b/src/app_input/normal.rs
@@ -126,6 +126,9 @@ pub fn handle_normal_key_event(
     {
         return event;
     }
+    if screen_mode == ScreenMode::DashboardErrors {
+        return super::errors::handle_errors_mode_key(app_state, ctx, key_event);
+    }
     if let KeyHandling::Handled(event) = resolve_dashboard_grab_key(app_state, key_event) {
         return event;
     }
@@ -186,7 +189,7 @@ fn normal_key_snapshot(app_state: &AppStateHandle) -> NormalKeySnapshot {
 /// bare `q` harmlessly advances the `qqq` sequence).
 fn quit_shortcut_active(state: &AppState, screen_mode: ScreenMode) -> bool {
     match screen_mode {
-        ScreenMode::Dashboard | ScreenMode::Split => true,
+        ScreenMode::Dashboard | ScreenMode::Split | ScreenMode::DashboardErrors => true,
         ScreenMode::DashboardIssues => issues_quit_shortcut_active(state),
         ScreenMode::DashboardPullRequests => prs_quit_shortcut_active(state),
         ScreenMode::DashboardActions => actions_quit_shortcut_active(state),
@@ -490,6 +493,9 @@ pub(super) fn resolve_mode_key(key_event: &KeyEvent, screen_mode: ScreenMode) ->
         KeyCode::Char('g' | 'G') if screen_mode == ScreenMode::Dashboard => {
             KeyHandling::Handled(Some(AppEvent::EnterActionsMode))
         }
+        KeyCode::Char('e' | 'E') if screen_mode == ScreenMode::Dashboard => {
+            KeyHandling::Handled(Some(AppEvent::EnterErrorsMode))
+        }
         KeyCode::Char('s' | 'S') if screen_mode == ScreenMode::Dashboard => {
             KeyHandling::Handled(Some(AppEvent::EnterSplitMode))
         }
@@ -707,8 +713,7 @@ mod tests {
         assert!(issues_quit_shortcut_active(&state));
     }
 
-    /// The quit shortcut must NOT act when the filter controls overlay is open
-    /// — `q` types into the filter instead.
+    /// Quit shortcut must NOT act when filter controls overlay is open.
     #[test]
     fn quit_shortcut_inactive_when_filter_controls_open() {
         let mut state = issues_base_state();
@@ -720,8 +725,7 @@ mod tests {
         assert!(!issues_quit_shortcut_active(&state));
     }
 
-    /// The quit shortcut must NOT act when the search input is focused — `q`
-    /// types into the search query instead.
+    /// Quit shortcut must NOT act when search input is focused.
     #[test]
     fn quit_shortcut_inactive_when_search_input_focused() {
         let mut state = issues_base_state();
@@ -733,8 +737,7 @@ mod tests {
         assert!(!issues_quit_shortcut_active(&state));
     }
 
-    /// The quit shortcut must NOT act when an inline composer/editor is active
-    /// — `q` types into the composer body instead.
+    /// Quit shortcut must NOT act when inline composer/editor is active.
     #[test]
     fn quit_shortcut_inactive_when_inline_composer_active() {
         let mut state = issues_base_state();
@@ -771,8 +774,7 @@ mod tests {
         assert!(!issues_quit_shortcut_active(&state));
     }
 
-    /// Sanity: for a plain `ScreenMode::Dashboard` state the issues predicate
-    /// returns false, because `input_mode_for_state` would be `Normal`.
+    /// Issues predicate is false for plain Dashboard state.
     #[test]
     fn issues_predicate_false_for_non_issues_dashboard_state() {
         let state = AppState {
@@ -942,8 +944,7 @@ mod tests {
         }
     }
 
-    /// Ctrl-r on a dead agent should also emit `RestartAgent` — restart works
-    /// regardless of status (unlike `l` which only relaunches dead agents).
+    /// Ctrl-r on a dead agent also emits RestartAgent.
     #[test]
     fn restart_event_is_emitted_for_dead_agent() {
         let snapshot = snapshot_with_agent("a2", false);
@@ -957,9 +958,7 @@ mod tests {
         }
     }
 
-    /// Plain `r` without CONTROL must NOT produce a restart event — it should
-    /// be unhandled by `resolve_agent_lifecycle_key` so it falls through to
-    /// `handle_direct_pane_focus_key` (focus repositories pane).
+    /// Plain `r` without CONTROL must NOT produce a restart event.
     #[test]
     fn plain_r_does_not_restart() {
         let snapshot = snapshot_with_agent("a1", true);

--- a/src/domain/errors.rs
+++ b/src/domain/errors.rs
@@ -1,0 +1,59 @@
+//! Domain types for the in-app error log.
+//!
+//! Errors captured from runtime failures, GitHub operations, and validation
+//! paths are recorded here so the user can review them in the dedicated errors
+//! panel (issue #292). These are plain data records — all state transitions
+//! happen in the reducer layer.
+
+use serde::{Deserialize, Serialize};
+
+/// Maximum number of errors retained in the ring buffer.
+pub const ERROR_STORE_CAPACITY: usize = 50;
+
+/// The source screen or subsystem that produced an error, for display.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum ErrorSource {
+    Issues,
+    PullRequests,
+    Actions,
+    Persistence,
+    Agent,
+    Startup,
+    #[default]
+    Other,
+}
+
+impl ErrorSource {
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Issues => "issues",
+            Self::PullRequests => "prs",
+            Self::Actions => "actions",
+            Self::Persistence => "persistence",
+            Self::Agent => "agent",
+            Self::Startup => "startup",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// A single captured error entry in the error log.
+///
+/// `title` is a short summary for the list pane; `detail` is the full error
+/// message for the detail pane. Both are stored as plain strings because they
+/// originate from heterogeneous sources (GitHub API errors, persistence
+/// failures, validation messages).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ErrorEntry {
+    /// Monotonically increasing sequence number for stable ordering.
+    pub seq: u64,
+    /// Short title (first line / summary) shown in the list pane.
+    pub title: String,
+    /// Full error message shown in the detail pane.
+    pub detail: String,
+    /// Where the error originated.
+    pub source: ErrorSource,
+    /// ISO 8601 timestamp of when the error was captured.
+    pub timestamp: String,
+}

--- a/src/domain/errors.rs
+++ b/src/domain/errors.rs
@@ -54,6 +54,6 @@ pub struct ErrorEntry {
     pub detail: String,
     /// Where the error originated.
     pub source: ErrorSource,
-    /// ISO 8601 timestamp of when the error was captured.
+    /// Unix epoch seconds (UTC) of when the error was captured.
     pub timestamp: String,
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -18,6 +18,10 @@ mod quick_resume;
 pub use actions::*;
 pub use quick_resume::QuickResume;
 
+// Error-log domain types (issue #292).
+mod errors;
+pub use errors::{ERROR_STORE_CAPACITY, ErrorEntry, ErrorSource};
+
 /// Pagination contracts shared across list state and boundary messages.
 // Sandbox engine + platform capability types extracted to keep this file
 // under the source-file-size limit.

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -23,6 +23,9 @@ mod actions_conversion;
 mod prs_conversion;
 mod prs_property_conversion;
 pub use actions::ActionsMessage;
+mod errors;
+mod errors_conversion;
+pub use errors::ErrorsMessage;
 
 // @plan PLAN-20260624-PR-MODE.P03
 // @requirement REQ-PR-002
@@ -44,6 +47,7 @@ pub enum MessageDomain {
     /// @requirement REQ-PR-001
     PullRequests,
     Actions,
+    Errors,
     System,
 }
 
@@ -839,6 +843,7 @@ pub enum AppMessage {
     /// @requirement REQ-PR-001
     PullRequests(PullRequestsMessage),
     Actions(ActionsMessage),
+    Errors(ErrorsMessage),
     System(SystemMessage),
 }
 
@@ -857,6 +862,7 @@ impl AppMessage {
             // @requirement REQ-PR-001
             Self::PullRequests(_) => MessageDomain::PullRequests,
             Self::Actions(_) => MessageDomain::Actions,
+            Self::Errors(_) => MessageDomain::Errors,
             Self::System(_) => MessageDomain::System,
         }
     }
@@ -883,6 +889,7 @@ impl AppMessage {
             // @requirement REQ-PR-002
             Self::PullRequests(message) => message.name(),
             Self::Actions(message) => message.name(),
+            Self::Errors(message) => message.name(),
             Self::System(message) => message.name(),
         }
     }

--- a/src/messages/errors.rs
+++ b/src/messages/errors.rs
@@ -1,0 +1,38 @@
+//! Errors-mode messages (issue #292).
+//!
+//! The error log is purely local — no remote fetching, no async loads, no
+//! mutation correlation. Messages cover only mode lifecycle, list navigation,
+//! detail scrolling, and clearing the log.
+
+use crate::messages::{NavDir, ScrollDir};
+
+/// Errors mode messages.
+#[derive(Debug, Clone)]
+pub enum ErrorsMessage {
+    EnterMode,
+    ExitMode,
+    RefocusList,
+    Navigate(NavDir),
+    Enter,
+    CycleFocus,
+    CycleFocusReverse,
+    ScrollDetail(ScrollDir),
+    ClearAll,
+}
+
+impl ErrorsMessage {
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::EnterMode => "EnterErrorsMode",
+            Self::ExitMode => "ExitErrorsMode",
+            Self::RefocusList => "RefocusErrorList",
+            Self::Navigate(_) => "ErrorsNavigate",
+            Self::Enter => "ErrorsEnter",
+            Self::CycleFocus => "ErrorsCycleFocus",
+            Self::CycleFocusReverse => "ErrorsCycleFocusReverse",
+            Self::ScrollDetail(_) => "ErrorsScrollDetail",
+            Self::ClearAll => "ErrorsClearAll",
+        }
+    }
+}

--- a/src/messages/errors_conversion.rs
+++ b/src/messages/errors_conversion.rs
@@ -30,6 +30,8 @@ impl ErrorsMessage {
             AppEvent::ErrorsCycleFocusReverse => Self::CycleFocusReverse,
             AppEvent::ErrorsScrollDetailUp => Self::ScrollDetail(ScrollDir::Up),
             AppEvent::ErrorsScrollDetailDown => Self::ScrollDetail(ScrollDir::Down),
+            AppEvent::ErrorsScrollDetailPageUp => Self::ScrollDetail(ScrollDir::PageUp),
+            AppEvent::ErrorsScrollDetailPageDown => Self::ScrollDetail(ScrollDir::PageDown),
             AppEvent::ErrorsClearAll => Self::ClearAll,
             _ => unreachable!("unhandled event for ErrorsMessage: {:?}", event),
         }
@@ -60,15 +62,17 @@ impl ErrorsMessage {
             // handler maps PageUp/PageDown to scroll events directly, so these
             // branches are only reached if Navigate(PageUp/Down) is constructed
             // programmatically).
-            NavDir::PageUp(_) => AppEvent::ErrorsScrollDetailUp,
-            NavDir::PageDown(_) => AppEvent::ErrorsScrollDetailDown,
+            NavDir::PageUp(_) => AppEvent::ErrorsScrollDetailPageUp,
+            NavDir::PageDown(_) => AppEvent::ErrorsScrollDetailPageDown,
         }
     }
 
     fn map_scroll(dir: ScrollDir) -> AppEvent {
         match dir {
-            ScrollDir::Up | ScrollDir::PageUp => AppEvent::ErrorsScrollDetailUp,
-            ScrollDir::Down | ScrollDir::PageDown => AppEvent::ErrorsScrollDetailDown,
+            ScrollDir::Up => AppEvent::ErrorsScrollDetailUp,
+            ScrollDir::Down => AppEvent::ErrorsScrollDetailDown,
+            ScrollDir::PageUp => AppEvent::ErrorsScrollDetailPageUp,
+            ScrollDir::PageDown => AppEvent::ErrorsScrollDetailPageDown,
         }
     }
 }

--- a/src/messages/errors_conversion.rs
+++ b/src/messages/errors_conversion.rs
@@ -52,15 +52,16 @@ impl ErrorsMessage {
 
     fn map_navigation(dir: NavDir) -> AppEvent {
         match dir {
-            NavDir::Up => AppEvent::ErrorsNavigateUp,
+            NavDir::Up | NavDir::Next | NavDir::Prev => AppEvent::ErrorsNavigateUp,
             NavDir::Down => AppEvent::ErrorsNavigateDown,
             NavDir::Home => AppEvent::ErrorsNavigateHome,
             NavDir::End => AppEvent::ErrorsNavigateEnd,
-            // Page/Next/Prev don't have dedicated error variants; map Up/Down
-            // as no-ops to keep the enum closed.
-            NavDir::PageUp(_) | NavDir::PageDown(_) | NavDir::Next | NavDir::Prev => {
-                AppEvent::ErrorsNavigateUp
-            }
+            // PageUp/PageDown scroll the detail pane in errors mode (the key
+            // handler maps PageUp/PageDown to scroll events directly, so these
+            // branches are only reached if Navigate(PageUp/Down) is constructed
+            // programmatically).
+            NavDir::PageUp(_) => AppEvent::ErrorsScrollDetailUp,
+            NavDir::PageDown(_) => AppEvent::ErrorsScrollDetailDown,
         }
     }
 

--- a/src/messages/errors_conversion.rs
+++ b/src/messages/errors_conversion.rs
@@ -1,0 +1,73 @@
+//! `AppEvent` <-> `ErrorsMessage` conversion (issue #292).
+
+use crate::messages::{ErrorsMessage, NavDir, ScrollDir};
+use crate::state::AppEvent;
+
+impl From<ErrorsMessage> for AppEvent {
+    fn from(message: ErrorsMessage) -> Self {
+        message.into_app_event()
+    }
+}
+
+impl ErrorsMessage {
+    /// Convert an [`AppEvent`] into the corresponding [`ErrorsMessage`].
+    ///
+    /// # Panics
+    /// Panics via `unreachable!` if the event does not belong to the Errors
+    /// domain. Callers must only pass errors-domain events (guaranteed by
+    /// [`AppMessage::from`]'s routing gate).
+    pub(super) fn from_app_event(event: AppEvent) -> Self {
+        match event {
+            AppEvent::EnterErrorsMode => Self::EnterMode,
+            AppEvent::ExitErrorsMode => Self::ExitMode,
+            AppEvent::RefocusErrorList => Self::RefocusList,
+            AppEvent::ErrorsNavigateUp => Self::Navigate(NavDir::Up),
+            AppEvent::ErrorsNavigateDown => Self::Navigate(NavDir::Down),
+            AppEvent::ErrorsNavigateHome => Self::Navigate(NavDir::Home),
+            AppEvent::ErrorsNavigateEnd => Self::Navigate(NavDir::End),
+            AppEvent::ErrorsEnter => Self::Enter,
+            AppEvent::ErrorsCycleFocus => Self::CycleFocus,
+            AppEvent::ErrorsCycleFocusReverse => Self::CycleFocusReverse,
+            AppEvent::ErrorsScrollDetailUp => Self::ScrollDetail(ScrollDir::Up),
+            AppEvent::ErrorsScrollDetailDown => Self::ScrollDetail(ScrollDir::Down),
+            AppEvent::ErrorsClearAll => Self::ClearAll,
+            _ => unreachable!("unhandled event for ErrorsMessage: {:?}", event),
+        }
+    }
+
+    #[must_use]
+    pub fn into_app_event(self) -> AppEvent {
+        match self {
+            Self::EnterMode => AppEvent::EnterErrorsMode,
+            Self::ExitMode => AppEvent::ExitErrorsMode,
+            Self::RefocusList => AppEvent::RefocusErrorList,
+            Self::Navigate(dir) => Self::map_navigation(dir),
+            Self::Enter => AppEvent::ErrorsEnter,
+            Self::CycleFocus => AppEvent::ErrorsCycleFocus,
+            Self::CycleFocusReverse => AppEvent::ErrorsCycleFocusReverse,
+            Self::ScrollDetail(dir) => Self::map_scroll(dir),
+            Self::ClearAll => AppEvent::ErrorsClearAll,
+        }
+    }
+
+    fn map_navigation(dir: NavDir) -> AppEvent {
+        match dir {
+            NavDir::Up => AppEvent::ErrorsNavigateUp,
+            NavDir::Down => AppEvent::ErrorsNavigateDown,
+            NavDir::Home => AppEvent::ErrorsNavigateHome,
+            NavDir::End => AppEvent::ErrorsNavigateEnd,
+            // Page/Next/Prev don't have dedicated error variants; map Up/Down
+            // as no-ops to keep the enum closed.
+            NavDir::PageUp(_) | NavDir::PageDown(_) | NavDir::Next | NavDir::Prev => {
+                AppEvent::ErrorsNavigateUp
+            }
+        }
+    }
+
+    fn map_scroll(dir: ScrollDir) -> AppEvent {
+        match dir {
+            ScrollDir::Up | ScrollDir::PageUp => AppEvent::ErrorsScrollDetailUp,
+            ScrollDir::Down | ScrollDir::PageDown => AppEvent::ErrorsScrollDetailDown,
+        }
+    }
+}

--- a/src/messages/event_conversion.rs
+++ b/src/messages/event_conversion.rs
@@ -232,6 +232,8 @@ impl AppMessage {
                 | AppEvent::ErrorsCycleFocusReverse
                 | AppEvent::ErrorsScrollDetailUp
                 | AppEvent::ErrorsScrollDetailDown
+                | AppEvent::ErrorsScrollDetailPageUp
+                | AppEvent::ErrorsScrollDetailPageDown
                 | AppEvent::ErrorsClearAll
         )
     }

--- a/src/messages/event_conversion.rs
+++ b/src/messages/event_conversion.rs
@@ -7,7 +7,7 @@
 use crate::state::AppEvent;
 
 use super::{
-    ActionsMessage, AppMessage, IssuesMessage, ModalMessage, PersistenceMessage,
+    ActionsMessage, AppMessage, ErrorsMessage, IssuesMessage, ModalMessage, PersistenceMessage,
     PullRequestsMessage, RepositoryAgentMessage, RuntimeMessage, SystemMessage, ThemeMessage,
     UiNavigationMessage,
 };
@@ -202,6 +202,8 @@ impl AppMessage {
             Self::Issues(IssuesMessage::from_app_event(event))
         } else if Self::is_actions_event(&event) {
             Self::Actions(ActionsMessage::from_app_event(event))
+        } else if Self::is_errors_event(&event) {
+            Self::Errors(ErrorsMessage::from_app_event(event))
         } else {
             // @plan PLAN-20260624-PR-MODE.P03
             // @requirement REQ-PR-002
@@ -212,6 +214,26 @@ impl AppMessage {
     /// Whether the event belongs to the issues domain.
     fn is_issues_event(event: &AppEvent) -> bool {
         Self::is_issues_nav_event(event) || Self::is_issues_data_event(event)
+    }
+
+    /// Whether the event belongs to the errors domain (issue #292).
+    fn is_errors_event(event: &AppEvent) -> bool {
+        matches!(
+            event,
+            AppEvent::EnterErrorsMode
+                | AppEvent::ExitErrorsMode
+                | AppEvent::RefocusErrorList
+                | AppEvent::ErrorsNavigateUp
+                | AppEvent::ErrorsNavigateDown
+                | AppEvent::ErrorsNavigateHome
+                | AppEvent::ErrorsNavigateEnd
+                | AppEvent::ErrorsEnter
+                | AppEvent::ErrorsCycleFocus
+                | AppEvent::ErrorsCycleFocusReverse
+                | AppEvent::ErrorsScrollDetailUp
+                | AppEvent::ErrorsScrollDetailDown
+                | AppEvent::ErrorsClearAll
+        )
     }
 
     /// Whether the event belongs to the actions domain.
@@ -419,6 +441,7 @@ impl From<AppMessage> for AppEvent {
             // @requirement REQ-PR-002
             AppMessage::PullRequests(message) => message.into(),
             AppMessage::Actions(message) => message.into(),
+            AppMessage::Errors(message) => message.into(),
             AppMessage::System(message) => message.into(),
         }
     }

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -756,7 +756,7 @@ fn screen_layout_for(state: &AppState, cols: u16, rows: u16) -> ScreenLayout {
             state.actions_state.error.is_some(),
             state.actions_state.ui.filter_ui_open,
         ),
-        ScreenMode::Dashboard | ScreenMode::Split => (false, false),
+        ScreenMode::DashboardErrors | ScreenMode::Dashboard | ScreenMode::Split => (false, false),
     };
     let error_visible = state.error_message.is_some() || mode_error;
     ScreenLayout::new(cols, rows, state.screen_mode, error_visible, filter_open)

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -758,7 +758,9 @@ fn screen_layout_for(state: &AppState, cols: u16, rows: u16) -> ScreenLayout {
         ),
         ScreenMode::DashboardErrors | ScreenMode::Dashboard | ScreenMode::Split => (false, false),
     };
-    let error_visible = state.error_message.is_some() || mode_error;
+    let error_visible = (state.error_message.is_some()
+        && !matches!(state.screen_mode, ScreenMode::DashboardErrors))
+        || mode_error;
     ScreenLayout::new(cols, rows, state.screen_mode, error_visible, filter_open)
         .with_overlay(active_overlay_for(state))
 }

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -121,6 +121,8 @@ pub fn pane_content_lines_with_context(
         SelectablePane::ActionsDetail => {
             super::actions_content::actions_detail_lines(state, render_cols, render_rows)
         }
+        SelectablePane::ErrorList => super::errors_content::error_list_lines(state, render_cols),
+        SelectablePane::ErrorDetail => super::errors_content::error_detail_lines(state),
         SelectablePane::Sidebar => sidebar_lines(state, render_cols, render_rows),
         SelectablePane::AgentList => super::dashboard_content::agent_list_lines(
             state,

--- a/src/selection/errors_content.rs
+++ b/src/selection/errors_content.rs
@@ -14,14 +14,17 @@ pub fn error_list_lines(state: &AppState, render_cols: u16) -> PaneContent {
         .errors
         .iter()
         .map(|entry| {
-            let title = if entry.title.len() > content_width.saturating_sub(10) {
-                format!(
-                    "[{}] {}…",
-                    entry.seq,
-                    &entry.title[..content_width.saturating_sub(13)]
-                )
+            let prefix = format!("[{}] ", entry.seq);
+            let remaining = content_width.saturating_sub(prefix.chars().count());
+            let title = if entry.title.chars().count() > remaining {
+                let truncated: String = entry
+                    .title
+                    .chars()
+                    .take(remaining.saturating_sub(1))
+                    .collect();
+                format!("{prefix}{truncated}…")
             } else {
-                format!("[{}] {}", entry.seq, entry.title)
+                format!("{prefix}{}", entry.title)
             };
             crate::list_viewport::fit_text_to_width(&title, content_width)
         })

--- a/src/selection/errors_content.rs
+++ b/src/selection/errors_content.rs
@@ -1,0 +1,63 @@
+//! Errors pane content projections used by mouse selection and copy (issue #292).
+
+use crate::selection::SelectablePane;
+use crate::state::AppState;
+
+use super::content::PaneContent;
+
+/// Build the error list pane content lines (one per stored error).
+#[must_use]
+pub fn error_list_lines(state: &AppState, render_cols: u16) -> PaneContent {
+    let content_width = crate::layout::pr_list_content_width(render_cols) as usize;
+    let lines: Vec<String> = state
+        .errors_state
+        .errors
+        .iter()
+        .map(|entry| {
+            let title = if entry.title.len() > content_width.saturating_sub(10) {
+                format!(
+                    "[{}] {}…",
+                    entry.seq,
+                    &entry.title[..content_width.saturating_sub(13)]
+                )
+            } else {
+                format!("[{}] {}", entry.seq, entry.title)
+            };
+            crate::list_viewport::fit_text_to_width(&title, content_width)
+        })
+        .collect();
+    if lines.is_empty() {
+        return PaneContent::new(
+            SelectablePane::ErrorList,
+            vec!["No errors recorded.".to_string()],
+        );
+    }
+    PaneContent::new(SelectablePane::ErrorList, lines)
+}
+
+/// Build the error detail pane content lines (header + detail body).
+#[must_use]
+pub fn error_detail_lines(state: &AppState) -> PaneContent {
+    let Some(entry) = state.errors_state.selected_error() else {
+        return PaneContent::new(
+            SelectablePane::ErrorDetail,
+            vec!["Select an error to view details.".to_string()],
+        );
+    };
+    let source_label = match entry.source {
+        crate::domain::ErrorSource::Issues => "Issues",
+        crate::domain::ErrorSource::PullRequests => "PRs",
+        crate::domain::ErrorSource::Actions => "Actions",
+        crate::domain::ErrorSource::Persistence => "Persistence",
+        crate::domain::ErrorSource::Agent => "Agent",
+        crate::domain::ErrorSource::Startup => "Startup",
+        crate::domain::ErrorSource::Other => "Other",
+    };
+    let mut lines = vec![
+        format!("[{}] {}", entry.seq, entry.title),
+        format!("Source: {source_label}  ·  {}", entry.timestamp),
+        crate::ui::components::SEPARATOR_LINE.to_string(),
+    ];
+    lines.extend(entry.detail.lines().map(String::from));
+    PaneContent::new(SelectablePane::ErrorDetail, lines)
+}

--- a/src/selection/geometry.rs
+++ b/src/selection/geometry.rs
@@ -164,7 +164,8 @@ pub fn pane_at(
         crate::state::ScreenMode::Split => split_pane_at(col, row, render_cols, render_rows),
         crate::state::ScreenMode::DashboardIssues
         | crate::state::ScreenMode::DashboardPullRequests
-        | crate::state::ScreenMode::DashboardActions => {
+        | crate::state::ScreenMode::DashboardActions
+        | crate::state::ScreenMode::DashboardErrors => {
             issues_pane_at(col, row, render_cols, render_rows, *layout)
         }
     }
@@ -372,6 +373,8 @@ fn list_pane(
         SelectablePane::PrList
     } else if layout.is_actions_mode() {
         SelectablePane::ActionsList
+    } else if layout.is_errors_mode() {
+        SelectablePane::ErrorList
     } else {
         SelectablePane::IssueList
     };
@@ -400,6 +403,8 @@ fn detail_pane(
         SelectablePane::PrDetail
     } else if layout.is_actions_mode() {
         SelectablePane::ActionsDetail
+    } else if layout.is_errors_mode() {
+        SelectablePane::ErrorDetail
     } else {
         SelectablePane::IssueDetail
     };

--- a/src/selection/layout_descriptor.rs
+++ b/src/selection/layout_descriptor.rs
@@ -133,4 +133,11 @@ impl ScreenLayout {
     pub fn is_actions_mode(self) -> bool {
         matches!(self.screen_mode, ScreenMode::DashboardActions)
     }
+
+    /// Whether this layout is for Errors mode (affects pane identity, not
+    /// geometry — Errors shares the Issues/PR list+detail split). Issue #292.
+    #[must_use]
+    pub fn is_errors_mode(self) -> bool {
+        matches!(self.screen_mode, ScreenMode::DashboardErrors)
+    }
 }

--- a/src/selection/mod.rs
+++ b/src/selection/mod.rs
@@ -27,6 +27,7 @@
 mod actions_content;
 mod content;
 mod dashboard_content;
+mod errors_content;
 mod form_content;
 mod geometry;
 mod gesture;

--- a/src/selection/text.rs
+++ b/src/selection/text.rs
@@ -34,6 +34,10 @@ pub enum SelectablePane {
     ActionsList,
     /// Actions run detail (Actions-mode workspace, bottom split).
     ActionsDetail,
+    /// Error list (errors-mode workspace, top split). Issue #292.
+    ErrorList,
+    /// Error detail (errors-mode workspace, bottom split). Issue #292.
+    ErrorDetail,
     /// Help modal overlay text.
     HelpModal,
     /// Top status bar (low priority, but selectable).

--- a/src/state/errors_ops.rs
+++ b/src/state/errors_ops.rs
@@ -1,0 +1,194 @@
+//! Errors-mode reducer operations (issue #292).
+//!
+//! The error log is purely local — no remote data, no async loads. This module
+//! handles mode enter/exit (with prior-focus save/restore, mirroring
+//! issues/prs/actions), list navigation, detail scrolling, focus cycling, and
+//! clearing the log.
+
+use super::{AppState, ErrorsFocus, PaneFocus, PriorAgentFocus, ScreenMode};
+use crate::messages::{ErrorsMessage, NavDir, ScrollDir};
+
+impl AppState {
+    /// Enter errors mode, saving prior focus state.
+    fn enter_errors_mode(&mut self) -> bool {
+        self.errors_state.prior_agent_focus = Some(PriorAgentFocus {
+            pane_focus: self.pane_focus,
+            selected_repository_index: self.selected_repository_index,
+            selected_agent_index: self.selected_agent_index,
+        });
+        self.screen_mode = ScreenMode::DashboardErrors;
+        self.errors_state.active = true;
+        self.errors_state.focus = ErrorsFocus::ErrorList;
+        // Ensure selection is valid (newest error after any recent push).
+        if self.errors_state.errors.is_empty() {
+            self.errors_state.selected_index = None;
+        } else {
+            self.errors_state.selected_index = Some(0);
+        }
+        self.errors_state.detail_scroll_offset = 0;
+        true
+    }
+
+    /// Exit errors mode, restoring prior focus state.
+    fn exit_errors_mode(&mut self) {
+        self.screen_mode = ScreenMode::Dashboard;
+        self.errors_state.active = false;
+        if let Some(prior) = self.errors_state.prior_agent_focus.take() {
+            self.pane_focus = prior.pane_focus;
+            if let Some(idx) = prior.selected_agent_index
+                && idx < self.agents.len()
+            {
+                self.selected_agent_index = Some(idx);
+            }
+            if let Some(idx) = prior.selected_repository_index
+                && idx < self.repositories.len()
+            {
+                self.selected_repository_index = Some(idx);
+            }
+        } else {
+            self.pane_focus = PaneFocus::Agents;
+        }
+    }
+
+    fn refocus_error_list(&mut self) -> bool {
+        self.errors_state.focus = ErrorsFocus::ErrorList;
+        true
+    }
+
+    fn handle_error_navigation(&mut self, dir: NavDir) -> bool {
+        if matches!(self.errors_state.focus, ErrorsFocus::RepoList)
+            && matches!(dir, NavDir::Up | NavDir::Down)
+        {
+            self.move_repo_selection(dir);
+            return true;
+        }
+        let count = self.errors_state.errors.len();
+        if count == 0 {
+            return true;
+        }
+        let current = self.errors_state.selected_index.unwrap_or(0);
+        let new_index = match dir {
+            NavDir::Up => current.saturating_sub(1),
+            NavDir::Down => (current + 1).min(count - 1),
+            NavDir::Home => 0,
+            NavDir::End => count - 1,
+            NavDir::PageUp(_) | NavDir::PageDown(_) | NavDir::Next | NavDir::Prev => current,
+        };
+        self.errors_state.selected_index = Some(new_index);
+        self.errors_state.detail_scroll_offset = 0;
+        true
+    }
+
+    fn handle_error_enter(&mut self) -> bool {
+        if matches!(self.errors_state.focus, ErrorsFocus::ErrorList)
+            && self.errors_state.selected_error().is_some()
+        {
+            self.errors_state.focus = ErrorsFocus::ErrorDetail;
+        }
+        true
+    }
+
+    fn cycle_error_focus(&mut self) -> bool {
+        self.errors_state.focus = match self.errors_state.focus {
+            ErrorsFocus::RepoList => ErrorsFocus::ErrorList,
+            ErrorsFocus::ErrorList => ErrorsFocus::ErrorDetail,
+            ErrorsFocus::ErrorDetail => ErrorsFocus::RepoList,
+        };
+        true
+    }
+
+    fn cycle_error_focus_reverse(&mut self) -> bool {
+        self.errors_state.focus = match self.errors_state.focus {
+            ErrorsFocus::RepoList => ErrorsFocus::ErrorDetail,
+            ErrorsFocus::ErrorList => ErrorsFocus::RepoList,
+            ErrorsFocus::ErrorDetail => ErrorsFocus::ErrorList,
+        };
+        true
+    }
+
+    fn handle_error_scroll(&mut self, dir: ScrollDir) -> bool {
+        let detail_lines = self.errors_detail_line_count();
+        let max = detail_lines.saturating_sub(self.errors_state.detail_viewport_rows);
+        let current = self.errors_state.detail_scroll_offset.min(max);
+        self.errors_state.detail_scroll_offset = match dir {
+            ScrollDir::Up => current.saturating_sub(1),
+            ScrollDir::Down => current.saturating_add(1).min(max),
+            ScrollDir::PageUp => current.saturating_sub(super::VIEWPORT_PAGE_JUMP),
+            ScrollDir::PageDown => current.saturating_add(super::VIEWPORT_PAGE_JUMP).min(max),
+        };
+        true
+    }
+
+    fn clear_all_errors(&mut self) -> bool {
+        self.errors_state.errors.clear();
+        self.errors_state.selected_index = None;
+        self.errors_state.detail_scroll_offset = 0;
+        true
+    }
+
+    /// Number of wrapped detail lines for the selected error (approximation:
+    /// one line per detail line in the stored text; the renderer wraps further
+    /// but the scroll offset only needs to stay within a reasonable bound).
+    fn errors_detail_line_count(&self) -> usize {
+        self.errors_state.selected_error().map_or(0, |e| {
+            // Header lines (title, source, timestamp) + detail body lines.
+            let header = 4;
+            let body = e.detail.lines().count().max(1);
+            header + body
+        })
+    }
+
+    /// Handle all Errors events.
+    pub(super) fn apply_errors_message(&mut self, message: ErrorsMessage) -> bool {
+        match message {
+            ErrorsMessage::EnterMode => self.enter_errors_mode(),
+            ErrorsMessage::ExitMode => {
+                self.exit_errors_mode();
+                true
+            }
+            ErrorsMessage::RefocusList => self.refocus_error_list(),
+            ErrorsMessage::Navigate(dir) => self.handle_error_navigation(dir),
+            ErrorsMessage::Enter => self.handle_error_enter(),
+            ErrorsMessage::CycleFocus => self.cycle_error_focus(),
+            ErrorsMessage::CycleFocusReverse => self.cycle_error_focus_reverse(),
+            ErrorsMessage::ScrollDetail(dir) => self.handle_error_scroll(dir),
+            ErrorsMessage::ClearAll => self.clear_all_errors(),
+        }
+    }
+}
+
+/// Capture runtime errors into the errors ring buffer (issue #292).
+///
+/// Called from `finalize_message` after every reducer step. Inspects all known
+/// error slots (global `error_message`, per-mode `issues_state.error`,
+/// `prs_state.error`, `actions_state.error`) and pushes a new entry into
+/// `errors_state` when the text changes. Deduplication is per-slot.
+pub(super) fn capture_runtime_errors(state: &mut AppState) {
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| format!("{}", d.as_secs()))
+        .unwrap_or_default();
+
+    if let Some(ref msg) = state.error_message {
+        state
+            .errors_state
+            .capture_global(msg, crate::domain::ErrorSource::Persistence, &timestamp);
+    } else {
+        state.errors_state.reset_global_tracker();
+    }
+    if let Some(ref msg) = state.issues_state.error {
+        state.errors_state.capture_issues(msg, &timestamp);
+    } else {
+        state.errors_state.reset_issues_tracker();
+    }
+    if let Some(ref msg) = state.prs_state.error {
+        state.errors_state.capture_prs(msg, &timestamp);
+    } else {
+        state.errors_state.reset_prs_tracker();
+    }
+    if let Some(ref msg) = state.actions_state.error {
+        state.errors_state.capture_actions(msg, &timestamp);
+    } else {
+        state.errors_state.reset_actions_tracker();
+    }
+}

--- a/src/state/errors_ops.rs
+++ b/src/state/errors_ops.rs
@@ -56,10 +56,11 @@ impl AppState {
     }
 
     fn handle_error_navigation(&mut self, dir: NavDir) -> bool {
-        if matches!(self.errors_state.focus, ErrorsFocus::RepoList)
-            && matches!(dir, NavDir::Up | NavDir::Down)
-        {
-            self.move_repo_selection(dir);
+        if matches!(self.errors_state.focus, ErrorsFocus::RepoList) {
+            if matches!(dir, NavDir::Up | NavDir::Down) {
+                self.move_repo_selection(dir);
+            }
+            // Home/End/Page/Next/Prev are no-ops for the repo sidebar today.
             return true;
         }
         let count = self.errors_state.errors.len();
@@ -187,9 +188,12 @@ pub(super) fn capture_runtime_errors(state: &mut AppState) {
         .unwrap_or_default();
 
     if let Some(ref msg) = state.error_message {
+        // `error_message` is a catch-all slot written from many subsystems
+        // (agent lifecycle, availability, forms, auth, persistence, etc.),
+        // so it cannot be attributed to a single source.
         state
             .errors_state
-            .capture_global(msg, crate::domain::ErrorSource::Persistence, &timestamp);
+            .capture_global(msg, crate::domain::ErrorSource::Other, &timestamp);
     } else {
         state.errors_state.reset_global_tracker();
     }

--- a/src/state/errors_ops.rs
+++ b/src/state/errors_ops.rs
@@ -163,7 +163,24 @@ impl AppState {
 /// error slots (global `error_message`, per-mode `issues_state.error`,
 /// `prs_state.error`, `actions_state.error`) and pushes a new entry into
 /// `errors_state` when the text changes. Deduplication is per-slot.
+///
+/// The timestamp is only allocated when at least one slot has changed, to
+/// avoid per-message heap allocation on the hot path.
 pub(super) fn capture_runtime_errors(state: &mut AppState) {
+    // Quick-change check: see if any slot differs from the last captured value.
+    let global_changed =
+        state.error_message.as_deref() != state.errors_state.last_captured_global_snapshot();
+    let issues_changed =
+        state.issues_state.error.as_deref() != state.errors_state.last_captured_issues_snapshot();
+    let prs_changed =
+        state.prs_state.error.as_deref() != state.errors_state.last_captured_prs_snapshot();
+    let actions_changed =
+        state.actions_state.error.as_deref() != state.errors_state.last_captured_actions_snapshot();
+
+    if !global_changed && !issues_changed && !prs_changed && !actions_changed {
+        return;
+    }
+
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| format!("{}", d.as_secs()))

--- a/src/state/errors_tests.rs
+++ b/src/state/errors_tests.rs
@@ -1,0 +1,312 @@
+//! Unit tests for the errors-mode state and reducer (issue #292).
+
+use crate::domain::ErrorSource;
+use crate::messages::{ErrorsMessage, NavDir, ScrollDir};
+use crate::state::events::AppEvent;
+use crate::state::{AppState, ErrorsFocus, ScreenMode};
+
+/// In-place apply helper to avoid the take/replace dance on owned AppState.
+fn apply_in_place(state: &mut AppState, event: AppEvent) {
+    let old = std::mem::take(state);
+    *state = old.apply(event);
+}
+
+/// A fresh `ErrorsState` starts empty with no selection.
+#[test]
+fn default_errors_state_is_empty() {
+    let state = AppState::default();
+    assert!(state.errors_state.is_empty());
+    assert_eq!(state.errors_state.count(), 0);
+    assert!(state.errors_state.selected_index.is_none());
+}
+
+/// Pushing an error adds it at the head and selects it.
+#[test]
+fn push_adds_to_head_and_selects() {
+    let mut state = AppState::default();
+    state.errors_state.push(
+        "First error".to_string(),
+        "detail one".to_string(),
+        ErrorSource::Issues,
+        "2025-01-01T00:00:00Z".to_string(),
+    );
+    assert_eq!(state.errors_state.count(), 1);
+    assert_eq!(state.errors_state.selected_index, Some(0));
+    assert_eq!(
+        state
+            .errors_state
+            .last_error()
+            .map_or(String::new(), |e| e.title.clone()),
+        "First error"
+    );
+
+    state.errors_state.push(
+        "Second error".to_string(),
+        "detail two".to_string(),
+        ErrorSource::PullRequests,
+        "2025-01-01T00:00:01Z".to_string(),
+    );
+    assert_eq!(state.errors_state.count(), 2);
+    assert_eq!(
+        state
+            .errors_state
+            .last_error()
+            .map_or(String::new(), |e| e.title.clone()),
+        "Second error"
+    );
+}
+
+/// Pushing more than `ERROR_STORE_CAPACITY` errors evicts the oldest.
+#[test]
+fn push_evicts_oldest_at_capacity() {
+    let mut state = AppState::default();
+    for i in 0..crate::domain::ERROR_STORE_CAPACITY + 5 {
+        state.errors_state.push(
+            format!("error {i}"),
+            format!("detail {i}"),
+            ErrorSource::Other,
+            "ts".to_string(),
+        );
+    }
+    assert_eq!(
+        state.errors_state.count(),
+        crate::domain::ERROR_STORE_CAPACITY
+    );
+    // The newest error should be the last pushed.
+    let last_title = state
+        .errors_state
+        .last_error()
+        .map_or(String::new(), |e| e.title.clone());
+    assert_eq!(
+        last_title,
+        format!("error {}", crate::domain::ERROR_STORE_CAPACITY + 4)
+    );
+}
+
+/// `EnterErrorsMode` switches screen mode, activates state, and focuses list.
+#[test]
+fn enter_errors_mode_sets_screen_and_focus() {
+    let mut state = AppState::default();
+    apply_in_place(&mut state, AppEvent::EnterErrorsMode);
+    assert_eq!(state.screen_mode, ScreenMode::DashboardErrors);
+    assert!(state.errors_state.active);
+    assert_eq!(state.errors_state.focus, ErrorsFocus::ErrorList);
+}
+
+/// `EnterErrorsMode` saves prior focus; `ExitErrorsMode` restores it.
+#[test]
+fn enter_exit_restores_focus() {
+    let mut state = AppState::default();
+    state.pane_focus = crate::state::PaneFocus::Repositories;
+    state.selected_repository_index = Some(0);
+
+    apply_in_place(&mut state, AppEvent::EnterErrorsMode);
+    assert!(state.errors_state.prior_agent_focus.is_some());
+
+    apply_in_place(&mut state, AppEvent::ExitErrorsMode);
+    assert_eq!(state.screen_mode, ScreenMode::Dashboard);
+    assert!(!state.errors_state.active);
+    // Prior focus restored.
+    assert_eq!(state.pane_focus, crate::state::PaneFocus::Repositories);
+}
+
+/// Navigation down/up moves the selected error index.
+#[test]
+fn navigate_down_up_moves_selection() {
+    let mut state = AppState::default();
+    for i in 0..5 {
+        state.errors_state.push(
+            format!("err {i}"),
+            format!("detail {i}"),
+            ErrorSource::Other,
+            "ts".to_string(),
+        );
+    }
+    // Errors are newest-first, so index 0 = "err 4", index 4 = "err 0".
+    apply_in_place(&mut state, AppEvent::EnterErrorsMode);
+
+    // Start at index 0 (newest).
+    assert_eq!(state.errors_state.selected_index, Some(0));
+
+    // Navigate down to index 1.
+    state.apply_errors_message(ErrorsMessage::Navigate(NavDir::Down));
+    assert_eq!(state.errors_state.selected_index, Some(1));
+
+    // Navigate down further to index 2.
+    state.apply_errors_message(ErrorsMessage::Navigate(NavDir::Down));
+    assert_eq!(state.errors_state.selected_index, Some(2));
+
+    // Navigate up back to index 1.
+    state.apply_errors_message(ErrorsMessage::Navigate(NavDir::Up));
+    assert_eq!(state.errors_state.selected_index, Some(1));
+}
+
+/// Navigation clamps at the last item.
+#[test]
+fn navigate_clamps_at_end() {
+    let mut state = AppState::default();
+    state
+        .errors_state
+        .push("a".into(), "da".into(), ErrorSource::Other, "ts".into());
+    state
+        .errors_state
+        .push("b".into(), "db".into(), ErrorSource::Other, "ts".into());
+    apply_in_place(&mut state, AppEvent::EnterErrorsMode);
+
+    state.apply_errors_message(ErrorsMessage::Navigate(NavDir::End));
+    assert_eq!(state.errors_state.selected_index, Some(1));
+
+    // Down past end stays at last.
+    state.apply_errors_message(ErrorsMessage::Navigate(NavDir::Down));
+    assert_eq!(state.errors_state.selected_index, Some(1));
+}
+
+/// Navigation home goes to index 0.
+#[test]
+fn navigate_home_goes_to_first() {
+    let mut state = AppState::default();
+    for i in 0..3 {
+        state.errors_state.push(
+            format!("e{i}"),
+            format!("d{i}"),
+            ErrorSource::Other,
+            "ts".into(),
+        );
+    }
+    apply_in_place(&mut state, AppEvent::EnterErrorsMode);
+    state.errors_state.selected_index = Some(2);
+
+    state.apply_errors_message(ErrorsMessage::Navigate(NavDir::Home));
+    assert_eq!(state.errors_state.selected_index, Some(0));
+}
+
+/// Cycle focus rotates RepoList → ErrorList → ErrorDetail → RepoList.
+#[test]
+fn cycle_focus_rotates() {
+    let mut state = AppState::default();
+    state
+        .errors_state
+        .push("e".into(), "d".into(), ErrorSource::Other, "ts".into());
+    apply_in_place(&mut state, AppEvent::EnterErrorsMode);
+    assert_eq!(state.errors_state.focus, ErrorsFocus::ErrorList);
+
+    state.apply_errors_message(ErrorsMessage::CycleFocus);
+    assert_eq!(state.errors_state.focus, ErrorsFocus::ErrorDetail);
+
+    state.apply_errors_message(ErrorsMessage::CycleFocus);
+    assert_eq!(state.errors_state.focus, ErrorsFocus::RepoList);
+
+    state.apply_errors_message(ErrorsMessage::CycleFocus);
+    assert_eq!(state.errors_state.focus, ErrorsFocus::ErrorList);
+}
+
+/// Enter on the error list moves focus to detail.
+#[test]
+fn enter_on_list_moves_to_detail() {
+    let mut state = AppState::default();
+    state
+        .errors_state
+        .push("e".into(), "d".into(), ErrorSource::Other, "ts".into());
+    apply_in_place(&mut state, AppEvent::EnterErrorsMode);
+
+    state.apply_errors_message(ErrorsMessage::Enter);
+    assert_eq!(state.errors_state.focus, ErrorsFocus::ErrorDetail);
+}
+
+/// ClearAll empties the error log and resets selection.
+#[test]
+fn clear_all_empties_errors() {
+    let mut state = AppState::default();
+    state
+        .errors_state
+        .push("e1".into(), "d1".into(), ErrorSource::Other, "ts".into());
+    state
+        .errors_state
+        .push("e2".into(), "d2".into(), ErrorSource::Other, "ts".into());
+
+    state.apply_errors_message(ErrorsMessage::ClearAll);
+    assert!(state.errors_state.is_empty());
+    assert!(state.errors_state.selected_index.is_none());
+}
+
+/// Capture dedup: same error text doesn't create duplicate entries.
+#[test]
+fn capture_global_dedup() {
+    let mut state = AppState::default();
+    let pushed1 = state
+        .errors_state
+        .capture_global("disk full", ErrorSource::Persistence, "ts1");
+    assert!(pushed1);
+    assert_eq!(state.errors_state.count(), 1);
+
+    // Same text → not captured again.
+    let pushed2 = state
+        .errors_state
+        .capture_global("disk full", ErrorSource::Persistence, "ts2");
+    assert!(!pushed2);
+    assert_eq!(state.errors_state.count(), 1);
+
+    // Different text → captured.
+    let pushed3 = state
+        .errors_state
+        .capture_global("network error", ErrorSource::Other, "ts3");
+    assert!(pushed3);
+    assert_eq!(state.errors_state.count(), 2);
+}
+
+/// `capture_global` resets the tracker when called with `reset_*_tracker`.
+#[test]
+fn reset_global_tracker_allows_recapture() {
+    let mut state = AppState::default();
+    state
+        .errors_state
+        .capture_global("err", ErrorSource::Other, "ts");
+    state.errors_state.reset_global_tracker();
+    // After reset, same text is captured again.
+    let pushed = state
+        .errors_state
+        .capture_global("err", ErrorSource::Other, "ts");
+    assert!(pushed);
+}
+
+/// Sequence numbers are monotonically increasing.
+#[test]
+fn seq_numbers_increase() {
+    let mut state = AppState::default();
+    state
+        .errors_state
+        .push("a".into(), "da".into(), ErrorSource::Other, "ts".into());
+    state
+        .errors_state
+        .push("b".into(), "db".into(), ErrorSource::Other, "ts".into());
+    let seqs: Vec<u64> = state.errors_state.errors.iter().map(|e| e.seq).collect();
+    assert_eq!(seqs, vec![2, 1]);
+}
+
+/// Scroll detail clamps at bounds.
+#[test]
+fn scroll_detail_clamps() {
+    let mut state = AppState::default();
+    let long_detail = (0..50)
+        .map(|i| format!("line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    state
+        .errors_state
+        .push("e".into(), long_detail, ErrorSource::Other, "ts".into());
+    apply_in_place(&mut state, AppEvent::EnterErrorsMode);
+    state.errors_state.detail_viewport_rows = 10;
+
+    // Scroll down should increase offset.
+    state.apply_errors_message(ErrorsMessage::ScrollDetail(ScrollDir::Down));
+    assert_eq!(state.errors_state.detail_scroll_offset, 1);
+
+    // Page down should jump by VIEWPORT_PAGE_JUMP.
+    state.apply_errors_message(ErrorsMessage::ScrollDetail(ScrollDir::PageDown));
+    assert!(state.errors_state.detail_scroll_offset > 1);
+
+    // Scroll up from 0 stays at 0.
+    state.errors_state.detail_scroll_offset = 0;
+    state.apply_errors_message(ErrorsMessage::ScrollDetail(ScrollDir::Up));
+    assert_eq!(state.errors_state.detail_scroll_offset, 0);
+}

--- a/src/state/errors_tests.rs
+++ b/src/state/errors_tests.rs
@@ -29,6 +29,7 @@ fn push_adds_to_head_and_selects() {
         "detail one".to_string(),
         ErrorSource::Issues,
         "2025-01-01T00:00:00Z".to_string(),
+        true,
     );
     assert_eq!(state.errors_state.count(), 1);
     assert_eq!(state.errors_state.selected_index, Some(0));
@@ -45,6 +46,7 @@ fn push_adds_to_head_and_selects() {
         "detail two".to_string(),
         ErrorSource::PullRequests,
         "2025-01-01T00:00:01Z".to_string(),
+        true,
     );
     assert_eq!(state.errors_state.count(), 2);
     assert_eq!(
@@ -66,6 +68,7 @@ fn push_evicts_oldest_at_capacity() {
             format!("detail {i}"),
             ErrorSource::Other,
             "ts".to_string(),
+            true,
         );
     }
     assert_eq!(
@@ -137,6 +140,7 @@ fn navigate_down_up_moves_selection() {
             format!("detail {i}"),
             ErrorSource::Other,
             "ts".to_string(),
+            true,
         );
     }
     // Errors are newest-first, so index 0 = "err 4", index 4 = "err 0".
@@ -162,12 +166,20 @@ fn navigate_down_up_moves_selection() {
 #[test]
 fn navigate_clamps_at_end() {
     let mut state = AppState::default();
-    state
-        .errors_state
-        .push("a".into(), "da".into(), ErrorSource::Other, "ts".into());
-    state
-        .errors_state
-        .push("b".into(), "db".into(), ErrorSource::Other, "ts".into());
+    state.errors_state.push(
+        "a".into(),
+        "da".into(),
+        ErrorSource::Other,
+        "ts".into(),
+        true,
+    );
+    state.errors_state.push(
+        "b".into(),
+        "db".into(),
+        ErrorSource::Other,
+        "ts".into(),
+        true,
+    );
     apply_in_place(&mut state, AppEvent::EnterErrorsMode);
 
     state.apply_errors_message(ErrorsMessage::Navigate(NavDir::End));
@@ -188,6 +200,7 @@ fn navigate_home_goes_to_first() {
             format!("d{i}"),
             ErrorSource::Other,
             "ts".into(),
+            true,
         );
     }
     apply_in_place(&mut state, AppEvent::EnterErrorsMode);
@@ -201,9 +214,13 @@ fn navigate_home_goes_to_first() {
 #[test]
 fn cycle_focus_rotates() {
     let mut state = AppState::default();
-    state
-        .errors_state
-        .push("e".into(), "d".into(), ErrorSource::Other, "ts".into());
+    state.errors_state.push(
+        "e".into(),
+        "d".into(),
+        ErrorSource::Other,
+        "ts".into(),
+        true,
+    );
     apply_in_place(&mut state, AppEvent::EnterErrorsMode);
     assert_eq!(state.errors_state.focus, ErrorsFocus::ErrorList);
 
@@ -221,9 +238,13 @@ fn cycle_focus_rotates() {
 #[test]
 fn enter_on_list_moves_to_detail() {
     let mut state = AppState::default();
-    state
-        .errors_state
-        .push("e".into(), "d".into(), ErrorSource::Other, "ts".into());
+    state.errors_state.push(
+        "e".into(),
+        "d".into(),
+        ErrorSource::Other,
+        "ts".into(),
+        true,
+    );
     apply_in_place(&mut state, AppEvent::EnterErrorsMode);
 
     state.apply_errors_message(ErrorsMessage::Enter);
@@ -234,12 +255,20 @@ fn enter_on_list_moves_to_detail() {
 #[test]
 fn clear_all_empties_errors() {
     let mut state = AppState::default();
-    state
-        .errors_state
-        .push("e1".into(), "d1".into(), ErrorSource::Other, "ts".into());
-    state
-        .errors_state
-        .push("e2".into(), "d2".into(), ErrorSource::Other, "ts".into());
+    state.errors_state.push(
+        "e1".into(),
+        "d1".into(),
+        ErrorSource::Other,
+        "ts".into(),
+        true,
+    );
+    state.errors_state.push(
+        "e2".into(),
+        "d2".into(),
+        ErrorSource::Other,
+        "ts".into(),
+        true,
+    );
 
     state.apply_errors_message(ErrorsMessage::ClearAll);
     assert!(state.errors_state.is_empty());
@@ -290,12 +319,20 @@ fn reset_global_tracker_allows_recapture() {
 #[test]
 fn seq_numbers_increase() {
     let mut state = AppState::default();
-    state
-        .errors_state
-        .push("a".into(), "da".into(), ErrorSource::Other, "ts".into());
-    state
-        .errors_state
-        .push("b".into(), "db".into(), ErrorSource::Other, "ts".into());
+    state.errors_state.push(
+        "a".into(),
+        "da".into(),
+        ErrorSource::Other,
+        "ts".into(),
+        true,
+    );
+    state.errors_state.push(
+        "b".into(),
+        "db".into(),
+        ErrorSource::Other,
+        "ts".into(),
+        true,
+    );
     let seqs: Vec<u64> = state.errors_state.errors.iter().map(|e| e.seq).collect();
     assert_eq!(seqs, vec![2, 1]);
 }
@@ -308,9 +345,13 @@ fn scroll_detail_clamps() {
         .map(|i| format!("line {i}"))
         .collect::<Vec<_>>()
         .join("\n");
-    state
-        .errors_state
-        .push("e".into(), long_detail, ErrorSource::Other, "ts".into());
+    state.errors_state.push(
+        "e".into(),
+        long_detail,
+        ErrorSource::Other,
+        "ts".into(),
+        true,
+    );
     apply_in_place(&mut state, AppEvent::EnterErrorsMode);
     state.errors_state.detail_viewport_rows = 10;
 
@@ -329,4 +370,87 @@ fn scroll_detail_clamps() {
     state.errors_state.detail_scroll_offset = 0;
     state.apply_errors_message(ErrorsMessage::ScrollDetail(ScrollDir::Up));
     assert_eq!(state.errors_state.detail_scroll_offset, 0);
+}
+
+/// While the user is actively browsing errors mode, a background error push
+/// preserves the selection and scroll position (CodeRabbit review finding).
+#[test]
+fn push_preserves_selection_when_active() {
+    let mut state = AppState::default();
+    state.errors_state.push(
+        "first".into(),
+        "d1".into(),
+        ErrorSource::Other,
+        "ts".into(),
+        true,
+    );
+    state.errors_state.push(
+        "second".into(),
+        "d2".into(),
+        ErrorSource::Other,
+        "ts".into(),
+        true,
+    );
+    apply_in_place(&mut state, AppEvent::EnterErrorsMode);
+    // Navigate to the second entry (index 1).
+    state.apply_errors_message(ErrorsMessage::Navigate(NavDir::Down));
+    assert_eq!(state.errors_state.selected_index, Some(1));
+    state.errors_state.detail_scroll_offset = 3;
+
+    // A background push with snap_to_newest=false must not clobber selection.
+    state.errors_state.push(
+        "third".into(),
+        "d3".into(),
+        ErrorSource::Other,
+        "ts".into(),
+        false,
+    );
+    assert_eq!(
+        state.errors_state.selected_index,
+        Some(1),
+        "selection should be preserved when not snapping"
+    );
+    assert_eq!(
+        state.errors_state.detail_scroll_offset, 3,
+        "scroll offset should be preserved when not snapping"
+    );
+
+    // But with snap_to_newest=true, selection resets to newest (index 0).
+    state.errors_state.push(
+        "fourth".into(),
+        "d4".into(),
+        ErrorSource::Other,
+        "ts".into(),
+        true,
+    );
+    assert_eq!(state.errors_state.selected_index, Some(0));
+    assert_eq!(state.errors_state.detail_scroll_offset, 0);
+}
+
+/// Navigation when focused on RepoList does not leak to the error list
+/// (CodeRabbit review finding).
+#[test]
+fn nav_while_repo_focused_does_not_move_error_selection() {
+    let mut state = AppState::default();
+    for i in 0..3 {
+        state.errors_state.push(
+            format!("e{i}"),
+            format!("d{i}"),
+            ErrorSource::Other,
+            "ts".into(),
+            true,
+        );
+    }
+    apply_in_place(&mut state, AppEvent::EnterErrorsMode);
+    // Cycle to repo list focus.
+    state.apply_errors_message(ErrorsMessage::CycleFocus); // ErrorDetail
+    state.apply_errors_message(ErrorsMessage::CycleFocus); // RepoList
+    assert_eq!(state.errors_state.focus, ErrorsFocus::RepoList);
+
+    let before = state.errors_state.selected_index;
+    // Home/End should NOT change error-list selection.
+    state.apply_errors_message(ErrorsMessage::Navigate(NavDir::Home));
+    assert_eq!(state.errors_state.selected_index, before);
+    state.apply_errors_message(ErrorsMessage::Navigate(NavDir::End));
+    assert_eq!(state.errors_state.selected_index, before);
 }

--- a/src/state/errors_tests.rs
+++ b/src/state/errors_tests.rs
@@ -81,6 +81,23 @@ fn push_evicts_oldest_at_capacity() {
         last_title,
         format!("error {}", crate::domain::ERROR_STORE_CAPACITY + 4)
     );
+    // The oldest 5 errors should have been evicted.
+    let titles: Vec<&str> = state
+        .errors_state
+        .errors
+        .iter()
+        .map(|e| e.title.as_str())
+        .collect();
+    for i in 0..5 {
+        let evicted = format!("error {i}");
+        assert!(
+            !titles.contains(&evicted.as_str()),
+            "evicted error {i} should not be present"
+        );
+    }
+    // The oldest remaining error should be error 5.
+    let oldest = titles.last().unwrap_or(&"");
+    assert_eq!(*oldest, "error 5");
 }
 
 /// `EnterErrorsMode` switches screen mode, activates state, and focuses list.
@@ -180,7 +197,7 @@ fn navigate_home_goes_to_first() {
     assert_eq!(state.errors_state.selected_index, Some(0));
 }
 
-/// Cycle focus rotates RepoList → ErrorList → ErrorDetail → RepoList.
+/// Cycle focus rotates ErrorList -> ErrorDetail -> RepoList -> ErrorList.
 #[test]
 fn cycle_focus_rotates() {
     let mut state = AppState::default();
@@ -301,9 +318,12 @@ fn scroll_detail_clamps() {
     state.apply_errors_message(ErrorsMessage::ScrollDetail(ScrollDir::Down));
     assert_eq!(state.errors_state.detail_scroll_offset, 1);
 
-    // Page down should jump by VIEWPORT_PAGE_JUMP.
+    // Page down should jump by VIEWPORT_PAGE_JUMP from current offset (1).
     state.apply_errors_message(ErrorsMessage::ScrollDetail(ScrollDir::PageDown));
-    assert!(state.errors_state.detail_scroll_offset > 1);
+    assert_eq!(
+        state.errors_state.detail_scroll_offset,
+        1 + crate::state::VIEWPORT_PAGE_JUMP
+    );
 
     // Scroll up from 0 stays at 0.
     state.errors_state.detail_scroll_offset = 0;

--- a/src/state/errors_types.rs
+++ b/src/state/errors_types.rs
@@ -1,0 +1,194 @@
+//! Errors-mode aggregate state types (issue #292).
+//!
+//! The error log is a bounded ring buffer of the last N errors captured from
+//! runtime failures, GitHub operations, and validation paths. It is purely
+//! local (no remote fetching), so all data is eager-loaded.
+
+use crate::domain::{ERROR_STORE_CAPACITY, ErrorEntry, ErrorSource};
+
+/// Focus domain within Errors Mode — mirrors Issues/PRs/Actions mode.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ErrorsFocus {
+    RepoList,
+    #[default]
+    ErrorList,
+    ErrorDetail,
+}
+
+/// Aggregate state for Errors Mode.
+#[derive(Debug, Clone)]
+pub struct ErrorsState {
+    pub active: bool,
+    /// Ring buffer of captured errors, newest first.
+    pub errors: Vec<ErrorEntry>,
+    /// Next sequence number to assign.
+    pub next_seq: u64,
+    /// Currently selected error index in the list (for detail display).
+    pub selected_index: Option<usize>,
+    /// Scroll offset for the detail pane viewport.
+    pub detail_scroll_offset: usize,
+    /// Last rendered detail viewport height in rows.
+    pub detail_viewport_rows: usize,
+    pub focus: ErrorsFocus,
+    /// Saved agent-mode focus for restoration on exit (mirrors issues/prs/actions).
+    pub prior_agent_focus: Option<super::PriorAgentFocus>,
+    // ── Error-capture dedup tracking (runtime-only) ────────────────────────
+    //
+    // `finalize_message` runs after every reducer step and inspects the various
+    // error slots. These fields remember the last text seen in each slot so we
+    // only push a new entry when the text actually changes (not on every
+    // subsequent message that leaves the same error visible).
+    last_captured_global: Option<String>,
+    last_captured_issues: Option<String>,
+    last_captured_prs: Option<String>,
+    last_captured_actions: Option<String>,
+}
+
+impl ErrorsState {
+    /// Reset the global-error dedup tracker (called when `error_message` is None).
+    pub(super) fn reset_global_tracker(&mut self) {
+        self.last_captured_global = None;
+    }
+
+    /// Reset the issues-error dedup tracker.
+    pub(super) fn reset_issues_tracker(&mut self) {
+        self.last_captured_issues = None;
+    }
+
+    /// Reset the PRs-error dedup tracker.
+    pub(super) fn reset_prs_tracker(&mut self) {
+        self.last_captured_prs = None;
+    }
+
+    /// Reset the Actions-error dedup tracker.
+    pub(super) fn reset_actions_tracker(&mut self) {
+        self.last_captured_actions = None;
+    }
+}
+
+impl Default for ErrorsState {
+    fn default() -> Self {
+        Self {
+            active: false,
+            errors: Vec::new(),
+            next_seq: 1,
+            selected_index: None,
+            detail_scroll_offset: 0,
+            detail_viewport_rows: 0,
+            focus: ErrorsFocus::ErrorList,
+            prior_agent_focus: None,
+            last_captured_global: None,
+            last_captured_issues: None,
+            last_captured_prs: None,
+            last_captured_actions: None,
+        }
+    }
+}
+
+impl ErrorsState {
+    /// Push a new error entry, evicting the oldest when at capacity.
+    /// Returns the entry that was stored (with its assigned seq).
+    pub fn push(&mut self, title: String, detail: String, source: ErrorSource, timestamp: String) {
+        let entry = ErrorEntry {
+            seq: self.next_seq,
+            title,
+            detail,
+            source,
+            timestamp,
+        };
+        self.next_seq = self.next_seq.saturating_add(1);
+        self.errors.insert(0, entry);
+        if self.errors.len() > ERROR_STORE_CAPACITY {
+            self.errors.truncate(ERROR_STORE_CAPACITY);
+        }
+        // Reset selection to the newest error.
+        self.selected_index = Some(0);
+        self.detail_scroll_offset = 0;
+    }
+
+    /// The most recent error, if any.
+    #[must_use]
+    pub fn last_error(&self) -> Option<&ErrorEntry> {
+        self.errors.first()
+    }
+
+    /// Whether the error log is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    /// The currently selected error, if any.
+    #[must_use]
+    pub fn selected_error(&self) -> Option<&ErrorEntry> {
+        self.selected_index.and_then(|idx| self.errors.get(idx))
+    }
+
+    /// Number of stored errors.
+    #[must_use]
+    pub fn count(&self) -> usize {
+        self.errors.len()
+    }
+
+    /// Capture a global `error_message` change. Returns `true` if a new entry
+    /// was pushed (caller may clear `error_message` to avoid duplicate UI
+    /// rendering).
+    pub fn capture_global(&mut self, msg: &str, source: ErrorSource, timestamp: &str) -> bool {
+        if self.last_captured_global.as_deref() == Some(msg) {
+            return false;
+        }
+        self.last_captured_global = Some(msg.to_string());
+        self.push(
+            msg.to_string(),
+            msg.to_string(),
+            source,
+            timestamp.to_string(),
+        );
+        true
+    }
+
+    /// Capture a per-mode issues error change.
+    pub fn capture_issues(&mut self, msg: &str, timestamp: &str) -> bool {
+        if self.last_captured_issues.as_deref() == Some(msg) {
+            return false;
+        }
+        self.last_captured_issues = Some(msg.to_string());
+        self.push(
+            msg.to_string(),
+            msg.to_string(),
+            ErrorSource::Issues,
+            timestamp.to_string(),
+        );
+        true
+    }
+
+    /// Capture a per-mode PRs error change.
+    pub fn capture_prs(&mut self, msg: &str, timestamp: &str) -> bool {
+        if self.last_captured_prs.as_deref() == Some(msg) {
+            return false;
+        }
+        self.last_captured_prs = Some(msg.to_string());
+        self.push(
+            msg.to_string(),
+            msg.to_string(),
+            ErrorSource::PullRequests,
+            timestamp.to_string(),
+        );
+        true
+    }
+
+    /// Capture a per-mode Actions error change.
+    pub fn capture_actions(&mut self, msg: &str, timestamp: &str) -> bool {
+        if self.last_captured_actions.as_deref() == Some(msg) {
+            return false;
+        }
+        self.last_captured_actions = Some(msg.to_string());
+        self.push(
+            msg.to_string(),
+            msg.to_string(),
+            ErrorSource::Actions,
+            timestamp.to_string(),
+        );
+        true
+    }
+}

--- a/src/state/errors_types.rs
+++ b/src/state/errors_types.rs
@@ -64,6 +64,26 @@ impl ErrorsState {
     pub(super) fn reset_actions_tracker(&mut self) {
         self.last_captured_actions = None;
     }
+
+    /// Read-only snapshot of the global dedup tracker for fast-change checks.
+    pub(super) fn last_captured_global_snapshot(&self) -> Option<&str> {
+        self.last_captured_global.as_deref()
+    }
+
+    /// Read-only snapshot of the issues dedup tracker.
+    pub(super) fn last_captured_issues_snapshot(&self) -> Option<&str> {
+        self.last_captured_issues.as_deref()
+    }
+
+    /// Read-only snapshot of the PRs dedup tracker.
+    pub(super) fn last_captured_prs_snapshot(&self) -> Option<&str> {
+        self.last_captured_prs.as_deref()
+    }
+
+    /// Read-only snapshot of the actions dedup tracker.
+    pub(super) fn last_captured_actions_snapshot(&self) -> Option<&str> {
+        self.last_captured_actions.as_deref()
+    }
 }
 
 impl Default for ErrorsState {

--- a/src/state/errors_types.rs
+++ b/src/state/errors_types.rs
@@ -107,8 +107,20 @@ impl Default for ErrorsState {
 
 impl ErrorsState {
     /// Push a new error entry, evicting the oldest when at capacity.
-    /// Returns the entry that was stored (with its assigned seq).
-    pub fn push(&mut self, title: String, detail: String, source: ErrorSource, timestamp: String) {
+    ///
+    /// When `snap_to_newest` is true (the errors mode is not active), the
+    /// selection/scroll is reset to the newest entry so the status bar's
+    /// last-error indicator shows the just-pushed error. When the user is
+    /// actively browsing (`snap_to_newest` = false), the existing selection
+    /// and scroll position are preserved.
+    pub fn push(
+        &mut self,
+        title: String,
+        detail: String,
+        source: ErrorSource,
+        timestamp: String,
+        snap_to_newest: bool,
+    ) {
         let entry = ErrorEntry {
             seq: self.next_seq,
             title,
@@ -121,9 +133,10 @@ impl ErrorsState {
         if self.errors.len() > ERROR_STORE_CAPACITY {
             self.errors.truncate(ERROR_STORE_CAPACITY);
         }
-        // Reset selection to the newest error.
-        self.selected_index = Some(0);
-        self.detail_scroll_offset = 0;
+        if snap_to_newest {
+            self.selected_index = Some(0);
+            self.detail_scroll_offset = 0;
+        }
     }
 
     /// The most recent error, if any.
@@ -163,6 +176,7 @@ impl ErrorsState {
             msg.to_string(),
             source,
             timestamp.to_string(),
+            !self.active,
         );
         true
     }
@@ -178,6 +192,7 @@ impl ErrorsState {
             msg.to_string(),
             ErrorSource::Issues,
             timestamp.to_string(),
+            !self.active,
         );
         true
     }
@@ -193,6 +208,7 @@ impl ErrorsState {
             msg.to_string(),
             ErrorSource::PullRequests,
             timestamp.to_string(),
+            !self.active,
         );
         true
     }
@@ -208,6 +224,7 @@ impl ErrorsState {
             msg.to_string(),
             ErrorSource::Actions,
             timestamp.to_string(),
+            !self.active,
         );
         true
     }

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -857,5 +857,7 @@ pub enum AppEvent {
     ErrorsCycleFocusReverse,
     ErrorsScrollDetailUp,
     ErrorsScrollDetailDown,
+    ErrorsScrollDetailPageUp,
+    ErrorsScrollDetailPageDown,
     ErrorsClearAll,
 }

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -843,4 +843,19 @@ pub enum AppEvent {
         kind: super::PrPropertyKind,
         error: String,
     },
+
+    // Errors Mode events (issue #292)
+    EnterErrorsMode,
+    ExitErrorsMode,
+    RefocusErrorList,
+    ErrorsNavigateUp,
+    ErrorsNavigateDown,
+    ErrorsNavigateHome,
+    ErrorsNavigateEnd,
+    ErrorsEnter,
+    ErrorsCycleFocus,
+    ErrorsCycleFocusReverse,
+    ErrorsScrollDetailUp,
+    ErrorsScrollDetailDown,
+    ErrorsClearAll,
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -17,6 +17,8 @@ mod auth_ops;
 #[cfg(test)]
 mod comment_pagination_tests;
 mod dashboard_grab_ops;
+mod errors_ops;
+mod errors_types;
 mod events;
 mod form_build;
 mod form_cursor;
@@ -60,16 +62,15 @@ pub mod transient_ops;
 mod types;
 mod util;
 
+pub use errors_types::{ErrorsFocus, ErrorsState};
 pub use events::*;
 pub use issues_close_reason_ops::filter_duplicate_candidates;
 pub use property_edit::PROPERTY_CLEAR_LABEL;
 pub use scrollback_ops::{FollowIndicator, terminal_follow_indicator};
 pub use state_ops::{delete_selected_agent, delete_selected_repository};
 pub use types::*;
-
 /// Default row jump for list and detail page navigation without a measured viewport.
 pub(super) const VIEWPORT_PAGE_JUMP: usize = 10;
-
 pub use form_projection::{
     AgentFormFieldVisibility, agent_form_visibility, effective_agent_kinds, effective_kinds_hint,
     is_field_visible, is_repository_field_visible, kind_from_form_value, next_visible_focus,
@@ -335,6 +336,10 @@ impl AppState {
                 let handled = self.apply_actions_message(message);
                 debug_assert!(handled, "unhandled actions message in apply_message()");
             }
+            AppMessage::Errors(message) => {
+                let handled = self.apply_errors_message(message);
+                debug_assert!(handled, "unhandled errors message in apply_message()");
+            }
         }
 
         self.finalize_message(route);
@@ -376,6 +381,7 @@ impl AppState {
         self.rebuild_repository_agent_ids();
         self.normalize_selection_indices();
         self.validate_dashboard_grab();
+        errors_ops::capture_runtime_errors(self);
         self.last_selected_agent_by_repo
             .retain(|(repo_id, agent_id)| {
                 self.repositories.iter().any(|repo| repo.id == *repo_id)
@@ -881,11 +887,9 @@ impl AppState {
     }
 }
 
-// In-app device-code auth dialog state-machine tests (issue #244).
 #[cfg(test)]
 #[path = "auth_ops_tests.rs"]
 mod auth_ops_tests;
-
 #[cfg(test)]
 #[path = "confirm_focus_tests.rs"]
 mod confirm_focus_tests;
@@ -916,6 +920,9 @@ mod issues_tests_mutations;
 #[path = "issues_tests_repo_nav.rs"]
 mod issues_tests_repo_nav;
 #[cfg(test)]
+#[path = "issues_tests_self_assignment.rs"]
+mod issues_tests_self_assignment;
+#[cfg(test)]
 #[path = "issues_tests_send_to_agent.rs"]
 mod issues_tests_send_to_agent;
 #[cfg(test)]
@@ -923,39 +930,29 @@ mod issues_tests_send_to_agent;
 mod issues_tests_subfocus;
 
 #[cfg(test)]
-#[path = "issues_tests_self_assignment.rs"]
-mod issues_tests_self_assignment;
-
-#[cfg(test)]
-#[path = "issues_tests_close_delete.rs"]
-mod issues_tests_close_delete;
-
-#[cfg(test)]
-#[path = "issues_tests_close_reason.rs"]
-mod issues_tests_close_reason;
-
-#[cfg(test)]
-#[path = "prs_tests.rs"]
-mod prs_tests;
-#[cfg(test)]
-#[path = "prs_tests_detail.rs"]
-mod prs_tests_detail;
-#[cfg(test)]
-#[path = "prs_tests_filter.rs"]
-mod prs_tests_filter;
-#[cfg(test)]
-#[path = "prs_tests_merge.rs"]
-mod prs_tests_merge;
-
+#[path = "errors_tests.rs"]
+mod errors_tests;
 #[cfg(test)]
 #[path = "issues_test_fixtures.rs"]
 mod issues_test_fixtures;
 #[cfg(test)]
+#[path = "issues_tests_close_delete.rs"]
+mod issues_tests_close_delete;
+#[cfg(test)]
+#[path = "issues_tests_close_reason.rs"]
+mod issues_tests_close_reason;
+#[cfg(test)]
 #[path = "preferences_tests.rs"]
 mod preferences_tests;
 #[cfg(test)]
+#[path = "prs_integration_tests.rs"]
+mod prs_integration_tests;
+#[cfg(test)]
 #[path = "prs_test_fixtures.rs"]
 mod prs_test_fixtures;
+#[cfg(test)]
+#[path = "prs_tests.rs"]
+mod prs_tests;
 #[cfg(test)]
 #[path = "prs_tests_bodyless_review_nav.rs"]
 mod prs_tests_bodyless_review_nav;
@@ -968,13 +965,24 @@ mod prs_tests_components;
 #[cfg(test)]
 #[path = "prs_tests_composer_focus.rs"]
 mod prs_tests_composer_focus;
-/// @plan PLAN-20260624-PR-MODE.P14 @requirement REQ-PR-010
 #[cfg(test)]
 #[path = "prs_tests_cursor_arrows.rs"]
 mod prs_tests_cursor_arrows;
 #[cfg(test)]
+#[path = "prs_tests_detail.rs"]
+mod prs_tests_detail;
+#[cfg(test)]
 #[path = "prs_tests_detail_flow.rs"]
 mod prs_tests_detail_flow;
+#[cfg(test)]
+#[path = "prs_tests_filter.rs"]
+mod prs_tests_filter;
+#[cfg(test)]
+#[path = "prs_tests_merge.rs"]
+mod prs_tests_merge;
+#[cfg(test)]
+#[path = "prs_tests_pagination.rs"]
+mod prs_tests_pagination;
 #[cfg(test)]
 #[path = "prs_tests_repo_nav.rs"]
 mod prs_tests_repo_nav;
@@ -984,13 +992,6 @@ mod prs_tests_review_threads;
 #[cfg(test)]
 #[path = "prs_tests_silent_refresh.rs"]
 mod prs_tests_silent_refresh;
-// @plan PLAN-20260624-PR-MODE.P15 @requirement REQ-PR-001
-#[cfg(test)]
-#[path = "prs_integration_tests.rs"]
-mod prs_integration_tests;
-#[cfg(test)]
-#[path = "prs_tests_pagination.rs"]
-mod prs_tests_pagination;
 #[cfg(test)]
 #[path = "transient_agent_tests.rs"]
 mod transient_agent_tests;

--- a/src/state/selectors.rs
+++ b/src/state/selectors.rs
@@ -208,6 +208,15 @@ impl AppState {
             .filter(|a| a.is_transient() && a.repository_id == *repo_id && a.is_running())
             .count()
     }
+
+    /// Last error title for status-bar display (issue #292).
+    ///
+    /// Centralizes the `last_error().map(|e| e.title.clone())` lookup so all
+    /// screen files share one source of truth.
+    #[must_use]
+    pub fn last_error_title(&self) -> Option<String> {
+        self.errors_state.last_error().map(|e| e.title.clone())
+    }
 }
 
 /// Build typed chooser entries by joining state-computed eligible agents with

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -276,6 +276,7 @@ pub enum ScreenMode {
     /// @pseudocode component-001 lines 66-76
     DashboardPullRequests,
     DashboardActions,
+    DashboardErrors,
 }
 
 /// Pane focus within a view.
@@ -377,6 +378,10 @@ pub struct AppState {
 
     /// GitHub Actions mode state (runtime-only — omitted from persisted DTO).
     pub actions_state: ActionsState,
+
+    /// Errors-mode state (runtime-only — omitted from persisted DTO).
+    /// Captures the last N errors for the dedicated errors panel (issue #292).
+    pub errors_state: super::ErrorsState,
 
     /// Rapid `qqq` quit-sequence bookkeeping. Runtime-only — never persisted.
     pub quit_sequence: QuitSequenceState,

--- a/src/ui/components/keybind_bar.rs
+++ b/src/ui/components/keybind_bar.rs
@@ -61,7 +61,7 @@ pub fn keybind_hints_for(
             }
         },
         ScreenMode::DashboardErrors => {
-            "^/v errors | Enter detail | Tab pane | PgUp/PgDn scroll | C clear all | Esc exit"
+            "^/v errors | Enter detail | Tab pane | PgUp/PgDn scroll | Ctrl-C clear | Esc exit"
         }
     }
 }

--- a/src/ui/components/keybind_bar.rs
+++ b/src/ui/components/keybind_bar.rs
@@ -60,6 +60,9 @@ pub fn keybind_hints_for(
                 "^/v jobs | Enter/Right expand | Left collapse | Esc collapse/back | PgUp/PgDn scroll | Tab pane | ? help"
             }
         },
+        ScreenMode::DashboardErrors => {
+            "^/v errors | Enter detail | Tab pane | PgUp/PgDn scroll | C clear all | Esc exit"
+        }
     }
 }
 

--- a/src/ui/components/status_bar.rs
+++ b/src/ui/components/status_bar.rs
@@ -58,9 +58,11 @@ pub fn StatusBar(props: &StatusBarProps) -> impl Into<AnyElement<'static>> {
         format!("WARN: {warning}")
     } else if let Some(error) = &props.last_error {
         // Truncate to keep the single-line bar readable (issue #292).
-        let max_len = 50;
-        let display = if error.len() > max_len {
-            format!("{}…", &error[..max_len])
+        // Use char-based truncation to avoid splitting multi-byte UTF-8.
+        let max_chars = 50;
+        let display = if error.chars().count() > max_chars {
+            let truncated: String = error.chars().take(max_chars).collect();
+            format!("{truncated}…")
         } else {
             error.clone()
         };

--- a/src/ui/components/status_bar.rs
+++ b/src/ui/components/status_bar.rs
@@ -25,6 +25,9 @@ pub struct StatusBarProps {
     pub kennel_mode: bool,
     /// Optional warning text shown in the center status area.
     pub warning_message: Option<String>,
+    /// Last error title (issue #292). Shown in the center area with precedence
+    /// below warnings (ssh agent socket) so legacy warnings still surface.
+    pub last_error: Option<String>,
     /// Theme colors.
     pub colors: ThemeColors,
     /// Active text selection, if any. When it targets this pane the whole
@@ -51,15 +54,23 @@ pub fn StatusBar(props: &StatusBarProps) -> impl Into<AnyElement<'static>> {
     } else {
         ""
     };
-    let stats = props.warning_message.as_ref().map_or_else(
-        || {
-            format!(
-                "{} repos | {}/{} running",
-                props.repo_count, props.running_count, props.agent_count
-            )
-        },
-        |warning| format!("WARN: {warning}"),
-    );
+    let stats = if let Some(warning) = &props.warning_message {
+        format!("WARN: {warning}")
+    } else if let Some(error) = &props.last_error {
+        // Truncate to keep the single-line bar readable (issue #292).
+        let max_len = 50;
+        let display = if error.len() > max_len {
+            format!("{}…", &error[..max_len])
+        } else {
+            error.clone()
+        };
+        format!("ERR: {display}")
+    } else {
+        format!(
+            "{} repos | {}/{} running",
+            props.repo_count, props.running_count, props.agent_count
+        )
+    };
 
     element! {
         Box(

--- a/src/ui/orchestration.rs
+++ b/src/ui/orchestration.rs
@@ -7,7 +7,9 @@ use iocraft::prelude::*;
 
 use crate::state::{AppState, ConfirmFocus, ModalState, ScreenMode};
 use crate::theme::ThemeColors;
-use crate::ui::screens::{ActionsScreen, IssuesScreen, PullRequestsScreen, ThemePickerScreen};
+use crate::ui::screens::{
+    ActionsScreen, ErrorsScreen, IssuesScreen, PullRequestsScreen, ThemePickerScreen,
+};
 use crate::ui::{
     AuthModal, ConfirmModal, Dashboard, HelpModal, NewAgentForm, NewRepositoryForm, SplitScreen,
     WorkflowDispatchForm,
@@ -239,6 +241,14 @@ pub fn build_screen_element(
         .into_any(),
         ScreenMode::DashboardActions => element! {
             ActionsScreen(
+                state: Some(snapshot.clone()),
+                colors: Some(colors.clone()),
+                theme_name: theme_name.to_owned(),
+            )
+        }
+        .into_any(),
+        ScreenMode::DashboardErrors => element! {
+            ErrorsScreen(
                 state: Some(snapshot.clone()),
                 colors: Some(colors.clone()),
                 theme_name: theme_name.to_owned(),

--- a/src/ui/screens/actions.rs
+++ b/src/ui/screens/actions.rs
@@ -134,6 +134,9 @@ pub fn ActionsScreen(props: &ActionsScreenProps) -> impl Into<AnyElement<'static
                 theme_name: props.theme_name.clone(),
                 version: crate::VERSION.to_owned(),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
+                last_error: state.and_then(|s| {
+                    s.errors_state.last_error().map(|e| e.title.clone())
+                }),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/actions.rs
+++ b/src/ui/screens/actions.rs
@@ -134,9 +134,7 @@ pub fn ActionsScreen(props: &ActionsScreenProps) -> impl Into<AnyElement<'static
                 theme_name: props.theme_name.clone(),
                 version: crate::VERSION.to_owned(),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
-                last_error: state.and_then(|s| {
-                    s.errors_state.last_error().map(|e| e.title.clone())
-                }),
+                last_error: state.and_then(AppState::last_error_title),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -158,9 +158,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                 version: crate::VERSION.to_owned(),
                 kennel_mode: state.is_some_and(crate::state::AppState::is_kennel_mode),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
-                last_error: state.and_then(|s| {
-                    s.errors_state.last_error().map(|e| e.title.clone())
-                }),
+                last_error: state.and_then(AppState::last_error_title),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -158,6 +158,9 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                 version: crate::VERSION.to_owned(),
                 kennel_mode: state.is_some_and(crate::state::AppState::is_kennel_mode),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
+                last_error: state.and_then(|s| {
+                    s.errors_state.last_error().map(|e| e.title.clone())
+                }),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/errors.rs
+++ b/src/ui/screens/errors.rs
@@ -94,15 +94,17 @@ pub fn ErrorsScreen(props: &ErrorsScreenProps) -> impl Into<AnyElement<'static>>
         .iter()
         .enumerate()
         .map(|(idx, entry)| {
-            let title = if entry.title.len() > list_content_width as usize - 10 {
-                // Truncate to fit: "[seq] title..."
-                format!(
-                    "[{}] {}…",
-                    entry.seq,
-                    &entry.title[..list_content_width as usize - 13]
-                )
+            let prefix = format!("[{}] ", entry.seq);
+            let remaining = (list_content_width as usize).saturating_sub(prefix.chars().count());
+            let title = if entry.title.chars().count() > remaining {
+                let truncated: String = entry
+                    .title
+                    .chars()
+                    .take(remaining.saturating_sub(1))
+                    .collect();
+                format!("{prefix}{truncated}…")
             } else {
-                format!("[{}] {}", entry.seq, entry.title)
+                format!("{prefix}{}", entry.title)
             };
             let source_label = match entry.source {
                 crate::domain::ErrorSource::Issues => "Issues",
@@ -156,13 +158,14 @@ pub fn ErrorsScreen(props: &ErrorsScreenProps) -> impl Into<AnyElement<'static>>
         (vec![], String::new())
     };
 
+    let header_line_offset = header_rows.len();
     let detail_props = DetailPaneProps {
         header_rows,
         content: detail_content,
         content_cursor: None,
         scroll_offset: detail_scroll_offset,
         viewport_rows: detail_viewport_rows,
-        content_line_offset: 3, // header rows
+        content_line_offset: header_line_offset,
         max_line_width: detail_content_width,
         focused: detail_focused,
         pane: SelectablePane::ErrorDetail,

--- a/src/ui/screens/errors.rs
+++ b/src/ui/screens/errors.rs
@@ -190,9 +190,7 @@ pub fn ErrorsScreen(props: &ErrorsScreenProps) -> impl Into<AnyElement<'static>>
                 theme_name: props.theme_name.clone(),
                 version: crate::VERSION.to_owned(),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
-                last_error: state.and_then(|s| {
-                    s.errors_state.last_error().map(|e| e.title.clone())
-                }),
+                last_error: state.and_then(AppState::last_error_title),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/errors.rs
+++ b/src/ui/screens/errors.rs
@@ -1,0 +1,257 @@
+//! Errors mode screen — two-column layout: repos sidebar + errors workspace.
+//!
+//! Mirrors the Actions/PRs/Issues screen patterns: a fixed sidebar + a list
+//! pane (top split) + a detail pane (bottom split). The error log is purely
+//! local (no remote fetching), so all data is eager-loaded from
+//! [`crate::state::ErrorsState`].
+
+use iocraft::prelude::*;
+
+use crate::selection::SelectablePane;
+use crate::state::{AppState, ErrorsFocus, ScreenMode};
+use crate::theme::{ResolvedColors, ThemeColors};
+
+use super::super::components::detail_pane::{DetailHeaderColor, DetailHeaderRow, DetailPaneProps};
+use super::super::components::selectable_list::{
+    ListBorder, SelectableListProps, SelectableRow, SelectableSpan, SelectionStyle, SpanColor,
+};
+use super::super::components::{
+    KeybindBar, Sidebar, StatusBar, detail_pane_element, selectable_list_element,
+};
+
+/// Props for the errors mode screen.
+#[derive(Default, Props)]
+pub struct ErrorsScreenProps {
+    /// Application state (cloned snapshot).
+    pub state: Option<AppState>,
+    /// Theme colors.
+    pub colors: Option<ThemeColors>,
+    /// Active theme name.
+    pub theme_name: String,
+}
+
+/// Errors mode screen layout — two-column: repos sidebar + errors workspace.
+#[component]
+pub fn ErrorsScreen(props: &ErrorsScreenProps) -> impl Into<AnyElement<'static>> {
+    let state = props.state.as_ref();
+    let colors = props.colors.clone().unwrap_or_default();
+    let rc = ResolvedColors::from_theme(Some(&colors));
+    let selection = state.and_then(|s| s.selection);
+
+    // ── Sidebar data ────────────────────────────────────────────────────────
+    let selected_repo_idx = state
+        .and_then(AppState::selected_repository_visible_index)
+        .unwrap_or(0);
+    let visible_repo_indices = state.map_or_else(Vec::new, AppState::visible_repository_indices);
+    let repositories: Vec<_> = state.map_or_else(Vec::new, |s| {
+        visible_repo_indices
+            .iter()
+            .filter_map(|idx| s.repositories.get(*idx).cloned())
+            .collect()
+    });
+    let agent_counts: Vec<usize> = state.map_or_else(Vec::new, |s| {
+        visible_repo_indices
+            .iter()
+            .filter_map(|idx| {
+                s.repositories
+                    .get(*idx)
+                    .map(|repo| s.visible_agent_count_for_repository(&repo.id))
+            })
+            .collect()
+    });
+
+    // ── Status bar data ─────────────────────────────────────────────────────
+    let repo_count = visible_repo_indices.len();
+    let running_count = state.map_or(0, |s| s.agents.iter().filter(|a| a.is_running()).count());
+    let agent_count = state.map_or(0, AppState::visible_agent_count);
+
+    // ── Errors data ─────────────────────────────────────────────────────────
+    let errors_focus = state.map_or(ErrorsFocus::ErrorList, |s| s.errors_state.focus);
+    let errors: Vec<_> = state.map_or_else(Vec::new, |s| s.errors_state.errors.clone());
+    let selected_error_idx = state.and_then(|s| s.errors_state.selected_index);
+    let detail_scroll_offset = state.map_or(0, |s| s.errors_state.detail_scroll_offset);
+    let selected_error = selected_error_idx.and_then(|idx| errors.get(idx));
+
+    // ── Layout geometry ─────────────────────────────────────────────────────
+    let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((120, 40));
+    let (render_cols, render_rows) = crate::layout::effective_render_size(term_cols, term_rows);
+    // Errors mode has no error banner and no filter band.
+    let (list_pane_rows, _) =
+        crate::layout::actions_pane_rows(usize::from(render_rows), false, false);
+    let list_pane_rows = u16::try_from(list_pane_rows).unwrap_or(u16::MAX);
+    let sidebar_width = u32::from(crate::layout::prs_main_columns(render_cols).sidebar_width);
+    let list_content_width = crate::layout::pr_list_content_width(render_cols);
+    let detail_viewport_rows =
+        crate::layout::prs_detail_viewport_rows(usize::from(render_rows), false, false);
+    let detail_content_width = usize::from(crate::layout::prs_detail_content_width(render_cols));
+
+    let sidebar_focused = errors_focus == ErrorsFocus::RepoList;
+    let list_focused = errors_focus == ErrorsFocus::ErrorList;
+    let detail_focused = errors_focus == ErrorsFocus::ErrorDetail;
+
+    // ── Error list rows ─────────────────────────────────────────────────────
+    let list_rows: Vec<SelectableRow> = errors
+        .iter()
+        .enumerate()
+        .map(|(idx, entry)| {
+            let title = if entry.title.len() > list_content_width as usize - 10 {
+                // Truncate to fit: "[seq] title..."
+                format!(
+                    "[{}] {}…",
+                    entry.seq,
+                    &entry.title[..list_content_width as usize - 13]
+                )
+            } else {
+                format!("[{}] {}", entry.seq, entry.title)
+            };
+            let source_label = match entry.source {
+                crate::domain::ErrorSource::Issues => "Issues",
+                crate::domain::ErrorSource::PullRequests => "PRs",
+                crate::domain::ErrorSource::Actions => "Actions",
+                crate::domain::ErrorSource::Persistence => "Persistence",
+                crate::domain::ErrorSource::Agent => "Agent",
+                crate::domain::ErrorSource::Startup => "Startup",
+                crate::domain::ErrorSource::Other => "Other",
+            };
+            let meta = format!("{source_label} · {}", entry.timestamp);
+            SelectableRow {
+                source_index: idx,
+                spans: vec![SelectableSpan {
+                    text: title,
+                    color: SpanColor::Themed,
+                }],
+                meta_line: Some(meta),
+                is_selected: selected_error_idx == Some(idx),
+            }
+        })
+        .collect();
+
+    let empty_message = if errors.is_empty() {
+        Some("No errors recorded.".to_string())
+    } else {
+        None
+    };
+
+    // ── Error detail ────────────────────────────────────────────────────────
+    let (header_rows, detail_content) = if let Some(entry) = selected_error {
+        let hdr = vec![
+            DetailHeaderRow {
+                content: format!("[{}] {}", entry.seq, entry.title),
+                color: DetailHeaderColor::Bright,
+                line: 0,
+            },
+            DetailHeaderRow {
+                content: format!("Source: {:?}  ·  {}", entry.source, entry.timestamp),
+                color: DetailHeaderColor::Dim,
+                line: 1,
+            },
+            DetailHeaderRow {
+                content: crate::ui::components::SEPARATOR_LINE.to_string(),
+                color: DetailHeaderColor::Dim,
+                line: 2,
+            },
+        ];
+        (hdr, entry.detail.clone())
+    } else {
+        (vec![], String::new())
+    };
+
+    let detail_props = DetailPaneProps {
+        header_rows,
+        content: detail_content,
+        content_cursor: None,
+        scroll_offset: detail_scroll_offset,
+        viewport_rows: detail_viewport_rows,
+        content_line_offset: 3, // header rows
+        max_line_width: detail_content_width,
+        focused: detail_focused,
+        pane: SelectablePane::ErrorDetail,
+        colors: colors.clone(),
+        selection,
+        composer: None,
+        composer_rows: 0,
+    };
+
+    element! {
+        Box(
+            flex_direction: FlexDirection::Column,
+            background_color: rc.bg,
+            width: 100pct,
+            height: 100pct,
+        ) {
+            // ── Status bar ──────────────────────────────────────────────────
+            StatusBar(
+                repo_count: repo_count,
+                running_count: running_count,
+                agent_count: agent_count,
+                theme_name: props.theme_name.clone(),
+                version: crate::VERSION.to_owned(),
+                warning_message: state.and_then(|s| s.warning_message.clone()),
+                last_error: state.and_then(|s| {
+                    s.errors_state.last_error().map(|e| e.title.clone())
+                }),
+                colors: colors.clone(),
+                selection: selection,
+            )
+
+            // ── Main body: sidebar + errors workspace ───────────────────────
+            Box(
+                flex_direction: FlexDirection::Row,
+                flex_grow: 1.0_f32,
+                width: 100pct,
+            ) {
+                // Repos sidebar (fixed width, full height)
+                Box(width: sidebar_width, height: 100pct) {
+                    Sidebar(
+                        repositories: repositories,
+                        agent_counts: agent_counts,
+                        selected: selected_repo_idx,
+                        focused: sidebar_focused,
+                        grabbed: None,
+                        pane_rows: render_rows.saturating_sub(crate::layout::OUTER_BARS_HEIGHT),
+                        content_width: crate::list_viewport::bordered_padded_content_width(crate::layout::PRS_SIDEBAR_WIDTH),
+                        colors: colors.clone(),
+                        selection: selection,
+                    )
+                }
+
+                // Errors workspace (flex-grow)
+                Box(
+                    flex_direction: FlexDirection::Column,
+                    flex_grow: 1.0_f32,
+                    height: 100pct,
+                ) {
+                    // Error list (top split)
+                    Box(height: list_pane_rows, width: 100pct) {
+                        #(vec![selectable_list_element(SelectableListProps {
+                            title: "Errors".to_string(),
+                            rows: list_rows,
+                            focused: list_focused,
+                            empty_message,
+                            colors: colors.clone(),
+                            selection,
+                            pane: SelectablePane::ErrorList,
+                            border: ListBorder::DoubleOnFocus,
+                            content_padding: false,
+                            selection_style: SelectionStyle::BoldSelected,
+                            content_width: list_content_width as usize,
+                        })])
+                    }
+
+                    // Error detail (bottom split)
+                    Box(flex_grow: 1.0_f32, width: 100pct) {
+                        #(vec![detail_pane_element(detail_props)])
+                    }
+                }
+            }
+
+            // ── Keybind bar ─────────────────────────────────────────────────
+            KeybindBar(
+                screen_mode: state.map_or(ScreenMode::DashboardErrors, |s| s.screen_mode),
+                terminal_focused: false,
+                actions_focus: None,
+                colors: colors.clone(),
+            )
+        }
+    }
+}

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -235,6 +235,9 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                 version: crate::VERSION.to_owned(),
                 kennel_mode: state.is_some_and(crate::state::AppState::is_kennel_mode),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
+                last_error: state.and_then(|s| {
+                    s.errors_state.last_error().map(|e| e.title.clone())
+                }),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -235,9 +235,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                 version: crate::VERSION.to_owned(),
                 kennel_mode: state.is_some_and(crate::state::AppState::is_kennel_mode),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
-                last_error: state.and_then(|s| {
-                    s.errors_state.last_error().map(|e| e.title.clone())
-                }),
+                last_error: state.and_then(AppState::last_error_title),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/mod.rs
+++ b/src/ui/screens/mod.rs
@@ -5,6 +5,7 @@
 
 mod actions;
 mod dashboard;
+mod errors;
 mod issues;
 mod new_agent;
 mod new_repository;
@@ -17,6 +18,7 @@ mod workflow_dispatch;
 
 pub use actions::{ActionsScreen, ActionsScreenProps};
 pub use dashboard::{Dashboard, DashboardProps};
+pub use errors::{ErrorsScreen, ErrorsScreenProps};
 pub use issues::{IssuesScreen, IssuesScreenProps};
 pub use new_agent::{NewAgentForm, NewAgentFormProps};
 pub use new_repository::{NewRepositoryForm, NewRepositoryFormProps};

--- a/src/ui/screens/pull_requests.rs
+++ b/src/ui/screens/pull_requests.rs
@@ -206,6 +206,9 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                 version: crate::VERSION.to_owned(),
                 kennel_mode: state.is_some_and(crate::state::AppState::is_kennel_mode),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
+                last_error: state.and_then(|s| {
+                    s.errors_state.last_error().map(|e| e.title.clone())
+                }),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/pull_requests.rs
+++ b/src/ui/screens/pull_requests.rs
@@ -206,9 +206,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                 version: crate::VERSION.to_owned(),
                 kennel_mode: state.is_some_and(crate::state::AppState::is_kennel_mode),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
-                last_error: state.and_then(|s| {
-                    s.errors_state.last_error().map(|e| e.title.clone())
-                }),
+                last_error: state.and_then(AppState::last_error_title),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/split.rs
+++ b/src/ui/screens/split.rs
@@ -99,9 +99,7 @@ pub fn SplitScreen(props: &SplitScreenProps) -> impl Into<AnyElement<'static>> {
                 version: crate::VERSION.to_owned(),
                 kennel_mode: state.is_some_and(crate::state::AppState::is_kennel_mode),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
-                last_error: state.and_then(|s| {
-                    s.errors_state.last_error().map(|e| e.title.clone())
-                }),
+                last_error: state.and_then(AppState::last_error_title),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/split.rs
+++ b/src/ui/screens/split.rs
@@ -99,6 +99,9 @@ pub fn SplitScreen(props: &SplitScreenProps) -> impl Into<AnyElement<'static>> {
                 version: crate::VERSION.to_owned(),
                 kennel_mode: state.is_some_and(crate::state::AppState::is_kennel_mode),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
+                last_error: state.and_then(|s| {
+                    s.errors_state.last_error().map(|e| e.title.clone())
+                }),
                 colors: colors.clone(),
                 selection: selection,
             )


### PR DESCRIPTION
## Summary

Adds a dedicated **Errors Mode** to the jefe TUI, replacing the transient error banner that flashes above selection panels with a persistent, browsable error log (issue #292).

### What changes

- **Error ring buffer** (`src/domain/errors.rs`): A bounded `Vec<ErrorEntry>` capped at 50 entries (newest-first), capturing title, detail, source, and timestamp for every runtime error.

- **Centralized error capture** (`src/state/errors_ops.rs`): `capture_runtime_errors()` runs in `finalize_message` after every reducer step, inspecting all four error slots (global `error_message`, `issues_state.error`, `prs_state.error`, `actions_state.error`) with per-slot dedup so the same error text is not captured twice.

- **Status bar last-error indicator** (`src/ui/components/status_bar.rs`): The center status area now shows `ERR: <truncated title>` when the most recent error is present (warning takes precedence if both exist).

- **Errors Mode screen** (`src/ui/screens/errors.rs`): A two-column layout (repo sidebar + list/detail split) mirroring Issues/PRs/Actions modes. The list shows `[seq] title` entries; the detail pane shows the full error metadata + body. All data is local — no remote loading.

- **Keybind**: `e`/`E` from Dashboard enters Errors Mode. Esc exits (or refocuses the list from detail). Navigation: Up/Down/Home/End, Enter (list to detail), Tab/Shift-Tab (focus cycling), PageUp/PageDown (detail scroll), `c` (clear all).

- **Selection/mouse routing**: New `SelectablePane::ErrorList` and `SelectablePane::ErrorDetail` variants with content projections for text selection and copy.

### Architecture

Follows the established pattern for each dashboard sub-mode:
- Domain types -> State aggregate -> Message enum + conversion -> Reducer ops -> UI screen -> Input dispatch -> Selection content
- Prior focus save/restore on mode enter/exit (mirrors issues/prs/actions)
- 15 unit tests covering push/cap/eviction, navigation clamping, focus cycling, dedup, scroll clamping, clear

### Test plan

- [x] 15 new unit tests (all passing)
- [x] Full workspace test suite (3226 tests, all passing)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy` no new warnings
- [x] Source file size check all files under 1000 lines
- [ ] TUI scenario script
- [ ] CI workflows pass

Closes #292
