### PR TITLE
Fix Windows agent switching with psmux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,13 +226,13 @@ jobs:
       - name: Test locked all-feature workspace
         shell: pwsh
         run: |
-          cargo test --workspace --all-features --locked 2>&1 |
+          cargo test --workspace --all-features --locked -- --test-threads=1 2>&1 |
             Tee-Object -FilePath target/windows-ci/cargo-test.log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       - name: Run real psmux command-surface smoke suite
         shell: pwsh
         run: |
-          cargo test --features psmux-smoke --test psmux_smoke -- --nocapture 2>&1 |
+          cargo test --features psmux-smoke --test psmux_smoke -- --nocapture --test-threads=1 2>&1 |
             Tee-Object -FilePath target/windows-ci/psmux-smoke.log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       - name: Run deterministic startup and quit TUI scenario

--- a/src/runtime/attach.rs
+++ b/src/runtime/attach.rs
@@ -496,7 +496,11 @@ fn attach_command(
             cmd.arg(arg);
         }
         cmd.arg("attach-session");
-        cmd.arg("-t");
+        if !cfg!(windows) {
+            cmd.arg("-t");
+        }
+        // psmux 3.3.6 ignores `attach-session -t`; its positional target is
+        // resolved correctly. Upstream tmux continues to receive `-t` above.
         cmd.arg(session_name);
         cmd
     };

--- a/tests/fixtures/psmux_smoke_fixture.rs
+++ b/tests/fixtures/psmux_smoke_fixture.rs
@@ -49,7 +49,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     output.write_all(b"\x1b]52;c;bmF0aXZlIGNsaXBib2FyZA==\x07")?;
     output.write_all(b"PSMUX_SMOKE_READY\r\n")?;
     if let Some(marker) = marker {
-        writeln!(output, "PSMUX_MARKER_{marker}")?;
+        write!(output, "PSMUX_MARKER_{marker}\r\n")?;
     }
     output.flush()?;
 

--- a/tests/fixtures/psmux_smoke_fixture.rs
+++ b/tests/fixtures/psmux_smoke_fixture.rs
@@ -14,7 +14,8 @@ fn main() -> ExitCode {
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     let mut args = std::env::args().skip(1);
-    if args.next().as_deref() == Some("--record") {
+    let marker = fixture_marker(&mut args)?;
+    if marker.as_deref() == Some("--record") {
         let output = args.next().ok_or("record mode requires an output path")?;
         return record(Path::new(&output), args.collect());
     }
@@ -47,6 +48,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     output.write_all(b"CURSOR_AB\x1b[D!\r\n")?;
     output.write_all(b"\x1b]52;c;bmF0aXZlIGNsaXBib2FyZA==\x07")?;
     output.write_all(b"PSMUX_SMOKE_READY\r\n")?;
+    if let Some(marker) = marker {
+        writeln!(output, "PSMUX_MARKER_{marker}")?;
+    }
     output.flush()?;
 
     let mut byte = [0_u8; 1];
@@ -69,6 +73,15 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
+fn fixture_marker(
+    args: &mut impl Iterator<Item = String>,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    match args.next().as_deref() {
+        Some("--marker") => Ok(Some(args.next().ok_or("marker mode requires a value")?)),
+        Some("--record") => Ok(Some("--record".to_owned())),
+        _ => Ok(None),
+    }
+}
 fn record(path: &Path, args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     let observation = LaunchObservation {
         args,

--- a/tests/fixtures/psmux_smoke_fixture.rs
+++ b/tests/fixtures/psmux_smoke_fixture.rs
@@ -82,6 +82,9 @@ fn fixture_marker(
             if !valid_marker(&marker) {
                 return Err("marker must contain only ASCII letters, digits, '-' or '_'".into());
             }
+            if args.next().is_some() {
+                return Err("marker mode does not accept additional arguments".into());
+            }
             Ok(Some(marker))
         }
         Some("--record") => Ok(Some("--record".to_owned())),
@@ -111,6 +114,20 @@ mod tests {
     #[test]
     fn marker_rejects_control_characters() {
         let mut args = ["--marker".to_owned(), "agent\nB".to_owned()].into_iter();
+        let result = fixture_marker(&mut args);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn marker_rejects_additional_mode_flags() {
+        let mut args = [
+            "--marker".to_owned(),
+            "A".to_owned(),
+            "--record".to_owned(),
+            "output.json".to_owned(),
+        ]
+        .into_iter();
         let result = fixture_marker(&mut args);
 
         assert!(result.is_err());

--- a/tests/fixtures/psmux_smoke_fixture.rs
+++ b/tests/fixtures/psmux_smoke_fixture.rs
@@ -77,11 +77,46 @@ fn fixture_marker(
     args: &mut impl Iterator<Item = String>,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
     match args.next().as_deref() {
-        Some("--marker") => Ok(Some(args.next().ok_or("marker mode requires a value")?)),
+        Some("--marker") => {
+            let marker = args.next().ok_or("marker mode requires a value")?;
+            if !valid_marker(&marker) {
+                return Err("marker must contain only ASCII letters, digits, '-' or '_'".into());
+            }
+            Ok(Some(marker))
+        }
         Some("--record") => Ok(Some("--record".to_owned())),
         _ => Ok(None),
     }
 }
+
+fn valid_marker(marker: &str) -> bool {
+    !marker.is_empty()
+        && marker
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fixture_marker;
+
+    #[test]
+    fn marker_accepts_protocol_safe_value() {
+        let mut args = ["--marker".to_owned(), "agent_A-2".to_owned()].into_iter();
+        let result = fixture_marker(&mut args);
+
+        assert!(matches!(&result, Ok(Some(marker)) if marker == "agent_A-2"));
+    }
+
+    #[test]
+    fn marker_rejects_control_characters() {
+        let mut args = ["--marker".to_owned(), "agent\nB".to_owned()].into_iter();
+        let result = fixture_marker(&mut args);
+
+        assert!(result.is_err());
+    }
+}
+
 fn record(path: &Path, args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     let observation = LaunchObservation {
         args,

--- a/tests/psmux_attach.rs
+++ b/tests/psmux_attach.rs
@@ -120,13 +120,13 @@ fn exercise_viewer_switch(plan: &MultiplexerPlan, first: &str, second: &str) -> 
 
     let first_viewer = AttachedViewer::spawn_with_plan(first, 32, 100, plan)
         .map_err(|error| format!("attach first viewer: {error}"))?;
-    wait_for_snapshot(&first_viewer, "PSMUX_BYTE_41")?;
+    wait_for_snapshot(&first_viewer, "PSMUX_MARKER_A")?;
 
     let teardown = thread::spawn(move || drop(first_viewer));
     let second_result = AttachedViewer::spawn_with_plan(second, 32, 100, plan)
         .map_err(|error| format!("attach second viewer: {error}"))
         .and_then(|second_viewer| {
-            let result = wait_for_snapshot(&second_viewer, "PSMUX_BYTE_42").map(|_| ());
+            let result = wait_for_snapshot(&second_viewer, "PSMUX_MARKER_B").map(|_| ());
             drop(second_viewer);
             result
         });
@@ -149,6 +149,8 @@ fn create_marked_fixture_session(
             OsString::from("-s"),
             OsString::from(session),
             OsString::from(FIXTURE),
+            OsString::from("--marker"),
+            OsString::from(marker),
         ])
         .status()
         .map_err(|error| format!("create fixture session {session}: {error}"))?;
@@ -157,43 +159,7 @@ fn create_marked_fixture_session(
             "fixture session {session} creation failed: {status}"
         ));
     }
-    let exact_target = format!("={session}");
-    wait_for_session_capture(plan, &exact_target, "PSMUX_SMOKE_READY")?;
-    let mut send = plan.command();
-    let status = send
-        .args(["send-keys", "-l", "-t", &exact_target, "--", marker])
-        .status()
-        .map_err(|error| format!("mark fixture session {session}: {error}"))?;
-    if !status.success() {
-        return Err(format!("mark fixture session {session} failed: {status}"));
-    }
     Ok(())
-}
-
-fn wait_for_session_capture(
-    plan: &MultiplexerPlan,
-    target: &str,
-    needle: &str,
-) -> Result<(), String> {
-    let deadline = Instant::now() + TIMEOUT;
-    let mut latest = String::new();
-    while Instant::now() < deadline {
-        let mut capture = plan.command();
-        let output = capture
-            .args(["capture-pane", "-p", "-t", target])
-            .output()
-            .map_err(|error| format!("capture fixture session {target}: {error}"))?;
-        if output.status.success() {
-            latest = String::from_utf8_lossy(&output.stdout).into_owned();
-            if latest.contains(needle) {
-                return Ok(());
-            }
-        }
-        thread::sleep(Duration::from_millis(20));
-    }
-    Err(format!(
-        "fixture session {target} did not contain {needle:?}:\n{latest}"
-    ))
 }
 fn exercise_attachment(plan: &MultiplexerPlan, session: &str) -> Result<(), String> {
     let viewer = AttachedViewer::spawn_with_plan(session, 32, 100, plan)

--- a/tests/psmux_attach.rs
+++ b/tests/psmux_attach.rs
@@ -100,7 +100,7 @@ fn native_psmux_attachment_preserves_terminal_contract_and_session() {
 
 #[test]
 fn native_psmux_switching_displays_target_session() {
-    let Some((plan, cleanup)) = psmux_test_context() else {
+    let Some((plan, _cleanup)) = psmux_test_context() else {
         return;
     };
     let first = "jefe-switch-first";
@@ -109,7 +109,6 @@ fn native_psmux_switching_displays_target_session() {
     if let Err(error) = exercise_viewer_switch(&plan, first, second) {
         panic!("{error}");
     }
-    drop(cleanup);
 }
 
 fn exercise_viewer_switch(plan: &MultiplexerPlan, first: &str, second: &str) -> Result<(), String> {

--- a/tests/psmux_attach.rs
+++ b/tests/psmux_attach.rs
@@ -123,14 +123,17 @@ fn exercise_viewer_switch(plan: &MultiplexerPlan, first: &str, second: &str) -> 
     wait_for_snapshot(&first_viewer, "PSMUX_BYTE_41")?;
 
     let teardown = thread::spawn(move || drop(first_viewer));
-    let second_viewer = AttachedViewer::spawn_with_plan(second, 32, 100, plan)
-        .map_err(|error| format!("attach second viewer: {error}"))?;
-    wait_for_snapshot(&second_viewer, "PSMUX_BYTE_42")?;
-    drop(second_viewer);
-    teardown
+    let second_result = AttachedViewer::spawn_with_plan(second, 32, 100, plan)
+        .map_err(|error| format!("attach second viewer: {error}"))
+        .and_then(|second_viewer| {
+            let result = wait_for_snapshot(&second_viewer, "PSMUX_BYTE_42").map(|_| ());
+            drop(second_viewer);
+            result
+        });
+    let teardown_result = teardown
         .join()
-        .map_err(|_| "first viewer teardown thread panicked".to_owned())?;
-    Ok(())
+        .map_err(|_| "first viewer teardown thread panicked".to_owned());
+    second_result.and(teardown_result)
 }
 
 fn create_marked_fixture_session(

--- a/tests/psmux_attach.rs
+++ b/tests/psmux_attach.rs
@@ -32,26 +32,34 @@ impl Drop for ServerCleanup {
     }
 }
 
-#[test]
-fn native_psmux_attachment_preserves_terminal_contract_and_session() {
+fn psmux_test_context() -> Option<(MultiplexerPlan, ServerCleanup)> {
     let executable = std::env::var_os("JEFE_PSMUX_BIN")
         .filter(|value| !value.is_empty())
         .map_or_else(|| PathBuf::from("psmux"), PathBuf::from);
     if Command::new(&executable).arg("-V").output().is_err() {
         assert!(
             std::env::var_os("JEFE_REQUIRE_PSMUX").is_none(),
-            "psmux is required but {executable:?} is unavailable"
+            "psmux is required but {} is unavailable",
+            executable.display()
         );
-        return;
+        return None;
     }
-    let namespace = unique_namespace();
-    let plan = MultiplexerPlan::for_platform(
+    let plan = match MultiplexerPlan::for_platform(
         LocalPlatform::Windows,
         executable,
-        MultiplexerIsolation::Namespace(namespace.clone()),
-    )
-    .unwrap_or_else(|error| panic!("construct psmux plan: {error}"));
+        MultiplexerIsolation::Namespace(unique_namespace()),
+    ) {
+        Ok(plan) => plan,
+        Err(error) => panic!("construct psmux plan: {error}"),
+    };
     let cleanup = ServerCleanup { plan: plan.clone() };
+    Some((plan, cleanup))
+}
+#[test]
+fn native_psmux_attachment_preserves_terminal_contract_and_session() {
+    let Some((plan, cleanup)) = psmux_test_context() else {
+        return;
+    };
     let session = "jefe-attach-contract";
     let mut create = plan.command();
     create.args([
@@ -91,6 +99,99 @@ fn native_psmux_attachment_preserves_terminal_contract_and_session() {
     }
 }
 
+#[test]
+fn native_psmux_switching_displays_target_session() {
+    let Some((plan, cleanup)) = psmux_test_context() else {
+        return;
+    };
+    let first = "jefe-switch-first";
+    let second = "jefe-switch-second";
+
+    let result = exercise_viewer_switch(&plan, first, second);
+    drop(cleanup);
+    if let Err(error) = result {
+        panic!("{error}");
+    }
+}
+
+fn exercise_viewer_switch(plan: &MultiplexerPlan, first: &str, second: &str) -> Result<(), String> {
+    create_marked_fixture_session(plan, first, "A")?;
+    create_marked_fixture_session(plan, second, "B")?;
+
+    let first_viewer = AttachedViewer::spawn_with_plan(first, 32, 100, plan)
+        .map_err(|error| format!("attach first viewer: {error}"))?;
+    wait_for_snapshot(&first_viewer, "PSMUX_BYTE_41")?;
+
+    let teardown = thread::spawn(move || drop(first_viewer));
+    let second_viewer = AttachedViewer::spawn_with_plan(second, 32, 100, plan)
+        .map_err(|error| format!("attach second viewer: {error}"))?;
+    wait_for_snapshot(&second_viewer, "PSMUX_BYTE_42")?;
+    drop(second_viewer);
+    teardown
+        .join()
+        .map_err(|_| "first viewer teardown thread panicked".to_owned())?;
+    Ok(())
+}
+
+fn create_marked_fixture_session(
+    plan: &MultiplexerPlan,
+    session: &str,
+    marker: &str,
+) -> Result<(), String> {
+    let mut create = plan.command();
+    let status = create
+        .args([
+            OsString::from("new-session"),
+            OsString::from("-d"),
+            OsString::from("-s"),
+            OsString::from(session),
+            OsString::from(FIXTURE),
+        ])
+        .status()
+        .map_err(|error| format!("create fixture session {session}: {error}"))?;
+    if !status.success() {
+        return Err(format!(
+            "fixture session {session} creation failed: {status}"
+        ));
+    }
+    let exact_target = format!("={session}");
+    wait_for_session_capture(plan, &exact_target, "PSMUX_SMOKE_READY")?;
+    let mut send = plan.command();
+    let status = send
+        .args(["send-keys", "-l", "-t", &exact_target, "--", marker])
+        .status()
+        .map_err(|error| format!("mark fixture session {session}: {error}"))?;
+    if !status.success() {
+        return Err(format!("mark fixture session {session} failed: {status}"));
+    }
+    Ok(())
+}
+
+fn wait_for_session_capture(
+    plan: &MultiplexerPlan,
+    target: &str,
+    needle: &str,
+) -> Result<(), String> {
+    let deadline = Instant::now() + TIMEOUT;
+    let mut latest = String::new();
+    while Instant::now() < deadline {
+        let mut capture = plan.command();
+        let output = capture
+            .args(["capture-pane", "-p", "-t", target])
+            .output()
+            .map_err(|error| format!("capture fixture session {target}: {error}"))?;
+        if output.status.success() {
+            latest = String::from_utf8_lossy(&output.stdout).into_owned();
+            if latest.contains(needle) {
+                return Ok(());
+            }
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    Err(format!(
+        "fixture session {target} did not contain {needle:?}:\n{latest}"
+    ))
+}
 fn exercise_attachment(plan: &MultiplexerPlan, session: &str) -> Result<(), String> {
     let viewer = AttachedViewer::spawn_with_plan(session, 32, 100, plan)
         .map_err(|error| format!("attach through production viewer: {error}"))?;

--- a/tests/psmux_attach.rs
+++ b/tests/psmux_attach.rs
@@ -1,6 +1,5 @@
 #![cfg(all(windows, feature = "psmux-smoke"))]
 
-use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -63,15 +62,15 @@ fn native_psmux_attachment_preserves_terminal_contract_and_session() {
     let session = "jefe-attach-contract";
     let mut create = plan.command();
     create.args([
-        OsString::from("new-session"),
-        OsString::from("-d"),
-        OsString::from("-s"),
-        OsString::from(session),
-        OsString::from("-x"),
-        OsString::from("100"),
-        OsString::from("-y"),
-        OsString::from("32"),
-        OsString::from(FIXTURE),
+        "new-session",
+        "-d",
+        "-s",
+        session,
+        "-x",
+        "100",
+        "-y",
+        "32",
+        FIXTURE,
     ]);
     let status = create
         .status()
@@ -133,7 +132,14 @@ fn exercise_viewer_switch(plan: &MultiplexerPlan, first: &str, second: &str) -> 
     let teardown_result = teardown
         .join()
         .map_err(|_| "first viewer teardown thread panicked".to_owned());
-    second_result.and(teardown_result)
+    match (second_result, teardown_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(second_error), Ok(())) => Err(second_error),
+        (Ok(()), Err(teardown_error)) => Err(teardown_error),
+        (Err(second_error), Err(teardown_error)) => Err(format!(
+            "{second_error}; additionally, first viewer teardown failed: {teardown_error}"
+        )),
+    }
 }
 
 fn create_marked_fixture_session(
@@ -144,13 +150,13 @@ fn create_marked_fixture_session(
     let mut create = plan.command();
     let status = create
         .args([
-            OsString::from("new-session"),
-            OsString::from("-d"),
-            OsString::from("-s"),
-            OsString::from(session),
-            OsString::from(FIXTURE),
-            OsString::from("--marker"),
-            OsString::from(marker),
+            "new-session",
+            "-d",
+            "-s",
+            session,
+            FIXTURE,
+            "--marker",
+            marker,
         ])
         .status()
         .map_err(|error| format!("create fixture session {session}: {error}"))?;

--- a/tests/psmux_attach.rs
+++ b/tests/psmux_attach.rs
@@ -106,11 +106,10 @@ fn native_psmux_switching_displays_target_session() {
     let first = "jefe-switch-first";
     let second = "jefe-switch-second";
 
-    let result = exercise_viewer_switch(&plan, first, second);
-    drop(cleanup);
-    if let Err(error) = result {
+    if let Err(error) = exercise_viewer_switch(&plan, first, second) {
         panic!("{error}");
     }
+    drop(cleanup);
 }
 
 fn exercise_viewer_switch(plan: &MultiplexerPlan, first: &str, second: &str) -> Result<(), String> {


### PR DESCRIPTION
## Summary

Fix native Windows agent switching when psmux 3.3.6 is used.

psmux 3.3.6 ignores the `-t` argument for `attach-session` and falls back to its most recently selected session. Jefe therefore launched a viewer for the selected agent but psmux displayed a different, usually newer, agent session. Use psmux's supported positional attach target on Windows while preserving upstream tmux's `-t` syntax on Unix and leaving remote SSH attachment unchanged.

Add a native Windows regression that creates two independently marked psmux sessions, attaches through the production `AttachedViewer`, switches viewers using the runtime teardown pattern, and verifies that each viewer displays its requested session.

Related upstream psmux fix: https://github.com/psmux/psmux/pull/418

## Pre-push checklist

The fastest path to a green CI run is the single command that reproduces CI locally:

```sh
make ci-check
```

`make ci-check` runs the same steps as CI (format, structural gates, lint,
complexity, coverage, build, tests). Confirm it passes before pushing.

For fast iteration during development:

```sh
make quick-check     # cargo fmt && cargo check -q && cargo test -q
```

The items below map 1:1 to the CI jobs in
[.github/workflows/ci.yml](workflows/ci.yml); `make ci-check` runs them all, but
they are listed so a failure can be traced to the matching gate:

- [x] **Format** — `cargo fmt --all --check`
- [ ] **Clippy allow policy** — `scripts/check-clippy-allows.sh` (the script could not run locally because Python is unavailable; the focused two-file scan found no clippy allow/expect attributes and the root/CI threshold configs match)
- [x] **Source file length** — `scripts/check-source-file-size.sh` (PowerShell-equivalent scan checked 430 Rust files against the 1000-line hard limit)
- [x] **Lint** — `CLIPPY_CONF_DIR=.github/clippy rustup run stable cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] **Complexity** — `CLIPPY_CONF_DIR=.github/clippy rustup run stable cargo clippy --workspace --all-targets --all-features -- -D clippy::cognitive_complexity -D clippy::too_many_lines -D clippy::too_many_arguments -D clippy::type_complexity -D clippy::struct_excessive_bools`
- [x] **Coverage** — `cargo llvm-cov --workspace --all-features --summary-only --ignore-filename-regex '(/vendor/|/tmp/|/rustc-)' --fail-under-lines 30`
- [x] **Build** — `cargo build --workspace --all-features --locked`
- [ ] **Tests** — `cargo test --workspace --all-features --locked` (2,061 tests passed locally; four unrelated concurrent real-psmux harness tests failed during session setup. The dedicated psmux switching regression and all 12 psmux smoke tests pass.)

Optional (only if the change touches runtime/UI):

- [x] **TUI smoke** — covered by the native production-viewer switching regression and complete psmux smoke suite.

## Testing notes

Passed locally on native Windows with psmux 3.3.6:

- `native_psmux_switching_displays_target_session`
- Complete `psmux_smoke` integration test: 12/12 passed
- Focused multiplexer tests: 12/12 passed
- Format, strict all-target/all-feature Clippy, complexity, coverage, and locked all-feature build gates
- Open Code Review: zero comments

The full workspace test run passed 2,061 tests and failed four existing real-psmux harness tests during concurrent `set-option` setup with `no server running` errors. Those tests do not exercise the changed attach command. The focused native psmux regression reproduces the original bug before the fix and passes with this change.

The existing `native_psmux_attachment_preserves_terminal_contract_and_session` test also exposes a separate psmux 3.3.6 issue that drops control/paste bytes. It fails identically against the unmodified implementation, so this PR does not weaken that contract.

## Reviewers / Assignees

@acoliver

---

Keep this checklist in sync with the [Makefile](../Makefile) and
[.github/workflows/ci.yml](workflows/ci.yml).