### PR TITLE
Fix gh issue view JSON field stateReason (Fixes #358)

### DIFF
--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -114,6 +114,28 @@ pub struct CommentsResponse {
 }
 
 const ISSUE_DETAIL_COMMENT_PAGE_SIZE: u32 = 30;
+
+/// `gh issue view --json` field list for issue detail (issue #358).
+///
+/// Field names must match the `gh` CLI schema (camelCase). Using REST-style
+/// `state_reason` causes `Unknown JSON field: "state_reason"` and blocks detail
+/// loads. The parser still accepts both `stateReason` and `state_reason` keys.
+pub const ISSUE_DETAIL_JSON_FIELDS: &str = "number,title,state,stateReason,author,createdAt,updatedAt,labels,assignees,milestone,body,url,comments,id";
+
+/// Build `gh issue view --json ...` args for [`GhClient::get_issue_detail`].
+#[must_use]
+pub fn build_issue_detail_args(owner: &str, repo: &str, number: u64) -> Vec<String> {
+    vec![
+        "issue".to_string(),
+        "view".to_string(),
+        "--repo".to_string(),
+        format!("{owner}/{repo}"),
+        number.to_string(),
+        "--json".to_string(),
+        ISSUE_DETAIL_JSON_FIELDS.to_string(),
+    ]
+}
+
 /// Default page size for the PR list GraphQL search query.
 ///
 /// @plan PLAN-20260624-PR-MODE.P08
@@ -229,15 +251,7 @@ impl GhClient {
         number: u64,
     ) -> Result<IssueDetail, GhError> {
         let output = gh_command()?
-            .args([
-                "issue",
-                "view",
-                "--repo",
-                &format!("{owner}/{repo}"),
-                &number.to_string(),
-                "--json",
-                "number,title,state,state_reason,author,createdAt,updatedAt,labels,assignees,milestone,body,url,comments,id",
-            ])
+            .args(build_issue_detail_args(owner, repo, number))
             .output()
             .map_err(|e| {
                 if e.kind() == std::io::ErrorKind::NotFound {

--- a/src/github/tests/state_reason.rs
+++ b/src/github/tests/state_reason.rs
@@ -202,3 +202,31 @@ fn test_issue_detail_state_reason_none_for_reopened_and_unknown() {
         parse_issue_detail_json(&detail_json("dismissed")).value_or_panic("should parse unknown");
     assert_eq!(unknown.state_reason, None);
 }
+
+/// Issue #358: `gh issue view --json` must request camelCase `stateReason`.
+#[test]
+fn test_issue_detail_json_fields_use_gh_cli_state_reason() {
+    use crate::github::{ISSUE_DETAIL_JSON_FIELDS, build_issue_detail_args};
+
+    assert!(
+        ISSUE_DETAIL_JSON_FIELDS
+            .split(',')
+            .any(|field| field == "stateReason"),
+        "field list must include gh CLI token stateReason, got {ISSUE_DETAIL_JSON_FIELDS}"
+    );
+    assert!(
+        !ISSUE_DETAIL_JSON_FIELDS
+            .split(',')
+            .any(|field| field == "state_reason"),
+        "field list must not use REST token state_reason, got {ISSUE_DETAIL_JSON_FIELDS}"
+    );
+
+    let args = build_issue_detail_args("owner", "repo", 42);
+    let json_fields = args
+        .windows(2)
+        .find_map(|pair| (pair[0] == "--json").then_some(pair[1].as_str()))
+        .unwrap_or_else(|| panic!("missing --json in args: {args:?}"));
+    assert_eq!(json_fields, ISSUE_DETAIL_JSON_FIELDS);
+    assert!(json_fields.split(',').any(|field| field == "stateReason"));
+    assert!(!json_fields.split(',').any(|field| field == "state_reason"));
+}


### PR DESCRIPTION
## Summary
- Request camelCase `stateReason` in `gh issue view --json` (was REST-style `state_reason`, which `gh` rejects)
- Extract `ISSUE_DETAIL_JSON_FIELDS` / `build_issue_detail_args` and add a regression test so the wrong field name cannot ship again

Fixes #358

## Test plan
- [x] `cargo test --lib state_reason`
- [x] `cargo fmt --all --check`
- [ ] Manual: Enter on an issue in Issues mode loads detail without `Unknown JSON field`
- [ ] Manual: closed issue still shows COMPLETED / NOT_PLANNED / DUPLICATE when present