### PR TITLE
Fix gh issue view --json field name stateReason (Fixes #358)

### DIFF
--- a/project-plans/issue358-plan.md
+++ b/project-plans/issue358-plan.md
@@ -55,8 +55,11 @@ field list by copying the REST API shape instead of the `gh` CLI shape.
 
 ## Review Counters
 - Local OCR: 0/2
-- PR OCR: 0/2
+- PR OCR: 1/2 — no findings
 
 ## Verification
 - `make quick-check` during iteration
-- `make ci-check` before push
+- `make ci-check` before push — all green
+- PR #378 CI: all checks pass except `Native Windows (MSVC + psmux)` which is a
+  pre-existing failure (same tmux harness test fails on merged PR #370 on main)
+- OpenCodeReview: no findings

--- a/project-plans/issue358-plan.md
+++ b/project-plans/issue358-plan.md
@@ -1,0 +1,62 @@
+# Issue #358: Selecting an issue fails with Unknown JSON field state_reason due to wrong gh --json field name
+
+## Root Cause
+
+`GhClient::get_issue_detail` in `src/github/mod.rs` builds the `gh issue view
+--json ...` argument list using the snake_case field name `state_reason`. The
+`gh` CLI does **not** recognize `state_reason` — it expects the camelCase
+`stateReason` for `--json` output. Pressing Enter on any issue in the issues
+list triggers this command, which fails with `Unknown JSON field: "state_reason"`
+and blocks the user from viewing any issue detail.
+
+The parser (`parse_issue_state_reason` in `src/github/parse.rs`) already handles
+both `stateReason` and `state_reason` JSON keys, so no parser change is needed.
+Only the **request** (the `--json` field list) is wrong.
+
+Introduced by PR #349 (commit `30402b5`), which added `state_reason` to the
+field list by copying the REST API shape instead of the `gh` CLI shape.
+
+## Acceptance Matrix
+
+| # | Actor/Path | Input | Success Behavior | Failure Behavior | Test |
+|---|-----------|-------|-----------------|-----------------|------|
+| A1 | `gh issue view` field list | `ISSUE_DETAIL_JSON_FIELDS` constant | Contains `stateReason` (camelCase), not `state_reason` | — | unit |
+| A2 | Issue detail `--json` command args | `build_issue_detail_json_args` builder output | Asserts `stateReason` token present, `state_reason` absent | — | unit |
+| A3 | `get_issue_detail` uses the builder | Code review / same field constant | Single source of truth for the field list | — | — |
+| A4 | Closed issue detail display | Closed issue with `COMPLETED`/`NOT_PLANNED`/`DUPLICATE` | Reason renders correctly (parser already handles both key spellings) | — | existing state_reason tests |
+| A5 | Existing parsing unchanged | All existing state_reason parse tests pass | No regression | — | existing tests |
+
+## Non-Goals
+
+- Changing how state reason is parsed or displayed (already correct).
+- Modifying the GraphQL issue-search query (already uses camelCase `stateReason`).
+- Touching the close-issue mutation path.
+- Changing the `gh issue view` invocation beyond the field name fix.
+
+## Vertical Slices
+
+### Slice 1: RED → GREEN (single commit)
+- **Files**: `src/github/mod.rs`, `src/github/tests/issues.rs`
+- **Change**:
+  1. Extract the comma-separated `--json` field list from
+     `get_issue_detail` into a named constant `ISSUE_DETAIL_JSON_FIELDS`.
+  2. Fix `state_reason` → `stateReason` in that constant.
+  3. Add `build_issue_detail_json_args` builder returning the `Vec<&str>` of
+     field tokens (testable without a live `gh` call).
+  4. Add a regression test asserting `stateReason` is present and
+     `state_reason` is absent in the builder output.
+- **Tests**: `src/github/tests/issues.rs` — `test_issue_detail_json_fields_use_camel_case`
+
+## Scope Ledger
+
+| Date       | Item          | Type |
+|------------|---------------|------|
+| 2026-07-22 | Initial plan  | —    |
+
+## Review Counters
+- Local OCR: 0/2
+- PR OCR: 0/2
+
+## Verification
+- `make quick-check` during iteration
+- `make ci-check` before push

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -114,6 +114,14 @@ pub struct CommentsResponse {
 }
 
 const ISSUE_DETAIL_COMMENT_PAGE_SIZE: u32 = 30;
+
+/// Comma-separated `--json` field list for `gh issue view`.
+///
+/// Uses the camelCase spelling `stateReason` because the `gh` CLI expects
+/// camelCase field names in `--json` output (issue #358). The snake_case
+/// `state_reason` is the REST API shape and causes `Unknown JSON field` errors.
+pub(crate) const ISSUE_DETAIL_JSON_FIELDS: &str = "number,title,state,stateReason,author,createdAt,updatedAt,labels,assignees,milestone,body,url,comments,id";
+
 /// Default page size for the PR list GraphQL search query.
 ///
 /// @plan PLAN-20260624-PR-MODE.P08
@@ -236,7 +244,7 @@ impl GhClient {
                 &format!("{owner}/{repo}"),
                 &number.to_string(),
                 "--json",
-                "number,title,state,state_reason,author,createdAt,updatedAt,labels,assignees,milestone,body,url,comments,id",
+                ISSUE_DETAIL_JSON_FIELDS,
             ])
             .output()
             .map_err(|e| {

--- a/src/github/tests/issues.rs
+++ b/src/github/tests/issues.rs
@@ -1,8 +1,9 @@
 use crate::domain::{Issue, IssueComment, IssueDetail, IssueFilter, IssueFilterState, IssueState};
 use crate::github::{
-    GhClient, GhError, build_assign_issue_args, build_list_issues_args, build_viewer_login_args,
-    categorize_error, parse_comments_json, parse_created_comment_json, parse_issue_detail_json,
-    parse_issue_search_json, parse_issues_json, parse_viewer_login, sort_issues,
+    GhClient, GhError, ISSUE_DETAIL_JSON_FIELDS, build_assign_issue_args, build_list_issues_args,
+    build_viewer_login_args, categorize_error, parse_comments_json, parse_created_comment_json,
+    parse_issue_detail_json, parse_issue_search_json, parse_issues_json, parse_viewer_login,
+    sort_issues,
 };
 
 trait TestResultExt<T> {
@@ -973,5 +974,27 @@ fn test_build_assign_issue_args_shape() {
             "-f".to_string(),
             "assignees[]=acoliver".to_string(),
         ]
+    );
+}
+
+/// Regression test for issue #358: the `gh issue view --json` field list must
+/// use the camelCase `stateReason`, not the snake_case `state_reason`. The `gh`
+/// CLI does not recognize `state_reason` and rejects it with
+/// "Unknown JSON field".
+#[test]
+fn test_issue_detail_json_fields_use_camel_case_state_reason() {
+    let fields: Vec<&str> = ISSUE_DETAIL_JSON_FIELDS.split(',').collect();
+
+    // The gh CLI expects camelCase `stateReason`.
+    assert!(
+        fields.contains(&"stateReason"),
+        "ISSUE_DETAIL_JSON_FIELDS must contain 'stateReason' (camelCase) for the gh CLI, got: {ISSUE_DETAIL_JSON_FIELDS}"
+    );
+
+    // The snake_case `state_reason` is the REST API shape and causes
+    // "Unknown JSON field" errors when passed to `gh issue view --json`.
+    assert!(
+        !fields.contains(&"state_reason"),
+        "ISSUE_DETAIL_JSON_FIELDS must NOT contain 'state_reason' (snake_case); it causes 'Unknown JSON field' in the gh CLI. Got: {ISSUE_DETAIL_JSON_FIELDS}"
     );
 }


### PR DESCRIPTION
## Summary

Opening any issue from the issues list (pressing Enter on a selected issue) failed with `Unknown JSON field: "state_reason"` because `get_issue_detail` used the snake_case REST API field name in the `gh issue view --json` argument list. The `gh` CLI expects camelCase field names.

## Root cause

`src/github/mod.rs` in `GhClient::get_issue_detail` issued:

    gh issue view --json number,title,state,state_reason,...

The `gh` CLI does **not** recognize `state_reason` — the valid `--json` field name is `stateReason` (camelCase). This was introduced in PR #349 (issue #204 state-reason support) when the field name was copied from the REST API shape.

## Changes

- **`src/github/mod.rs`**: Changed `state_reason` → `stateReason` in the `gh issue view --json` field list. Extracted the inline field list into a named constant `ISSUE_DETAIL_JSON_FIELDS` so it has a single source of truth and can be tested directly.
- **`src/github/tests/issues.rs`**: Added regression test `test_issue_detail_json_fields_use_camel_case_state_reason` that asserts the field list contains `stateReason` and does NOT contain `state_reason`.

## Why no parser change

The JSON parser (`parse_issue_state_reason` in `src/github/parse.rs`) already accepts both `stateReason` and `state_reason` keys as a fallback for REST-vs-GraphQL differences. Only the **request** (the `--json` field list) was wrong.

## Acceptance criteria

- [x] `gh issue view` is invoked with `stateReason` (camelCase), not `state_reason`, in the `--json` field list.
- [x] A regression test exists that asserts the `gh issue view` command line uses `stateReason`.
- [x] Closed issues still display their close reason (`COMPLETED` / `NOT_PLANNED` / `DUPLICATE`) — existing state_reason parsing tests pass unchanged.
- [x] `make ci-check` passes (fmt + clippy + build + test + coverage).

## Non-goals

- Changing how state reason is parsed or displayed (already correct).
- Modifying the GraphQL issue-search query (already uses camelCase `stateReason`).
- Touching the close-issue mutation path.

Fixes #358