### PR TITLE
Bound fresh issue delivery prompts to accepted scope (Fixes #313)

### DIFF
--- a/project-plans/issue313-plan.md
+++ b/project-plans/issue313-plan.md
@@ -1,0 +1,98 @@
+# Issue 313: bounded fresh issue delivery prompts
+
+## Issue and decision
+
+Issue: https://github.com/vybestack/llxprt-jefe/issues/313
+
+Fresh Send Issue launches currently append an open-ended implementation and review loop to the issue prompt. The replacement will be one concise, runtime-neutral launch instruction that points agents to `dev-docs/workflow/ISSUE-DELIVERY.md` and states the policy's essential scope, review, exact-head, and stopping guardrails. The generated `.jefe/issue-prompt.md` remains owned by the existing issue formatter; the canonical workflow is referenced from the launch instruction rather than copied into that file.
+
+The issue and its single automated planning comment are decision-complete: they require the documented four review dispositions (`Blocker-Fix`, `In-scope-Fix`, `Reject`, and `Defer`), the documented file/line thresholds, and the two-local/two-PR OCR cap. No prompt-generation, pull-request, runtime-command, workflow, dependency, or quality-policy change is needed.
+
+## Acceptance matrix
+
+| ID | Actor / launch path | Input and boundary | Observable success | Failure / diagnostic | Side effects before failure | Persistence / compatibility | Behavioral evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| A1 | LLxprt fresh Send Issue | Issue prompt path plus persisted LLxprt mode flags, including optional `--yolo` and stale `--continue` | Launch receives the bounded issue contract after `-i`; existing flags are preserved except `--continue` | Existing launch diagnostics remain authoritative | No new side effects | Existing fresh/non-resuming behavior remains | Unit tests compare runtime contracts and preserve LLxprt flags |
+| A2 | Code Puppy fresh Send Issue | Issue prompt path and any stale runtime flags | Launch receives the same bounded issue contract as its sole positional prompt | Existing launch diagnostics remain authoritative | No new side effects | Existing positional-prompt behavior remains | Unit tests compare runtime contracts and assert one positional argument |
+| A3 | Either fresh Send Issue runtime | Delivery instruction is constructed | Instruction references the canonical policy; requires acceptance shaping, non-goals, bounded slices, expected paths, scope ledger, approval stops, documented thresholds, four-way review triage, the two-local/two-PR OCR cap, exact-head readiness, and successful stopping | A missing contract clause fails a focused semantic assertion | None | Runtime-neutral string contract | Focused semantic unit tests, not a giant exact-string assertion |
+| A4 | Either fresh Send Issue runtime | Review produces a valid suggestion outside accepted scope | Contract permits `Reject` or `Defer` and does not require implementing every actionable suggestion | Semantic negative assertion detects the superseded open-ended command | None | Canonical review policy remains authoritative | Unit test rejects the old "address every actionable finding" wording |
+| A5 | LLxprt or Code Puppy fresh Send PR | Pull-request prompt path | Existing PR instruction remains exactly unchanged | Unit regression identifies any accidental issue-contract append | None | Existing PR launch behavior remains | Existing exact PR prompt tests |
+| A6 | Issue prompt formatter | Issue facts, focused comment, and configured issue base prompt | No canonical workflow text is embedded in `.jefe/issue-prompt.md`; launch instruction owns the policy reference | Existing formatter tests remain authoritative | Existing prompt write only | Prompt format remains unchanged | No formatter production change; full regression suite |
+
+## Explicit non-goals
+
+- Weakening architecture, lint, complexity, source-size, safety, coverage, cross-platform, TDD, or CI requirements.
+- Embedding the canonical workflow text in `.jefe/issue-prompt.md` or changing issue prompt formatting.
+- Adding automatic issue decomposition, a mechanical scope checker, or a new public abstraction.
+- Changing pull-request fresh prompts, runtime command construction, launch flags, persistence, or orchestration.
+- Changing `.llxprt/`, `.code_puppy/`, `.github/`, dependencies, quality gates, or workflow policy.
+- Expanding the canonical policy itself; this issue only makes fresh issue launches reference and summarize it.
+
+## Vertical slice
+
+### Slice 1: bounded runtime-neutral Send Issue contract
+
+- Acceptance: A1-A6.
+- Owner: fresh-prompt launch-signature adapter.
+- Allowed paths: `src/app_input/fresh_prompt.rs`, the end-to-end launch assertion in `src/app_input/issue_send_modal_tests.rs`, and this issue plan.
+- RED: replace the giant exact-string test with semantic contract tests that require every accepted guardrail and reject the superseded open-ended review command; run the focused test target and confirm failure against the old constant.
+- GREEN: replace `ISSUE_DELIVERY_WORKFLOW` with the concise canonical-policy reference and required bounded clauses.
+- Refactor: keep semantic groups in focused tests and preserve existing runtime/PR regression coverage.
+- Verification: focused fresh-prompt tests, `make quick-check`, then exact-head `make ci-check`.
+- Stop for approval: any need to change the issue formatter, PR behavior, runtime command layer, canonical workflow policy, public API, dependency/tooling, or files outside the allowed paths.
+
+## Expected paths by layer
+
+- Launch adapter and unit behavior: `src/app_input/fresh_prompt.rs`.
+- Send Issue integration assertion: `src/app_input/issue_send_modal_tests.rs`.
+- Planning, scope, review counters, and evidence: `project-plans/issue313-plan.md`.
+- Canonical policy: `dev-docs/workflow/ISSUE-DELIVERY.md` is read-only for this issue.
+- Prompt formatter: `src/app_input/issues_dispatch.rs` is read-only; no workflow text is added to generated issue facts/comments.
+
+## Test-first sequence
+
+1. Replace the exact full-string workflow assertion with focused semantic assertions for policy reference, acceptance shaping, scope-expansion stops and thresholds, review dispositions/cap, and exact-head successful stopping.
+2. Add a negative assertion that the old command to address every actionable finding is absent.
+3. Run the focused library tests and record RED against the existing open-ended instruction.
+4. Replace only `ISSUE_DELIVERY_WORKFLOW` with the bounded runtime-neutral contract.
+5. Run the focused tests to GREEN and retain existing LLxprt, Code Puppy, and PR regression tests.
+6. Run `make quick-check`, inspect the diff and scope counts, then run exact-head `make ci-check`.
+7. Use review runs only on a stable verified checkpoint and triage each finding under the canonical four dispositions.
+
+## Scope ledger
+
+| Discovered item | Disposition | Acceptance / reason |
+| --- | --- | --- |
+| Existing test asserts the entire old instruction as one exact string | Planned | A3 explicitly requires semantic tests instead |
+| Existing negative assertion forbids `OCR`, while the new contract must state the OCR cap | Planned | A3 requires two local and two PR OCR reviews |
+| Existing issue formatter can include a configured issue base prompt under `## Instructions` | Reject for this issue | Pre-existing user-configured issue content; the requested workflow remains separate and no formatter change is authorized |
+| Pull-request prompt uses the same adapter but no issue workflow suffix | Preserve | A5; exact existing tests protect it |
+| Send Issue integration test asserted superseded operational clauses | In-scope fix | A1 and A3; update it to assert the canonical reference and bounded scope/review contract |
+| Canonical policy contains broader operational detail than the launch string | Preserve by reference | Concision and single-policy ownership are explicit requirements |
+
+## Review counters
+
+- Local Open Code Review runs: 1 / 2
+- Post-PR Open Code Review runs: 0 / 2
+
+## Verification evidence
+
+- RED: `cargo test --bin jefe issue_delivery_workflow -- --nocapture` failed all four new semantic tests against the old contract, first identifying the missing canonical-policy reference, scope stop, review dispositions, and exact-head rule.
+- Focused GREEN: `cargo test --bin jefe issue_delivery_workflow -- --nocapture` passes all 4 contract tests.
+- Fresh-prompt regression GREEN: `cargo test --bin jefe fresh_prompt -- --nocapture` passes all 12 tests, including identical runtime contracts, LLxprt flag preservation, Code Puppy positional prompting, and unchanged PR prompts.
+- `make quick-check` initially exposed the related Send Issue integration assertion's superseded operational wording; after the in-scope semantic update, the command passes all format, check, unit, integration, and doctest targets.
+- Review-finding RED: the focused exact-head test failed until completion explicitly required resolving all `Blocker-Fix` and `In-scope-Fix` findings; it and all 12 fresh-prompt tests pass after the prompt update.
+- Exact-head `make ci-check` passes format, policy, source-size, both Clippy gates, 72.77% line coverage, locked build, and all locked tests.
+- Pending PR CI and review triage.
+
+## Review findings and dispositions
+
+| Reviewer | Finding | Disposition |
+| --- | --- | --- |
+| Open Code Review | Restore a giant exact-string assertion because semantic clause tests permit textual drift | Reject: issue 313 explicitly requires semantic verification without one giant exact-string assertion; focused positive groups plus negative superseded-wording coverage protect the accepted contract while allowing harmless prose edits |
+| Open Code Review | Retain the removed operational workflow inline in case the canonical policy is unavailable | Reject: the issue explicitly requires a concise policy reference and avoiding duplicated workflow text; fresh issue agents run in the prepared repository where the versioned policy path is available |
+| Open Code Review | Exact-head completion could classify findings without resolving accepted blocker and in-scope fixes | In-scope fix: added an explicit resolution requirement and test-first semantic coverage |
+
+## Deferred findings / follow-ups
+
+None.

--- a/project-plans/issue313-plan.md
+++ b/project-plans/issue313-plan.md
@@ -73,7 +73,7 @@ The issue and its single automated planning comment are decision-complete: they 
 ## Review counters
 
 - Local Open Code Review runs: 1 / 2
-- Post-PR Open Code Review runs: 0 / 2
+- Post-PR Open Code Review runs: 1 / 2
 
 ## Verification evidence
 
@@ -82,8 +82,8 @@ The issue and its single automated planning comment are decision-complete: they 
 - Fresh-prompt regression GREEN: `cargo test --bin jefe fresh_prompt -- --nocapture` passes all 12 tests, including identical runtime contracts, LLxprt flag preservation, Code Puppy positional prompting, and unchanged PR prompts.
 - `make quick-check` initially exposed the related Send Issue integration assertion's superseded operational wording; after the in-scope semantic update, the command passes all format, check, unit, integration, and doctest targets.
 - Review-finding RED: the focused exact-head test failed until completion explicitly required resolving all `Blocker-Fix` and `In-scope-Fix` findings; it and all 12 fresh-prompt tests pass after the prompt update.
-- Exact-head `make ci-check` passes format, policy, source-size, both Clippy gates, 72.77% line coverage, locked build, and all locked tests.
-- Pending PR CI and review triage.
+- Exact-head `make ci-check` passes format, policy, source-size, both Clippy gates, 72.77% line coverage, locked build, and all locked tests; it passed again after rebasing onto current `origin/main`.
+- PR CI passes on reviewed head `2431c3d`, including native Windows, coverage, build, tests, and Open Code Review; the PR is conflict-free with correct main ancestry.
 
 ## Review findings and dispositions
 
@@ -92,6 +92,7 @@ The issue and its single automated planning comment are decision-complete: they 
 | Open Code Review | Restore a giant exact-string assertion because semantic clause tests permit textual drift | Reject: issue 313 explicitly requires semantic verification without one giant exact-string assertion; focused positive groups plus negative superseded-wording coverage protect the accepted contract while allowing harmless prose edits |
 | Open Code Review | Retain the removed operational workflow inline in case the canonical policy is unavailable | Reject: the issue explicitly requires a concise policy reference and avoiding duplicated workflow text; fresh issue agents run in the prepared repository where the versioned policy path is available |
 | Open Code Review | Exact-head completion could classify findings without resolving accepted blocker and in-scope fixes | In-scope fix: added an explicit resolution requirement and test-first semantic coverage |
+| Post-PR Open Code Review | Add direct unit proof that the composed issue instruction includes the workflow suffix | Reject as already covered: `issue_send_forces_pass_continue_false_on_launch_signature` exercises the public Send Issue composition and asserts representative bounded clauses, while the runtime-equality test proves both launch paths receive that composed instruction |
 
 ## Deferred findings / follow-ups
 

--- a/src/app_input/fresh_prompt.rs
+++ b/src/app_input/fresh_prompt.rs
@@ -22,20 +22,24 @@ impl FreshPromptKind {
 /// instruction. Issue-specific content remains in the prompt file; this text
 /// defines how an agent must carry that issue through review and CI.
 const ISSUE_DELIVERY_WORKFLOW: &str = concat!(
-    "Complete the issue end to end: start from the latest base branch without deleting unrelated ",
-    "or agent-configuration files; create a dedicated issue branch before changing code; use gh ",
-    "to fetch the issue and all comments; research the codebase and make a test-first ",
-    "implementation plan; implement the change and run the repository's complete verification ",
-    "suite; commit and push the branch; create a detailed pull request linked to the issue; watch ",
-    "every pull-request workflow until terminal completion, continuing to poll with a bounded delay ",
-    "even when a watch command or shell invocation times out; inspect failed workflow logs, fix ",
-    "failures, rerun verification, commit, push, and watch again; collect all project review ",
-    "feedback, including ordinary reviews, inline threads, and automated review comments; address ",
-    "every actionable finding, reply in the corresponding review thread with the fix or why it does ",
-    "not apply, and resolve addressed threads where supported; repeat the checks, reviews, fixes, ",
-    "replies, and workflow watches until all required checks pass and no actionable unresolved review ",
-    "feedback remains. Do not return merely because workflows are pending; report only completion or ",
-    "a genuine external blocker."
+    "Follow the canonical bounded issue-delivery policy in ",
+    "dev-docs/workflow/ISSUE-DELIVERY.md. Before implementation, shape a decision-complete ",
+    "acceptance matrix and record explicit non-goals, bounded vertical slices, expected paths, and a ",
+    "scope ledger. Agents must stop for approval before adding an unplanned subsystem or public ",
+    "abstraction, ",
+    "making a workflow, agent-memory, quality-tool, or dependency change, moving an unrelated ",
+    "refactor or test move into scope, implementing behavior outside the acceptance matrix, or ",
+    "exceeding the hard scope budget. Target no more than 25 files or 1,500 net changed lines, perform ",
+    "a mandatory scope review above either threshold, and stop without approval above 40 files or ",
+    "2,500 net changed lines. Classify every review finding as Blocker-Fix, In-scope-Fix, Reject, or ",
+    "Defer; reviewer suggestions do not authorize scope expansion. Limit Open Code Review to two ",
+    "local and two PR OCR reviews per issue/PR effort. Declare exact-head completion only when every ",
+    "accepted behavior has behavioral evidence, local verification and CI pass on the candidate head, ",
+    "reviews are complete and triaged, all Blocker-Fix and In-scope-Fix findings are resolved, correct ",
+    "ancestry is confirmed, the PR is conflict-free, and the scope ",
+    "ledger is clean. Stop successfully when accepted behavior and all required gates are complete. ",
+    "Do not continue optional hardening or cleanup, and do not weaken architecture, TDD, lint, ",
+    "complexity, source-size, safety, coverage, cross-platform, or CI requirements."
 );
 
 fn fresh_prompt_instruction(prompt_kind: FreshPromptKind, prompt_relative_path: &str) -> String {
@@ -106,18 +110,79 @@ mod tests {
     }
 
     #[test]
-    fn issue_delivery_workflow_is_exact_and_runtime_neutral() {
-        let expected = concat!(
-            "Read and work on the GitHub issue described in .jefe/issue-prompt.md. ",
-            "Complete the issue end to end: start from the latest base branch without deleting unrelated or agent-configuration files; create a dedicated issue branch before changing code; use gh to fetch the issue and all comments; research the codebase and make a test-first implementation plan; implement the change and run the repository's complete verification suite; commit and push the branch; create a detailed pull request linked to the issue; watch every pull-request workflow until terminal completion, continuing to poll with a bounded delay even when a watch command or shell invocation times out; inspect failed workflow logs, fix failures, rerun verification, commit, push, and watch again; collect all project review feedback, including ordinary reviews, inline threads, and automated review comments; address every actionable finding, reply in the corresponding review thread with the fix or why it does not apply, and resolve addressed threads where supported; repeat the checks, reviews, fixes, replies, and workflow watches until all required checks pass and no actionable unresolved review feedback remains. Do not return merely because workflows are pending; report only completion or a genuine external blocker."
-        );
-
-        assert_eq!(
-            fresh_prompt_instruction(FreshPromptKind::Issue, ".jefe/issue-prompt.md"),
-            expected
-        );
-        assert!(!ISSUE_DELIVERY_WORKFLOW.contains("OCR"));
+    fn issue_delivery_workflow_references_policy_and_shapes_accepted_scope() {
+        for required in [
+            "dev-docs/workflow/ISSUE-DELIVERY.md",
+            "decision-complete acceptance matrix",
+            "explicit non-goals",
+            "bounded vertical slices",
+            "expected paths",
+            "scope ledger",
+        ] {
+            assert!(
+                ISSUE_DELIVERY_WORKFLOW.contains(required),
+                "issue delivery workflow must require {required}"
+            );
+        }
         assert!(!ISSUE_DELIVERY_WORKFLOW.contains("CodeRabbit"));
+    }
+
+    #[test]
+    fn issue_delivery_workflow_stops_unplanned_scope_expansion() {
+        for required in [
+            "stop for approval",
+            "unplanned subsystem",
+            "public abstraction",
+            "workflow, agent-memory, quality-tool, or dependency change",
+            "unrelated refactor or test move",
+            "behavior outside the acceptance matrix",
+            "25 files or 1,500 net changed lines",
+            "40 files or 2,500 net changed lines",
+        ] {
+            assert!(
+                ISSUE_DELIVERY_WORKFLOW.contains(required),
+                "issue delivery workflow must include scope guardrail: {required}"
+            );
+        }
+    }
+
+    #[test]
+    fn issue_delivery_workflow_bounds_and_triages_review() {
+        for required in [
+            "Blocker-Fix",
+            "In-scope-Fix",
+            "Reject",
+            "Defer",
+            "two local and two PR OCR reviews",
+        ] {
+            assert!(
+                ISSUE_DELIVERY_WORKFLOW.contains(required),
+                "issue delivery workflow must include review rule: {required}"
+            );
+        }
+        assert!(!ISSUE_DELIVERY_WORKFLOW.contains("address every actionable finding"));
+    }
+
+    #[test]
+    fn issue_delivery_workflow_defines_exact_head_success() {
+        for required in [
+            "exact-head",
+            "behavioral evidence",
+            "local verification",
+            "CI",
+            "reviews are complete and triaged",
+            "Blocker-Fix and In-scope-Fix findings are resolved",
+            "correct ancestry",
+            "conflict-free",
+            "scope ledger is clean",
+            "Stop successfully",
+            "Do not continue optional hardening",
+        ] {
+            assert!(
+                ISSUE_DELIVERY_WORKFLOW.contains(required),
+                "issue delivery workflow must include completion rule: {required}"
+            );
+        }
     }
 
     #[test]

--- a/src/app_input/issue_send_modal_tests.rs
+++ b/src/app_input/issue_send_modal_tests.rs
@@ -134,12 +134,11 @@ fn issue_send_forces_pass_continue_false_on_launch_signature() {
         .find(|arg| arg.contains(".jefe/issue-prompt.md"))
         .value_or_panic("issue launch signature must include an instruction");
     assert!(instruction.contains(".jefe/issue-prompt.md"));
-    assert!(instruction.contains("create a dedicated issue branch"));
-    assert!(instruction.contains("create a detailed pull request"));
-    assert!(instruction.contains("continuing to poll with a bounded delay"));
-    assert!(instruction.contains("ordinary reviews, inline threads"));
-    assert!(instruction.contains("reply in the corresponding review thread"));
-    assert!(instruction.contains("no actionable unresolved review feedback remains"));
+    assert!(instruction.contains("dev-docs/workflow/ISSUE-DELIVERY.md"));
+    assert!(instruction.contains("decision-complete acceptance matrix"));
+    assert!(instruction.contains("stop for approval"));
+    assert!(instruction.contains("Blocker-Fix"));
+    assert!(instruction.contains("scope ledger is clean"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Replace the open-ended fresh Send Issue workflow with a concise runtime-neutral contract that references the canonical bounded policy.
- Require acceptance shaping, explicit scope budgets and approval stops, four-way review triage, bounded OCR runs, exact-head readiness, and a successful stopping condition.
- Preserve identical LLxprt and Code Puppy issue contracts, existing LLxprt flags, Code Puppy positional prompting, generated issue prompt content, and unchanged pull-request prompts.
- Record the acceptance matrix, non-goals, scope ledger, verification evidence, and local review dispositions in the issue plan.

Fixes #313

## Pre-push checklist

- [x] Format
- [x] Clippy allow policy
- [x] Source file length
- [x] Lint
- [x] Complexity
- [x] Coverage
- [x] Build
- [x] Tests
- [ ] TUI smoke — not applicable; this changes launch instruction text and unit/integration coverage, not rendered TUI behavior

## Testing notes

- Proved four semantic contract tests fail against the old open-ended instruction.
- Proved the review-resolution completion rule fail before adding its production clause.
- `cargo test --bin jefe fresh_prompt -- --nocapture`
- `make quick-check`
- `make ci-check` on the reviewed candidate and again on the rebased exact head
- Coverage: 72.77% lines
- Local Open Code Review: 1 of 2; all three findings triaged, with one in-scope fix and two issue-contradicted suggestions rejected in the plan

## Scope

- 3 changed files
- No dependency, workflow, quality-gate, runtime-command, pull-request prompt, or issue prompt formatter changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved fresh issue delivery guidance with clearer scope limits, review thresholds, and stop conditions.
  * Added explicit triage categories and bounded review expectations for blockers and in-scope findings.
  * Added exact-head completion requirements to clarify when issue delivery is complete.

* **Documentation**
  * Added a detailed implementation and acceptance plan for bounded issue delivery prompts.

* **Tests**
  * Updated validation to check the new workflow requirements and acceptance language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->