### PR TITLE
Keep multiplexer work outside shared runtime lock (Fixes #374)

### DIFF
--- a/project-plans/issue374-plan.md
+++ b/project-plans/issue374-plan.md
@@ -1,0 +1,113 @@
+# Issue 374 delivery plan: partition blocking runtime operations from AppContext
+
+## Issue and decisions
+
+- GitHub: https://github.com/vybestack/llxprt-jefe/issues/374
+- Branch: `issue374`
+- Base: `origin/main` at `529085a`
+- Delivery: one bounded PR.
+- Architecture decision: use concrete immutable runtime snapshots and operation-specific stale guards. Do not introduce a generic `RuntimeOperation` framework because attach, capture, persistence, shell-overlay, and pending-focus operations have different ownership and generation identities.
+- Input decision: F10/F12 remain synchronous. Multiplexer subprocesses execute without an `AppContext` guard, while existing success/failure ordering remains unchanged.
+- Stale-owner decision: an open/select result whose attached owner changed is discarded and best-effort window-0 compensation restores the hidden-shell invariant.
+- Preview decision: remove dead-pane multiplexer capture from the render path by capturing once during off-lock liveness detection and storing runtime-only preview lines.
+- Cache decision: mouse history reads use existing cache data and preserve geometry on cache miss; no synchronous capture is performed while an `AppContext` guard is held.
+
+## Acceptance matrix
+
+| ID | Actor / path | Boundary case | Observable success | Failure and permitted side effects | Persistence / compatibility | Proof |
+| --- | --- | --- | --- | --- | --- | --- |
+| A1 | Visible-shell exit observer | Overlay owner/generation may change while probing | Shell-existence subprocess runs without an `AppContext` guard; matching natural exit restores the correct surface | Probe error warns and retries; stale result is discarded | Runtime-only; Unix and psmux commands unchanged | snapshot/guard unit tests, observer seam test, existing shell scenarios |
+| A2 | Hidden-shell inventory observer | Batched probe failure or concurrent inventory change | Observation runs without an `AppContext` guard and removes only confirmed missing entries | Any probe error retains inventory and warns | Existing runtime-only inventory | observer seam and reconciliation tests |
+| A3 | Dashboard F10 open/resume | Background attach changes owner during operation | Snapshot is taken under a short lock, subprocess runs off-lock, matching owner opens/resumes and resizes | Runtime error preserves UI and warns; stale owner does not dispatch success and selects window 0 best-effort | Existing key semantics and single viewer | stale-owner decision tests and issue364 scenario |
+| A4 | Visible-shell F10 close / F12 hide | Multiplexer operation fails | Kill/select-0 executes off-lock and reducer transition occurs only after success | Existing warning; overlay remains retryable | Existing shortcuts and lifecycle | operation seam tests and issue222/364 scenarios |
+| A5 | Terminal Manager Enter | Pending generation or attached owner changes | Select-existing-only operation runs off-lock and confirms only the matching pending request | Stale result is discarded/compensated; failure warns and clears matching request | No shell recreation or second viewer | focus decision tests and issue364 scenario |
+| A6 | Startup and shutdown | Unknown/orphan shells or close failures | Stateless observe/close-all operations run without `AppContext`; startup classification and best-effort shutdown remain intact | Failures retain diagnostic behavior and never kill agent sessions | Existing tmux/psmux plans unchanged | reconciliation/runtime tests |
+| A7 | Dead-agent render preview | Dead pane selected for repeated frames | Pane capture occurs once in off-lock liveness work; render uses runtime-only cached lines and never shells out | Capture failure logs and leaves preview empty; stale liveness result is discarded | Preview is not persisted | liveness reducer/projection tests |
+| A8 | Mouse scroll/selection | Context contention or cold cache | Cached history is read without a multiplexer subprocess; geometry is preserved on miss | Empty fallback only where existing contention already permits it | Existing selection behavior | cache/geometry contention tests |
+| A9 | Existing attach path | Attach completes after target changes | Existing snapshot/build/apply path rejects stale attachment and preserves one viewer | Existing typed failure behavior | No attach architecture change | existing attach tests and scenarios; new snapshot semantics tests only |
+
+## Explicit non-goals
+
+- No cloneable runtime manager, second live viewer, weakened owner/generation checks, or persisted runtime preview/inventory.
+- No generic operation trait/framework.
+- No asynchronous pending state machine for F10/F12.
+- No multiplexer argument, executable-resolution, dependency, workflow, quality-tool, `.llxprt/`, or `.github/` changes.
+- No broad refactor of attach/capture/persist workers that already follow the accepted pattern.
+- No unrelated launch/kill/relaunch input-path refactor.
+- No poison-recovery hardening beyond behavior required by issue 374.
+- No removal of legacy runtime trait methods merely because call sites become unused.
+
+## Bounded vertical slices
+
+### S1: immutable shell-operation snapshot boundary
+
+- Acceptance: A1-A6, A9.
+- Owner: runtime shell-window boundary.
+- Allowed paths: `src/runtime/shell_window.rs`, `src/runtime/mod.rs`, `src/runtime/shell_window_tests.rs`, `src/runtime/manager_tests.rs`.
+- RED: tests require typed local snapshot inputs, remote/missing rejection, and attached-owner matching.
+- GREEN: execute functions accept owned snapshot fields rather than a manager guard; command construction is unchanged.
+- Stop: any generic operation framework or `RuntimeManager` trait expansion.
+
+### S2: shell observers and lifecycle operations
+
+- Acceptance: A1-A6.
+- Owner: shell input/orchestration boundary plus deterministic stale guards.
+- Allowed paths: `src/app_input/shell_overlay.rs`, `src/app_input/terminal_manager.rs`, `src/app_init_shell_reconcile.rs`, `src/state/shell_overlay_ops.rs`, focused tests.
+- RED: closure seams prove subprocess execution can acquire the context lock; stale owner/generation decisions reject apply.
+- GREEN: short-lock snapshot, off-lock execution, revalidation/compensation, unchanged failure ordering.
+- Stop: new user-visible state or async shortcut machinery.
+
+### S3: cache-only selection history
+
+- Acceptance: A8.
+- Owner: existing capture worker/cache boundary.
+- Allowed paths: `src/app_shell_workers.rs`, `src/mouse_routing.rs`, `src/mouse_routing_tests.rs`, existing focused tests.
+- RED: cold-cache geometry remains unchanged and contention returns without blocking.
+- GREEN: no mouse path invokes `RuntimeManager::capture_history` under a guard.
+- Constraint: `src/mouse_routing.rs` must remain at or below 1,000 lines.
+
+### S4: capture dead preview at liveness boundary
+
+- Acceptance: A7.
+- Owner: existing off-lock liveness worker and deterministic state event.
+- Allowed paths: `src/app_shell.rs`, `src/app_shell_workers.rs`, `src/runtime/capture_ops.rs`, state event/type/reducer files, focused tests.
+- RED: repeated dead snapshot projection requires cached lines and no runtime context.
+- GREEN: off-lock liveness result carries preview lines, stale apply is rejected, render is pure/cache-only.
+- Stop: a new worker subsystem or persisted preview.
+
+## Expected paths and scope
+
+Expected: 16-20 files and fewer than 1,200 net changed lines. Target remains 25 files / 1,500 net lines; stop for approval above 40 files or 2,500 net lines.
+
+## Scope ledger
+
+| Discovery | Classification | Disposition |
+| --- | --- | --- |
+| Shell open/close/hide/select/observe/close-all and pane capture execute subprocesses | In-scope | Partition concrete call sites using immutable inputs |
+| Resize, PTY writes, snapshots, dirty flags, generations, and attached-owner reads are in-memory/PTY operations | Reject | Do not refactor |
+| Attach/capture/persist already snapshot and stale-guard | In-scope evidence | Reuse patterns; do not rewrite |
+| Explicit launch/kill/relaunch paths also hold the lock across work | Defer | Separate follow-up; not background terminal operations accepted here |
+| Poison-recovery tests | Defer | Existing unrelated hardening |
+| `manager.rs` is near 1,000 lines; `mouse_routing.rs` is at 1,000 | Blocker constraint | Add runtime code in shell/capture modules; keep mouse edit net non-positive |
+
+## Review counters
+
+- Pre-PR Open Code Review: 1 completed full review; 1 OCR invocation terminated without output / 2 permitted successful runs.
+- Post-PR Open Code Review: 0 / 2.
+
+## Verification evidence
+
+| Candidate | Command | Result |
+| --- | --- | --- |
+| Base | architecture/source inspection | confirmed blocking subprocesses under `AppContext` in shell observers, shell shortcuts, manager focus, dead preview, and mouse history |
+| RED | focused snapshot/locking tests during implementation | failed before concrete shell inputs, lifecycle guards, and cache-only geometry were implemented |
+| GREEN | `cargo test --lib shell_window::snapshot_tests -- --nocapture` | PASS: 10 typed snapshot, lifecycle-stale, remote, and pane-target tests |
+| GREEN | focused shell-overlay/dead-preview/terminal-manager tests | PASS: 1 F10 route, 22 overlay reducer, 17 manager, and dead-preview cache tests |
+| GREEN | `scripts/issue222-run-scenario.sh` | PASS: 50 real-tmux steps |
+| GREEN | `scripts/issue364-manager-run-scenario.sh` | PASS: 84 real-tmux steps |
+| GREEN | `make ci-check` plus exact fmt/clippy/build/test rerun | PASS after strict Clippy remediation |
+| Scope | working-copy review | 15 files, below 25-file / 1,500-line target |
+
+## Deferred findings
+
+- None created yet. Any valid out-of-scope discovery will be recorded as a follow-up rather than expanding this PR.

--- a/src/app_init_shell_reconcile.rs
+++ b/src/app_init_shell_reconcile.rs
@@ -18,7 +18,7 @@
 //! unit-tested without a multiplexer.
 
 use jefe::domain::AgentId;
-use jefe::runtime::{RuntimeError, RuntimeManager, RuntimeSession};
+use jefe::runtime::{RuntimeError, RuntimeSession};
 use jefe::state::AppState;
 use tracing::{debug, warn};
 
@@ -108,23 +108,18 @@ pub fn reconcile_shell_inventory(
             .collect()
     };
 
-    // Observe every session hosting a jefe-shell window (batched). Returns
-    // raw session names so orphans are discovered.
-    let observed_sessions: Vec<String> = {
-        let Ok(ctx_guard) = ctx_arc.lock() else {
-            warn!("startup shell reconcile: runtime context mutex poisoned");
-            return Some(
-                "could not reconcile shell windows: runtime context unavailable".to_owned(),
-            );
-        };
-        match ctx_guard.runtime.observe_shell_window_sessions() {
-            Ok(sessions) => sessions,
-            Err(error) => {
-                // Probe failure: warn and do NOT touch inventory or agent
-                // status (issue #361 invariant).
-                warn!(error = %error, "startup shell reconcile: observation failed");
-                return Some(format!("could not reconcile shell windows: {error}"));
-            }
+    // Observe every session hosting a jefe-shell window (batched). This runs
+    // without an AppContext guard (issue #374): it is a stateless multiplexer
+    // observation that needs no manager in-memory state. Returns raw session
+    // names so orphans are discovered.
+    let _ = ctx_arc; // retained for API compatibility; no lock is taken.
+    let observed_sessions: Vec<String> = match jefe::runtime::observe_shell_window_sessions() {
+        Ok(sessions) => sessions,
+        Err(error) => {
+            // Probe failure: warn and do NOT touch inventory or agent
+            // status (issue #361 invariant).
+            warn!(error = %error, "startup shell reconcile: observation failed");
+            return Some(format!("could not reconcile shell windows: {error}"));
         }
     };
 

--- a/src/app_input/shell_overlay.rs
+++ b/src/app_input/shell_overlay.rs
@@ -28,10 +28,7 @@ use super::{AppStateHandle, SharedContext, dispatch_app_event};
 /// lock. Clears the shell inventory afterward so the cleanup is observable.
 /// Failures are logged by the runtime boundary and also returned for any
 /// caller that wants to surface them.
-pub fn shutdown_all_shells(
-    app_state: &mut AppStateHandle,
-    ctx: &SharedContext,
-) -> Vec<jefe::runtime::RuntimeError> {
+pub fn shutdown_all_shells(app_state: &mut AppStateHandle) -> Vec<jefe::runtime::RuntimeError> {
     // Snapshot every shell owner (visible + hidden) so the visible shell is
     // closed exactly once here and not separately by cleanup_active_shell.
     let owners = app_state.read().shell_window_owners();
@@ -40,7 +37,6 @@ pub fn shutdown_all_shells(
     }
     // Observe + close run without an AppContext guard (issue #374). These are
     // stateless multiplexer operations that need no manager in-memory state.
-    let _ = ctx; // retained for API compatibility; no lock is taken.
     let failures = match jefe::runtime::observe_shell_window_sessions() {
         Ok(session_names) => jefe::runtime::close_all_shell_windows(&session_names),
         Err(error) => vec![error],

--- a/src/app_input/shell_overlay.rs
+++ b/src/app_input/shell_overlay.rs
@@ -102,7 +102,7 @@ pub async fn observe_shell_exit(mut app_state: AppStateHandle, ctx: SharedContex
 ///
 /// Probe failures (`Err`) retain entries and retry — a transient error never
 /// removes inventory or marks an agent Dead (issue #361 invariant).
-pub async fn observe_shell_inventory(mut app_state: AppStateHandle, _ctx: SharedContext) {
+pub async fn observe_shell_inventory(mut app_state: AppStateHandle) {
     loop {
         // Slow cadence (~2s) so the multiplexer is not hammered and the
         // executor stays free for input/render (issue #361 invariant).
@@ -305,10 +305,10 @@ fn open_embedded_shell(app_state: &mut AppStateHandle, ctx: &SharedContext) {
             }
             Ok(false) => {
                 warn!(agent_id = %agent_id.0, "open shell: attached owner changed while off-lock; discarding");
-                let _ = jefe::runtime::hide_shell_window(&inputs.session_name);
+                compensate_open_shell(&inputs.session_name, "stale-result compensation failed");
             }
             Err(error) => {
-                let _ = jefe::runtime::hide_shell_window(&inputs.session_name);
+                compensate_open_shell(&inputs.session_name, "revalidation compensation failed");
                 warn!(error = %error, "open shell: unable to revalidate owner");
                 set_warning(app_state, &error.to_string());
             }
@@ -347,6 +347,12 @@ fn open_external_terminal(app_state: &mut AppStateHandle, _ctx: &SharedContext) 
         Err(ExternalTerminalError::SpawnFailed(msg)) => {
             set_warning(app_state, &msg);
         }
+    }
+}
+
+fn compensate_open_shell(session_name: &str, phase: &'static str) {
+    if let Err(error) = jefe::runtime::hide_shell_window(session_name) {
+        warn!(session_name, error = %error, phase, "open shell: compensation failed");
     }
 }
 

--- a/src/app_input/shell_overlay.rs
+++ b/src/app_input/shell_overlay.rs
@@ -38,13 +38,12 @@ pub fn shutdown_all_shells(
     if owners.is_empty() {
         return Vec::new();
     }
-    let Some(ctx_arc) = ctx.as_ref() else {
-        return Vec::new();
-    };
-    let failures = if let Ok(mut guard) = ctx_arc.lock() {
-        guard.runtime.close_all_shell_windows()
-    } else {
-        Vec::new()
+    // Observe + close run without an AppContext guard (issue #374). These are
+    // stateless multiplexer operations that need no manager in-memory state.
+    let _ = ctx; // retained for API compatibility; no lock is taken.
+    let failures = match jefe::runtime::observe_shell_window_sessions() {
+        Ok(session_names) => jefe::runtime::close_all_shell_windows(&session_names),
+        Err(error) => vec![error],
     };
     // Clear the runtime inventory so the cleanup is observable. The visible
     // overlay is also gone after this process exits, so clearing is safe.
@@ -69,17 +68,10 @@ pub async fn observe_shell_exit(mut app_state: AppStateHandle, ctx: SharedContex
         let Some((agent_id, generation)) = observed else {
             continue;
         };
-        let Some(ctx_arc) = ctx.clone() else {
-            continue;
-        };
-        let queried_agent = agent_id.clone();
-        let result = smol::unblock(move || {
-            let guard = ctx_arc.lock().map_err(|_| {
-                RuntimeError::CapabilityProbeFailed("runtime context lock unavailable".to_owned())
-            })?;
-            guard.runtime.shell_window_exists(&queried_agent)
-        })
-        .await;
+        // Snapshot the session name under a short lock, then release it so the
+        // multiplexer subprocess runs without an AppContext guard (issue #374).
+        let session_name = RuntimeSession::session_name_for(&agent_id);
+        let result = smol::unblock(move || jefe::runtime::shell_window_exists(&session_name)).await;
         match result {
             Ok(false) => {
                 let mut state = app_state.write();
@@ -110,7 +102,7 @@ pub async fn observe_shell_exit(mut app_state: AppStateHandle, ctx: SharedContex
 ///
 /// Probe failures (`Err`) retain entries and retry — a transient error never
 /// removes inventory or marks an agent Dead (issue #361 invariant).
-pub async fn observe_shell_inventory(mut app_state: AppStateHandle, ctx: SharedContext) {
+pub async fn observe_shell_inventory(mut app_state: AppStateHandle, _ctx: SharedContext) {
     loop {
         // Slow cadence (~2s) so the multiplexer is not hammered and the
         // executor stays free for input/render (issue #361 invariant).
@@ -129,16 +121,10 @@ pub async fn observe_shell_inventory(mut app_state: AppStateHandle, ctx: SharedC
         if candidates.is_empty() {
             continue;
         }
-        let Some(ctx_arc) = ctx.clone() else {
-            continue;
-        };
-        // Offload the batched multiplexer query to a background OS thread so
-        // the smol executor can keep processing input/render (issue #361).
-        let observed = smol::unblock(move || -> Result<Vec<String>, RuntimeError> {
-            let guard = ctx_arc.lock().map_err(|_| {
-                RuntimeError::CapabilityProbeFailed("runtime context lock unavailable".to_owned())
-            })?;
-            guard.runtime.observe_shell_window_sessions()
+        // The batched multiplexer query runs without an AppContext guard
+        // (issue #374): it is a stateless observe that needs no manager state.
+        let observed = smol::unblock(|| -> Result<Vec<String>, RuntimeError> {
+            jefe::runtime::observe_shell_window_sessions()
         })
         .await;
         match observed {
@@ -306,11 +292,27 @@ fn open_embedded_shell(app_state: &mut AppStateHandle, ctx: &SharedContext) {
         return;
     }
 
+    // The open subprocess runs off-lock (issue #374 S2). Snapshot real
+    // session_name/work_dir/remote from the manager under a short lock,
+    // verify the owner is attached, release the lock, run the subprocess,
+    // then reacquire AppContext and revalidate the attached owner before
+    // dispatching the success transition.
     match open_runtime_shell_window(ctx, &agent_id) {
-        Ok(()) => {
-            dispatch_app_event(app_state, ctx, AppEvent::OpenShellOverlay);
-            resize_for_active_layout(app_state, ctx);
-        }
+        Ok(inputs) => match owner_still_attached(ctx, &inputs) {
+            Ok(true) => {
+                dispatch_app_event(app_state, ctx, AppEvent::OpenShellOverlay);
+                resize_for_active_layout(app_state, ctx);
+            }
+            Ok(false) => {
+                warn!(agent_id = %agent_id.0, "open shell: attached owner changed while off-lock; discarding");
+                let _ = jefe::runtime::hide_shell_window(&inputs.session_name);
+            }
+            Err(error) => {
+                let _ = jefe::runtime::hide_shell_window(&inputs.session_name);
+                warn!(error = %error, "open shell: unable to revalidate owner");
+                set_warning(app_state, &error.to_string());
+            }
+        },
         Err(error) => {
             warn!(error = %error, "failed to open shell window");
             set_warning(app_state, &error.to_string());
@@ -349,17 +351,29 @@ fn open_external_terminal(app_state: &mut AppStateHandle, _ctx: &SharedContext) 
 }
 
 /// Close the shell overlay, kill the temporary window, and restore the dashboard.
+///
+/// The close subprocess runs off-lock (issue #374 S2). The decision seam
+/// revalidates the visible owner/generation after the subprocess: a stale
+/// result is discarded (the overlay was already closed/changed) and a
+/// matching result applies the transition. Failure ordering is preserved.
 fn close_overlay_and_restore(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
     agent_id: &jefe::domain::AgentId,
 ) {
-    let result = close_runtime_shell_window(ctx, agent_id);
-    match result {
-        Ok(()) => {
-            dispatch_app_event(app_state, ctx, AppEvent::CloseShellOverlay);
-            resize_for_active_layout(app_state, ctx);
-        }
+    let overlay_generation = app_state.read().shell_overlay.generation;
+    match close_runtime_shell_window(ctx, agent_id) {
+        Ok(inputs) => match owner_still_attached(ctx, &inputs) {
+            Ok(true) if overlay_still_matches(app_state, agent_id, overlay_generation) => {
+                dispatch_app_event(app_state, ctx, AppEvent::CloseShellOverlay);
+                resize_for_active_layout(app_state, ctx);
+            }
+            Ok(_) => warn!(agent_id = %agent_id.0, "close shell: stale completion discarded"),
+            Err(error) => {
+                warn!(error = %error, "close shell: unable to revalidate owner");
+                set_warning(app_state, &error.to_string());
+            }
+        },
         Err(error) => {
             warn!(error = %error, "failed to close shell window");
             set_warning(app_state, &error.to_string());
@@ -368,19 +382,27 @@ fn close_overlay_and_restore(
 }
 
 /// Hide the shell overlay by selecting window 0, leaving the shell alive
-/// (issue #361 PR A). Runtime side effect (select-window 0) runs before the
-/// state transition; on failure the overlay stays visible and warns.
+/// (issue #361 PR A). Runtime side effect (select-window 0) runs off-lock
+/// before the state transition (issue #374 S2); on failure the overlay stays
+/// visible and warns.
 fn hide_overlay_and_restore(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
     agent_id: &jefe::domain::AgentId,
 ) {
-    let result = hide_runtime_shell_window(ctx, agent_id);
-    match result {
-        Ok(()) => {
-            dispatch_app_event(app_state, ctx, AppEvent::HideShellOverlay);
-            resize_for_active_layout(app_state, ctx);
-        }
+    let overlay_generation = app_state.read().shell_overlay.generation;
+    match hide_runtime_shell_window(ctx, agent_id) {
+        Ok(inputs) => match owner_still_attached(ctx, &inputs) {
+            Ok(true) if overlay_still_matches(app_state, agent_id, overlay_generation) => {
+                dispatch_app_event(app_state, ctx, AppEvent::HideShellOverlay);
+                resize_for_active_layout(app_state, ctx);
+            }
+            Ok(_) => warn!(agent_id = %agent_id.0, "hide shell: stale completion discarded"),
+            Err(error) => {
+                warn!(error = %error, "hide shell: unable to revalidate owner");
+                set_warning(app_state, &error.to_string());
+            }
+        },
         Err(error) => {
             warn!(error = %error, "failed to hide shell window");
             set_warning(app_state, &error.to_string());
@@ -394,6 +416,16 @@ fn read_dashboard_agent(
     app_state: &AppStateHandle,
 ) -> Option<(jefe::domain::AgentId, std::path::PathBuf)> {
     read_local_agent(app_state, true)
+}
+
+fn overlay_still_matches(
+    app_state: &AppStateHandle,
+    agent_id: &jefe::domain::AgentId,
+    generation: u64,
+) -> bool {
+    let state = app_state.read();
+    state.shell_overlay.agent_id.as_ref() == Some(agent_id)
+        && state.shell_overlay.generation == generation
 }
 
 fn read_local_agent(
@@ -417,60 +449,90 @@ fn read_local_agent(
     Some(selected)
 }
 
+/// Snapshot the owner's shell-window inputs under a short lock, verify the
+/// owner is attached, release the lock, then run the open subprocess without
+/// an AppContext guard (issue #374 S2). Returns the snapshot inputs alongside
+/// the subprocess result so the caller can revalidate ownership afterwards.
 fn open_runtime_shell_window(
     ctx: &SharedContext,
     agent_id: &jefe::domain::AgentId,
-) -> Result<(), RuntimeError> {
+) -> Result<jefe::runtime::ShellWindowInputs, RuntimeError> {
     let Some(ctx_arc) = ctx.as_ref() else {
         return Err(RuntimeError::SpawnFailed(
             "runtime context unavailable".into(),
         ));
     };
-    let Ok(mut guard) = ctx_arc.lock() else {
-        return Err(RuntimeError::SpawnFailed(
-            "runtime context lock unavailable".into(),
-        ));
+    let inputs = {
+        let guard = ctx_arc
+            .lock()
+            .map_err(|_| RuntimeError::SpawnFailed("runtime context lock unavailable".into()))?;
+        if guard.runtime.attached_agent() != Some(agent_id) {
+            return Err(RuntimeError::SpawnFailed(
+                "wait for the selected agent terminal to attach before opening its shell".into(),
+            ));
+        }
+        guard
+            .runtime
+            .shell_window_inputs(agent_id)
+            .ok_or_else(|| RuntimeError::SessionNotFound(agent_id.0.clone()))?
     };
-    if guard.runtime.attached_agent() != Some(agent_id) {
-        return Err(RuntimeError::SpawnFailed(
-            "wait for the selected agent terminal to attach before opening its shell".into(),
-        ));
-    }
-    guard.runtime.open_shell_window(agent_id)
+    inputs.execute_open()?;
+    Ok(inputs)
 }
 
+/// Reacquire AppContext and validate that the attached owner still matches
+/// the snapshot inputs (issue #374 S2 stale-owner guard for open/select).
+/// Returns `false` on lock failure or owner mismatch.
+fn owner_still_attached(
+    ctx: &SharedContext,
+    inputs: &jefe::runtime::ShellWindowInputs,
+) -> Result<bool, RuntimeError> {
+    let ctx_arc = ctx
+        .as_ref()
+        .ok_or_else(|| RuntimeError::SpawnFailed("runtime context unavailable".into()))?;
+    let guard = ctx_arc
+        .lock()
+        .map_err(|_| RuntimeError::SpawnFailed("runtime context lock unavailable".into()))?;
+    Ok(guard.runtime.attached_agent() == Some(&inputs.owner)
+        && guard.runtime.shell_window_owner_matches(inputs))
+}
+
+/// Snapshot the owner's session name under a short lock, release, then run
+/// the close subprocess without an AppContext guard (issue #374 S2).
 fn close_runtime_shell_window(
     ctx: &SharedContext,
     agent_id: &jefe::domain::AgentId,
-) -> Result<(), RuntimeError> {
-    let Some(ctx_arc) = ctx.as_ref() else {
-        return Err(RuntimeError::SpawnFailed(
-            "runtime context unavailable".into(),
-        ));
-    };
-    let Ok(mut guard) = ctx_arc.lock() else {
-        return Err(RuntimeError::SpawnFailed(
-            "runtime context lock unavailable".into(),
-        ));
-    };
-    guard.runtime.close_shell_window(agent_id)
+) -> Result<jefe::runtime::ShellWindowInputs, RuntimeError> {
+    let ctx_arc = ctx
+        .as_ref()
+        .ok_or_else(|| RuntimeError::SpawnFailed("runtime context unavailable".into()))?;
+    let inputs = ctx_arc
+        .lock()
+        .map_err(|_| RuntimeError::SpawnFailed("runtime context lock unavailable".into()))?
+        .runtime
+        .shell_window_inputs(agent_id)
+        .ok_or_else(|| RuntimeError::SessionNotFound(agent_id.0.clone()))?;
+    inputs.execute_close()?;
+    Ok(inputs)
 }
 
+/// Snapshot the owner's session name, release, then run the hide subprocess
+/// (select window 0) without an AppContext guard (issue #374 S2).
 fn hide_runtime_shell_window(
     ctx: &SharedContext,
     agent_id: &jefe::domain::AgentId,
-) -> Result<(), RuntimeError> {
-    let Some(ctx_arc) = ctx.as_ref() else {
-        return Err(RuntimeError::SpawnFailed(
-            "runtime context unavailable".into(),
-        ));
-    };
-    let Ok(mut guard) = ctx_arc.lock() else {
-        return Err(RuntimeError::SpawnFailed(
-            "runtime context lock unavailable".into(),
-        ));
-    };
-    guard.runtime.hide_shell_window(agent_id)
+) -> Result<jefe::runtime::ShellWindowInputs, RuntimeError> {
+    let ctx_arc = ctx
+        .as_ref()
+        .ok_or_else(|| RuntimeError::SpawnFailed("runtime context unavailable".into()))?;
+    let inputs = ctx_arc
+        .lock()
+        .map_err(|_| RuntimeError::SpawnFailed("runtime context lock unavailable".into()))?
+        .runtime
+        .shell_window_inputs(agent_id)
+        .ok_or_else(|| RuntimeError::SessionNotFound(agent_id.0.clone()))?;
+    inputs.execute_hide()?;
+    Ok(inputs)
 }
 
 pub(super) fn resize_for_active_layout(app_state: &AppStateHandle, ctx: &SharedContext) {

--- a/src/app_input/terminal_manager.rs
+++ b/src/app_input/terminal_manager.rs
@@ -339,7 +339,7 @@ pub async fn complete_pending_shell_focus(
     };
     let SelectOutcome::Selected = outcome else {
         // PendingGone or Stale: do not confirm focus. On Stale, best-effort
-        // select window 0 to restore the hidden-shell invariant (issue #374).
+        // hide the shell to restore the hidden-shell invariant (issue #374).
         if matches!(outcome, SelectOutcome::Stale) {
             warn!(
                 agent_id = %attached_agent_id.0,

--- a/src/app_input/terminal_manager.rs
+++ b/src/app_input/terminal_manager.rs
@@ -254,23 +254,50 @@ fn select_pending_runtime_shell(
     ctx: &std::sync::Arc<std::sync::Mutex<crate::AppContext>>,
     owner: &AgentId,
     generation: u64,
-) -> Result<bool, jefe::runtime::RuntimeError> {
+) -> Result<SelectOutcome, jefe::runtime::RuntimeError> {
     if !pending_focus_matches(state, owner, generation) {
-        return Ok(false);
+        return Ok(SelectOutcome::PendingGone);
     }
-    let mut guard = ctx.lock().map_err(|_| {
+    let inputs = {
+        let guard = ctx.lock().map_err(|_| {
+            jefe::runtime::RuntimeError::CapabilityProbeFailed(
+                "runtime context lock unavailable".to_owned(),
+            )
+        })?;
+        if guard.runtime.attached_agent() != Some(owner) {
+            return Err(jefe::runtime::RuntimeError::SessionNotFound(
+                owner.0.clone(),
+            ));
+        }
+        guard
+            .runtime
+            .shell_window_inputs(owner)
+            .ok_or_else(|| jefe::runtime::RuntimeError::SessionNotFound(owner.0.clone()))?
+    };
+    inputs.execute_select()?;
+    let guard = ctx.lock().map_err(|_| {
         jefe::runtime::RuntimeError::CapabilityProbeFailed(
             "runtime context lock unavailable".to_owned(),
         )
     })?;
-    if guard.runtime.attached_agent() != Some(owner) {
-        return Err(jefe::runtime::RuntimeError::SessionNotFound(
-            owner.0.clone(),
-        ));
+    if guard.runtime.attached_agent() == Some(owner)
+        && guard.runtime.shell_window_owner_matches(&inputs)
+    {
+        Ok(SelectOutcome::Selected)
+    } else {
+        Ok(SelectOutcome::Stale)
     }
-    guard.runtime.select_shell_window(owner)?;
-    drop(guard);
-    Ok(true)
+}
+
+/// Outcome of an off-lock select-existing shell operation (issue #374 S5).
+enum SelectOutcome {
+    /// Pending focus no longer matches — nothing to confirm.
+    PendingGone,
+    /// Select succeeded and the owner is still attached — confirm focus.
+    Selected,
+    /// Select succeeded but the attached owner changed while off-lock —
+    /// discard and best-effort compensate by selecting window 0.
+    Stale,
 }
 
 /// Complete a pending manager focus only after the expected owner is attached
@@ -302,17 +329,27 @@ pub async fn complete_pending_shell_focus(
         select_pending_runtime_shell(&state_for_guard, &ctx_clone, &owner, pending_generation)
     })
     .await;
-    let selected = match result {
-        Ok(selected) => selected,
+    let outcome = match result {
+        Ok(outcome) => outcome,
         Err(error) => {
             warn!(agent_id = %attached_agent_id.0, error = %error, "manager: focus shell failed");
             on_shell_attach_failed(&mut app_state, &attached_agent_id);
             return;
         }
     };
-    if !selected {
+    let SelectOutcome::Selected = outcome else {
+        // PendingGone or Stale: do not confirm focus. On Stale, best-effort
+        // select window 0 to restore the hidden-shell invariant (issue #374).
+        if matches!(outcome, SelectOutcome::Stale) {
+            warn!(
+                agent_id = %attached_agent_id.0,
+                "manager: attached owner changed during focus select; discarding"
+            );
+            let session_name = RuntimeSession::session_name_for(&attached_agent_id);
+            let _ = jefe::runtime::hide_shell_window(&session_name);
+        }
         return;
-    }
+    };
     let current = app_state.read().terminal_manager.pending_focus.clone();
     if !matches!(
         current.as_ref(),
@@ -320,6 +357,8 @@ pub async fn complete_pending_shell_focus(
             if value.agent_id == attached_agent_id
                 && value.generation == pending.generation
     ) {
+        let session_name = RuntimeSession::session_name_for(&attached_agent_id);
+        let _ = jefe::runtime::hide_shell_window(&session_name);
         return;
     }
     dispatch_app_event(

--- a/src/app_input/terminal_manager.rs
+++ b/src/app_input/terminal_manager.rs
@@ -274,6 +274,9 @@ fn select_pending_runtime_shell(
             .shell_window_inputs(owner)
             .ok_or_else(|| jefe::runtime::RuntimeError::SessionNotFound(owner.0.clone()))?
     };
+    // Selecting the snapshotted multiplexer session mutates only external tmux/
+    // psmux state. It intentionally runs without AppContext, then the manager
+    // owner and lifecycle generation are revalidated under the short lock.
     inputs.execute_select()?;
     let guard = ctx.lock().map_err(|_| {
         jefe::runtime::RuntimeError::CapabilityProbeFailed(

--- a/src/app_input/terminal_manager.rs
+++ b/src/app_input/terminal_manager.rs
@@ -285,7 +285,7 @@ fn select_pending_runtime_shell(
     {
         Ok(SelectOutcome::Selected)
     } else {
-        Ok(SelectOutcome::Stale)
+        Ok(SelectOutcome::Stale(inputs.session_name))
     }
 }
 
@@ -295,9 +295,9 @@ enum SelectOutcome {
     PendingGone,
     /// Select succeeded and the owner is still attached — confirm focus.
     Selected,
-    /// Select succeeded but the attached owner changed while off-lock —
-    /// discard and best-effort compensate by selecting window 0.
-    Stale,
+    /// Select succeeded but the attached owner changed while off-lock. Carries
+    /// the snapshotted session so compensation targets the selected shell.
+    Stale(String),
 }
 
 /// Complete a pending manager focus only after the expected owner is attached
@@ -337,19 +337,18 @@ pub async fn complete_pending_shell_focus(
             return;
         }
     };
-    let SelectOutcome::Selected = outcome else {
-        // PendingGone or Stale: do not confirm focus. On Stale, best-effort
-        // hide the shell to restore the hidden-shell invariant (issue #374).
-        if matches!(outcome, SelectOutcome::Stale) {
+    match outcome {
+        SelectOutcome::PendingGone => return,
+        SelectOutcome::Stale(session_name) => {
             warn!(
                 agent_id = %attached_agent_id.0,
                 "manager: attached owner changed during focus select; discarding"
             );
-            let session_name = RuntimeSession::session_name_for(&attached_agent_id);
             let _ = jefe::runtime::hide_shell_window(&session_name);
+            return;
         }
-        return;
-    };
+        SelectOutcome::Selected => {}
+    }
     let current = app_state.read().terminal_manager.pending_focus.clone();
     if !matches!(
         current.as_ref(),

--- a/src/app_input/terminal_manager.rs
+++ b/src/app_input/terminal_manager.rs
@@ -261,7 +261,7 @@ fn select_pending_runtime_shell(
     let inputs = {
         let guard = ctx.lock().map_err(|_| {
             jefe::runtime::RuntimeError::CapabilityProbeFailed(
-                "runtime context lock unavailable".to_owned(),
+                "runtime context lock unavailable while capturing shell inputs".to_owned(),
             )
         })?;
         if guard.runtime.attached_agent() != Some(owner) {
@@ -277,13 +277,13 @@ fn select_pending_runtime_shell(
     inputs.execute_select()?;
     let guard = ctx.lock().map_err(|_| {
         jefe::runtime::RuntimeError::CapabilityProbeFailed(
-            "runtime context lock unavailable".to_owned(),
+            "runtime context lock unavailable while revalidating shell owner".to_owned(),
         )
     })?;
     if guard.runtime.attached_agent() == Some(owner)
         && guard.runtime.shell_window_owner_matches(&inputs)
     {
-        Ok(SelectOutcome::Selected)
+        Ok(SelectOutcome::Selected(inputs.session_name))
     } else {
         Ok(SelectOutcome::Stale(inputs.session_name))
     }
@@ -293,11 +293,18 @@ fn select_pending_runtime_shell(
 enum SelectOutcome {
     /// Pending focus no longer matches — nothing to confirm.
     PendingGone,
-    /// Select succeeded and the owner is still attached — confirm focus.
-    Selected,
+    /// Select succeeded and the owner is still attached. Carries the
+    /// snapshotted session for compensation if confirmation later goes stale.
+    Selected(String),
     /// Select succeeded but the attached owner changed while off-lock. Carries
     /// the snapshotted session so compensation targets the selected shell.
     Stale(String),
+}
+
+fn compensate_stale_selection(session_name: &str, phase: &'static str) {
+    if let Err(error) = jefe::runtime::hide_shell_window(session_name) {
+        warn!(session_name, error = %error, phase, "manager: stale selection compensation failed");
+    }
 }
 
 /// Complete a pending manager focus only after the expected owner is attached
@@ -337,18 +344,18 @@ pub async fn complete_pending_shell_focus(
             return;
         }
     };
-    match outcome {
+    let selected_session_name = match outcome {
         SelectOutcome::PendingGone => return,
         SelectOutcome::Stale(session_name) => {
             warn!(
                 agent_id = %attached_agent_id.0,
                 "manager: attached owner changed during focus select; discarding"
             );
-            let _ = jefe::runtime::hide_shell_window(&session_name);
+            compensate_stale_selection(&session_name, "owner revalidation");
             return;
         }
-        SelectOutcome::Selected => {}
-    }
+        SelectOutcome::Selected(session_name) => session_name,
+    };
     let current = app_state.read().terminal_manager.pending_focus.clone();
     if !matches!(
         current.as_ref(),
@@ -356,8 +363,7 @@ pub async fn complete_pending_shell_focus(
             if value.agent_id == attached_agent_id
                 && value.generation == pending.generation
     ) {
-        let session_name = RuntimeSession::session_name_for(&attached_agent_id);
-        let _ = jefe::runtime::hide_shell_window(&session_name);
+        compensate_stale_selection(&selected_session_name, "pending focus changed");
         return;
     }
     dispatch_app_event(

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -198,29 +198,39 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
                         count = dead_identities.len(),
                         "liveness poll found dead agents"
                     );
-                    let dead_previews =
+                    let dead_previews: std::collections::HashMap<_, _> =
                         crate::app_shell_workers::capture_dead_previews(dead_identities.clone())
-                            .await;
+                            .await
+                            .into_iter()
+                            .map(|(identity, lines)| (identity.agent_id, lines))
+                            .collect();
                     let mut state = app_state.write();
+                    let current_bindings: std::collections::HashMap<_, _> = state
+                        .agents
+                        .iter()
+                        .map(|agent| {
+                            let identity = agent.runtime_binding.as_ref().map_or((None, 0), |binding| {
+                                (
+                                    Some(binding.session_name.clone()),
+                                    binding.lifecycle_generation,
+                                )
+                            });
+                            (agent.id.clone(), identity)
+                        })
+                        .collect();
                     let mut changed = false;
                     for identity in &dead_identities {
-                        let binding_matches = state.agents.iter().any(|agent| {
-                            agent.id == identity.agent_id
-                                && agent.runtime_binding.as_ref().is_some_and(|binding| {
-                                    Some(binding.session_name.as_str())
-                                        == identity.binding_session_name.as_deref()
-                                        && binding.lifecycle_generation
-                                            == identity.lifecycle_generation
-                                })
-                        });
+                        let binding_matches = current_bindings
+                            .get(&identity.agent_id)
+                            .is_some_and(|(session_name, lifecycle_generation)| {
+                                session_name.as_deref() == identity.binding_session_name.as_deref()
+                                    && *lifecycle_generation == identity.lifecycle_generation
+                            });
                         if !binding_matches {
                             debug!(agent_id = %identity.agent_id.0, "liveness: stale result after preview capture; skipping");
                             continue;
                         }
-                        let preview = dead_previews
-                            .iter()
-                            .find(|(captured, _)| captured == identity)
-                            .map(|(_, lines)| lines.clone());
+                        let preview = dead_previews.get(&identity.agent_id).cloned();
                         *state = std::mem::take(&mut *state).apply(AppEvent::AgentStatusChanged(
                             identity.agent_id.clone(),
                             AgentStatus::Dead,

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -124,8 +124,7 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     // hidden shells against the multiplexer off the input/render path.
     hooks.use_future({
         let app_state = app_state;
-        let ctx = ctx.clone();
-        async move { crate::app_input::shell_overlay::observe_shell_inventory(app_state, ctx).await }
+        async move { crate::app_input::shell_overlay::observe_shell_inventory(app_state).await }
     });
     hooks.use_future({
         let app_state = app_state;
@@ -205,26 +204,19 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
                             .map(|(identity, lines)| (identity.agent_id, lines))
                             .collect();
                     let mut state = app_state.write();
-                    let current_bindings: std::collections::HashMap<_, _> = state
-                        .agents
-                        .iter()
-                        .map(|agent| {
-                            let identity = agent.runtime_binding.as_ref().map_or((None, 0), |binding| {
-                                (
-                                    Some(binding.session_name.clone()),
-                                    binding.lifecycle_generation,
-                                )
-                            });
-                            (agent.id.clone(), identity)
-                        })
-                        .collect();
                     let mut changed = false;
                     for identity in &dead_identities {
-                        let binding_matches = current_bindings
-                            .get(&identity.agent_id)
-                            .is_some_and(|(session_name, lifecycle_generation)| {
-                                session_name.as_deref() == identity.binding_session_name.as_deref()
-                                    && *lifecycle_generation == identity.lifecycle_generation
+                        let binding_matches = state
+                            .agents
+                            .iter()
+                            .find(|agent| agent.id == identity.agent_id)
+                            .is_some_and(|agent| {
+                                agent.runtime_binding.as_ref().is_some_and(|binding| {
+                                    Some(binding.session_name.as_str())
+                                        == identity.binding_session_name.as_deref()
+                                        && binding.lifecycle_generation
+                                            == identity.lifecycle_generation
+                                })
                             });
                         if !binding_matches {
                             debug!(agent_id = %identity.agent_id.0, "liveness: stale result after preview capture; skipping");
@@ -913,9 +905,9 @@ pub fn wants_live_snapshot_pub(status: AgentStatus) -> bool {
 
 /// Capture terminal output for the currently selected agent if available.
 ///
-/// Dead agents read their preview from the runtime-only `dead_preview` cache
-/// populated once by the off-lock liveness worker (issue #374 S4), so the
-/// render path never shells out to tmux per-frame for crash text.
+/// Dead agents read their preview from an in-memory cache within `AppState`,
+/// populated once by the off-lock liveness worker (issue #374 S4) and excluded
+/// from persistence, so rendering never shells out to tmux per frame.
 pub fn capture_terminal_snapshot(
     ctx: Option<&CtxArc>,
     snapshot: &AppState,

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -198,7 +198,7 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
                         count = dead_identities.len(),
                         "liveness poll found dead agents"
                     );
-                    let dead_previews: std::collections::HashMap<_, _> =
+                    let mut dead_previews: std::collections::HashMap<_, _> =
                         crate::app_shell_workers::capture_dead_previews(dead_identities.clone())
                             .await
                             .into_iter()
@@ -230,7 +230,7 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
                             debug!(agent_id = %identity.agent_id.0, "liveness: stale result after preview capture; skipping");
                             continue;
                         }
-                        let preview = dead_previews.get(&identity.agent_id).cloned();
+                        let preview = dead_previews.remove(&identity.agent_id);
                         *state = std::mem::take(&mut *state).apply(AppEvent::AgentStatusChanged(
                             identity.agent_id.clone(),
                             AgentStatus::Dead,

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -198,72 +198,51 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
                         count = dead_identities.len(),
                         "liveness poll found dead agents"
                     );
-                    // Issue #301 Phase 4: stale-result protection. Before
-                    // marking an agent dead, verify the agent's current
-                    // binding session name and lifecycle generation still
-                    // match the liveness snapshot. A mismatch means the
-                    // agent was rebound/restarted after the check was
-                    // dispatched; skip it.
+                    let dead_previews =
+                        crate::app_shell_workers::capture_dead_previews(dead_identities.clone())
+                            .await;
                     let mut state = app_state.write();
-                    // Build a lookup map from agent_id → (session_name, gen)
-                    // from the current state to avoid O(n*m) scan for each
-                    // identity (issue #301 review feedback).
-                    let current_bindings: std::collections::HashMap<
-                        &AgentId,
-                        (Option<&String>, u64),
-                    > = state
-                        .agents
-                        .iter()
-                        .map(|a| {
-                            let session = a.runtime_binding.as_ref().map(|b| &b.session_name);
-                            let lifecycle_gen = a
-                                .runtime_binding
-                                .as_ref()
-                                .map_or(0, |b| b.lifecycle_generation);
-                            (&a.id, (session, lifecycle_gen))
-                        })
-                        .collect();
-                    let mut to_apply: Vec<AgentId> = Vec::new();
+                    let mut changed = false;
                     for identity in &dead_identities {
-                        let Some(&(current_session, current_gen)) =
-                            current_bindings.get(&identity.agent_id)
-                        else {
-                            // Agent removed from state since the check — skip.
+                        let binding_matches = state.agents.iter().any(|agent| {
+                            agent.id == identity.agent_id
+                                && agent.runtime_binding.as_ref().is_some_and(|binding| {
+                                    Some(binding.session_name.as_str())
+                                        == identity.binding_session_name.as_deref()
+                                        && binding.lifecycle_generation
+                                            == identity.lifecycle_generation
+                                })
+                        });
+                        if !binding_matches {
+                            debug!(agent_id = %identity.agent_id.0, "liveness: stale result after preview capture; skipping");
                             continue;
-                        };
-                        let session_matches =
-                            current_session == identity.binding_session_name.as_ref();
-                        let gen_matches = current_gen == identity.lifecycle_generation;
-                        if session_matches && gen_matches {
-                            to_apply.push(identity.agent_id.clone());
-                        } else {
-                            debug!(
-                                agent_id = %identity.agent_id.0,
-                                checked_session = ?identity.binding_session_name,
-                                current_session = ?current_session,
-                                checked_gen = identity.lifecycle_generation,
-                                current_gen,
-                                "liveness: stale result after rebind/restart; skipping"
-                            );
                         }
-                    }
-                    for agent_id in &to_apply {
+                        let preview = dead_previews
+                            .iter()
+                            .find(|(captured, _)| captured == identity)
+                            .map(|(_, lines)| lines.clone());
                         *state = std::mem::take(&mut *state).apply(AppEvent::AgentStatusChanged(
-                            agent_id.clone(),
+                            identity.agent_id.clone(),
                             AgentStatus::Dead,
                         ));
-                        if let Some(agent) =
-                            state.agents.iter_mut().find(|agent| &agent.id == agent_id)
+                        if let Some(agent) = state
+                            .agents
+                            .iter_mut()
+                            .find(|agent| agent.id == identity.agent_id)
                         {
                             agent.runtime_binding = None;
                         }
+                        if let Some(lines) = preview {
+                            state.store_dead_preview(identity.agent_id.clone(), lines);
+                        }
+                        changed = true;
                     }
-                    if to_apply.is_empty() {
-                        drop(state);
-                    } else {
+                    if changed {
                         let persisted = to_persisted_state(&state);
                         drop(state);
                         persist_state(&ctx, &persisted);
+                    } else {
+                        drop(state);
                     }
                 }
             }
@@ -923,6 +902,10 @@ pub fn wants_live_snapshot_pub(status: AgentStatus) -> bool {
 }
 
 /// Capture terminal output for the currently selected agent if available.
+///
+/// Dead agents read their preview from the runtime-only `dead_preview` cache
+/// populated once by the off-lock liveness worker (issue #374 S4), so the
+/// render path never shells out to tmux per-frame for crash text.
 pub fn capture_terminal_snapshot(
     ctx: Option<&CtxArc>,
     snapshot: &AppState,
@@ -944,21 +927,25 @@ pub fn capture_terminal_snapshot(
         return None;
     }
 
-    // `try_lock` keeps the render cycle non-blocking: when a background attach
-    // holds the ctx mutex, this frame simply returns None and the next frame
-    // picks up the snapshot.
-    let ctx_arc = ctx?;
-    let ctx_guard = ctx_arc.try_lock().ok()?;
     match selected_agent.status {
-        AgentStatus::Running => selected_running_agent_id
-            .as_ref()
-            .filter(|id| ctx_guard.runtime.attached_agent() == Some(*id))
-            .and_then(|_| ctx_guard.runtime.snapshot()),
+        AgentStatus::Running => {
+            // `try_lock` keeps the render cycle non-blocking: when a background
+            // attach holds the ctx mutex, this frame simply returns None and
+            // the next frame picks up the snapshot.
+            let ctx_arc = ctx?;
+            let ctx_guard = ctx_arc.try_lock().ok()?;
+            selected_running_agent_id
+                .as_ref()
+                .filter(|id| ctx_guard.runtime.attached_agent() == Some(*id))
+                .and_then(|_| ctx_guard.runtime.snapshot())
+        }
         AgentStatus::Dead => selected_agent_id.as_ref().and_then(|agent_id| {
             snapshot
                 .repository_for_agent(agent_id)
-                .filter(|repository| !repository.remote.enabled)
-                .and_then(|_| ctx_guard.runtime.capture_session_output(agent_id))
+                .filter(|repository| !repository.remote.enabled)?;
+            snapshot
+                .dead_preview(agent_id)
+                .map(jefe::runtime::snapshot_from_lines)
         }),
         _ => None,
     }

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -387,7 +387,7 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
         // and hidden) exactly once, best-effort, without killing agent
         // sessions (issue #361 PR A). Replaces the prior separate
         // cleanup_active_shell call so the visible shell is not closed twice.
-        crate::app_input::shell_overlay::shutdown_all_shells(&mut app_state, &ctx);
+        crate::app_input::shell_overlay::shutdown_all_shells(&mut app_state);
         // Issue #301: flush the coalescing persistence worker so the final
         // state is durable before exit.
         crate::app_shell_workers::shutdown_flush_persist(ctx.as_ref());

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -204,20 +204,39 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
                             .map(|(identity, lines)| (identity.agent_id, lines))
                             .collect();
                     let mut state = app_state.write();
-                    let mut changed = false;
-                    for identity in &dead_identities {
-                        let binding_matches = state
+                    let binding_matches = {
+                        let current_bindings: std::collections::HashMap<_, _> = state
                             .agents
                             .iter()
-                            .find(|agent| agent.id == identity.agent_id)
-                            .is_some_and(|agent| {
-                                agent.runtime_binding.as_ref().is_some_and(|binding| {
-                                    Some(binding.session_name.as_str())
-                                        == identity.binding_session_name.as_deref()
-                                        && binding.lifecycle_generation
-                                            == identity.lifecycle_generation
+                            .filter_map(|agent| {
+                                agent.runtime_binding.as_ref().map(|binding| {
+                                    (
+                                        &agent.id,
+                                        (
+                                            binding.session_name.as_str(),
+                                            binding.lifecycle_generation,
+                                        ),
+                                    )
                                 })
-                            });
+                            })
+                            .collect();
+                        dead_identities
+                            .iter()
+                            .map(|identity| {
+                                current_bindings.get(&identity.agent_id).is_some_and(
+                                    |(session_name, generation)| {
+                                        Some(*session_name)
+                                            == identity.binding_session_name.as_deref()
+                                            && *generation == identity.lifecycle_generation
+                                    },
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                    };
+                    let mut changed = false;
+                    for (identity, binding_matches) in
+                        dead_identities.iter().zip(binding_matches)
+                    {
                         if !binding_matches {
                             debug!(agent_id = %identity.agent_id.0, "liveness: stale result after preview capture; skipping");
                             continue;

--- a/src/app_shell_workers.rs
+++ b/src/app_shell_workers.rs
@@ -9,7 +9,9 @@ use std::time::Duration;
 use tracing::{debug, warn};
 
 use jefe::domain::AgentId;
-use jefe::runtime::{HISTORY_LINE_CAP, RuntimeManager, capture_pane_history, strip_trailing_rows};
+use jefe::runtime::{
+    HISTORY_LINE_CAP, LivenessIdentity, RuntimeManager, capture_pane_history, strip_trailing_rows,
+};
 use jefe::services::capture_worker::{CaptureHandle, should_store_result};
 
 use crate::AppContext;
@@ -26,6 +28,30 @@ pub fn is_pty_dirty(ctx: Option<&Arc<std::sync::Mutex<AppContext>>>) -> bool {
         return false;
     };
     ctx_guard.runtime.take_dirty()
+}
+
+/// Capture frozen pane previews for newly dead local agents without holding
+/// `AppContext` (issue #374).
+pub async fn capture_dead_previews(
+    targets: Vec<LivenessIdentity>,
+) -> Vec<(LivenessIdentity, Vec<String>)> {
+    smol::unblock(move || {
+        targets
+            .into_iter()
+            .filter_map(|target| {
+                let session_name = target.binding_session_name.as_deref()?;
+                let pane_target = format!("{session_name}:0");
+                match jefe::runtime::capture_pane_lines_result(&pane_target) {
+                    Ok(lines) => Some((target, lines)),
+                    Err(error) => {
+                        warn!(agent_id = %target.agent_id.0, error = %error, "dead preview capture failed");
+                        None
+                    }
+                }
+            })
+            .collect()
+    })
+    .await
 }
 
 /// Poll interval for the persistence worker drain loop.
@@ -207,6 +233,53 @@ pub fn capture_history_from_cache(ctx: Option<&Arc<std::sync::Mutex<AppContext>>
         .history_cache_get(&attached_agent, generation)
         .cloned()
         .unwrap_or_default()
+}
+
+/// Try to read cached history lines for the attached session without a
+/// multiplexer subprocess, returning `None` on contention, no attached
+/// session, or a cold cache miss (issue #374 S3).
+///
+/// Unlike [`capture_history_from_cache`], this preserves prior geometry on a
+/// cold miss: callers (mouse scroll/selection geometry) can return early
+/// instead of zeroing `history_count`, which would clear the scroll offset
+/// and jump to follow-tail during attach.
+#[must_use]
+pub fn try_capture_history_geometry_from_cache(
+    ctx: Option<&Arc<std::sync::Mutex<AppContext>>>,
+) -> Option<(usize, usize)> {
+    let ctx_arc = ctx?;
+    let ctx_guard = ctx_arc.try_lock().ok()?;
+    let attached_agent = ctx_guard.runtime.attached_agent()?;
+    let session = ctx_guard.runtime.get_session(attached_agent)?;
+    let generation = ctx_guard.runtime.output_generation();
+    let handle: &CaptureHandle = &ctx_guard.capture_handle;
+    let need_request = LAST_CAPTURE_REQUEST.with(|cell| {
+        let prev = cell.borrow();
+        let changed = prev
+            .as_ref()
+            .is_some_and(|(a, g)| a != attached_agent || *g != generation)
+            || prev.is_none();
+        drop(prev);
+        if changed {
+            *cell.borrow_mut() = Some((attached_agent.clone(), generation));
+        }
+        changed
+    });
+    if need_request {
+        handle.request(
+            attached_agent.clone(),
+            session.session_name.clone(),
+            generation,
+        );
+    }
+    let history_count = ctx_guard
+        .runtime
+        .history_cache_get(attached_agent, generation)
+        .or_else(|| ctx_guard.runtime.history_cache_fallback(attached_agent))?
+        .len();
+    let live_rows = ctx_guard.runtime.snapshot()?.rows;
+    drop(ctx_guard);
+    Some((history_count, live_rows))
 }
 
 thread_local! {

--- a/src/app_shell_workers.rs
+++ b/src/app_shell_workers.rs
@@ -32,6 +32,9 @@ pub fn is_pty_dirty(ctx: Option<&Arc<std::sync::Mutex<AppContext>>>) -> bool {
 
 /// Capture frozen pane previews for newly dead local agents without holding
 /// `AppContext` (issue #374).
+///
+/// Runtime sessions dedicate window 0 to the owning agent; embedded shells use
+/// the separately named `jefe-shell` window, so dead-agent capture targets `:0`.
 pub async fn capture_dead_previews(
     targets: Vec<LivenessIdentity>,
 ) -> Vec<(LivenessIdentity, Vec<String>)> {

--- a/src/app_shell_workers.rs
+++ b/src/app_shell_workers.rs
@@ -241,9 +241,9 @@ pub fn capture_history_from_cache(ctx: Option<&Arc<std::sync::Mutex<AppContext>>
         .unwrap_or_default()
 }
 
-/// Try to read cached history lines for the attached session without a
-/// multiplexer subprocess, returning `None` on contention, no attached
-/// session, or a cold cache miss (issue #374 S3).
+/// Try to read cached history geometry for the attached session without a
+/// multiplexer subprocess. Contention, no attachment, and a cold cache all
+/// return `None` so mouse routing preserves its prior geometry (issue #374 S3).
 ///
 /// Unlike [`capture_history_from_cache`], this preserves prior geometry on a
 /// cold miss: callers (mouse scroll/selection geometry) can return early

--- a/src/app_shell_workers.rs
+++ b/src/app_shell_workers.rs
@@ -39,7 +39,10 @@ pub async fn capture_dead_previews(
         targets
             .into_iter()
             .filter_map(|target| {
-                let session_name = target.binding_session_name.as_deref()?;
+                let Some(session_name) = target.binding_session_name.as_deref() else {
+                    debug!(agent_id = %target.agent_id.0, "dead preview skipped without a runtime binding");
+                    return None;
+                };
                 let pane_target = format!("{session_name}:0");
                 match jefe::runtime::capture_pane_lines_result(&pane_target) {
                     Ok(lines) => Some((target, lines)),

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -645,7 +645,7 @@ fn finalize_terminal_selection(
             // read so no multiplexer subprocess runs under a guard (issue #374
             // S3).
             let (cols, rows) = terminal_size();
-            let history_lines = crate::app_shell_workers::capture_history_from_cache(ctx).clone();
+            let history_lines = crate::app_shell_workers::capture_history_from_cache(ctx);
             let state = app_state.read();
             let content =
                 projected_pane_content(selection.pane(), &state, None, &history_lines, cols, rows);
@@ -700,7 +700,7 @@ fn finalize_and_copy_selection(
         // Capture history lines for the selection content projection (issue
         // #198). Cache-only read so no multiplexer subprocess runs under a
         // guard (issue #374 S3).
-        let history_lines = crate::app_shell_workers::capture_history_from_cache(ctx).clone();
+        let history_lines = crate::app_shell_workers::capture_history_from_cache(ctx);
         let (cols, rows) = terminal_size();
         let content = projected_pane_content(
             selection.pane(),

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -38,25 +38,20 @@ fn refresh_terminal_scroll_geometry_from_ctx(
     let (cols, rows) = terminal_size();
     let pty_layout = active_pty_layout(cols, rows, overlay_active);
 
+    // Cache-only history read: no multiplexer subprocess while holding the
+    // context guard (issue #374 S3). On cold miss/contention, preserve prior
+    // geometry instead of zeroing it (which would clear the scroll offset
+    // and jump to follow-tail during attach).
     let (history_count, live_rows) = match ctx {
-        Some(ctx_arc) => match ctx_arc.try_lock() {
-            Ok(mut guard) => {
-                let history_count = guard.runtime.capture_history().map_or(0, |v| v.len());
-                let live_rows = guard.runtime.snapshot().map_or(0, |s| s.rows);
-                (history_count, live_rows)
-            }
-            Err(_) => {
-                // Lock contention: preserve existing geometry instead of
-                // zeroing it. Zeroing would clear the scroll offset and jump
-                // to follow-tail during attach.
+        Some(ctx_arc) => {
+            let Some(geometry) =
+                crate::app_shell_workers::try_capture_history_geometry_from_cache(Some(ctx_arc))
+            else {
                 return;
-            }
-        },
-        None => {
-            // No context: preserve existing geometry instead of zeroing it.
-            // Zeroing would clear the scroll offset.
-            return;
+            };
+            geometry
         }
+        None => return,
     };
 
     let mut state = app_state.write();
@@ -646,12 +641,11 @@ fn finalize_terminal_selection(
             terminal_selection_text(snap, &selection)
         } else {
             // No bound snapshot — fall back to generic extraction (issue #198:
-            // include retained history lines for the terminal pane).
+            // include retained history lines for the terminal pane). Cache-only
+            // read so no multiplexer subprocess runs under a guard (issue #374
+            // S3).
             let (cols, rows) = terminal_size();
-            let history_lines = ctx
-                .and_then(|ctx_arc| ctx_arc.try_lock().ok())
-                .and_then(|mut guard| guard.runtime.capture_history())
-                .unwrap_or_default();
+            let history_lines = crate::app_shell_workers::capture_history_from_cache(ctx).clone();
             let state = app_state.read();
             let content =
                 projected_pane_content(selection.pane(), &state, None, &history_lines, cols, rows);
@@ -703,15 +697,10 @@ fn finalize_and_copy_selection(
                 .filter(|a| a.is_running())
                 .map(|a| &a.id),
         );
-        // Capture history lines for the selection content projection (issue #198).
-        let history_lines = ctx
-            .and_then(|ctx_arc| {
-                ctx_arc
-                    .try_lock()
-                    .ok()
-                    .and_then(|mut guard| guard.runtime.capture_history())
-            })
-            .unwrap_or_default();
+        // Capture history lines for the selection content projection (issue
+        // #198). Cache-only read so no multiplexer subprocess runs under a
+        // guard (issue #374 S3).
+        let history_lines = crate::app_shell_workers::capture_history_from_cache(ctx).clone();
         let (cols, rows) = terminal_size();
         let content = projected_pane_content(
             selection.pane(),

--- a/src/runtime/capture_ops.rs
+++ b/src/runtime/capture_ops.rs
@@ -25,6 +25,12 @@ pub fn capture_session_output(
 
     let lines = commands::capture_pane_lines(&session.session_name)?;
 
+    Some(snapshot_from_lines(&lines))
+}
+
+/// Project plain pane lines into an unstyled terminal snapshot.
+#[must_use]
+pub fn snapshot_from_lines(lines: &[String]) -> TerminalSnapshot {
     let rows = lines.len();
     let cols = lines
         .iter()
@@ -33,7 +39,7 @@ pub fn capture_session_output(
         .unwrap_or(0);
 
     if rows == 0 || cols == 0 {
-        return Some(TerminalSnapshot::default());
+        return TerminalSnapshot::default();
     }
 
     let default_style = TerminalCellStyle {
@@ -43,7 +49,6 @@ pub fn capture_session_output(
         dim: false,
         underline: false,
     };
-
     let mut snapshot = TerminalSnapshot::blank(rows, cols, default_style);
     for (r, line) in lines.iter().enumerate() {
         for (c, ch) in line.chars().enumerate() {
@@ -54,8 +59,7 @@ pub fn capture_session_output(
             };
         }
     }
-
-    Some(snapshot)
+    snapshot
 }
 
 /// Retrieve retained scrollback history lines for the currently attached

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -48,9 +48,10 @@ pub use capabilities::{
     AgentRuntimeCapabilities, ModelDiscovery, code_puppy_help_supports_yolo, static_capabilities,
     validate_code_puppy_launch,
 };
-pub use commands::build_remote_attach_plan;
+pub use capture_ops::snapshot_from_lines;
 #[cfg(feature = "psmux-smoke")]
 pub use commands::configure_prefix_for_passthrough_with_plan;
+pub use commands::{build_remote_attach_plan, capture_pane_lines};
 pub use errors::RuntimeError;
 pub use external_terminal::{
     DesktopPlatform, ExternalTerminalError, ExternalTerminalPlan, build_external_terminal_plan,
@@ -85,8 +86,9 @@ pub use process::{
 };
 pub use session::{RuntimeSession, TerminalCell, TerminalCellStyle, TerminalSnapshot};
 pub use shell_window::{
-    SHELL_WINDOW_NAME, capture_shell_preview, close_shell_window, hide_shell_window,
-    open_shell_window, shell_window_exists,
+    SHELL_WINDOW_NAME, ShellWindowInputs, capture_shell_preview, close_all_shell_windows,
+    close_shell_window, hide_shell_window, observe_shell_window_sessions, open_shell_window,
+    shell_window_exists,
 };
 pub use socket::jefe_tmux_socket_path;
 pub use stub_manager::StubRuntimeManager;
@@ -94,7 +96,7 @@ pub use stub_manager::StubRuntimeManager;
 /// Issue #301 Phase 2: re-export history cache types and pane capture for
 /// the async capture worker in `app_shell`.
 pub use manager::history_cache::{HistoryCache, strip_trailing_rows};
-pub use pane_capture::capture_pane_history;
+pub use pane_capture::{capture_pane_history, capture_pane_lines_args, capture_pane_lines_result};
 
 #[cfg(test)]
 #[path = "agent_executable_tests.rs"]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -96,7 +96,7 @@ pub use stub_manager::StubRuntimeManager;
 /// Issue #301 Phase 2: re-export history cache types and pane capture for
 /// the async capture worker in `app_shell`.
 pub use manager::history_cache::{HistoryCache, strip_trailing_rows};
-pub use pane_capture::{capture_pane_history, capture_pane_lines_args, capture_pane_lines_result};
+pub use pane_capture::{capture_pane_history, capture_pane_lines_result};
 
 #[cfg(test)]
 #[path = "agent_executable_tests.rs"]

--- a/src/runtime/pane_capture.rs
+++ b/src/runtime/pane_capture.rs
@@ -4,21 +4,40 @@
 //! hard limit. Each function shells out to the jefe-private tmux socket via
 //! [`super::commands::tmux_command`].
 
+use super::RuntimeError;
 use super::commands::tmux_command;
 
-/// Capture pane output for a session as plain text lines.
-pub fn capture_pane_lines(session_name: &str) -> Option<Vec<String>> {
-    let output = tmux_command()
-        .ok()?
-        .args(["capture-pane", "-p", "-t", session_name])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
+/// Build the plain pane-capture argv for an explicit multiplexer target.
+#[must_use]
+pub fn capture_pane_lines_args(target: &str) -> Vec<String> {
+    vec![
+        "capture-pane".to_owned(),
+        "-p".to_owned(),
+        "-t".to_owned(),
+        target.to_owned(),
+    ]
+}
 
+/// Capture pane output for an explicit target with typed diagnostics.
+pub fn capture_pane_lines_result(target: &str) -> Result<Vec<String>, RuntimeError> {
+    let output = tmux_command()?
+        .args(capture_pane_lines_args(target))
+        .output()
+        .map_err(|error| RuntimeError::CapabilityProbeFailed(error.to_string()))?;
+    if !output.status.success() {
+        return Err(RuntimeError::CapabilityProbeFailed(format!(
+            "tmux capture-pane failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
     let text = String::from_utf8_lossy(&output.stdout);
-    Some(text.lines().map(std::borrow::ToOwned::to_owned).collect())
+    Ok(text.lines().map(std::borrow::ToOwned::to_owned).collect())
+}
+
+/// Capture pane output for a session as plain text lines.
+#[must_use]
+pub fn capture_pane_lines(session_name: &str) -> Option<Vec<String>> {
+    capture_pane_lines_result(session_name).ok()
 }
 
 /// Build the `capture-pane -p -S -<N> -E -` argv for a bounded history capture.

--- a/src/runtime/pane_capture.rs
+++ b/src/runtime/pane_capture.rs
@@ -130,3 +130,16 @@ pub fn pane_pid(session_name: &str) -> Option<u32> {
     }
     parse_pane_pid(&String::from_utf8_lossy(&output.stdout))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::capture_pane_lines_args;
+
+    #[test]
+    fn pane_capture_targets_explicit_window() {
+        assert_eq!(
+            capture_pane_lines_args("jefe-owner:0"),
+            ["capture-pane", "-p", "-t", "jefe-owner:0"]
+        );
+    }
+}

--- a/src/runtime/pane_capture.rs
+++ b/src/runtime/pane_capture.rs
@@ -9,7 +9,7 @@ use super::commands::tmux_command;
 
 /// Build the plain pane-capture argv for an explicit multiplexer target.
 #[must_use]
-pub fn capture_pane_lines_args(target: &str) -> Vec<String> {
+fn capture_pane_lines_args(target: &str) -> Vec<String> {
     vec![
         "capture-pane".to_owned(),
         "-p".to_owned(),

--- a/src/runtime/shell_window.rs
+++ b/src/runtime/shell_window.rs
@@ -23,35 +23,155 @@ fn manager_session<'a>(
         .ok_or_else(|| RuntimeError::SessionNotFound(agent_id.0.clone()))
 }
 
+/// Immutable inputs needed to drive a shell-window subprocess without holding
+/// an `AppContext` guard (issue #374 S1).
+///
+/// Mirrors the existing `AttachInputs` snapshot/free-execute boundary: the
+/// caller captures this under a short lock, releases the lock, runs the
+/// (potentially blocking) multiplexer subprocess via `execute_*`, then
+/// revalidates ownership with [`ShellWindowInputs::owner_still_matches`]
+/// before applying the result. Command construction is unchanged from the
+/// in-lock path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ShellWindowInputs {
+    /// The owning agent id captured at snapshot time.
+    pub owner: AgentId,
+    /// The multiplexer session name backing the owner (e.g. `jefe-{agent_id}`).
+    pub session_name: String,
+    /// Runtime lifecycle captured with the session identity.
+    pub lifecycle_generation: u64,
+    /// Whether the owner's repository is remote. Remote snapshots are rejected
+    /// by `execute_*` because the embedded shell is local-only.
+    pub remote_enabled: bool,
+    /// The owner's working directory, needed only by `execute_open`.
+    pub work_dir: std::path::PathBuf,
+}
+
+impl ShellWindowInputs {
+    /// Open (create-or-select) the shell window off-lock. Remote snapshots are
+    /// rejected without a subprocess, matching the in-lock path's invariant.
+    pub fn execute_open(&self) -> Result<(), RuntimeError> {
+        if self.remote_enabled {
+            return Err(RuntimeError::SpawnFailed(
+                "embedded shell is local-only for remote repositories".to_owned(),
+            ));
+        }
+        open_shell_window(&self.session_name, &self.work_dir)
+    }
+
+    /// Select the existing shell window off-lock. Remote snapshots are rejected
+    /// without a subprocess; a missing window surfaces `SessionNotFound`.
+    pub fn execute_select(&self) -> Result<(), RuntimeError> {
+        if self.remote_enabled {
+            return Err(RuntimeError::SpawnFailed(
+                "embedded shell is local-only for remote repositories".to_owned(),
+            ));
+        }
+        if !shell_window_exists(&self.session_name)? {
+            return Err(RuntimeError::SessionNotFound(self.owner.0.clone()));
+        }
+        select_shell_window(&self.session_name)
+    }
+
+    /// Close (kill) the shell window off-lock. No owner restriction: the
+    /// session-name-free close path tolerates dead owners.
+    pub fn execute_close(&self) -> Result<(), RuntimeError> {
+        close_shell_window(&self.session_name)
+    }
+
+    /// Hide the shell window off-lock by selecting window 0.
+    pub fn execute_hide(&self) -> Result<(), RuntimeError> {
+        hide_shell_window(&self.session_name)
+    }
+
+    /// Revalidate that the owner is still tracked with the same session name
+    /// after an off-lock subprocess (issue #374 stale-owner guard).
+    ///
+    /// `sessions` is the current `TmuxRuntimeManager::sessions` map; a mismatch
+    /// means the attached owner changed while the subprocess was in flight and
+    /// the result must be discarded.
+    #[must_use]
+    pub fn owner_still_matches(&self, sessions: &HashMap<AgentId, RuntimeSession>) -> bool {
+        sessions.get(&self.owner).is_some_and(|session| {
+            session.session_name == self.session_name
+                && session.lifecycle_generation == self.lifecycle_generation
+        })
+    }
+}
+
+/// Build a [`ShellWindowInputs`] snapshot for `agent_id` from the current
+/// sessions map (issue #374 S1). Returns `None` for an untracked agent so the
+/// caller surfaces the typed `SessionNotFound` failure under the short lock
+/// before releasing it.
+#[must_use]
+pub fn shell_window_inputs_for(
+    sessions: &HashMap<AgentId, RuntimeSession>,
+    agent_id: &AgentId,
+) -> Option<ShellWindowInputs> {
+    let session = sessions.get(agent_id)?;
+    Some(ShellWindowInputs {
+        owner: agent_id.clone(),
+        session_name: session.session_name.clone(),
+        lifecycle_generation: session.lifecycle_generation,
+        remote_enabled: session.launch_signature.remote.enabled,
+        work_dir: session.launch_signature.work_dir.clone(),
+    })
+}
+
+impl super::manager::TmuxRuntimeManager {
+    /// Snapshot the actual session_name/work_dir/remote for `agent_id` while
+    /// the manager lock is held, so the shell-window subprocess can run
+    /// off-lock (issue #374 S1).
+    ///
+    /// This is the concrete snapshot boundary: the caller holds the
+    /// `AppContext` mutex, calls this to capture typed inputs, then releases
+    /// the lock and dispatches `ShellWindowInputs::execute_*`. Returns `None`
+    /// for an untracked agent so the caller surfaces `SessionNotFound` under
+    /// the short lock.
+    #[must_use]
+    pub fn shell_window_inputs(&self, agent_id: &AgentId) -> Option<ShellWindowInputs> {
+        shell_window_inputs_for(&self.sessions, agent_id)
+    }
+
+    /// Revalidate that the owner captured in `inputs` is still tracked with
+    /// the same session name after an off-lock subprocess (issue #374 S2).
+    ///
+    /// Used by open/select paths to reject stale results when the attached
+    /// owner changed while the subprocess was in flight.
+    #[must_use]
+    pub fn shell_window_owner_matches(&self, inputs: &ShellWindowInputs) -> bool {
+        inputs.owner_still_matches(&self.sessions)
+    }
+}
+
 pub(super) fn open_manager_shell_window(
     sessions: &HashMap<AgentId, RuntimeSession>,
     agent_id: &AgentId,
 ) -> Result<(), RuntimeError> {
-    let session = manager_session(sessions, agent_id)?;
-    if session.launch_signature.remote.enabled {
-        return Err(RuntimeError::SpawnFailed(
-            "embedded shell is local-only for remote repositories".to_owned(),
-        ));
-    }
-    open_shell_window(&session.session_name, &session.launch_signature.work_dir)
+    let Some(inputs) = shell_window_inputs_for(sessions, agent_id) else {
+        return Err(RuntimeError::SessionNotFound(agent_id.0.clone()));
+    };
+    inputs.execute_open()
 }
 
 pub(super) fn select_manager_shell_window(
     sessions: &HashMap<AgentId, RuntimeSession>,
     agent_id: &AgentId,
 ) -> Result<(), RuntimeError> {
-    let session = manager_session(sessions, agent_id)?;
-    if !shell_window_exists(&session.session_name)? {
+    let Some(inputs) = shell_window_inputs_for(sessions, agent_id) else {
         return Err(RuntimeError::SessionNotFound(agent_id.0.clone()));
-    }
-    select_shell_window(&session.session_name)
+    };
+    inputs.execute_select()
 }
 
 pub(super) fn close_manager_shell_window(
     sessions: &HashMap<AgentId, RuntimeSession>,
     agent_id: &AgentId,
 ) -> Result<(), RuntimeError> {
-    close_shell_window(&manager_session(sessions, agent_id)?.session_name)
+    let Some(inputs) = shell_window_inputs_for(sessions, agent_id) else {
+        return Err(RuntimeError::SessionNotFound(agent_id.0.clone()));
+    };
+    inputs.execute_close()
 }
 
 /// Hide the embedded shell window for an agent by selecting window 0
@@ -60,7 +180,10 @@ pub(super) fn hide_manager_shell_window(
     sessions: &HashMap<AgentId, RuntimeSession>,
     agent_id: &AgentId,
 ) -> Result<(), RuntimeError> {
-    hide_shell_window(&manager_session(sessions, agent_id)?.session_name)
+    let Some(inputs) = shell_window_inputs_for(sessions, agent_id) else {
+        return Err(RuntimeError::SessionNotFound(agent_id.0.clone()));
+    };
+    inputs.execute_hide()
 }
 
 /// Close every tracked `jefe-shell` window best-effort (issue #361 PR A).
@@ -483,3 +606,7 @@ mod tests;
 #[cfg(test)]
 #[path = "shell_lifecycle_tests.rs"]
 mod lifecycle_tests;
+
+#[cfg(test)]
+#[path = "shell_window_snapshot_tests.rs"]
+mod snapshot_tests;

--- a/src/runtime/shell_window.rs
+++ b/src/runtime/shell_window.rs
@@ -40,8 +40,8 @@ pub struct ShellWindowInputs {
     pub session_name: String,
     /// Runtime lifecycle captured with the session identity.
     pub lifecycle_generation: u64,
-    /// Whether the owner's repository is remote. Remote snapshots are rejected
-    /// by `execute_*` because the embedded shell is local-only.
+    /// Whether the owner's repository is remote. Open/select reject remote
+    /// snapshots; close/hide remain available for cleanup and compensation.
     pub remote_enabled: bool,
     /// The owner's working directory, needed only by `execute_open`.
     pub work_dir: std::path::PathBuf,

--- a/src/runtime/shell_window.rs
+++ b/src/runtime/shell_window.rs
@@ -73,8 +73,8 @@ impl ShellWindowInputs {
         select_shell_window(&self.session_name)
     }
 
-    /// Close (kill) the shell window off-lock. No owner restriction: the
-    /// session-name-free close path tolerates dead owners.
+    /// Close (kill) the shell window off-lock after its tracked session was
+    /// snapshotted. The operation itself does not require the owner to be live.
     pub fn execute_close(&self) -> Result<(), RuntimeError> {
         close_shell_window(&self.session_name)
     }

--- a/src/runtime/shell_window.rs
+++ b/src/runtime/shell_window.rs
@@ -32,7 +32,7 @@ fn manager_session<'a>(
 /// revalidates ownership with [`ShellWindowInputs::owner_still_matches`]
 /// before applying the result. Command construction is unchanged from the
 /// in-lock path.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct ShellWindowInputs {
     /// The owning agent id captured at snapshot time.
     pub owner: AgentId,

--- a/src/runtime/shell_window_snapshot_tests.rs
+++ b/src/runtime/shell_window_snapshot_tests.rs
@@ -8,8 +8,8 @@
 
 use std::collections::HashMap;
 
+use super::super::RuntimeError;
 use super::super::manager::TmuxRuntimeManager;
-use super::super::*;
 use super::{ShellWindowInputs, shell_window_inputs_for};
 use crate::domain::{AgentId, LaunchSignature};
 use crate::runtime::RuntimeSession;
@@ -217,12 +217,4 @@ fn revalidate_rejects_when_lifecycle_generation_changes() {
         session.lifecycle_generation = session.lifecycle_generation.wrapping_add(1);
     }
     assert!(!inputs.owner_still_matches(&mgr.sessions));
-}
-
-#[test]
-fn dead_preview_capture_targets_agent_window_zero() {
-    assert_eq!(
-        crate::runtime::capture_pane_lines_args("jefe-owner:0"),
-        ["capture-pane", "-p", "-t", "jefe-owner:0"]
-    );
 }

--- a/src/runtime/shell_window_snapshot_tests.rs
+++ b/src/runtime/shell_window_snapshot_tests.rs
@@ -1,0 +1,224 @@
+//! Tests for the immutable shell-operation snapshot boundary (issue #374 S1).
+//!
+//! These tests verify the typed `ShellWindowInputs` snapshot/free-execute
+//! boundary: a snapshot is taken under a short lock, subprocess execution
+//! happens off-lock, and revalidation rejects stale owners. The tests target
+//! the pure decision seams (snapshot construction, owner matching, remote
+//! rejection) without live tmux.
+
+use std::collections::HashMap;
+
+use super::super::manager::TmuxRuntimeManager;
+use super::super::*;
+use super::{ShellWindowInputs, shell_window_inputs_for};
+use crate::domain::{AgentId, LaunchSignature};
+use crate::runtime::RuntimeSession;
+
+fn local_signature(work_dir: &str) -> LaunchSignature {
+    LaunchSignature {
+        work_dir: std::path::PathBuf::from(work_dir),
+        profile: "default".into(),
+        code_puppy_model: String::new(),
+        code_puppy_version: String::new(),
+        code_puppy_yolo: Some(false),
+        code_puppy_quick_resume: false,
+        mode_flags: vec![],
+        llxprt_debug: String::new(),
+        pass_continue: true,
+        sandbox_enabled: false,
+        sandbox_engine: crate::domain::SandboxEngine::Podman,
+        sandbox_flags: crate::domain::DEFAULT_SANDBOX_FLAGS.to_owned(),
+        remote: crate::domain::RemoteRepositorySettings::default(),
+        agent_kind: crate::domain::AgentKind::Llxprt,
+        llxprt_version: None,
+    }
+}
+
+fn remote_signature() -> LaunchSignature {
+    let mut sig = local_signature("/tmp/remote");
+    sig.remote.enabled = true;
+    sig.remote.host = "example.com".into();
+    sig
+}
+
+fn manager_with_session(agent_id: &AgentId, signature: LaunchSignature) -> TmuxRuntimeManager {
+    let mut mgr = TmuxRuntimeManager::new(24, 80);
+    let session_name = RuntimeSession::session_name_for(agent_id);
+    let mut session = RuntimeSession::new(agent_id.clone(), session_name, signature);
+    session.lifecycle_generation = 7;
+    mgr.sessions.insert(agent_id.clone(), session);
+    mgr
+}
+
+// --- S1: snapshot construction (local/missing/remote) ---
+
+#[test]
+fn snapshot_inputs_carries_session_name_and_local_owner_for_local_agent() {
+    let agent_id = AgentId("local-agent".into());
+    let mgr = manager_with_session(&agent_id, local_signature("/tmp/work"));
+    let inputs = shell_window_inputs_for(&mgr.sessions, &agent_id);
+    assert!(inputs.is_some(), "local session yields snapshot inputs");
+    let inputs = inputs.map(|i| {
+        (
+            i.session_name.clone(),
+            i.owner.clone(),
+            i.lifecycle_generation,
+            i.remote_enabled,
+        )
+    });
+    assert_eq!(
+        inputs,
+        Some(("jefe-local-agent".to_owned(), agent_id.clone(), 7, false))
+    );
+}
+
+#[test]
+fn snapshot_inputs_missing_for_unknown_agent() {
+    let mgr = TmuxRuntimeManager::new(24, 80);
+    let agent_id = AgentId("ghost".into());
+    let inputs = shell_window_inputs_for(&mgr.sessions, &agent_id);
+    assert!(
+        inputs.is_none(),
+        "snapshot must be None for an untracked agent"
+    );
+}
+
+#[test]
+fn snapshot_inputs_reports_remote_enabled_for_remote_agent() {
+    let agent_id = AgentId("remote-agent".into());
+    let mgr = manager_with_session(&agent_id, remote_signature());
+    let inputs = shell_window_inputs_for(&mgr.sessions, &agent_id);
+    assert!(
+        inputs.is_some(),
+        "remote session still yields snapshot inputs for owner/generation checks"
+    );
+    let inputs = inputs.map(|i| (i.remote_enabled, i.owner.clone(), i.session_name.clone()));
+    assert_eq!(
+        inputs,
+        Some((true, agent_id.clone(), "jefe-remote-agent".to_owned()))
+    );
+}
+
+// --- S1: execute rejection (remote, missing session) ---
+
+#[test]
+fn execute_open_rejects_remote_snapshot_without_subprocess() {
+    let inputs = ShellWindowInputs {
+        owner: AgentId("r".into()),
+        session_name: "jefe-r".to_owned(),
+        lifecycle_generation: 0,
+        remote_enabled: true,
+        work_dir: std::path::PathBuf::from("/tmp/remote"),
+    };
+    let result = inputs.execute_open();
+    assert!(result.is_err(), "open must reject a remote snapshot");
+    match result {
+        Err(RuntimeError::SpawnFailed(msg)) => {
+            assert!(
+                msg.contains("remote"),
+                "remote rejection message should mention remote: {msg}"
+            );
+        }
+        other => panic!("expected SpawnFailed for remote open, got {other:?}"),
+    }
+}
+
+#[test]
+fn execute_select_rejects_remote_snapshot_without_subprocess() {
+    let inputs = ShellWindowInputs {
+        owner: AgentId("r".into()),
+        session_name: "jefe-r".to_owned(),
+        lifecycle_generation: 0,
+        remote_enabled: true,
+        work_dir: std::path::PathBuf::from("/tmp/remote"),
+    };
+    let result = inputs.execute_select();
+    assert!(result.is_err(), "select must reject a remote snapshot");
+}
+
+// --- S1: owner revalidation (stale owner rejected) ---
+
+#[test]
+fn revalidate_accepts_matching_owner() {
+    let agent_id = AgentId("owner-1".into());
+    let mgr = manager_with_session(&agent_id, local_signature("/tmp/w"));
+    let sessions: HashMap<AgentId, RuntimeSession> = mgr.sessions.clone();
+    let inputs = shell_window_inputs_for(&mgr.sessions, &agent_id)
+        .unwrap_or_else(|| panic!("expected matching shell inputs"));
+    assert!(
+        inputs.owner_still_matches(&sessions),
+        "matching owner and session name must revalidate"
+    );
+}
+
+#[test]
+fn revalidate_rejects_when_owner_changed() {
+    let original = AgentId("owner-orig".into());
+    let next = AgentId("owner-next".into());
+    let mut mgr = manager_with_session(&original, local_signature("/tmp/w"));
+    // Simulate the background attach swapping the attached session to a
+    // different owner while the shell operation was off-lock.
+    mgr.sessions.clear();
+    let session_name = RuntimeSession::session_name_for(&next);
+    let session = RuntimeSession::new(next.clone(), session_name, local_signature("/tmp/w"));
+    mgr.sessions.insert(next, session);
+    let sessions = mgr.sessions.clone();
+
+    let inputs = ShellWindowInputs {
+        owner: original,
+        session_name: "jefe-owner-orig".to_owned(),
+        lifecycle_generation: 0,
+        remote_enabled: false,
+        work_dir: std::path::PathBuf::from("/tmp/w"),
+    };
+    assert!(
+        !inputs.owner_still_matches(&sessions),
+        "a snapshot whose owner is no longer tracked must be stale"
+    );
+}
+
+#[test]
+fn revalidate_rejects_when_session_name_differs() {
+    // The owner agent id is tracked but its session name changed (rebind).
+    let agent_id = AgentId("owner-rebind".into());
+    let mut sessions = HashMap::new();
+    let session = RuntimeSession::new(
+        agent_id.clone(),
+        "jefe-different-name".to_owned(),
+        local_signature("/tmp/w"),
+    );
+    sessions.insert(agent_id, session);
+
+    let inputs = ShellWindowInputs {
+        owner: AgentId("owner-rebind".into()),
+        session_name: "jefe-owner-rebind".to_owned(),
+        lifecycle_generation: 0,
+        remote_enabled: false,
+
+        work_dir: std::path::PathBuf::from("/tmp/w"),
+    };
+    assert!(
+        !inputs.owner_still_matches(&sessions),
+        "a snapshot whose session name no longer matches must be stale"
+    );
+}
+
+#[test]
+fn revalidate_rejects_when_lifecycle_generation_changes() {
+    let agent_id = AgentId("owner-generation".into());
+    let mut mgr = manager_with_session(&agent_id, local_signature("/tmp/w"));
+    let inputs = shell_window_inputs_for(&mgr.sessions, &agent_id)
+        .unwrap_or_else(|| panic!("expected matching shell inputs"));
+    if let Some(session) = mgr.sessions.get_mut(&agent_id) {
+        session.lifecycle_generation = session.lifecycle_generation.wrapping_add(1);
+    }
+    assert!(!inputs.owner_still_matches(&mgr.sessions));
+}
+
+#[test]
+fn dead_preview_capture_targets_agent_window_zero() {
+    assert_eq!(
+        crate::runtime::capture_pane_lines_args("jefe-owner:0"),
+        ["capture-pane", "-p", "-t", "jefe-owner:0"]
+    );
+}

--- a/src/runtime/shell_window_snapshot_tests.rs
+++ b/src/runtime/shell_window_snapshot_tests.rs
@@ -132,8 +132,12 @@ fn execute_select_rejects_remote_snapshot_without_subprocess() {
         remote_enabled: true,
         work_dir: std::path::PathBuf::from("/tmp/remote"),
     };
-    let result = inputs.execute_select();
-    assert!(result.is_err(), "select must reject a remote snapshot");
+    match inputs.execute_select() {
+        Err(RuntimeError::SpawnFailed(message)) => {
+            assert!(message.contains("remote"));
+        }
+        other => panic!("expected SpawnFailed for remote select, got {other:?}"),
+    }
 }
 
 // --- S1: owner revalidation (stale owner rejected) ---

--- a/src/state/dead_preview_ops.rs
+++ b/src/state/dead_preview_ops.rs
@@ -16,11 +16,11 @@ use crate::state::AppState;
 /// agent is confirmed dead, and read by the pure render projection. Cleared
 /// on revival, restart, or deletion.
 #[derive(Debug, Clone, Default)]
-pub struct DeadAgentPreview {
+pub struct DeadAgentPreviewCache {
     previews: HashMap<AgentId, Vec<String>>,
 }
 
-impl DeadAgentPreview {
+impl DeadAgentPreviewCache {
     /// Whether the cache holds no previews.
     #[must_use]
     pub fn is_empty(&self) -> bool {

--- a/src/state/dead_preview_ops.rs
+++ b/src/state/dead_preview_ops.rs
@@ -1,0 +1,74 @@
+//! Runtime-only dead-agent preview cache (issue #374 S4).
+//!
+//! The dead-pane preview is captured once during off-lock liveness detection
+//! and stored here as a runtime-only snapshot keyed by agent id. The render
+//! path reads from this cache without shelling out to tmux per-frame. The
+//! cache is never persisted: it is rebuilt from liveness on each run.
+
+use std::collections::HashMap;
+
+use crate::domain::AgentId;
+use crate::state::AppState;
+
+/// Runtime-only cache of dead-agent pane previews (issue #374 S4).
+///
+/// Keyed by agent id. Populated once by the off-lock liveness worker when an
+/// agent is confirmed dead, and read by the pure render projection. Cleared
+/// on revival, restart, or deletion.
+#[derive(Debug, Clone, Default)]
+pub struct DeadAgentPreview {
+    previews: HashMap<AgentId, Vec<String>>,
+}
+
+impl DeadAgentPreview {
+    /// Whether the cache holds no previews.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.previews.is_empty()
+    }
+}
+
+impl AppState {
+    /// Store captured dead-pane lines for `agent_id`.
+    pub fn store_dead_preview(&mut self, agent_id: AgentId, lines: Vec<String>) {
+        self.dead_preview.previews.insert(agent_id, lines);
+    }
+
+    /// Read the cached dead-pane lines for `agent_id` without runtime I/O.
+    #[must_use]
+    pub fn dead_preview(&self, agent_id: &AgentId) -> Option<&[String]> {
+        self.dead_preview.previews.get(agent_id).map(Vec::as_slice)
+    }
+
+    /// Remove the cached dead-pane preview for `agent_id` (issue #374 S4).
+    /// Called on revival/restart so a stale preview does not leak.
+    pub fn clear_dead_preview(&mut self, agent_id: &AgentId) {
+        self.dead_preview.previews.remove(agent_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dead_preview_cache_stores_replaces_and_clears_lines() {
+        let mut state = AppState::default();
+        let agent_id = AgentId("dead-agent".to_owned());
+
+        state.store_dead_preview(agent_id.clone(), vec!["first".to_owned()]);
+        assert_eq!(
+            state.dead_preview(&agent_id),
+            Some(["first".to_owned()].as_slice())
+        );
+
+        state.store_dead_preview(agent_id.clone(), vec!["second".to_owned()]);
+        assert_eq!(
+            state.dead_preview(&agent_id),
+            Some(["second".to_owned()].as_slice())
+        );
+
+        state.clear_dead_preview(&agent_id);
+        assert!(state.dead_preview(&agent_id).is_none());
+    }
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -58,7 +58,7 @@ mod shell_overlay_ops;
 mod shortcut_ops;
 mod terminal_manager_ops;
 mod terminal_manager_types;
-pub use dead_preview_ops::DeadAgentPreview;
+pub use dead_preview_ops::DeadAgentPreviewCache;
 pub use selectors::ChooserAgentInfo;
 pub(crate) use selectors::build_chooser_entries_from_state;
 pub use shell_focus_resolution::resolve_repository_shell;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -3,7 +3,6 @@
 //! @requirement REQ-TECH-001
 //! @requirement REQ-TECH-003
 //! Pseudocode reference: component-001 lines 01-12
-
 mod actions_job_ops;
 mod actions_load_ops;
 #[cfg(test)]
@@ -15,6 +14,7 @@ mod auth_ops;
 #[cfg(test)]
 mod comment_pagination_tests;
 mod dashboard_grab_ops;
+mod dead_preview_ops;
 mod errors_ops;
 mod errors_types;
 mod events;
@@ -58,6 +58,7 @@ mod shell_overlay_ops;
 mod shortcut_ops;
 mod terminal_manager_ops;
 mod terminal_manager_types;
+pub use dead_preview_ops::DeadAgentPreview;
 pub use selectors::ChooserAgentInfo;
 pub(crate) use selectors::build_chooser_entries_from_state;
 pub use shell_focus_resolution::resolve_repository_shell;
@@ -79,8 +80,13 @@ pub use terminal_manager_types::{
     TerminalManagerState, status_label_for,
 };
 pub use types::*;
-/// Default row jump for list and detail page navigation without a measured viewport.
 pub(super) const VIEWPORT_PAGE_JUMP: usize = 10;
+use crate::domain::{Agent, AgentId, AgentStatus, Repository, RepositoryId};
+use crate::list_viewport::ListMove;
+use crate::messages::{
+    AppMessage, MessageRoute, PersistenceMessage, RuntimeMessage, SystemMessage, ThemeMessage,
+    UiNavigationMessage,
+};
 pub use form_projection::{
     AgentFormFieldVisibility, agent_form_visibility, effective_agent_kinds, effective_kinds_hint,
     is_field_visible, is_repository_field_visible, kind_from_form_value, next_visible_focus,
@@ -88,17 +94,7 @@ pub use form_projection::{
 };
 use tracing::{debug, trace};
 
-use crate::domain::{Agent, AgentId, AgentStatus, Repository, RepositoryId};
-use crate::list_viewport::ListMove;
-use crate::messages::{
-    AppMessage, MessageRoute, PersistenceMessage, RuntimeMessage, SystemMessage, ThemeMessage,
-    UiNavigationMessage,
-};
-
-// Re-exported so sibling inline-cursor modules and tests can keep using
-// `super::inline_cursor_vertical` after the helper moved into `util`.
 pub use util::inline_cursor_vertical;
-
 impl AppState {
     /// Reset terminal scrollback state to defaults (fix #4). Called from
     /// every path that changes the selected agent or repository.
@@ -669,12 +665,14 @@ impl AppState {
                 // shell window is gone. Natural AgentStatusChanged->Dead is
                 // NOT touched here; natural death keeps shell close-only.
                 self.remove_shell_window(&agent_id);
+                self.clear_dead_preview(&agent_id);
             }
             RuntimeMessage::AgentStatusChanged(agent_id, status) => {
                 if let Some(agent) = self.agents.iter_mut().find(|a| a.id == agent_id) {
                     agent.status = status;
                     if status == AgentStatus::Running {
                         self.sticky_dead_agent_ids.remove(&agent_id);
+                        self.clear_dead_preview(&agent_id);
                     }
                     // Reset scroll state when selected agent's status changes
                     // (fix #6).
@@ -689,6 +687,7 @@ impl AppState {
                 {
                     agent.status = AgentStatus::Running;
                     self.sticky_dead_agent_ids.remove(&agent_id);
+                    self.clear_dead_preview(&agent_id);
                 }
             }
             // RestartAgent handles the edge case where apply_and_persist is
@@ -701,6 +700,7 @@ impl AppState {
                     && agent.runtime_binding.is_some()
                 {
                     agent.status = AgentStatus::Running;
+                    self.clear_dead_preview(&agent_id);
                 }
             }
         }

--- a/src/state/state_ops.rs
+++ b/src/state/state_ops.rs
@@ -31,6 +31,7 @@ pub fn delete_selected_repository(state: &mut AppState, repository_id: &Reposito
             .retain(|agent| &agent.repository_id != repository_id);
         for agent_id in &removed_agent_ids {
             state.remove_shell_window(agent_id);
+            state.clear_dead_preview(agent_id);
         }
 
         // Drop the deleted repo's remembered preferences so they cannot be
@@ -77,6 +78,8 @@ pub fn delete_selected_agent(
     // Immediate shell-inventory cleanup on agent deletion (issue #361 PR A):
     // the agent is gone from state, so any tracked shell window must be too.
     state.remove_shell_window(&removed_agent.id);
+    // Clear the runtime-only dead preview for the deleted agent (issue #374 S4).
+    state.clear_dead_preview(&removed_agent.id);
     let repository_remote_enabled = state
         .repositories
         .iter()

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -470,7 +470,7 @@ pub struct AppState {
     /// Runtime-only cache of dead-agent pane previews (issue #374 S4).
     /// Populated once by the off-lock liveness worker; read by the pure render
     /// projection. Never persisted.
-    pub dead_preview: super::DeadAgentPreview,
+    pub dead_preview: super::DeadAgentPreviewCache,
 }
 
 /// Embedded agent-shell overlay state (issue #222).

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -466,6 +466,11 @@ pub struct AppState {
     /// #361 PR B). Set when entering a shell from the manager so F12/F10/natural
     /// exit restore the manager; Dashboard-entered shells keep Dashboard.
     pub shell_return_target: super::ShellReturnTarget,
+
+    /// Runtime-only cache of dead-agent pane previews (issue #374 S4).
+    /// Populated once by the off-lock liveness worker; read by the pure render
+    /// projection. Never persisted.
+    pub dead_preview: super::DeadAgentPreview,
 }
 
 /// Embedded agent-shell overlay state (issue #222).


### PR DESCRIPTION
## Summary

- snapshot concrete shell-window operation inputs while holding AppContext only briefly
- execute blocking tmux and psmux work after releasing the shared runtime lock
- reject stale open, close, hide, and manager-focus completions using owner, session, lifecycle, overlay, and pending-focus generations
- move dead-agent preview capture into off-lock liveness work and keep render and mouse history paths cache-only
- preserve startup reconciliation, shutdown cleanup, one-viewer ownership, and typed runtime failures

## Acceptance evidence

- shell open/select/close/hide operations use immutable ShellWindowInputs and post-operation identity validation
- visible and hidden shell observers, startup normalization, orphan cleanup, and shutdown shell cleanup execute without AppContext ownership
- dead previews explicitly capture agent window 0 and are revalidated before runtime-only cache application
- mouse scroll geometry is read atomically from cached history and the live viewer under one non-blocking lock
- stale success selects window 0 best-effort and never installs a second viewer

## Verification

- 10 focused shell-window snapshot, lifecycle-generation, remote, and pane-target tests
- shell overlay reducer tests: 22 passed
- terminal manager tests: 17 passed
- issue 222 real-tmux scenario: 50 steps passed
- issue 364 real-tmux scenario: 84 steps passed
- make ci-check passed before rebase
- exact rebased HEAD: formatting, strict Clippy, all-features build, workspace tests, and doctests passed

## Scope

- 16 files
- within the 25-file and 1,500-line target budget
- no dependency, workflow, persistence-schema, or viewer-model changes

Fixes #374
