### PR TITLE
Route checkout blockers through dirty-copy confirmation (Fixes #316)

### DIFF
--- a/dev-docs/tmux-scenarios/issue-dirty-copy-confirm.json
+++ b/dev-docs/tmux-scenarios/issue-dirty-copy-confirm.json
@@ -33,10 +33,9 @@
     { "key": "Right" },
     { "expect": "( Confirm )" },
     { "capture": "dirty-copy-focus-confirm" },
-    { "key": "Left" },
-    { "expect": "( Cancel )" },
-    { "key": "Escape" },
+    { "key": "Enter" },
     { "waitForNot": "Dirty Working Copy" },
+    { "capture": "dirty-copy-confirm-activated" },
     { "key": "Escape" },
     { "key": "q" },
     { "waitForExit": 3000 }

--- a/project-plans/issue316-plan.md
+++ b/project-plans/issue316-plan.md
@@ -1,0 +1,128 @@
+# Issue #316 plan: selectable dirty-copy overwrite recovery
+
+## Goal
+
+When issue handoff cannot move an agent working copy to the repository default
+branch because local tracked changes would be overwritten, treat that condition
+like every other dirty working copy: show the safe-by-default selectable confirm
+dialog, allow cancellation without mutation, and after explicit confirmation
+clobber the blocking tracked state, remove non-owned untracked state, and reset
+the worktree to the fetched default branch before launch.
+
+The existing issue #228 control remains the shared interaction: Cancel is focused
+by default, Left/Right/Tab changes focus, Enter activates the focused button,
+and Escape or `n` cancels. Issue #316 closes the preparation gap where
+jefe-owned tracked paths are intentionally omitted from ordinary dirty status but
+can still make Git reject the default-branch checkout before that dialog appears.
+
+## Acceptance matrix
+
+| Row | Actor / launch path | Input and boundary | Observable success | Failure / side effects | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| A1 | User sends an issue to an existing local agent | Non-owned tracked or untracked changes | Dirty Working Copy opens with Cancel focused and selectable Cancel/Confirm buttons | No cleanup, checkout, prompt write, or launch before confirmation | Existing modal/reducer tests plus updated TUI scenario |
+| A2 | User cancels the dirty-copy dialog | Enter on default Cancel, Escape, or `n` | Dialog closes and handoff stops | Working copy remains byte-for-byte untouched | Existing confirm tests and TUI scenario |
+| A3 | User sends an issue from a branch whose modified tracked `.jefe`/`.llxprt` path would be overwritten by default-branch checkout | Ordinary dirty parser ignores the owned path, but Git reports checkout overwrite protection | The checkout-protection result is classified as dirty and the selectable dialog opens instead of surfacing a raw Git error | Fetch/default-branch discovery may run; no destructive mutation or prompt write | New real-Git regression test |
+| A4 | User selects Confirm for A1 or A3 | Explicit destructive opt-in | Blocking tracked changes are discarded, non-owned untracked paths are removed, owned untracked metadata is retained, and worktree HEAD/index are reset to fetched default branch before prompt write/launch | Cleanup or Git failures are surfaced and stop launch | New real-Git discard regression tests; existing preparation tests |
+| A5 | User confirms from a local or remote target | Existing target-aware orchestration | Existing local/remote behavior and origin mismatch handling remain unchanged | No new shell or process abstraction; remote plan retains explicit reset/clean semantics | Existing local/remote preparation suite and full CI |
+
+## Non-goals
+
+- Do not delete the whole working-copy directory or force-reclone a correctly
+  configured repository.
+- Do not remove untracked `.jefe/` or `.llxprt/` metadata.
+- Do not change confirmation behavior for delete, kill, preflight, or origin
+  mismatch dialogs.
+- Do not change dependencies, persistence schemas, workflow/quality tooling,
+  public APIs, or agent configuration outside the target working copy.
+- Do not attempt to preserve explicitly confirmed, tracked worktree edits: the
+  requested Confirm action is the opt-in clobber operation needed to reach the
+  fetched default branch cleanly.
+
+## Vertical slices
+
+### Slice 1: classify checkout overwrite protection as dirty
+
+- Rows: A1-A3.
+- Owner / boundary: `app_input::issue_git_prep` Git boundary and
+  `app_input::issue_prep` orchestration.
+- RED: real-Git test with a modified tracked owned path and divergent target
+  branch expects `PrepOutcome::Dirty`, no checkout, and no prompt write.
+- GREEN: preserve typed preparation semantics while recognizing Git's
+  locale-stabilized checkout overwrite diagnostic as a dirty outcome.
+- Allowed paths: `src/app_input/issue_git_prep.rs`,
+  `src/app_input/issue_prep.rs`, `src/app_input/issue_prep_tests.rs`.
+
+### Slice 2: confirmed clobber reaches fetched default branch
+
+- Rows: A4-A5.
+- Owner / boundary: ownership-scoped cleanup followed by existing Git prep.
+- RED: real-Git test confirms the Discard policy removes the blocking tracked
+  edit, retains untracked owned metadata, checks out/reset to origin default,
+  writes the prompt last, and reports Ready.
+- GREEN: extend confirmed cleanup only as needed for tracked blocking state;
+  retain constrained per-path untracked deletion.
+- Allowed paths: `src/app_input/issue_cleanup.rs`,
+  `src/app_input/issue_git_prep.rs`, `src/app_input/issue_prep.rs`,
+  `src/app_input/issue_prep_tests.rs`.
+
+### Slice 3: UI scenario documents actual affirmative selection
+
+- Rows: A1-A2 and A4.
+- Owner / boundary: existing TUI scenario only; no new UI abstraction.
+- RED: update the dirty-copy scenario before production edits so it selects
+  Confirm and activates it rather than only moving focus back to Cancel.
+- GREEN: scenario reaches the post-confirm handoff state with the modal gone.
+- Allowed path: `dev-docs/tmux-scenarios/issue-dirty-copy-confirm.json`.
+
+## Expected paths by layer
+
+- Git/process boundary: `src/app_input/issue_git_prep.rs`.
+- Cleanup boundary: `src/app_input/issue_cleanup.rs`.
+- Issue preparation orchestration: `src/app_input/issue_prep.rs`.
+- Behavioral regression tests: `src/app_input/issue_prep_tests.rs`.
+- TUI behavior: `dev-docs/tmux-scenarios/issue-dirty-copy-confirm.json`.
+- Delivery record: `project-plans/issue316-plan.md`.
+
+## Scope ledger
+
+| Discovery | Disposition | Reason |
+| --- | --- | --- |
+| Issue #228 already supplies keyboard focus and unified confirm handling | Reuse / no production UI change | Issue #316 is the preparation-path gap, not a second confirm control |
+| Owned paths are intentionally ignored for ordinary dirty display | Preserve for initial fast path; classify only checkout-blocking state | Avoid prompting for routine owned metadata unless Git cannot reach the target branch |
+| Confirmed cleanup currently preserves tracked owned edits | In-scope change | Those edits can make the requested clobber-and-reset operation impossible |
+
+No unapproved scope additions.
+
+## Review counters
+
+- Local rustreviewer runs: 1
+- Local OCR runs before PR: 1 / 2
+- OCR runs after PR: 0 / 2
+- GitHub review rounds: 0
+
+## Verification evidence
+
+- RED: real Git rejected checkout because local tracked `.llxprt/LLXPRT.md`
+  would be overwritten.
+- Focused issue tests: both independently named checkout-blocker tests pass.
+- Full gate: `make ci-check` passed with matching Rust/Cargo/Clippy 1.97.
+- Rustreviewer: test assertions and contracts strengthened; remote behavior and
+  deterministic TUI fixture were deferred as scope expansions described below.
+- OCR: reviewed all five changed implementation/test/scenario files and
+  reported no findings.
+- PR CI: pending.
+
+## Deferred findings / follow-ups
+
+- Remote issue preparation has a pre-existing broad checkout fallback that can
+  reset the current default branch after an unclassified checkout failure. The
+  issue #316 acceptance matrix explicitly preserves remote behavior; replacing
+  that shell orchestration with typed remote checkout outcomes is a separate
+  safety change requiring remote fixtures and broader cross-platform coverage.
+- The dirty-copy TUI scenario still relies on configured issue/agent state. A
+  deterministic scenario runner would require new fixture scripts and GitHub CLI
+  shims beyond this issue's bounded local checkout-classification change.
+- The initial Stop attempt fetches before checkout classification. Cancellation
+  preserves the branch, HEAD, index, status, and working-copy bytes; fetch
+  metadata is intentionally permitted by A3 so the eventual confirmation resets
+  to the current remote default.

--- a/src/app_input/issue_cleanup.rs
+++ b/src/app_input/issue_cleanup.rs
@@ -28,10 +28,22 @@ pub(in crate::app_input) fn discard_workdir_changes(work_dir: &Path) -> Result<(
         remove_untracked_path(work_dir, relative)?;
     }
     remove_empty_untracked_parents(work_dir, &untracked)?;
-    restore_tracked_paths(work_dir)
+    restore_tracked_paths(work_dir, TrackedPathScope::NonOwned)
 }
 
-fn restore_tracked_paths(work_dir: &Path) -> Result<(), String> {
+pub(in crate::app_input) fn discard_checkout_blocking_tracked_changes(
+    work_dir: &Path,
+) -> Result<(), String> {
+    restore_tracked_paths(work_dir, TrackedPathScope::All)
+}
+
+#[derive(Clone, Copy)]
+enum TrackedPathScope {
+    NonOwned,
+    All,
+}
+
+fn restore_tracked_paths(work_dir: &Path, scope: TrackedPathScope) -> Result<(), String> {
     let output = git_capture(
         work_dir,
         [
@@ -44,7 +56,11 @@ fn restore_tracked_paths(work_dir: &Path) -> Result<(), String> {
         ],
     )?;
     require_success(&output, "diff --name-only -z HEAD")?;
-    for relative in parse_changed_paths(&output.stdout)? {
+    let paths = match scope {
+        TrackedPathScope::NonOwned => parse_changed_paths(&output.stdout)?,
+        TrackedPathScope::All => parse_paths(&output.stdout)?,
+    };
+    for relative in paths {
         git_require_success(
             work_dir,
             [

--- a/src/app_input/issue_git_prep.rs
+++ b/src/app_input/issue_git_prep.rs
@@ -26,7 +26,9 @@ mod issue_cleanup;
 /// module split.
 #[path = "reclone_safety.rs"]
 mod reclone_safety;
-pub(super) use issue_cleanup::discard_workdir_changes;
+pub(super) use issue_cleanup::{
+    discard_checkout_blocking_tracked_changes, discard_workdir_changes,
+};
 pub(super) use reclone_safety::validate_reclone_target;
 
 /// Check whether `work_dir` exists and is a git working copy.
@@ -303,12 +305,17 @@ fn clone_repository(work_dir: &Path, clone_url: &str) -> PrepResult {
     Ok(())
 }
 
-/// Outcome of preparing the working copy for an issue-driven launch.
-///
-/// `Ok(())` means the working copy is now on the default branch and clean
-/// (modulo ignored jefe/llxprt paths) and the launch may proceed.
-/// `Err(_)` carries a human-readable error for the user.
+/// Result returned by Git preparation boundaries that only succeed or fail.
 pub(super) type PrepResult = Result<(), String>;
+
+/// Outcome of synchronizing a working copy to its fetched default branch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum WorkdirPrepOutcome {
+    /// Fetch and checkout completed; the worktree matches the remote default.
+    Ready,
+    /// Checkout refused because local tracked changes would be overwritten.
+    CheckoutBlockedByLocalChanges,
+}
 
 /// Resolve the repository's default branch for the working copy at `work_dir`.
 ///
@@ -399,7 +406,7 @@ pub(super) use jefe::git_info::porcelain_is_dirty;
 /// `branch` must be validated by [`is_valid_branch_name`] (called from
 /// [`resolve_default_branch`]) before being passed here, to prevent option
 /// injection.
-fn checkout_and_pull(work_dir: &Path, branch: &str) -> Result<(), String> {
+fn checkout_and_pull(work_dir: &Path, branch: &str) -> Result<WorkdirPrepOutcome, String> {
     debug_assert!(
         is_valid_branch_name(branch),
         "branch must be validated by resolve_default_branch before calling checkout_and_pull"
@@ -412,7 +419,7 @@ fn checkout_and_pull(work_dir: &Path, branch: &str) -> Result<(), String> {
     // The `--` disambiguates the following args (none here) from pathspecs.
     let checkout_result = git_capture(work_dir, ["checkout", "-B", branch, &remote_ref, "--"]);
     match checkout_result {
-        Ok(output) if output.status.success() => Ok(()),
+        Ok(output) if output.status.success() => Ok(WorkdirPrepOutcome::Ready),
         Ok(output) => {
             // checkout failed — could be a linked worktree where the branch
             // is already checked out in the primary worktree. Only reset
@@ -420,12 +427,17 @@ fn checkout_and_pull(work_dir: &Path, branch: &str) -> Result<(), String> {
             // branch; otherwise resetting would move the wrong branch ref
             // and risk discarding commits on an unrelated branch.
             let stderr = String::from_utf8_lossy(&output.stderr);
-            // Locale-independent: git_capture sets LC_ALL=C, so this English
-            // fragment is reliable regardless of the user's locale.
-            if stderr.contains("already used by worktree") {
+            // Locale-independent: git_capture sets LC_ALL=C, so these English
+            // fragments are reliable regardless of the user's locale.
+            if stderr
+                .contains("local changes to the following files would be overwritten by checkout")
+            {
+                Ok(WorkdirPrepOutcome::CheckoutBlockedByLocalChanges)
+            } else if stderr.contains("already used by worktree") {
                 let current = current_branch_name(work_dir)?;
                 if current == branch {
-                    git_require_success(work_dir, ["reset", "--hard", &remote_ref])
+                    git_require_success(work_dir, ["reset", "--hard", &remote_ref])?;
+                    Ok(WorkdirPrepOutcome::Ready)
                 } else {
                     Err(format!(
                         "Cannot reset to {remote_ref}: worktree is on branch '{current}', \
@@ -462,7 +474,7 @@ fn current_branch_name(work_dir: &Path) -> Result<String, String> {
 /// Prepare the working copy for a fresh issue-driven launch: resolve the
 /// default branch, check it out, and pull. Does **not** touch uncommitted
 /// changes — callers must gate on [`is_workdir_dirty`] first.
-pub(super) fn prepare_issue_workdir(work_dir: &Path) -> PrepResult {
+pub(super) fn prepare_issue_workdir(work_dir: &Path) -> Result<WorkdirPrepOutcome, String> {
     let branch = resolve_default_branch(work_dir)?;
     checkout_and_pull(work_dir, &branch)
 }

--- a/src/app_input/issue_prep.rs
+++ b/src/app_input/issue_prep.rs
@@ -34,8 +34,9 @@ use jefe::domain::RemoteRepositorySettings;
 
 use super::clone_identity::CloneIdentity;
 use super::issue_git_prep::{
-    WorkdirAssurance, discard_workdir_changes, ensure_workdir_cloned, ensure_workdir_with_origin,
-    is_workdir_dirty, prepare_issue_workdir, remove_workdir,
+    WorkdirAssurance, WorkdirPrepOutcome, discard_checkout_blocking_tracked_changes,
+    discard_workdir_changes, ensure_workdir_cloned, ensure_workdir_with_origin, is_workdir_dirty,
+    prepare_issue_workdir, remove_workdir,
 };
 
 /// Relative path of the issue prompt inside the work dir. This is the single
@@ -241,7 +242,21 @@ fn run_local_policy_and_prep(
             DirtyPolicy::Discard => discard_workdir_changes(work_dir)?,
         }
     }
-    prepare_issue_workdir(work_dir)?;
+    match prepare_issue_workdir(work_dir)? {
+        WorkdirPrepOutcome::Ready => {}
+        WorkdirPrepOutcome::CheckoutBlockedByLocalChanges => match policy {
+            DirtyPolicy::Stop => return Ok(PrepOutcome::Dirty),
+            DirtyPolicy::Discard => {
+                discard_checkout_blocking_tracked_changes(work_dir)?;
+                if prepare_issue_workdir(work_dir)? != WorkdirPrepOutcome::Ready {
+                    return Err(
+                        "Working copy is still blocking default-branch checkout after discard"
+                            .to_owned(),
+                    );
+                }
+            }
+        },
+    }
     write_prompt_local(work_dir, prompt)?;
     Ok(PrepOutcome::Ready)
 }

--- a/src/app_input/issue_prep_tests.rs
+++ b/src/app_input/issue_prep_tests.rs
@@ -134,6 +134,117 @@ fn run_git(cwd: &Path, args: &[&str]) {
     );
 }
 
+fn owned_checkout_conflict(label: &str) -> (PathBuf, PathBuf) {
+    let origin = bare_origin_with_commit(label);
+    let work = clone_origin(&origin, label);
+    run_git(&work, &["config", "user.email", "test@example.com"]);
+    run_git(&work, &["config", "user.name", "Test"]);
+    std::fs::create_dir_all(work.join(".llxprt")).value_or_panic("create owned directory");
+    std::fs::write(work.join(".llxprt/LLXPRT.md"), "main memory")
+        .value_or_panic("write main owned file");
+    run_git(&work, &["add", ".llxprt/LLXPRT.md"]);
+    run_git(&work, &["commit", "-m", "add main owned metadata"]);
+    run_git(&work, &["push", "origin", "main"]);
+    run_git(&work, &["checkout", "-b", "feature"]);
+    std::fs::write(work.join(".llxprt/LLXPRT.md"), "feature memory")
+        .value_or_panic("write feature owned file");
+    run_git(&work, &["add", ".llxprt/LLXPRT.md"]);
+    run_git(&work, &["commit", "-m", "change feature owned metadata"]);
+    std::fs::write(work.join(".llxprt/LLXPRT.md"), "local memory")
+        .value_or_panic("modify owned metadata locally");
+    (origin, work)
+}
+
+fn git_stdout(work_dir: &Path, args: &[&str]) -> String {
+    let output = issue_git_prep::git_capture(work_dir, args)
+        .unwrap_or_else(|error| panic!("git {} failed: {error}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn local_checkout_blocker_returns_dirty_without_changing_worktree_or_index() {
+    let (origin, work) = owned_checkout_conflict("owned-checkout-stop");
+    let branch_before = git_stdout(&work, &["branch", "--show-current"]);
+    let head_before = git_stdout(&work, &["rev-parse", "HEAD"]);
+    let index_before = git_stdout(&work, &["ls-files", "--stage"]);
+    let status_before = git_stdout(&work, &["status", "--porcelain=v1"]);
+
+    let outcome = prepare_local(&work, None, DirtyPolicy::Stop, "prompt")
+        .value_or_panic("checkout conflict should become dirty outcome");
+
+    assert_eq!(outcome, PrepOutcome::Dirty);
+    assert_eq!(
+        git_stdout(&work, &["branch", "--show-current"]),
+        branch_before
+    );
+    assert_eq!(git_stdout(&work, &["rev-parse", "HEAD"]), head_before);
+    assert_eq!(git_stdout(&work, &["ls-files", "--stage"]), index_before);
+    assert_eq!(
+        git_stdout(&work, &["status", "--porcelain=v1"]),
+        status_before
+    );
+    assert_eq!(
+        std::fs::read_to_string(work.join(".llxprt/LLXPRT.md"))
+            .value_or_panic("read preserved local memory"),
+        "local memory"
+    );
+    assert!(!work.join(".jefe/issue-prompt.md").exists());
+    cleanup(origin.parent().unwrap_or(&origin));
+    cleanup(&work);
+}
+
+#[test]
+fn local_confirmed_checkout_blocker_discard_reaches_fetched_main() {
+    let (origin, work) = owned_checkout_conflict("owned-checkout-discard");
+    std::fs::write(work.join(".llxprt/session.json"), "preserve me")
+        .value_or_panic("write untracked owned metadata");
+    std::fs::write(work.join("remove-me.txt"), "discard me")
+        .value_or_panic("write non-owned untracked file");
+    let prompt = "Work issue 316.";
+
+    let outcome = prepare_local(&work, None, DirtyPolicy::Discard, prompt)
+        .value_or_panic("confirmed checkout conflict cleanup");
+
+    assert_eq!(outcome, PrepOutcome::Ready);
+    assert_eq!(
+        git_stdout(&work, &["rev-parse", "HEAD"]),
+        git_stdout(&work, &["rev-parse", "origin/main"])
+    );
+    assert_eq!(
+        git_stdout(&work, &["branch", "--show-current"]).trim(),
+        "main"
+    );
+    assert!(
+        git_stdout(&work, &["diff", "--cached", "--name-only"])
+            .trim()
+            .is_empty(),
+        "confirmed cleanup must leave no staged changes"
+    );
+    assert!(!work.join("remove-me.txt").exists());
+    assert_eq!(
+        std::fs::read_to_string(work.join(".llxprt/LLXPRT.md"))
+            .value_or_panic("read main owned metadata"),
+        "main memory"
+    );
+    assert_eq!(
+        std::fs::read_to_string(work.join(".llxprt/session.json"))
+            .value_or_panic("read preserved untracked owned metadata"),
+        "preserve me"
+    );
+    assert_eq!(
+        std::fs::read_to_string(work.join(".jefe/issue-prompt.md")).value_or_panic("read prompt"),
+        prompt
+    );
+    cleanup(origin.parent().unwrap_or(&origin));
+    cleanup(&work);
+}
+
 fn cleanup(path: &Path) {
     // Best-effort cleanup; failures are silently ignored because this runs at
     // the end of every test and a missing/non-empty dir is not actionable.


### PR DESCRIPTION
## Summary

- classify locale-stabilized Git checkout failures caused by tracked local changes as a typed preparation outcome
- route those checkout blockers into the existing safe-by-default dirty-working-copy confirmation dialog
- after explicit confirmation, restore blocking tracked paths, preserve untracked Jefe/LLxprt metadata, retry preparation, and continue from the fetched default branch
- extend the TUI scenario so it activates the selected Confirm action instead of only moving focus

## Acceptance behavior

- Sending an issue with ordinary dirty changes continues to open the existing confirmation dialog.
- A checkout blocked by tracked Jefe/LLxprt metadata now opens the same confirmation dialog rather than surfacing raw Git stderr.
- Cancel leaves the branch, HEAD, index, status, working-copy bytes, and prompt state unchanged.
- Confirm discards the blocking tracked changes, removes non-owned untracked files, preserves untracked Jefe/LLxprt metadata, checks out the fetched main branch, writes the issue prompt, and allows launch preparation to continue.
- Unrelated checkout failures remain errors; remote preparation behavior is unchanged.

## Test evidence

- Added real-Git regression coverage for non-destructive Stop behavior.
- Added real-Git regression coverage for confirmed cleanup and synchronization to origin/main.
- Updated the dirty-copy TUI scenario to focus Confirm and press Enter.
- Full exact-head local gate passed after rebasing onto current main:

    PATH=/Users/acoliver/.rustup/toolchains/stable-aarch64-apple-darwin/bin:/Users/acoliver/.cargo/bin:/opt/homebrew/bin:/usr/bin:/bin CARGO_TARGET_DIR=target/issue316-ci make ci-check

## Reviews

- rustreviewer completed; actionable in-scope test and documentation findings were addressed.
- Open Code Review completed over all changed implementation/test/scenario files and reported no findings.
- Broader remote-shell safety redesign and deterministic TUI fixture infrastructure are recorded as bounded follow-ups in the issue plan.

Fixes #316
