### PR TITLE
Keep embedded shells alive across dashboard navigation (#361)

### DIFF
--- a/dev-docs/tmux-scenarios/agent-shell-overlay.json
+++ b/dev-docs/tmux-scenarios/agent-shell-overlay.json
@@ -27,7 +27,7 @@
 
     { "key": "F10" },
     { "waitFor": "Agent Shell" },
-    { "waitFor": "F10 close shell" },
+    { "waitFor": "F12 hide shell" },
     { "line": "printf 'issue222-shell-ready\\n'" },
     { "waitFor": "issue222-shell-ready" },
     { "capture": "agent-shell-overlay" },
@@ -35,11 +35,34 @@
     { "line": "stty -echo -icanon min 5 time 0; bytes=$(dd bs=5 count=1 2>/dev/null | od -An -tx1 | tr -d ' '); stty sane; printf 'issue355-f11-forwarded-%s\\n' \"$bytes\"" },
     { "key": "F11" },
     { "waitFor": "issue355-f11-forwarded-1b5b32337e" },
+
+    { "waitFor": "F12 hide shell" },
+    { "key": "F12" },
+    { "waitForNot": "Agent Shell" },
+    { "waitFor": "Shell Agent" },
+    { "waitFor": "F10 resume shell" },
+    { "key": "Down" },
+    { "key": "Up" },
+
+    { "key": "F10" },
+    { "waitFor": "Agent Shell" },
+    { "waitFor": "issue222-shell-ready" },
     { "waitFor": "F10 close shell" },
+
     { "key": "F10" },
     { "waitForNot": "Agent Shell" },
     { "waitFor": "Shell Agent" },
     { "waitFor": "t/f12 terminal focus" },
+
+    { "key": "F10" },
+    { "waitFor": "Agent Shell" },
+    { "line": "printf 'issue361-new-shell-ready\n'" },
+    { "waitFor": "issue361-new-shell-ready" },
+    { "line": "exit" },
+    { "waitFor": "Shell Agent" },
+    { "waitForNot": "Agent Shell" },
+    { "waitFor": "t/f12 terminal focus" },
+
     { "key": "C-q" },
     { "waitForExit": 3000 }
   ]

--- a/project-plans/issue361-plan.md
+++ b/project-plans/issue361-plan.md
@@ -1,0 +1,127 @@
+# Issue 361 delivery plan: persistent embedded shells and terminal manager
+
+## Issue and decisions
+
+- GitHub: https://github.com/vybestack/llxprt-jefe/issues/361
+- Branches: `issue361` for PR A; `issue361-manager` stacked on PR A for PR B.
+- Base: current `origin/main` at `74b2f7360c85d70567f5768fe05d91806ce3969f`.
+- Delivery: one issue, two stacked PRs because the accepted behavior crosses state, runtime, orchestration, startup, UI, and harness ownership.
+- Keys: F12 hides a focused shell; F10 resumes a hidden shell from Dashboard and closes a visible shell; F7 opens the manager; Ctrl-k closes the selected managed shell; Enter focuses it; Esc/F12 leaves the manager.
+- Runtime ground truth is tmux/psmux shell windows. Application inventory and view state are runtime-only and are not persisted.
+- Manager previews are throttled targeted captures, not a second live viewer.
+- One fixed `jefe-shell` window per agent is the structural accumulation limit.
+
+## Acceptance matrix
+
+| ID | Actor / boundary | Success | Failure and side-effect ordering | Proof |
+| --- | --- | --- | --- | --- |
+| A1 | F12 in visible focused shell | Intercept before PTY; select agent window 0; retain shell process; restore prior dashboard focus/layout and resize | Select failure leaves overlay unchanged and warns; select attempt is the only side effect | routing/reducer/runtime tests and real-tmux survival marker |
+| A2 | F10 on Dashboard with hidden shell | Resume exact shell with cwd/process/history/content; no duplicate | Existing attach/open warnings; runtime operation precedes state | runtime create-or-select test and hide/resume scenario |
+| A3 | F10 in visible shell | Kill only `jefe-shell`; agent remains Running; restore launch view | Kill failure keeps overlay and warns | existing and extended scenario/tests |
+| A4 | `exit` in visible shell | Natural disappearance removes state/inventory and restores launch view | Probe errors warn/retry and never mark agent Dead | observer tests and real-tmux exit scenario |
+| A5 | hidden shell exits | Batch reconciliation removes inventory entry without disrupting current view | Probe failure retains entry and retries | reconciler tests and scenario |
+| A6 | F7 manager entry | List all shells above and selected reduced preview below; useful empty state | Capture failure cannot create a second viewer or stale inventory | render tests and manager scenario |
+| A7 | Enter on Running owner in manager | Attach owner, resume exact shell, and return to manager on hide/exit | Failed attach clears generation-guarded pending focus and warns | reducer/orchestration tests and two-agent scenario |
+| A8 | Ctrl-k in manager | Close selected shell only; keep agent; update list/preview | Failure keeps entry, warns, and forces reconciliation | dispatch/runtime tests and scenario |
+| A9 | agent kill/delete | Session teardown removes visible/hidden shell and inventory | Existing agent failure behavior remains authoritative | lifecycle tests |
+| A10 | graceful quit with N shells | Close all Jefe-created shell windows without killing agent sessions | Best effort; failures logged and do not block quit | shutdown tests |
+| A11 | restart after crash | Adopt known shells, select window 0 for each, kill unknown shell windows | Probe errors warn/retry; do not mark agents Dead | startup tests and restart scenario |
+| A12 | naturally dead owner | Manager lists shell as unavailable and close-only | Resume attempt warns without side effects | manager state/dispatch tests |
+| A13 | footer/help/chrome | Focused shell documents F10 close/F12 hide; F7 manager documented; no dead F12 hint | Stale text fails tests | component/help tests and scenarios |
+| A14 | Windows/psmux | F12 is Jefe-owned while shell visible; all commands are structured with bounded fallback | Typed runtime errors use warning paths | command structural tests and native Windows CI |
+
+## Invariants
+
+1. Preserve the single attached viewer; no parallel PTY viewer or process manager.
+2. Runtime side effects complete before deterministic state transitions.
+3. Shell inventory, overlay visibility, manager selection, and pending focus are runtime-only.
+4. Agent liveness derives only from window 0; shells never mask agent death.
+5. Non-intercepted focused-shell keys continue to reach the PTY; F12 is intercepted on all platforms.
+6. Whenever a shell is not visible, its session current window is window 0.
+7. Close kills only `jefe-shell`, never the agent session.
+8. At most one shell per agent.
+9. Graceful quit cleans every tracked shell; restart reconciles runtime ground truth.
+10. Reducers contain no I/O; side effects stay in runtime/app-input/startup boundaries.
+
+## PR A: hide/resume and lifecycle safety
+
+### Slice A1: F12 hide, F10 resume, and visible natural exit
+
+- Acceptance: A1-A4 and focused-shell portions of A13-A14.
+- Scenario-first RED: update `dev-docs/tmux-scenarios/agent-shell-overlay.json` to prove marker survives F12 hide and F10 resume, F10 still closes, and a recreated shell closes via typed `exit`.
+- Unit RED: route F12 to hide while preserving F11 PTY forwarding; runtime select-window-0 structural tests; state hide behavior.
+- GREEN owner paths: `src/app_shell_key_routing.rs`, `src/app_input/shell_overlay.rs`, `src/runtime/shell_window.rs`, runtime trait/stub, shell state/events/messages, footer/help/chrome, scenario.
+- Stop if this requires persistence, a new viewer, or changing agent lifecycle.
+
+### Slice A2: inventory, reconciliation, startup, and shutdown
+
+- Acceptance: A5, A9-A12 plus inventory portions of A1-A4.
+- RED: pure inventory transition tests; runtime list-window tests; hidden-exit reconciliation; startup adoption/orphan/window-0 normalization; close-all shutdown tests; restart scenario first.
+- GREEN: typed runtime-only inventory; batched runtime observation with bounded psmux fallback; startup reconciliation; immediate lifecycle updates with reconciliation backstop; close-all shutdown.
+- Stop if batching requires a new generic process subsystem, persistence, or crossing the PR hard budget.
+
+## PR B: terminal manager and cross-agent focus
+
+### Slice B1: manager list, static preview, and close
+
+- Acceptance: A6, A8, A12-A14.
+- Scenario-first RED: new terminal-manager scenario and runner.
+- Unit RED: screen projection, navigation, empty state, close dispatch, Help/footer, targeted preview capture.
+- GREEN: F7 entry, typed manager state/input mode, list above, static selected preview below, Ctrl-k close, Esc/F12 return.
+
+### Slice B2: manager-to-shell focus
+
+- Acceptance: A7.
+- RED: generation-guarded pending-focus reducer/orchestration tests and two-agent scenario.
+- GREEN: select owner, request existing background attach, resume only after the expected agent attaches, and preserve manager return target.
+
+## Expected paths
+
+- State: `src/state/types.rs`, `src/state/shell_overlay_ops.rs`, terminal-manager state/reducer modules, `src/state/events.rs`, `src/state/mod.rs`.
+- Messages: `src/messages.rs`, `src/messages/names.rs`, `src/messages/event_conversion.rs`.
+- Input/app shell: `src/app_input/shell_overlay.rs`, terminal-manager input module, `src/app_input/normal.rs`, `src/app_input/mod.rs`, `src/app_shell_key_routing.rs`, `src/app_shell.rs`.
+- Runtime/startup: `src/runtime/shell_window.rs` and tests, `src/runtime/manager.rs`, `src/runtime/stub_manager.rs`, `src/runtime/mod.rs`, `src/app_init.rs`.
+- UI: terminal manager screen, screen registration/orchestration, keybind bar, terminal view, Help, and layout only if required.
+- Evidence: shell scenario update, manager/restart scenarios and runners, this plan.
+
+Combined target: approximately 26-32 files and 1,500-2,200 net changed lines, split so each PR targets no more than 25 files / 1,500 net lines. Stop without approval above 40 files / 2,500 net lines for either PR.
+
+## Explicit non-goals
+
+- Multiple shells per agent or remote-repository shells.
+- Persisting shell inventory or visible/hidden state.
+- A second live attached viewer in the manager.
+- Configurable keybindings, mouse support, or close confirmation in v1.
+- Resuming a shell whose owner is not Running.
+- Changes to external-terminal F8, agent launch signatures, or agent liveness semantics.
+
+## Scope ledger
+
+| Discovery | Classification | Disposition |
+| --- | --- | --- |
+| Existing `open_shell_window` already selects an existing `jefe-shell` | In-scope design evidence | Reuse for F10 resume; do not add duplicate shell creation |
+| Viewer and captures follow multiplexer current window | Blocker-Fix invariant | Every hide/adoption must select window 0 before state says shell is hidden |
+| F12 currently reaches psmux prefix in overlay mode | In-scope cross-platform bug | Intercept in overlay-first route and cover structurally |
+| Existing #356 overlaps hide/resume | Resolved duplicate | Closed as superseded by #361 |
+
+## Review counters
+
+- PR A local pre-PR Open Code Review: 1 / 2 attempted; the CLI was terminated without output, so no findings were produced.
+- PR A post-PR Open Code Review: 0 / 2.
+- PR B local pre-PR Open Code Review: 0 / 2.
+- PR B post-PR Open Code Review: 0 / 2.
+
+## Verification evidence
+
+| Candidate | Command | Result |
+| --- | --- | --- |
+| base | current main and issue/architecture analysis | COMPLETE at `74b2f736`; scenario/tests were authored before production changes, but the interrupted session did not retain runnable RED command output, so the evidence gap is recorded rather than reconstructed |
+| PR A candidate | focused runtime/state/startup/UI tests | PASS: shell inventory 15, shell overlay 20, binary routing 1, Help 15, keybind bar 12 |
+| PR A candidate | `scripts/issue222-run-scenario.sh` | PASS: 50 real-tmux steps; F12 hide preserved the marker, dashboard navigation remained usable, F10 resumed the same shell, F10 destroyed it, and typed `exit` restored Dashboard |
+| PR A candidate | `make quick-check` | PASS: all workspace tests and doctests |
+| PR A candidate | `make ci-check` | PASS: fmt, allow/source-size gates, clippy, coverage >=30%, locked build, tests |
+| PR A candidate | scope review | APPROVED by user for issue #361 split delivery; PR A is 25 implementation/test/scenario files and 1 delivery record, 1,985 net lines. This exceeds the 25-file/1,500-line target only by the required delivery record and lifecycle coverage, remains below the 40-file/2,500-line hard stop, and introduces no dependency/workflow/persistence subsystem. |
+
+## Review findings and deferred follow-ups
+
+- PR A pre-PR OCR attempt produced no artifact because the CLI process was terminated; exact-head local gates and manual source review remain green.

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -1,5 +1,8 @@
 //! One-time application startup: state hydration and runtime session restore.
 
+#[path = "app_init_shell_reconcile.rs"]
+mod shell_reconcile;
+
 use iocraft::hooks::State as HookState;
 use tracing::warn;
 
@@ -503,16 +506,20 @@ pub fn restore_runtime_sessions(app_state: &mut HookState<AppState>, ctx: &Share
 
     drop(ctx_guard);
 
-    if revived_running.is_empty() && newly_dead.is_empty() && runtime_warning.is_none() {
-        return;
+    let state_changed =
+        !revived_running.is_empty() || !newly_dead.is_empty() || runtime_warning.is_some();
+    if state_changed {
+        let mut state = app_state.write();
+        apply_restored_state(&mut state, revived_running, newly_dead, runtime_warning);
     }
 
-    let mut state = app_state.write();
-    apply_restored_state(&mut state, revived_running, newly_dead, runtime_warning);
-
-    let persisted = to_persisted_state(&state);
-    drop(state);
-    persist_state(ctx, &persisted);
+    if let Some(warning) = shell_reconcile::reconcile_shell_inventory(app_state, ctx) {
+        append_warning(&mut app_state.write(), warning);
+    }
+    if state_changed {
+        let state = app_state.read();
+        persist_state(ctx, &to_persisted_state(&state));
+    }
 }
 
 /// Outcome of attempting to revive a single Running agent's session.

--- a/src/app_init_shell_reconcile.rs
+++ b/src/app_init_shell_reconcile.rs
@@ -20,7 +20,7 @@
 use jefe::domain::AgentId;
 use jefe::runtime::{RuntimeError, RuntimeManager, RuntimeSession};
 use jefe::state::AppState;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::app_input::SharedContext;
 
@@ -112,7 +112,10 @@ pub fn reconcile_shell_inventory(
     // raw session names so orphans are discovered.
     let observed_sessions: Vec<String> = {
         let Ok(ctx_guard) = ctx_arc.lock() else {
-            return None;
+            warn!("startup shell reconcile: runtime context mutex poisoned");
+            return Some(
+                "could not reconcile shell windows: runtime context unavailable".to_owned(),
+            );
         };
         match ctx_guard.runtime.observe_shell_window_sessions() {
             Ok(sessions) => sessions,
@@ -143,23 +146,29 @@ pub fn reconcile_shell_inventory(
                 ));
             }
         }
-        for orphan in &orphans {
-            match jefe::runtime::close_shell_window(orphan) {
-                Ok(()) | Err(RuntimeError::KillFailed(_) | RuntimeError::SessionNotFound(_)) => {}
-                Err(error) => {
-                    warn!(session = %orphan, error = %error, "startup shell reconcile: orphan kill failed");
-                    warnings.push(format!(
-                        "could not remove orphan shell in {orphan}: {error}"
-                    ));
-                }
-            }
-        }
+        reconcile_orphans(&orphans, &mut warnings);
     }
 
     // Inventory is runtime-only and must never trigger persisted-state writes.
     app_state.write().replace_shell_inventory(adopted);
 
-    warnings.into_iter().next()
+    (!warnings.is_empty()).then(|| warnings.join("; "))
+}
+fn reconcile_orphans(orphans: &[String], warnings: &mut Vec<String>) {
+    for orphan in orphans {
+        match jefe::runtime::close_shell_window(orphan) {
+            Ok(()) | Err(RuntimeError::SessionNotFound(_)) => {}
+            Err(error @ RuntimeError::KillFailed(_)) => {
+                debug!(session = %orphan, error = %error, "startup shell reconcile: orphan already absent or could not be killed");
+            }
+            Err(error) => {
+                warn!(session = %orphan, error = %error, "startup shell reconcile: orphan kill failed");
+                warnings.push(format!(
+                    "could not remove orphan shell in {orphan}: {error}"
+                ));
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/app_init_shell_reconcile.rs
+++ b/src/app_init_shell_reconcile.rs
@@ -1,0 +1,213 @@
+//! Startup shell-window reconciliation (issue #361 PR A).
+//!
+//! After runtime sessions restore, Jefe reconciles the multiplexer's
+//! ground-truth shell windows against AppState's runtime-only inventory:
+//!
+//! - **Adopt**: known-agent sessions that host a `jefe-shell` window are
+//!   recorded in the shell inventory so F10 can resume them.
+//! - **Normalize**: for every adopted known session, select window 0 so the
+//!   multiplexer current-window invariant holds (a hidden shell leaves window
+//!   0 current).
+//! - **Orphan cleanup**: `jefe-shell` windows belonging to *unknown* sessions
+//!   (left over from a crashed/killed prior Jefe run) are killed best-effort.
+//! - **Warnings only**: probe errors surface as a warning and never mark an
+//!   agent Dead (issue #361 invariant: shells never mask agent death).
+//!
+//! All I/O happens here, at the startup boundary; AppState transitions are
+//! deterministic. The pure decision seam (`classify_shell_reconciliation`) is
+//! unit-tested without a multiplexer.
+
+use jefe::domain::AgentId;
+use jefe::runtime::{RuntimeError, RuntimeManager, RuntimeSession};
+use jefe::state::AppState;
+use tracing::warn;
+
+use crate::app_input::SharedContext;
+
+use iocraft::hooks::State as HookState;
+
+/// Outcome of classifying one observed shell-window owner session against the
+/// set of known agent sessions (issue #361). Pure: no I/O.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ShellReconciliation {
+    /// The session belongs to a known agent → adopt into inventory + select
+    /// window 0.
+    Adopt(AgentId),
+    /// The session is unknown (orphan from a prior run) → kill its
+    /// `jefe-shell` window.
+    Orphan,
+}
+
+/// Classify an observed `jefe-shell`-owning session against the known
+/// agent→session map (issue #361). Pure decision seam, unit-tested.
+///
+/// Returns `Adopt(agent_id)` when `observed_session` matches a known agent's
+/// session name, otherwise `Orphan`.
+#[must_use]
+pub(super) fn classify_shell_reconciliation(
+    observed_session: &str,
+    known_sessions: &[(AgentId, String)],
+) -> ShellReconciliation {
+    for (agent_id, session_name) in known_sessions {
+        if session_name == observed_session {
+            return ShellReconciliation::Adopt(agent_id.clone());
+        }
+    }
+    ShellReconciliation::Orphan
+}
+
+/// Reconcile runtime shell windows against AppState after sessions restore
+/// (issue #361 PR A).
+///
+/// Drives the runtime boundary (observe + select-window-0 + kill-window) and
+/// applies deterministic AppState transitions (record inventory). Probe
+/// failures surface as a warning via the returned string and never mark an
+/// agent Dead. Returns the warning (if any) so the caller can append it to
+/// AppState and persist.
+fn classify_observed_sessions(
+    observed_sessions: &[String],
+    known_sessions: &[(AgentId, String)],
+) -> (Vec<AgentId>, Vec<String>) {
+    let mut adopted = Vec::new();
+    let mut orphans = Vec::new();
+    for session in observed_sessions {
+        match classify_shell_reconciliation(session, known_sessions) {
+            ShellReconciliation::Adopt(agent_id) => adopted.push(agent_id),
+            ShellReconciliation::Orphan => orphans.push(session.clone()),
+        }
+    }
+    (adopted, orphans)
+}
+
+pub fn reconcile_shell_inventory(
+    app_state: &mut HookState<AppState>,
+    ctx: &SharedContext,
+) -> Option<String> {
+    let Some(ctx_arc) = ctx else {
+        return None;
+    };
+
+    // Every known local agent has a deterministic session name, including a
+    // naturally dead owner whose still-live shell must remain adoptable.
+    let known_sessions: Vec<(AgentId, String)> = {
+        let state = app_state.read();
+        state
+            .agents
+            .iter()
+            .filter(|agent| {
+                state
+                    .repository_for_agent(&agent.id)
+                    .is_some_and(|repository| !repository.remote.enabled)
+            })
+            .map(|agent| {
+                (
+                    agent.id.clone(),
+                    RuntimeSession::session_name_for(&agent.id),
+                )
+            })
+            .collect()
+    };
+
+    // Observe every session hosting a jefe-shell window (batched). Returns
+    // raw session names so orphans are discovered.
+    let observed_sessions: Vec<String> = {
+        let Ok(ctx_guard) = ctx_arc.lock() else {
+            return None;
+        };
+        match ctx_guard.runtime.observe_shell_window_sessions() {
+            Ok(sessions) => sessions,
+            Err(error) => {
+                // Probe failure: warn and do NOT touch inventory or agent
+                // status (issue #361 invariant).
+                warn!(error = %error, "startup shell reconcile: observation failed");
+                return Some(format!("could not reconcile shell windows: {error}"));
+            }
+        }
+    };
+
+    let (adopted, orphans) = classify_observed_sessions(&observed_sessions, &known_sessions);
+
+    let mut warnings: Vec<String> = Vec::new();
+
+    // Drive runtime side effects for adoption (select window 0) and orphan
+    // cleanup (kill jefe-shell). Failures are best-effort and surface as
+    // warnings, never as agent death.
+    if !adopted.is_empty() || !orphans.is_empty() {
+        for agent_id in &adopted {
+            let session_name = RuntimeSession::session_name_for(agent_id);
+            if let Err(error) = jefe::runtime::hide_shell_window(&session_name) {
+                warn!(agent_id = %agent_id.0, error = %error, "startup shell reconcile: select window 0 failed");
+                warnings.push(format!(
+                    "could not normalize shell window for {}: {error}",
+                    agent_id.0
+                ));
+            }
+        }
+        for orphan in &orphans {
+            match jefe::runtime::close_shell_window(orphan) {
+                Ok(()) | Err(RuntimeError::KillFailed(_) | RuntimeError::SessionNotFound(_)) => {}
+                Err(error) => {
+                    warn!(session = %orphan, error = %error, "startup shell reconcile: orphan kill failed");
+                    warnings.push(format!(
+                        "could not remove orphan shell in {orphan}: {error}"
+                    ));
+                }
+            }
+        }
+    }
+
+    // Inventory is runtime-only and must never trigger persisted-state writes.
+    app_state.write().replace_shell_inventory(adopted);
+
+    warnings.into_iter().next()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn known(pairs: &[(&str, &str)]) -> Vec<(AgentId, String)> {
+        pairs
+            .iter()
+            .map(|(id, session)| (AgentId((*id).to_owned()), (*session).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn classify_adopts_known_session() {
+        let known = known(&[("agent-1", "jefe-agent-1")]);
+        let decision = classify_shell_reconciliation("jefe-agent-1", &known);
+        assert_eq!(
+            decision,
+            ShellReconciliation::Adopt(AgentId("agent-1".into()))
+        );
+    }
+
+    #[test]
+    fn classify_marks_unknown_session_as_orphan() {
+        let known = known(&[("agent-1", "jefe-agent-1")]);
+        let decision = classify_shell_reconciliation("jefe-agent-ghost", &known);
+        assert_eq!(decision, ShellReconciliation::Orphan);
+    }
+
+    #[test]
+    fn classify_does_not_match_partial_session_name() {
+        let known = known(&[("agent-1", "jefe-agent-1")]);
+        // Prefix must not match.
+        let decision = classify_shell_reconciliation("jefe-agent", &known);
+        assert_eq!(decision, ShellReconciliation::Orphan);
+    }
+
+    #[test]
+    fn classify_adopts_when_multiple_known_sessions() {
+        let known = known(&[("agent-1", "jefe-agent-1"), ("agent-2", "jefe-agent-2")]);
+        assert_eq!(
+            classify_shell_reconciliation("jefe-agent-2", &known),
+            ShellReconciliation::Adopt(AgentId("agent-2".into()))
+        );
+        assert_eq!(
+            classify_shell_reconciliation("jefe-agent-1", &known),
+            ShellReconciliation::Adopt(AgentId("agent-1".into()))
+        );
+    }
+}

--- a/src/app_input/shell_overlay.rs
+++ b/src/app_input/shell_overlay.rs
@@ -1,31 +1,58 @@
-//! Shell-overlay key dispatch (issue #222).
+//! Shell-overlay key dispatch (issue #222) extended with hide/resume and
+//! runtime-only shell inventory (issue #361 PR A).
 //!
-//! Handles F10 (open/close embedded shell) and F8 (open external terminal).
-//! F10 is checked early in the key event flow while the shell is active so it
-//! works even while `TerminalCapture` mode owns input.
+//! Handles F10 (open/resume/close embedded shell), F12 (hide visible shell),
+//! and F8 (open external terminal). F10/F12 are checked early in the key
+//! event flow while the shell is active so they work even while
+//! `TerminalCapture` mode owns input.
 
 use iocraft::prelude::{KeyCode, KeyEvent};
 use tracing::warn;
 
 use jefe::domain::AgentStatus;
 use jefe::runtime::{
-    DesktopPlatform, ExternalTerminalError, RuntimeError, RuntimeManager,
+    DesktopPlatform, ExternalTerminalError, RuntimeError, RuntimeManager, RuntimeSession,
     build_external_terminal_plan, spawn_external_terminal,
 };
 use jefe::state::{AppEvent, ScreenMode};
 
 use super::{AppStateHandle, SharedContext, dispatch_app_event};
-pub fn cleanup_active_shell(state: &jefe::state::AppState, ctx: &SharedContext) {
-    let Some(agent_id) = state.shell_overlay_agent_id() else {
-        return;
-    };
-    if let Some(ctx_arc) = ctx
-        && let Ok(mut guard) = ctx_arc.lock()
-    {
-        if let Err(error) = guard.runtime.close_shell_window(agent_id) {
-            warn!(error = %error, "failed to clean up active shell window");
-        }
+
+/// Graceful shutdown: close every tracked `jefe-shell` window best-effort
+/// without killing agent sessions (issue #361 PR A).
+///
+/// Closes all shells exactly once, including the currently visible shell, so
+/// the caller must not close the visible shell separately (avoids duplicate
+/// close). Snapshots the visible owner + hidden inventory under a read lock,
+/// releases it, then drives the best-effort runtime close under the runtime
+/// lock. Clears the shell inventory afterward so the cleanup is observable.
+/// Failures are logged by the runtime boundary and also returned for any
+/// caller that wants to surface them.
+pub fn shutdown_all_shells(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+) -> Vec<jefe::runtime::RuntimeError> {
+    // Snapshot every shell owner (visible + hidden) so the visible shell is
+    // closed exactly once here and not separately by cleanup_active_shell.
+    let owners = app_state.read().shell_window_owners();
+    if owners.is_empty() {
+        return Vec::new();
     }
+    let Some(ctx_arc) = ctx.as_ref() else {
+        return Vec::new();
+    };
+    let failures = if let Ok(mut guard) = ctx_arc.lock() {
+        guard.runtime.close_all_shell_windows()
+    } else {
+        Vec::new()
+    };
+    // Clear the runtime inventory so the cleanup is observable. The visible
+    // overlay is also gone after this process exits, so clearing is safe.
+    {
+        let mut state = app_state.write();
+        state.clear_shell_inventory();
+    }
+    failures
 }
 
 /// Observe natural shell-window exit and restore dashboard state.
@@ -67,6 +94,75 @@ pub async fn observe_shell_exit(mut app_state: AppStateHandle, ctx: SharedContex
             }
             Ok(true) => {}
             Err(error) => set_warning(&mut app_state, &error.to_string()),
+        }
+    }
+}
+
+/// Batched inventory observer (issue #361 PR A).
+///
+/// Periodically reconciles the runtime-only shell inventory against the
+/// multiplexer ground truth off the input/render path via `smol::unblock`.
+/// When a hidden shell exits naturally (e.g. the user typed `exit`), its
+/// inventory entry is removed without disrupting the current view. The visible
+/// overlay is handled by [`observe_shell_exit`]; this observer covers hidden
+/// shells only. The runtime probe uses one batched `list-windows -a` query in
+/// the supported path (issue #361 invariant: one batch query).
+///
+/// Probe failures (`Err`) retain entries and retry — a transient error never
+/// removes inventory or marks an agent Dead (issue #361 invariant).
+pub async fn observe_shell_inventory(mut app_state: AppStateHandle, ctx: SharedContext) {
+    loop {
+        // Slow cadence (~2s) so the multiplexer is not hammered and the
+        // executor stays free for input/render (issue #361 invariant).
+        smol::Timer::after(std::time::Duration::from_secs(2)).await;
+        let candidates = {
+            let state = app_state.read();
+            // Only reconcile hidden shells; the visible overlay is handled by
+            // observe_shell_exit.
+            let visible = state.shell_overlay_agent_id().cloned();
+            state
+                .shell_window_owners()
+                .into_iter()
+                .filter(|agent_id| visible.as_ref() != Some(agent_id))
+                .collect::<Vec<_>>()
+        };
+        if candidates.is_empty() {
+            continue;
+        }
+        let Some(ctx_arc) = ctx.clone() else {
+            continue;
+        };
+        // Offload the batched multiplexer query to a background OS thread so
+        // the smol executor can keep processing input/render (issue #361).
+        let observed = smol::unblock(move || -> Result<Vec<String>, RuntimeError> {
+            let guard = ctx_arc.lock().map_err(|_| {
+                RuntimeError::CapabilityProbeFailed("runtime context lock unavailable".to_owned())
+            })?;
+            guard.runtime.observe_shell_window_sessions()
+        })
+        .await;
+        match observed {
+            Ok(session_names) => {
+                let missing: Vec<_> = candidates
+                    .iter()
+                    .filter(|agent_id| {
+                        let session_name = RuntimeSession::session_name_for(agent_id);
+                        !session_names.iter().any(|owner| owner == &session_name)
+                    })
+                    .cloned()
+                    .collect();
+                if missing.is_empty() {
+                    continue;
+                }
+                let mut state = app_state.write();
+                for agent_id in &missing {
+                    state.remove_shell_window(agent_id);
+                }
+            }
+            Err(error) => {
+                // Retain entries on probe failure; warn without removing.
+                warn!(error = %error, "shell inventory probe failed; retaining entries");
+            }
         }
     }
 }
@@ -115,6 +211,35 @@ pub fn try_close_shell_overlay(
     true
 }
 
+/// Intercept F12 to hide the visible shell overlay (issue #361 PR A).
+///
+/// Hiding selects agent window 0 (so the multiplexer current window is the
+/// agent pane, not `jefe-shell`), leaves the `jefe-shell` process alive, and
+/// restores the previous dashboard focus/layout. The inventory entry is kept
+/// so F10 can resume the exact shell later.
+///
+/// Called from the overlay-first key route so F12 never reaches the PTY or
+/// the Windows psmux prefix. On a select-window-0 failure the overlay stays
+/// visible and a warning is shown.
+pub fn try_hide_shell_overlay(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    key_event: &KeyEvent,
+) -> bool {
+    if key_event.code != KeyCode::F(12) {
+        return false;
+    }
+    let agent_id = {
+        let state = app_state.read();
+        state.shell_overlay_agent_id().cloned()
+    };
+    let Some(agent_id) = agent_id else {
+        return false;
+    };
+    hide_overlay_and_restore(app_state, ctx, &agent_id);
+    true
+}
+
 /// Handle the F10 / F8 shortcuts from the dashboard. Returns `true` if the key
 /// was consumed.
 pub fn handle_shell_shortcut_key(
@@ -136,6 +261,11 @@ pub fn handle_shell_shortcut_key(
 }
 
 /// Open the embedded shell overlay for the selected local running agent.
+///
+/// Issue #361 PR A: if the agent already owns a hidden shell (tracked in the
+/// runtime inventory), F10 resumes it instead of creating a duplicate. The
+/// runtime `open_shell_window` is create-or-select so it never duplicates,
+/// and the inventory records the owner after success.
 fn open_embedded_shell(app_state: &mut AppStateHandle, ctx: &SharedContext) {
     let snapshot = read_dashboard_agent(app_state);
     let Some((agent_id, _work_dir)) = snapshot else {
@@ -144,19 +274,29 @@ fn open_embedded_shell(app_state: &mut AppStateHandle, ctx: &SharedContext) {
     };
 
     // Idempotency: if the overlay is already active for this agent, no-op.
-    let already_active = {
+    let (already_active, was_hidden) = {
         let state = app_state.read();
-        state.shell_overlay_agent_id() == Some(&agent_id)
+        (
+            state.shell_overlay_agent_id() == Some(&agent_id),
+            state.has_shell_window(&agent_id),
+        )
     };
     if already_active {
         return;
     }
 
-    // Call the runtime to open the shell window before transitioning state.
+    // Call the runtime to open/resume the shell window before transitioning
+    // state. open_shell_window is create-or-select: it selects an existing
+    // jefe-shell window if present, otherwise creates one.
     let result = open_runtime_shell_window(ctx, &agent_id);
     match result {
         Ok(()) => {
-            dispatch_app_event(app_state, ctx, AppEvent::OpenShellOverlay);
+            let event = if was_hidden {
+                AppEvent::ResumeShellOverlay(agent_id)
+            } else {
+                AppEvent::OpenShellOverlay
+            };
+            dispatch_app_event(app_state, ctx, event);
             resize_for_active_layout(ctx, true);
         }
         Err(error) => {
@@ -210,6 +350,27 @@ fn close_overlay_and_restore(
         }
         Err(error) => {
             warn!(error = %error, "failed to close shell window");
+            set_warning(app_state, &error.to_string());
+        }
+    }
+}
+
+/// Hide the shell overlay by selecting window 0, leaving the shell alive
+/// (issue #361 PR A). Runtime side effect (select-window 0) runs before the
+/// state transition; on failure the overlay stays visible and warns.
+fn hide_overlay_and_restore(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    agent_id: &jefe::domain::AgentId,
+) {
+    let result = hide_runtime_shell_window(ctx, agent_id);
+    match result {
+        Ok(()) => {
+            dispatch_app_event(app_state, ctx, AppEvent::HideShellOverlay);
+            resize_for_active_layout(ctx, false);
+        }
+        Err(error) => {
+            warn!(error = %error, "failed to hide shell window");
             set_warning(app_state, &error.to_string());
         }
     }
@@ -281,6 +442,23 @@ fn close_runtime_shell_window(
         ));
     };
     guard.runtime.close_shell_window(agent_id)
+}
+
+fn hide_runtime_shell_window(
+    ctx: &SharedContext,
+    agent_id: &jefe::domain::AgentId,
+) -> Result<(), RuntimeError> {
+    let Some(ctx_arc) = ctx.as_ref() else {
+        return Err(RuntimeError::SpawnFailed(
+            "runtime context unavailable".into(),
+        ));
+    };
+    let Ok(mut guard) = ctx_arc.lock() else {
+        return Err(RuntimeError::SpawnFailed(
+            "runtime context lock unavailable".into(),
+        ));
+    };
+    guard.runtime.hide_shell_window(agent_id)
 }
 
 fn resize_for_active_layout(ctx: &SharedContext, overlay_active: bool) {

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -120,6 +120,13 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
         let ctx = ctx.clone();
         async move { crate::app_input::shell_overlay::observe_shell_exit(app_state, ctx).await }
     });
+    // Batched shell-window inventory observer (issue #361 PR A): reconciles
+    // hidden shells against the multiplexer off the input/render path.
+    hooks.use_future({
+        let app_state = app_state;
+        let ctx = ctx.clone();
+        async move { crate::app_input::shell_overlay::observe_shell_inventory(app_state, ctx).await }
+    });
 
     // Slow-poll LOCAL agent liveness (~every 2s). The batched check uses
     // exactly two tmux subprocess invocations (list-sessions + list-panes -a)
@@ -375,8 +382,12 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
         {
             let state = app_state.read();
             crate::app_input::transient_cleanup::cleanup_transient_agent_dirs(&state);
-            crate::app_input::shell_overlay::cleanup_active_shell(&state, &ctx);
         }
+        // Graceful shutdown: close every tracked `jefe-shell` window (visible
+        // and hidden) exactly once, best-effort, without killing agent
+        // sessions (issue #361 PR A). Replaces the prior separate
+        // cleanup_active_shell call so the visible shell is not closed twice.
+        crate::app_input::shell_overlay::shutdown_all_shells(&mut app_state, &ctx);
         // Issue #301: flush the coalescing persistence worker so the final
         // state is durable before exit.
         crate::app_shell_workers::shutdown_flush_persist(ctx.as_ref());

--- a/src/app_shell_key_routing.rs
+++ b/src/app_shell_key_routing.rs
@@ -18,13 +18,19 @@ pub fn route_shell_overlay_key(
     suppress_next_enter: &mut HookState<PasteEnterSuppression>,
     key_event: &KeyEvent,
 ) -> bool {
-    if !crate::app_input::shell_overlay::try_close_shell_overlay(
-        app_state,
-        &ctx.cloned(),
-        key_event,
-    ) {
-        forward_key_to_pty(ctx, suppress_next_enter, key_event);
+    // F12 hides the visible shell overlay (issue #361): intercept before PTY
+    // forwarding so the key never reaches the multiplexer prefix on any
+    // platform. F10 close is handled next; everything else forwards.
+    if crate::app_input::shell_overlay::try_hide_shell_overlay(app_state, &ctx.cloned(), key_event)
+        || crate::app_input::shell_overlay::try_close_shell_overlay(
+            app_state,
+            &ctx.cloned(),
+            key_event,
+        )
+    {
+        return true;
     }
+    forward_key_to_pty(ctx, suppress_next_enter, key_event);
     true
 }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -98,6 +98,11 @@ pub enum UiNavigationMessage {
     OpenShellOverlay,
     /// Close the embedded agent-shell overlay (F10 toggle, issue #355).
     CloseShellOverlay,
+    /// Hide the visible shell overlay while keeping the `jefe-shell` window
+    /// alive (F12, issue #361).
+    HideShellOverlay,
+    /// Resume a hidden shell for `agent_id` (F10 from dashboard, issue #361).
+    ResumeShellOverlay(crate::domain::AgentId),
 }
 
 /// Modal and form-editing messages.

--- a/src/messages/event_conversion.rs
+++ b/src/messages/event_conversion.rs
@@ -27,14 +27,10 @@ impl From<AppEvent> for AppMessage {
             AppEvent::NavigateEnd => Self::UiNavigation(UiNavigationMessage::NavigateEnd),
             AppEvent::NavigateLeft => Self::UiNavigation(UiNavigationMessage::NavigateLeft),
             AppEvent::NavigateRight => Self::UiNavigation(UiNavigationMessage::NavigateRight),
-            AppEvent::SelectRepository(index) => {
-                Self::UiNavigation(UiNavigationMessage::SelectRepository(index))
-            }
-            AppEvent::SelectAgent(index) => {
-                Self::UiNavigation(UiNavigationMessage::SelectAgent(index))
-            }
+            AppEvent::SelectRepository(index) => ui(UiNavigationMessage::SelectRepository(index)),
+            AppEvent::SelectAgent(index) => ui(UiNavigationMessage::SelectAgent(index)),
             AppEvent::JumpToAgentByShortcut(slot) => {
-                Self::UiNavigation(UiNavigationMessage::JumpToAgentByShortcut(slot))
+                ui(UiNavigationMessage::JumpToAgentByShortcut(slot))
             }
             AppEvent::CyclePaneFocus => Self::UiNavigation(UiNavigationMessage::CyclePaneFocus),
             AppEvent::ToggleTerminalFocus => {
@@ -61,7 +57,9 @@ impl From<AppEvent> for AppMessage {
             | AppEvent::TerminalFollowTail
             | AppEvent::TerminalScrollToTop
             | AppEvent::OpenShellOverlay
-            | AppEvent::CloseShellOverlay => Self::from_split_grab_or_scroll_event(event),
+            | AppEvent::CloseShellOverlay
+            | AppEvent::HideShellOverlay
+            | AppEvent::ResumeShellOverlay(_) => Self::from_split_grab_or_scroll_event(event),
             AppEvent::OpenHelp => Self::Modal(ModalMessage::OpenHelp),
             AppEvent::OpenSearch => Self::Modal(ModalMessage::OpenSearch),
             AppEvent::CloseModal => Self::Modal(ModalMessage::CloseModal),
@@ -108,6 +106,10 @@ impl AppMessage {
             // Shell-overlay events (issue #222).
             AppEvent::OpenShellOverlay => Self::UiNavigation(U::OpenShellOverlay),
             AppEvent::CloseShellOverlay => Self::UiNavigation(U::CloseShellOverlay),
+            AppEvent::HideShellOverlay => Self::UiNavigation(U::HideShellOverlay),
+            AppEvent::ResumeShellOverlay(agent_id) => {
+                Self::UiNavigation(U::ResumeShellOverlay(agent_id))
+            }
             // Catch-all is required: the caller passes an `AppEvent` value that
             // is known at the call site to be split/grab/scroll, but the type
             // system cannot enforce that constraint. This arm delegates to the
@@ -493,6 +495,8 @@ impl From<UiNavigationMessage> for AppEvent {
             UiNavigationMessage::TerminalScrollToTop => Self::TerminalScrollToTop,
             UiNavigationMessage::OpenShellOverlay => Self::OpenShellOverlay,
             UiNavigationMessage::CloseShellOverlay => Self::CloseShellOverlay,
+            UiNavigationMessage::HideShellOverlay => Self::HideShellOverlay,
+            UiNavigationMessage::ResumeShellOverlay(agent_id) => Self::ResumeShellOverlay(agent_id),
         }
     }
 }

--- a/src/messages/names.rs
+++ b/src/messages/names.rs
@@ -56,6 +56,8 @@ message_names!(UiNavigationMessage {
     Self::TerminalScrollToTop => "TerminalScrollToTop",
     Self::OpenShellOverlay => "OpenShellOverlay",
     Self::CloseShellOverlay => "CloseShellOverlay",
+    Self::HideShellOverlay => "HideShellOverlay",
+    Self::ResumeShellOverlay(_) => "ResumeShellOverlay",
 });
 
 message_names!(ModalMessage {

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -977,7 +977,7 @@ impl RuntimeManager for TmuxRuntimeManager {
         super::shell_window::observe_shell_window_sessions()
     }
     fn close_all_shell_windows(&mut self) -> Vec<RuntimeError> {
-        super::shell_window::close_all_manager_shell_windows(&self.sessions)
+        super::shell_window::close_all_manager_shell_windows()
     }
 }
 

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -4,22 +4,18 @@
 //! @plan PLAN-20260216-FIRSTVERSION-V1.P08
 //! @requirement REQ-TECH-004
 //! @requirement REQ-FUNC-007
-
-use std::collections::{HashMap, HashSet};
-use std::num::NonZeroUsize;
-use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
-
-use lru::LruCache;
-use tracing::{debug, info};
-
 use super::attach::AttachedViewer;
 use super::commands;
 use super::errors::RuntimeError;
 use super::liveness;
 use super::session::{RuntimeSession, TerminalSnapshot};
 use crate::domain::{AgentId, LaunchSignature, RemoteRepositorySettings};
-
+use lru::LruCache;
+use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tracing::{debug, info};
 /// Inputs needed to build an `AttachedViewer` without holding the runtime lock
 /// (issue #301 Phase 3).
 ///
@@ -32,11 +28,9 @@ pub struct AttachInputs {
     pub rows: u16,
     pub cols: u16,
 }
-
 #[path = "history_cache.rs"]
 pub mod history_cache;
 use history_cache::HistoryCache;
-
 /// Maximum number of dead-session launch signatures retained for relaunch.
 ///
 /// Repeated kill/recreate cycles of *different* agents would otherwise grow
@@ -230,6 +224,9 @@ pub trait RuntimeManager: Send {
     fn open_shell_window(&mut self, agent_id: &AgentId) -> Result<(), RuntimeError>;
     fn close_shell_window(&mut self, agent_id: &AgentId) -> Result<(), RuntimeError>;
     fn shell_window_exists(&self, agent_id: &AgentId) -> Result<bool, RuntimeError>;
+    fn hide_shell_window(&mut self, agent_id: &AgentId) -> Result<(), RuntimeError>;
+    fn observe_shell_window_sessions(&self) -> Result<Vec<String>, RuntimeError>;
+    fn close_all_shell_windows(&mut self) -> Vec<RuntimeError>;
 }
 /// Real tmux-based runtime manager.
 ///
@@ -967,13 +964,20 @@ impl RuntimeManager for TmuxRuntimeManager {
     fn open_shell_window(&mut self, agent_id: &AgentId) -> Result<(), RuntimeError> {
         super::shell_window::open_manager_shell_window(&self.sessions, agent_id)
     }
-
     fn close_shell_window(&mut self, agent_id: &AgentId) -> Result<(), RuntimeError> {
         super::shell_window::close_manager_shell_window(&self.sessions, agent_id)
     }
-
     fn shell_window_exists(&self, agent_id: &AgentId) -> Result<bool, RuntimeError> {
         super::shell_window::manager_shell_window_exists(&self.sessions, agent_id)
+    }
+    fn hide_shell_window(&mut self, agent_id: &AgentId) -> Result<(), RuntimeError> {
+        super::shell_window::hide_manager_shell_window(&self.sessions, agent_id)
+    }
+    fn observe_shell_window_sessions(&self) -> Result<Vec<String>, RuntimeError> {
+        super::shell_window::observe_shell_window_sessions()
+    }
+    fn close_all_shell_windows(&mut self) -> Vec<RuntimeError> {
+        super::shell_window::close_all_manager_shell_windows(&self.sessions)
     }
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -85,7 +85,8 @@ pub use process::{
 };
 pub use session::{RuntimeSession, TerminalCell, TerminalCellStyle, TerminalSnapshot};
 pub use shell_window::{
-    SHELL_WINDOW_NAME, close_shell_window, open_shell_window, shell_window_exists,
+    SHELL_WINDOW_NAME, close_shell_window, hide_shell_window, open_shell_window,
+    shell_window_exists,
 };
 pub use socket::jefe_tmux_socket_path;
 pub use stub_manager::StubRuntimeManager;

--- a/src/runtime/shell_lifecycle_tests.rs
+++ b/src/runtime/shell_lifecycle_tests.rs
@@ -1,0 +1,257 @@
+//! Structural and decision tests for shell-window lifecycle commands
+//! (issue #361 PR A).
+//!
+//! These tests exercise the command-construction layer and pure parsing /
+//! decision seams (not live tmux) so the Unix and Windows/psmux command
+//! shapes and observation decisions stay correct without a multiplexer
+//! dependency. Live behavior is proven by the tmux scenario in
+//! `dev-docs/tmux-scenarios/agent-shell-overlay.json`.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+
+use super::{
+    SHELL_WINDOW_NAME, close_all_shell_windows_plan, list_all_shell_windows_plan,
+    list_shell_windows_plan, new_window_command, parse_sessions_with_shell_windows,
+    parse_shell_window_names, select_window_command,
+};
+use crate::runtime::multiplexer::{LocalPlatform, MultiplexerIsolation, MultiplexerPlan};
+
+fn plan(platform: LocalPlatform) -> MultiplexerPlan {
+    let executable = if platform == LocalPlatform::Windows {
+        PathBuf::from("psmux.exe")
+    } else {
+        PathBuf::from("tmux")
+    };
+    let isolation = if platform == LocalPlatform::Windows {
+        MultiplexerIsolation::Namespace("jefe-test-lifecycle".to_owned())
+    } else {
+        MultiplexerIsolation::Socket(PathBuf::from("/tmp/jefe-shell-lifecycle.sock"))
+    };
+    MultiplexerPlan::for_platform(platform, executable, isolation)
+        .unwrap_or_else(|error| panic!("test plan: {error}"))
+}
+
+// ---------------------------------------------------------------------------
+// select-window (hide) command shape: Unix + psmux
+// ---------------------------------------------------------------------------
+
+#[test]
+fn select_window_command_targets_window_zero_for_unix() {
+    let command = select_window_command(&plan(LocalPlatform::Unix), "jefe-agent:0");
+    let args = command.get_args().collect::<Vec<_>>();
+    assert!(args.contains(&OsStr::new("select-window")));
+    assert!(
+        args.windows(2)
+            .any(|pair| pair == [OsStr::new("-t"), OsStr::new("jefe-agent:0")]),
+        "select-window must target jefe-agent:0, got args: {args:?}"
+    );
+}
+
+#[test]
+fn select_window_command_carries_psmux_namespace_prefix() {
+    let command = select_window_command(&plan(LocalPlatform::Windows), "jefe-agent:0");
+    let args = command.get_args().collect::<Vec<_>>();
+    assert!(args.contains(&OsStr::new("select-window")));
+    assert!(
+        args.windows(2)
+            .any(|pair| pair == [OsStr::new("-t"), OsStr::new("jefe-agent:0")])
+    );
+    // psmux `-L` namespace prefix invariant must be present on Windows.
+    assert!(
+        args.contains(&OsStr::new("-L")),
+        "psmux select-window must carry -L namespace, got args: {args:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Batched observation command shape: list-windows -a (the single supported
+// path) across Unix + psmux.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_all_shell_windows_plan_uses_batched_all_sessions_for_unix() {
+    let command = list_all_shell_windows_plan(&plan(LocalPlatform::Unix));
+    let args = command.get_args().collect::<Vec<_>>();
+    assert!(args.contains(&OsStr::new("list-windows")));
+    assert!(
+        args.contains(&OsStr::new("-a")),
+        "batched observe must enumerate all sessions with -a, got args: {args:?}"
+    );
+    // The format string must join session and window name so orphan sessions
+    // are discoverable.
+    assert!(
+        args.iter()
+            .any(|arg| *arg == OsStr::new("#{session_name}:#{window_name}")),
+        "batched observe must use session:window format, got args: {args:?}"
+    );
+}
+
+#[test]
+fn list_all_shell_windows_plan_carries_psmux_namespace() {
+    let command = list_all_shell_windows_plan(&plan(LocalPlatform::Windows));
+    let args = command.get_args().collect::<Vec<_>>();
+    assert!(args.contains(&OsStr::new("list-windows")));
+    assert!(args.contains(&OsStr::new("-a")));
+    assert!(
+        args.contains(&OsStr::new("-L")),
+        "psmux batched observe must carry -L namespace, got args: {args:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bounded fallback command shape: per-session list-windows -t
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_shell_windows_plan_targets_single_session_for_unix() {
+    let command = list_shell_windows_plan(&plan(LocalPlatform::Unix), "jefe-agent");
+    let args = command.get_args().collect::<Vec<_>>();
+    assert!(args.contains(&OsStr::new("list-windows")));
+    assert!(
+        args.windows(2)
+            .any(|pair| pair == [OsStr::new("-t"), OsStr::new("jefe-agent")]),
+        "fallback list-windows must target the session, got args: {args:?}"
+    );
+    assert!(
+        args.iter().any(|arg| *arg == OsStr::new("#{window_name}")),
+        "fallback must request window names, got args: {args:?}"
+    );
+}
+
+#[test]
+fn list_shell_windows_plan_carries_psmux_namespace() {
+    let command = list_shell_windows_plan(&plan(LocalPlatform::Windows), "jefe-agent");
+    let args = command.get_args().collect::<Vec<_>>();
+    assert!(
+        args.contains(&OsStr::new("-L")),
+        "psmux fallback observe must carry -L namespace, got args: {args:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Pure parsing: parse_sessions_with_shell_windows (batched format)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_sessions_extracts_jefe_shell_owners_deterministically() {
+    let raw = "jefe-agent-a:0\njefe-agent-a:jefe-shell\njefe-agent-b:bash\njefe-agent-c:jefe-shell";
+    let sessions = parse_sessions_with_shell_windows(raw);
+    assert_eq!(
+        sessions,
+        vec!["jefe-agent-a".to_owned(), "jefe-agent-c".to_owned()],
+        "must return only sessions owning jefe-shell, in sorted order"
+    );
+}
+
+#[test]
+fn parse_sessions_deduplicates_multiple_shell_windows_per_session() {
+    let raw = "jefe-agent-a:jefe-shell\njefe-agent-a:jefe-shell";
+    let sessions = parse_sessions_with_shell_windows(raw);
+    assert_eq!(sessions, vec!["jefe-agent-a".to_owned()]);
+}
+
+#[test]
+fn parse_sessions_returns_empty_when_no_jefe_shell() {
+    let raw = "jefe-agent-a:bash\njefe-agent-b:vim";
+    assert!(parse_sessions_with_shell_windows(raw).is_empty());
+}
+
+#[test]
+fn parse_sessions_ignores_blank_and_malformed_lines() {
+    let raw = "\n\njefe-agent-a:jefe-shell\n::\nno-colon\n";
+    let sessions = parse_sessions_with_shell_windows(raw);
+    assert_eq!(sessions, vec!["jefe-agent-a".to_owned()]);
+}
+
+#[test]
+fn parse_sessions_uses_last_colon_as_delimiter() {
+    // A session name containing a colon (rare) must still parse: the window
+    // name is the trailing segment after the last colon.
+    let raw = "weird:session:jefe-shell";
+    let sessions = parse_sessions_with_shell_windows(raw);
+    assert_eq!(sessions, vec!["weird:session".to_owned()]);
+}
+
+// ---------------------------------------------------------------------------
+// Pure parsing: parse_shell_window_names (fallback per-session format)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_shell_window_names_detects_jefe_shell_membership() {
+    assert!(parse_shell_window_names(
+        "jefe-shell\nbash\njefe-shell\nvim"
+    ));
+}
+
+#[test]
+fn parse_shell_window_names_absent_when_no_jefe_shell() {
+    assert!(!parse_shell_window_names("bash\nvim\nzsh"));
+}
+
+#[test]
+fn parse_shell_window_names_trims_whitespace() {
+    assert!(parse_shell_window_names("  jefe-shell  \n bash "));
+}
+
+// ---------------------------------------------------------------------------
+// close-all shutdown command plan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn close_all_shell_windows_plan_targets_jefe_shell_per_session() {
+    let multiplexer = plan(LocalPlatform::Unix);
+    let session_names = vec!["jefe-agent-a".to_owned(), "jefe-agent-b".to_owned()];
+    let commands = close_all_shell_windows_plan(&multiplexer, &session_names);
+    assert_eq!(
+        commands.len(),
+        session_names.len(),
+        "one kill-window command per session"
+    );
+    for (command, session) in commands.iter().zip(session_names.iter()) {
+        let args = command.get_args().collect::<Vec<_>>();
+        assert!(args.contains(&OsStr::new("kill-window")));
+        let expected_target = format!("{session}:{SHELL_WINDOW_NAME}");
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == [OsStr::new("-t"), OsStr::new(&expected_target)]),
+            "kill-window must target {expected_target}, got args: {args:?}"
+        );
+    }
+}
+
+#[test]
+fn close_all_shell_windows_plan_is_empty_for_no_sessions() {
+    let multiplexer = plan(LocalPlatform::Unix);
+    assert!(close_all_shell_windows_plan(&multiplexer, &[]).is_empty());
+}
+
+#[test]
+fn close_all_shell_windows_plan_carries_psmux_namespace() {
+    let multiplexer = plan(LocalPlatform::Windows);
+    let commands = close_all_shell_windows_plan(&multiplexer, &["jefe-agent".to_owned()]);
+    let args = commands[0].get_args().collect::<Vec<_>>();
+    assert!(
+        args.contains(&OsStr::new("-L")),
+        "psmux shutdown must carry -L namespace, got args: {args:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// new-window command shape (open path)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn new_window_command_for_unix_includes_work_dir_and_env_scrub() {
+    let work_dir = Path::new("/tmp/work dir");
+    let shell = OsString::from("/bin/bash");
+    let command = new_window_command(&plan(LocalPlatform::Unix), "jefe-agent", work_dir, &shell)
+        .unwrap_or_else(|error| panic!("new-window command: {error}"));
+    let args = command.get_args().collect::<Vec<_>>();
+    assert!(
+        args.windows(2)
+            .any(|pair| pair == [OsStr::new("-c"), work_dir.as_os_str()])
+    );
+    assert!(args.contains(&shell.as_os_str()));
+    assert!(args.contains(&OsStr::new(SHELL_WINDOW_NAME)));
+}

--- a/src/runtime/shell_window.rs
+++ b/src/runtime/shell_window.rs
@@ -1,6 +1,6 @@
 //! Embedded shell-window multiplexer operations (issue #222).
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::ffi::OsString;
 use std::path::Path;
 use std::process::Command;
@@ -57,10 +57,8 @@ pub(super) fn hide_manager_shell_window(
 ///
 /// Returns the per-session failures so callers (graceful shutdown) can report
 /// them without blocking the quit path. Sessions whose close succeeds are not
-/// represented; the order of returned errors follows `sessions.values()`.
-pub(super) fn close_all_manager_shell_windows(
-    _sessions: &HashMap<AgentId, RuntimeSession>,
-) -> Vec<RuntimeError> {
+/// represented; failures follow the deterministic discovery order.
+pub(super) fn close_all_manager_shell_windows() -> Vec<RuntimeError> {
     match observe_shell_window_sessions() {
         Ok(session_names) => close_all_shell_windows(&session_names),
         Err(error) => vec![error],
@@ -334,26 +332,15 @@ pub(super) fn list_all_shell_windows_plan(multiplexer: &MultiplexerPlan) -> Comm
 /// no I/O, deterministic, unit-testable.
 #[must_use]
 pub fn parse_sessions_with_shell_windows(raw: &str) -> Vec<String> {
-    let mut owners = Vec::new();
-    for line in raw.lines() {
-        // Use rsplit_once so a session name containing a colon (rare but
-        // possible) is still parsed correctly; the window name is the
-        // trailing segment.
-        let Some((session, window)) = line.rsplit_once(':') else {
-            continue;
-        };
-        if window.trim() != SHELL_WINDOW_NAME {
-            continue;
-        }
-        let session = session.trim();
-        if session.is_empty() || owners.iter().any(|s: &String| s == session) {
-            continue;
-        }
-        owners.push(session.to_owned());
-    }
-    // Deterministic order for callers that diff successive observations.
-    owners.sort();
-    owners
+    raw.lines()
+        .filter_map(|line| line.rsplit_once(':'))
+        .filter(|(_, window)| window.trim() == SHELL_WINDOW_NAME)
+        .map(|(session, _)| session.trim())
+        .filter(|session| !session.is_empty())
+        .map(String::from)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
 }
 
 /// Parse raw `list-windows -t <session> -F #{window_name}` stdout and report

--- a/src/runtime/shell_window.rs
+++ b/src/runtime/shell_window.rs
@@ -43,6 +43,30 @@ pub(super) fn close_manager_shell_window(
     close_shell_window(&manager_session(sessions, agent_id)?.session_name)
 }
 
+/// Hide the embedded shell window for an agent by selecting window 0
+/// (issue #361 PR A). Manager-scoped helper so the trait impl stays thin.
+pub(super) fn hide_manager_shell_window(
+    sessions: &HashMap<AgentId, RuntimeSession>,
+    agent_id: &AgentId,
+) -> Result<(), RuntimeError> {
+    hide_shell_window(&manager_session(sessions, agent_id)?.session_name)
+}
+
+/// Close every tracked `jefe-shell` window best-effort (issue #361 PR A).
+/// Manager-scoped helper.
+///
+/// Returns the per-session failures so callers (graceful shutdown) can report
+/// them without blocking the quit path. Sessions whose close succeeds are not
+/// represented; the order of returned errors follows `sessions.values()`.
+pub(super) fn close_all_manager_shell_windows(
+    _sessions: &HashMap<AgentId, RuntimeSession>,
+) -> Vec<RuntimeError> {
+    match observe_shell_window_sessions() {
+        Ok(session_names) => close_all_shell_windows(&session_names),
+        Err(error) => vec![error],
+    }
+}
+
 pub(super) fn manager_shell_window_exists(
     sessions: &HashMap<AgentId, RuntimeSession>,
     agent_id: &AgentId,
@@ -133,9 +157,8 @@ fn select_shell_window(session_name: &str) -> Result<(), RuntimeError> {
 
 fn select_window(target: &str) -> Result<(), RuntimeError> {
     let multiplexer = MultiplexerPlan::current().map_err(RuntimeError::Multiplexer)?;
-    let output = multiplexer
-        .command()
-        .args(["select-window", "-t", target])
+    let mut command = select_window_command(&multiplexer, target);
+    let output = command
         .output()
         .map_err(|error| RuntimeError::SpawnFailed(format!("tmux select-window: {error}")))?;
     if output.status.success() {
@@ -146,6 +169,16 @@ fn select_window(target: &str) -> Result<(), RuntimeError> {
             String::from_utf8_lossy(&output.stderr)
         )))
     }
+}
+
+/// Build a `select-window -t <target>` command carrying the plan's base args.
+///
+/// Exposed so structural tests can verify the command shape (including the
+/// psmux `-L` namespace prefix invariant) without live tmux.
+pub(super) fn select_window_command(multiplexer: &MultiplexerPlan, target: &str) -> Command {
+    let mut command = multiplexer.command();
+    command.args(["select-window", "-t", target]);
+    command
 }
 
 fn agent_window_alive(session_name: &str) -> Result<bool, RuntimeError> {
@@ -169,7 +202,7 @@ fn agent_window_alive(session_name: &str) -> Result<bool, RuntimeError> {
         .any(|value| value.trim() == "0"))
 }
 
-fn new_window_command(
+pub(super) fn new_window_command(
     multiplexer: &MultiplexerPlan,
     session_name: &str,
     work_dir: &Path,
@@ -203,6 +236,212 @@ fn default_shell() -> OsString {
     std::env::var_os("SHELL").unwrap_or_else(|| OsString::from("/bin/sh"))
 }
 
+/// Hide the embedded shell window for `session_name` by selecting the agent
+/// window 0 (issue #361 PR A).
+///
+/// This leaves the `jefe-shell` window alive but makes window 0 the
+/// multiplexer's current window, satisfying the invariant that whenever a
+/// shell is not visible, the owning session's current window is window 0.
+/// The viewer/capture path follows the multiplexer current window, so this
+/// restores the agent pane without disturbing the shell.
+pub fn hide_shell_window(session_name: &str) -> Result<(), RuntimeError> {
+    select_window(&format!("{session_name}:0"))
+}
+
+/// Observe every session hosting a `jefe-shell` window via one batched
+/// `list-windows -a` query, with a bounded fallback (issue #361).
+pub fn observe_shell_window_sessions() -> Result<Vec<String>, RuntimeError> {
+    let multiplexer = MultiplexerPlan::current().map_err(RuntimeError::Multiplexer)?;
+    let mut batched = list_all_shell_windows_plan(&multiplexer);
+    match batched.output() {
+        Ok(output) if output.status.success() => Ok(parse_sessions_with_shell_windows(
+            &String::from_utf8_lossy(&output.stdout),
+        )),
+        Ok(_failed) => {
+            // Bounded fallback enumerates all sessions so orphans are still
+            // discovered.
+            let mut sessions_command = multiplexer.command();
+            sessions_command.args(["list-sessions", "-F", "#{session_name}"]);
+            let sessions_output = sessions_command.output().map_err(|error| {
+                RuntimeError::CapabilityProbeFailed(format!(
+                    "tmux list-sessions spawn failed: {error}"
+                ))
+            })?;
+            if !sessions_output.status.success() {
+                return Err(RuntimeError::CapabilityProbeFailed(format!(
+                    "tmux list-sessions failed: {}",
+                    String::from_utf8_lossy(&sessions_output.stderr)
+                )));
+            }
+            let known: Vec<String> = String::from_utf8_lossy(&sessions_output.stdout)
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(String::from)
+                .collect();
+            let mut owners = Vec::new();
+            for session in &known {
+                let mut command = list_shell_windows_plan(&multiplexer, session);
+                match command.output() {
+                    Ok(output) if output.status.success() => {
+                        if parse_shell_window_names(&String::from_utf8_lossy(&output.stdout)) {
+                            owners.push(session.clone());
+                        }
+                    }
+                    Ok(output) => {
+                        return Err(RuntimeError::CapabilityProbeFailed(format!(
+                            "tmux list-windows failed for {session}: {}",
+                            String::from_utf8_lossy(&output.stderr)
+                        )));
+                    }
+                    Err(error) => {
+                        return Err(RuntimeError::CapabilityProbeFailed(format!(
+                            "tmux list-windows spawn failed for {session}: {error}"
+                        )));
+                    }
+                }
+            }
+            Ok(owners)
+        }
+        Err(error) => Err(RuntimeError::CapabilityProbeFailed(format!(
+            "tmux list-windows -a spawn failed: {error}"
+        ))),
+    }
+}
+
+/// Build a `list-windows -a -F #{session_name}:#{window_name}` command for
+/// observing every `jefe-shell` window across all sessions in a single batched
+/// query (issue #361 PR A).
+///
+/// `-a` enumerates windows in every session; the format string joins session
+/// and window name so one query discovers owners even for sessions the caller
+/// does not know about yet (needed for startup orphan detection). Exposed so
+/// structural tests can verify the command shape across Unix and Windows/psmux
+/// without live tmux.
+pub(super) fn list_all_shell_windows_plan(multiplexer: &MultiplexerPlan) -> Command {
+    let mut command = multiplexer.command();
+    command.args(["list-windows", "-a", "-F", "#{session_name}:#{window_name}"]);
+    command
+}
+
+/// Parse raw `list-windows -a -F #{session_name}:#{window_name}` stdout into
+/// the set of session names that host a `jefe-shell` window (issue #361).
+///
+/// Each non-empty line is `<session_name>:<window_name>`. A session owns a
+/// shell window when at least one of its lines names `jefe-shell`. Window
+/// names may themselves contain colons, so only the *last* colon is treated
+/// as the delimiter (window names are the trailing segment). Pure function:
+/// no I/O, deterministic, unit-testable.
+#[must_use]
+pub fn parse_sessions_with_shell_windows(raw: &str) -> Vec<String> {
+    let mut owners = Vec::new();
+    for line in raw.lines() {
+        // Use rsplit_once so a session name containing a colon (rare but
+        // possible) is still parsed correctly; the window name is the
+        // trailing segment.
+        let Some((session, window)) = line.rsplit_once(':') else {
+            continue;
+        };
+        if window.trim() != SHELL_WINDOW_NAME {
+            continue;
+        }
+        let session = session.trim();
+        if session.is_empty() || owners.iter().any(|s: &String| s == session) {
+            continue;
+        }
+        owners.push(session.to_owned());
+    }
+    // Deterministic order for callers that diff successive observations.
+    owners.sort();
+    owners
+}
+
+/// Parse raw `list-windows -t <session> -F #{window_name}` stdout and report
+/// whether a `jefe-shell` window is present (issue #361). Used by the bounded
+/// fallback path only.
+#[must_use]
+pub fn parse_shell_window_names(stdout: &str) -> bool {
+    stdout.lines().any(|name| name.trim() == SHELL_WINDOW_NAME)
+}
+
+/// Build one `kill-window -t <session>:jefe-shell` command per session name
+/// for graceful shutdown (issue #361 PR A).
+///
+/// Returns the commands without executing them so the caller can drive them
+/// best-effort (log failures, do not block quit). Exposed for structural
+/// tests.
+pub(super) fn close_all_shell_windows_plan(
+    multiplexer: &MultiplexerPlan,
+    session_names: &[String],
+) -> Vec<Command> {
+    session_names
+        .iter()
+        .map(|session| {
+            let target = format!("{session}:{SHELL_WINDOW_NAME}");
+            let mut command = multiplexer.command();
+            command.args(["kill-window", "-t", &target]);
+            command
+        })
+        .collect()
+}
+
+/// Close every known `jefe-shell` window best-effort (issue #361 PR A).
+///
+/// Used by graceful shutdown. Failures are collected and logged via `tracing`
+/// and returned so the caller can surface them; they do not block the quit
+/// path. Does not kill agent sessions — only the temporary `jefe-shell`
+/// windows. Each session is closed exactly once (the visible shell is closed
+/// here too, so the caller must not double-close it separately).
+pub fn close_all_shell_windows(session_names: &[String]) -> Vec<RuntimeError> {
+    let multiplexer = match MultiplexerPlan::current() {
+        Ok(plan) => plan,
+        Err(error) => {
+            tracing::warn!(error = %error, "shutdown: multiplexer unavailable, skipping shell cleanup");
+            return vec![RuntimeError::Multiplexer(error)];
+        }
+    };
+    let mut failures = Vec::new();
+    for mut command in close_all_shell_windows_plan(&multiplexer, session_names) {
+        let args: Vec<String> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        match command.output() {
+            Ok(output) if output.status.success() => {}
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+                tracing::warn!(target = ?args, stderr = %stderr, "shutdown: best-effort shell close failed");
+                failures.push(RuntimeError::KillFailed(format!(
+                    "tmux kill-window failed: {stderr}"
+                )));
+            }
+            Err(error) => {
+                tracing::warn!(target = ?args, error = %error, "shutdown: best-effort shell close spawn failed");
+                failures.push(RuntimeError::KillFailed(format!(
+                    "tmux kill-window spawn failed: {error}"
+                )));
+            }
+        }
+    }
+    failures
+}
+
+/// Build a `list-windows -t <session> -F #{window_name}` command for the
+/// bounded fallback observation path (issue #361 PR A). Exposed so structural
+/// tests can verify the command shape across Unix and Windows/psmux.
+pub(super) fn list_shell_windows_plan(
+    multiplexer: &MultiplexerPlan,
+    session_name: &str,
+) -> Command {
+    let mut command = multiplexer.command();
+    command.args(["list-windows", "-t", session_name, "-F", "#{window_name}"]);
+    command
+}
+
 #[cfg(test)]
 #[path = "shell_window_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "shell_lifecycle_tests.rs"]
+mod lifecycle_tests;

--- a/src/runtime/stub_manager.rs
+++ b/src/runtime/stub_manager.rs
@@ -98,6 +98,7 @@ impl RuntimeManager for StubRuntimeManager {
     fn kill(&mut self, agent_id: &AgentId) -> Result<(), RuntimeError> {
         if let Some(idx) = self.sessions.iter().position(|s| &s.agent_id == agent_id) {
             self.sessions.remove(idx);
+            self.open_shell_windows.remove(agent_id);
             // Adjust attached_index
             match self.attached_index {
                 Some(i) if i == idx => self.attached_index = None,
@@ -227,5 +228,126 @@ impl RuntimeManager for StubRuntimeManager {
             return Err(RuntimeError::SessionNotFound(agent_id.0.clone()));
         }
         Ok(self.open_shell_windows.contains(agent_id))
+    }
+
+    fn hide_shell_window(&mut self, agent_id: &AgentId) -> Result<(), RuntimeError> {
+        // The stub models shell-window visibility only as set membership; the
+        // real implementation selects window 0. Hiding is a no-op for the
+        // stub because the window stays tracked.
+        if !self.sessions.iter().any(|s| &s.agent_id == agent_id) {
+            return Err(RuntimeError::SessionNotFound(agent_id.0.clone()));
+        }
+        Ok(())
+    }
+
+    fn observe_shell_window_sessions(&self) -> Result<Vec<String>, RuntimeError> {
+        Ok(self
+            .sessions
+            .iter()
+            .filter(|session| self.open_shell_windows.contains(&session.agent_id))
+            .map(|session| session.session_name.clone())
+            .collect())
+    }
+
+    fn close_all_shell_windows(&mut self) -> Vec<RuntimeError> {
+        self.open_shell_windows.clear();
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{LaunchSignature, RemoteRepositorySettings};
+
+    fn local_signature() -> LaunchSignature {
+        LaunchSignature {
+            work_dir: std::path::PathBuf::from("/tmp/work"),
+            profile: String::new(),
+            code_puppy_model: String::new(),
+            code_puppy_version: String::new(),
+            code_puppy_yolo: None,
+            code_puppy_quick_resume: false,
+            mode_flags: Vec::new(),
+            llxprt_debug: String::new(),
+            pass_continue: false,
+            sandbox_enabled: false,
+            sandbox_engine: crate::domain::SandboxEngine::default(),
+            sandbox_flags: String::new(),
+            remote: RemoteRepositorySettings::default(),
+            agent_kind: crate::domain::AgentKind::default(),
+            llxprt_version: None,
+        }
+    }
+
+    fn stub_with_session(agent_id: &AgentId) -> StubRuntimeManager {
+        let mut stub = StubRuntimeManager::default();
+        stub.spawn_session(
+            agent_id,
+            std::path::Path::new("/tmp/work"),
+            &local_signature(),
+        )
+        .unwrap_or_else(|e| panic!("spawn: {e}"));
+        stub
+    }
+
+    #[test]
+    fn stub_close_all_shell_windows_clears_tracked_set() {
+        let a = AgentId("a".into());
+        let b = AgentId("b".into());
+        let mut stub = stub_with_session(&a);
+        stub.spawn_session(&b, std::path::Path::new("/tmp/work"), &local_signature())
+            .unwrap_or_else(|e| panic!("spawn: {e}"));
+        stub.open_shell_window(&a)
+            .unwrap_or_else(|e| panic!("open shell: {e}"));
+        stub.open_shell_window(&b)
+            .unwrap_or_else(|e| panic!("open shell: {e}"));
+        assert!(
+            stub.shell_window_exists(&a)
+                .unwrap_or_else(|e| panic!("observe shell: {e}"))
+        );
+
+        let failures = stub.close_all_shell_windows();
+        assert!(
+            failures.is_empty(),
+            "best-effort stub cleanup reports no failures"
+        );
+        assert!(
+            !stub
+                .shell_window_exists(&a)
+                .unwrap_or_else(|e| panic!("observe shell: {e}")),
+            "close_all must actually clear the tracked shell set (issue #361)"
+        );
+    }
+
+    #[test]
+    fn stub_hide_shell_window_succeeds_for_known_session() {
+        let a = AgentId("a".into());
+        let mut stub = stub_with_session(&a);
+        stub.open_shell_window(&a)
+            .unwrap_or_else(|e| panic!("open shell: {e}"));
+        stub.hide_shell_window(&a)
+            .unwrap_or_else(|e| panic!("hide: {e}"));
+        // Hide keeps the window tracked in the stub model.
+        assert!(
+            stub.shell_window_exists(&a)
+                .unwrap_or_else(|e| panic!("observe shell: {e}"))
+        );
+    }
+
+    #[test]
+    fn stub_observe_all_shell_window_sessions_returns_session_names() {
+        let a = AgentId("a".into());
+        let mut stub = stub_with_session(&a);
+        stub.open_shell_window(&a)
+            .unwrap_or_else(|e| panic!("open shell: {e}"));
+        let sessions = stub
+            .observe_shell_window_sessions()
+            .unwrap_or_else(|e| panic!("observe all: {e}"));
+        assert_eq!(
+            sessions,
+            vec![RuntimeSession::session_name_for(&a)],
+            "stub must map open shells to session names for startup reconcile"
+        );
     }
 }

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -28,6 +28,13 @@ pub enum AppEvent {
     OpenShellOverlay,
     /// Close/restore the embedded shell overlay (F10 toggle or natural exit detected).
     CloseShellOverlay,
+    /// Hide the visible shell overlay while keeping the `jefe-shell` window
+    /// alive (issue #361). Selects the agent window 0 so the multiplexer
+    /// current window invariant holds, then restores dashboard focus/layout.
+    HideShellOverlay,
+    /// Resume a hidden shell for the selected agent (issue #361). Re-selects
+    /// the existing `jefe-shell` window without duplicating it.
+    ResumeShellOverlay(crate::domain::AgentId),
 
     // Screen mode
     EnterSplitMode,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -52,9 +52,12 @@ mod prs_property_ops;
 mod prs_thread_ops;
 pub mod scrollback_ops;
 mod selectors;
+mod shell_inventory_ops;
 mod shell_overlay_ops;
+mod shortcut_ops;
 pub use selectors::ChooserAgentInfo;
 pub(crate) use selectors::build_chooser_entries_from_state;
+pub use shell_inventory_ops::ShellInventory;
 pub mod state_ops;
 pub mod theme_picker_view;
 pub mod transient_ops;
@@ -113,29 +116,6 @@ impl AppState {
     pub fn repository_for_agent(&self, agent_id: &AgentId) -> Option<&Repository> {
         let agent = self.agents.iter().find(|agent| &agent.id == agent_id)?;
         self.repository_by_id(&agent.repository_id)
-    }
-
-    pub(super) fn first_unused_shortcut_slot(&self, ignore_agent: Option<&AgentId>) -> Option<u8> {
-        (1u8..=9u8).find(|slot| {
-            self.agents.iter().all(|agent| {
-                if ignore_agent.is_some_and(|id| &agent.id == id) {
-                    true
-                } else {
-                    agent.shortcut_slot != Some(*slot)
-                }
-            })
-        })
-    }
-
-    fn enforce_shortcut_uniqueness(&mut self, owner_id: &AgentId, slot: Option<u8>) {
-        let Some(slot) = slot else {
-            return;
-        };
-        for agent in &mut self.agents {
-            if agent.id != *owner_id && agent.shortcut_slot == Some(slot) {
-                agent.shortcut_slot = None;
-            }
-        }
     }
 
     fn remember_selected_agent_for_current_repo(&mut self) {
@@ -357,6 +337,8 @@ impl AppState {
                     | UiNavigationMessage::CyclePaneFocus
                     | UiNavigationMessage::OpenShellOverlay
                     | UiNavigationMessage::CloseShellOverlay
+                    | UiNavigationMessage::HideShellOverlay
+                    | UiNavigationMessage::ResumeShellOverlay(_)
             )
         {
             return false;
@@ -477,8 +459,7 @@ impl AppState {
                     message,
                 );
             }
-            message @ (UiNavigationMessage::OpenShellOverlay
-            | UiNavigationMessage::CloseShellOverlay) => self.apply_shell_overlay_message(message),
+            shell_message => self.apply_shell_overlay_message(shell_message),
         }
     }
 
@@ -668,8 +649,13 @@ impl AppState {
                 if let Some(agent) = self.agents.iter_mut().find(|a| a.id == agent_id) {
                     agent.status = AgentStatus::Dead;
                     agent.runtime_binding = None;
-                    self.sticky_dead_agent_ids.insert(agent_id);
+                    self.sticky_dead_agent_ids.insert(agent_id.clone());
                 }
+                // Immediate shell-inventory cleanup on explicit kill (issue
+                // #361 PR A): the session is being torn down, so any tracked
+                // shell window is gone. Natural AgentStatusChanged->Dead is
+                // NOT touched here; natural death keeps shell close-only.
+                self.remove_shell_window(&agent_id);
             }
             RuntimeMessage::AgentStatusChanged(agent_id, status) => {
                 if let Some(agent) = self.agents.iter_mut().find(|a| a.id == agent_id) {

--- a/src/state/shell_inventory_ops.rs
+++ b/src/state/shell_inventory_ops.rs
@@ -1,0 +1,211 @@
+//! Runtime-only shell-window inventory and hide/resume reducer operations
+//! (issue #361 PR A).
+//!
+//! Pure state transitions for the embedded agent-shell inventory. The
+//! inventory mirrors which agents currently own a live `jefe-shell` window
+//! (visible or hidden). Ground truth remains the multiplexer runtime; this
+//! typed mirror is updated only after runtime operations succeed so failures
+//! leave state intact (see invariants in `project-plans/issue361-plan.md`).
+//!
+//! Reducers here perform no I/O. The runtime boundary modules
+//! (`app_input::shell_overlay`, `runtime::shell_window`) drive the actual
+//! tmux/psmux commands and then apply the deterministic transitions here.
+
+use crate::domain::AgentId;
+
+/// Runtime-only inventory of agents that own a live `jefe-shell` window
+/// (issue #361).
+///
+/// Membership means "a `jefe-shell` window exists for this agent in the
+/// multiplexer". It does NOT mean the overlay is visible — visibility is
+/// tracked separately by [`crate::state::ShellOverlayState::agent_id`].
+/// Ground truth is the runtime multiplexer; this mirror is updated only
+/// after a runtime operation succeeds, and removed only after a runtime
+/// disappearance/success, so a transient probe failure cannot corrupt the
+/// inventory.
+///
+/// At most one shell per agent is enforced structurally by the fixed
+/// `jefe-shell` window name.
+///
+/// Backed by a sorted `Vec<AgentId>` (sorted by the inner `String`) so
+/// iteration order is deterministic without requiring `AgentId: Ord`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ShellInventory {
+    agents: Vec<AgentId>,
+}
+
+impl ShellInventory {
+    /// Construct an empty inventory.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether `agent_id` owns a tracked shell window.
+    #[must_use]
+    pub fn contains(&self, agent_id: &AgentId) -> bool {
+        self.agents.iter().any(|entry| entry == agent_id)
+    }
+
+    /// Number of tracked shell windows.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.agents.len()
+    }
+
+    /// Whether no shell windows are tracked.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.agents.is_empty()
+    }
+
+    /// Iterate over the agent IDs owning tracked shell windows, in stable
+    /// lexicographic order of the underlying string.
+    pub fn iter(&self) -> impl Iterator<Item = &AgentId> {
+        self.agents.iter()
+    }
+
+    /// Snapshot the tracked agent IDs as a `Vec`.
+    #[must_use]
+    pub fn to_vec(&self) -> Vec<AgentId> {
+        self.agents.clone()
+    }
+
+    /// Record a shell window for `agent_id` after a successful runtime
+    /// open/resume. Idempotent: re-recording an existing entry is a no-op so
+    /// resume of a hidden shell does not duplicate.
+    pub fn record(&mut self, agent_id: AgentId) {
+        let position = self.agents.partition_point(|entry| entry.0 < agent_id.0);
+        if self
+            .agents
+            .get(position)
+            .is_some_and(|existing| existing == &agent_id)
+        {
+            return;
+        }
+        self.agents.insert(position, agent_id);
+    }
+
+    /// Remove `agent_id` from the inventory after a runtime close/disappearance.
+    /// Returns whether an entry was actually removed.
+    pub fn remove(&mut self, agent_id: &AgentId) -> bool {
+        let position = self.agents.partition_point(|entry| entry.0 < agent_id.0);
+        if self
+            .agents
+            .get(position)
+            .is_some_and(|existing| existing == agent_id)
+        {
+            self.agents.remove(position);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Replace the entire inventory with `agents`. Used by startup adoption
+    /// and batched reconciliation which observe runtime ground truth. The
+    /// resulting inventory is deduplicated and sorted.
+    pub fn replace(&mut self, agents: impl IntoIterator<Item = AgentId>) {
+        self.agents = agents.into_iter().collect();
+        self.agents.sort_by(|a, b| a.0.cmp(&b.0));
+        self.agents.dedup_by(|a, b| a == b);
+    }
+
+    /// Clear every entry. Used by graceful shutdown.
+    pub fn clear(&mut self) {
+        self.agents.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(name: &str) -> AgentId {
+        AgentId(name.to_owned())
+    }
+
+    #[test]
+    fn new_inventory_is_empty() {
+        let inventory = ShellInventory::new();
+        assert!(inventory.is_empty());
+        assert_eq!(inventory.len(), 0);
+    }
+
+    #[test]
+    fn record_then_contains() {
+        let mut inventory = ShellInventory::new();
+        inventory.record(id("a"));
+        assert!(inventory.contains(&id("a")));
+        assert!(!inventory.contains(&id("b")));
+        assert_eq!(inventory.len(), 1);
+    }
+
+    #[test]
+    fn record_is_idempotent_so_resume_does_not_duplicate() {
+        let mut inventory = ShellInventory::new();
+        inventory.record(id("a"));
+        inventory.record(id("a"));
+        assert_eq!(inventory.len(), 1);
+    }
+
+    #[test]
+    fn remove_returns_whether_entry_existed() {
+        let mut inventory = ShellInventory::new();
+        inventory.record(id("a"));
+        assert!(inventory.remove(&id("a")));
+        assert!(!inventory.remove(&id("a")));
+        assert!(inventory.is_empty());
+    }
+
+    #[test]
+    fn iter_is_stable_lexicographic_order() {
+        let mut inventory = ShellInventory::new();
+        inventory.record(id("b"));
+        inventory.record(id("a"));
+        inventory.record(id("c"));
+        let ordered: Vec<_> = inventory.iter().cloned().collect();
+        assert_eq!(ordered, vec![id("a"), id("b"), id("c")]);
+    }
+
+    #[test]
+    fn replace_overwrites_membership_and_sorts() {
+        let mut inventory = ShellInventory::new();
+        inventory.record(id("old"));
+        inventory.replace([id("b"), id("a")]);
+        assert!(!inventory.contains(&id("old")));
+        assert!(inventory.contains(&id("a")));
+        assert!(inventory.contains(&id("b")));
+        assert_eq!(inventory.len(), 2);
+        let ordered: Vec<_> = inventory.iter().cloned().collect();
+        assert_eq!(ordered, vec![id("a"), id("b")]);
+    }
+
+    #[test]
+    fn replace_deduplicates() {
+        let mut inventory = ShellInventory::new();
+        inventory.replace([id("a"), id("a"), id("b")]);
+        assert_eq!(inventory.len(), 2);
+    }
+
+    #[test]
+    fn clear_empties_inventory() {
+        let mut inventory = ShellInventory::new();
+        inventory.record(id("a"));
+        inventory.record(id("b"));
+        inventory.clear();
+        assert!(inventory.is_empty());
+    }
+
+    #[test]
+    fn to_vec_snapshots_membership() {
+        let mut inventory = ShellInventory::new();
+        inventory.record(id("b"));
+        inventory.record(id("a"));
+        let snapshot = inventory.to_vec();
+        assert_eq!(snapshot, vec![id("a"), id("b")]);
+        // Mutating the inventory after snapshot does not affect the snapshot.
+        inventory.remove(&id("a"));
+        assert_eq!(snapshot.len(), 2);
+    }
+}

--- a/src/state/shell_inventory_ops.rs
+++ b/src/state/shell_inventory_ops.rs
@@ -44,7 +44,9 @@ impl ShellInventory {
     /// Whether `agent_id` owns a tracked shell window.
     #[must_use]
     pub fn contains(&self, agent_id: &AgentId) -> bool {
-        self.agents.iter().any(|entry| entry == agent_id)
+        self.agents
+            .binary_search_by(|entry| entry.0.cmp(&agent_id.0))
+            .is_ok()
     }
 
     /// Number of tracked shell windows.

--- a/src/state/shell_overlay_ops.rs
+++ b/src/state/shell_overlay_ops.rs
@@ -82,6 +82,7 @@ impl AppState {
         self.shell_overlay.agent_id = None;
         self.shell_overlay.generation = self.shell_overlay.generation.wrapping_add(1);
         self.terminal_focused = false;
+        self.dashboard_grab = None;
         self.pane_focus = self
             .shell_overlay
             .previous_pane_focus

--- a/src/state/shell_overlay_ops.rs
+++ b/src/state/shell_overlay_ops.rs
@@ -29,10 +29,15 @@ impl AppState {
     /// Activate the shell overlay for `agent_id`.
     pub fn open_shell_overlay(&mut self, agent_id: AgentId) {
         self.shell_overlay = ShellOverlayState {
-            agent_id: Some(agent_id),
+            agent_id: Some(agent_id.clone()),
             generation: self.shell_overlay.generation.wrapping_add(1),
             previous_pane_focus: Some(self.pane_focus),
+            inventory: self.shell_overlay.inventory.clone(),
         };
+        // Record the shell window in the runtime inventory (issue #361). The
+        // caller (runtime boundary) only invokes this after a successful open,
+        // so recording here keeps the inventory consistent with visibility.
+        self.shell_overlay.inventory.record(agent_id);
         // Focus the terminal so keyboard input is forwarded to the shell.
         self.terminal_focused = true;
         self.pane_focus = crate::state::PaneFocus::Terminal;
@@ -43,6 +48,12 @@ impl AppState {
     /// Deactivate the shell overlay, restoring normal dashboard state.
     pub fn close_shell_overlay(&mut self) {
         if self.shell_overlay.agent_id.is_some() {
+            // Remove from inventory only after the runtime close succeeded;
+            // the runtime boundary calls this after a successful close, so the
+            // inventory entry is dropped here (issue #361).
+            if let Some(agent_id) = self.shell_overlay.agent_id.clone() {
+                self.shell_overlay.inventory.remove(&agent_id);
+            }
             self.shell_overlay.agent_id = None;
             self.terminal_focused = false;
             self.pane_focus = self
@@ -52,6 +63,91 @@ impl AppState {
                 .unwrap_or(crate::state::PaneFocus::Agents);
             self.reset_shell_terminal_view();
         }
+    }
+
+    /// Hide the visible shell overlay while keeping its `jefe-shell` window
+    /// alive (issue #361 PR A).
+    ///
+    /// Clears the visible `agent_id` and restores dashboard focus/layout, but
+    /// keeps the inventory entry so F10 can resume the exact shell. Bumps the
+    /// generation so the background observer recognizes the new state. The
+    /// runtime boundary is responsible for selecting agent window 0 before
+    /// invoking this; this reducer performs no I/O.
+    pub fn hide_shell_overlay(&mut self) {
+        let Some(agent_id) = self.shell_overlay.agent_id.clone() else {
+            return;
+        };
+        // Inventory entry persists: the shell window is alive, just hidden.
+        let _ = agent_id;
+        self.shell_overlay.agent_id = None;
+        self.shell_overlay.generation = self.shell_overlay.generation.wrapping_add(1);
+        self.terminal_focused = false;
+        self.pane_focus = self
+            .shell_overlay
+            .previous_pane_focus
+            .take()
+            .unwrap_or(crate::state::PaneFocus::Agents);
+        self.reset_shell_terminal_view();
+    }
+
+    /// Resume a hidden shell for `agent_id`, making the overlay visible again
+    /// (issue #361 PR A).
+    ///
+    /// The runtime boundary invokes this after successfully re-selecting the
+    /// existing `jefe-shell` window. This reducer records the inventory entry
+    /// (idempotent) and restores the visible overlay state. It does not
+    /// duplicate the window because the runtime only re-selects an existing
+    /// window.
+    pub fn resume_shell_overlay(&mut self, agent_id: AgentId) {
+        self.shell_overlay.inventory.record(agent_id.clone());
+        self.shell_overlay = ShellOverlayState {
+            agent_id: Some(agent_id),
+            generation: self.shell_overlay.generation.wrapping_add(1),
+            previous_pane_focus: Some(self.pane_focus),
+            inventory: self.shell_overlay.inventory.clone(),
+        };
+        self.terminal_focused = true;
+        self.pane_focus = crate::state::PaneFocus::Terminal;
+        self.dashboard_grab = None;
+        self.reset_shell_terminal_view();
+    }
+
+    /// Whether `agent_id` owns a tracked shell window (visible or hidden).
+    #[must_use]
+    pub fn has_shell_window(&self, agent_id: &AgentId) -> bool {
+        self.shell_overlay.inventory.contains(agent_id)
+    }
+
+    /// Record a shell window in the runtime inventory (issue #361). Called by
+    /// the runtime boundary after a successful open/resume/adopt.
+    pub fn record_shell_window(&mut self, agent_id: AgentId) {
+        self.shell_overlay.inventory.record(agent_id);
+    }
+
+    /// Remove `agent_id` from the runtime inventory (issue #361). Called by
+    /// the runtime boundary after a successful close, disappearance, kill, or
+    /// startup orphan cleanup. Returns whether an entry was removed.
+    pub fn remove_shell_window(&mut self, agent_id: &AgentId) -> bool {
+        self.shell_overlay.inventory.remove(agent_id)
+    }
+
+    /// Snapshot the agent IDs owning tracked shell windows (issue #361).
+    /// Used by graceful shutdown to close every Jefe-created shell.
+    #[must_use]
+    pub fn shell_window_owners(&self) -> Vec<AgentId> {
+        self.shell_overlay.inventory.to_vec()
+    }
+
+    /// Replace the entire shell inventory from runtime ground truth
+    /// (issue #361). Used by startup adoption and batched reconciliation.
+    pub fn replace_shell_inventory(&mut self, agents: Vec<AgentId>) {
+        self.shell_overlay.inventory.replace(agents);
+    }
+
+    /// Clear the entire shell inventory (issue #361). Used by graceful
+    /// shutdown after best-effort close attempts.
+    pub fn clear_shell_inventory(&mut self) {
+        self.shell_overlay.inventory.clear();
     }
 
     fn reset_shell_terminal_view(&mut self) {
@@ -71,6 +167,10 @@ impl AppState {
                 }
             }
             UiNavigationMessage::CloseShellOverlay => self.close_shell_overlay(),
+            UiNavigationMessage::HideShellOverlay => self.hide_shell_overlay(),
+            UiNavigationMessage::ResumeShellOverlay(agent_id) => {
+                self.resume_shell_overlay(agent_id);
+            }
             _ => {}
         }
     }
@@ -129,5 +229,218 @@ mod tests {
             Some(crate::state::DashboardGrabPane::Repository { visible_index: 0 });
         state.open_shell_overlay(AgentId("agent-1".into()));
         assert!(state.dashboard_grab.is_none());
+    }
+
+    #[test]
+    fn hide_shell_overlay_clears_visible_overlay_but_keeps_inventory() {
+        let mut state = AppState {
+            pane_focus: PaneFocus::Agents,
+            ..AppState::default()
+        };
+        state.open_shell_overlay(AgentId("agent-1".into()));
+        state.hide_shell_overlay();
+        assert_eq!(state.shell_overlay.agent_id, None);
+        assert!(!state.terminal_focused);
+        assert_eq!(state.pane_focus, PaneFocus::Agents);
+        assert!(!state.shell_overlay_active());
+        // Inventory still tracks the hidden shell.
+        assert!(state.has_shell_window(&AgentId("agent-1".into())));
+    }
+
+    #[test]
+    fn hide_shell_overlay_restores_repository_focus() {
+        let mut state = AppState::default();
+        state.open_shell_overlay(AgentId("agent-1".into()));
+        state.hide_shell_overlay();
+        assert_eq!(state.pane_focus, PaneFocus::Repositories);
+    }
+
+    #[test]
+    fn hide_shell_overlay_is_noop_when_not_visible() {
+        let mut state = AppState::default();
+        state.hide_shell_overlay();
+        assert_eq!(state.shell_overlay.agent_id, None);
+        assert!(state.shell_overlay.inventory.is_empty());
+    }
+
+    #[test]
+    fn hide_shell_overlay_bumps_generation() {
+        let mut state = AppState::default();
+        state.open_shell_overlay(AgentId("agent-1".into()));
+        let gen_before = state.shell_overlay.generation;
+        state.hide_shell_overlay();
+        assert_eq!(
+            state.shell_overlay.generation,
+            gen_before.wrapping_add(1),
+            "hide must bump generation so observers recognize the new state"
+        );
+    }
+
+    #[test]
+    fn resume_shell_overlay_makes_overlay_visible_and_keeps_inventory() {
+        let mut state = AppState::default();
+        let agent_id = AgentId("agent-1".into());
+        state.open_shell_overlay(agent_id.clone());
+        state.hide_shell_overlay();
+        state.resume_shell_overlay(agent_id.clone());
+        assert_eq!(state.shell_overlay.agent_id, Some(agent_id.clone()));
+        assert!(state.terminal_focused);
+        assert_eq!(state.pane_focus, PaneFocus::Terminal);
+        assert!(state.shell_overlay_active());
+        assert!(state.has_shell_window(&agent_id));
+        // Resume does not duplicate the inventory entry.
+        assert_eq!(state.shell_overlay.inventory.len(), 1);
+    }
+
+    #[test]
+    fn resume_shell_overlay_bumps_generation() {
+        let mut state = AppState::default();
+        let agent_id = AgentId("agent-1".into());
+        state.open_shell_overlay(agent_id.clone());
+        state.hide_shell_overlay();
+        let gen_before = state.shell_overlay.generation;
+        state.resume_shell_overlay(agent_id);
+        assert_eq!(
+            state.shell_overlay.generation,
+            gen_before.wrapping_add(1),
+            "resume must bump generation so observers recognize the new state"
+        );
+    }
+
+    #[test]
+    fn close_shell_overlay_removes_inventory_entry() {
+        let mut state = AppState::default();
+        let agent_id = AgentId("agent-1".into());
+        state.open_shell_overlay(agent_id.clone());
+        assert!(state.has_shell_window(&agent_id));
+        state.close_shell_overlay();
+        assert!(!state.has_shell_window(&agent_id));
+    }
+
+    #[test]
+    fn close_after_hide_via_remove_window_clears_inventory_entry() {
+        let mut state = AppState::default();
+        let agent_id = AgentId("agent-1".into());
+        state.open_shell_overlay(agent_id.clone());
+        state.hide_shell_overlay();
+        assert!(state.has_shell_window(&agent_id));
+        // When the shell was hidden, the natural-exit observer/reconciler
+        // removes the inventory entry directly by agent_id (it cannot use
+        // close_shell_overlay because the visible overlay is already gone).
+        assert!(state.remove_shell_window(&agent_id));
+        assert!(!state.has_shell_window(&agent_id));
+    }
+
+    #[test]
+    fn record_shell_window_is_idempotent() {
+        let mut state = AppState::default();
+        let agent_id = AgentId("agent-1".into());
+        state.record_shell_window(agent_id.clone());
+        state.record_shell_window(agent_id.clone());
+        assert_eq!(state.shell_overlay.inventory.len(), 1);
+    }
+
+    #[test]
+    fn remove_shell_window_returns_whether_entry_existed() {
+        let mut state = AppState::default();
+        let agent_id = AgentId("agent-1".into());
+        state.record_shell_window(agent_id.clone());
+        assert!(state.remove_shell_window(&agent_id));
+        assert!(!state.remove_shell_window(&agent_id));
+    }
+
+    #[test]
+    fn replace_shell_inventory_overwrites_membership() {
+        let mut state = AppState::default();
+        state.record_shell_window(AgentId("old".into()));
+        state.replace_shell_inventory(vec![AgentId("a".into()), AgentId("b".into())]);
+        assert!(!state.has_shell_window(&AgentId("old".into())));
+        assert!(state.has_shell_window(&AgentId("a".into())));
+        assert!(state.has_shell_window(&AgentId("b".into())));
+    }
+
+    #[test]
+    fn clear_shell_inventory_empties_all_entries() {
+        let mut state = AppState::default();
+        state.record_shell_window(AgentId("a".into()));
+        state.record_shell_window(AgentId("b".into()));
+        state.clear_shell_inventory();
+        assert!(state.shell_overlay.inventory.is_empty());
+    }
+
+    #[test]
+    fn shell_window_owners_snapshots_inventory() {
+        let mut state = AppState::default();
+        state.record_shell_window(AgentId("b".into()));
+        state.record_shell_window(AgentId("a".into()));
+        let owners = state.shell_window_owners();
+        assert_eq!(
+            owners,
+            vec![AgentId("a".into()), AgentId("b".into())],
+            "owners snapshot must be deterministic lexicographic order"
+        );
+    }
+
+    #[test]
+    fn kill_agent_message_removes_shell_inventory_entry() {
+        use crate::domain::{Agent, AgentStatus, RepositoryId};
+        use crate::messages::RuntimeMessage;
+        use crate::state::AppMessage;
+
+        let agent_id = AgentId("agent-kill".into());
+        let mut state = AppState::default();
+        let mut agent = Agent::new(
+            agent_id.clone(),
+            RepositoryId("repo".into()),
+            "Agent".into(),
+            std::path::PathBuf::from("/tmp/agent"),
+        );
+        agent.status = AgentStatus::Running;
+        state.agents.push(agent);
+        state.record_shell_window(agent_id.clone());
+        assert!(state.has_shell_window(&agent_id));
+
+        state = state.apply_message(AppMessage::Runtime(RuntimeMessage::KillAgent(
+            agent_id.clone(),
+        )));
+
+        assert!(
+            !state.has_shell_window(&agent_id),
+            "KillAgent must remove the shell inventory entry (issue #361)"
+        );
+    }
+
+    #[test]
+    fn natural_agent_status_changed_to_dead_does_not_remove_shell_inventory() {
+        // Natural death (AgentStatusChanged->Dead) must NOT remove inventory
+        // on its own: the shell window is closed close-only and the inventory
+        // is cleaned by the close/runtime disappearance path, not by the
+        // natural-death reducer (issue #361 invariant #4).
+        use crate::domain::{Agent, AgentStatus, RepositoryId};
+        use crate::messages::RuntimeMessage;
+        use crate::state::AppMessage;
+
+        let agent_id = AgentId("agent-natural".into());
+        let mut state = AppState::default();
+        let mut agent = Agent::new(
+            agent_id.clone(),
+            RepositoryId("repo".into()),
+            "Agent".into(),
+            std::path::PathBuf::from("/tmp/agent"),
+        );
+        agent.status = AgentStatus::Running;
+        state.agents.push(agent);
+        state.record_shell_window(agent_id.clone());
+        assert!(state.has_shell_window(&agent_id));
+
+        state = state.apply_message(AppMessage::Runtime(RuntimeMessage::AgentStatusChanged(
+            agent_id.clone(),
+            AgentStatus::Dead,
+        )));
+
+        assert!(
+            state.has_shell_window(&agent_id),
+            "natural death must retain shell inventory (close-only cleanup, issue #361)"
+        );
     }
 }

--- a/src/state/shortcut_ops.rs
+++ b/src/state/shortcut_ops.rs
@@ -1,0 +1,36 @@
+//! Agent shortcut-slot selection helpers (extracted from `mod.rs` to keep
+//! that file under the source-file size hard limit).
+//!
+//! Pure read/mutate operations on `AppState` that derive and enforce the
+//! Option-digit shortcut slot uniqueness invariant.
+
+use crate::domain::AgentId;
+
+use super::AppState;
+
+impl AppState {
+    /// First Option-digit slot (1-9) not claimed by another agent.
+    pub(super) fn first_unused_shortcut_slot(&self, ignore_agent: Option<&AgentId>) -> Option<u8> {
+        (1u8..=9u8).find(|slot| {
+            self.agents.iter().all(|agent| {
+                if ignore_agent.is_some_and(|id| &agent.id == id) {
+                    true
+                } else {
+                    agent.shortcut_slot != Some(*slot)
+                }
+            })
+        })
+    }
+
+    /// Clear `slot` from any agent other than `owner_id` so the slot stays unique.
+    pub(super) fn enforce_shortcut_uniqueness(&mut self, owner_id: &AgentId, slot: Option<u8>) {
+        let Some(slot) = slot else {
+            return;
+        };
+        for agent in &mut self.agents {
+            if agent.id != *owner_id && agent.shortcut_slot == Some(slot) {
+                agent.shortcut_slot = None;
+            }
+        }
+    }
+}

--- a/src/state/state_ops.rs
+++ b/src/state/state_ops.rs
@@ -18,9 +18,20 @@ pub fn delete_selected_repository(state: &mut AppState, repository_id: &Reposito
         state.repositories.remove(repo_idx);
 
         // Remove all agents belonging to the deleted repository.
+        // Capture the agents about to be removed so their shell windows can
+        // be cleaned up too (issue #361 PR A).
+        let removed_agent_ids: Vec<AgentId> = state
+            .agents
+            .iter()
+            .filter(|agent| &agent.repository_id == repository_id)
+            .map(|agent| agent.id.clone())
+            .collect();
         state
             .agents
             .retain(|agent| &agent.repository_id != repository_id);
+        for agent_id in &removed_agent_ids {
+            state.remove_shell_window(agent_id);
+        }
 
         // Drop the deleted repo's remembered preferences so they cannot be
         // restored if the id is ever reused (issue #163).
@@ -63,6 +74,9 @@ pub fn delete_selected_agent(
     let agent_idx = state.agents.iter().position(|a| &a.id == agent_id)?;
 
     let removed_agent = state.agents.remove(agent_idx);
+    // Immediate shell-inventory cleanup on agent deletion (issue #361 PR A):
+    // the agent is gone from state, so any tracked shell window must be too.
+    state.remove_shell_window(&removed_agent.id);
     let repository_remote_enabled = state
         .repositories
         .iter()
@@ -161,5 +175,78 @@ mod tests {
 
         // Clean up.
         let _ = std::fs::remove_dir_all(&tmp_dir);
+    }
+
+    fn state_with_agent_in_shell_inventory(agent_id: &AgentId) -> AppState {
+        let repo_id = RepositoryId("repo-1".into());
+        let repository = Repository::new(
+            repo_id.clone(),
+            "Repo".into(),
+            "repo".into(),
+            PathBuf::from("/tmp/repo"),
+        );
+        let mut agent = Agent::new(
+            agent_id.clone(),
+            repo_id.clone(),
+            "Agent".into(),
+            PathBuf::from("/tmp/agent"),
+        );
+        agent.status = crate::domain::AgentStatus::Running;
+        let mut state = AppState::default();
+        state.repositories.push(repository);
+        state.agents.push(agent);
+        state.record_shell_window(agent_id.clone());
+        state.selected_repository_index = Some(0);
+        state.selected_agent_index = Some(0);
+        state.rebuild_repository_agent_ids();
+        state.normalize_selection_indices();
+        state
+    }
+
+    #[test]
+    fn delete_selected_agent_removes_shell_inventory_entry() {
+        let agent_id = AgentId("agent-shell".into());
+        let mut state = state_with_agent_in_shell_inventory(&agent_id);
+        assert!(state.has_shell_window(&agent_id));
+
+        delete_selected_agent(&mut state, &agent_id, false);
+
+        assert!(
+            !state.has_shell_window(&agent_id),
+            "deleting an agent must remove its shell inventory entry (issue #361)"
+        );
+    }
+
+    #[test]
+    fn delete_selected_repository_removes_shell_inventory_for_all_its_agents() {
+        let repo_id = RepositoryId("repo-1".into());
+        let agent_a = AgentId("agent-a".into());
+        let agent_b = AgentId("agent-b".into());
+        let repository = Repository::new(
+            repo_id.clone(),
+            "Repo".into(),
+            "repo".into(),
+            PathBuf::from("/tmp/repo"),
+        );
+        let mut state = AppState::default();
+        state.repositories.push(repository);
+        for id in [&agent_a, &agent_b] {
+            let mut agent = Agent::new(
+                id.clone(),
+                repo_id.clone(),
+                "Agent".into(),
+                PathBuf::from("/tmp/agent"),
+            );
+            agent.status = crate::domain::AgentStatus::Running;
+            state.agents.push(agent);
+            state.record_shell_window(id.clone());
+        }
+        assert!(state.has_shell_window(&agent_a));
+        assert!(state.has_shell_window(&agent_b));
+
+        delete_selected_repository(&mut state, &repo_id);
+
+        assert!(!state.has_shell_window(&agent_a));
+        assert!(!state.has_shell_window(&agent_b));
     }
 }

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -461,15 +461,25 @@ pub struct AppState {
 /// Tracks whether the temporary shell window is open and which agent it
 /// belongs to. The overlay is runtime-only: it is not persisted, and closing
 /// it restores the normal dashboard.
+///
+/// Issue #361 PR A: `inventory` mirrors every agent that currently owns a
+/// live `jefe-shell` window (visible or hidden). The visible overlay is
+/// still tracked by `agent_id`; the inventory lets F10 resume a hidden
+/// shell and lets the background observer reconcile hidden exits.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ShellOverlayState {
-    /// The agent whose session hosts the temporary shell window. `None` means
-    /// the overlay is inactive.
+    /// The agent whose session hosts the currently *visible* temporary shell
+    /// window. `None` means no shell overlay is visible (the dashboard owns
+    /// the layout). A hidden shell still exists in `inventory`.
     pub agent_id: Option<crate::domain::AgentId>,
-    /// Monotonic identity for an open operation, used to reject stale observers.
+    /// Monotonic identity for an open/resume operation, used to reject stale observers.
     pub generation: u64,
-    /// Dashboard pane focus restored when the shell closes.
+    /// Dashboard pane focus restored when the visible shell hides/closes.
     pub previous_pane_focus: Option<PaneFocus>,
+    /// Runtime-only inventory of every agent owning a live `jefe-shell`
+    /// window, visible or hidden (issue #361). Updated only after runtime
+    /// success/disappearance.
+    pub inventory: super::ShellInventory,
 }
 
 /// @plan PLAN-20260329-ISSUES-MODE.P03

--- a/src/ui/components/keybind_bar.rs
+++ b/src/ui/components/keybind_bar.rs
@@ -16,8 +16,11 @@ pub struct KeybindBarProps {
     pub screen_mode: ScreenMode,
     /// Whether terminal is focused.
     pub terminal_focused: bool,
-    /// Whether the embedded agent shell owns the workspace.
+    /// Whether the embedded agent shell overlay is visible (issue #222/#361).
     pub shell_overlay_active: bool,
+    /// Whether the selected agent owns a hidden shell that F10 can resume
+    /// (issue #361 PR A).
+    pub shell_resume_available: bool,
     /// Active Actions pane when Actions mode is rendered.
     pub actions_focus: Option<ActionsFocus>,
     /// Process-identity label (pid + commit) shown in the lower-right corner
@@ -77,7 +80,11 @@ pub fn KeybindBar(props: &KeybindBarProps) -> impl Into<AnyElement<'static>> {
     let rc = ResolvedColors::from_theme(Some(&props.colors));
 
     let hints = if props.shell_overlay_active {
-        "F10 close shell"
+        // Shell is visible: F12 hides (keeps alive), F10 closes/destroys.
+        "F12 hide shell | F10 close shell"
+    } else if props.shell_resume_available {
+        // Selected agent has a hidden shell F10 can resume.
+        "F10 resume shell"
     } else {
         keybind_hints_for(
             props.screen_mode,
@@ -157,13 +164,14 @@ mod tests {
     }
 
     #[test]
-    fn active_shell_footer_documents_f10_close_shortcut() {
+    fn active_shell_footer_documents_f12_hide_and_f10_close_shortcuts() {
         let mut element = element! {
             Box(width: 80u32, height: 1u32) {
                 KeybindBar(
                     screen_mode: ScreenMode::Dashboard,
                     terminal_focused: true,
                     shell_overlay_active: true,
+                    shell_resume_available: false,
                     actions_focus: None,
                     identity_label: "pid:1 abc".to_string(),
                     colors: ThemeColors::default(),
@@ -177,8 +185,34 @@ mod tests {
             .unwrap_or_else(|error| panic!("render keybind bar: {error}"));
         let rendered = String::from_utf8_lossy(&output);
 
+        assert!(rendered.contains("F12 hide shell"));
         assert!(rendered.contains("F10 close shell"));
         assert!(!rendered.contains("F11 close shell"));
+    }
+
+    #[test]
+    fn dashboard_footer_offers_f10_resume_when_selected_agent_has_hidden_shell() {
+        let mut element = element! {
+            Box(width: 80u32, height: 1u32) {
+                KeybindBar(
+                    screen_mode: ScreenMode::Dashboard,
+                    terminal_focused: false,
+                    shell_overlay_active: false,
+                    shell_resume_available: true,
+                    actions_focus: None,
+                    identity_label: "pid:1 abc".to_string(),
+                    colors: ThemeColors::default(),
+                )
+            }
+        };
+        let canvas = element.render(Some(80));
+        let mut output = Vec::new();
+        canvas
+            .write_ansi(&mut output)
+            .unwrap_or_else(|error| panic!("render keybind bar: {error}"));
+        let rendered = String::from_utf8_lossy(&output);
+
+        assert!(rendered.contains("F10 resume shell"));
     }
 
     #[test]

--- a/src/ui/components/terminal_view.rs
+++ b/src/ui/components/terminal_view.rs
@@ -90,7 +90,7 @@ pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>>
     };
 
     let focus_hint = if props.focused {
-        "F12 to unfocus"
+        "F12 hide shell"
     } else {
         "F12/t to focus"
     };

--- a/src/ui/modals/help.rs
+++ b/src/ui/modals/help.rs
@@ -69,7 +69,8 @@ pub fn help_content_lines() -> &'static [&'static str] {
         "  s           Split mode",
         "  Space       Grab/move/drop reorder",
         "  v           Toggle active-only (repos + agents)",
-        "  F10         Open/close embedded agent shell",
+        "  F10         Open/resume or close embedded shell",
+        "  F12         Hide embedded shell (keeps it running)",
         "  F8          Open external terminal",
         "  \u{2325}1-\u{2325}9       Jump to agent shortcut",
         "",
@@ -235,7 +236,8 @@ mod tests {
         assert!(joined.contains("Space       Grab/move/drop reorder"));
         assert!(joined.contains("v           Toggle active-only"));
         assert!(joined.contains("F9          Theme picker"));
-        assert!(joined.contains("F10         Open/close embedded agent shell"));
+        assert!(joined.contains("F10         Open/resume or close embedded shell"));
+        assert!(joined.contains("F12         Hide embedded shell (keeps it running)"));
         assert!(!joined.contains("F11         Close embedded agent shell"));
         for action in [
             "Open run detail / expand focused job",

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -145,6 +145,13 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
     // Shell overlay (issue #222): when active, the terminal expands to fill
     // the area between sidebar and right edge (no agent list, no preview).
     let shell_overlay_active = state.is_some_and(AppState::shell_overlay_active);
+    // Whether the selected agent owns a hidden shell F10 can resume
+    // (issue #361 PR A). Only relevant when the overlay is not visible.
+    let shell_resume_available = state.is_some_and(|s| {
+        !s.shell_overlay_active()
+            && s.selected_agent()
+                .is_some_and(|agent| s.has_shell_window(&agent.id))
+    });
     let overlay_terminal_rows = render_rows.saturating_sub(crate::layout::OUTER_BARS_HEIGHT);
     let terminal_snapshot = state
         .filter(|s| {
@@ -292,6 +299,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                 screen_mode: state.map_or(ScreenMode::Dashboard, |s| s.screen_mode),
                 terminal_focused: terminal_focused,
                 shell_overlay_active: shell_overlay_active,
+                shell_resume_available: shell_resume_available,
                 actions_focus: None,
                 identity_label: crate::process_identity_label(std::process::id(), crate::GIT_COMMIT),
                 colors: colors,


### PR DESCRIPTION
## Summary

- make F12 hide the visible embedded shell before PTY forwarding while preserving the shell process
- make dashboard F10 resume the same hidden shell and keep visible F10 as destructive close
- add runtime-only shell inventory with hidden-exit reconciliation, startup adoption/orphan cleanup, and best-effort shutdown cleanup
- preserve naturally dead owners as close-only inventory while explicit kill/delete removes their shell entry
- update footer, terminal chrome, Help, and the real-tmux lifecycle scenario

## Scope

This is PR A of the issue 361 stacked delivery. The terminal-manager UI and cross-agent focus are intentionally deferred to PR B, which will stack on this branch.

## Verification

- focused runtime, state, startup, routing, Help, and footer tests
- scripts/issue222-run-scenario.sh: 50 steps passed, including F12 hide, marker-preserving F10 resume, F10 destruction, F11 PTY forwarding, and natural exit
- make quick-check
- make ci-check on exact commit ed329d7

Refs #361
