### PR TITLE
Read agent rewrite output from a temp file (Fixes #359)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,11 @@ lru = "0.12"
 # jefe's iocraft pipeline.
 comrak = { version = "0.53", default-features = false }
 
+# Temp files for the issue-rewrite agent handoff (issue #359): the agent writes
+# the rewritten draft to a NamedTempFile so stdout thinking/tool noise cannot
+# pollute the composer.
+tempfile = "3.0"
+
 [target.'cfg(windows)'.dependencies]
 winsafe = { version = "0.0.27", features = ["kernel"] }
 whoami = "2.1.2"
@@ -64,9 +69,6 @@ required-features = ["psmux-smoke"]
 
 [patch.crates-io]
 iocraft = { path = "vendor/iocraft" }
-
-[dev-dependencies]
-tempfile = "3.0"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/src/app_input/issues_rewrite_dispatch.rs
+++ b/src/app_input/issues_rewrite_dispatch.rs
@@ -1,10 +1,12 @@
-//! Orchestration for the agent-driven new-issue draft rewrite (issue #214).
+//! Orchestration for the agent-driven new-issue draft rewrite (issue #214 / #359).
 //!
 //! Triggered from the new-issue composer by `Ctrl+R`. Reads the current draft,
 //! resolves the configured default agent for the focused repository, runs that
-//! agent **non-interactively** (single prompt → stdout → exit) so it can study
-//! the repository source and produce a cleaner, plan-like issue, then replaces
-//! the composer draft with the rewritten text for review before submission.
+//! agent **non-interactively** (single prompt → write output file → exit) so it
+//! can study the repository source and produce a cleaner, plan-like issue, then
+//! replaces the composer draft with the rewritten text for review before
+//! submission. The rewritten issue is read from a known temp file so
+//! thinking/tool/session noise on stdout cannot pollute the draft (issue #359).
 //!
 //! The deterministic state transitions live in the reducer
 //! (`state::issues_rewrite_ops`); this module owns only the boundary I/O
@@ -13,6 +15,7 @@
 use jefe::domain::{LaunchSignature, Repository, build_rewrite_instruction};
 use jefe::runtime::run_non_interactive;
 use jefe::state::{AppEvent, AppState, InlineState};
+use tempfile::NamedTempFile;
 
 use super::{
     AppStateHandle, SharedContext, apply_and_persist, gh_async, launch_signature_for_transient,
@@ -26,24 +29,14 @@ use super::{
 /// `apply_and_persist`.
 pub(super) fn handle_request_issue_rewrite(app_state: &mut AppStateHandle, ctx: &SharedContext) {
     let context = match rewrite_context(app_state) {
-        Ok(None) => {
-            // No actionable rewrite request (not a NewIssue composer, no draft,
-            // no repo, or already pending). The reducer still consumes the
-            // event as a no-op; nothing to spawn.
-            return;
-        }
+        Ok(None) => return,
         Err(error) => {
-            // A resolvable precondition failed (e.g. the working directory
-            // could not be determined). Surface it as a non-fatal failure so
-            // the draft is preserved and the user is informed.
             apply_and_persist(app_state, ctx, AppEvent::IssueRewriteFailed { error });
             return;
         }
         Ok(Some(context)) => context,
     };
 
-    // Availability guard BEFORE applying the pending flag: a missing agent
-    // runtime must not flip the UI into a waiting state.
     if !super::availability::launch_available_or_error(
         app_state,
         context.signature.agent_kind,
@@ -54,37 +47,49 @@ pub(super) fn handle_request_issue_rewrite(app_state: &mut AppStateHandle, ctx: 
         return;
     }
 
-    // Record the pending state so the UI shows the rewrite is in flight.
     apply_and_persist(app_state, ctx, AppEvent::RequestIssueRewrite);
+    spawn_rewrite_task(app_state, ctx, context);
+}
 
+/// Spawn the non-interactive rewrite on a background task (issue #359).
+fn spawn_rewrite_task(app_state: &AppStateHandle, ctx: &SharedContext, context: RewriteContext) {
     let RewriteContext {
         instruction,
         signature,
+        output_file,
     } = context;
 
     gh_async::spawn_gh_task_with_panic(
         app_state,
         ctx,
-        move |mut app_state, ctx| match run_non_interactive(
-            &signature,
-            signature.work_dir.as_path(),
-            &instruction,
-        ) {
-            Ok(text) => {
-                apply_and_persist(
-                    &mut app_state,
-                    &ctx,
-                    AppEvent::IssueRewriteSucceeded { text },
-                );
-            }
-            Err(error) => {
-                apply_and_persist(
-                    &mut app_state,
-                    &ctx,
-                    AppEvent::IssueRewriteFailed {
-                        error: error.to_string(),
-                    },
-                );
+        move |mut app_state, ctx| {
+            // Keep `output_file` alive until after the agent exits and we read
+            // the path (issue #359 temp-file protocol).
+            let output_path = output_file.path().to_path_buf();
+            let result = run_non_interactive(
+                &signature,
+                signature.work_dir.as_path(),
+                &instruction,
+                &output_path,
+            );
+            drop(output_file);
+            match result {
+                Ok(text) => {
+                    apply_and_persist(
+                        &mut app_state,
+                        &ctx,
+                        AppEvent::IssueRewriteSucceeded { text },
+                    );
+                }
+                Err(error) => {
+                    apply_and_persist(
+                        &mut app_state,
+                        &ctx,
+                        AppEvent::IssueRewriteFailed {
+                            error: error.to_string(),
+                        },
+                    );
+                }
             }
         },
         move |mut app_state, ctx, message| {
@@ -103,6 +108,9 @@ pub(super) fn handle_request_issue_rewrite(app_state: &mut AppStateHandle, ctx: 
 struct RewriteContext {
     instruction: String,
     signature: LaunchSignature,
+    /// Agent writes ONLY the rewritten issue here; kept alive across the
+    /// async spawn so the OS does not delete the path early (issue #359).
+    output_file: NamedTempFile,
 }
 
 /// Resolve the rewrite context from the current state.
@@ -152,10 +160,14 @@ fn resolve_rewrite_context_from_state(state: &AppState) -> Result<Option<Rewrite
     } else {
         Some(trimmed_repo)
     };
-    let instruction = build_rewrite_instruction(&draft, github_repo);
+    let output_file = NamedTempFile::new().map_err(|error| {
+        format!("Could not create rewrite output file for the agent rewrite: {error}")
+    })?;
+    let instruction = build_rewrite_instruction(&draft, github_repo, output_file.path());
     Ok(Some(RewriteContext {
         instruction,
         signature,
+        output_file,
     }))
 }
 

--- a/src/app_input/issues_rewrite_dispatch_tests.rs
+++ b/src/app_input/issues_rewrite_dispatch_tests.rs
@@ -100,6 +100,12 @@ fn resolves_instruction_and_signature_from_draft_and_repo() {
         "instruction must reference the github repo: {}",
         ctx.instruction
     );
+    assert!(
+        ctx.instruction
+            .contains(ctx.output_file.path().to_string_lossy().as_ref()),
+        "instruction must name the temp-file output path (issue #359): {}",
+        ctx.instruction
+    );
     assert_eq!(ctx.signature.agent_kind, AgentKind::Llxprt);
 }
 

--- a/src/domain/issue_rewrite.rs
+++ b/src/domain/issue_rewrite.rs
@@ -1,13 +1,15 @@
-//! Issue-draft rewrite instruction construction (issue #214).
+//! Issue-draft rewrite instruction construction (issue #214 / #359).
 //!
 //! Pure helper that builds the natural-language instruction handed to the
 //! configured default agent when the user asks it to rewrite a new-issue
-//! draft non-interactively. The instruction is deliberately output-constrained
-//! so the captured stdout can replace the composer text verbatim: the first
-//! line is the issue title and the remaining lines are the body, with no
-//! surrounding prose or code fences.
+//! draft non-interactively. The instruction tells the agent to write the
+//! rewritten issue to a known output path so thinking/tool/session noise on
+//! stdout cannot pollute the draft (issue #359).
 //!
 //! No I/O lives here — the function is fully deterministic and unit-tested.
+
+use std::fmt::Write as _;
+use std::path::Path;
 
 /// Build the non-interactive rewrite instruction for a new-issue draft.
 ///
@@ -15,8 +17,14 @@
 /// `github_repo`, when provided (e.g. `"owner/repo"`), tells the agent which
 /// repository's source to study so the rewrite is grounded in the actual
 /// codebase. When `None`, the agent rewrites from the draft alone.
+/// `output_path` is the absolute file the agent must overwrite with ONLY the
+/// rewritten issue text (title on the first line, body after).
 #[must_use]
-pub fn build_rewrite_instruction(draft: &str, github_repo: Option<&str>) -> String {
+pub fn build_rewrite_instruction(
+    draft: &str,
+    github_repo: Option<&str>,
+    output_path: &Path,
+) -> String {
     let mut out = String::new();
     out.push_str("You are rewriting a GitHub issue draft to make it clearer, ");
     out.push_str("more complete, and better structured.\n\n");
@@ -26,17 +34,22 @@ pub fn build_rewrite_instruction(draft: &str, github_repo: Option<&str>) -> Stri
     out.push_str("Preserve all of the author's original intent and technical detail; ");
     out.push_str("do not invent requirements that are not implied by the draft.\n\n");
     if let Some(repo) = github_repo.filter(|repo| !repo.trim().is_empty()) {
-        use std::fmt::Write as _;
         let _ = write!(
             out,
             "This issue is for the repository {repo}. Study the source code in the \
              current working directory to ground the rewrite in the real codebase.\n\n"
         );
     }
-    out.push_str("Output ONLY the rewritten issue. The FIRST line MUST be the issue ");
-    out.push_str("title and every following line MUST be the body. Do not include ");
-    out.push_str("any commentary, explanations, markdown code fences, or labels ");
-    out.push_str("before or after the issue text.\n\n");
+    let _ = write!(
+        out,
+        "Write ONLY the rewritten issue text to this file (overwrite it completely):\n\
+         {}\n\n\
+         The FIRST line in that file MUST be the issue title and every following line \
+         MUST be the body. Do not write thinking, tool output, session metadata, \
+         commentary, explanations, markdown code fences, or labels to the file. \
+         Do not rely on stdout for the issue text — the file is the only handoff.\n\n",
+        output_path.display()
+    );
     out.push_str("Draft to rewrite:\n\n");
     out.push_str(draft.trim_end());
     out

--- a/src/domain/issue_rewrite_tests.rs
+++ b/src/domain/issue_rewrite_tests.rs
@@ -1,11 +1,16 @@
-//! Tests for the issue-draft rewrite instruction builder (issue #214).
+//! Tests for the issue-draft rewrite instruction builder (issue #214 / #359).
 
 use super::build_rewrite_instruction;
+use std::path::Path;
+
+fn out_path() -> &'static Path {
+    Path::new("/tmp/jefe-rewrite-out.md")
+}
 
 #[test]
 fn instruction_includes_the_draft_verbatim() {
     let draft = "Fix login bug\nThe login button does nothing on Safari.";
-    let instruction = build_rewrite_instruction(draft, None);
+    let instruction = build_rewrite_instruction(draft, None, out_path());
     assert!(
         instruction.contains(draft),
         "instruction must embed the draft"
@@ -14,7 +19,7 @@ fn instruction_includes_the_draft_verbatim() {
 
 #[test]
 fn instruction_trims_trailing_whitespace_from_draft() {
-    let instruction = build_rewrite_instruction("Title\nBody   \n\n", None);
+    let instruction = build_rewrite_instruction("Title\nBody   \n\n", None, out_path());
     assert!(
         !instruction.ends_with("\n\n\n"),
         "trailing blank lines are trimmed"
@@ -22,21 +27,25 @@ fn instruction_trims_trailing_whitespace_from_draft() {
 }
 
 #[test]
-fn instruction_constrains_output_format() {
-    let instruction = build_rewrite_instruction("t", None);
+fn instruction_constrains_output_to_temp_file() {
+    let instruction = build_rewrite_instruction("t", None, out_path());
     assert!(
-        instruction.contains("FIRST line MUST be the issue title"),
-        "must constrain the output to title-then-body"
+        instruction.contains(out_path().to_string_lossy().as_ref()),
+        "must name the output file path"
     );
     assert!(
-        instruction.contains("ONLY"),
-        "must forbid surrounding commentary"
+        instruction.contains("FIRST line in that file MUST be the issue title"),
+        "must constrain the file contents to title-then-body"
+    );
+    assert!(
+        instruction.contains("only handoff"),
+        "must forbid relying on stdout for the issue text"
     );
 }
 
 #[test]
 fn instruction_references_repo_when_provided() {
-    let instruction = build_rewrite_instruction("t", Some("vybestack/llxprt-jefe"));
+    let instruction = build_rewrite_instruction("t", Some("vybestack/llxprt-jefe"), out_path());
     assert!(
         instruction.contains("vybestack/llxprt-jefe"),
         "must name the repository so the agent studies the right source"
@@ -49,7 +58,7 @@ fn instruction_references_repo_when_provided() {
 
 #[test]
 fn instruction_omits_repo_section_when_none() {
-    let instruction = build_rewrite_instruction("t", None);
+    let instruction = build_rewrite_instruction("t", None, out_path());
     assert!(
         !instruction.contains("source code in the"),
         "must not reference an unknown repository"
@@ -58,7 +67,7 @@ fn instruction_omits_repo_section_when_none() {
 
 #[test]
 fn instruction_omits_repo_section_when_blank() {
-    let instruction = build_rewrite_instruction("t", Some("   "));
+    let instruction = build_rewrite_instruction("t", Some("   "), out_path());
     assert!(
         !instruction.contains("source code in the"),
         "a blank repo must be treated as absent"

--- a/src/runtime/non_interactive.rs
+++ b/src/runtime/non_interactive.rs
@@ -1,14 +1,15 @@
-//! Non-interactive (single-prompt, capture-stdout) agent execution (issue #214).
+//! Non-interactive (single-prompt) agent execution (issue #214 / #359).
 //!
 //! Used to ask the configured default agent to rewrite an issue draft. Unlike
 //! the interactive tmux-pane launch in [`super::commands`], this runs the agent
-//! with its `-p`/`--prompt` print mode: it answers one prompt, prints the
-//! response to stdout, and exits. No tmux session is created.
+//! with its `-p`/`--prompt` print mode. The rewritten issue is read from a
+//! known temp file so thinking/tool/session noise on stdout cannot pollute the
+//! draft (issue #359). Stdout/stderr are used only for failure diagnostics.
 //!
 //! Two halves:
 //! - [`non_interactive_argv`]: pure argv/target construction (unit-tested).
 //! - [`run_non_interactive`]: the I/O boundary (resolves the binary, runs it
-//!   with a bounded timeout, captures and trims stdout).
+//!   with a bounded timeout, reads and trims the output file).
 
 use std::ffi::OsString;
 use std::path::Path;
@@ -140,35 +141,50 @@ fn stderr_excerpt(stderr: &[u8]) -> Option<String> {
     }
 }
 
+/// Read and validate the rewrite output file written by the agent (issue #359).
+///
+/// Pure enough for unit tests: no process spawn. Returns trimmed UTF-8 text or
+/// a diagnostic that may include `stderr_hint` when the file is missing/empty.
+fn read_rewrite_output_file(
+    output_path: &Path,
+    stderr_hint: Option<&str>,
+) -> Result<String, RuntimeError> {
+    let with_hint = |base: &str| match stderr_hint.filter(|s| !s.is_empty()) {
+        Some(stderr) => format!("{base}; stderr: {stderr}"),
+        None => base.to_owned(),
+    };
+    let text = std::fs::read_to_string(output_path).map_err(|error| {
+        RuntimeError::RemoteExecutionFailed(with_hint(&format!(
+            "agent did not write rewrite output to {}: {error}",
+            output_path.display()
+        )))
+    })?;
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Err(RuntimeError::RemoteExecutionFailed(with_hint(
+            "agent wrote an empty rewrite output file",
+        )));
+    }
+    Ok(trimmed.to_owned())
+}
+
 /// Run the configured default agent non-interactively in `work_dir`, feeding
-/// it `instruction` via `--prompt`, and return the captured, trimmed stdout.
+/// it `instruction` via `--prompt`, then return the rewritten issue text from
+/// `output_path` (issue #359 temp-file protocol).
 ///
 /// Local execution only: non-interactive remote capture requires dedicated
 /// SSH plumbing and is out of scope for issue #214.
 ///
-/// # Why a direct subprocess, not the secure launch-plan flow
-///
-/// The interactive agent launch (`commands.rs`) routes through
-/// `write_launch_plan`/`run_launch_plan` because it must spawn the agent into
-/// a tmux/psmux pane with argv scrubbing and `TMUX` env cleanup. That boundary
-/// returns only an `ExitStatus` — it cannot capture the agent's stdout, which
-/// is the whole point of a non-interactive rewrite. This path therefore builds
-/// a foreground capture subprocess via `command_for_executable` (the same
-/// resolver/wrapper logic, minus the pane-launch serialization) and pipes
-/// stdout/stderr through `run_command_capture_with_timeout`. The `TMUX` env
-/// scrub in the launch-plan exists so a child pane does not inherit the parent
-/// multiplexer; a non-interactive `--prompt` run ignores multiplexers, so the
-/// scrub does not apply here.
-///
 /// # Errors
 ///
 /// Returns a [`RuntimeError`] when the binary cannot be resolved, the process
-/// cannot be spawned, it times out, or it exits non-zero / produces empty
-/// output.
+/// cannot be spawned, it times out, exits non-zero, or the output file is
+/// missing/empty.
 pub fn run_non_interactive(
     signature: &LaunchSignature,
     work_dir: &Path,
     instruction: &str,
+    output_path: &Path,
 ) -> Result<String, RuntimeError> {
     let (target, args) = non_interactive_argv(signature, instruction);
     let executable = AgentExecutableResolver::current()
@@ -196,34 +212,19 @@ pub fn run_non_interactive(
         NON_INTERACTIVE_TIMEOUT,
         "agent rewrite (non-interactive)",
     )?;
+    let stderr_hint = stderr_excerpt(&output.stderr);
     if !output.status.success() {
         let status = output
             .status
             .code()
             .map_or_else(|| "signal".to_owned(), |c| c.to_string());
-        let detail = match stderr_excerpt(&output.stderr) {
+        let detail = match &stderr_hint {
             Some(stderr) => format!("agent exited with status {status}: {stderr}"),
             None => format!("agent exited with status {status}"),
         };
         return Err(RuntimeError::RemoteExecutionFailed(detail));
     }
-    let Ok(stdout) = String::from_utf8(output.stdout) else {
-        let detail = match stderr_excerpt(&output.stderr) {
-            Some(stderr) => format!("agent produced non-UTF-8 output; stderr: {stderr}"),
-            None => "agent produced non-UTF-8 output that could not be used as an issue draft"
-                .to_owned(),
-        };
-        return Err(RuntimeError::RemoteExecutionFailed(detail));
-    };
-    let trimmed = stdout.trim();
-    if trimmed.is_empty() {
-        let detail = match stderr_excerpt(&output.stderr) {
-            Some(stderr) => format!("agent produced no output; stderr: {stderr}"),
-            None => "agent produced no output".to_owned(),
-        };
-        return Err(RuntimeError::RemoteExecutionFailed(detail));
-    }
-    Ok(trimmed.to_owned())
+    read_rewrite_output_file(output_path, stderr_hint.as_deref())
 }
 
 #[cfg(test)]

--- a/src/runtime/non_interactive_tests.rs
+++ b/src/runtime/non_interactive_tests.rs
@@ -156,3 +156,46 @@ fn llxprt_npm_backed_wraps_with_exec_package() {
     assert!(args.contains(&"llxprt".to_owned()));
     assert!(args.contains(&"--prompt".to_owned()));
 }
+
+#[test]
+fn read_rewrite_output_file_returns_trimmed_contents() {
+    let dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let path = dir.path().join("out.md");
+    std::fs::write(&path, "  Title\nBody  \n").unwrap_or_else(|error| panic!("write: {error}"));
+    let text = super::read_rewrite_output_file(&path, None)
+        .unwrap_or_else(|error| panic!("read: {error}"));
+    assert_eq!(text, "Title\nBody");
+}
+
+#[test]
+fn read_rewrite_output_file_rejects_empty_with_stderr_hint() {
+    let dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let path = dir.path().join("empty.md");
+    std::fs::write(&path, "   \n").unwrap_or_else(|error| panic!("write: {error}"));
+    let err = match super::read_rewrite_output_file(&path, Some("model noise")) {
+        Ok(text) => panic!("empty file must fail, got: {text}"),
+        Err(error) => error,
+    };
+    let message = err.to_string();
+    assert!(
+        message.contains("empty rewrite output file"),
+        "message={message}"
+    );
+    assert!(
+        message.contains("model noise"),
+        "stderr hint must surface: {message}"
+    );
+}
+
+#[test]
+fn read_rewrite_output_file_rejects_missing_path() {
+    let path = std::path::Path::new("/tmp/jefe-rewrite-missing-does-not-exist.md");
+    let err = match super::read_rewrite_output_file(path, None) {
+        Ok(text) => panic!("missing file must fail, got: {text}"),
+        Err(error) => error,
+    };
+    assert!(
+        err.to_string().contains("did not write rewrite output"),
+        "message={err}"
+    );
+}


### PR DESCRIPTION
## Summary
- Switch Ctrl+R issue rewrite from stdout capture to a temp-file handoff so thinking/tool/session noise cannot land in the draft.
- Instruction builder and `run_non_interactive` now take an output path; dispatch keeps a `NamedTempFile` alive until the agent exits and the file is read.
- Regression coverage for empty/missing output files and instruction path embedding.

## Test plan
- [x] `cargo test --lib rewrite`
- [x] `cargo test --bin jefe resolves_`
- [x] `cargo clippy --bin jefe` / `--lib` with `-D warnings`
- [ ] Manually: Ctrl+R on a new-issue draft and confirm the composer receives clean title/body only

Fixes #359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue rewriting reliability by retrieving rewritten content from a dedicated output file instead of process output.
  * Prevented diagnostic messages from being mixed into rewritten issue drafts.
  * Added clearer errors when rewritten content is missing, empty, or invalid.
  * Ensured rewritten issues preserve the expected title-and-body format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->