### PR TITLE
Keep tutorial captures inside the SVG viewport (Fixes #342)

### DIFF
--- a/docs/assets/first-agent-new-agent.svg
+++ b/docs/assets/first-agent-new-agent.svg
@@ -1,37 +1,37 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="594" viewBox="0 0 800 594" role="img">
-<rect width="800" height="594" fill="#000000"/>
-<text x="8" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">
-<tspan x="8" y="20">╭──────────────────────────────────────────────────────────────────────────────────────────────────╮</tspan>
-<tspan x="8" y="38">│                                                                                                  │</tspan>
-<tspan x="8" y="56">│  New Agent                                                                                       │</tspan>
-<tspan x="8" y="74">│                                                                                                  │</tspan>
-<tspan x="8" y="92">│   Shortcut (1-9)   [1]                                                                           │</tspan>
-<tspan x="8" y="110">│   Name             []                                                                            │</tspan>
-<tspan x="8" y="128">│   Description      []                                                                            │</tspan>
-<tspan x="8" y="146">│   Work Dir         [fixture-repo]                                                                │</tspan>
-<tspan x="8" y="164">│   Profile          []                                                                            │</tspan>
-<tspan x="8" y="182">│   Agent Runtime    [LLxprt]  (space cycles: LLxprt / code_puppy)                                 │</tspan>
-<tspan x="8" y="200">│   Mode Flags       [--yolo]                                                                      │</tspan>
-<tspan x="8" y="218">│   Version          []                                                                            │</tspan>
-<tspan x="8" y="236">│   LLXPRT_DEBUG     []                                                                            │</tspan>
-<tspan x="8" y="254">│   Pass --continue  [x]  (space toggles)                                                          │</tspan>
-<tspan x="8" y="272">│   Sandbox          [ ]  (space toggles)                                                          │</tspan>
-<tspan x="8" y="290">│   Sandbox Engine   [Podman]  (disabled)                                                          │</tspan>
-<tspan x="8" y="308">│   Sandbox Flags    [--cpus=2 --memory=12288m --pids-limit=256]                                   │</tspan>
-<tspan x="8" y="326">│                                                                                                  │</tspan>
-<tspan x="8" y="344">│   Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles/cycles checkboxes      │</tspan>
-<tspan x="8" y="362">│                                                                                                  │</tspan>
-<tspan x="8" y="380">│                                                                                                  │</tspan>
-<tspan x="8" y="398">│                                                                                                  │</tspan>
-<tspan x="8" y="416">│                                                                                                  │</tspan>
-<tspan x="8" y="434">│                                                                                                  │</tspan>
-<tspan x="8" y="452">│                                                                                                  │</tspan>
-<tspan x="8" y="470">│                                                                                                  │</tspan>
-<tspan x="8" y="488">│                                                                                                  │</tspan>
-<tspan x="8" y="506">│                                                                                                  │</tspan>
-<tspan x="8" y="524">│                                                                                                  │</tspan>
-<tspan x="8" y="542">│                                                                                                  │</tspan>
-<tspan x="8" y="560">│                                                                                                  │</tspan>
-<tspan x="8" y="578">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</tspan>
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="594" viewBox="0 0 880 594" role="img">
+<rect width="880" height="594" fill="#000000"/>
+<text x="16" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">
+<tspan x="16" y="20" textLength="848" lengthAdjust="spacingAndGlyphs">╭──────────────────────────────────────────────────────────────────────────────────────────────────╮</tspan>
+<tspan x="16" y="38" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="56" textLength="848" lengthAdjust="spacingAndGlyphs">│  New Agent                                                                                       │</tspan>
+<tspan x="16" y="74" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="92" textLength="848" lengthAdjust="spacingAndGlyphs">│   Shortcut (1-9)   [1]                                                                           │</tspan>
+<tspan x="16" y="110" textLength="848" lengthAdjust="spacingAndGlyphs">│   Name             []                                                                            │</tspan>
+<tspan x="16" y="128" textLength="848" lengthAdjust="spacingAndGlyphs">│   Description      []                                                                            │</tspan>
+<tspan x="16" y="146" textLength="848" lengthAdjust="spacingAndGlyphs">│   Work Dir         [fixture-repo]                                                                │</tspan>
+<tspan x="16" y="164" textLength="848" lengthAdjust="spacingAndGlyphs">│   Profile          []                                                                            │</tspan>
+<tspan x="16" y="182" textLength="848" lengthAdjust="spacingAndGlyphs">│   Agent Runtime    [LLxprt]  (space cycles: LLxprt / code_puppy)                                 │</tspan>
+<tspan x="16" y="200" textLength="848" lengthAdjust="spacingAndGlyphs">│   Mode Flags       [--yolo]                                                                      │</tspan>
+<tspan x="16" y="218" textLength="848" lengthAdjust="spacingAndGlyphs">│   Version          []                                                                            │</tspan>
+<tspan x="16" y="236" textLength="848" lengthAdjust="spacingAndGlyphs">│   LLXPRT_DEBUG     []                                                                            │</tspan>
+<tspan x="16" y="254" textLength="848" lengthAdjust="spacingAndGlyphs">│   Pass --continue  [x]  (space toggles)                                                          │</tspan>
+<tspan x="16" y="272" textLength="848" lengthAdjust="spacingAndGlyphs">│   Sandbox          [ ]  (space toggles)                                                          │</tspan>
+<tspan x="16" y="290" textLength="848" lengthAdjust="spacingAndGlyphs">│   Sandbox Engine   [Podman]  (disabled)                                                          │</tspan>
+<tspan x="16" y="308" textLength="848" lengthAdjust="spacingAndGlyphs">│   Sandbox Flags    [--cpus=2 --memory=12288m --pids-limit=256]                                   │</tspan>
+<tspan x="16" y="326" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="344" textLength="848" lengthAdjust="spacingAndGlyphs">│   Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles/cycles checkboxes      │</tspan>
+<tspan x="16" y="362" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="380" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="398" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="416" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="434" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="452" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="470" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="488" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="506" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="524" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="542" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="560" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="578" textLength="848" lengthAdjust="spacingAndGlyphs">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</tspan>
 </text>
 </svg>

--- a/docs/assets/first-agent-new-repository.svg
+++ b/docs/assets/first-agent-new-repository.svg
@@ -1,37 +1,37 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="594" viewBox="0 0 800 594" role="img">
-<rect width="800" height="594" fill="#000000"/>
-<text x="8" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">
-<tspan x="8" y="20">╭──────────────────────────────────────────────────────────────────────────────────────────────────╮</tspan>
-<tspan x="8" y="38">│                                                                                                  │</tspan>
-<tspan x="8" y="56">│  New Repository                                                                                  │</tspan>
-<tspan x="8" y="74">│                                                                                                  │</tspan>
-<tspan x="8" y="92">│   Name             [▏]                                                                           │</tspan>
-<tspan x="8" y="110">│   Base Dir         []                                                                            │</tspan>
-<tspan x="8" y="128">│   Default Profile  []                                                                            │</tspan>
-<tspan x="8" y="146">│   Default Agent    [LLxprt]  (space cycles: LLxprt / code_puppy)                                 │</tspan>
-<tspan x="8" y="164">│   Default Mode     [--yolo]                                                                      │</tspan>
-<tspan x="8" y="182">│   Default Version  []                                                                            │</tspan>
-<tspan x="8" y="200">│   GitHub Repo      []                                                                            │</tspan>
-<tspan x="8" y="218">│   Issues / PRs Repo []  (blank uses GitHub Repo)                                                 │</tspan>
-<tspan x="8" y="236">│   Remote Repository [ ]  (space toggles)                                                         │</tspan>
-<tspan x="8" y="254">│   Login User       []                                                                            │</tspan>
-<tspan x="8" y="272">│   Host / IP        []                                                                            │</tspan>
-<tspan x="8" y="290">│   SSH Port         []                                                                            │</tspan>
-<tspan x="8" y="308">│   Identity File    []                                                                            │</tspan>
-<tspan x="8" y="326">│   SSH Options (space-separated) []                                                               │</tspan>
-<tspan x="8" y="344">│   Run As User      []                                                                            │</tspan>
-<tspan x="8" y="362">│   Setup Env Default [ ]  (space toggles)                                                         │</tspan>
-<tspan x="8" y="380">│   Transient Dir    []  (blank uses /tmp)                                                         │</tspan>
-<tspan x="8" y="398">│   Max Transient    []  (0 = no limit)                                                            │</tspan>
-<tspan x="8" y="416">│                                                                                                  │</tspan>
-<tspan x="8" y="434">│   Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles remote options  Enter  │</tspan>
-<tspan x="8" y="452">│                                                                                                  │</tspan>
-<tspan x="8" y="470">│                                                                                                  │</tspan>
-<tspan x="8" y="488">│                                                                                                  │</tspan>
-<tspan x="8" y="506">│                                                                                                  │</tspan>
-<tspan x="8" y="524">│                                                                                                  │</tspan>
-<tspan x="8" y="542">│                                                                                                  │</tspan>
-<tspan x="8" y="560">│                                                                                                  │</tspan>
-<tspan x="8" y="578">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</tspan>
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="594" viewBox="0 0 880 594" role="img">
+<rect width="880" height="594" fill="#000000"/>
+<text x="16" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">
+<tspan x="16" y="20" textLength="848" lengthAdjust="spacingAndGlyphs">╭──────────────────────────────────────────────────────────────────────────────────────────────────╮</tspan>
+<tspan x="16" y="38" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="56" textLength="848" lengthAdjust="spacingAndGlyphs">│  New Repository                                                                                  │</tspan>
+<tspan x="16" y="74" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="92" textLength="848" lengthAdjust="spacingAndGlyphs">│   Name             [▏]                                                                           │</tspan>
+<tspan x="16" y="110" textLength="848" lengthAdjust="spacingAndGlyphs">│   Base Dir         []                                                                            │</tspan>
+<tspan x="16" y="128" textLength="848" lengthAdjust="spacingAndGlyphs">│   Default Profile  []                                                                            │</tspan>
+<tspan x="16" y="146" textLength="848" lengthAdjust="spacingAndGlyphs">│   Default Agent    [LLxprt]  (space cycles: LLxprt / code_puppy)                                 │</tspan>
+<tspan x="16" y="164" textLength="848" lengthAdjust="spacingAndGlyphs">│   Default Mode     [--yolo]                                                                      │</tspan>
+<tspan x="16" y="182" textLength="848" lengthAdjust="spacingAndGlyphs">│   Default Version  []                                                                            │</tspan>
+<tspan x="16" y="200" textLength="848" lengthAdjust="spacingAndGlyphs">│   GitHub Repo      []                                                                            │</tspan>
+<tspan x="16" y="218" textLength="848" lengthAdjust="spacingAndGlyphs">│   Issues / PRs Repo []  (blank uses GitHub Repo)                                                 │</tspan>
+<tspan x="16" y="236" textLength="848" lengthAdjust="spacingAndGlyphs">│   Remote Repository [ ]  (space toggles)                                                         │</tspan>
+<tspan x="16" y="254" textLength="848" lengthAdjust="spacingAndGlyphs">│   Login User       []                                                                            │</tspan>
+<tspan x="16" y="272" textLength="848" lengthAdjust="spacingAndGlyphs">│   Host / IP        []                                                                            │</tspan>
+<tspan x="16" y="290" textLength="848" lengthAdjust="spacingAndGlyphs">│   SSH Port         []                                                                            │</tspan>
+<tspan x="16" y="308" textLength="848" lengthAdjust="spacingAndGlyphs">│   Identity File    []                                                                            │</tspan>
+<tspan x="16" y="326" textLength="848" lengthAdjust="spacingAndGlyphs">│   SSH Options (space-separated) []                                                               │</tspan>
+<tspan x="16" y="344" textLength="848" lengthAdjust="spacingAndGlyphs">│   Run As User      []                                                                            │</tspan>
+<tspan x="16" y="362" textLength="848" lengthAdjust="spacingAndGlyphs">│   Setup Env Default [ ]  (space toggles)                                                         │</tspan>
+<tspan x="16" y="380" textLength="848" lengthAdjust="spacingAndGlyphs">│   Transient Dir    []  (blank uses /tmp)                                                         │</tspan>
+<tspan x="16" y="398" textLength="848" lengthAdjust="spacingAndGlyphs">│   Max Transient    []  (0 = no limit)                                                            │</tspan>
+<tspan x="16" y="416" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="434" textLength="848" lengthAdjust="spacingAndGlyphs">│   Tab/Down next  Shift+Tab/Up prev  Left/Right move cursor  Space toggles remote options  Enter  │</tspan>
+<tspan x="16" y="452" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="470" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="488" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="506" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="524" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="542" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="560" textLength="848" lengthAdjust="spacingAndGlyphs">│                                                                                                  │</tspan>
+<tspan x="16" y="578" textLength="848" lengthAdjust="spacingAndGlyphs">╰──────────────────────────────────────────────────────────────────────────────────────────────────╯</tspan>
 </text>
 </svg>

--- a/docs/assets/first-agent-result.svg
+++ b/docs/assets/first-agent-result.svg
@@ -1,37 +1,37 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="594" viewBox="0 0 800 594" role="img">
-<rect width="800" height="594" fill="#000000"/>
-<text x="8" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">
-<tspan x="8" y="20"> LLxprt Jefe WARN: SSH agent socket is present but no identities are loaded. Run `ssh-add`  Green</tspan>
-<tspan x="8" y="38">╭────────────────────╮╭────────────────────────────────────────╮╭──────────────────────────────────╮</tspan>
-<tspan x="8" y="56">│ Repositories       ││ Agents                                 ││ Preview                          │</tspan>
-<tspan x="8" y="74">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="92">│ &gt; Tutorial Reposi… ││ &gt; * [1] Tutorial Agent                 ││ Name: Tutorial Agent             │</tspan>
-<tspan x="8" y="110">│                    ││                                        ││ Status: Running                  │</tspan>
-<tspan x="8" y="128">│                    ││                                        ││ Repo: (unknown)                  │</tspan>
-<tspan x="8" y="146">│                    ││                                        ││ Branch: (unknown)                │</tspan>
-<tspan x="8" y="164">│                    │╰────────────────────────────────────────╯│ Dir: fixture-repo/tutorial-agent │</tspan>
-<tspan x="8" y="182">│                    │╭────────────────────────────────────────╮│                                  │</tspan>
-<tspan x="8" y="200">│                    ││ Terminal (F12/t to focus)              ││ Todo:                            │</tspan>
-<tspan x="8" y="218">│                    ││tutorial-shim: ready                    ││   (no tasks)                     │</tspan>
-<tspan x="8" y="236">│                    ││hello from the tutorial                 ││                                  │</tspan>
-<tspan x="8" y="254">│                    ││tutorial-shim: response: hello from the ││                                  │</tspan>
-<tspan x="8" y="272">│                    ││tutorial                                ││                                  │</tspan>
-<tspan x="8" y="290">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="308">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="326">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="344">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="362">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="380">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="398">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="416">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="434">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="452">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="470">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="488">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="506">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="524">│                    ││                                        ││                                  │</tspan>
-<tspan x="8" y="542">│                    ││[terminal status redacted]││                                  │</tspan>
-<tspan x="8" y="560">╰────────────────────╯╰────────────────────────────────────────╯╰──────────────────────────────────╯</tspan>
-<tspan x="8" y="578"> ^/v navigate | &lt;/&gt; pane | t/f12 terminal focus | v active-only (repos+agents) | ⌥1-9        pid:[redacted]</tspan>
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="594" viewBox="0 0 880 594" role="img">
+<rect width="880" height="594" fill="#000000"/>
+<text x="16" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">
+<tspan x="16" y="20" textLength="848" lengthAdjust="spacingAndGlyphs"> LLxprt Jefe WARN: SSH agent socket is present but no identities are loaded. Run `ssh-add`  Green   </tspan>
+<tspan x="16" y="38" textLength="848" lengthAdjust="spacingAndGlyphs">╭────────────────────╮╭────────────────────────────────────────╮╭──────────────────────────────────╮</tspan>
+<tspan x="16" y="56" textLength="848" lengthAdjust="spacingAndGlyphs">│ Repositories       ││ Agents                                 ││ Preview                          │</tspan>
+<tspan x="16" y="74" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="92" textLength="848" lengthAdjust="spacingAndGlyphs">│ &gt; Tutorial Reposi… ││ &gt; * [1] Tutorial Agent                 ││ Name: Tutorial Agent             │</tspan>
+<tspan x="16" y="110" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││ Status: Running                  │</tspan>
+<tspan x="16" y="128" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││ Repo: (unknown)                  │</tspan>
+<tspan x="16" y="146" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││ Branch: (unknown)                │</tspan>
+<tspan x="16" y="164" textLength="848" lengthAdjust="spacingAndGlyphs">│                    │╰────────────────────────────────────────╯│ Dir: fixture-repo/tutorial-agent │</tspan>
+<tspan x="16" y="182" textLength="848" lengthAdjust="spacingAndGlyphs">│                    │╭────────────────────────────────────────╮│                                  │</tspan>
+<tspan x="16" y="200" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││ Terminal (F12/t to focus)              ││ Todo:                            │</tspan>
+<tspan x="16" y="218" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││tutorial-shim: ready                    ││   (no tasks)                     │</tspan>
+<tspan x="16" y="236" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││hello from the tutorial                 ││                                  │</tspan>
+<tspan x="16" y="254" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││tutorial-shim: response: hello from the ││                                  │</tspan>
+<tspan x="16" y="272" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││tutorial                                ││                                  │</tspan>
+<tspan x="16" y="290" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="308" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="326" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="344" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="362" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="380" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="398" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="416" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="434" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="452" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="470" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="488" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="506" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="524" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││                                        ││                                  │</tspan>
+<tspan x="16" y="542" textLength="848" lengthAdjust="spacingAndGlyphs">│                    ││[terminal status redacted]              ││                                  │</tspan>
+<tspan x="16" y="560" textLength="848" lengthAdjust="spacingAndGlyphs">╰────────────────────╯╰────────────────────────────────────────╯╰──────────────────────────────────╯</tspan>
+<tspan x="16" y="578" textLength="848" lengthAdjust="spacingAndGlyphs"> ^/v navigate | &lt;/&gt; pane | t/f12 terminal focus | v active-only (repos+agents) | ⌥1-9 pid:[redacted]</tspan>
 </text>
 </svg>

--- a/project-plans/issue342-plan.md
+++ b/project-plans/issue342-plan.md
@@ -1,0 +1,116 @@
+# Issue 342: first-agent tutorial SVG geometry
+
+## Objective
+
+Correct the bounded issue 241 publication renderer so its fixed 100-column,
+32-row tutorial captures retain the complete terminal grid inside an SVG with
+explicit horizontal padding. Regenerate the three published tutorial assets
+from the unchanged semantic capture scenario without changing the tutorial
+narrative or publication redaction.
+
+## Acceptance matrix
+
+| Row | Actor / launch path | Input and boundaries | Observable success | Observable failure / diagnostics | Permitted side effects | Proof |
+| --- | --- | --- | --- | --- | --- | --- |
+| A1 | Documentation reader opens `docs/getting-started.md` on GitHub | Any of the three existing first-agent images generated from the fixed 100x32 scenario | The complete 100-column terminal grid, including rightmost borders and final-column text, is visible with intentional left/right padding | A renderer geometry contract fails when the final terminal column reaches or crosses the SVG edge | None at read time | Deterministic integration test over all committed tutorial SVGs plus rendered-image inspection |
+| A2 | Documentation author runs `scripts/issue241-capture.sh capture` | Existing six semantic checkpoints, 100 columns, 32 rows, publication redaction enabled | Every generated SVG uses one fixed cross-image width/height and an explicit 100-column text extent contained between equal horizontal padding | Contract test identifies missing or inconsistent width, text extent, padding, or final-column containment | Existing run-root publication files only | RED/GREEN capture workflow contract test |
+| A3 | Documentation author republishes selected checkpoints | Unchanged first-agent scenario and tutorial narrative | The three affected assets are regenerated, retain safe redacted content, and preserve useful existing Markdown alt text | Existing publication validation rejects unsafe content; asset contract rejects stale geometry | Replace only the three selected SVG assets | Real capture run, byte/content inspection, and unchanged tutorial diff |
+
+## Explicit non-goals
+
+- No generalized image-rendering platform, dynamic terminal-size support, ANSI
+  renderer, dependency, application UI behavior, or harness scenario change.
+- No change to the tutorial prose, image selection, filenames, alt text,
+  publication redaction policy, capture isolation, or cleanup behavior.
+- No attempt to redesign issue 241's fixed 100x32 publication contract.
+
+## Vertical slice
+
+### Slice 1: fixed terminal-grid geometry (RED -> GREEN)
+
+- Rows: A1-A3.
+- Owner/boundary: the existing issue-specific publication renderer and its Unix
+  integration contract.
+- RED: add deterministic checks proving the current 800-pixel viewport cannot
+  contain the declared 100-column text extent with horizontal padding and that
+  all committed assets carry the same safe geometry.
+- GREEN: give every rendered row an explicit fixed terminal-grid text extent,
+  widen the fixed SVG/background to contain it with equal padding, and
+  regenerate the three selected assets from the unchanged semantic scenario.
+- Allowed paths: `scripts/issue241-capture.sh`, `tests/issue241_capture.rs`,
+  `docs/assets/first-agent-{new-repository,new-agent,result}.svg`, and this plan.
+- Verification: focused issue 241 capture tests, real issue 241 capture,
+  independent SVG rasterization/inspection, `make quick-check`, and
+  `make ci-check`.
+- Stop if deterministic containment requires a new renderer/dependency, a
+  scenario or tutorial narrative change, or files outside the allowed paths.
+
+## Expected paths and architecture layers
+
+- Unix documentation-production boundary: `scripts/issue241-capture.sh`.
+- Behavioral contract: `tests/issue241_capture.rs`.
+- Generated documentation assets: the three existing `docs/assets/first-agent-*.svg` files.
+- Plan/evidence ledger: this file.
+
+Target: 6 changed files and fewer than 250 net changed lines. Generated line
+replacements count toward the file budget but do not add a new subsystem.
+
+## Scope ledger
+
+| Discovery | Disposition | Reason |
+| --- | --- | --- |
+| The existing 800-pixel viewport is narrower than 100 monospace glyphs at 14px plus padding | Blocker—Fix | Direct reproduction of issue 342 |
+| Publication redaction changes some row string lengths | In-scope geometry handling | Unicode-aware publication normalization preserves redaction markers while restoring each semantic row to the fixed 100-column grid |
+| Generic SVG text-length support is inconsistent across renderers | In-scope fallback geometry | The explicit text extent proves the contract, while a wider viewport and normalized rows also keep all glyphs visible when a renderer ignores `textLength` |
+| OCR found that consuming whitespace before `pid:` skipped a PID at column zero | Blocker—Fix | The redaction now preserves either the start-of-line or whitespace prefix and tests both positions |
+| Unicode-aware row normalization uses Perl | Reject portability finding | POSIX shell and the available awk count UTF-8 bytes on supported macOS; Perl is already available in the bounded Unix capture environment and preserves the required Unicode character-column contract without a new project dependency |
+| PR 339 already pins height to 32 rows and 594 pixels | No change | Issue 342 is horizontal clipping only; preserving fixed height is required |
+
+No unapproved scope changes.
+
+## Review counters
+
+- Open Code Review before PR: 1 / 2. StepFun `step-3.7-flash`, OCR workspace scope,
+  `complete_best_effort`; two duplicate high-impact findings identified a
+  leading-PID redaction regression and were fixed with RED/GREEN coverage. One
+  low-impact greedy-marker finding was also fixed. The Perl portability concern
+  was rejected because preserving Unicode character columns is required, the
+  existing capture contract is explicitly bounded Unix tooling, and POSIX
+  shell/awk on supported macOS count UTF-8 bytes rather than characters.
+- Open Code Review after PR: 0 / 2.
+
+## Verification evidence
+
+- Reproduction: all three current assets declare an 800-pixel viewport while
+  100 glyphs at the renderer's 14px monospace settings exceed the available
+  784 pixels between the existing 8-pixel side margins; independent
+  `rsvg-convert` rasterization retains the clipped 800x594 canvas.
+- RED focused regressions: generated SVG rows lacked `textLength`; committed
+  assets lacked containment geometry; publication rows were not normalized to
+  100 columns; and a narrower viewBox was not detected.
+- GREEN focused regression: all 11 issue 241 capture contracts pass, including
+  final-column containment, actual viewBox-width agreement, fixed row width,
+  redaction, and committed-asset borders.
+- Real semantic capture and asset regeneration:
+  `/private/tmp/jefe-issue342-publication-20260716` completed successfully using
+  the unchanged scenario; all three selected assets were copied from that run.
+- Independent rasterization: all three assets render at 880x594 with visible
+  content ending at x=856, leaving 24 pixels before the viewport edge in the
+  local fallback renderer.
+- Publication audit: every selected asset contains 32 rows of exactly 100
+  Unicode characters; no local path, identity, or credential-like content was
+  found; tutorial prose and scenario remain unchanged.
+- Local OpenCodeReview artifact:
+  `/Users/acoliver/Library/Logs/llxprt-code/opencodereview/runs/20260716T190441Z-81d2ad9f`;
+  OCR reported `complete_best_effort` coverage over the changed script and test.
+- OCR remediation: leading and interior PID redaction now pass RED/GREEN focused
+  coverage; the status-marker split uses the first marker; focused Clippy passes.
+- `make quick-check`: passed on the completed implementation.
+- `make ci-check`: passed after correcting focused Clippy findings; format,
+  policy, source-size, both Clippy passes, 73.39% line coverage, locked build,
+  and the complete locked test suite all completed successfully.
+- PR exact-head CI: pending.
+
+## Deferred findings / follow-ups
+
+None.

--- a/project-plans/issue342-plan.md
+++ b/project-plans/issue342-plan.md
@@ -62,7 +62,7 @@ replacements count toward the file budget but do not add a new subsystem.
 | The existing 800-pixel viewport is narrower than 100 monospace glyphs at 14px plus padding | Blocker—Fix | Direct reproduction of issue 342 |
 | Publication redaction changes some row string lengths | In-scope geometry handling | Unicode-aware publication normalization preserves redaction markers while restoring each semantic row to the fixed 100-column grid |
 | Generic SVG text-length support is inconsistent across renderers | In-scope fallback geometry | The explicit text extent proves the contract, while a wider viewport and normalized rows also keep all glyphs visible when a renderer ignores `textLength` |
-| OCR found that consuming whitespace before `pid:` skipped a PID at column zero | Blocker—Fix | The redaction now preserves either the start-of-line or whitespace prefix and tests both positions |
+| OCR found that consuming whitespace before `pid:` skipped PIDs at column zero or after punctuation | Blocker—Fix | The redaction again matches `pid:` in any position and tests leading, whitespace-prefixed, and parenthesized forms |
 | Unicode-aware row normalization uses Perl | Reject portability finding | POSIX shell and the available awk count UTF-8 bytes on supported macOS; Perl is already available in the bounded Unix capture environment and preserves the required Unicode character-column contract without a new project dependency |
 | PR 339 already pins height to 32 rows and 594 pixels | No change | Issue 342 is horizontal clipping only; preserving fixed height is required |
 
@@ -103,8 +103,9 @@ No unapproved scope changes.
 - Local OpenCodeReview artifact:
   `/Users/acoliver/Library/Logs/llxprt-code/opencodereview/runs/20260716T190441Z-81d2ad9f`;
   OCR reported `complete_best_effort` coverage over the changed script and test.
-- OCR remediation: leading and interior PID redaction now pass RED/GREEN focused
-  coverage; the status-marker split uses the first marker; focused Clippy passes.
+- OCR remediation: leading, whitespace-prefixed, and parenthesized PID redaction
+  pass RED/GREEN focused coverage; the status-marker split uses the first marker;
+  malformed geometry is checked before subtraction; focused Clippy passes.
 - `make quick-check`: passed on the completed implementation.
 - `make ci-check`: passed after correcting focused Clippy findings; format,
   policy, source-size, both Clippy passes, 73.39% line coverage, locked build,

--- a/scripts/issue241-capture.sh
+++ b/scripts/issue241-capture.sh
@@ -146,23 +146,30 @@ publication_text() {
     source=$1
     target=$2
     sed -E \
-        -e 's/pid:[0-9]+/pid:[redacted]/g' \
+        -e 's/(^|[[:space:]])pid:[0-9]+/\1pid:[redacted]/g' \
         -e 's/\[[^]]+ [0-9]{1,2}:[0-9]{2} [0-9]{1,2}-[A-Za-z]{3}-[0-9]{2}/[terminal status redacted]/g' \
-        "$source" > "$target"
+        "$source" | perl -CS -Mutf8 -ne '
+            chomp;
+            if (/^(.*?\[terminal status redacted\])(.*)$/) {
+                $_ = $1 . (" " x (100 - length($1) - length($2))) . $2;
+            }
+            $_ .= " " x (100 - length($_)) if length($_) < 100;
+            print "$_\n";
+        ' > "$target"
 }
 
 render_svg() {
     source=$1
     target=$2
     {
-        printf '%s\n' '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="594" viewBox="0 0 800 594" role="img">'
-        printf '%s\n' '<rect width="800" height="594" fill="#000000"/>'
-        printf '%s\n' '<text x="8" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">'
+        printf '%s\n' '<svg xmlns="http://www.w3.org/2000/svg" width="880" height="594" viewBox="0 0 880 594" role="img">'
+        printf '%s\n' '<rect width="880" height="594" fill="#000000"/>'
+        printf '%s\n' '<text x="16" y="20" fill="#6a9955" font-family="monospace" font-size="14" xml:space="preserve">'
         row=0
         while IFS= read -r line || [ -n "$line" ]; do
             escaped=$(printf '%s' "$line" | sed -e 's/\&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
             y=$((20 + row * 18))
-            printf '<tspan x="8" y="%s">%s</tspan>\n' "$y" "$escaped"
+            printf '<tspan x="16" y="%s" textLength="848" lengthAdjust="spacingAndGlyphs">%s</tspan>\n' "$y" "$escaped"
             row=$((row + 1))
         done < "$source"
         printf '%s\n' '</text>' '</svg>'

--- a/scripts/issue241-capture.sh
+++ b/scripts/issue241-capture.sh
@@ -146,7 +146,7 @@ publication_text() {
     source=$1
     target=$2
     sed -E \
-        -e 's/(^|[[:space:]])pid:[0-9]+/\1pid:[redacted]/g' \
+        -e 's/pid:[0-9]+/pid:[redacted]/g' \
         -e 's/\[[^]]+ [0-9]{1,2}:[0-9]{2} [0-9]{1,2}-[A-Za-z]{3}-[0-9]{2}/[terminal status redacted]/g' \
         "$source" | perl -CS -Mutf8 -ne '
             chomp;

--- a/tests/issue241_capture.rs
+++ b/tests/issue241_capture.rs
@@ -55,6 +55,77 @@ fn cleanup(root: &Path, mode: &str) -> Output {
         .unwrap_or_else(|error| panic!("run cleanup: {error}"))
 }
 
+fn attribute_value<'a>(element: &'a str, name: &str) -> &'a str {
+    let prefix = format!("{name}=\"");
+    element
+        .split_once(&prefix)
+        .and_then(|(_, remainder)| remainder.split_once('"'))
+        .map_or_else(
+            || panic!("missing {name} attribute in {element}"),
+            |(value, _)| value,
+        )
+}
+
+fn numeric_attribute(element: &str, name: &str) -> u32 {
+    let value = attribute_value(element, name);
+    value
+        .parse()
+        .unwrap_or_else(|error| panic!("invalid {name} attribute {value}: {error}"))
+}
+
+fn rendered_text(row: &str) -> String {
+    let content = row
+        .split_once('>')
+        .and_then(|(_, remainder)| remainder.split_once("</tspan>"))
+        .map_or_else(
+            || panic!("invalid tspan row: {row}"),
+            |(content, _)| content,
+        );
+    content
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+}
+
+fn assert_terminal_grid_is_contained(svg: &str, context: &str) {
+    let root = svg
+        .lines()
+        .find(|line| line.starts_with("<svg "))
+        .unwrap_or_else(|| panic!("missing SVG root in {context}"));
+    let viewport_width = numeric_attribute(root, "width");
+    let viewbox_width = attribute_value(root, "viewBox")
+        .split_whitespace()
+        .nth(2)
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or_else(|| panic!("invalid viewBox attribute in {context}"));
+    assert_eq!(
+        viewport_width, viewbox_width,
+        "SVG width and viewBox width differ in {context}"
+    );
+
+    let mut row_count = 0;
+    for row in svg.lines().filter(|line| line.starts_with("<tspan ")) {
+        let text_x = numeric_attribute(row, "x");
+        let text_length = numeric_attribute(row, "textLength");
+        let right_padding = viewport_width - text_x - text_length;
+        assert_eq!(
+            text_x, right_padding,
+            "unequal horizontal padding in {context}"
+        );
+        assert!(
+            text_x + text_length < viewbox_width,
+            "rendered terminal row extends outside {context}"
+        );
+        assert_eq!(
+            rendered_text(row).chars().count(),
+            100,
+            "rendered row must preserve 100 terminal columns in {context}"
+        );
+        row_count += 1;
+    }
+    assert!(row_count > 0, "missing rendered terminal rows in {context}");
+}
+
 #[test]
 fn capture_refuses_relative_and_existing_roots() {
     let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
@@ -106,7 +177,7 @@ fn successful_capture_records_provenance_and_renders_fixed_safe_svgs() {
     let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
     let (jefe, harness) = fake_binaries(
         &temp,
-        "Tutorial Agent ready pid:123 [private-host 12:34 16-Jul-26",
+        "pid:123\nTutorial Agent ready        pid:456\n[private-host 12:34 16-Jul-26",
     );
     let root = temp.path().join("capture");
     let output = capture(&root, &jefe, &harness);
@@ -133,12 +204,94 @@ fn successful_capture_records_provenance_and_renders_fixed_safe_svgs() {
     );
     let svg = fs::read_to_string(root.join("publication/first-agent-result.svg"))
         .unwrap_or_else(|error| panic!("read svg: {error}"));
-    assert!(svg.contains("width=\"800\" height=\"594\""));
+    assert!(svg.contains("width=\"880\" height=\"594\""));
     assert!(svg.contains("Tutorial Agent ready"));
     assert!(svg.contains("pid:[redacted]"));
     assert!(svg.contains("[terminal status redacted]"));
     assert!(!svg.contains("pid:123"));
+    assert!(!svg.contains("pid:456"));
     assert!(!svg.contains("private-host"));
+    let publication = fs::read_to_string(root.join("private/first-agent-result.publication.txt"))
+        .unwrap_or_else(|error| panic!("read publication text: {error}"));
+    assert!(
+        publication.lines().all(|line| line.chars().count() == 100),
+        "publication rows must preserve the fixed 100-column capture grid"
+    );
+}
+
+#[test]
+fn renderer_contains_the_final_terminal_column_inside_fixed_padding() {
+    let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let final_column = format!("{}│", " ".repeat(99));
+    let (jefe, harness) = fake_binaries(&temp, &final_column);
+    let root = temp.path().join("geometry");
+    let output = capture(&root, &jefe, &harness);
+    assert!(
+        output.status.success(),
+        "capture failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    for name in [
+        "first-agent-dashboard",
+        "first-agent-new-repository",
+        "first-agent-new-agent",
+        "first-agent-terminal-ready",
+        "first-agent-terminal-response",
+        "first-agent-result",
+    ] {
+        let path = root.join(format!("publication/{name}.svg"));
+        let svg = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+        assert!(
+            svg.lines()
+                .filter(|line| line.starts_with("<tspan "))
+                .any(|line| rendered_text(line).trim_end().ends_with('│')),
+            "final terminal column missing from {name}"
+        );
+        assert_terminal_grid_is_contained(&svg, name);
+    }
+}
+
+#[test]
+fn committed_tutorial_assets_keep_right_borders_inside_the_viewport() {
+    let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("docs/assets");
+    for name in [
+        "first-agent-new-repository.svg",
+        "first-agent-new-agent.svg",
+        "first-agent-result.svg",
+    ] {
+        let path = assets.join(name);
+        let svg = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+        let rows = svg
+            .lines()
+            .filter(|line| line.starts_with("<tspan "))
+            .map(rendered_text)
+            .collect::<Vec<_>>();
+        assert!(
+            rows.iter()
+                .any(|row| row.trim_end_matches([' ', '*']).ends_with('╮')),
+            "right border missing from {name}"
+        );
+        assert!(
+            rows.iter()
+                .any(|row| row.trim_end_matches([' ', '*']).ends_with('│')),
+            "right border missing from {name}"
+        );
+        assert_terminal_grid_is_contained(&svg, name);
+    }
+}
+
+#[test]
+#[should_panic(expected = "SVG width and viewBox width differ")]
+fn geometry_contract_rejects_a_viewbox_narrower_than_the_canvas() {
+    let row = "x".repeat(100);
+    let svg = format!(
+        "<svg width=\"880\" viewBox=\"0 0 800 594\">\n<tspan x=\"16\" textLength=\"848\">{row}</tspan>"
+    );
+
+    assert_terminal_grid_is_contained(&svg, "narrow viewBox fixture");
 }
 
 #[test]

--- a/tests/issue241_capture.rs
+++ b/tests/issue241_capture.rs
@@ -107,14 +107,17 @@ fn assert_terminal_grid_is_contained(svg: &str, context: &str) {
     for row in svg.lines().filter(|line| line.starts_with("<tspan ")) {
         let text_x = numeric_attribute(row, "x");
         let text_length = numeric_attribute(row, "textLength");
-        let right_padding = viewport_width - text_x - text_length;
+        let text_end = text_x
+            .checked_add(text_length)
+            .unwrap_or_else(|| panic!("rendered terminal row overflows geometry in {context}"));
+        assert!(
+            text_end < viewbox_width,
+            "rendered terminal row extends outside {context}"
+        );
+        let right_padding = viewport_width - text_end;
         assert_eq!(
             text_x, right_padding,
             "unequal horizontal padding in {context}"
-        );
-        assert!(
-            text_x + text_length < viewbox_width,
-            "rendered terminal row extends outside {context}"
         );
         assert_eq!(
             rendered_text(row).chars().count(),
@@ -177,7 +180,7 @@ fn successful_capture_records_provenance_and_renders_fixed_safe_svgs() {
     let temp = TempDir::new().unwrap_or_else(|error| panic!("tempdir: {error}"));
     let (jefe, harness) = fake_binaries(
         &temp,
-        "pid:123\nTutorial Agent ready        pid:456\n[private-host 12:34 16-Jul-26",
+        "pid:123\nTutorial Agent ready        pid:456\nProcess (pid:789) exited\n[private-host 12:34 16-Jul-26",
     );
     let root = temp.path().join("capture");
     let output = capture(&root, &jefe, &harness);
@@ -210,6 +213,7 @@ fn successful_capture_records_provenance_and_renders_fixed_safe_svgs() {
     assert!(svg.contains("[terminal status redacted]"));
     assert!(!svg.contains("pid:123"));
     assert!(!svg.contains("pid:456"));
+    assert!(!svg.contains("pid:789"));
     assert!(!svg.contains("private-host"));
     let publication = fs::read_to_string(root.join("private/first-agent-result.publication.txt"))
         .unwrap_or_else(|error| panic!("read publication text: {error}"));


### PR DESCRIPTION
## Summary

- normalize the fixed first-agent publication output to exactly 100 Unicode terminal columns while preserving PID and tmux-status redaction
- widen the deterministic SVG canvas to 880x594, declare a fixed 848-pixel text extent, and provide equal 16-pixel horizontal geometry margins
- regenerate the three existing tutorial images from the unchanged real 100x32 semantic capture scenario
- add deterministic contracts for final-column containment, viewBox agreement, fixed dimensions, row width, committed right borders, and leading/interior PID redaction

## Acceptance evidence

- reproduced the original defect: the committed 800-pixel viewport had only 784 pixels between margins for 100 14-pixel monospace cells
- real scenario capture completed at `/private/tmp/jefe-issue342-publication-20260716` with a success manifest
- every selected SVG contains 32 rows of exactly 100 Unicode characters and retains the existing semantic tutorial content and redaction markers
- independent rsvg rasterization renders all three assets at 880x594; visible content ends at x=856, leaving 24 pixels before the viewport edge in that fallback renderer
- `docs/getting-started.md` and `dev-docs/tmux-scenarios/first-agent-tutorial.json` are unchanged, preserving the narrative, alt text, and scenario
- publication audit found no local identity/path or credential-like content

## Test-first record

- RED: generated SVG rows lacked an explicit text extent and committed assets had no deterministic containment contract
- RED: publication redaction produced rows shorter or longer than the fixed 100-column grid
- RED: a deliberately narrow viewBox was accepted when only the outer width was checked
- RED: local review identified a leading-PID redaction gap and the focused fixture reproduced the leak
- GREEN: all 11 issue 241 capture contracts pass, including leading/interior PID redaction, final-column preservation, viewBox containment, and committed-asset border checks

## Verification

- `make quick-check`
- `make ci-check`
  - format and policy gates
  - source-size policy
  - standard and complexity Clippy gates
  - line coverage: 73.39%
  - locked workspace build
  - complete locked workspace tests
- independent `rsvg-convert` rasterization and pixel-bound inspection
- local OpenCodeReview workspace review with `complete_best_effort` coverage over the changed script and tests; actionable findings were fixed and reverified

## Scope

Six files, 389 additions and 113 deletions including generated SVG line replacements and the issue plan. No application UI behavior, capture scenario, tutorial narrative, dependency, workflow, generalized renderer, or agent configuration changed.

Fixes #342
