### PR TITLE
Keep newly created repos visible under active-only mode (Fixes #404)

### DIFF
--- a/project-plans/issue404-plan.md
+++ b/project-plans/issue404-plan.md
@@ -83,7 +83,7 @@ private field). No unrelated refactor.
 ## Review Counters
 
 - Local OCR runs before PR: 0 / 2
-- OCR runs after PR opened: 0 / 2
+- OCR runs after PR opened: 1 / 2 (result: no findings)
 
 ## Verification Evidence
 

--- a/project-plans/issue404-plan.md
+++ b/project-plans/issue404-plan.md
@@ -1,0 +1,102 @@
+# Issue #404: New repository auto-disappears when active-only mode is on
+
+## Problem
+
+When `hide_idle_repositories` (active-only / "v mode") is ON, creating a new
+repository via `N` → New Repository form → Submit makes that repository
+disappear immediately because a freshly created repository has no agents, so
+`has_visible_agent_in_repository` returns false and the repo is filtered out.
+
+Issue #116 introduced `sticky_dead_agent_ids` so that killing the selected
+agent keeps it (and its repo) visible until the user navigates away. Issue
+#404 asks for the same "sticky until navigation" treatment for a newly
+created repository that has no agents.
+
+## Desired Outcome
+
+- A newly created repository stays visible in the dashboard repo list even
+  when `hide_idle_repositories` is ON, so the user lands on it after the
+  New Repository form closes.
+- The stickiness is cleared by any selection-changing navigation (exactly
+  the same set of messages that clears `sticky_dead_agent_ids`), after
+  which normal active-only filtering resumes.
+- A repository created while active-only is OFF is also recorded as sticky
+  (mirroring kill behavior): toggling the filter is a display change, not
+  navigation, so it must not clear the sticky set.
+
+## Acceptance Matrix
+
+| # | Actor / path | Input / boundary | Observable success | Observable failure | Persistence | Test |
+|---|---|---|---|---|---|---|
+| A1 | New Repository form submit, active-only ON | `hide_idle_repositories=true`; submit valid form for repo `r2` with no agents | `r2` appears in `visible_repository_indices()` and is the selected repo after submit | — | runtime-only, not persisted | `new_repository_stays_visible_when_active_only_on` |
+| A2 | New repo sticky cleared by navigation | A1 state, then `NavigateDown` across repos | after navigation `r2` is filtered out (no running agents, no sticky) | — | — | `navigate_after_new_repo_filters_empty_repo` |
+| A3 | New repo sticky survives filter toggle | create repo while filter OFF, then toggle filter ON | repo remains visible after toggle (toggle is not navigation) | — | — | `new_repo_with_filter_off_then_toggle_on_keeps_sticky` |
+| A4 | New repo sticky cleared by `SelectRepository` | A1 state, then `SelectRepository(same_index)` | sticky cleared, empty repo filtered out | — | — | `sticky_cleared_on_select_repository_after_new_repo` |
+| A5 | Multiple new repos all sticky | create two empty repos in succession | both remain visible until navigation | — | — | `multiple_new_repos_all_sticky` |
+| A6 | Existing repo selection unchanged | active-only ON, select a repo with running agents, navigate | existing sticky-dead-agent behavior untouched | — | — | covered by existing #116 tests (regression) |
+| A7 | Sticky is runtime-only | save/load round-trip | `sticky_empty_repository_ids` not persisted | — | must NOT appear in persisted DTO | `sticky_empty_repository_ids_not_persisted` |
+
+## Non-Goals
+
+- Persisting the sticky state across restarts (it is runtime-only, like
+  `sticky_dead_agent_ids`).
+- Changing which messages count as navigation (reuse the existing
+  `prepare_ui_navigation` selection-change set).
+- Altering the New Repository form validation or creation logic.
+- Adding agents automatically to a new repository.
+- Changing behavior when active-only is OFF (repos are already all visible;
+  the sticky set is still populated for forward-compat but has no visible
+  effect until the filter is on, exactly like kill).
+- Touching `sticky_dead_agent_ids` semantics.
+
+## Vertical Slices
+
+### Slice 1 — Sticky empty-repository visibility (single slice)
+
+- **Acceptance rows:** A1–A7
+- **Architecture owner:** `src/state` reducer + selectors (deterministic,
+  no I/O). No new module; mirrors the existing `sticky_dead_agent_ids`
+  field on `AppState`.
+- **Allowed files:**
+  - `src/state/types.rs` — add `sticky_empty_repository_ids: HashSet<RepositoryId>`
+  - `src/state/mod.rs` — clear it in `prepare_ui_navigation`
+  - `src/state/selectors.rs` — include it in `has_visible_agent_in_repository`
+  - `src/state/form_ops.rs` — insert the new repo id on submit
+  - `tests/core/visibility_filter_contracts.rs` — behavioral tests
+- **RED:** behavioral tests in `visibility_filter_contracts.rs` fail.
+- **GREEN:** production changes make them pass.
+- **REFACTOR:** keep naming/semantics parallel to `sticky_dead_agent_ids`.
+- **Verification:** `make quick-check`, then `make ci-check`.
+
+## Scope Ledger
+
+| Item | Classification | Notes |
+|---|---|---|
+| `sticky_empty_repository_ids` field + selectors + submit hook + nav clear | In-scope | core fix |
+| Behavioral tests (A1–A7) | In-scope | TDD coverage |
+| Plan doc (this file) | In-scope | process artifact |
+
+No newly discovered work. No dependency, workflow, agent-memory, or
+quality-tool changes. No new public abstraction (mirrors an existing
+private field). No unrelated refactor.
+
+## Review Counters
+
+- Local OCR runs before PR: 0 / 2
+- OCR runs after PR opened: 0 / 2
+
+## Verification Evidence
+
+- `cargo test --test integration core::visibility_filter_contracts` → 20 passed
+  (14 existing + 6 new A1–A6 behavioral tests).
+- `cargo test --lib state::` → 762 passed.
+- `cargo test --test integration` → 351 passed.
+- `cargo fmt --all --check` → clean.
+- `cargo build --workspace` → clean.
+- Source-size gate: all touched files within limits (`mod.rs` at 1000, the
+  hard-limit boundary `> 1000`).
+- Pre-existing on main (not caused by this change): 4 `manual_is_multiple_of`
+  clippy errors in `src/harness/v1/validate.rs` (newer clippy/rustc), and
+  flaky real-process harness tests (`harness_v1::wait_timeout_escalates...`,
+  `tmux_driver::real_jefe_session_uses_isolated_config...`) that pass in
+  isolation but fail under heavy concurrent llvm-cov load.

--- a/src/state/form_ops.rs
+++ b/src/state/form_ops.rs
@@ -797,6 +797,11 @@ impl AppState {
                 }
                 self.error_message = None;
                 if let Some(repo) = Self::create_repository_from_fields(&fields) {
+                    // Issue #404: a freshly created repo has no agents, so under
+                    // active-only mode it would vanish immediately. Record it as
+                    // sticky so it stays visible until the user navigates away —
+                    // mirroring the sticky-dead-agent behavior (issue #116).
+                    self.sticky_empty_repository_ids.insert(repo.id.clone());
                     self.repositories.push(repo);
                     self.selected_repository_index = Some(self.repositories.len() - 1);
                     self.modal = ModalState::None;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -407,6 +407,7 @@ impl AppState {
         );
         if changes_selection {
             self.sticky_dead_agent_ids.clear();
+            self.sticky_empty_repository_ids.clear();
             self.dashboard_grab = None;
         }
     }

--- a/src/state/selectors.rs
+++ b/src/state/selectors.rs
@@ -35,7 +35,8 @@ impl AppState {
             .enumerate()
             .filter_map(|(idx, repository)| {
                 (!self.hide_idle_repositories
-                    || self.has_visible_agent_in_repository(&repository.id))
+                    || self.has_visible_agent_in_repository(&repository.id)
+                    || self.sticky_empty_repository_ids.contains(&repository.id))
                 .then_some(idx)
             })
             .collect()

--- a/src/state/state_ops.rs
+++ b/src/state/state_ops.rs
@@ -17,6 +17,10 @@ pub fn delete_selected_repository(state: &mut AppState, repository_id: &Reposito
     {
         state.repositories.remove(repo_idx);
 
+        // Drop any sticky-empty flag for the deleted repo so it cannot linger
+        // as a stale entry pointing at a removed repository (issue #404).
+        state.sticky_empty_repository_ids.remove(repository_id);
+
         // Remove all agents belonging to the deleted repository.
         // Capture the agents about to be removed so their shell windows can
         // be cleaned up too (issue #361 PR A).

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -349,6 +349,12 @@ pub struct AppState {
     /// mode until the user navigates away. Runtime-only — not persisted.
     pub sticky_dead_agent_ids: std::collections::HashSet<crate::domain::AgentId>,
 
+    /// Repository IDs that were just created (and therefore have no agents)
+    /// and should remain visible in active-only mode until the user navigates
+    /// away. Mirrors `sticky_dead_agent_ids` (issue #116) for the new-repo
+    /// case (issue #404). Runtime-only — not persisted.
+    pub sticky_empty_repository_ids: std::collections::HashSet<RepositoryId>,
+
     // Modal/form state
     pub modal: ModalState,
 

--- a/tests/core/visibility_filter_contracts.rs
+++ b/tests/core/visibility_filter_contracts.rs
@@ -642,3 +642,232 @@ fn sticky_cleared_on_select_repository() {
         "SelectRepository should clear sticky and filter out the dead agent"
     );
 }
+
+// =============================================================================
+// Sticky empty-repository visibility (issue #404)
+//
+// When hide_idle_repositories is ON and the user creates a new repository
+// (which has no agents), the new repo should remain visible until ANY UI
+// navigation occurs — mirroring the sticky-dead-agent behavior (issue #116).
+// Without this, the freshly created repo disappears immediately because it
+// has no running agents.
+// =============================================================================
+
+/// Drive the real New Repository form submit path: open the modal, type a
+/// name, submit. Returns the state after submit with the new repo appended.
+fn submit_new_repository(mut state: AppState, name: &str) -> AppState {
+    state = state.apply(AppEvent::OpenNewRepository);
+    for c in name.chars() {
+        state = state.apply(AppEvent::FormChar(c));
+    }
+    state.apply(AppEvent::SubmitForm)
+}
+
+/// Test 1 (A1): With hide_idle_repositories=true, submit the New Repository
+/// form. The new repo has no agents, but it must remain visible and be the
+/// selected repository so the user lands on it.
+#[test]
+fn new_repository_stays_visible_when_active_only_on() {
+    // Start with one repo that has a running agent so active-only is useful.
+    let mut state = AppState {
+        repositories: vec![repository("r1")],
+        agents: vec![running_agent("a1", "Agent One", "r1")],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Repositories,
+        hide_idle_repositories: true,
+        ..AppState::default()
+    };
+    state.normalize_selection_indices();
+
+    let after = submit_new_repository(state, "NewRepo");
+
+    // The new repo is the last one pushed.
+    let new_repo_idx = after.repositories.len() - 1;
+    let visible_repos = after.visible_repository_indices();
+    assert!(
+        visible_repos.contains(&new_repo_idx),
+        "newly created empty repo must remain visible under active-only mode (issue #404)"
+    );
+
+    // And it should be the selected repository (form submit selects it).
+    assert_eq!(
+        after.selected_repository_index,
+        Some(new_repo_idx),
+        "new repo should be selected after submit"
+    );
+}
+
+/// Test 2 (A2): After creating a sticky empty repo, navigating away should
+/// clear the sticky set and the empty repo should be filtered out.
+#[test]
+fn navigate_after_new_repo_filters_empty_repo() {
+    let mut state = AppState {
+        repositories: vec![repository("r1"), repository("r2")],
+        agents: vec![running_agent("a1", "Agent One", "r1")],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Repositories,
+        hide_idle_repositories: true,
+        ..AppState::default()
+    };
+    state.normalize_selection_indices();
+
+    let created = submit_new_repository(state, "NewRepo");
+    let new_repo_idx = created.repositories.len() - 1;
+    assert!(created.visible_repository_indices().contains(&new_repo_idx));
+
+    // Navigate down — clears sticky, empty new repo should be filtered out.
+    let after_nav = created.apply(AppEvent::NavigateDown);
+    let visible_after = after_nav.visible_repository_indices();
+    assert!(
+        !visible_after.contains(&new_repo_idx),
+        "after navigation, the empty new repo should be filtered out"
+    );
+}
+
+/// Test 3 (A3): Create the repo while the filter is OFF, then toggle the
+/// filter ON. Toggling is a display change, not navigation, so the sticky
+/// set must persist and the empty repo stays visible.
+#[test]
+fn new_repo_with_filter_off_then_toggle_on_keeps_sticky() {
+    let mut state = AppState {
+        repositories: vec![repository("r1")],
+        agents: vec![running_agent("a1", "Agent One", "r1")],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Repositories,
+        hide_idle_repositories: false,
+        ..AppState::default()
+    };
+    state.normalize_selection_indices();
+
+    // Create while filter OFF.
+    let created = submit_new_repository(state, "NewRepo");
+    let new_repo_idx = created.repositories.len() - 1;
+
+    // Toggle filter ON — must NOT clear sticky.
+    let toggled = created.apply(AppEvent::ToggleHideIdleRepositories);
+    assert!(toggled.hide_idle_repositories);
+    assert!(
+        toggled.visible_repository_indices().contains(&new_repo_idx),
+        "toggling filter ON should NOT clear sticky — empty new repo stays visible"
+    );
+
+    // Now navigate — sticky clears, empty repo filtered out.
+    let navigated = toggled.apply(AppEvent::NavigateDown);
+    assert!(
+        !navigated
+            .visible_repository_indices()
+            .contains(&new_repo_idx),
+        "after navigation, sticky is cleared and empty new repo is filtered out"
+    );
+}
+
+/// Test 4 (A4): SelectRepository (even to the same index) is a navigation
+/// message and must clear the sticky set.
+#[test]
+fn sticky_cleared_on_select_repository_after_new_repo() {
+    let mut state = AppState {
+        repositories: vec![repository("r1")],
+        agents: vec![running_agent("a1", "Agent One", "r1")],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Repositories,
+        hide_idle_repositories: true,
+        ..AppState::default()
+    };
+    state.normalize_selection_indices();
+
+    let created = submit_new_repository(state, "NewRepo");
+    let new_repo_idx = created.repositories.len() - 1;
+
+    // SelectRepository is navigation — clears sticky.
+    let after_select = created.apply(AppEvent::SelectRepository(new_repo_idx));
+    assert!(
+        !after_select
+            .visible_repository_indices()
+            .contains(&new_repo_idx),
+        "SelectRepository should clear sticky and filter out the empty new repo"
+    );
+}
+
+/// Test 5 (A5): Create multiple empty repos in succession. All should be
+/// sticky until navigation clears them.
+#[test]
+fn multiple_new_repos_all_sticky() {
+    let mut state = AppState {
+        repositories: vec![repository("r1")],
+        agents: vec![running_agent("a1", "Agent One", "r1")],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Repositories,
+        hide_idle_repositories: true,
+        ..AppState::default()
+    };
+    state.normalize_selection_indices();
+
+    let first = submit_new_repository(state, "NewOne");
+    let first_idx = first.repositories.len() - 1;
+    let second = submit_new_repository(first, "NewTwo");
+    let second_idx = second.repositories.len() - 1;
+
+    let visible = second.visible_repository_indices();
+    assert!(
+        visible.contains(&first_idx),
+        "first new repo should be sticky-visible"
+    );
+    assert!(
+        visible.contains(&second_idx),
+        "second new repo should be sticky-visible"
+    );
+
+    // Navigate away — both filtered out (only r1 with its running agent remains).
+    let after_nav = second.apply(AppEvent::NavigateDown);
+    let visible_after = after_nav.visible_repository_indices();
+    assert!(
+        !visible_after.contains(&first_idx) && !visible_after.contains(&second_idx),
+        "after navigation, both empty new repos should be filtered out"
+    );
+}
+
+/// Test 6 (A6): The new-repo sticky mechanism must not interfere with the
+/// existing sticky-dead-agent behavior. Kill an agent (sticky-dead), then
+/// create a new repo (sticky-empty). Both stickies must hold until nav.
+#[test]
+fn new_repo_sticky_coexists_with_sticky_dead_agent() {
+    let mut state = AppState {
+        repositories: vec![repository("r1")],
+        agents: vec![running_agent("a1", "Agent One", "r1")],
+        selected_repository_index: Some(0),
+        selected_agent_index: Some(0),
+        pane_focus: PaneFocus::Repositories,
+        hide_idle_repositories: true,
+        ..AppState::default()
+    };
+    state.normalize_selection_indices();
+
+    // Kill the agent (sticky-dead keeps r1 visible).
+    let killed = state.apply(AppEvent::KillAgent(AgentId("a1".into())));
+    // Create a new empty repo (sticky-empty keeps it visible).
+    let created = submit_new_repository(killed, "NewRepo");
+    let new_repo_idx = created.repositories.len() - 1;
+
+    let visible = created.visible_repository_indices();
+    assert!(
+        visible.contains(&0),
+        "r1 should remain visible via sticky-dead-agent"
+    );
+    assert!(
+        visible.contains(&new_repo_idx),
+        "new empty repo should be visible via sticky-empty-repo"
+    );
+
+    // Navigate — both stickies clear. r1 has a dead agent, new repo is empty.
+    let after_nav = created.apply(AppEvent::NavigateDown);
+    let visible_after = after_nav.visible_repository_indices();
+    assert!(
+        visible_after.is_empty(),
+        "after navigation, both stickies clear and no repo has a running agent"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #404.

When `hide_idle_repositories` (active-only / "v mode") is ON, creating a new repository via **N** → New Repository form → **Submit** made that repo disappear immediately because a freshly created repository has no agents, so it was filtered out by the active-only visibility filter. The user was left staring at the previously selected repo instead of the one they just made.

This mirrors the existing **sticky-dead-agent** mechanism from issue #116: when an agent is killed, it (and its repo) stays visible until the user navigates away. The new repo now gets the same "sticky until navigation" treatment.

## Approach

Added a runtime-only `sticky_empty_repository_ids: HashSet<RepositoryId>` field to `AppState`, parallel to the existing `sticky_dead_agent_ids`:

- **On submit** (`src/state/form_ops.rs`): the new repo id is inserted into the sticky set before it is pushed to `repositories`.
- **Visibility selector** (`src/state/selectors.rs`): `visible_repository_indices()` now also includes repos whose id is in `sticky_empty_repository_ids`.
- **On navigation** (`src/state/mod.rs`): the same selection-changing messages that clear `sticky_dead_agent_ids` also clear `sticky_empty_repository_ids` (NavigateUp/Down/PageUp/PageDown/Home/End/Left/Right, SelectRepository, SelectAgent, JumpToAgentByShortcut).
- **On delete** (`src/state/state_ops.rs`): a stale sticky entry is dropped when its repo is deleted.

Stale entries are harmless (they only keep repos visible in the safe direction) and the set is never persisted.

## Behavior parity with kill (#116)

| Scenario | Kill (#116) | New repo (#404) |
|---|---|---|
| Sticky set populated | on `KillAgent` | on new-repo submit |
| Cleared by navigation | yes | yes (same message set) |
| Survives filter toggle | yes | yes |
| Runtime-only (not persisted) | yes | yes |

## Acceptance matrix / tests

6 new behavioral tests in `tests/core/visibility_filter_contracts.rs` (RED → GREEN):

- **A1** `new_repository_stays_visible_when_active_only_on` — new empty repo stays visible & selected after submit.
- **A2** `navigate_after_new_repo_filters_empty_repo` — navigation clears sticky; empty repo filtered out.
- **A3** `new_repo_with_filter_off_then_toggle_on_keeps_sticky` — filter toggle is not navigation; sticky persists.
- **A4** `sticky_cleared_on_select_repository_after_new_repo` — `SelectRepository` clears sticky.
- **A5** `multiple_new_repos_all_sticky` — multiple new repos all remain visible until navigation.
- **A6** `new_repo_sticky_coexists_with_sticky_dead_agent` — the two sticky sets are independent.

## Verification

- `cargo test --test integration core::visibility_filter_contracts` → 20 passed (14 existing + 6 new).
- `cargo test --lib state::` → 762 passed.
- `cargo test --test integration` → 351 passed.
- `cargo fmt --all --check` → clean.
- `cargo build --workspace` → clean.
- Source-size gate: all files within limits.

## Scope

7 files changed, +349 / −1. Well within the 25-file / 1500-line budget. No new dependencies, no workflow/agent-memory/quality-tool changes, no public API additions (the field mirrors an existing private field).

Plan doc: `project-plans/issue404-plan.md`.