### PR TITLE
Embed live shells in the Terminal Manager (Fixes #364)

### DIFF
--- a/dev-docs/tmux-scenarios/terminal-manager.json
+++ b/dev-docs/tmux-scenarios/terminal-manager.json
@@ -7,88 +7,257 @@
     "assert_mode": "strict"
   },
   "steps": [
-    { "waitFor": "LLxprt Jefe" },
-    { "key": "F7" },
-    { "waitFor": "Terminal Manager" },
-    { "waitFor": "No shells" },
-    { "key": "Escape" },
-    { "waitFor": "F7 shells" },
-
-    { "key": "N" },
-    { "waitFor": "New Repository" },
-    { "type": "Alpha Repository" },
-    { "key": "Tab" },
-    { "type": "fixture-repo-alpha" },
-    { "key": "Enter" },
-    { "waitFor": "1 repos | 0/0 running" },
-    { "key": "n" },
-    { "waitFor": "New Agent" },
-    { "key": "Tab" },
-    { "type": "Alpha Agent" },
-    { "key": "Enter" },
-    { "waitFor": "issue364-agent-ready" },
-    { "key": "F12" },
-    { "waitFor": "F7 shells" },
-    { "key": "F10" },
-    { "waitFor": "Agent Shell" },
-    { "line": "printf 'issue364-shell-alpha\\n'" },
-    { "waitFor": "issue364-shell-alpha" },
-    { "key": "F12" },
-    { "waitFor": "F10 resume shell" },
-    { "key": "F10" },
-    { "waitFor": "Agent Shell" },
-    { "waitFor": "issue364-shell-alpha" },
-    { "key": "F12" },
-    { "waitFor": "F7 shells" },
-
-    { "key": "N" },
-    { "waitFor": "New Repository" },
-    { "type": "Beta Repository" },
-    { "key": "Tab" },
-    { "type": "fixture-repo-beta" },
-    { "key": "Enter" },
-    { "waitFor": "Beta Repository" },
-    { "key": "n" },
-    { "waitFor": "New Agent" },
-    { "key": "Tab" },
-    { "type": "Beta Agent" },
-    { "key": "Enter" },
-    { "waitFor": "issue364-agent-ready" },
-    { "key": "F12" },
-    { "waitFor": "F7 shells" },
-    { "key": "F10" },
-    { "waitFor": "Agent Shell" },
-    { "line": "printf 'issue364-shell-beta\\n'" },
-    { "waitFor": "issue364-shell-beta" },
-    { "key": "F12" },
-    { "waitFor": "F7 shells" },
-    { "wait": 1000 },
-
-    { "key": "F7" },
-    { "waitFor": "Terminal Manager" },
-    { "waitFor": "Alpha Agent" },
-    { "waitFor": "Beta Agent" },
-    { "key": "Home" },
-    { "waitFor": "Agent: Alpha Agent" },
-    { "waitFor": "issue364-shell-alpha" },
-    { "key": "Down" },
-    { "waitFor": "Agent: Beta Agent" },
-    { "waitFor": "issue364-shell-beta" },
-    { "key": "C-k" },
-    { "waitFor": "Agent: Alpha Agent" },
-    { "key": "Enter" },
-    { "waitFor": "Agent Shell" },
-    { "waitFor": "issue364-shell-alpha" },
-    { "key": "F12" },
-    { "waitFor": "Terminal Manager" },
-    { "key": "Enter" },
-    { "waitFor": "Agent Shell" },
-    { "line": "exit" },
-    { "waitFor": "Terminal Manager" },
-    { "waitFor": "No shells" },
-    { "key": "Escape" },
-    { "waitFor": "F7 shells" },
-    { "key": "C-q" },
-    { "waitForExit": 10000 }
+    {
+      "waitFor": "LLxprt Jefe"
+    },
+    {
+      "key": "F7"
+    },
+    {
+      "waitFor": "Terminal Manager"
+    },
+    {
+      "waitFor": "No shells"
+    },
+    {
+      "key": "Escape"
+    },
+    {
+      "waitFor": "F7 shells"
+    },
+    {
+      "key": "N"
+    },
+    {
+      "waitFor": "New Repository"
+    },
+    {
+      "type": "Alpha Repository"
+    },
+    {
+      "key": "Tab"
+    },
+    {
+      "type": "fixture-repo-alpha"
+    },
+    {
+      "key": "Enter"
+    },
+    {
+      "waitFor": "1 repos | 0/0 running"
+    },
+    {
+      "key": "n"
+    },
+    {
+      "waitFor": "New Agent"
+    },
+    {
+      "key": "Tab"
+    },
+    {
+      "type": "Alpha Agent"
+    },
+    {
+      "key": "Enter"
+    },
+    {
+      "waitFor": "issue364-agent-ready"
+    },
+    {
+      "key": "F12"
+    },
+    {
+      "waitFor": "F7 shells"
+    },
+    {
+      "key": "F10"
+    },
+    {
+      "waitFor": "Agent Shell"
+    },
+    {
+      "line": "printf 'issue364-shell-alpha\\n'"
+    },
+    {
+      "waitFor": "issue364-shell-alpha"
+    },
+    {
+      "key": "F12"
+    },
+    {
+      "waitFor": "F10 resume shell"
+    },
+    {
+      "key": "F10"
+    },
+    {
+      "waitFor": "Agent Shell"
+    },
+    {
+      "waitFor": "issue364-shell-alpha"
+    },
+    {
+      "key": "F12"
+    },
+    {
+      "waitFor": "F7 shells"
+    },
+    {
+      "key": "N"
+    },
+    {
+      "waitFor": "New Repository"
+    },
+    {
+      "type": "Beta Repository"
+    },
+    {
+      "key": "Tab"
+    },
+    {
+      "type": "fixture-repo-beta"
+    },
+    {
+      "key": "Enter"
+    },
+    {
+      "waitFor": "Beta Repository"
+    },
+    {
+      "key": "n"
+    },
+    {
+      "waitFor": "New Agent"
+    },
+    {
+      "key": "Tab"
+    },
+    {
+      "type": "Beta Agent"
+    },
+    {
+      "key": "Enter"
+    },
+    {
+      "waitFor": "issue364-agent-ready"
+    },
+    {
+      "key": "F12"
+    },
+    {
+      "waitFor": "F7 shells"
+    },
+    {
+      "key": "F10"
+    },
+    {
+      "waitFor": "Agent Shell"
+    },
+    {
+      "line": "printf 'issue364-shell-beta\\n'"
+    },
+    {
+      "waitFor": "issue364-shell-beta"
+    },
+    {
+      "key": "F12"
+    },
+    {
+      "waitFor": "F7 shells"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "key": "F7"
+    },
+    {
+      "waitFor": "Terminal Manager"
+    },
+    {
+      "waitFor": "Alpha Agent"
+    },
+    {
+      "waitFor": "Beta Agent"
+    },
+    {
+      "key": "Home"
+    },
+    {
+      "waitFor": "Agent: Alpha Agent"
+    },
+    {
+      "waitFor": "issue364-shell-alpha"
+    },
+    {
+      "key": "Down"
+    },
+    {
+      "waitFor": "Agent: Beta Agent"
+    },
+    {
+      "waitFor": "issue364-shell-beta"
+    },
+    {
+      "key": "C-k"
+    },
+    {
+      "waitFor": "Agent: Alpha Agent"
+    },
+    {
+      "key": "Enter"
+    },
+    {
+      "waitFor": "Terminal Manager"
+    },
+    {
+      "waitFor": "F12 list | F10 close shell"
+    },
+    {
+      "line": "printf 'issue364-manager-live\\n'"
+    },
+    {
+      "waitFor": "issue364-manager-live"
+    },
+    {
+      "key": "F12"
+    },
+    {
+      "waitFor": "Terminal Manager"
+    },
+    {
+      "waitFor": "Ctrl-k close"
+    },
+    {
+      "key": "Enter"
+    },
+    {
+      "waitFor": "Terminal Manager"
+    },
+    {
+      "waitFor": "F12 list | F10 close shell"
+    },
+    {
+      "line": "exit"
+    },
+    {
+      "waitFor": "Terminal Manager"
+    },
+    {
+      "waitFor": "No shells"
+    },
+    {
+      "key": "Escape"
+    },
+    {
+      "waitFor": "F7 shells"
+    },
+    {
+      "key": "C-q"
+    },
+    {
+      "waitForExit": 10000
+    }
   ]
 }

--- a/project-plans/issue364-plan.md
+++ b/project-plans/issue364-plan.md
@@ -206,7 +206,7 @@ PR A changes 32 paths and 2,229 net lines including the scenario, runner, plan, 
 The issue-wide Open Code Review budget is four runs total: no more than two before a PR is opened and no more than two after PR opening across both stacked PRs.
 
 - Issue-wide pre-PR Open Code Review: 2 attempted / 2; both runs were terminated before producing output, leaving zero-byte result files and no findings to triage.
-- Issue-wide post-PR Open Code Review: 0 / 2.
+- Issue-wide post-PR Open Code Review: 2 / 2; both workflow runs completed successfully on PR A, all first-run findings were dispositioned, replied to, and resolved, and the final run left zero unresolved threads. No OCR budget remains for PR B.
 
 ## Verification evidence
 
@@ -219,8 +219,11 @@ The issue-wide Open Code Review budget is four runs total: no more than two befo
 | PR A scenario GREEN | `scripts/issue364-manager-run-scenario.sh` | PASS: all 80 real-tmux steps; repository resume, two rows, preview navigation, close/clamp, focus/return, natural exit, and empty manager |
 | PR A source-size gate | `./scripts/check-source-file-size.sh` after `cargo fmt --all` | PASS: no production source exceeds 1,000 lines |
 | PR A exact candidate | `make ci-check` | PASS: format, Clippy policy, format-stable source-size, strict Clippy, coverage, locked all-feature build, and full workspace tests |
-| PR B scenario RED/GREEN | updated manager scenario | PENDING |
-| PR B exact head | `make ci-check` | PENDING |
+| PR B scenario RED | `scripts/issue364-manager-run-scenario.sh` | RED as intended on PR A head `face6c0`: step 73 timed out because Enter replaced the manager with the expanded Agent Shell instead of keeping the list visible |
+| PR B focused tests | manager, shell-overlay, and manager-layout filters | PASS: manager state 15, shell-overlay lifecycle 21, and reduced lower-pane geometry coverage |
+| PR B quick suite | `make quick-check` | PASS: 2,262 library tests, 729 binary tests, all integration targets and doctests |
+| PR B scenario GREEN | `scripts/issue364-manager-run-scenario.sh` | PASS: all 84 real-tmux steps; in-place live shell, typed PTY marker, F12 list return/resume, and natural exit to empty manager |
+| PR B exact candidate | `make ci-check` | PASS: format, Clippy policy, source-size, strict all-target/all-feature Clippy, coverage, locked build, full workspace tests, and doctests |
 
 ## Deferred findings and follow-ups
 

--- a/src/app_input/shell_overlay.rs
+++ b/src/app_input/shell_overlay.rs
@@ -90,7 +90,7 @@ pub async fn observe_shell_exit(mut app_state: AppStateHandle, ctx: SharedContex
                 }
                 *state = std::mem::take(&mut *state).apply(AppEvent::CloseShellOverlay);
                 drop(state);
-                resize_for_active_layout(&ctx, false);
+                resize_for_active_layout(&app_state, &ctx);
             }
             Ok(true) => {}
             Err(error) => set_warning(&mut app_state, &error.to_string()),
@@ -167,18 +167,21 @@ pub async fn observe_shell_inventory(mut app_state: AppStateHandle, ctx: SharedC
     }
 }
 
-pub fn resize_terminal(ctx: &SharedContext, cols: u16, rows: u16, overlay_active: bool) {
+pub fn resize_terminal(ctx: &SharedContext, cols: u16, rows: u16, state: &jefe::state::AppState) {
     let Some(ctx_arc) = ctx else {
         return;
     };
     let Ok(mut guard) = ctx_arc.lock() else {
         return;
     };
-    let layout = if overlay_active {
-        jefe::layout::compute_shell_overlay_pty_layout(cols, rows)
-    } else {
-        jefe::layout::compute_pty_layout(cols, rows)
-    };
+    let layout =
+        if state.shell_overlay_active() && state.screen_mode == ScreenMode::DashboardTerminals {
+            jefe::layout::compute_terminal_manager_pty_layout(cols, rows)
+        } else if state.shell_overlay_active() {
+            jefe::layout::compute_shell_overlay_pty_layout(cols, rows)
+        } else {
+            jefe::layout::compute_pty_layout(cols, rows)
+        };
     if let Err(error) = guard.runtime.resize(layout.pty_rows, layout.pty_cols) {
         warn!(error = %error, "failed to resize shell terminal");
     }
@@ -306,7 +309,7 @@ fn open_embedded_shell(app_state: &mut AppStateHandle, ctx: &SharedContext) {
     match open_runtime_shell_window(ctx, &agent_id) {
         Ok(()) => {
             dispatch_app_event(app_state, ctx, AppEvent::OpenShellOverlay);
-            resize_for_active_layout(ctx, true);
+            resize_for_active_layout(app_state, ctx);
         }
         Err(error) => {
             warn!(error = %error, "failed to open shell window");
@@ -355,7 +358,7 @@ fn close_overlay_and_restore(
     match result {
         Ok(()) => {
             dispatch_app_event(app_state, ctx, AppEvent::CloseShellOverlay);
-            resize_for_active_layout(ctx, false);
+            resize_for_active_layout(app_state, ctx);
         }
         Err(error) => {
             warn!(error = %error, "failed to close shell window");
@@ -376,7 +379,7 @@ fn hide_overlay_and_restore(
     match result {
         Ok(()) => {
             dispatch_app_event(app_state, ctx, AppEvent::HideShellOverlay);
-            resize_for_active_layout(ctx, false);
+            resize_for_active_layout(app_state, ctx);
         }
         Err(error) => {
             warn!(error = %error, "failed to hide shell window");
@@ -470,9 +473,10 @@ fn hide_runtime_shell_window(
     guard.runtime.hide_shell_window(agent_id)
 }
 
-pub(super) fn resize_for_active_layout(ctx: &SharedContext, overlay_active: bool) {
+pub(super) fn resize_for_active_layout(app_state: &AppStateHandle, ctx: &SharedContext) {
     let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
-    resize_terminal(ctx, cols, rows, overlay_active);
+    let state = app_state.read();
+    resize_terminal(ctx, cols, rows, &state);
 }
 
 fn warn_no_selection(app_state: &mut AppStateHandle, action: &str) {

--- a/src/app_input/terminal_manager.rs
+++ b/src/app_input/terminal_manager.rs
@@ -327,7 +327,7 @@ pub async fn complete_pending_shell_focus(
         &ctx,
         AppEvent::ConfirmShellFocus(attached_agent_id),
     );
-    crate::app_input::shell_overlay::resize_for_active_layout(&ctx, true);
+    crate::app_input::shell_overlay::resize_for_active_layout(&app_state, &ctx);
 }
 
 /// Poll pending focus requests so same-owner `Stable` scheduler outcomes also

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -501,7 +501,10 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     // requests a background capture via the `CaptureHandle` and reads the
     // runtime's `HistoryCache` directly (non-blocking `get`). The background
     // worker drains the request and stores the result in the cache.
-    let history_lines: Vec<String> = if snapshot.screen_mode == ScreenMode::Dashboard {
+    let history_lines: Vec<String> = if snapshot.screen_mode == ScreenMode::Dashboard
+        || (snapshot.screen_mode == ScreenMode::DashboardTerminals
+            && snapshot.shell_overlay_active())
+    {
         crate::app_shell_workers::capture_history_from_cache(ctx.as_ref())
     } else {
         Vec::new()
@@ -513,7 +516,11 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     // again), starving the input loop (qqq never processed). The geometry is
     // refreshed at dispatch time instead — see refresh_terminal_scroll_geometry
     // (mirrors the detail-pane viewport-refresh pattern).
-    let pty_layout = if snapshot.shell_overlay_active() {
+    let pty_layout = if snapshot.shell_overlay_active()
+        && snapshot.screen_mode == ScreenMode::DashboardTerminals
+    {
+        jefe::layout::compute_terminal_manager_pty_layout(term_cols, term_rows)
+    } else if snapshot.shell_overlay_active() {
         jefe::layout::compute_shell_overlay_pty_layout(term_cols, term_rows)
     } else {
         compute_pty_layout(term_cols, term_rows)
@@ -576,13 +583,8 @@ fn handle_terminal_event(
         TerminalEvent::Resize(cols, rows) => {
             crate::mouse_routing::clear_selection(app_state);
             synchronize_actions_geometry(app_state, cols, rows);
-            let overlay_active = app_state.read().shell_overlay_active();
-            crate::app_input::shell_overlay::resize_terminal(
-                &ctx.cloned(),
-                cols,
-                rows,
-                overlay_active,
-            );
+            let state = app_state.read();
+            crate::app_input::shell_overlay::resize_terminal(&ctx.cloned(), cols, rows, &state);
         }
         TerminalEvent::FullscreenMouse(mouse_event) => {
             crate::mouse_routing::handle_fullscreen_mouse(ctx, app_state, mouse_event);

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -296,6 +296,29 @@ pub fn compute_shell_overlay_pty_layout(term_cols: u16, term_rows: u16) -> PtyLa
     }
 }
 
+/// Compute PTY geometry for the live Terminal Manager lower pane.
+#[must_use]
+pub fn compute_terminal_manager_pty_layout(term_cols: u16, term_rows: u16) -> PtyLayout {
+    let (render_cols, render_rows) =
+        effective_render_size_inner(term_cols, term_rows, is_fullscreen_enabled());
+    let (list_rows, detail_rows) = actions_pane_rows(usize::from(render_rows), false, false);
+    let terminal_slot_rows = u16::try_from(detail_rows).unwrap_or(u16::MAX);
+    let workspace_cols = render_cols.saturating_sub(LEFT_COL_WIDTH);
+
+    PtyLayout {
+        pty_rows: terminal_slot_rows
+            .saturating_sub(TERMINAL_WIDGET_CHROME_ROWS)
+            .max(2),
+        pty_cols: workspace_cols
+            .saturating_sub(TERMINAL_WIDGET_CHROME_COLS)
+            .max(2),
+        pane_col0: LEFT_COL_WIDTH.saturating_add(1),
+        pane_row0: 1u16
+            .saturating_add(u16::try_from(list_rows).unwrap_or(u16::MAX))
+            .saturating_add(2),
+    }
+}
+
 // -----------------------------------------------------------------------------
 // Issues-mode detail-pane layout
 // -----------------------------------------------------------------------------

--- a/src/layout_tests.rs
+++ b/src/layout_tests.rs
@@ -60,6 +60,27 @@ fn split_layout_saturates_at_tiny_render_sizes() {
 }
 
 #[test]
+fn terminal_manager_pty_layout_matches_lower_workspace_pane() {
+    let layout = compute_terminal_manager_pty_layout(120, 40);
+    let (_, render_rows) = effective_render_size(120, 40);
+    let (list_rows, detail_rows) = actions_pane_rows(usize::from(render_rows), false, false);
+
+    assert_eq!(
+        layout.pty_cols,
+        120 - LEFT_COL_WIDTH - TERMINAL_WIDGET_CHROME_COLS
+    );
+    assert_eq!(
+        layout.pty_rows,
+        u16::try_from(detail_rows).unwrap_or(u16::MAX) - TERMINAL_WIDGET_CHROME_ROWS
+    );
+    assert_eq!(layout.pane_col0, LEFT_COL_WIDTH + 1);
+    assert_eq!(
+        layout.pane_row0,
+        u16::try_from(list_rows).unwrap_or(u16::MAX) + 3
+    );
+}
+
+#[test]
 fn compute_pty_layout_pane_origin() {
     let layout = compute_pty_layout_inner(120, 40, true);
     assert_eq!(layout.pane_col0, LEFT_COL_WIDTH + 1);

--- a/src/state/shell_overlay_ops.rs
+++ b/src/state/shell_overlay_ops.rs
@@ -79,10 +79,10 @@ impl AppState {
             self.screen_mode = crate::state::ScreenMode::DashboardTerminals;
             self.terminal_manager.active = true;
             self.pane_focus = crate::state::PaneFocus::Agents;
-            self.shell_return_target = crate::state::ShellReturnTarget::Dashboard;
         } else {
             self.pane_focus = previous_pane_focus.unwrap_or(crate::state::PaneFocus::Agents);
         }
+        self.shell_return_target = crate::state::ShellReturnTarget::Dashboard;
         self.reset_shell_terminal_view();
     }
 
@@ -298,6 +298,28 @@ mod tests {
             state.shell_overlay.generation,
             gen_before.wrapping_add(1),
             "hide must bump generation so observers recognize the new state"
+        );
+    }
+
+    #[test]
+    fn manager_shell_hide_returns_to_manager_and_clears_return_target() {
+        let mut state = AppState::default();
+        state.screen_mode = crate::state::ScreenMode::DashboardTerminals;
+        state.terminal_manager.active = true;
+        state.shell_return_target = crate::state::ShellReturnTarget::TerminalManager;
+        state.resume_shell_overlay(AgentId("agent-1".into()));
+
+        state.hide_shell_overlay();
+
+        assert_eq!(
+            state.screen_mode,
+            crate::state::ScreenMode::DashboardTerminals
+        );
+        assert!(state.terminal_manager.active);
+        assert!(!state.shell_overlay_active());
+        assert_eq!(
+            state.shell_return_target,
+            crate::state::ShellReturnTarget::Dashboard
         );
     }
 

--- a/src/state/terminal_manager_ops.rs
+++ b/src/state/terminal_manager_ops.rs
@@ -163,12 +163,18 @@ impl AppState {
         }
         self.terminal_manager.clear_pending_focus();
         self.record_shell_focus(attached_agent_id);
-        self.terminal_manager.active = false;
-        self.screen_mode = ScreenMode::Dashboard;
-        self.shell_return_target = match pending.origin {
-            ShellFocusOrigin::DashboardF10 => ShellReturnTarget::Dashboard,
-            ShellFocusOrigin::ManagerEnter => ShellReturnTarget::TerminalManager,
-        };
+        match pending.origin {
+            ShellFocusOrigin::DashboardF10 => {
+                self.terminal_manager.active = false;
+                self.screen_mode = ScreenMode::Dashboard;
+                self.shell_return_target = ShellReturnTarget::Dashboard;
+            }
+            ShellFocusOrigin::ManagerEnter => {
+                self.terminal_manager.active = true;
+                self.screen_mode = ScreenMode::DashboardTerminals;
+                self.shell_return_target = ShellReturnTarget::TerminalManager;
+            }
+        }
         self.resume_shell_overlay(attached_agent_id.clone());
         true
     }
@@ -410,6 +416,14 @@ mod tests {
             AgentId("agent-1".into()),
         ));
         assert!(ok);
+        assert_eq!(state.screen_mode, ScreenMode::DashboardTerminals);
+        assert!(state.terminal_manager.active);
+        assert!(state.shell_overlay_active());
+        assert!(state.terminal_focused);
+        assert_eq!(
+            state.shell_return_target,
+            ShellReturnTarget::TerminalManager
+        );
     }
 
     #[test]

--- a/src/ui/components/terminal_view.rs
+++ b/src/ui/components/terminal_view.rs
@@ -63,6 +63,8 @@ pub struct TerminalViewProps {
     /// whole retained history (issue #198 follow-up).
     pub pane_rows: usize,
     pub pane_cols: usize,
+    /// Focused-mode hint for the owning shell surface.
+    pub focused_hint: Option<String>,
 }
 
 /// Empty-state message for the terminal pane when no snapshot is available.
@@ -90,7 +92,7 @@ pub fn TerminalView(props: &TerminalViewProps) -> impl Into<AnyElement<'static>>
     };
 
     let focus_hint = if props.focused {
-        "F12 hide shell"
+        props.focused_hint.as_deref().unwrap_or("F12 hide shell")
     } else {
         "F12/t to focus"
     };

--- a/src/ui/orchestration.rs
+++ b/src/ui/orchestration.rs
@@ -195,12 +195,17 @@ fn terminal_manager_element(
     snapshot: &AppState,
     colors: &ThemeColors,
     theme_name: &str,
+    terminal: TerminalRenderData,
 ) -> AnyElement<'static> {
     element! {
         TerminalManagerScreen(
             state: Some(snapshot.clone()),
             colors: Some(colors.clone()),
             theme_name: theme_name.to_owned(),
+            terminal_snapshot: terminal.snapshot,
+            history_lines: terminal.history_lines,
+            terminal_pane_rows: u16::try_from(terminal.pane_rows).unwrap_or(u16::MAX),
+            terminal_pane_cols: u16::try_from(terminal.pane_cols).unwrap_or(u16::MAX),
         )
     }
     .into_any()
@@ -272,7 +277,9 @@ pub fn build_screen_element(
             )
         }
         .into_any(),
-        ScreenMode::DashboardTerminals => terminal_manager_element(snapshot, colors, theme_name),
+        ScreenMode::DashboardTerminals => {
+            terminal_manager_element(snapshot, colors, theme_name, terminal)
+        }
     }
 }
 

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -182,6 +182,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                         override_theme: state.is_some_and(|s| s.override_agent_theme),
                         pane_rows: props.terminal_pane_rows,
                         pane_cols: props.terminal_pane_cols,
+                        focused_hint: None,
                     )
                 }
             }
@@ -226,6 +227,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                             override_theme: state.is_some_and(|s| s.override_agent_theme),
                             pane_rows: props.terminal_pane_rows,
                             pane_cols: props.terminal_pane_cols,
+                            focused_hint: None,
                         )
                     }
                 }

--- a/src/ui/screens/terminal_manager.rs
+++ b/src/ui/screens/terminal_manager.rs
@@ -9,6 +9,7 @@
 
 use iocraft::prelude::*;
 
+use crate::runtime::TerminalSnapshot;
 use crate::selection::SelectablePane;
 use crate::state::project_managed_shell_rows;
 use crate::state::{AppState, ManagedShellRow, ScreenMode};
@@ -19,7 +20,7 @@ use super::super::components::selectable_list::{
     ListBorder, SelectableListProps, SelectableRow, SelectableSpan, SelectionStyle, SpanColor,
 };
 use super::super::components::{
-    KeybindBar, Sidebar, StatusBar, detail_pane_element, selectable_list_element,
+    KeybindBar, Sidebar, StatusBar, TerminalView, detail_pane_element, selectable_list_element,
 };
 
 /// Props for the Terminal Manager screen.
@@ -31,6 +32,14 @@ pub struct TerminalManagerScreenProps {
     pub colors: Option<ThemeColors>,
     /// Active theme name.
     pub theme_name: String,
+    /// Live snapshot from the single attached viewer.
+    pub terminal_snapshot: Option<TerminalSnapshot>,
+    /// Scrollback history for the live lower-pane terminal.
+    pub history_lines: Vec<String>,
+    /// Inner PTY rows allocated to the lower pane.
+    pub terminal_pane_rows: u16,
+    /// Inner PTY columns allocated to the lower pane.
+    pub terminal_pane_cols: u16,
 }
 
 /// Terminal Manager screen layout — two-column: repos sidebar + shell workspace.
@@ -75,6 +84,7 @@ pub fn TerminalManagerScreen(props: &TerminalManagerScreenProps) -> impl Into<An
         .map(|s| s.terminal_manager.preview.clone())
         .unwrap_or_default();
     let pending_focus = state.and_then(|s| s.terminal_manager.pending_focus.as_ref());
+    let live_shell_active = state.is_some_and(AppState::shell_overlay_active);
 
     // ── Layout geometry ─────────────────────────────────────────────────────
     let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((120, 40));
@@ -214,9 +224,28 @@ pub fn TerminalManagerScreen(props: &TerminalManagerScreenProps) -> impl Into<An
                         })])
                     }
 
-                    // Preview detail (bottom split)
+                    // Static preview or the single live viewer (bottom split)
                     Box(flex_grow: 1.0_f32, width: 100pct) {
-                        #(vec![detail_pane_element(detail_props)])
+                        #(if live_shell_active {
+                            vec![element! {
+                                TerminalView(
+                                    snapshot: props.terminal_snapshot.clone(),
+                                    focused: true,
+                                    title: "Agent Shell".to_owned(),
+                                    colors: colors.clone(),
+                                    selection: selection,
+                                    session_live: true,
+                                    history_lines: props.history_lines.clone(),
+                                    terminal_history_offset: state.and_then(|s| s.terminal_history_offset),
+                                    override_theme: state.is_some_and(|s| s.override_agent_theme),
+                                    pane_rows: props.terminal_pane_rows,
+                                    pane_cols: props.terminal_pane_cols,
+                                    focused_hint: Some("F12 list | F10 close shell".to_owned()),
+                                )
+                            }.into_any()]
+                        } else {
+                            vec![detail_pane_element(detail_props)]
+                        })
                     }
                 }
             }
@@ -224,7 +253,7 @@ pub fn TerminalManagerScreen(props: &TerminalManagerScreenProps) -> impl Into<An
             // ── Keybind bar ─────────────────────────────────────────────────
             KeybindBar(
                 screen_mode: state.map_or(ScreenMode::DashboardTerminals, |s| s.screen_mode),
-                terminal_focused: false,
+                terminal_focused: live_shell_active,
                 actions_focus: None,
                 colors: colors.clone(),
             )


### PR DESCRIPTION
## Summary

- keep the Terminal Manager shell list visible while the selected existing viewer is focused in the lower pane
- resize the single attached PTY to manager-specific lower-pane geometry without creating a second viewer
- route ordinary keys to the embedded shell while F12 returns to the manager list and F10 closes only that shell
- return naturally exited shells to the manager list and refresh the runtime-only inventory
- provide surface-specific focused-shell hints

## Stack

This PR is stacked on PR #371 and should be reviewed as the PR A head plus commit cb349b6. Its base is the `issue364` branch.

## Test-first evidence

- RED: the updated real-tmux scenario failed because Enter replaced Terminal Manager with the expanded Agent Shell surface
- GREEN: the integrated scenario passes all 84 steps, including manager-visible live input, F12 list return, re-entry, natural exit, and final empty inventory

## Verification

- focused terminal-manager, PTY geometry, and manager-shell lifecycle tests pass
- `scripts/issue364-manager-run-scenario.sh` passes all 84 steps
- `make ci-check` passes on exact commit cb349b6
- stacked scope: 13 files, 419 insertions, 121 deletions

Fixes #364
