### PR TITLE
Suppress PR background refresh when user is idle (Fixes #411)

### DIFF
--- a/src/app_input/prs_integration_tests.rs
+++ b/src/app_input/prs_integration_tests.rs
@@ -915,7 +915,7 @@ fn test_pr_merged_clears_pending_and_marks_merged() {
 /// @requirement issue #128
 #[test]
 fn test_background_refresh_function_exists_and_checks_screen_mode() {
-    let _: fn(&mut AppStateHandle, &SharedContext) =
+    let _: fn(&mut AppStateHandle, &SharedContext, bool) =
         crate::app_input::request_pr_background_refresh;
 }
 
@@ -927,32 +927,69 @@ fn test_background_refresh_function_exists_and_checks_screen_mode() {
 /// @requirement issue #128
 #[test]
 fn test_background_refresh_skips_when_detail_load_in_flight() {
-    use super::prs_orchestration::should_background_refresh;
+    use super::prs_orchestration::{BackgroundRefreshGuard, should_background_refresh};
     use jefe::state::ScreenMode;
     let pr_view = ScreenMode::DashboardPullRequests;
     // No in-flight loads → should refresh.
     assert!(
-        should_background_refresh(pr_view, false, false, false),
+        should_background_refresh(BackgroundRefreshGuard {
+            screen_mode: pr_view,
+            list_reload_pending: false,
+            detail_pending: false,
+            is_idle: false,
+        }),
         "should refresh when PR view is open and nothing is in flight"
     );
     // Detail load in flight → must NOT refresh (clobber guard).
     assert!(
-        !should_background_refresh(pr_view, false, false, true),
+        !should_background_refresh(BackgroundRefreshGuard {
+            screen_mode: pr_view,
+            list_reload_pending: false,
+            detail_pending: true,
+            is_idle: false,
+        }),
         "must NOT refresh when a detail load is in flight"
     );
     // List reload pending → must NOT refresh.
     assert!(
-        !should_background_refresh(pr_view, true, false, false),
+        !should_background_refresh(BackgroundRefreshGuard {
+            screen_mode: pr_view,
+            list_reload_pending: true,
+            detail_pending: false,
+            is_idle: false,
+        }),
         "must NOT refresh when a list reload is pending"
-    );
-    // List page pending → must NOT refresh.
-    assert!(
-        !should_background_refresh(pr_view, false, true, false),
-        "must NOT refresh when a list page load is pending"
     );
     // Not on the PR view → must NOT refresh.
     assert!(
-        !should_background_refresh(ScreenMode::Dashboard, false, false, false),
+        !should_background_refresh(BackgroundRefreshGuard {
+            screen_mode: ScreenMode::Dashboard,
+            list_reload_pending: false,
+            detail_pending: false,
+            is_idle: false,
+        }),
         "must NOT refresh when not on the PR view"
+    );
+}
+
+/// Idle user (no keyboard/mouse/paste input for the idle threshold) must
+/// not background-refresh, to conserve the GraphQL rate-limit budget (#411).
+#[test]
+fn test_background_refresh_skips_when_idle() {
+    use super::prs_orchestration::{BackgroundRefreshGuard, should_background_refresh};
+    use jefe::state::ScreenMode;
+    let guard = |is_idle| BackgroundRefreshGuard {
+        screen_mode: ScreenMode::DashboardPullRequests,
+        list_reload_pending: false,
+        detail_pending: false,
+        is_idle,
+    };
+    assert!(
+        should_background_refresh(guard(false)),
+        "active user should refresh"
+    );
+    assert!(
+        !should_background_refresh(guard(true)),
+        "idle user must not refresh"
     );
 }

--- a/src/app_input/prs_orchestration.rs
+++ b/src/app_input/prs_orchestration.rs
@@ -208,21 +208,28 @@ fn dispatch_prs_post_mutation(
 
 /// Request a silent background refresh of the PR list + detail (issue #128).
 ///
-/// Fires ONLY when the PR view is open (`DashboardPullRequests`) and no list
-/// or detail load is already in flight. The refresh is silent: it preserves
-/// selection, scroll offset, filter, and search query, and does NOT flash the
-/// loading spinner.
+/// Fires ONLY when the PR view is open (`DashboardPullRequests`), no list
+/// or detail load is already in flight, and the user is not idle. The
+/// refresh is silent: it preserves selection, scroll offset, filter, and
+/// search query, and does NOT flash the loading spinner.
 ///
-/// @requirement issue #128
-pub fn request_pr_background_refresh(app_state: &mut AppStateHandle, ctx: &SharedContext) {
+/// `is_idle` suppresses the refresh when the user has had no input for the
+/// idle threshold (issue #411), preventing GraphQL budget drain.
+///
+/// @requirement issue #128, issue #411
+pub fn request_pr_background_refresh(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    is_idle: bool,
+) {
     let should_refresh = {
         let state = app_state.read();
-        should_background_refresh(
-            state.screen_mode,
-            state.prs_state.list.has_pending_request(),
-            false,
-            state.prs_state.detail_pending.is_some(),
-        )
+        should_background_refresh(BackgroundRefreshGuard {
+            screen_mode: state.screen_mode,
+            list_reload_pending: state.prs_state.list.has_pending_request(),
+            detail_pending: state.prs_state.detail_pending.is_some(),
+            is_idle,
+        })
     };
     if should_refresh {
         prs_list_dispatch::request_pr_list_silent_refresh(app_state, ctx);
@@ -245,22 +252,31 @@ pub(super) fn resume_pr_post_mutation_refresh(app_state: &mut AppStateHandle, ct
     load_pr_detail_silent_refresh(app_state, ctx);
 }
 
+/// Guard conditions for [`should_background_refresh`] (issue #128, #411).
+/// Grouped into a struct to avoid excessive bool parameters.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct BackgroundRefreshGuard {
+    pub screen_mode: jefe::state::ScreenMode,
+    pub list_reload_pending: bool,
+    pub detail_pending: bool,
+    pub is_idle: bool,
+}
+
 /// Pure guard predicate for `request_pr_background_refresh` (issue #128).
-/// Returns `true` when the PR view is open AND no list/detail load is in
-/// flight. Extracted so the guard logic is unit-testable without an
-/// `AppStateHandle`.
+/// Returns `true` when the PR view is open, no list/detail load is in
+/// flight, and the user is not idle. Extracted so the guard logic is
+/// unit-testable without an `AppStateHandle`.
 ///
-/// @requirement issue #128
-pub(super) fn should_background_refresh(
-    screen_mode: jefe::state::ScreenMode,
-    list_reload_pending: bool,
-    list_page_pending: bool,
-    detail_pending: bool,
-) -> bool {
-    screen_mode == jefe::state::ScreenMode::DashboardPullRequests
-        && !list_reload_pending
-        && !list_page_pending
-        && !detail_pending
+/// `is_idle` suppresses background refresh when the user has had no
+/// keyboard/mouse/paste input for the idle threshold (issue #411), so
+/// leaving jefe open on the PR screen cannot drain the GraphQL budget.
+///
+/// @requirement issue #128, issue #411
+pub(super) fn should_background_refresh(guard: BackgroundRefreshGuard) -> bool {
+    guard.screen_mode == jefe::state::ScreenMode::DashboardPullRequests
+        && !guard.list_reload_pending
+        && !guard.detail_pending
+        && !guard.is_idle
 }
 
 /// Silently refresh PR detail for the currently selected PR (issue #128).

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -51,6 +51,7 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     let mut startup_sessions_restored = hooks.use_state(|| false);
     let mut attach_scheduler = hooks.use_state(|| AttachScheduler::new(DEFAULT_DEBOUNCE));
     let mut suppress_next_enter = hooks.use_state(PasteEnterSuppression::new);
+    let last_activity = hooks.use_state(Instant::now);
 
     let ctx = props.context.clone();
 
@@ -366,14 +367,20 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     // poll pattern: a background loop that fires while the PR view is open and
     // silently refreshes the PR list + detail without flashing the loading
     // spinner or disrupting the user's selection/scroll position.
+    //
+    // Issue #411: the refresh is suppressed when the user has been idle (no
+    // keyboard/mouse/paste input) for longer than the idle threshold, so
+    // leaving jefe open on the PR screen cannot drain the GraphQL budget.
     hooks.use_future({
         let ctx = ctx.clone();
         let mut app_state = app_state;
         async move {
+            const REFRESH_INTERVAL_SECONDS: u64 = 60;
+            const IDLE_THRESHOLD_SECONDS: u64 = 5 * 60;
             loop {
-                const REFRESH_INTERVAL_SECONDS: u64 = 60;
                 smol::Timer::after(std::time::Duration::from_secs(REFRESH_INTERVAL_SECONDS)).await;
-                request_pr_background_refresh(&mut app_state, &ctx);
+                let is_idle = last_activity.get().elapsed().as_secs() >= IDLE_THRESHOLD_SECONDS;
+                request_pr_background_refresh(&mut app_state, &ctx, is_idle);
             }
         }
     });
@@ -383,8 +390,12 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
         let mut app_state = app_state;
         let mut should_quit = should_quit;
         let mut help_scroll = help_scroll;
+        let mut last_activity = last_activity;
 
         move |event| {
+            // Issue #411: any terminal event (key, mouse, paste, resize)
+            // resets the idle timer so the background refresh resumes.
+            last_activity.set(Instant::now());
             handle_terminal_event(
                 event,
                 ctx.as_ref(),


### PR DESCRIPTION
## Summary

The 60-second PR background refresh loop was firing unconditionally whenever the PR view was open — even when the user had walked away from the keyboard. Since each refresh fires multiple expensive GraphQL queries (list search with nested `statusCheckRollup`, detail with comments + review threads), leaving jefe open on the PR screen could drain the entire 5000-point/hour GraphQL budget in under an hour of idleness.

This PR adds an idle-suppression guard: after 5 minutes of no keyboard/mouse/paste input, background refreshes are paused. Any terminal event (key press, mouse click, paste, resize) immediately resets the idle timer, resuming refreshes on the next 60-second tick.

## Root Cause

GitHub's GraphQL rate limit is **cost-based** (5000 points/hour), not call-count-based. Jefe's PR listing query nests `statusCheckRollup { contexts(first: 100) }` per PR (30 PRs × 100 checks = 3000 nested nodes), making each list refresh very expensive. Combined with the unconditional 60s background refresh loop, an idle jefe instance on the PR screen burns through the budget without any user interaction.

## Changes

- **`src/app_shell.rs`**: Track `last_activity: Instant` via a hook state, updated on every terminal event. The 60s background refresh loop now computes `is_idle` (true when 5+ minutes have elapsed since last input) and passes it to `request_pr_background_refresh`.
- **`src/app_input/prs_orchestration.rs`**: Added `is_idle` parameter to `request_pr_background_refresh`. Refactored `should_background_refresh` from 5 bool params into a `BackgroundRefreshGuard` struct (resolves clippy `fn_params_excessive_bools`).
- **`src/app_input/prs_integration_tests.rs`**: Updated existing tests for the new struct API. Added `test_background_refresh_skips_when_idle` proving the idle guard.

## Test Plan

- [x] `test_background_refresh_skips_when_idle` — verifies refresh is suppressed when idle
- [x] `test_background_refresh_skips_when_detail_load_in_flight` — updated for struct API, all existing guard conditions still pass
- [x] `test_background_refresh_function_exists_and_checks_screen_mode` — updated signature
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] Full test suite passes (2 flaky pre-existing failures unrelated to this change: tmux capture + npm package_probe, both pass individually on main)