### PR TITLE
Publish minimal first-agent tutorial capture (Fixes #241)

### DIFF
--- a/dev-docs/testing/tmux-harness.md
+++ b/dev-docs/testing/tmux-harness.md
@@ -75,7 +75,8 @@ Each step object has one primitive key.
 | Step | Example | Behavior |
 | --- | --- | --- |
 | `wait` | `{ "wait": 100 }` | Sleep for milliseconds. Prefer `waitFor` where possible. |
-| `line` | `{ "line": "hello" }` | Type a full line and press Enter. |
+| `line` | `{ "line": "hello" }` | Type literal text and press Enter. |
+| `type` | `{ "type": "hello" }` | Type literal text without pressing Enter; use this for form fields. |
 | `key` | `{ "key": "?" }` | Send one tmux key token. |
 | `keys` | `{ "keys": ["Tab", "Enter"] }` | Send a sequence of key tokens. |
 | `waitFor` | `{ "waitFor": "Help" }` | Poll the screen until a literal appears. |
@@ -168,6 +169,38 @@ artifact directory.
 - Capture useful checkpoints before quitting so alternate-buffer teardown does
   not hide the interesting screen.
 - Keep scratch/manual scenarios outside required CI until they prove stable.
+
+## First-agent tutorial capture
+
+The Unix-only tutorial workflow creates one exclusive run-owned root, starts the
+real Jefe binary with isolated config and runtime socket paths, and puts a
+local deterministic `llxprt` shim first on its isolated `PATH`:
+
+```bash
+cargo build --workspace --all-features --locked --bins
+scripts/issue241-capture.sh capture \
+  --root /tmp/jefe-first-agent-capture \
+  --jefe-bin "$PWD/target/debug/jefe" \
+  --harness-bin "$PWD/target/debug/jefe-tmux-harness"
+```
+
+The root must be an absolute path that does not already exist. Semantic evidence
+is retained under `evidence/`; publication-validated fixed-size SVGs are written
+under `publication/`; `private/` is diagnostic and is never publication-safe.
+The success or failed outcome and exact Jefe revision/version are recorded in
+`manifest.txt`.
+
+Preview manifest-scoped cleanup before confirming it:
+
+```bash
+scripts/issue241-capture.sh cleanup --dry-run \
+  --root /tmp/jefe-first-agent-capture
+scripts/issue241-capture.sh cleanup --confirm \
+  --root /tmp/jefe-first-agent-capture
+```
+
+Cleanup removes only exact contained paths recorded by that run. Evidence,
+publication assets, the manifest, and unowned paths are retained.
 
 ## Tmux availability and skipping
 

--- a/dev-docs/tmux-scenarios/first-agent-tutorial.json
+++ b/dev-docs/tmux-scenarios/first-agent-tutorial.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "cols": 100,
+    "rows": 32,
+    "history_limit": 2000,
+    "wait_timeout_ms": 10000,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "expect": "No terminal attached" },
+    { "capture": "first-agent-dashboard" },
+
+    { "key": "N" },
+    { "waitFor": "New Repository" },
+    { "expect": "Base Dir" },
+    { "capture": "first-agent-new-repository" },
+    { "type": "Tutorial Repository" },
+    { "key": "Tab" },
+    { "type": "fixture-repo" },
+    { "key": "Enter" },
+    { "waitFor": "1 repos | 0/0 running" },
+
+    { "key": "n" },
+    { "waitFor": "New Agent" },
+    { "expect": "Agent Runtime" },
+    { "capture": "first-agent-new-agent" },
+    { "key": "Tab" },
+    { "type": "Tutorial Agent" },
+    { "key": "Enter" },
+    { "waitFor": "Tutorial Agent" },
+    { "waitFor": "tutorial-shim: ready" },
+    { "expect": "F12 unfocus" },
+    { "capture": "first-agent-terminal-ready" },
+
+    { "type": "hello from the tutorial" },
+    { "key": "Enter" },
+    { "waitFor": "tutorial-shim: response: hello from the" },
+    { "expect": "tutorial" },
+    { "capture": "first-agent-terminal-response" },
+
+    { "key": "F12" },
+    { "waitFor": "t/f12 terminal focus" },
+    { "expect": "Tutorial Agent" },
+    { "capture": "first-agent-result" },
+    { "key": "C-q" },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/docs/assets/first-agent-new-agent.svg
+++ b/docs/assets/first-agent-new-agent.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="576" viewBox="0 0 800 576" role="img">
-<rect width="800" height="576" fill="#000000"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="594" viewBox="0 0 800 594" role="img">
+<rect width="800" height="594" fill="#000000"/>
 <text x="8" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">
 <tspan x="8" y="20">╭──────────────────────────────────────────────────────────────────────────────────────────────────╮</tspan>
 <tspan x="8" y="38">│                                                                                                  │</tspan>

--- a/docs/assets/first-agent-new-agent.svg
+++ b/docs/assets/first-agent-new-agent.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="576" viewBox="0 0 800 576" role="img">
+<rect width="800" height="576" fill="#000000"/>
+<text x="8" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">
+<tspan x="8" y="20">╭──────────────────────────────────────────────────────────────────────────────────────────────────╮</tspan>
+<tspan x="8" y="38">│                                                                                                  │</tspan>
+<tspan x="8" y="56">│  New Agent                                                                                       │</tspan>
+<tspan x="8" y="74">│                                                                                                  │</tspan>
+<tspan x="8" y="92">│   Shortcut (1-9)   [1]                                                                           │</tspan>
+<tspan x="8" y="110">│   Name             []                                                                            │</tspan>
+<tspan x="8" y="128">│   Description      []                                                                            │</tspan>
+<tspan x="8" y="146">│   Work Dir         [fixture-repo]                                                                │</tspan>
+<tspan x="8" y="164">│   Profile          []                                                                            │</tspan>
+<tspan x="8" y="182">│   Agent Runtime    [LLxprt]  (space cycles: LLxprt / code_puppy)                                 │</tspan>
+<tspan x="8" y="200">│   Mode Flags       [--yolo]                                                                      │</tspan>
+<tspan x="8" y="218">│   Version          []                                                                            │</tspan>
+<tspan x="8" y="236">│   LLXPRT_DEBUG     []                                                                            │</tspan>
+<tspan x="8" y="254">│   Pass --continue  [x]  (space toggles)                                                          │</tspan>
+<tspan x="8" y="272">│   Sandbox          [ ]  (space toggles)                                                          │</tspan>
+<tspan x="8" y="290">│   Sandbox Engine   [Podman]  (disabled)                                                          │</tspan>
+<tspan x="8" y="308">│   Sandbox Flags    [--cpus=2 --memory=12288m --pids-limit=256]                                   │</tspan>
+<tspan x="8" y="326">│                                                                                                  │</tspan>
+<tspan x="8" y="344">│   Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles/cycles checkboxes      │</tspan>
+<tspan x="8" y="362">│                                                                                                  │</tspan>
+<tspan x="8" y="380">│                                                                                                  │</tspan>
+<tspan x="8" y="398">│                                                                                                  │</tspan>
+<tspan x="8" y="416">│                                                                                                  │</tspan>
+<tspan x="8" y="434">│                                                                                                  │</tspan>
+<tspan x="8" y="452">│                                                                                                  │</tspan>
+<tspan x="8" y="470">│                                                                                                  │</tspan>
+<tspan x="8" y="488">│                                                                                                  │</tspan>
+<tspan x="8" y="506">│                                                                                                  │</tspan>
+<tspan x="8" y="524">│                                                                                                  │</tspan>
+<tspan x="8" y="542">│                                                                                                  │</tspan>
+<tspan x="8" y="560">│                                                                                                  │</tspan>
+<tspan x="8" y="578">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</tspan>
+</text>
+</svg>

--- a/docs/assets/first-agent-new-repository.svg
+++ b/docs/assets/first-agent-new-repository.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="576" viewBox="0 0 800 576" role="img">
-<rect width="800" height="576" fill="#000000"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="594" viewBox="0 0 800 594" role="img">
+<rect width="800" height="594" fill="#000000"/>
 <text x="8" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">
 <tspan x="8" y="20">╭──────────────────────────────────────────────────────────────────────────────────────────────────╮</tspan>
 <tspan x="8" y="38">│                                                                                                  │</tspan>

--- a/docs/assets/first-agent-new-repository.svg
+++ b/docs/assets/first-agent-new-repository.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="576" viewBox="0 0 800 576" role="img">
+<rect width="800" height="576" fill="#000000"/>
+<text x="8" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">
+<tspan x="8" y="20">╭──────────────────────────────────────────────────────────────────────────────────────────────────╮</tspan>
+<tspan x="8" y="38">│                                                                                                  │</tspan>
+<tspan x="8" y="56">│  New Repository                                                                                  │</tspan>
+<tspan x="8" y="74">│                                                                                                  │</tspan>
+<tspan x="8" y="92">│   Name             [▏]                                                                           │</tspan>
+<tspan x="8" y="110">│   Base Dir         []                                                                            │</tspan>
+<tspan x="8" y="128">│   Default Profile  []                                                                            │</tspan>
+<tspan x="8" y="146">│   Default Agent    [LLxprt]  (space cycles: LLxprt / code_puppy)                                 │</tspan>
+<tspan x="8" y="164">│   Default Mode     [--yolo]                                                                      │</tspan>
+<tspan x="8" y="182">│   Default Version  []                                                                            │</tspan>
+<tspan x="8" y="200">│   GitHub Repo      []                                                                            │</tspan>
+<tspan x="8" y="218">│   Issues / PRs Repo []  (blank uses GitHub Repo)                                                 │</tspan>
+<tspan x="8" y="236">│   Remote Repository [ ]  (space toggles)                                                         │</tspan>
+<tspan x="8" y="254">│   Login User       []                                                                            │</tspan>
+<tspan x="8" y="272">│   Host / IP        []                                                                            │</tspan>
+<tspan x="8" y="290">│   SSH Port         []                                                                            │</tspan>
+<tspan x="8" y="308">│   Identity File    []                                                                            │</tspan>
+<tspan x="8" y="326">│   SSH Options (space-separated) []                                                               │</tspan>
+<tspan x="8" y="344">│   Run As User      []                                                                            │</tspan>
+<tspan x="8" y="362">│   Setup Env Default [ ]  (space toggles)                                                         │</tspan>
+<tspan x="8" y="380">│   Transient Dir    []  (blank uses /tmp)                                                         │</tspan>
+<tspan x="8" y="398">│   Max Transient    []  (0 = no limit)                                                            │</tspan>
+<tspan x="8" y="416">│                                                                                                  │</tspan>
+<tspan x="8" y="434">│   Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles remote options  Enter  │</tspan>
+<tspan x="8" y="452">│                                                                                                  │</tspan>
+<tspan x="8" y="470">│                                                                                                  │</tspan>
+<tspan x="8" y="488">│                                                                                                  │</tspan>
+<tspan x="8" y="506">│                                                                                                  │</tspan>
+<tspan x="8" y="524">│                                                                                                  │</tspan>
+<tspan x="8" y="542">│                                                                                                  │</tspan>
+<tspan x="8" y="560">│                                                                                                  │</tspan>
+<tspan x="8" y="578">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</tspan>
+</text>
+</svg>

--- a/docs/assets/first-agent-result.svg
+++ b/docs/assets/first-agent-result.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="576" viewBox="0 0 800 576" role="img">
+<rect width="800" height="576" fill="#000000"/>
+<text x="8" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">
+<tspan x="8" y="20"> LLxprt Jefe WARN: SSH agent socket is present but no identities are loaded. Run `ssh-add`  Green</tspan>
+<tspan x="8" y="38">╭────────────────────╮╭────────────────────────────────────────╮╭──────────────────────────────────╮</tspan>
+<tspan x="8" y="56">│ Repositories       ││ Agents                                 ││ Preview                          │</tspan>
+<tspan x="8" y="74">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="92">│ &gt; Tutorial Reposi… ││ &gt; * [1] Tutorial Agent                 ││ Name: Tutorial Agent             │</tspan>
+<tspan x="8" y="110">│                    ││                                        ││ Status: Running                  │</tspan>
+<tspan x="8" y="128">│                    ││                                        ││ Repo: (unknown)                  │</tspan>
+<tspan x="8" y="146">│                    ││                                        ││ Branch: (unknown)                │</tspan>
+<tspan x="8" y="164">│                    │╰────────────────────────────────────────╯│ Dir: fixture-repo/tutorial-agent │</tspan>
+<tspan x="8" y="182">│                    │╭────────────────────────────────────────╮│                                  │</tspan>
+<tspan x="8" y="200">│                    ││ Terminal (F12/t to focus)              ││ Todo:                            │</tspan>
+<tspan x="8" y="218">│                    ││tutorial-shim: ready                    ││   (no tasks)                     │</tspan>
+<tspan x="8" y="236">│                    ││hello from the tutorial                 ││                                  │</tspan>
+<tspan x="8" y="254">│                    ││tutorial-shim: response: hello from the ││                                  │</tspan>
+<tspan x="8" y="272">│                    ││tutorial                                ││                                  │</tspan>
+<tspan x="8" y="290">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="308">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="326">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="344">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="362">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="380">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="398">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="416">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="434">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="452">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="470">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="488">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="506">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="524">│                    ││                                        ││                                  │</tspan>
+<tspan x="8" y="542">│                    ││[terminal status redacted]││                                  │</tspan>
+<tspan x="8" y="560">╰────────────────────╯╰────────────────────────────────────────╯╰──────────────────────────────────╯</tspan>
+<tspan x="8" y="578"> ^/v navigate | &lt;/&gt; pane | t/f12 terminal focus | v active-only (repos+agents) | ⌥1-9        pid:[redacted]</tspan>
+</text>
+</svg>

--- a/docs/assets/first-agent-result.svg
+++ b/docs/assets/first-agent-result.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="576" viewBox="0 0 800 576" role="img">
-<rect width="800" height="576" fill="#000000"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="594" viewBox="0 0 800 594" role="img">
+<rect width="800" height="594" fill="#000000"/>
 <text x="8" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">
 <tspan x="8" y="20"> LLxprt Jefe WARN: SSH agent socket is present but no identities are loaded. Run `ssh-add`  Green</tspan>
 <tspan x="8" y="38">╭────────────────────╮╭────────────────────────────────────────╮╭──────────────────────────────────╮</tspan>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,10 @@ This guide is for the common first-run workflow:
 
 1. Create a repository in Jefe.
 2. Create your first agent in that repository.
-3. Start working without terminal-tab chaos.
+3. Send input to the agent and return to the dashboard.
+
+Start Jefe with `jefe` (or `cargo run` from a source checkout). The dashboard
+begins with the repository list focused and no terminal attached.
 
 ---
 
@@ -12,7 +15,7 @@ This guide is for the common first-run workflow:
 
 From the dashboard, press `N` (capital N) to open **New Repository**.
 
-![Create repository form](assets/jefe-create-repository.png)
+![New Repository form showing Name, Base Dir, runtime defaults, and optional remote fields](assets/first-agent-new-repository.svg)
 
 ### Repository fields
 
@@ -54,7 +57,7 @@ After submit, the repository is added and selected.
 
 With your repository selected, press `n` (lowercase n) to open **New Agent**.
 
-![Create agent form](assets/jefe-create-agent.png)
+![New Agent form showing its generated work directory, LLxprt runtime, and launch options](assets/first-agent-new-agent.svg)
 
 ### Agent fields and what they mean
 
@@ -113,7 +116,14 @@ With your repository selected, press `n` (lowercase n) to open **New Agent**.
 - `Enter`: submit
 - `Esc`: cancel
 
-After submit, the agent is created and selected.
+After submit, the agent is created and selected. Jefe focuses the terminal, so
+ordinary keystrokes go to the agent. Type your prompt and press `Enter`; the
+agent response appears in the same pane.
+
+Press `F12` to return keyboard control to Jefe. The terminal remains visible as
+a read-only preview, and the created agent remains selected and running.
+
+![Jefe dashboard after returning from terminal capture, with Tutorial Agent selected and its response visible](assets/first-agent-result.svg)
 
 ---
 

--- a/project-plans/issue241-plan.md
+++ b/project-plans/issue241-plan.md
@@ -1,0 +1,132 @@
+# Issue 241: minimal first-agent tutorial capture
+
+## Objective
+
+Ship the existing first-agent tutorial with current-main evidence from one safe,
+repeatable Unix-only run. The implementation is deliberately limited to one
+scenario, one LLxprt-named local shim, one run-owned root, plain semantic
+captures, and deterministic publication SVGs.
+
+## Acceptance matrix
+
+| Row | Actor / launch path | Input and boundaries | Observable success | Observable failure / diagnostics | Permitted side effects | Proof |
+| --- | --- | --- | --- | --- | --- | --- |
+| A1 | Documentation author runs `scripts/issue241-capture.sh capture` | Absolute, nonexistent run root; real Jefe and harness binaries | Root contains isolated home/config, local git fixture, socket directory, evidence, publication SVGs, and a success manifest with exact Jefe commit/version | Existing, relative, home-owned, or unsafe root is refused before creation; failed runs retain `private/diagnostic.txt`, harness failure artifacts, and a failed manifest | Create only beneath the requested root; no network or `gh` calls | Unix script contract tests plus two clean real runs and one final documented run |
+| A2 | Existing tmux harness executes `first-agent-tutorial.json` | Fixed 100x32 terminal; literal typing must not append Enter | Real UI adds the repository, then creates the agent without premature form submission | Parser/driver failures identify the exact failed scenario step | Harness-owned tmux session and run-root Jefe state only | Scenario is added first and shown RED because current main has no `type` primitive; focused parser/runner/driver tests then GREEN |
+| A3 | Jefe startup and runtime boundaries | Wrapper gives Jefe isolated HOME/config/socket and prepends one deterministic `llxprt` shim | Startup detects LLxprt by its normal PATH probe; launched agent prints ready text, accepts `hello from the tutorial`, and prints the expected response | Missing shim/runtime response fails a stable `waitFor`, preserving partial evidence | Local shim process and Jefe-private tmux socket under run root | Real scenario semantic checkpoints |
+| A4 | Beginner follows the documented UI path | Dashboard -> New Repository -> New Agent -> focused terminal -> F12 return | Captures occur only after stable visible assertions and show final dashboard/agent state | No fixed wait is used as evidence; assertion failure records failing step | UI persistence only in isolated config | Scenario review plus successful evidence text |
+| A5 | Documentation author publishes selected checkpoints | Six semantic captures with fixed dimensions/theme | Three selected deterministic SVGs have semantic filenames, no host/user/home/token/private-repo content, and are referenced with useful alt text | Publication validation rejects forbidden capture text before rendering/copying | Write run-root publication files; selected reviewed SVGs are committed under `docs/assets` | Script tests, content inspection, and tutorial link check |
+| A6 | Documentation author previews or performs cleanup | Manifest and sentinel must identify this run; only exact contained owned paths qualify | Dry-run lists only owned config/home/socket/fixture/private paths; confirmed cleanup removes those and preserves evidence/publication/manifest | Missing sentinel, changed paths, symlinks, or containment failures refuse cleanup | Recursive removal only for exact manifest-listed immediate children beneath this run root; no force operations | Unix cleanup contract tests and real-run dry-run/cleanup checks |
+
+## Explicit non-goals
+
+- No GitHub fixture, authenticated `gh`, remote read/mutation, branch/PR lifecycle,
+  or remote cleanup in the capture workflow.
+- No real LLxprt or Code Puppy validation, runtime matrix, Windows/psmux capture
+  behavior, or retry redesign.
+- No general capture framework, process supervisor, publication system, report
+  generator, ANSI parser, annotation system, or persistence/runtime/UI refactor.
+- No application behavior beyond the current visible first-agent path. The real
+  scenario demonstrated one narrow focus invariant missing after form submit;
+  this issue fixes only that responsible state boundary plus the harness
+  distinction between literal typing and line submit.
+- No automatic modification of committed documentation assets. The issue run is
+  editorially inspected and selected SVGs are copied into `docs/assets`.
+
+## Vertical slices
+
+### Slice 1: literal scenario typing (RED -> GREEN)
+
+- Rows: A2, A4.
+- Owner/boundary: typed harness scenario -> runner -> existing tmux/psmux drivers.
+- RED: add the real tutorial scenario with `type` steps and prove current main
+  rejects the primitive / cannot drive forms without implicit Enter.
+- GREEN: add one `Step::Type` variant that sends tmux literal text without Enter;
+  cover parsing, macro substitution, runner dispatch, and both driver argv paths.
+- Allowed paths: `dev-docs/tmux-scenarios/first-agent-tutorial.json`,
+  `src/harness/{step,expand,runner,tests,runner_tests,tmux_driver,tmux_driver_tests,psmux_driver,psmux_driver_tests}.rs`,
+  `dev-docs/testing/tmux-harness.md`.
+- Stop if reliable input requires app-state/runtime/persistence changes beyond a
+  small responsible-boundary fix.
+
+### Slice 2: bounded local capture and safety
+
+- Rows: A1, A3, A5, A6.
+- Owner/boundary: one private Unix shell workflow consuming the real binaries
+  and existing harness CLI.
+- RED: Unix contract tests for root refusal, failed-manifest truthfulness,
+  publication redaction refusal, and manifest-scoped dry-run/cleanup.
+- GREEN: add one issue-specific script that prepares the fixture/shim/wrapper,
+  runs the scenario, records the exact revision/version and outcome, validates
+  publication text, renders fixed SVGs, and performs exact manifest cleanup.
+- Allowed paths: `scripts/issue241-capture.sh`, `tests/issue241_capture.rs`.
+- Stop if this requires a reusable process, persistence, cleanup, or rendering
+  subsystem.
+
+### Slice 3: observed tutorial delivery
+
+- Rows: A1-A5.
+- Run the exact command twice from distinct clean roots, inspect semantic text
+  and SVGs, then edit prose to describe only observed behavior and commit three
+  to five selected images.
+- Allowed paths: `docs/getting-started.md`, `docs/assets/first-agent-*.svg`.
+- Stop if observed UI differs materially from the required narrative; adjust the
+  bounded scenario/tutorial rather than adding infrastructure.
+
+## Expected paths and architecture layers
+
+- Harness model/orchestration boundary: existing `src/harness/*` files above.
+- TUI acceptance: one JSON scenario and the existing real tmux CLI.
+- Unix documentation-production boundary: one issue-specific script and one
+  integration contract test.
+- Documentation: one existing tutorial, harness guide update, and three selected SVGs.
+- Plan/evidence ledger: this file.
+
+Target: at most 20 changed files and below 1,500 net lines. Generated SVG lines
+count toward the budget; reduce selected images before expanding the budget.
+
+## Scope ledger
+
+| Discovery | Disposition | Reason |
+| --- | --- | --- |
+| Current main includes issue 301 terminal focus/input responsiveness changes | In-scope fix at demonstrated boundary | Real run B routed the first prompt character to dashboard Help because form submit set `terminal_focused` without setting `pane_focus=Terminal`; a deterministic state regression and two clean real runs prove the narrow paired-state fix |
+| Initial attach-failure hypothesis | Reject and remove | A focused unit change passed but real run C failed identically; the ineffective experiment was removed rather than retained as speculative hardening |
+| Existing harness `line` always presses Enter and cannot fill a form field | In-scope fix | Smallest responsible harness boundary and the prior prototype's useful lesson |
+| Harness outer socket uses a per-process `-L` namespace outside the run root | No change | Acceptance's run-root socket is the Jefe runtime socket; broad harness socket redesign is unnecessary because the harness namespace is private and cleaned by its existing guard |
+| Prior PR 279 generalized capture, ANSI, GitHub, reports, and cleanup | Reject wholesale reuse | Explicitly outside this issue; only the literal `type` semantics inform Slice 1 |
+
+No unapproved scope changes.
+
+## Review counters
+
+- Open Code Review before PR: 2 / 2 attempted; both external OCR invocations
+  were terminated without producing output, so no findings were available to
+  triage.
+- Open Code Review after PR: 0 / 2.
+
+## Verification evidence
+
+Current implementation evidence (base revision `35cef9ddd4db24b32956de3369113e27b5f78139`):
+
+- RED scenario: parser rejected the initially unsupported `type` step.
+- Focused GREEN: 91 harness tests and four capture contract tests passed.
+- Real diagnosis: run B exposed terminal input routed to dashboard Help; run C
+  disproved the attach-failure hypothesis; run D proved the paired focus fix
+  and exposed only a wrapped semantic assertion.
+- Two clean capture roots: `/tmp/jefe-issue241-run-g` and
+  `/tmp/jefe-issue241-run-h` both succeeded with the real Jefe/tmux path and
+  success manifests; all selected SVGs compare byte-for-byte.
+- Publication audit: selected output contains no local user/home/repository/token
+  text; PID and tmux status content are deterministically redacted.
+- `make quick-check`: passed (all workspace tests).
+- Full CI-equivalent gates: format, policy, source-size, both Clippy passes,
+  coverage (72.75% lines), locked build, and locked tests passed. Two monolithic
+  invocations were externally interrupted during coverage compilation, so the
+  same exact gates were completed individually to terminal success.
+- Final documented capture: `/tmp/jefe-issue241-final-verified` succeeded after
+  the full gates; all three committed SVGs compare byte-for-byte with its output.
+- PR exact-head CI: pending.
+
+## Deferred findings / follow-ups
+
+None.

--- a/scripts/issue241-capture.sh
+++ b/scripts/issue241-capture.sh
@@ -179,6 +179,8 @@ publish_captures() {
 
 capture_run() {
     parse_capture "$@"
+    [ -x "$JEFE_BIN" ] || fail "jefe binary not found or not executable: $JEFE_BIN"
+    [ -x "$HARNESS_BIN" ] || fail "harness binary not found or not executable: $HARNESS_BIN"
     NORMAL_HOME=$HOME
     validate_new_root
     mkdir "$ROOT" || fail "could not create exclusive run root: $ROOT"

--- a/scripts/issue241-capture.sh
+++ b/scripts/issue241-capture.sh
@@ -49,6 +49,9 @@ validate_new_root() {
     case "$ROOT" in
         "$HOME"|"$HOME"/*) fail "run root must not be the normal home directory" ;;
     esac
+    ROOT_PARENT=$(dirname -- "$ROOT")
+    [ -d "$ROOT_PARENT" ] || fail "run root parent directory does not exist: $ROOT_PARENT"
+    [ ! -L "$ROOT_PARENT" ] || fail "run root parent directory must not be a symlink: $ROOT_PARENT"
     [ ! -e "$ROOT" ] && [ ! -L "$ROOT" ] || fail "run root must not exist"
 }
 

--- a/scripts/issue241-capture.sh
+++ b/scripts/issue241-capture.sh
@@ -2,6 +2,7 @@
 # Produce the bounded, local-only evidence for the first-agent tutorial.
 
 set -eu
+umask 077
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
@@ -183,7 +184,7 @@ capture_run() {
     [ -x "$HARNESS_BIN" ] || fail "harness binary not found or not executable: $HARNESS_BIN"
     NORMAL_HOME=$HOME
     validate_new_root
-    mkdir "$ROOT" || fail "could not create exclusive run root: $ROOT"
+    mkdir "$ROOT" 2>/dev/null || fail "run root already exists or cannot be created: $ROOT"
     JEFE_COMMIT=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || printf unknown)
     JEFE_VERSION=$($JEFE_BIN --version 2>/dev/null | head -n 1 || printf unknown)
     [ -n "$JEFE_VERSION" ] || JEFE_VERSION=unknown
@@ -213,14 +214,18 @@ validate_cleanup_root() {
     [ -f "$ROOT/manifest.txt" ] && [ ! -L "$ROOT/manifest.txt" ] || fail "run manifest is missing or unsafe"
 }
 
-cleanup_path() {
+validate_owned_path() {
     relative=$1
     case "$relative" in
         home|config|socket|fixture-repo|private|bin) ;;
         *) fail "manifest contains an unrecognized owned path: $relative" ;;
     esac
+    [ ! -L "$ROOT/$relative" ] || fail "refusing symlink cleanup path: $relative"
+}
+
+cleanup_path() {
+    relative=$1
     path="$ROOT/$relative"
-    [ ! -L "$path" ] || fail "refusing symlink cleanup path: $relative"
     [ -e "$path" ] || return 0
     printf '%s\n' "$path"
     [ "$CLEANUP_MODE" = "dry-run" ] || find "$path" -depth -delete
@@ -240,10 +245,17 @@ cleanup_run() {
     [ -n "$CLEANUP_MODE" ] || fail "cleanup requires --dry-run or --confirm"
     [ -n "$ROOT" ] || fail "cleanup requires --root"
     validate_cleanup_root
-    grep '^owned_path=' "$ROOT/manifest.txt" | while IFS='=' read -r key relative; do
-        [ "$key" = "owned_path" ] || fail "invalid manifest ownership entry"
+    owned_count=0
+    while IFS='=' read -r key relative; do
+        [ "$key" = "owned_path" ] || continue
+        validate_owned_path "$relative"
+        owned_count=$((owned_count + 1))
+    done < "$ROOT/manifest.txt"
+    [ "$owned_count" -gt 0 ] || fail "manifest contains no owned paths"
+    while IFS='=' read -r key relative; do
+        [ "$key" = "owned_path" ] || continue
         cleanup_path "$relative"
-    done
+    done < "$ROOT/manifest.txt"
 }
 
 COMMAND=${1-}

--- a/scripts/issue241-capture.sh
+++ b/scripts/issue241-capture.sh
@@ -133,7 +133,7 @@ validate_capture() {
     forbidden_literal "$file" "$NORMAL_HOME" "normal home path"
     forbidden_literal "$file" "$ROOT" "run-root path"
     forbidden_literal "$file" "$REPO_ROOT" "unrelated repository path"
-    if grep -Ei '(gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|(token|password|secret)[=:][^[:space:]]+)' "$file" >/dev/null 2>&1; then
+    if grep -Ei '(gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|(token|password|secret)[[:space:]]*[=:][[:space:]]*[^[:space:]]+)' "$file" >/dev/null 2>&1; then
         record_failure "publication validation rejected credential-like content in $(basename "$file")"
     fi
 }
@@ -151,8 +151,8 @@ render_svg() {
     source=$1
     target=$2
     {
-        printf '%s\n' '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="576" viewBox="0 0 800 576" role="img">'
-        printf '%s\n' '<rect width="800" height="576" fill="#000000"/>'
+        printf '%s\n' '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="594" viewBox="0 0 800 594" role="img">'
+        printf '%s\n' '<rect width="800" height="594" fill="#000000"/>'
         printf '%s\n' '<text x="8" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">'
         row=0
         while IFS= read -r line || [ -n "$line" ]; do

--- a/scripts/issue241-capture.sh
+++ b/scripts/issue241-capture.sh
@@ -1,0 +1,255 @@
+#!/bin/sh
+# Produce the bounded, local-only evidence for the first-agent tutorial.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+SCENARIO="$REPO_ROOT/dev-docs/tmux-scenarios/first-agent-tutorial.json"
+OWNED_PATHS="home config socket fixture-repo private bin"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/issue241-capture.sh capture --root ABSOLUTE_PATH --jefe-bin PATH --harness-bin PATH
+  scripts/issue241-capture.sh cleanup --dry-run --root ABSOLUTE_PATH
+  scripts/issue241-capture.sh cleanup --confirm --root ABSOLUTE_PATH
+EOF
+}
+
+fail() {
+    printf '%s\n' "$*" >&2
+    exit 1
+}
+
+parse_capture() {
+    ROOT=
+    JEFE_BIN=
+    HARNESS_BIN=
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --root) ROOT=${2-}; shift 2 ;;
+            --jefe-bin) JEFE_BIN=${2-}; shift 2 ;;
+            --harness-bin) HARNESS_BIN=${2-}; shift 2 ;;
+            *) fail "unknown capture argument: $1" ;;
+        esac
+    done
+    [ -n "$ROOT" ] || fail "capture requires --root"
+    [ -n "$JEFE_BIN" ] || fail "capture requires --jefe-bin"
+    [ -n "$HARNESS_BIN" ] || fail "capture requires --harness-bin"
+}
+
+validate_new_root() {
+    case "$ROOT" in
+        /*) ;;
+        *) fail "run root must be an absolute path" ;;
+    esac
+    [ "$ROOT" != "/" ] || fail "run root must not be filesystem root"
+    case "$ROOT" in
+        "$HOME"|"$HOME"/*) fail "run root must not be the normal home directory" ;;
+    esac
+    [ ! -e "$ROOT" ] && [ ! -L "$ROOT" ] || fail "run root must not exist"
+}
+
+write_manifest() {
+    outcome=$1
+    detail=$2
+    {
+        printf 'format_version=1\n'
+        printf 'outcome=%s\n' "$outcome"
+        printf 'jefe_commit=%s\n' "$JEFE_COMMIT"
+        printf 'jefe_version=%s\n' "$JEFE_VERSION"
+        printf 'scenario=%s\n' "dev-docs/tmux-scenarios/first-agent-tutorial.json"
+        printf 'detail=%s\n' "$detail"
+        for path in $OWNED_PATHS; do
+            printf 'owned_path=%s\n' "$path"
+        done
+    } > "$ROOT/manifest.txt"
+}
+
+record_failure() {
+    detail=$1
+    printf '%s\n' "$detail" > "$ROOT/private/diagnostic.txt"
+    if [ -f "$ROOT/evidence/error.txt" ]; then
+        cat "$ROOT/evidence/error.txt" >> "$ROOT/private/diagnostic.txt"
+    fi
+    write_manifest failed "$detail"
+    fail "$detail; private diagnostics retained under $ROOT/private"
+}
+
+shell_quote() {
+    printf "'"
+    printf '%s' "$1" | sed "s/'/'\\\\''/g"
+    printf "'"
+}
+
+create_runtime_files() {
+    mkdir -p "$ROOT/home" "$ROOT/config" "$ROOT/socket" \
+        "$ROOT/fixture-repo/tutorial-agent" "$ROOT/private" \
+        "$ROOT/evidence" "$ROOT/publication" "$ROOT/bin"
+    printf 'jefe-issue241-capture-v1\n' > "$ROOT/.issue241-run"
+
+    git -C "$ROOT/fixture-repo/tutorial-agent" init -q
+    git -C "$ROOT/fixture-repo/tutorial-agent" config user.name "Tutorial User"
+    git -C "$ROOT/fixture-repo/tutorial-agent" config user.email "tutorial@example.invalid"
+
+    cat > "$ROOT/bin/llxprt" <<'EOF'
+#!/bin/sh
+case " ${*} " in
+    *" --version "*) printf 'llxprt 0.0.0-tutorial\n'; exit 0 ;;
+esac
+printf 'tutorial-shim: ready\n'
+while IFS= read -r line; do
+    printf 'tutorial-shim: response: %s\n' "$line"
+done
+EOF
+    chmod +x "$ROOT/bin/llxprt"
+
+    {
+        printf '#!/bin/sh\n'
+        printf 'export HOME='; shell_quote "$ROOT/home"; printf '\n'
+        printf 'export JEFE_SOCKET_PATH='; shell_quote "$ROOT/socket/jefe.sock"; printf '\n'
+        printf 'export PATH='; shell_quote "$ROOT/bin:$PATH"; printf '\n'
+        printf 'exec '; shell_quote "$JEFE_BIN"; printf ' "$@"\n'
+    } > "$ROOT/bin/jefe-isolated"
+    chmod +x "$ROOT/bin/jefe-isolated"
+}
+
+forbidden_literal() {
+    forbidden_file=$1
+    forbidden_value=$2
+    forbidden_name=$3
+    [ -n "$forbidden_value" ] || return 0
+    if grep -F "$forbidden_value" "$forbidden_file" >/dev/null 2>&1; then
+        record_failure "publication validation rejected $forbidden_name in $(basename "$forbidden_file")"
+    fi
+}
+
+validate_capture() {
+    file=$1
+    forbidden_literal "$file" "${USER-}" "username"
+    forbidden_literal "$file" "$(id -un 2>/dev/null || true)" "username"
+    forbidden_literal "$file" "$(hostname 2>/dev/null || true)" "hostname"
+    forbidden_literal "$file" "$NORMAL_HOME" "normal home path"
+    forbidden_literal "$file" "$ROOT" "run-root path"
+    forbidden_literal "$file" "$REPO_ROOT" "unrelated repository path"
+    if grep -Ei '(gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|(token|password|secret)[=:][^[:space:]]+)' "$file" >/dev/null 2>&1; then
+        record_failure "publication validation rejected credential-like content in $(basename "$file")"
+    fi
+}
+
+publication_text() {
+    source=$1
+    target=$2
+    sed -E \
+        -e 's/pid:[0-9]+/pid:[redacted]/g' \
+        -e 's/\[[^]]+ [0-9]{1,2}:[0-9]{2} [0-9]{1,2}-[A-Za-z]{3}-[0-9]{2}/[terminal status redacted]/g' \
+        "$source" > "$target"
+}
+
+render_svg() {
+    source=$1
+    target=$2
+    {
+        printf '%s\n' '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="576" viewBox="0 0 800 576" role="img">'
+        printf '%s\n' '<rect width="800" height="576" fill="#000000"/>'
+        printf '%s\n' '<text x="8" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">'
+        row=0
+        while IFS= read -r line || [ -n "$line" ]; do
+            escaped=$(printf '%s' "$line" | sed -e 's/\&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
+            y=$((20 + row * 18))
+            printf '<tspan x="8" y="%s">%s</tspan>\n' "$y" "$escaped"
+            row=$((row + 1))
+        done < "$source"
+        printf '%s\n' '</text>' '</svg>'
+    } > "$target"
+}
+
+publish_captures() {
+    for label in first-agent-dashboard first-agent-new-repository first-agent-new-agent \
+        first-agent-terminal-ready first-agent-terminal-response first-agent-result; do
+        source="$ROOT/evidence/$label.screen.txt"
+        safe_text="$ROOT/private/$label.publication.txt"
+        [ -f "$source" ] || record_failure "missing semantic capture: $label"
+        publication_text "$source" "$safe_text"
+        validate_capture "$safe_text"
+        render_svg "$safe_text" "$ROOT/publication/$label.svg"
+    done
+}
+
+capture_run() {
+    parse_capture "$@"
+    NORMAL_HOME=$HOME
+    validate_new_root
+    mkdir "$ROOT" || fail "could not create exclusive run root: $ROOT"
+    JEFE_COMMIT=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || printf unknown)
+    JEFE_VERSION=$($JEFE_BIN --version 2>/dev/null | head -n 1 || printf unknown)
+    [ -n "$JEFE_VERSION" ] || JEFE_VERSION=unknown
+    create_runtime_files
+    write_manifest running "scenario not yet complete"
+
+    if ! "$HARNESS_BIN" \
+        --scenario "$SCENARIO" \
+        --jefe-bin "$ROOT/bin/jefe-isolated" \
+        --config "$ROOT/config" \
+        --working-dir "$ROOT" \
+        --session "jefe-issue241-$$" \
+        --out-dir "$ROOT/evidence" \
+        > "$ROOT/private/harness.stdout.txt" \
+        2> "$ROOT/private/harness.stderr.txt"; then
+        record_failure "first-agent tutorial scenario failed"
+    fi
+    publish_captures
+    write_manifest success "scenario and publication validation completed"
+    printf 'capture complete: %s\n' "$ROOT"
+}
+
+validate_cleanup_root() {
+    case "$ROOT" in /*) ;; *) fail "run root must be an absolute path" ;; esac
+    [ -d "$ROOT" ] && [ ! -L "$ROOT" ] || fail "run root must be a non-symlink directory"
+    [ "$(cat "$ROOT/.issue241-run" 2>/dev/null || true)" = "jefe-issue241-capture-v1" ] || fail "run sentinel is missing or invalid"
+    [ -f "$ROOT/manifest.txt" ] && [ ! -L "$ROOT/manifest.txt" ] || fail "run manifest is missing or unsafe"
+}
+
+cleanup_path() {
+    relative=$1
+    case "$relative" in
+        home|config|socket|fixture-repo|private|bin) ;;
+        *) fail "manifest contains an unrecognized owned path: $relative" ;;
+    esac
+    path="$ROOT/$relative"
+    [ ! -L "$path" ] || fail "refusing symlink cleanup path: $relative"
+    [ -e "$path" ] || return 0
+    printf '%s\n' "$path"
+    [ "$CLEANUP_MODE" = "dry-run" ] || find "$path" -depth -delete
+}
+
+cleanup_run() {
+    CLEANUP_MODE=
+    ROOT=
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --dry-run) CLEANUP_MODE=dry-run; shift ;;
+            --confirm) CLEANUP_MODE=confirm; shift ;;
+            --root) ROOT=${2-}; shift 2 ;;
+            *) fail "unknown cleanup argument: $1" ;;
+        esac
+    done
+    [ -n "$CLEANUP_MODE" ] || fail "cleanup requires --dry-run or --confirm"
+    [ -n "$ROOT" ] || fail "cleanup requires --root"
+    validate_cleanup_root
+    grep '^owned_path=' "$ROOT/manifest.txt" | while IFS='=' read -r key relative; do
+        [ "$key" = "owned_path" ] || fail "invalid manifest ownership entry"
+        cleanup_path "$relative"
+    done
+}
+
+COMMAND=${1-}
+[ -n "$COMMAND" ] || { usage >&2; exit 2; }
+shift
+case "$COMMAND" in
+    capture) capture_run "$@" ;;
+    cleanup) cleanup_run "$@" ;;
+    -h|--help) usage ;;
+    *) usage >&2; fail "unknown command: $COMMAND" ;;
+esac

--- a/src/app_input/modal_handlers.rs
+++ b/src/app_input/modal_handlers.rs
@@ -9,7 +9,7 @@ use jefe::domain::{AgentId, LaunchSignature, SandboxEngine};
 use jefe::persistence::PersistenceManager;
 use jefe::runtime::{RuntimeError, RuntimeManager};
 use jefe::state::{
-    AgentFormFocus, AppEvent, AuthDialogPhase, ConfirmFocus, ModalState, PaneFocus,
+    AgentFormFocus, AppEvent, AppState, AuthDialogPhase, ConfirmFocus, ModalState, PaneFocus,
     RepositoryFormFocus,
 };
 use jefe::theme::ThemeManager;
@@ -728,10 +728,15 @@ fn submit_form_and_snapshot_launch(
 
 fn focus_terminal_after_submit(app_state: &mut AppStateHandle, ctx: &SharedContext) {
     let mut state = app_state.write();
-    state.terminal_focused = true;
+    focus_terminal_state(&mut state);
     let persisted = to_persisted_state(&state);
     drop(state);
     persist_state(ctx, &persisted);
+}
+
+pub(super) fn focus_terminal_state(state: &mut AppState) {
+    state.pane_focus = PaneFocus::Terminal;
+    state.terminal_focused = true;
 }
 
 fn handle_form_space(app_state: &mut AppStateHandle, ctx: &SharedContext) -> Option<AppEvent> {

--- a/src/app_input/modal_handlers_tests.rs
+++ b/src/app_input/modal_handlers_tests.rs
@@ -5,13 +5,13 @@
 //! Extracted from `modal_handlers.rs` to keep that handler module under the
 //! architecture per-file line limit.
 
-use super::modal_handlers::confirm_focus_is_cancel;
+use super::modal_handlers::{confirm_focus_is_cancel, focus_terminal_state};
 use jefe::domain::{
     AgentId, AgentKind, LaunchSignature, RemoteRepositorySettings, RepositoryId, SandboxEngine,
 };
 use jefe::github::SendPayload;
 use jefe::runtime::PreflightIssue;
-use jefe::state::{ConfirmFocus, ModalState};
+use jefe::state::{AppState, ConfirmFocus, ModalState, PaneFocus};
 
 fn sample_signature() -> LaunchSignature {
     LaunchSignature {
@@ -121,4 +121,18 @@ fn confirm_focus_is_cancel_uses_correct_field_not_default() {
         !confirm_focus_is_cancel(&modal),
         "must read the actual confirm_focus field, not a hardcoded Cancel default"
     );
+}
+
+#[test]
+fn successful_new_agent_submit_focuses_the_terminal_pane_and_capture_mode() {
+    let mut state = AppState {
+        pane_focus: PaneFocus::Repositories,
+        terminal_focused: false,
+        ..AppState::default()
+    };
+
+    focus_terminal_state(&mut state);
+
+    assert_eq!(state.pane_focus, PaneFocus::Terminal);
+    assert!(state.terminal_focused);
 }

--- a/src/app_input/modal_handlers_tests.rs
+++ b/src/app_input/modal_handlers_tests.rs
@@ -124,7 +124,7 @@ fn confirm_focus_is_cancel_uses_correct_field_not_default() {
 }
 
 #[test]
-fn successful_new_agent_submit_focuses_the_terminal_pane_and_capture_mode() {
+fn successful_new_agent_submit_focuses_terminal_pane_and_sets_focused() {
     let mut state = AppState {
         pane_focus: PaneFocus::Repositories,
         terminal_focused: false,

--- a/src/harness/expand.rs
+++ b/src/harness/expand.rs
@@ -129,6 +129,9 @@ fn substitute_step(step: &Step, args: &BTreeMap<String, String>) -> Step {
         Step::Line { text } => Step::Line {
             text: substitute(text, args),
         },
+        Step::Type { text } => Step::Type {
+            text: substitute(text, args),
+        },
         Step::Key { key } => Step::Key {
             key: substitute(key, args),
         },

--- a/src/harness/psmux_driver.rs
+++ b/src/harness/psmux_driver.rs
@@ -207,8 +207,13 @@ impl TmuxDriver {
     }
 
     pub fn send_line(&self, session: &TmuxSession, line: &str) -> Result<(), TmuxDriverError> {
-        self.run(&["send-keys", "-l", "-t", &session.name, "--", line])?;
+        self.send_type(session, line)?;
         self.send_key(session, "Enter")
+    }
+
+    pub fn send_type(&self, session: &TmuxSession, text: &str) -> Result<(), TmuxDriverError> {
+        self.run_owned(&literal_send_args(session, text), None)
+            .map(|_| ())
     }
 
     pub fn send_key(&self, session: &TmuxSession, key: &str) -> Result<(), TmuxDriverError> {
@@ -505,6 +510,12 @@ fn parse_version_part(part: Option<&str>, name: &str, source: &str) -> Result<u3
         .trim_matches(|character: char| !character.is_ascii_digit())
         .parse::<u32>()
         .map_err(|error| format!("invalid {name} version component in {source:?}: {error}"))
+}
+
+fn literal_send_args(session: &TmuxSession, text: &str) -> Vec<String> {
+    ["send-keys", "-l", "-t", &session.name, "--", text]
+        .map(str::to_string)
+        .to_vec()
 }
 
 fn new_session_args(request: &TmuxStartRequest) -> Vec<String> {

--- a/src/harness/psmux_driver_tests.rs
+++ b/src/harness/psmux_driver_tests.rs
@@ -26,6 +26,20 @@ fn windows_launch_plan_uses_platform_shell_without_a_unix_wrapper() {
 }
 
 #[test]
+fn literal_type_argv_does_not_append_enter() {
+    let session = TmuxSession {
+        name: "demo".to_string(),
+        cols: 100,
+        rows: 32,
+        keep_session: false,
+    };
+
+    assert_eq!(
+        literal_send_args(&session, "literal payload"),
+        ["send-keys", "-l", "-t", "demo", "--", "literal payload"].map(str::to_string)
+    );
+}
+#[test]
 fn every_driver_gets_a_unique_owned_namespace() {
     let first = TmuxDriver::new();
     let second = TmuxDriver::new();

--- a/src/harness/runner.rs
+++ b/src/harness/runner.rs
@@ -99,6 +99,7 @@ pub trait HarnessDriver {
     type Error: std::fmt::Display;
 
     fn send_line(&mut self, line: &str) -> Result<(), Self::Error>;
+    /// Send literal text without Enter; scenarios use `line` when submission is intended.
     fn send_type(&mut self, text: &str) -> Result<(), Self::Error>;
     fn send_key(&mut self, key: &str) -> Result<(), Self::Error>;
     fn send_keys(&mut self, keys: &[String]) -> Result<(), Self::Error>;

--- a/src/harness/runner.rs
+++ b/src/harness/runner.rs
@@ -99,6 +99,7 @@ pub trait HarnessDriver {
     type Error: std::fmt::Display;
 
     fn send_line(&mut self, line: &str) -> Result<(), Self::Error>;
+    fn send_type(&mut self, text: &str) -> Result<(), Self::Error>;
     fn send_key(&mut self, key: &str) -> Result<(), Self::Error>;
     fn send_keys(&mut self, keys: &[String]) -> Result<(), Self::Error>;
     fn capture_screen(&mut self) -> Result<ScreenCapture, Self::Error>;
@@ -129,6 +130,10 @@ impl HarnessDriver for TmuxHarnessDriver {
 
     fn send_line(&mut self, line: &str) -> Result<(), Self::Error> {
         self.driver.send_line(&self.session, line)
+    }
+
+    fn send_type(&mut self, text: &str) -> Result<(), Self::Error> {
+        self.driver.send_type(&self.session, text)
     }
 
     fn send_key(&mut self, key: &str) -> Result<(), Self::Error> {
@@ -320,6 +325,7 @@ fn execute_step<D: HarnessDriver>(
             Ok(())
         }
         Step::Line { text } => driver_call(driver.send_line(text)),
+        Step::Type { text } => driver_call(driver.send_type(text)),
         Step::Key { key } => driver_call(driver.send_key(key)),
         Step::Keys { keys } => driver_call(driver.send_keys(keys)),
         Step::WaitFor { pattern } => wait_for_pattern(index, step, driver, context, pattern, true),
@@ -648,6 +654,7 @@ fn step_kind(step: &Step) -> String {
     match step {
         Step::Wait { .. } => "wait",
         Step::Line { .. } => "line",
+        Step::Type { .. } => "type",
         Step::Key { .. } => "key",
         Step::Keys { .. } => "keys",
         Step::WaitFor { .. } => "waitFor",

--- a/src/harness/runner_tests.rs
+++ b/src/harness/runner_tests.rs
@@ -46,6 +46,7 @@ struct FakeDriver {
     pane_statuses: VecDeque<PaneStatus>,
     history_sizes: VecDeque<u64>,
     lines_sent: Vec<String>,
+    typed_text: Vec<String>,
     keys_sent: Vec<String>,
     copy_modes: Vec<bool>,
     screen_capture_count: usize,
@@ -76,6 +77,11 @@ impl HarnessDriver for FakeDriver {
 
     fn send_line(&mut self, line: &str) -> Result<(), Self::Error> {
         self.lines_sent.push(line.to_string());
+        Ok(())
+    }
+
+    fn send_type(&mut self, text: &str) -> Result<(), Self::Error> {
+        self.typed_text.push(text.to_string());
         Ok(())
     }
 
@@ -186,10 +192,11 @@ fn wait_for_succeeds_when_later_capture_matches() {
 }
 
 #[test]
-fn line_key_keys_and_copy_mode_forward_to_driver() {
+fn line_type_key_keys_and_copy_mode_forward_to_driver() {
     let scenario = scenario(
         r#"[
             { "line": "hello" },
+            { "type": "without enter" },
             { "key": "Enter" },
             { "keys": ["C-b", "["] },
             { "copyMode": true },
@@ -201,6 +208,7 @@ fn line_key_keys_and_copy_mode_forward_to_driver() {
     let _summary = run_scenario(&scenario, &mut driver, None).value_or_panic("runner should pass");
 
     assert_eq!(driver.lines_sent, ["hello"]);
+    assert_eq!(driver.typed_text, ["without enter"]);
     assert_eq!(driver.keys_sent, ["Enter", "C-b", "["]);
     assert_eq!(driver.copy_modes, [true, false]);
 }

--- a/src/harness/step.rs
+++ b/src/harness/step.rs
@@ -27,6 +27,8 @@ pub enum Step {
     Wait { milliseconds: u64 },
     /// Type a full line of text (implies a trailing Enter in later phases).
     Line { text: String },
+    /// Type literal text without pressing Enter.
+    Type { text: String },
     /// Send a single named key (e.g. `"Enter"`, `"Escape"`).
     Key { key: String },
     /// Send a sequence of named keys.
@@ -78,6 +80,7 @@ impl Step {
             Self::Macro { name, args } => validate_macro_invocation(name, args),
             Self::Wait { .. }
             | Self::Line { .. }
+            | Self::Type { .. }
             | Self::CopyMode { .. }
             | Self::WaitForExit { .. } => Ok(()),
         }
@@ -127,6 +130,7 @@ struct StepParts {
 enum StepCore {
     Wait(u64),
     Line(String),
+    Type(String),
     Key(String),
     Keys(Vec<String>),
     WaitFor(String),
@@ -177,6 +181,7 @@ impl StepParts {
                 no_aux(count, args.as_ref()).map(|()| Step::Wait { milliseconds })
             }
             StepCore::Line(text) => no_aux(count, args.as_ref()).map(|()| Step::Line { text }),
+            StepCore::Type(text) => no_aux(count, args.as_ref()).map(|()| Step::Type { text }),
             StepCore::Key(key) => no_aux(count, args.as_ref()).map(|()| Step::Key { key }),
             StepCore::Keys(keys) => no_aux(count, args.as_ref()).map(|()| Step::Keys { keys }),
             StepCore::WaitFor(pattern) => {
@@ -219,6 +224,7 @@ where
     match key.as_str() {
         "wait" => set_core(map, parts, &key, StepCore::Wait)?,
         "line" => set_core(map, parts, &key, StepCore::Line)?,
+        "type" => set_core(map, parts, &key, StepCore::Type)?,
         "key" => set_core(map, parts, &key, StepCore::Key)?,
         "keys" => set_core(map, parts, &key, StepCore::Keys)?,
         "waitFor" => set_core(map, parts, &key, StepCore::WaitFor)?,

--- a/src/harness/tests.rs
+++ b/src/harness/tests.rs
@@ -58,6 +58,21 @@ fn parses_minimal_valid_scenario() {
     ));
 }
 
+#[test]
+fn first_agent_tutorial_scenario_parses_literal_type_steps() {
+    let scenario = parse_scenario(include_str!(
+        "../../dev-docs/tmux-scenarios/first-agent-tutorial.json"
+    ))
+    .value_or_panic("first-agent tutorial scenario should parse");
+
+    assert!(
+        scenario
+            .steps
+            .iter()
+            .any(|step| matches!(step, Step::Type { text } if text == "hello from the tutorial"))
+    );
+}
+
 /// A scenario using every step primitive parses into its typed variant.
 ///
 /// Exercises the full `Step` surface so a missing/renamed variant is caught.

--- a/src/harness/tmux_driver.rs
+++ b/src/harness/tmux_driver.rs
@@ -333,8 +333,17 @@ impl TmuxDriver {
     ///
     /// Returns [`TmuxDriverError`] if tmux rejects the key send.
     pub fn send_line(&self, session: &TmuxSession, line: &str) -> Result<(), TmuxDriverError> {
-        run_tmux(&["send-keys", "-l", "-t", &session.name, "--", line], None)?;
+        self.send_type(session, line)?;
         self.send_key(session, "Enter")
+    }
+
+    /// Send literal text without pressing Enter.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TmuxDriverError`] if tmux rejects the key send.
+    pub fn send_type(&self, session: &TmuxSession, text: &str) -> Result<(), TmuxDriverError> {
+        run_tmux(&["send-keys", "-l", "-t", &session.name, "--", text], None)
     }
 
     /// Send a single named key.

--- a/src/harness/tmux_driver_tests.rs
+++ b/src/harness/tmux_driver_tests.rs
@@ -327,6 +327,47 @@ fn history_size_is_readable_and_monotonic_when_tmux_available() {
     );
 }
 
+#[test]
+fn literal_type_does_not_submit_until_enter_when_tmux_available() {
+    let driver = TmuxDriver::new();
+    if !driver.is_available() {
+        return;
+    }
+    let request = shell_request(
+        "literal-type",
+        "printf 'reader-ready\\n'; read line; printf 'received:<%s>\\n' \"$line\"",
+    );
+    let session = driver
+        .start_session(&request)
+        .value_or_panic("tmux session should start");
+    let guard = SessionGuard {
+        driver: &driver,
+        session,
+    };
+
+    let _ready = wait_for_screen_literal(&driver, &guard.session, "reader-ready")
+        .value_or_panic("reader should announce readiness");
+    driver
+        .send_type(&guard.session, "literal payload")
+        .value_or_panic("literal type should work");
+    let before_enter = driver
+        .capture_screen(&guard.session)
+        .value_or_panic("screen before Enter");
+    assert!(!before_enter.lines.join("\n").contains("received:<"));
+
+    driver
+        .send_key(&guard.session, "Enter")
+        .value_or_panic("Enter should work");
+    let received = wait_for_screen_literal(&driver, &guard.session, "received:<literal payload>")
+        .value_or_panic("reader should receive typed payload after Enter");
+    assert!(
+        received
+            .lines
+            .join("\n")
+            .contains("received:<literal payload>")
+    );
+}
+
 fn shell_request(label: &str, script: &str) -> TmuxStartRequest {
     TmuxStartRequest::command(
         unique_session(label),

--- a/tests/issue241_capture.rs
+++ b/tests/issue241_capture.rs
@@ -1,0 +1,145 @@
+//! Behavioral contracts for the bounded issue 241 tutorial capture workflow.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+fn script() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/issue241-capture.sh")
+}
+
+fn write_executable(path: &Path, body: &str) {
+    fs::write(path, body).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
+    let status = Command::new("chmod")
+        .args(["+x"])
+        .arg(path)
+        .status()
+        .unwrap_or_else(|error| panic!("chmod {}: {error}", path.display()));
+    assert!(status.success(), "chmod failed for {}", path.display());
+}
+
+fn fake_binaries(temp: &TempDir, capture_text: &str) -> (PathBuf, PathBuf) {
+    let jefe = temp.path().join("jefe");
+    write_executable(&jefe, "#!/bin/sh\nprintf 'jefe 0.0.29-test\\n'\n");
+    let harness = temp.path().join("harness");
+    let body = format!(
+        "#!/bin/sh\nset -eu\nout=''\nwhile [ \"$#\" -gt 0 ]; do\n  if [ \"$1\" = '--out-dir' ]; then out=$2; shift 2; else shift; fi\ndone\nmkdir -p \"$out\"\nfor name in first-agent-dashboard first-agent-new-repository first-agent-new-agent first-agent-terminal-ready first-agent-terminal-response first-agent-result; do\n  printf '%s\\n' '{}' > \"$out/$name.screen.txt\"\ndone\n",
+        capture_text.replace('\'', "'\\''")
+    );
+    write_executable(&harness, &body);
+    (jefe, harness)
+}
+
+fn capture(root: &Path, jefe: &Path, harness: &Path) -> Output {
+    Command::new("sh")
+        .arg(script())
+        .args(["capture", "--root"])
+        .arg(root)
+        .arg("--jefe-bin")
+        .arg(jefe)
+        .arg("--harness-bin")
+        .arg(harness)
+        .output()
+        .unwrap_or_else(|error| panic!("run capture: {error}"))
+}
+
+fn cleanup(root: &Path, mode: &str) -> Output {
+    Command::new("sh")
+        .arg(script())
+        .args(["cleanup", mode, "--root"])
+        .arg(root)
+        .output()
+        .unwrap_or_else(|error| panic!("run cleanup: {error}"))
+}
+
+#[test]
+fn capture_refuses_relative_and_existing_roots() {
+    let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let (jefe, harness) = fake_binaries(&temp, "publication-safe");
+    let relative = capture(Path::new("relative-run"), &jefe, &harness);
+    assert!(!relative.status.success());
+    assert!(String::from_utf8_lossy(&relative.stderr).contains("absolute"));
+
+    let existing = temp.path().join("existing");
+    fs::create_dir(&existing).unwrap_or_else(|error| panic!("create existing root: {error}"));
+    let output = capture(&existing, &jefe, &harness);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("must not exist"));
+}
+
+#[test]
+fn successful_capture_records_provenance_and_renders_fixed_safe_svgs() {
+    let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let (jefe, harness) = fake_binaries(
+        &temp,
+        "Tutorial Agent ready pid:123 [private-host 12:34 16-Jul-26",
+    );
+    let root = temp.path().join("capture");
+    let output = capture(&root, &jefe, &harness);
+    assert!(
+        output.status.success(),
+        "capture failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let manifest = fs::read_to_string(root.join("manifest.txt"))
+        .unwrap_or_else(|error| panic!("read manifest: {error}"));
+    assert!(manifest.contains("outcome=success"));
+    assert!(manifest.contains("jefe_version=jefe 0.0.29-test"));
+    assert!(manifest.contains("jefe_commit="));
+    let svg = fs::read_to_string(root.join("publication/first-agent-result.svg"))
+        .unwrap_or_else(|error| panic!("read svg: {error}"));
+    assert!(svg.contains("width=\"800\" height=\"576\""));
+    assert!(svg.contains("Tutorial Agent ready"));
+    assert!(svg.contains("pid:[redacted]"));
+    assert!(svg.contains("[terminal status redacted]"));
+    assert!(!svg.contains("pid:123"));
+    assert!(!svg.contains("private-host"));
+}
+
+#[test]
+fn unsafe_capture_fails_without_claiming_success_and_retains_diagnostics() {
+    let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let username = std::env::var("USER").unwrap_or_else(|_| "capture-user".to_string());
+    let (jefe, harness) = fake_binaries(&temp, &format!("private user: {username}"));
+    let root = temp.path().join("unsafe");
+    let output = capture(&root, &jefe, &harness);
+    assert!(!output.status.success());
+
+    let manifest = fs::read_to_string(root.join("manifest.txt"))
+        .unwrap_or_else(|error| panic!("read failed manifest: {error}"));
+    assert!(manifest.contains("outcome=failed"));
+    assert!(!manifest.contains("outcome=success"));
+    assert!(root.join("private/diagnostic.txt").is_file());
+    assert!(
+        root.join("evidence/first-agent-dashboard.screen.txt")
+            .is_file()
+    );
+}
+
+#[test]
+fn cleanup_is_manifest_scoped_dry_run_first_and_preserves_evidence() {
+    let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let (jefe, harness) = fake_binaries(&temp, "publication-safe");
+    let root = temp.path().join("cleanup");
+    let output = capture(&root, &jefe, &harness);
+    assert!(output.status.success());
+    fs::write(root.join("unowned.txt"), "preserve")
+        .unwrap_or_else(|error| panic!("write unowned: {error}"));
+
+    let dry_run = cleanup(&root, "--dry-run");
+    assert!(dry_run.status.success());
+    assert!(root.join("config").exists());
+    assert!(String::from_utf8_lossy(&dry_run.stdout).contains("config"));
+
+    let confirmed = cleanup(&root, "--confirm");
+    assert!(confirmed.status.success());
+    assert!(!root.join("config").exists());
+    assert!(!root.join("fixture-repo").exists());
+    assert!(root.join("evidence").is_dir());
+    assert!(root.join("publication").is_dir());
+    assert!(root.join("manifest.txt").is_file());
+    assert!(root.join("unowned.txt").is_file());
+}

--- a/tests/issue241_capture.rs
+++ b/tests/issue241_capture.rs
@@ -92,7 +92,7 @@ fn successful_capture_records_provenance_and_renders_fixed_safe_svgs() {
     assert!(manifest.contains("jefe_commit="));
     let svg = fs::read_to_string(root.join("publication/first-agent-result.svg"))
         .unwrap_or_else(|error| panic!("read svg: {error}"));
-    assert!(svg.contains("width=\"800\" height=\"576\""));
+    assert!(svg.contains("width=\"800\" height=\"594\""));
     assert!(svg.contains("Tutorial Agent ready"));
     assert!(svg.contains("pid:[redacted]"));
     assert!(svg.contains("[terminal status redacted]"));
@@ -120,6 +120,19 @@ fn unsafe_capture_fails_without_claiming_success_and_retains_diagnostics() {
     );
 }
 
+#[test]
+fn credential_validation_rejects_whitespace_around_delimiters() {
+    let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let (jefe, harness) = fake_binaries(&temp, "password : exposed-value");
+    let root = temp.path().join("credential");
+    let output = capture(&root, &jefe, &harness);
+    assert!(!output.status.success());
+
+    let manifest = fs::read_to_string(root.join("manifest.txt"))
+        .unwrap_or_else(|error| panic!("read failed manifest: {error}"));
+    assert!(manifest.contains("outcome=failed"));
+    assert!(manifest.contains("credential-like content"));
+}
 #[test]
 fn cleanup_is_manifest_scoped_dry_run_first_and_preserves_evidence() {
     let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));

--- a/tests/issue241_capture.rs
+++ b/tests/issue241_capture.rs
@@ -1,5 +1,6 @@
 //! Behavioral contracts for the bounded issue 241 tutorial capture workflow.
 
+#![cfg(unix)]
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};

--- a/tests/issue241_capture.rs
+++ b/tests/issue241_capture.rs
@@ -104,7 +104,17 @@ fn successful_capture_records_provenance_and_renders_fixed_safe_svgs() {
         .unwrap_or_else(|error| panic!("read manifest: {error}"));
     assert!(manifest.contains("outcome=success"));
     assert!(manifest.contains("jefe_version=jefe 0.0.29-test"));
-    assert!(manifest.contains("jefe_commit="));
+    let commit = manifest
+        .lines()
+        .find_map(|line| line.strip_prefix("jefe_commit="))
+        .unwrap_or_else(|| panic!("manifest must record jefe_commit"));
+    assert_eq!(commit.len(), 40, "expected a full git commit: {commit}");
+    assert!(
+        commit
+            .chars()
+            .all(|character| character.is_ascii_hexdigit()),
+        "expected hexadecimal git commit: {commit}"
+    );
     let svg = fs::read_to_string(root.join("publication/first-agent-result.svg"))
         .unwrap_or_else(|error| panic!("read svg: {error}"));
     assert!(svg.contains("width=\"800\" height=\"594\""));
@@ -148,6 +158,34 @@ fn credential_validation_rejects_whitespace_around_delimiters() {
     assert!(manifest.contains("outcome=failed"));
     assert!(manifest.contains("credential-like content"));
 }
+
+#[test]
+fn cleanup_rejects_an_invalid_owned_path_after_a_valid_entry() {
+    let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let root = temp.path().join("invalid-manifest");
+    fs::create_dir_all(root.join("config"))
+        .unwrap_or_else(|error| panic!("create config fixture: {error}"));
+    fs::write(root.join(".issue241-run"), "jefe-issue241-capture-v1\n")
+        .unwrap_or_else(|error| panic!("write sentinel: {error}"));
+    fs::write(
+        root.join("manifest.txt"),
+        "format_version=1\nowned_path=config\nowned_path=outside\n",
+    )
+    .unwrap_or_else(|error| panic!("write manifest: {error}"));
+
+    let output = cleanup(&root, "--confirm");
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unrecognized owned path"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        root.join("config").is_dir(),
+        "cleanup must validate every ownership entry before deleting anything"
+    );
+}
+
 #[test]
 fn cleanup_is_manifest_scoped_dry_run_first_and_preserves_evidence() {
     let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));

--- a/tests/issue241_capture.rs
+++ b/tests/issue241_capture.rs
@@ -71,6 +71,22 @@ fn capture_refuses_relative_and_existing_roots() {
 }
 
 #[test]
+fn capture_reports_a_missing_run_root_parent_before_creation() {
+    let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let (jefe, harness) = fake_binaries(&temp, "publication-safe");
+    let missing_parent = temp.path().join("missing-parent");
+    let root = missing_parent.join("capture");
+    let output = capture(&root, &jefe, &harness);
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("run root parent directory does not exist")
+    );
+    assert!(!missing_parent.exists());
+}
+
+#[test]
 fn capture_rejects_non_executable_binary_paths_before_creating_root() {
     let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
     let missing_jefe = temp.path().join("missing-jefe");

--- a/tests/issue241_capture.rs
+++ b/tests/issue241_capture.rs
@@ -71,6 +71,21 @@ fn capture_refuses_relative_and_existing_roots() {
 }
 
 #[test]
+fn capture_rejects_non_executable_binary_paths_before_creating_root() {
+    let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let missing_jefe = temp.path().join("missing-jefe");
+    let missing_harness = temp.path().join("missing-harness");
+    let root = temp.path().join("invalid-binaries");
+    let output = capture(&root, &missing_jefe, &missing_harness);
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("jefe binary not found or not executable")
+    );
+    assert!(!root.exists());
+}
+
+#[test]
 fn successful_capture_records_provenance_and_renders_fixed_safe_svgs() {
     let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
     let (jefe, harness) = fake_binaries(


### PR DESCRIPTION
## Summary

- add a typed harness `type` step that enters literal text without submitting, while preserving `line` as literal text plus Enter
- fix the demonstrated first-agent launch focus invariant so terminal capture owns both the focus flag and terminal pane
- add one Unix-only isolated capture workflow with a deterministic LLxprt shim, truthful manifests, publication redaction, fixed SVG rendering, and manifest-scoped cleanup
- publish an observed first-agent tutorial with three reviewed, deterministic SVG checkpoints

## Acceptance evidence

- the TUI scenario creates the repository and agent through the visible forms, waits on semantic assertions, enters a known prompt, observes the shim response, presses F12, and verifies the resulting dashboard state
- clean real runs under `/tmp/jefe-issue241-run-g` and `/tmp/jefe-issue241-run-h` both succeeded; selected SVGs compared byte-for-byte
- final post-gate run under `/tmp/jefe-issue241-final-verified` succeeded and reproduced every committed SVG byte-for-byte
- manifests record Jefe 0.0.29 and base revision 35cef9ddd4db24b32956de3369113e27b5f78139
- cleanup dry-run lists only exact run-owned paths; contract tests prove confirmed cleanup preserves evidence, publication output, the manifest, and unowned files

## Test-first record

- RED: the real scenario initially failed parsing because the harness had no `type` primitive
- RED: the real scenario then exposed the form-submit focus mismatch by routing the prompt's first character to dashboard Help
- GREEN: focused harness, state, real tmux, and shell workflow contracts pass; two clean real TUI captures and the final documented capture pass

## Verification

- `make quick-check`
- format, clippy-allow policy, source-size policy, standard Clippy, and complexity Clippy gates
- `cargo llvm-cov --workspace --all-features --summary-only --ignore-filename-regex '(/vendor/|/tmp/|/rustc-)' --fail-under-lines 30` (72.75% lines)
- `cargo build --workspace --all-features --locked`
- `cargo test --workspace --all-features --locked`
- `scripts/issue241-capture.sh capture --root /tmp/jefe-issue241-final-verified --jefe-bin "$PWD/target/debug/jefe" --harness-bin "$PWD/target/debug/jefe-tmux-harness"`

## Scope

20 files, 868 net added lines. The workflow remains Unix-only and local-only; it adds no GitHub mutation, runtime matrix, generalized capture platform, process supervisor, dependency, or workflow change.

Fixes #241
