### PR TITLE
Compare GitHub timestamps as parsed instants (Fixes #336)

### DIFF
--- a/project-plans/issue336-plan.md
+++ b/project-plans/issue336-plan.md
@@ -1,0 +1,100 @@
+# Issue #336 — Compare GitHub timestamps as parsed instants
+
+## Goal
+
+Sort issue, pull-request, and PR-review lists newest-first by the instant represented by each RFC 3339 timestamp, regardless of fractional-second precision or UTC-offset spelling, while retaining the existing tie-breaker keys.
+
+## Decisions
+
+- The GitHub boundary owns one shared, pure RFC 3339 comparison helper used by all three list sorters.
+- No date-time crate is currently present in `Cargo.toml` or `Cargo.lock`. Adding one requires separate approval, so the helper will parse the bounded RFC 3339 fields needed for comparison without changing dependencies.
+- Valid timestamps sort by their UTC instant. Equivalent instants compare equal even when their offsets or fractional precision differ, so the existing sorter-specific tie-breaker decides their order.
+- Valid timestamps sort before malformed or missing timestamps. Malformed timestamps retain deterministic reverse-lexicographic ordering among themselves; equal malformed timestamps use the existing sorter-specific tie-breaker. This preserves empty timestamps on the older side.
+- RFC 3339 comparison accepts uppercase or lowercase `T`/`Z`, required numeric UTC offsets in `±HH:MM` form, arbitrary fractional precision, calendar-valid dates, and leap-second syntax.
+- A TUI harness scenario is not applicable: this fixes pure GitHub-boundary list ordering and adds no interaction, rendering, or UI-state contract. Direct behavioral sorter tests exercise the exact data consumed by the existing list UI.
+
+## Acceptance matrix
+
+| ID | Actor / path | Input and boundary cases | Target | Observable success | Failure behavior / side effects | Compatibility | Evidence |
+|---|---|---|---|---|---|---|---|
+| A1 | Issues list sorter | Whole seconds, fractional seconds, and mixed precision | Local GitHub boundary; platform-neutral | Issues are ordered by parsed `updated_at` instant, newest first | Malformed/missing timestamps sort after valid timestamps; no side effects | Number-ascending tie-breaker unchanged | Focused `sort_issues` behavior tests |
+| A2 | Pull-request list sorter | `Z`, `+00:00`, and non-zero offsets | Local GitHub boundary; platform-neutral | PRs are ordered by parsed `updated_at` instant, newest first | Malformed/missing timestamps sort after valid timestamps; no side effects | Number-ascending tie-breaker unchanged | Focused `sort_pull_requests` behavior tests |
+| A3 | PR review sorter | Different offsets representing different and equal instants | Local GitHub boundary; platform-neutral | Reviews are ordered by parsed `submitted_at` instant, newest first | Malformed/missing timestamps sort after valid timestamps; attached threads remain on parents | Review-ID-descending then author-ascending tie-breakers unchanged | Focused `sort_pr_reviews` behavior tests |
+| A4 | All timestamp sorters | Equivalent instants expressed with different offset/precision forms | Local GitHub boundary; platform-neutral | Parsed timestamp comparison returns equality and each existing tie-breaker determines order | No I/O, persistence, or diagnostics | Existing public sort APIs unchanged | Tie-breaker regression tests with equivalent instants |
+| A5 | Shared parser/comparator | Invalid dates/times/offsets, lowercase markers, long fractions, leap second | Pure GitHub helper; platform-neutral | Accepted RFC 3339 forms compare chronologically; invalid forms use the documented deterministic fallback | Never panics; no partial state or side effects | No dependency or schema changes | Helper unit tests plus full verification |
+
+## Explicit non-goals
+
+- Changing newest-first ordering.
+- Changing issue/PR number or review ID/author tie-breaker keys.
+- Altering GitHub JSON parsing, fetches, pagination, persistence, or UI rendering.
+- Introducing a general date-time API outside the GitHub boundary.
+- Adding or changing dependencies.
+- Reformatting unrelated timestamp display values.
+
+## Bounded vertical slices
+
+### Slice 1 — Behavioral RED for all affected sorters
+
+- Acceptance: A1–A4.
+- Owner: GitHub boundary sorter behavior.
+- Allowed files: `src/github/tests_timestamp_sort.rs`, `src/lib.rs`.
+- RED: mixed precision/offset tests fail under raw `String::cmp`.
+- GREEN criterion: deferred to slice 2.
+- Stop condition: evidence requires UI/state/runtime changes.
+
+### Slice 2 — Shared parsed-instant comparison
+
+- Acceptance: A1–A5.
+- Owner: pure GitHub timestamp comparison integrated into existing sorters.
+- Allowed files: `src/github/timestamp.rs`, `src/github/mod.rs`, `src/github/parse.rs`, `src/github/parse_pr.rs`, and slice-1 tests.
+- RED: slice-1 failures.
+- GREEN: all focused timestamp-sort tests pass, including unchanged tie-breakers and malformed fallback.
+- REFACTOR: keep parsing helpers focused and dependency-free; add parser boundary tests.
+- Stop condition: dependency, public API, or cross-layer changes become necessary.
+
+### Slice 3 — Exact-head qualification
+
+- Acceptance: all rows.
+- Owner: repository quality gates.
+- Allowed files: only in-scope fixes discovered by verification/review; scope ledger updated first.
+- GREEN: `make quick-check`, `make ci-check`, review triage, and exact-head PR CI all pass.
+- Stop condition: unplanned subsystem/public abstraction/dependency/tooling change, unrelated test movement, or scope budget breach.
+
+## Expected paths and scope ledger
+
+| Path | Layer / purpose | Acceptance | Status |
+|---|---|---|---|
+| `project-plans/issue336-plan.md` | Delivery plan and evidence ledger | A1–A5 | Planned |
+| `src/github/tests_timestamp_sort.rs` | Cross-sort behavioral evidence | A1–A4 | Planned |
+| `src/lib.rs` | Test-module registration only | A1–A4 | Planned |
+| `src/github/timestamp.rs` | Shared pure RFC 3339 instant comparison | A1–A5 | Planned |
+| `src/github/mod.rs` | Private helper module registration | A1–A5 | Planned |
+| `src/github/parse.rs` | Issue sorter integration | A1, A4 | Planned |
+| `src/github/parse_pr.rs` | PR and review sorter integration | A2–A4 | Planned |
+
+Budget target: 7 files total, under 500 net changed lines. No workflow, agent-memory, dependency, quality-tool, persistence, runtime, state, or UI files.
+
+## Scope ledger
+
+- No discoveries beyond the accepted scope.
+
+## Review counters
+
+- Local Open Code Review: 2/2 attempts. Both verified-environment runs were terminated by the shell timeout without output and are not treated as successful reviews or approval.
+- Post-PR Open Code Review: 0/2.
+
+## Verification evidence
+
+- Base: `issue336` created from `origin/main` at `c4f36f6`; initial divergence `0/0`.
+- Issue and all comments fetched with `gh issue view 336 --comments`.
+- Dependency research: no `chrono`, `time`, or `jiff` package in the direct manifest or lockfile.
+- RED evidence: `cargo test -q github_tests_timestamp_sort -- --nocapture` failed all 3 new tests under raw string comparison, with observed orders `[4, 3, 1, 2]`, `[3, 2, 1]`, and `[PRR_3, PRR_2, PRR_4]` instead of parsed-instant order.
+- Focused GREEN evidence: 3 mixed-form sorter tests and 5 parser/comparator unit tests pass.
+- `make quick-check`: passed (2,095 library tests plus all integration and doctest targets).
+- `make ci-check`: passed with format, policy, source-size, Clippy, 72.43% line coverage, locked build, and locked tests successful.
+- Exact-head PR workflows: pending.
+
+## Review findings and deferred work
+
+- None yet.

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -54,6 +54,7 @@ pub use actions::{
 };
 
 mod parse;
+mod timestamp;
 use comment_pages::loaded_comments;
 use parse::{active_issue_type_filter, issue_type_requires_search_filter};
 pub use parse::{

--- a/src/github/parse.rs
+++ b/src/github/parse.rs
@@ -14,6 +14,7 @@ use crate::domain::{
 use serde_json::Value;
 
 use super::comment_pages::exhausted_comments;
+use super::timestamp::cmp_rfc3339_newest_first;
 use super::{GhError, IssueListResponse};
 
 /// Categorize a subprocess error into a GhError variant.
@@ -250,9 +251,7 @@ fn collect_nodes_field(item: &Value, field: &str) -> Vec<String> {
 /// @pseudocode component-002 lines 46-54
 pub fn sort_issues(issues: &mut [Issue]) {
     issues.sort_by(|a, b| {
-        b.updated_at
-            .cmp(&a.updated_at)
-            .then(a.number.cmp(&b.number))
+        cmp_rfc3339_newest_first(&a.updated_at, &b.updated_at).then(a.number.cmp(&b.number))
     });
 }
 

--- a/src/github/parse_pr.rs
+++ b/src/github/parse_pr.rs
@@ -17,6 +17,7 @@ use serde_json::Value;
 
 use super::comment_pages::exhausted_comments;
 use super::parse::parse_page_info;
+use super::timestamp::cmp_rfc3339_newest_first;
 use super::{GhError, PrListResponse};
 
 /// Build the GraphQL query string for the PR comments fetch
@@ -589,9 +590,7 @@ fn merged_at_non_empty(merged_at: &Value) -> bool {
 /// @pseudocode component-002 lines 194-196
 pub fn sort_pull_requests(items: &mut [PullRequest]) {
     items.sort_by(|a, b| {
-        b.updated_at
-            .cmp(&a.updated_at)
-            .then(a.number.cmp(&b.number))
+        cmp_rfc3339_newest_first(&a.updated_at, &b.updated_at).then(a.number.cmp(&b.number))
     });
 }
 
@@ -609,8 +608,7 @@ fn cmp_pr_reviews_newest_first(
     a: &crate::domain::PrReview,
     b: &crate::domain::PrReview,
 ) -> std::cmp::Ordering {
-    b.submitted_at
-        .cmp(&a.submitted_at)
+    cmp_rfc3339_newest_first(&a.submitted_at, &b.submitted_at)
         .then_with(|| b.review_id.cmp(&a.review_id))
         .then_with(|| a.author_login.cmp(&b.author_login))
 }

--- a/src/github/tests_timestamp_sort.rs
+++ b/src/github/tests_timestamp_sort.rs
@@ -1,0 +1,111 @@
+//! Behavioral coverage for RFC 3339 timestamp sorting (issue #336).
+
+use crate::domain::{
+    Issue, IssueState, PrCheckStatus, PrReview, PrReviewState, PrState, PullRequest,
+};
+use crate::github::{sort_issues, sort_pr_reviews, sort_pull_requests};
+
+fn issue(number: u64, updated_at: &str) -> Issue {
+    Issue {
+        number,
+        node_id: String::new(),
+        title: format!("issue {number}"),
+        state: IssueState::Open,
+        author_login: String::new(),
+        updated_at: updated_at.to_string(),
+        assignee_summary: String::new(),
+        labels_summary: String::new(),
+        assignees: Vec::new(),
+        labels: Vec::new(),
+        issue_type: String::new(),
+        milestone: String::new(),
+        module: String::new(),
+        comment_count: 0,
+        body: String::new(),
+    }
+}
+
+fn pull_request(number: u64, updated_at: &str) -> PullRequest {
+    PullRequest {
+        number,
+        title: format!("pull request {number}"),
+        state: PrState::Open,
+        author_login: String::new(),
+        updated_at: updated_at.to_string(),
+        head_ref: String::new(),
+        head_sha: String::new(),
+        base_ref: String::new(),
+        is_draft: false,
+        review_decision: None,
+        checks_status: PrCheckStatus::None,
+        assignee_summary: String::new(),
+        labels_summary: String::new(),
+        comment_count: 0,
+    }
+}
+
+fn review(review_id: &str, submitted_at: &str) -> PrReview {
+    PrReview {
+        review_id: Some(review_id.to_string()),
+        author_login: String::new(),
+        state: PrReviewState::Commented,
+        submitted_at: submitted_at.to_string(),
+        body: None,
+        review_threads: Vec::new(),
+    }
+}
+
+#[test]
+fn issues_sort_mixed_precision_by_instant_then_number() {
+    let mut issues = vec![
+        issue(4, "2026-07-02T10:00:00Z"),
+        issue(3, "2026-07-02T10:00:00.123Z"),
+        issue(2, "2026-07-02T09:00:00-01:00"),
+        issue(1, "2026-07-02T10:00:00+00:00"),
+    ];
+
+    sort_issues(&mut issues);
+
+    assert_eq!(
+        issues.iter().map(|item| item.number).collect::<Vec<_>>(),
+        vec![3, 1, 2, 4]
+    );
+}
+
+#[test]
+fn pull_requests_sort_mixed_offsets_by_instant_then_number() {
+    let mut pull_requests = vec![
+        pull_request(3, "2026-07-02T10:00:00+05:00"),
+        pull_request(2, "2026-07-02T06:00:00Z"),
+        pull_request(1, "2026-07-02T06:00:00+00:00"),
+    ];
+
+    sort_pull_requests(&mut pull_requests);
+
+    assert_eq!(
+        pull_requests
+            .iter()
+            .map(|item| item.number)
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+}
+
+#[test]
+fn pr_reviews_sort_mixed_forms_by_instant_then_review_id() {
+    let mut reviews = vec![
+        review("PRR_2", "2026-07-02T10:00:00Z"),
+        review("PRR_3", "2026-07-02T15:00:00+05:00"),
+        review("PRR_4", "2026-07-02T10:00:00.001Z"),
+    ];
+
+    sort_pr_reviews(&mut reviews);
+
+    assert_eq!(
+        reviews
+            .iter()
+            .map(|item| item.review_id.as_deref())
+            .collect::<Vec<_>>(),
+        vec![Some("PRR_4"), Some("PRR_3"), Some("PRR_2")]
+    );
+}

--- a/src/github/timestamp.rs
+++ b/src/github/timestamp.rs
@@ -1,0 +1,222 @@
+//! RFC 3339 instant comparison for timestamp-bearing GitHub responses.
+//!
+//! The comparator is dependency-free, side-effect-free, and shared by every
+//! GitHub list sorter so offset and fractional-second forms cannot drift.
+
+use std::cmp::Ordering;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Rfc3339Instant<'a> {
+    whole_seconds: i64,
+    fraction: &'a [u8],
+}
+
+impl Ord for Rfc3339Instant<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.whole_seconds
+            .cmp(&other.whole_seconds)
+            .then_with(|| self.fraction.cmp(other.fraction))
+    }
+}
+
+impl PartialOrd for Rfc3339Instant<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum TimestampSortKey<'a> {
+    Invalid(&'a str),
+    Valid(Rfc3339Instant<'a>),
+}
+
+/// Compare two RFC 3339 timestamps newest-first.
+///
+/// Valid timestamps precede malformed values. Malformed values retain their
+/// reverse-lexicographic order, which also keeps an empty timestamp last.
+pub(super) fn cmp_rfc3339_newest_first(a: &str, b: &str) -> Ordering {
+    timestamp_sort_key(b).cmp(&timestamp_sort_key(a))
+}
+
+fn timestamp_sort_key(value: &str) -> TimestampSortKey<'_> {
+    parse_rfc3339(value).map_or(TimestampSortKey::Invalid(value), TimestampSortKey::Valid)
+}
+
+fn parse_rfc3339(value: &str) -> Option<Rfc3339Instant<'_>> {
+    let bytes = value.as_bytes();
+    if !fixed_separators_are_valid(bytes) {
+        return None;
+    }
+
+    let year = i64::from(parse_digits(bytes, 0, 4)?);
+    let month = parse_digits(bytes, 5, 2)?;
+    let day = parse_digits(bytes, 8, 2)?;
+    let hour = parse_digits(bytes, 11, 2)?;
+    let minute = parse_digits(bytes, 14, 2)?;
+    let second = parse_digits(bytes, 17, 2)?;
+    if !date_time_fields_are_valid(year, month, day, hour, minute, second) {
+        return None;
+    }
+
+    let (fraction, timezone_position) = parse_fraction(bytes)?;
+    let offset_seconds = parse_utc_offset(bytes, timezone_position)?;
+    let whole_seconds = days_from_civil(year, month, day) * 86_400
+        + i64::from(hour) * 3_600
+        + i64::from(minute) * 60
+        + i64::from(second.min(59))
+        + i64::from(second == 60)
+        - offset_seconds;
+
+    Some(Rfc3339Instant {
+        whole_seconds,
+        fraction,
+    })
+}
+
+fn fixed_separators_are_valid(bytes: &[u8]) -> bool {
+    bytes.len() >= 20
+        && bytes.get(4) == Some(&b'-')
+        && bytes.get(7) == Some(&b'-')
+        && matches!(bytes.get(10), Some(b'T' | b't'))
+        && bytes.get(13) == Some(&b':')
+        && bytes.get(16) == Some(&b':')
+}
+
+fn parse_fraction(bytes: &[u8]) -> Option<(&[u8], usize)> {
+    if bytes.get(19) != Some(&b'.') {
+        return Some((&bytes[19..19], 19));
+    }
+
+    let start = 20;
+    let mut end = start;
+    while bytes.get(end).is_some_and(u8::is_ascii_digit) {
+        end += 1;
+    }
+    if end == start {
+        return None;
+    }
+    while end > start && bytes[end - 1] == b'0' {
+        end -= 1;
+    }
+    let timezone_position = bytes[20..].iter().position(|byte| !byte.is_ascii_digit())? + 20;
+    Some((&bytes[start..end], timezone_position))
+}
+
+fn parse_utc_offset(bytes: &[u8], position: usize) -> Option<i64> {
+    match bytes.get(position) {
+        Some(b'Z' | b'z') if position + 1 == bytes.len() => Some(0),
+        Some(sign @ (b'+' | b'-')) if position + 6 == bytes.len() => {
+            if bytes.get(position + 3) != Some(&b':') {
+                return None;
+            }
+            let hours = parse_digits(bytes, position + 1, 2)?;
+            let minutes = parse_digits(bytes, position + 4, 2)?;
+            if hours > 23 || minutes > 59 {
+                return None;
+            }
+            let magnitude = i64::from(hours * 3_600 + minutes * 60);
+            Some(if *sign == b'+' { magnitude } else { -magnitude })
+        }
+        _ => None,
+    }
+}
+
+fn parse_digits(bytes: &[u8], start: usize, length: usize) -> Option<u32> {
+    let mut value = 0_u32;
+    for byte in bytes.get(start..start + length)? {
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+        value = value * 10 + u32::from(byte - b'0');
+    }
+    Some(value)
+}
+
+fn date_time_fields_are_valid(
+    year: i64,
+    month: u32,
+    day: u32,
+    hour: u32,
+    minute: u32,
+    second: u32,
+) -> bool {
+    (1..=12).contains(&month)
+        && (1..=days_in_month(year, month)).contains(&day)
+        && hour <= 23
+        && minute <= 59
+        && second <= 60
+}
+
+fn days_in_month(year: i64, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        _ => 28,
+    }
+}
+
+fn is_leap_year(year: i64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
+    let adjusted_year = year - i64::from(month <= 2);
+    let era = adjusted_year.div_euclid(400);
+    let year_of_era = adjusted_year - era * 400;
+    let shifted_month = i64::from(month) + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * shifted_month + 2) / 5 + i64::from(day) - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cmp_rfc3339_newest_first, parse_rfc3339};
+    use std::cmp::Ordering;
+
+    #[test]
+    fn equivalent_offsets_and_fraction_precision_compare_equal() {
+        assert_eq!(
+            parse_rfc3339("2026-07-02T10:00:00.1000Z"),
+            parse_rfc3339("2026-07-02t11:00:00.1+01:00")
+        );
+    }
+
+    #[test]
+    fn arbitrary_fraction_precision_compares_chronologically() {
+        assert!(
+            parse_rfc3339("2026-07-02T10:00:00.00000000001Z")
+                > parse_rfc3339("2026-07-02T10:00:00.000000000001Z")
+        );
+    }
+
+    #[test]
+    fn leap_second_matches_the_next_whole_second() {
+        assert_eq!(
+            parse_rfc3339("2016-12-31T23:59:60Z"),
+            parse_rfc3339("2017-01-01T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn invalid_fields_are_rejected() {
+        for value in [
+            "2025-02-29T00:00:00Z",
+            "2026-01-01T24:00:00Z",
+            "2026-01-01T00:00:00+24:00",
+            "2026-01-01T00:00:00. Z",
+        ] {
+            assert_eq!(parse_rfc3339(value), None, "accepted {value}");
+        }
+    }
+
+    #[test]
+    fn valid_values_precede_malformed_and_empty_values() {
+        let mut values = vec!["", "bad", "2026-01-01T00:00:00Z"];
+        values.sort_by(|a, b| cmp_rfc3339_newest_first(a, b));
+        assert_eq!(values, vec!["2026-01-01T00:00:00Z", "bad", ""]);
+        assert_eq!(cmp_rfc3339_newest_first("bad", "bad"), Ordering::Equal);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,10 @@ mod github_tests_pr_detail;
 mod github_tests_pr_sort_reviews;
 
 #[cfg(test)]
+#[path = "github/tests_timestamp_sort.rs"]
+mod github_tests_timestamp_sort;
+
+#[cfg(test)]
 #[path = "github/tests_pr_threads.rs"]
 mod github_tests_pr_threads;
 


### PR DESCRIPTION
## Summary

- compare issue, pull-request, and PR-review timestamps as RFC 3339 instants instead of raw strings
- share one private GitHub-boundary comparator across all three sort paths
- preserve newest-first ordering and the existing number, review-ID, and author tie-breakers
- keep malformed or missing timestamps deterministic and older than valid timestamps
- avoid a new dependency because no date-time crate is currently present and dependency additions require approval

## Acceptance evidence

- mixed fractional precision now orders chronologically
- `Z`, `+00:00`, and non-zero offsets normalize to their represented UTC instant
- equivalent instants defer to the existing sorter-specific tie-breakers
- parser tests cover lowercase markers, arbitrary fractional precision, leap seconds, invalid dates/times/offsets, and malformed fallback

## Test-first evidence

The three new sorter tests were first run against the existing raw string comparators and all failed with incorrect orders. After introducing the shared comparator, those tests and five focused parser/comparator tests passed.

## Verification

- `make quick-check`
- `make ci-check`
  - formatting and policy checks
  - source-size and Clippy gates
  - 72.43% line coverage
  - locked workspace build
  - locked full test suite

## Scope

Seven files, 443 insertions, and 8 deletions. No dependency, workflow, agent-memory, quality-tool, persistence, runtime, state, or UI changes.

Fixes #336
