### PR TITLE
Add Home/End cursor movement to text editing surfaces (Fixes #406)

### DIFF
--- a/project-plans/issue406-plan.md
+++ b/project-plans/issue406-plan.md
@@ -1,0 +1,180 @@
+# Issue #406 — text boxes should support home/end/arrows/etc
+
+## Problem
+
+Text-editing surfaces in the TUI only handle a limited key set. The issue
+author cannot use `Home`/`End` to jump to the start/end of the line, and the
+"full common set" of line-editing keys is not uniformly supported across the
+various composer/editor inputs.
+
+The codebase already supports: chars, Backspace, Delete, Left, Right, Up,
+Down (vertical movement). It is **missing**: `Home`, `End`, and the common
+`Ctrl-A`/`Ctrl-E` Emacs-style line anchors (single-line text fields only —
+the multiline composer maps `Ctrl-A` is unused today; we only add it to
+single-line surfaces where Home/End map cleanly to "start/end of text").
+
+## Acceptance matrix
+
+For each text-editing surface, the **common set** must include the existing
+keys (chars, Backspace, Delete, Left, Right, Up, Down where applicable) PLUS
+`Home` and `End`.
+
+The semantics of `Home`/`End` differ by surface kind:
+
+| Surface | Home semantics | End semantics |
+|---|---|---|
+| Multiline inline composer/editor (issues + PRs) | Start of current line | End of current line |
+| Single-line title editor (issues + PRs property Title) | Start of title text | End of title text |
+| Form text fields (New/Edit Repo, Agent, WorkflowDispatch) | Start of field | End of field |
+| Search input (issues + PRs, close-reason duplicate search) | Start of query | End of query |
+| Filter text controls (issues + PRs) | Start of text field | End of text field |
+
+### Rows
+
+#### R1 — Multiline inline composer/editor (Issues)
+- Actor: user typing in the Issues inline composer or inline editor.
+- Input: `Home`, `End` keys (no modifiers).
+- Success: `Home` moves the byte cursor to the start of the current logical
+  line; `End` moves it to the end of the current logical line. Preserves
+  char-boundary safety (multibyte).
+- Failure: n/a (pure state transition).
+- Test: `state/issues_inline_ops` tests assert byte cursor after Home/End on
+  multiline text including a multibyte line.
+
+#### R2 — Multiline inline composer/editor (PRs)
+- Mirrors R1 for the PR inline composer/editor (NewComment, Reply).
+- Test: `state/prs_tests_cursor_arrows` (or a sibling test module) asserts
+  Home/End byte cursor on PR composer.
+
+#### R3 — Single-line title editor (Issues property)
+- Input: `Home`, `End`.
+- Success: cursor → 0 (Home) or → title_text.len() (End).
+- Test: `state/issues_property_ops_tests` asserts cursor position.
+
+#### R4 — Single-line title editor (PRs property)
+- Mirrors R3 for PR property Title editor.
+- Test: `state/prs_property_ops_tests` asserts cursor position.
+
+#### R5 — Form text fields (Repo/Agent/WorkflowDispatch)
+- Input: `Home`, `End`.
+- Success: cursor → 0 / → field length for the focused field.
+- Test: `state/form_ops_tests` asserts Home/End on a representative field.
+
+#### R6 — Key routing (modal handler)
+- Input: `Home`/`End` keys dispatched to `handle_mode_form_key`.
+- Success: `Home` → `FormMoveCursorStart`, `End` → `FormMoveCursorEnd`.
+- Test: `app_input/modal_handlers_tests` (or a sibling) asserts the mapping.
+
+#### R7 — Key routing (issues inline)
+- Input: `Home`/`End` keys.
+- Success: routes to `InlineCursorHome` / `InlineCursorEnd`.
+- Test: `app_input/issues_key_tests` asserts the routing.
+
+#### R8 — Key routing (PRs inline)
+- Mirrors R7 for PR inline key router.
+- Test: `app_input/prs_key_tests` asserts the routing.
+
+#### R9 — Key routing (issues/PRs property Title editor)
+- Input: `Home`/`End` keys while the property editor Title kind is open.
+- Success: routes to `...TitleCursorHome` / `...TitleCursorEnd`.
+- Test: `app_input/issues_property_key_tests`,
+  `app_input/prs_property_key_tests`.
+
+#### R10 — Key routing (search inputs)
+- `Home`/`End` move within the query. For the single-line search inputs we
+  model the cursor implicitly (they store the full query string and pop/append
+  at the end today). This is out of scope to refactor to a real cursor; we
+  treat Home/End as **no-op** for search inputs (consumed but no movement) to
+  avoid changing the storage model. **NON-GOAL** — see Non-goals.
+
+### Non-goals
+
+- **No real cursor model for search inputs.** The search input stores a
+  `query: String` and only supports append/pop at the end. Adding Home/End
+  would require a cursor field and a wider refactor. Search inputs already
+  support Backspace (pop) which is the common case; Home/End are left as
+  no-ops for search.
+- **No Emacs chords (Ctrl-A / Ctrl-E).** While common, adding them risks
+  colliding with existing Ctrl-A semantics and is not requested by the issue
+  body (which specifically names Home/End/arrows). The arrow keys already
+  work; we add Home/End.
+- **No word-movement (Ctrl-Left/Right, Alt-Left/Right).** Out of scope.
+- **No mouse selection / clipboard integration.** Out of scope.
+- **No changes to the close-reason duplicate-search digit-only input.** It
+  only accepts ASCII digits; Home/End are not meaningful there.
+- **No changes to filter control text fields beyond wiring Home/End to
+  move within the field** — but the filter text fields ALSO use the
+  append/pop model today, so they are treated like search (NON-GOAL).
+- **No new dependencies, no workflow/CI/quality-tool changes.**
+
+## Vertical slices
+
+### Slice 1 — Multiline composer/editor Home/End (issues + PRs)
+- Acceptance rows: R1, R2, R7, R8.
+- Architecture owner: `state` (reducer) + `app_input` (key routing) +
+  `messages` (event conversion for PRs).
+- Allowed files:
+  - `src/state/util.rs` (add `inline_cursor_line_start`/`_line_end`)
+  - `src/state/issues_inline_ops.rs` (handle new events)
+  - `src/state/prs_inline_ops.rs` (handle new events)
+  - `src/state/events.rs` (add `InlineCursorHome`, `InlineCursorEnd`)
+  - `src/messages.rs` (add `PrInlineMsg::CursorHome`, `CursorEnd`)
+  - `src/messages/prs_conversion.rs` (wire conversion)
+  - `src/messages/issues_conversion.rs` (wire conversion — Issues inline is
+    a flat AppEvent today, so conversion may be a no-op; verify)
+  - `src/messages/event_conversion.rs` (verify)
+  - `src/messages/names.rs` / `message_names.rs` (names)
+  - `src/app_input/issues.rs` (route Home/End)
+  - `src/app_input/prs.rs` (route Home/End)
+  - `src/messages/issues_dispatch.rs` (verify)
+  - new/sibling test files for state assertions
+- RED: state test asserting cursor moves to line start/end (fails: events
+  don't exist).
+- GREEN: add events + reducers + routing.
+
+### Slice 2 — Title editor Home/End (issues + PRs)
+- Acceptance rows: R3, R4, R9.
+- Allowed files:
+  - `src/state/issues_property_ops.rs`
+  - `src/state/prs_property_ops.rs`
+  - `src/state/events.rs` (add Title cursor Home/End variants)
+  - `src/messages.rs` (property conversion)
+  - `src/messages/*_property_conversion.rs`
+  - `src/app_input/issues.rs` / `prs.rs` (route)
+  - sibling test files.
+
+### Slice 3 — Form text field Home/End
+- Acceptance rows: R5, R6.
+- Allowed files:
+  - `src/state/util.rs` (`move_cursor_start`/`_end` already trivial; reuse
+    `clamp_cursor`/`chars().count()`)
+  - `src/state/form_cursor.rs` (per-field start/end)
+  - `src/state/form_workflow_dispatch.rs`
+  - `src/state/form_ops.rs` (handle_form_move_cursor_start/end)
+  - `src/state/events.rs` (`FormMoveCursorStart`, `FormMoveCursorEnd`)
+  - `src/messages.rs` (`ModalMessage` variants) + conversion
+  - `src/app_input/modal_handlers.rs` (route Home/End)
+  - `src/state/modal_op.rs` (dispatch)
+  - sibling test files.
+
+### Scope ledger
+
+- All additions are within the text-editing subsystem; no new public
+  abstraction, no new dependency, no workflow/CI/quality-tool change.
+- Estimated magnitude: ~600–900 net LoC across ~18 files (within the 25-file
+  / 1,500-line target).
+
+### Review counters
+
+- Local OCR runs: 0 / 2 (pre-PR).
+- PR OCR runs: 0 / 2 (post-PR).
+
+### Verification
+
+- `make quick-check` during iteration.
+- `make ci-check` before pushing the green checkpoint.
+- Focused tests: `cargo test -p jefe --lib state::issues_inline`,
+  `state::prs_tests_cursor_arrows`, `state::issues_property_ops_tests`,
+  `state::prs_property_ops_tests`, `state::form_ops_tests`,
+  `app_input::issues_key_tests`, `app_input::prs_key_tests`,
+  `app_input::modal_handlers_tests`.

--- a/src/app_input/issues.rs
+++ b/src/app_input/issues.rs
@@ -111,6 +111,8 @@ fn resolve_inline_key_event(key_event: &KeyEvent) -> Option<AppEvent> {
         KeyCode::Right => Some(AppEvent::InlineCursorRight),
         KeyCode::Up => Some(AppEvent::InlineCursorUp),
         KeyCode::Down => Some(AppEvent::InlineCursorDown),
+        KeyCode::Home => Some(AppEvent::InlineCursorHome),
+        KeyCode::End => Some(AppEvent::InlineCursorEnd),
         _ => None,
     }
 }
@@ -150,6 +152,8 @@ fn resolve_property_editor_key_event(
         KeyCode::Delete => Some(AppEvent::IssuePropertyEditorTitleDelete),
         KeyCode::Left => Some(AppEvent::IssuePropertyEditorTitleCursorLeft),
         KeyCode::Right => Some(AppEvent::IssuePropertyEditorTitleCursorRight),
+        KeyCode::Home => Some(AppEvent::IssuePropertyEditorTitleCursorHome),
+        KeyCode::End => Some(AppEvent::IssuePropertyEditorTitleCursorEnd),
         _ => None,
     }
 }

--- a/src/app_input/modal_handlers.rs
+++ b/src/app_input/modal_handlers.rs
@@ -279,6 +279,8 @@ pub fn handle_mode_form_key(
         KeyCode::BackTab | KeyCode::Up => Some(AppEvent::FormPrevField),
         KeyCode::Left => Some(AppEvent::FormMoveCursorLeft),
         KeyCode::Right => Some(AppEvent::FormMoveCursorRight),
+        KeyCode::Home => Some(AppEvent::FormMoveCursorStart),
+        KeyCode::End => Some(AppEvent::FormMoveCursorEnd),
         KeyCode::Backspace => Some(AppEvent::FormBackspace),
         KeyCode::Delete => Some(AppEvent::FormDelete),
         KeyCode::Char(' ') => handle_form_space(app_state, ctx),

--- a/src/app_input/prs.rs
+++ b/src/app_input/prs.rs
@@ -517,6 +517,8 @@ fn handle_pr_inline_key(_state: &AppState, key_event: &KeyEvent) -> Option<AppEv
         KeyCode::Right => Some(AppEvent::PrInlineCursorRight),
         KeyCode::Up => Some(AppEvent::PrInlineCursorUp),
         KeyCode::Down => Some(AppEvent::PrInlineCursorDown),
+        KeyCode::Home => Some(AppEvent::PrInlineCursorHome),
+        KeyCode::End => Some(AppEvent::PrInlineCursorEnd),
         _ => None,
     }
 }
@@ -571,6 +573,8 @@ fn handle_pr_property_editor_key(kind: PrPropertyKind, key_event: &KeyEvent) -> 
         KeyCode::Delete => Some(AppEvent::PrPropertyEditorTitleDelete),
         KeyCode::Left => Some(AppEvent::PrPropertyEditorTitleCursorLeft),
         KeyCode::Right => Some(AppEvent::PrPropertyEditorTitleCursorRight),
+        KeyCode::Home => Some(AppEvent::PrPropertyEditorTitleCursorHome),
+        KeyCode::End => Some(AppEvent::PrPropertyEditorTitleCursorEnd),
         _ => None,
     }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -120,6 +120,8 @@ pub enum ModalMessage {
     FormDelete,
     FormMoveCursorLeft,
     FormMoveCursorRight,
+    FormMoveCursorStart,
+    FormMoveCursorEnd,
     FormNextField,
     FormPrevField,
     FormToggleCheckbox,
@@ -314,6 +316,10 @@ pub enum IssuesMessage {
     InlineCursorRight,
     InlineCursorUp,
     InlineCursorDown,
+    /// Move the caret to the start of the current line (Home, issue #406).
+    InlineCursorHome,
+    /// Move the caret to the end of the current line (End, issue #406).
+    InlineCursorEnd,
     InlineSubmit,
     InlineCancelOrEsc,
     /// Ask the configured default agent to rewrite the new-issue draft
@@ -430,6 +436,8 @@ pub enum IssuesMessage {
     PropertyEditorTitleDelete,
     PropertyEditorTitleCursorLeft,
     PropertyEditorTitleCursorRight,
+    PropertyEditorTitleCursorHome,
+    PropertyEditorTitleCursorEnd,
     PropertyEditorOptionsLoaded {
         scope_repo_id: RepositoryId,
         issue_number: u64,
@@ -689,6 +697,8 @@ pub enum PullRequestsMessage {
     PropertyEditorTitleDelete,
     PropertyEditorTitleCursorLeft,
     PropertyEditorTitleCursorRight,
+    PropertyEditorTitleCursorHome,
+    PropertyEditorTitleCursorEnd,
     PropertyEditorOptionsLoaded {
         scope_repo_id: RepositoryId,
         pr_number: u64,
@@ -816,6 +826,10 @@ pub enum PrInlineMsg {
     CursorRight,
     CursorUp,
     CursorDown,
+    /// Move the caret to the start of the current line (Home, issue #406).
+    CursorHome,
+    /// Move the caret to the end of the current line (End, issue #406).
+    CursorEnd,
     Submit,
     CancelOrEsc,
 }

--- a/src/messages/event_conversion.rs
+++ b/src/messages/event_conversion.rs
@@ -70,6 +70,8 @@ impl From<AppEvent> for AppMessage {
             AppEvent::FormDelete => Self::Modal(ModalMessage::FormDelete),
             AppEvent::FormMoveCursorLeft => Self::Modal(ModalMessage::FormMoveCursorLeft),
             AppEvent::FormMoveCursorRight => Self::Modal(ModalMessage::FormMoveCursorRight),
+            AppEvent::FormMoveCursorStart => Self::Modal(ModalMessage::FormMoveCursorStart),
+            AppEvent::FormMoveCursorEnd => Self::Modal(ModalMessage::FormMoveCursorEnd),
             AppEvent::FormNextField => Self::Modal(ModalMessage::FormNextField),
             AppEvent::FormPrevField => Self::Modal(ModalMessage::FormPrevField),
             AppEvent::FormToggleCheckbox => Self::Modal(ModalMessage::FormToggleCheckbox),
@@ -385,6 +387,8 @@ impl AppMessage {
                 | AppEvent::InlineCursorRight
                 | AppEvent::InlineCursorUp
                 | AppEvent::InlineCursorDown
+                | AppEvent::InlineCursorHome
+                | AppEvent::InlineCursorEnd
                 | AppEvent::InlineSubmit
                 | AppEvent::InlineCancelOrEsc
                 | AppEvent::RequestIssueRewrite
@@ -439,6 +443,8 @@ impl AppMessage {
                 | AppEvent::IssuePropertyEditorTitleDelete
                 | AppEvent::IssuePropertyEditorTitleCursorLeft
                 | AppEvent::IssuePropertyEditorTitleCursorRight
+                | AppEvent::IssuePropertyEditorTitleCursorHome
+                | AppEvent::IssuePropertyEditorTitleCursorEnd
                 | AppEvent::IssuePropertyEditorOptionsLoaded { .. }
                 | AppEvent::IssuePropertyEditorOptionsFailed { .. }
                 | AppEvent::IssuePropertyEditSucceeded { .. }
@@ -536,6 +542,8 @@ impl From<ModalMessage> for AppEvent {
             ModalMessage::FormDelete => Self::FormDelete,
             ModalMessage::FormMoveCursorLeft => Self::FormMoveCursorLeft,
             ModalMessage::FormMoveCursorRight => Self::FormMoveCursorRight,
+            ModalMessage::FormMoveCursorStart => Self::FormMoveCursorStart,
+            ModalMessage::FormMoveCursorEnd => Self::FormMoveCursorEnd,
             ModalMessage::FormNextField => Self::FormNextField,
             ModalMessage::FormPrevField => Self::FormPrevField,
             ModalMessage::FormToggleCheckbox => Self::FormToggleCheckbox,

--- a/src/messages/issues_conversion.rs
+++ b/src/messages/issues_conversion.rs
@@ -251,6 +251,8 @@ impl IssuesMessage {
             | AppEvent::InlineCursorRight
             | AppEvent::InlineCursorUp
             | AppEvent::InlineCursorDown
+            | AppEvent::InlineCursorHome
+            | AppEvent::InlineCursorEnd
             | AppEvent::InlineSubmit
             | AppEvent::InlineCancelOrEsc
             | AppEvent::RequestIssueRewrite
@@ -303,6 +305,8 @@ impl IssuesMessage {
             AppEvent::InlineCursorRight => Self::InlineCursorRight,
             AppEvent::InlineCursorUp => Self::InlineCursorUp,
             AppEvent::InlineCursorDown => Self::InlineCursorDown,
+            AppEvent::InlineCursorHome => Self::InlineCursorHome,
+            AppEvent::InlineCursorEnd => Self::InlineCursorEnd,
             AppEvent::InlineSubmit => Self::InlineSubmit,
             AppEvent::InlineCancelOrEsc => Self::InlineCancelOrEsc,
             AppEvent::RequestIssueRewrite => Self::RequestIssueRewrite,
@@ -667,6 +671,8 @@ impl IssuesMessage {
             | Self::InlineCursorRight
             | Self::InlineCursorUp
             | Self::InlineCursorDown
+            | Self::InlineCursorHome
+            | Self::InlineCursorEnd
             | Self::InlineSubmit
             | Self::InlineCancelOrEsc
             | Self::RequestIssueRewrite
@@ -717,6 +723,8 @@ impl IssuesMessage {
             Self::InlineCursorRight => AppEvent::InlineCursorRight,
             Self::InlineCursorUp => AppEvent::InlineCursorUp,
             Self::InlineCursorDown => AppEvent::InlineCursorDown,
+            Self::InlineCursorHome => AppEvent::InlineCursorHome,
+            Self::InlineCursorEnd => AppEvent::InlineCursorEnd,
             Self::InlineSubmit => AppEvent::InlineSubmit,
             Self::InlineCancelOrEsc => AppEvent::InlineCancelOrEsc,
             Self::RequestIssueRewrite => AppEvent::RequestIssueRewrite,

--- a/src/messages/issues_property_conversion.rs
+++ b/src/messages/issues_property_conversion.rs
@@ -39,6 +39,8 @@ impl IssuesMessage {
             AppEvent::IssuePropertyEditorTitleDelete => Self::PropertyEditorTitleDelete,
             AppEvent::IssuePropertyEditorTitleCursorLeft => Self::PropertyEditorTitleCursorLeft,
             AppEvent::IssuePropertyEditorTitleCursorRight => Self::PropertyEditorTitleCursorRight,
+            AppEvent::IssuePropertyEditorTitleCursorHome => Self::PropertyEditorTitleCursorHome,
+            AppEvent::IssuePropertyEditorTitleCursorEnd => Self::PropertyEditorTitleCursorEnd,
             // Non-property events should never reach this converter; the
             // routing guard (`is_issue_property_app_event`) filters them
             // upstream. If one slips through, it is safer to no-op (close
@@ -132,6 +134,8 @@ impl IssuesMessage {
             Self::PropertyEditorTitleDelete => AppEvent::IssuePropertyEditorTitleDelete,
             Self::PropertyEditorTitleCursorLeft => AppEvent::IssuePropertyEditorTitleCursorLeft,
             Self::PropertyEditorTitleCursorRight => AppEvent::IssuePropertyEditorTitleCursorRight,
+            Self::PropertyEditorTitleCursorHome => AppEvent::IssuePropertyEditorTitleCursorHome,
+            Self::PropertyEditorTitleCursorEnd => AppEvent::IssuePropertyEditorTitleCursorEnd,
             // Non-property messages should never reach this converter. If
             // one slips through, close the editor rather than entering an
             // unrelated mode.

--- a/src/messages/message_names.rs
+++ b/src/messages/message_names.rs
@@ -60,6 +60,8 @@ message_names!(ModalMessage {
     Self::FormDelete => "FormDelete",
     Self::FormMoveCursorLeft => "FormMoveCursorLeft",
     Self::FormMoveCursorRight => "FormMoveCursorRight",
+    Self::FormMoveCursorStart => "FormMoveCursorStart",
+    Self::FormMoveCursorEnd => "FormMoveCursorEnd",
     Self::FormNextField => "FormNextField",
     Self::FormPrevField => "FormPrevField",
     Self::FormToggleCheckbox => "FormToggleCheckbox",
@@ -162,6 +164,8 @@ message_names!(IssuesMessage {
     Self::InlineCursorRight => "InlineCursorRight",
     Self::InlineCursorUp => "InlineCursorUp",
     Self::InlineCursorDown => "InlineCursorDown",
+    Self::InlineCursorHome => "InlineCursorHome",
+    Self::InlineCursorEnd => "InlineCursorEnd",
     Self::InlineSubmit => "InlineSubmit",
     Self::InlineCancelOrEsc => "InlineCancelOrEsc",
     Self::MutationSubmitted { .. } => "MutationSubmitted",
@@ -190,6 +194,8 @@ message_names!(IssuesMessage {
     Self::PropertyEditorTitleDelete => "IssuePropertyEditorTitleDelete",
     Self::PropertyEditorTitleCursorLeft => "IssuePropertyEditorTitleCursorLeft",
     Self::PropertyEditorTitleCursorRight => "IssuePropertyEditorTitleCursorRight",
+    Self::PropertyEditorTitleCursorHome => "IssuePropertyEditorTitleCursorHome",
+    Self::PropertyEditorTitleCursorEnd => "IssuePropertyEditorTitleCursorEnd",
     Self::PropertyEditorOptionsLoaded { .. } => "IssuePropertyEditorOptionsLoaded",
     Self::PropertyEditorOptionsFailed { .. } => "IssuePropertyEditorOptionsFailed",
     Self::PropertyEditSucceeded { .. } => "IssuePropertyEditSucceeded",
@@ -276,6 +282,8 @@ message_names!(PullRequestsMessage {
     Self::PropertyEditorTitleDelete => "PrPropertyEditorTitleDelete",
     Self::PropertyEditorTitleCursorLeft => "PrPropertyEditorTitleCursorLeft",
     Self::PropertyEditorTitleCursorRight => "PrPropertyEditorTitleCursorRight",
+    Self::PropertyEditorTitleCursorHome => "PrPropertyEditorTitleCursorHome",
+    Self::PropertyEditorTitleCursorEnd => "PrPropertyEditorTitleCursorEnd",
     Self::PropertyEditorOptionsLoaded { .. } => "PrPropertyEditorOptionsLoaded",
     Self::PropertyEditorOptionsFailed { .. } => "PrPropertyEditorOptionsFailed",
     Self::PropertyEditSucceeded { .. } => "PrPropertyEditSucceeded",
@@ -308,6 +316,8 @@ pub(super) fn is_issue_property_app_event(event: &AppEvent) -> bool {
             | AppEvent::IssuePropertyEditorTitleDelete
             | AppEvent::IssuePropertyEditorTitleCursorLeft
             | AppEvent::IssuePropertyEditorTitleCursorRight
+            | AppEvent::IssuePropertyEditorTitleCursorHome
+            | AppEvent::IssuePropertyEditorTitleCursorEnd
             | AppEvent::IssuePropertyEditorOptionsLoaded { .. }
             | AppEvent::IssuePropertyEditorOptionsFailed { .. }
             | AppEvent::IssuePropertyEditSucceeded { .. }
@@ -333,6 +343,8 @@ pub(super) fn is_issue_property_msg(message: &IssuesMessage) -> bool {
             | IssuesMessage::PropertyEditorTitleDelete
             | IssuesMessage::PropertyEditorTitleCursorLeft
             | IssuesMessage::PropertyEditorTitleCursorRight
+            | IssuesMessage::PropertyEditorTitleCursorHome
+            | IssuesMessage::PropertyEditorTitleCursorEnd
             | IssuesMessage::PropertyEditorOptionsLoaded { .. }
             | IssuesMessage::PropertyEditorOptionsFailed { .. }
             | IssuesMessage::PropertyEditSucceeded { .. }

--- a/src/messages/names.rs
+++ b/src/messages/names.rs
@@ -71,6 +71,8 @@ message_names!(ModalMessage {
     Self::FormDelete => "FormDelete",
     Self::FormMoveCursorLeft => "FormMoveCursorLeft",
     Self::FormMoveCursorRight => "FormMoveCursorRight",
+    Self::FormMoveCursorStart => "FormMoveCursorStart",
+    Self::FormMoveCursorEnd => "FormMoveCursorEnd",
     Self::FormNextField => "FormNextField",
     Self::FormPrevField => "FormPrevField",
     Self::FormToggleCheckbox => "FormToggleCheckbox",
@@ -181,6 +183,8 @@ message_names!(IssuesMessage {
     Self::InlineCursorRight => "InlineCursorRight",
     Self::InlineCursorUp => "InlineCursorUp",
     Self::InlineCursorDown => "InlineCursorDown",
+    Self::InlineCursorHome => "InlineCursorHome",
+    Self::InlineCursorEnd => "InlineCursorEnd",
     Self::InlineSubmit => "InlineSubmit",
     Self::InlineCancelOrEsc => "InlineCancelOrEsc",
     Self::RequestIssueRewrite => "RequestIssueRewrite",
@@ -228,6 +232,8 @@ message_names!(IssuesMessage {
     Self::PropertyEditorTitleDelete => "IssuePropertyEditorTitleDelete",
     Self::PropertyEditorTitleCursorLeft => "IssuePropertyEditorTitleCursorLeft",
     Self::PropertyEditorTitleCursorRight => "IssuePropertyEditorTitleCursorRight",
+    Self::PropertyEditorTitleCursorHome => "IssuePropertyEditorTitleCursorHome",
+    Self::PropertyEditorTitleCursorEnd => "IssuePropertyEditorTitleCursorEnd",
     Self::PropertyEditorOptionsLoaded { .. } => "IssuePropertyEditorOptionsLoaded",
     Self::PropertyEditorOptionsFailed { .. } => "IssuePropertyEditorOptionsFailed",
     Self::PropertyEditSucceeded { .. } => "IssuePropertyEditSucceeded",
@@ -315,6 +321,8 @@ message_names!(PullRequestsMessage {
     Self::PropertyEditorTitleDelete => "PrPropertyEditorTitleDelete",
     Self::PropertyEditorTitleCursorLeft => "PrPropertyEditorTitleCursorLeft",
     Self::PropertyEditorTitleCursorRight => "PrPropertyEditorTitleCursorRight",
+    Self::PropertyEditorTitleCursorHome => "PrPropertyEditorTitleCursorHome",
+    Self::PropertyEditorTitleCursorEnd => "PrPropertyEditorTitleCursorEnd",
     Self::PropertyEditorOptionsLoaded { .. } => "PrPropertyEditorOptionsLoaded",
     Self::PropertyEditorOptionsFailed { .. } => "PrPropertyEditorOptionsFailed",
     Self::PropertyEditSucceeded { .. } => "PrPropertyEditSucceeded",
@@ -340,6 +348,8 @@ pub(super) fn is_issue_property_app_event(event: &AppEvent) -> bool {
             | AppEvent::IssuePropertyEditorTitleDelete
             | AppEvent::IssuePropertyEditorTitleCursorLeft
             | AppEvent::IssuePropertyEditorTitleCursorRight
+            | AppEvent::IssuePropertyEditorTitleCursorHome
+            | AppEvent::IssuePropertyEditorTitleCursorEnd
             | AppEvent::IssuePropertyEditorOptionsLoaded { .. }
             | AppEvent::IssuePropertyEditorOptionsFailed { .. }
             | AppEvent::IssuePropertyEditSucceeded { .. }
@@ -364,6 +374,8 @@ pub(super) fn is_issue_property_msg(message: &IssuesMessage) -> bool {
             | IssuesMessage::PropertyEditorTitleDelete
             | IssuesMessage::PropertyEditorTitleCursorLeft
             | IssuesMessage::PropertyEditorTitleCursorRight
+            | IssuesMessage::PropertyEditorTitleCursorHome
+            | IssuesMessage::PropertyEditorTitleCursorEnd
             | IssuesMessage::PropertyEditorOptionsLoaded { .. }
             | IssuesMessage::PropertyEditorOptionsFailed { .. }
             | IssuesMessage::PropertyEditSucceeded { .. }

--- a/src/messages/prs_conversion.rs
+++ b/src/messages/prs_conversion.rs
@@ -329,6 +329,8 @@ impl PullRequestsMessage {
             AppEvent::PrInlineCursorRight => Self::Inline(PrInlineMsg::CursorRight),
             AppEvent::PrInlineCursorUp => Self::Inline(PrInlineMsg::CursorUp),
             AppEvent::PrInlineCursorDown => Self::Inline(PrInlineMsg::CursorDown),
+            AppEvent::PrInlineCursorHome => Self::Inline(PrInlineMsg::CursorHome),
+            AppEvent::PrInlineCursorEnd => Self::Inline(PrInlineMsg::CursorEnd),
             AppEvent::PrInlineSubmit => Self::Inline(PrInlineMsg::Submit),
             AppEvent::PrInlineCancelOrEsc => Self::Inline(PrInlineMsg::CancelOrEsc),
             other => Self::from_app_event_mutation_and_agent(other),
@@ -458,27 +460,37 @@ impl PullRequestsMessage {
                 pr_number,
                 allowed_methods,
             },
-            AppEvent::PrOpenPropertyEditor { .. }
-            | AppEvent::PrPropertyEditorNavigateUp
-            | AppEvent::PrPropertyEditorNavigateDown
-            | AppEvent::PrPropertyEditorToggle
-            | AppEvent::PrPropertyEditorConfirm
-            | AppEvent::PrPropertyEditorCancel
-            | AppEvent::PrPropertyEditorTitleChar(_)
-            | AppEvent::PrPropertyEditorTitleBackspace
-            | AppEvent::PrPropertyEditorTitleDelete
-            | AppEvent::PrPropertyEditorTitleCursorLeft
-            | AppEvent::PrPropertyEditorTitleCursorRight
-            | AppEvent::PrPropertyEditorOptionsLoaded { .. }
-            | AppEvent::PrPropertyEditorOptionsFailed { .. }
-            | AppEvent::PrPropertyEditSucceeded { .. }
-            | AppEvent::PrPostMutationRefreshStarted
-            | AppEvent::PrPropertyEditFailed { .. }
-            | AppEvent::PrPropertyEditorValidationError { .. } => {
-                Self::from_app_event_property(event)
+            property if Self::is_pr_property_app_event(&property) => {
+                Self::from_app_event_property(property)
             }
             _ => unreachable!("non-PR AppEvent routed to PR converter"),
         }
+    }
+
+    /// Whether an `AppEvent` is a PR property-editor event.
+    fn is_pr_property_app_event(event: &AppEvent) -> bool {
+        matches!(
+            event,
+            AppEvent::PrOpenPropertyEditor { .. }
+                | AppEvent::PrPropertyEditorNavigateUp
+                | AppEvent::PrPropertyEditorNavigateDown
+                | AppEvent::PrPropertyEditorToggle
+                | AppEvent::PrPropertyEditorConfirm
+                | AppEvent::PrPropertyEditorCancel
+                | AppEvent::PrPropertyEditorTitleChar(_)
+                | AppEvent::PrPropertyEditorTitleBackspace
+                | AppEvent::PrPropertyEditorTitleDelete
+                | AppEvent::PrPropertyEditorTitleCursorLeft
+                | AppEvent::PrPropertyEditorTitleCursorRight
+                | AppEvent::PrPropertyEditorTitleCursorHome
+                | AppEvent::PrPropertyEditorTitleCursorEnd
+                | AppEvent::PrPropertyEditorOptionsLoaded { .. }
+                | AppEvent::PrPropertyEditorOptionsFailed { .. }
+                | AppEvent::PrPropertyEditSucceeded { .. }
+                | AppEvent::PrPostMutationRefreshStarted
+                | AppEvent::PrPropertyEditFailed { .. }
+                | AppEvent::PrPropertyEditorValidationError { .. }
+        )
     }
 
     /// Convert this PR-domain message back into the [`AppEvent`].
@@ -789,6 +801,8 @@ impl PullRequestsMessage {
             Self::Inline(PrInlineMsg::CursorRight) => AppEvent::PrInlineCursorRight,
             Self::Inline(PrInlineMsg::CursorUp) => AppEvent::PrInlineCursorUp,
             Self::Inline(PrInlineMsg::CursorDown) => AppEvent::PrInlineCursorDown,
+            Self::Inline(PrInlineMsg::CursorHome) => AppEvent::PrInlineCursorHome,
+            Self::Inline(PrInlineMsg::CursorEnd) => AppEvent::PrInlineCursorEnd,
             Self::Inline(PrInlineMsg::Submit) => AppEvent::PrInlineSubmit,
             Self::Inline(PrInlineMsg::CancelOrEsc) => AppEvent::PrInlineCancelOrEsc,
             other => other.into_app_event_mutation_and_agent(),
@@ -929,6 +943,8 @@ impl PullRequestsMessage {
             | Self::PropertyEditorTitleDelete
             | Self::PropertyEditorTitleCursorLeft
             | Self::PropertyEditorTitleCursorRight
+            | Self::PropertyEditorTitleCursorHome
+            | Self::PropertyEditorTitleCursorEnd
             | Self::PropertyEditorOptionsLoaded { .. }
             | Self::PropertyEditorOptionsFailed { .. }
             | Self::PropertyEditSucceeded { .. }

--- a/src/messages/prs_property_conversion.rs
+++ b/src/messages/prs_property_conversion.rs
@@ -38,6 +38,8 @@ impl PullRequestsMessage {
             AppEvent::PrPropertyEditorTitleDelete => Self::PropertyEditorTitleDelete,
             AppEvent::PrPropertyEditorTitleCursorLeft => Self::PropertyEditorTitleCursorLeft,
             AppEvent::PrPropertyEditorTitleCursorRight => Self::PropertyEditorTitleCursorRight,
+            AppEvent::PrPropertyEditorTitleCursorHome => Self::PropertyEditorTitleCursorHome,
+            AppEvent::PrPropertyEditorTitleCursorEnd => Self::PropertyEditorTitleCursorEnd,
             // Non-property events should never reach this converter; the
             // routing guard filters them upstream. If one slips through,
             // it is safer to no-op (close the editor) than to panic or
@@ -168,6 +170,8 @@ impl PullRequestsMessage {
             Self::PropertyEditorTitleDelete => AppEvent::PrPropertyEditorTitleDelete,
             Self::PropertyEditorTitleCursorLeft => AppEvent::PrPropertyEditorTitleCursorLeft,
             Self::PropertyEditorTitleCursorRight => AppEvent::PrPropertyEditorTitleCursorRight,
+            Self::PropertyEditorTitleCursorHome => AppEvent::PrPropertyEditorTitleCursorHome,
+            Self::PropertyEditorTitleCursorEnd => AppEvent::PrPropertyEditorTitleCursorEnd,
             // Non-property messages should never reach this converter. If
             // one slips through, close the editor rather than entering an
             // unrelated mode.

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -67,6 +67,8 @@ pub enum AppEvent {
     FormDelete,
     FormMoveCursorLeft,
     FormMoveCursorRight,
+    FormMoveCursorStart,
+    FormMoveCursorEnd,
     FormNextField,
     FormPrevField,
     FormToggleCheckbox,
@@ -292,6 +294,12 @@ pub enum AppEvent {
     InlineCursorRight,
     InlineCursorUp,
     InlineCursorDown,
+    /// Move the inline composer/editor caret to the start of the current
+    /// logical line (Home key, issue #406).
+    InlineCursorHome,
+    /// Move the inline composer/editor caret to the end of the current
+    /// logical line (End key, issue #406).
+    InlineCursorEnd,
     InlineSubmit,
     InlineCancelOrEsc,
     /// Ask the configured default agent to rewrite the current new-issue
@@ -543,6 +551,12 @@ pub enum AppEvent {
     PrInlineCursorRight,
     PrInlineCursorUp,
     PrInlineCursorDown,
+    /// Move the PR composer/editor caret to the start of the current logical
+    /// line (Home key, issue #406).
+    PrInlineCursorHome,
+    /// Move the PR composer/editor caret to the end of the current logical
+    /// line (End key, issue #406).
+    PrInlineCursorEnd,
     PrInlineSubmit,
     PrInlineCancelOrEsc,
     PrCommentCreated {
@@ -784,6 +798,8 @@ pub enum AppEvent {
     IssuePropertyEditorTitleDelete,
     IssuePropertyEditorTitleCursorLeft,
     IssuePropertyEditorTitleCursorRight,
+    IssuePropertyEditorTitleCursorHome,
+    IssuePropertyEditorTitleCursorEnd,
     IssuePropertyEditorOptionsLoaded {
         scope_repo_id: RepositoryId,
         issue_number: u64,
@@ -835,6 +851,8 @@ pub enum AppEvent {
     PrPropertyEditorTitleDelete,
     PrPropertyEditorTitleCursorLeft,
     PrPropertyEditorTitleCursorRight,
+    PrPropertyEditorTitleCursorHome,
+    PrPropertyEditorTitleCursorEnd,
     PrPropertyEditorOptionsLoaded {
         scope_repo_id: RepositoryId,
         pr_number: u64,

--- a/src/state/form_cursor.rs
+++ b/src/state/form_cursor.rs
@@ -438,19 +438,6 @@ pub(super) fn move_agent_field_cursor_end(
         }
     }
 }
-
-pub(super) fn move_workflow_dispatch_field_cursor_end(
-    fields: &WorkflowDispatchFormFields,
-    cursor: &mut WorkflowDispatchFormCursor,
-    focus: WorkflowDispatchFormFocus,
-) {
-    match focus {
-        WorkflowDispatchFormFocus::RefName => cursor.ref_name = move_cursor_end(&fields.ref_name),
-        WorkflowDispatchFormFocus::Inputs => cursor.inputs = move_cursor_end(&fields.inputs),
-        WorkflowDispatchFormFocus::Submit | WorkflowDispatchFormFocus::Cancel => {}
-    }
-}
-
 pub(super) fn move_repository_field_cursor_left(
     cursor: &mut RepositoryFormCursor,
     focus: RepositoryFormFocus,

--- a/src/state/form_cursor.rs
+++ b/src/state/form_cursor.rs
@@ -3,7 +3,9 @@ use super::types::{
     RepositoryFormFocus, WorkflowDispatchFormCursor, WorkflowDispatchFormFields,
     WorkflowDispatchFormFocus,
 };
-use super::util::{insert_char_at, move_cursor_left, move_cursor_right};
+use super::util::{
+    insert_char_at, move_cursor_end, move_cursor_left, move_cursor_right, move_cursor_start,
+};
 
 fn insert_repository_char(value: &mut String, cursor: &mut usize, c: char) {
     *cursor = insert_char_at(value, *cursor, c);
@@ -288,6 +290,163 @@ pub(super) fn move_workflow_dispatch_field_cursor_right(
         WorkflowDispatchFormFocus::Inputs => {
             cursor.inputs = move_cursor_right(&fields.inputs, cursor.inputs);
         }
+        WorkflowDispatchFormFocus::Submit | WorkflowDispatchFormFocus::Cancel => {}
+    }
+}
+
+pub(super) fn move_repository_field_cursor_start(
+    cursor: &mut RepositoryFormCursor,
+    focus: RepositoryFormFocus,
+) {
+    match focus {
+        RepositoryFormFocus::DefaultAgentKind
+        | RepositoryFormFocus::DefaultCodePuppyYolo
+        | RepositoryFormFocus::RemoteEnabled
+        | RepositoryFormFocus::SetupEnvDefault => {}
+        RepositoryFormFocus::Name => cursor.name = move_cursor_start(),
+        RepositoryFormFocus::BaseDir => cursor.base_dir = move_cursor_start(),
+        RepositoryFormFocus::DefaultProfile => cursor.default_profile = move_cursor_start(),
+        RepositoryFormFocus::DefaultCodePuppyModel => {
+            cursor.default_code_puppy_model = move_cursor_start();
+        }
+        RepositoryFormFocus::DefaultCodePuppyVersion => {
+            cursor.default_code_puppy_version = move_cursor_start();
+        }
+        RepositoryFormFocus::DefaultLlxprtMode => cursor.default_llxprt_mode = move_cursor_start(),
+        RepositoryFormFocus::DefaultLlxprtVersion => {
+            cursor.default_llxprt_version = move_cursor_start();
+        }
+        RepositoryFormFocus::GitHubRepo => cursor.github_repo = move_cursor_start(),
+        RepositoryFormFocus::IssuePrRepo => cursor.github_issue_pr_repo = move_cursor_start(),
+        RepositoryFormFocus::LoginUser => cursor.login_user = move_cursor_start(),
+        RepositoryFormFocus::Host => cursor.host = move_cursor_start(),
+        RepositoryFormFocus::SshPort => cursor.ssh_port = move_cursor_start(),
+        RepositoryFormFocus::IdentityFile => cursor.identity_file = move_cursor_start(),
+        RepositoryFormFocus::SshOptions => cursor.ssh_options = move_cursor_start(),
+        RepositoryFormFocus::RunAsUser => cursor.run_as_user = move_cursor_start(),
+        RepositoryFormFocus::TransientAgentDir => cursor.transient_agent_dir = move_cursor_start(),
+        RepositoryFormFocus::TransientMaxConcurrent => {
+            cursor.transient_max_concurrent = move_cursor_start();
+        }
+    }
+}
+
+pub(super) fn move_repository_field_cursor_end(
+    fields: &RepositoryFormFields,
+    cursor: &mut RepositoryFormCursor,
+    focus: RepositoryFormFocus,
+) {
+    match focus {
+        RepositoryFormFocus::DefaultAgentKind
+        | RepositoryFormFocus::DefaultCodePuppyYolo
+        | RepositoryFormFocus::RemoteEnabled
+        | RepositoryFormFocus::SetupEnvDefault => {}
+        RepositoryFormFocus::Name => cursor.name = move_cursor_end(&fields.name),
+        RepositoryFormFocus::BaseDir => cursor.base_dir = move_cursor_end(&fields.base_dir),
+        RepositoryFormFocus::DefaultProfile => {
+            cursor.default_profile = move_cursor_end(&fields.default_profile);
+        }
+        RepositoryFormFocus::DefaultCodePuppyModel => {
+            cursor.default_code_puppy_model = move_cursor_end(&fields.default_code_puppy_model);
+        }
+        RepositoryFormFocus::DefaultCodePuppyVersion => {
+            cursor.default_code_puppy_version = move_cursor_end(&fields.default_code_puppy_version);
+        }
+        RepositoryFormFocus::DefaultLlxprtMode => {
+            cursor.default_llxprt_mode = move_cursor_end(&fields.default_llxprt_mode);
+        }
+        RepositoryFormFocus::DefaultLlxprtVersion => {
+            cursor.default_llxprt_version = move_cursor_end(&fields.default_llxprt_version);
+        }
+        RepositoryFormFocus::GitHubRepo => {
+            cursor.github_repo = move_cursor_end(&fields.github_repo);
+        }
+        RepositoryFormFocus::IssuePrRepo => {
+            cursor.github_issue_pr_repo = move_cursor_end(&fields.github_issue_pr_repo);
+        }
+        RepositoryFormFocus::LoginUser => cursor.login_user = move_cursor_end(&fields.login_user),
+        RepositoryFormFocus::Host => cursor.host = move_cursor_end(&fields.host),
+        RepositoryFormFocus::SshPort => cursor.ssh_port = move_cursor_end(&fields.ssh_port),
+        RepositoryFormFocus::IdentityFile => {
+            cursor.identity_file = move_cursor_end(&fields.identity_file);
+        }
+        RepositoryFormFocus::SshOptions => {
+            cursor.ssh_options = move_cursor_end(&fields.ssh_options);
+        }
+        RepositoryFormFocus::RunAsUser => cursor.run_as_user = move_cursor_end(&fields.run_as_user),
+        RepositoryFormFocus::TransientAgentDir => {
+            cursor.transient_agent_dir = move_cursor_end(&fields.transient_agent_dir);
+        }
+        RepositoryFormFocus::TransientMaxConcurrent => {
+            cursor.transient_max_concurrent = move_cursor_end(&fields.transient_max_concurrent);
+        }
+    }
+}
+
+pub(super) fn move_agent_field_cursor_start(cursor: &mut AgentFormCursor, focus: AgentFormFocus) {
+    match focus {
+        AgentFormFocus::Shortcut
+        | AgentFormFocus::AgentKind
+        | AgentFormFocus::CodePuppyYolo
+        | AgentFormFocus::CodePuppyQuickResume
+        | AgentFormFocus::PassContinue
+        | AgentFormFocus::Sandbox
+        | AgentFormFocus::SandboxEngine => {}
+        AgentFormFocus::Name => cursor.name = move_cursor_start(),
+        AgentFormFocus::Description => cursor.description = move_cursor_start(),
+        AgentFormFocus::WorkDir => cursor.work_dir = move_cursor_start(),
+        AgentFormFocus::Profile => cursor.profile = move_cursor_start(),
+        AgentFormFocus::CodePuppyModel => cursor.code_puppy_model = move_cursor_start(),
+        AgentFormFocus::CodePuppyVersion => cursor.code_puppy_version = move_cursor_start(),
+        AgentFormFocus::Mode => cursor.mode = move_cursor_start(),
+        AgentFormFocus::LlxprtVersion => cursor.llxprt_version = move_cursor_start(),
+        AgentFormFocus::LlxprtDebug => cursor.llxprt_debug = move_cursor_start(),
+        AgentFormFocus::SandboxFlags => cursor.sandbox_flags = move_cursor_start(),
+    }
+}
+
+pub(super) fn move_agent_field_cursor_end(
+    fields: &AgentFormFields,
+    cursor: &mut AgentFormCursor,
+    focus: AgentFormFocus,
+) {
+    match focus {
+        AgentFormFocus::Shortcut
+        | AgentFormFocus::AgentKind
+        | AgentFormFocus::CodePuppyYolo
+        | AgentFormFocus::CodePuppyQuickResume
+        | AgentFormFocus::PassContinue
+        | AgentFormFocus::Sandbox
+        | AgentFormFocus::SandboxEngine => {}
+        AgentFormFocus::Name => cursor.name = move_cursor_end(&fields.name),
+        AgentFormFocus::Description => cursor.description = move_cursor_end(&fields.description),
+        AgentFormFocus::WorkDir => cursor.work_dir = move_cursor_end(&fields.work_dir),
+        AgentFormFocus::Profile => cursor.profile = move_cursor_end(&fields.profile),
+        AgentFormFocus::CodePuppyModel => {
+            cursor.code_puppy_model = move_cursor_end(&fields.code_puppy_model);
+        }
+        AgentFormFocus::CodePuppyVersion => {
+            cursor.code_puppy_version = move_cursor_end(&fields.code_puppy_version);
+        }
+        AgentFormFocus::Mode => cursor.mode = move_cursor_end(&fields.mode),
+        AgentFormFocus::LlxprtVersion => {
+            cursor.llxprt_version = move_cursor_end(&fields.llxprt_version);
+        }
+        AgentFormFocus::LlxprtDebug => cursor.llxprt_debug = move_cursor_end(&fields.llxprt_debug),
+        AgentFormFocus::SandboxFlags => {
+            cursor.sandbox_flags = move_cursor_end(&fields.sandbox_flags);
+        }
+    }
+}
+
+pub(super) fn move_workflow_dispatch_field_cursor_end(
+    fields: &WorkflowDispatchFormFields,
+    cursor: &mut WorkflowDispatchFormCursor,
+    focus: WorkflowDispatchFormFocus,
+) {
+    match focus {
+        WorkflowDispatchFormFocus::RefName => cursor.ref_name = move_cursor_end(&fields.ref_name),
+        WorkflowDispatchFormFocus::Inputs => cursor.inputs = move_cursor_end(&fields.inputs),
         WorkflowDispatchFormFocus::Submit | WorkflowDispatchFormFocus::Cancel => {}
     }
 }

--- a/src/state/form_home_end_ops.rs
+++ b/src/state/form_home_end_ops.rs
@@ -1,0 +1,69 @@
+//! Home/End cursor movement for form text fields (issue #406).
+//!
+//! Extracted from `form_ops.rs` to stay within the per-file line budget.
+
+use super::AppState;
+use super::types::ModalState;
+
+impl AppState {
+    /// Move the focused form-field cursor to the start of the field
+    /// (Home key, issue #406).
+    pub(super) fn handle_form_move_cursor_start(&mut self) {
+        match &mut self.modal {
+            ModalState::NewRepository { focus, cursor, .. }
+            | ModalState::EditRepository { focus, cursor, .. } => {
+                crate::state::form_cursor::move_repository_field_cursor_start(cursor, *focus);
+            }
+            ModalState::NewAgent { focus, cursor, .. }
+            | ModalState::EditAgent { focus, cursor, .. } => {
+                crate::state::form_cursor::move_agent_field_cursor_start(cursor, *focus);
+            }
+            ModalState::WorkflowDispatch { focus, cursor, .. } => {
+                crate::state::form_workflow_dispatch::move_cursor_field_start(cursor, *focus);
+            }
+            _ => {}
+        }
+    }
+
+    /// Move the focused form-field cursor to the end of the field
+    /// (End key, issue #406).
+    pub(super) fn handle_form_move_cursor_end(&mut self) {
+        match &mut self.modal {
+            ModalState::NewRepository {
+                fields,
+                focus,
+                cursor,
+                ..
+            }
+            | ModalState::EditRepository {
+                fields,
+                focus,
+                cursor,
+                ..
+            } => {
+                crate::state::form_cursor::move_repository_field_cursor_end(fields, cursor, *focus);
+            }
+            ModalState::NewAgent {
+                fields,
+                focus,
+                cursor,
+                ..
+            }
+            | ModalState::EditAgent {
+                fields,
+                focus,
+                cursor,
+                ..
+            } => crate::state::form_cursor::move_agent_field_cursor_end(fields, cursor, *focus),
+            ModalState::WorkflowDispatch {
+                fields,
+                focus,
+                cursor,
+                ..
+            } => crate::state::form_cursor::move_workflow_dispatch_field_cursor_end(
+                fields, cursor, *focus,
+            ),
+            _ => {}
+        }
+    }
+}

--- a/src/state/form_home_end_ops.rs
+++ b/src/state/form_home_end_ops.rs
@@ -60,9 +60,9 @@ impl AppState {
                 focus,
                 cursor,
                 ..
-            } => crate::state::form_cursor::move_workflow_dispatch_field_cursor_end(
-                fields, cursor, *focus,
-            ),
+            } => {
+                crate::state::form_workflow_dispatch::move_cursor_field_end(fields, cursor, *focus);
+            }
             _ => {}
         }
     }

--- a/src/state/form_home_end_tests.rs
+++ b/src/state/form_home_end_tests.rs
@@ -1,0 +1,113 @@
+//! Issue #406: Home/End cursor movement tests for form text fields.
+//!
+//! FormMoveCursorStart moves the focused field's cursor to char index 0;
+//! FormMoveCursorEnd moves it to the field's char count. These apply to all
+//! text-entry form fields (repository, agent, workflow-dispatch).
+
+use crate::domain::RepositoryId;
+use crate::state::AppState;
+use crate::state::events::AppEvent;
+use crate::state::types::ModalState;
+
+/// A repository row suitable for seeding AppState in form tests.
+fn seed_repository() -> crate::domain::Repository {
+    crate::domain::Repository::new(
+        RepositoryId("repo-1".to_string()),
+        "Test Repo".to_string(),
+        "repo-1".to_string(),
+        std::path::PathBuf::from("/tmp/test"),
+    )
+}
+
+/// Open a NewAgent modal and type into the Name field so the cursor is at the
+/// end of the typed text, ready for a Home/End assertion.
+fn new_agent_form_with_typed_name(text: &str) -> AppState {
+    let mut state = AppState {
+        repositories: vec![seed_repository()],
+        ..AppState::default()
+    };
+    state = state.apply(AppEvent::OpenNewAgent(RepositoryId("repo-1".to_owned())));
+    // Move focus to the Name field (default focus is Shortcut).
+    state = state.apply(AppEvent::FormNextField);
+    for ch in text.chars() {
+        state = state.apply(AppEvent::FormChar(ch));
+    }
+    state
+}
+
+/// Extract the agent Name cursor from a NewAgent modal.
+fn agent_name_cursor(state: &AppState) -> usize {
+    let ModalState::NewAgent { cursor, .. } = &state.modal else {
+        panic!("expected NewAgent modal, got {:?}", state.modal);
+    };
+    cursor.name
+}
+
+/// Home moves the focused agent Name cursor to char index 0.
+#[test]
+fn form_home_moves_agent_name_cursor_to_start() {
+    let state = new_agent_form_with_typed_name("hello");
+    // Walk the cursor into the middle.
+    let state = state.apply(AppEvent::FormMoveCursorLeft);
+    let state = state.apply(AppEvent::FormMoveCursorLeft);
+    // Home -> 0.
+    let state = state.apply(AppEvent::FormMoveCursorStart);
+    assert_eq!(
+        agent_name_cursor(&state),
+        0,
+        "Home must move to char index 0"
+    );
+}
+
+/// End moves the focused agent Name cursor to the field's char count.
+#[test]
+fn form_end_moves_agent_name_cursor_to_end() {
+    let state = new_agent_form_with_typed_name("hello");
+    // Walk back to the start, then End -> char count (5).
+    let state = state.apply(AppEvent::FormMoveCursorStart);
+    let state = state.apply(AppEvent::FormMoveCursorEnd);
+    assert_eq!(
+        agent_name_cursor(&state),
+        5,
+        "End must move to the field's char count"
+    );
+}
+
+/// Home/End on a multibyte agent name never lands mid-codepoint (the cursor
+/// is char-count based, so this is structurally safe).
+#[test]
+fn form_home_end_utf8_safe_agent_name() {
+    // "héllo" is 5 chars but 6 bytes; the cursor counts chars.
+    let state = new_agent_form_with_typed_name("héllo");
+    let state = state.apply(AppEvent::FormMoveCursorStart);
+    assert_eq!(agent_name_cursor(&state), 0, "Home -> 0");
+    let state = state.apply(AppEvent::FormMoveCursorEnd);
+    assert_eq!(agent_name_cursor(&state), 5, "End -> char count (5)");
+}
+
+/// Home/End also works on a repository text field (BaseDir focus).
+#[test]
+fn form_home_end_repository_basedir() {
+    let mut state = AppState {
+        repositories: vec![seed_repository()],
+        ..AppState::default()
+    };
+    state = state.apply(AppEvent::OpenNewRepository);
+    // Move focus to BaseDir (Tab advances field focus).
+    state = state.apply(AppEvent::FormNextField);
+    // Type some text into BaseDir.
+    for ch in "my/path".chars() {
+        state = state.apply(AppEvent::FormChar(ch));
+    }
+    // Home -> 0, End -> char count.
+    let state = state.apply(AppEvent::FormMoveCursorStart);
+    let ModalState::NewRepository { cursor, .. } = &state.modal else {
+        panic!("expected NewRepository modal");
+    };
+    assert_eq!(cursor.base_dir, 0, "Home on BaseDir -> 0");
+    let state = state.apply(AppEvent::FormMoveCursorEnd);
+    let ModalState::NewRepository { cursor, .. } = &state.modal else {
+        panic!("expected NewRepository modal");
+    };
+    assert_eq!(cursor.base_dir, 7, "End on BaseDir -> char count (7)");
+}

--- a/src/state/form_home_end_tests.rs
+++ b/src/state/form_home_end_tests.rs
@@ -50,6 +50,12 @@ fn form_home_moves_agent_name_cursor_to_start() {
     // Walk the cursor into the middle.
     let state = state.apply(AppEvent::FormMoveCursorLeft);
     let state = state.apply(AppEvent::FormMoveCursorLeft);
+    // After two left-moves the cursor should be at 3 (middle of "hello").
+    assert_eq!(
+        agent_name_cursor(&state),
+        3,
+        "cursor should be at char 3 after two left-moves"
+    );
     // Home -> 0.
     let state = state.apply(AppEvent::FormMoveCursorStart);
     assert_eq!(

--- a/src/state/form_workflow_dispatch.rs
+++ b/src/state/form_workflow_dispatch.rs
@@ -8,7 +8,9 @@
 use super::types::{
     WorkflowDispatchFormCursor, WorkflowDispatchFormFields, WorkflowDispatchFormFocus,
 };
-use super::util::{delete_char_at, delete_char_before, insert_char_at, move_cursor_left};
+use super::util::{
+    delete_char_at, delete_char_before, insert_char_at, move_cursor_left, move_cursor_start,
+};
 
 /// Insert a character at the cursor position in the focused WorkflowDispatch
 /// text field.
@@ -77,6 +79,19 @@ pub(super) fn move_cursor_field_left(
         WorkflowDispatchFormFocus::Inputs => {
             cursor.inputs = move_cursor_left(cursor.inputs);
         }
+        WorkflowDispatchFormFocus::Submit | WorkflowDispatchFormFocus::Cancel => {}
+    }
+}
+
+/// Move the cursor to the start of the focused WorkflowDispatch text field
+/// (issue #406).
+pub(super) fn move_cursor_field_start(
+    cursor: &mut WorkflowDispatchFormCursor,
+    focus: WorkflowDispatchFormFocus,
+) {
+    match focus {
+        WorkflowDispatchFormFocus::RefName => cursor.ref_name = move_cursor_start(),
+        WorkflowDispatchFormFocus::Inputs => cursor.inputs = move_cursor_start(),
         WorkflowDispatchFormFocus::Submit | WorkflowDispatchFormFocus::Cancel => {}
     }
 }

--- a/src/state/form_workflow_dispatch.rs
+++ b/src/state/form_workflow_dispatch.rs
@@ -9,7 +9,8 @@ use super::types::{
     WorkflowDispatchFormCursor, WorkflowDispatchFormFields, WorkflowDispatchFormFocus,
 };
 use super::util::{
-    delete_char_at, delete_char_before, insert_char_at, move_cursor_left, move_cursor_start,
+    delete_char_at, delete_char_before, insert_char_at, move_cursor_end, move_cursor_left,
+    move_cursor_start,
 };
 
 /// Insert a character at the cursor position in the focused WorkflowDispatch
@@ -92,6 +93,20 @@ pub(super) fn move_cursor_field_start(
     match focus {
         WorkflowDispatchFormFocus::RefName => cursor.ref_name = move_cursor_start(),
         WorkflowDispatchFormFocus::Inputs => cursor.inputs = move_cursor_start(),
+        WorkflowDispatchFormFocus::Submit | WorkflowDispatchFormFocus::Cancel => {}
+    }
+}
+
+/// Move the cursor to the end of the focused WorkflowDispatch text field
+/// (issue #406).
+pub(super) fn move_cursor_field_end(
+    fields: &WorkflowDispatchFormFields,
+    cursor: &mut WorkflowDispatchFormCursor,
+    focus: WorkflowDispatchFormFocus,
+) {
+    match focus {
+        WorkflowDispatchFormFocus::RefName => cursor.ref_name = move_cursor_end(&fields.ref_name),
+        WorkflowDispatchFormFocus::Inputs => cursor.inputs = move_cursor_end(&fields.inputs),
         WorkflowDispatchFormFocus::Submit | WorkflowDispatchFormFocus::Cancel => {}
     }
 }

--- a/src/state/issues_inline_ops.rs
+++ b/src/state/issues_inline_ops.rs
@@ -4,7 +4,7 @@ use crate::issue_detail_content::{ISSUE_REPLY_ANCHOR, build_detail_content};
 
 use super::{
     AppEvent, AppState, ComposerTarget, DetailSubfocus, EditorTarget, InlineState, IssueFocus,
-    inline_cursor_vertical,
+    inline_cursor_line_end, inline_cursor_line_start, inline_cursor_vertical,
 };
 
 impl AppState {
@@ -57,6 +57,8 @@ impl AppState {
                 | AppEvent::InlineCursorRight
                 | AppEvent::InlineCursorUp
                 | AppEvent::InlineCursorDown
+                | AppEvent::InlineCursorHome
+                | AppEvent::InlineCursorEnd
         )
     }
 
@@ -147,6 +149,20 @@ impl AppState {
                     Self::active_inline_text(&mut self.issues_state.inline_state)
                 {
                     inline_cursor_vertical(text, cursor, 1);
+                }
+            }
+            AppEvent::InlineCursorHome => {
+                if let Some((text, cursor)) =
+                    Self::active_inline_text(&mut self.issues_state.inline_state)
+                {
+                    inline_cursor_line_start(text, cursor);
+                }
+            }
+            AppEvent::InlineCursorEnd => {
+                if let Some((text, cursor)) =
+                    Self::active_inline_text(&mut self.issues_state.inline_state)
+                {
+                    inline_cursor_line_end(text, cursor);
                 }
             }
             AppEvent::InlineCancelOrEsc => self.issues_state.inline_state = InlineState::None,

--- a/src/state/issues_property_ops.rs
+++ b/src/state/issues_property_ops.rs
@@ -23,7 +23,9 @@ impl AppState {
             | AppEvent::IssuePropertyEditorTitleBackspace
             | AppEvent::IssuePropertyEditorTitleDelete
             | AppEvent::IssuePropertyEditorTitleCursorLeft
-            | AppEvent::IssuePropertyEditorTitleCursorRight => {
+            | AppEvent::IssuePropertyEditorTitleCursorRight
+            | AppEvent::IssuePropertyEditorTitleCursorHome
+            | AppEvent::IssuePropertyEditorTitleCursorEnd => {
                 self.apply_issue_property_editor_ui(event)
             }
             AppEvent::IssuePropertyEditorOptionsLoaded { .. }
@@ -85,6 +87,14 @@ impl AppState {
             }
             AppEvent::IssuePropertyEditorTitleCursorRight => {
                 self.issue_property_title_cursor_right();
+                true
+            }
+            AppEvent::IssuePropertyEditorTitleCursorHome => {
+                self.issue_property_title_cursor_home();
+                true
+            }
+            AppEvent::IssuePropertyEditorTitleCursorEnd => {
+                self.issue_property_title_cursor_end();
                 true
             }
             _ => false,
@@ -367,6 +377,22 @@ impl AppState {
                 .next()
                 .map_or(0, char::len_utf8);
             editor.title_cursor += next;
+        }
+    }
+
+    fn issue_property_title_cursor_home(&mut self) {
+        if let Some(editor) = &mut self.issues_state.property_editor
+            && editor.kind == IssuePropertyKind::Title
+        {
+            editor.title_cursor = 0;
+        }
+    }
+
+    fn issue_property_title_cursor_end(&mut self) {
+        if let Some(editor) = &mut self.issues_state.property_editor
+            && editor.kind == IssuePropertyKind::Title
+        {
+            editor.title_cursor = editor.title_text.len();
         }
     }
 

--- a/src/state/issues_property_ops_tests.rs
+++ b/src/state/issues_property_ops_tests.rs
@@ -303,6 +303,12 @@ fn title_home_moves_to_start() {
     for _ in 0..title_len {
         state = state.apply(AppEvent::IssuePropertyEditorTitleCursorRight);
     }
+    // Verify the cursor reached the end before testing Home.
+    assert_eq!(
+        require_issue_editor(&state).title_cursor,
+        title_len,
+        "cursor must be at the end after walking right"
+    );
     state = state.apply(AppEvent::IssuePropertyEditorTitleCursorHome);
     let editor = require_issue_editor(&state);
     assert_eq!(editor.title_cursor, 0, "Home must move the cursor to 0");
@@ -337,6 +343,12 @@ fn title_home_end_utf8_safe() {
     for _ in 0..title_len {
         state = state.apply(AppEvent::IssuePropertyEditorTitleCursorRight);
     }
+    // Verify the cursor reached the byte length before testing Home.
+    assert_eq!(
+        require_issue_editor(&state).title_cursor,
+        title_len,
+        "cursor must be at the byte length after walking right on multibyte text"
+    );
     state = state.apply(AppEvent::IssuePropertyEditorTitleCursorHome);
     let editor = require_issue_editor(&state);
     assert_eq!(

--- a/src/state/issues_property_ops_tests.rs
+++ b/src/state/issues_property_ops_tests.rs
@@ -290,6 +290,68 @@ fn title_cursor_move() {
     assert_eq!(editor.title_cursor, 0);
 }
 
+// ── H1: Title Home/End (issue #406) ─────────────────────────────────
+
+#[test]
+fn title_home_moves_to_start() {
+    let mut state = make_state_with_detail();
+    state = state.apply(AppEvent::IssueOpenPropertyEditor {
+        kind: IssuePropertyKind::Title,
+    });
+    // Walk to the end of the title text.
+    let title_len = require_issue_editor(&state).title_text.len();
+    for _ in 0..title_len {
+        state = state.apply(AppEvent::IssuePropertyEditorTitleCursorRight);
+    }
+    state = state.apply(AppEvent::IssuePropertyEditorTitleCursorHome);
+    let editor = require_issue_editor(&state);
+    assert_eq!(editor.title_cursor, 0, "Home must move the cursor to 0");
+}
+
+#[test]
+fn title_end_moves_to_end() {
+    let mut state = make_state_with_detail();
+    state = state.apply(AppEvent::IssueOpenPropertyEditor {
+        kind: IssuePropertyKind::Title,
+    });
+    // Cursor starts at 0; End must jump to the byte length of the title.
+    state = state.apply(AppEvent::IssuePropertyEditorTitleCursorEnd);
+    let editor = require_issue_editor(&state);
+    assert_eq!(
+        editor.title_cursor,
+        editor.title_text.len(),
+        "End must move the cursor to the title byte length"
+    );
+}
+
+#[test]
+fn title_home_end_utf8_safe() {
+    let mut state = make_state_with_detail();
+    state = state.apply(AppEvent::IssueOpenPropertyEditor {
+        kind: IssuePropertyKind::Title,
+    });
+    // Insert a multibyte char at the start ("éTest Issue" — cursor at byte 2).
+    state = state.apply(AppEvent::IssuePropertyEditorTitleChar('é'));
+    // Walk to the end, then Home -> 0, then End -> byte length.
+    let title_len = require_issue_editor(&state).title_text.len();
+    for _ in 0..title_len {
+        state = state.apply(AppEvent::IssuePropertyEditorTitleCursorRight);
+    }
+    state = state.apply(AppEvent::IssuePropertyEditorTitleCursorHome);
+    let editor = require_issue_editor(&state);
+    assert_eq!(
+        editor.title_cursor, 0,
+        "Home on multibyte text must land on 0"
+    );
+    state = state.apply(AppEvent::IssuePropertyEditorTitleCursorEnd);
+    let editor = require_issue_editor(&state);
+    assert_eq!(
+        editor.title_cursor,
+        editor.title_text.len(),
+        "End on multibyte text must land on the byte length"
+    );
+}
+
 // ── H3: Single-select uses selected_index ──────────────────────────
 
 #[test]

--- a/src/state/issues_tests_home_end.rs
+++ b/src/state/issues_tests_home_end.rs
@@ -1,0 +1,231 @@
+//! Issue #406: Home/End cursor movement tests for the Issues inline
+//! composer/editor.
+//!
+//! Home moves the caret to the start of the current logical line; End moves it
+//! to the end of the current logical line. These mirror the existing
+//! CursorUp/CursorDown line-aware movement, reusing the shared UTF-8-safe
+//! helpers so multibyte text never lands mid-codepoint.
+
+use crate::domain::{IssueDetail, IssueState, Repository, RepositoryId};
+use crate::state::AppState;
+use crate::state::events::AppEvent;
+use crate::state::types::{ComposerTarget, InlineState};
+
+fn issues_mode_state_with_repo(repo_id: &str) -> AppState {
+    let mut state = AppState::default();
+    state.repositories.push(Repository::new(
+        RepositoryId(repo_id.to_string()),
+        "Test Repo".to_string(),
+        repo_id.to_string(),
+        std::path::PathBuf::from("/tmp/test"),
+    ));
+    state.selected_repository_index = Some(0);
+    state.apply(AppEvent::EnterIssuesMode)
+}
+
+fn detail(number: u64) -> IssueDetail {
+    IssueDetail {
+        repo_owner_name: "owner/repo".to_string(),
+        number,
+        node_id: String::new(),
+        title: format!("Issue #{number}"),
+        state: IssueState::Open,
+        author_login: "user".to_string(),
+        created_at: "2024-01-01T00:00:00Z".to_string(),
+        updated_at: "2024-01-02T00:00:00Z".to_string(),
+        labels: vec![],
+        assignees: vec![],
+        milestone: None,
+        body: "Issue body".to_string(),
+        external_url: format!("https://github.com/owner/repo/issues/{number}"),
+        comments: crate::domain::PaginatedList::from_loaded(
+            crate::domain::CommentDetailIdentity {
+                scope_repo_id: crate::domain::RepositoryId::default(),
+                number,
+            },
+            vec![],
+            crate::domain::PageToken::from_cursor(None, false),
+        ),
+        issue_type_name: None,
+        state_reason: None,
+    }
+}
+
+fn state_with_loaded_detail(repo_id: &RepositoryId, issue_number: u64) -> AppState {
+    let mut state = issues_mode_state_with_repo("repo-1");
+    state.mark_issue_detail_loading(repo_id.clone(), issue_number);
+    state.apply(AppEvent::IssueDetailLoaded {
+        scope_repo_id: repo_id.clone(),
+        issue_number,
+        request_id: 0,
+        detail: Box::new(detail(issue_number)),
+    })
+}
+
+fn open_new_comment_composer(state: AppState) -> AppState {
+    state.apply(AppEvent::OpenNewCommentComposer)
+}
+
+fn type_into_composer(mut state: AppState, text: &str) -> AppState {
+    for ch in text.chars() {
+        state = if ch == '\n' {
+            state.apply(AppEvent::InlineNewline)
+        } else {
+            state.apply(AppEvent::InlineChar(ch))
+        };
+    }
+    state
+}
+
+fn move_cursor_left(state: AppState, steps: usize) -> AppState {
+    let mut s = state;
+    for _ in 0..steps {
+        s = s.apply(AppEvent::InlineCursorLeft);
+    }
+    s
+}
+
+fn composer_text_cursor(state: &AppState) -> (String, usize) {
+    match &state.issues_state.inline_state {
+        InlineState::Composer { text, cursor, .. } | InlineState::Editor { text, cursor, .. } => {
+            (text.clone(), *cursor)
+        }
+        InlineState::None => panic!("expected an active composer/editor"),
+    }
+}
+
+/// Home on a single-line composer moves the caret to byte 0 (start of line).
+#[test]
+fn home_on_single_line_moves_to_start() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let state = state_with_loaded_detail(&repo_id, 42);
+    let state = open_new_comment_composer(state);
+    let state = type_into_composer(state, "abcdef");
+    // Caret at end (byte 6); Home must jump to byte 0.
+    let state = state.apply(AppEvent::InlineCursorHome);
+    let (_text, cursor) = composer_text_cursor(&state);
+    assert_eq!(
+        cursor, 0,
+        "Home must move the caret to byte 0 on a single line"
+    );
+}
+
+/// End on a single-line composer moves the caret to text.len() (end of line).
+#[test]
+fn end_on_single_line_moves_to_end() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let state = state_with_loaded_detail(&repo_id, 42);
+    let state = open_new_comment_composer(state);
+    let state = type_into_composer(state, "abcdef");
+    // Walk back to the middle, then End must return to the end.
+    let state = move_cursor_left(state, 3);
+    let state = state.apply(AppEvent::InlineCursorEnd);
+    let (text, cursor) = composer_text_cursor(&state);
+    assert_eq!(cursor, text.len(), "End must move the caret to text.len()");
+}
+
+/// Home on a multi-line composer moves the caret to the start of the CURRENT
+/// line (not the whole document).
+#[test]
+fn home_on_multiline_moves_to_current_line_start() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let state = state_with_loaded_detail(&repo_id, 42);
+    let state = open_new_comment_composer(state);
+    // "abcd\nefgh" — caret lands at byte 9 (end of second line).
+    let state = type_into_composer(state, "abcd\nefgh");
+    // Home must move to byte 5 (start of "efgh"), NOT byte 0.
+    let state = state.apply(AppEvent::InlineCursorHome);
+    let (_text, cursor) = composer_text_cursor(&state);
+    assert_eq!(
+        cursor, 5,
+        "Home must move to the start of the current line (byte 5), not the document start"
+    );
+}
+
+/// End on a multi-line composer moves the caret to the end of the CURRENT
+/// line (not the whole document).
+#[test]
+fn end_on_multiline_moves_to_current_line_end() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let state = state_with_loaded_detail(&repo_id, 42);
+    let state = open_new_comment_composer(state);
+    // "abcd\nefgh" — caret lands at byte 9.
+    let state = type_into_composer(state, "abcd\nefgh");
+    // Move to the first line (CursorUp), then End must land at byte 4 (end of
+    // "abcd"), NOT byte 9.
+    let state = state.apply(AppEvent::InlineCursorUp);
+    let state = state.apply(AppEvent::InlineCursorEnd);
+    let (_text, cursor) = composer_text_cursor(&state);
+    assert_eq!(
+        cursor, 4,
+        "End must move to the end of the current line (byte 4), not the document end"
+    );
+}
+
+/// Home/End must be UTF-8 safe: a multibyte caret never lands mid-codepoint.
+/// "héllo" — 'é' is two bytes; Home from the middle must land on byte 0, and
+/// End must land on byte 6 (the byte length, after the final 'o').
+#[test]
+fn home_end_are_utf8_safe() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let state = state_with_loaded_detail(&repo_id, 42);
+    let state = open_new_comment_composer(state);
+    let state = type_into_composer(state, "héllo");
+    // Caret at byte 6; Home -> 0.
+    let state = state.apply(AppEvent::InlineCursorHome);
+    let (_text, cursor) = composer_text_cursor(&state);
+    assert_eq!(cursor, 0, "Home on multibyte text must land on byte 0");
+    // End -> byte length (6).
+    let state = state.apply(AppEvent::InlineCursorEnd);
+    let (text, cursor) = composer_text_cursor(&state);
+    assert_eq!(
+        cursor,
+        text.len(),
+        "End on multibyte text must land on the byte length"
+    );
+}
+
+/// Home on the first line of an empty composer is a safe no-op (caret stays
+/// at 0).
+#[test]
+fn home_on_empty_composer_is_noop() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let state = state_with_loaded_detail(&repo_id, 42);
+    let state = open_new_comment_composer(state);
+    let state = state.apply(AppEvent::InlineCursorHome);
+    let (_text, cursor) = composer_text_cursor(&state);
+    assert_eq!(cursor, 0, "Home on an empty composer must be a no-op");
+}
+
+/// Home/End also work in the inline Editor (e.g. editing an issue body), not
+/// just the Composer.
+#[test]
+fn home_end_work_in_inline_editor() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let mut state = state_with_loaded_detail(&repo_id, 42);
+    // Open the inline editor for the issue body, then type to extend the text.
+    state.issues_state.inline_state = InlineState::Editor {
+        target: crate::state::types::EditorTarget::IssueBody,
+        text: "line1\nline2".to_string(),
+        cursor: 11, // end of text
+    };
+    let state = state.apply(AppEvent::InlineCursorHome);
+    let (_text, cursor) = composer_text_cursor(&state);
+    assert_eq!(
+        cursor, 6,
+        "Home in the editor must move to the start of the current line (byte 6)"
+    );
+    let state = state.apply(AppEvent::InlineCursorEnd);
+    let (text, cursor) = composer_text_cursor(&state);
+    assert_eq!(
+        cursor,
+        text.len(),
+        "End in the editor must move to the end of the current line"
+    );
+    // Confirm the composer target type is preserved (Editor, not Composer).
+    assert!(matches!(
+        state.issues_state.inline_state,
+        InlineState::Editor { .. }
+    ));
+    let _ = ComposerTarget::NewComment; // silence unused-import if Editor path changes
+}

--- a/src/state/issues_tests_home_end.rs
+++ b/src/state/issues_tests_home_end.rs
@@ -9,7 +9,7 @@
 use crate::domain::{IssueDetail, IssueState, Repository, RepositoryId};
 use crate::state::AppState;
 use crate::state::events::AppEvent;
-use crate::state::types::{ComposerTarget, InlineState};
+use crate::state::types::InlineState;
 
 fn issues_mode_state_with_repo(repo_id: &str) -> AppState {
     let mut state = AppState::default();
@@ -85,12 +85,12 @@ fn move_cursor_left(state: AppState, steps: usize) -> AppState {
     s
 }
 
-fn composer_text_cursor(state: &AppState) -> (String, usize) {
+fn inline_text_cursor(state: &AppState) -> (String, usize) {
     match &state.issues_state.inline_state {
         InlineState::Composer { text, cursor, .. } | InlineState::Editor { text, cursor, .. } => {
             (text.clone(), *cursor)
         }
-        InlineState::None => panic!("expected an active composer/editor"),
+        InlineState::None => panic!("expected an active composer or editor"),
     }
 }
 
@@ -103,7 +103,7 @@ fn home_on_single_line_moves_to_start() {
     let state = type_into_composer(state, "abcdef");
     // Caret at end (byte 6); Home must jump to byte 0.
     let state = state.apply(AppEvent::InlineCursorHome);
-    let (_text, cursor) = composer_text_cursor(&state);
+    let (_text, cursor) = inline_text_cursor(&state);
     assert_eq!(
         cursor, 0,
         "Home must move the caret to byte 0 on a single line"
@@ -120,7 +120,7 @@ fn end_on_single_line_moves_to_end() {
     // Walk back to the middle, then End must return to the end.
     let state = move_cursor_left(state, 3);
     let state = state.apply(AppEvent::InlineCursorEnd);
-    let (text, cursor) = composer_text_cursor(&state);
+    let (text, cursor) = inline_text_cursor(&state);
     assert_eq!(cursor, text.len(), "End must move the caret to text.len()");
 }
 
@@ -135,7 +135,7 @@ fn home_on_multiline_moves_to_current_line_start() {
     let state = type_into_composer(state, "abcd\nefgh");
     // Home must move to byte 5 (start of "efgh"), NOT byte 0.
     let state = state.apply(AppEvent::InlineCursorHome);
-    let (_text, cursor) = composer_text_cursor(&state);
+    let (_text, cursor) = inline_text_cursor(&state);
     assert_eq!(
         cursor, 5,
         "Home must move to the start of the current line (byte 5), not the document start"
@@ -155,7 +155,7 @@ fn end_on_multiline_moves_to_current_line_end() {
     // "abcd"), NOT byte 9.
     let state = state.apply(AppEvent::InlineCursorUp);
     let state = state.apply(AppEvent::InlineCursorEnd);
-    let (_text, cursor) = composer_text_cursor(&state);
+    let (_text, cursor) = inline_text_cursor(&state);
     assert_eq!(
         cursor, 4,
         "End must move to the end of the current line (byte 4), not the document end"
@@ -173,11 +173,11 @@ fn home_end_are_utf8_safe() {
     let state = type_into_composer(state, "héllo");
     // Caret at byte 6; Home -> 0.
     let state = state.apply(AppEvent::InlineCursorHome);
-    let (_text, cursor) = composer_text_cursor(&state);
+    let (_text, cursor) = inline_text_cursor(&state);
     assert_eq!(cursor, 0, "Home on multibyte text must land on byte 0");
     // End -> byte length (6).
     let state = state.apply(AppEvent::InlineCursorEnd);
-    let (text, cursor) = composer_text_cursor(&state);
+    let (text, cursor) = inline_text_cursor(&state);
     assert_eq!(
         cursor,
         text.len(),
@@ -193,7 +193,7 @@ fn home_on_empty_composer_is_noop() {
     let state = state_with_loaded_detail(&repo_id, 42);
     let state = open_new_comment_composer(state);
     let state = state.apply(AppEvent::InlineCursorHome);
-    let (_text, cursor) = composer_text_cursor(&state);
+    let (_text, cursor) = inline_text_cursor(&state);
     assert_eq!(cursor, 0, "Home on an empty composer must be a no-op");
 }
 
@@ -203,29 +203,30 @@ fn home_on_empty_composer_is_noop() {
 fn home_end_work_in_inline_editor() {
     let repo_id = RepositoryId("repo-1".to_string());
     let mut state = state_with_loaded_detail(&repo_id, 42);
-    // Open the inline editor for the issue body, then type to extend the text.
+    // Directly construct an Editor state for the issue body so Home/End can be
+    // exercised without dispatching an OpenInlineEditor event.
+    let body = "line1\nline2".to_string();
     state.issues_state.inline_state = InlineState::Editor {
         target: crate::state::types::EditorTarget::IssueBody,
-        text: "line1\nline2".to_string(),
-        cursor: 11, // end of text
+        text: body.clone(),
+        cursor: body.len(),
     };
     let state = state.apply(AppEvent::InlineCursorHome);
-    let (_text, cursor) = composer_text_cursor(&state);
+    let (_text, cursor) = inline_text_cursor(&state);
     assert_eq!(
-        cursor, 6,
-        "Home in the editor must move to the start of the current line (byte 6)"
+        cursor,
+        "line1\n".len(),
+        "Home in the editor must move to the start of the current line"
     );
     let state = state.apply(AppEvent::InlineCursorEnd);
-    let (text, cursor) = composer_text_cursor(&state);
+    let (text, cursor) = inline_text_cursor(&state);
     assert_eq!(
         cursor,
         text.len(),
         "End in the editor must move to the end of the current line"
     );
-    // Confirm the composer target type is preserved (Editor, not Composer).
     assert!(matches!(
         state.issues_state.inline_state,
         InlineState::Editor { .. }
     ));
-    let _ = ComposerTarget::NewComment; // silence unused-import if Editor path changes
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -21,6 +21,7 @@ mod events;
 mod form_build;
 mod form_cursor;
 mod form_delete_helpers;
+mod form_home_end_ops;
 mod form_ops;
 mod form_projection;
 mod form_runtime;
@@ -80,6 +81,7 @@ pub use terminal_manager_types::{
     TerminalManagerState, status_label_for,
 };
 pub use types::*;
+pub use util::{inline_cursor_line_end, inline_cursor_line_start, inline_cursor_vertical};
 pub(super) const VIEWPORT_PAGE_JUMP: usize = 10;
 use crate::domain::{Agent, AgentId, AgentStatus, Repository, RepositoryId};
 use crate::list_viewport::ListMove;
@@ -93,8 +95,6 @@ pub use form_projection::{
     next_visible_repository_focus, prev_visible_focus, prev_visible_repository_focus,
 };
 use tracing::{debug, trace};
-
-pub use util::inline_cursor_vertical;
 impl AppState {
     /// Reset terminal scrollback state to defaults (fix #4). Called from
     /// every path that changes the selected agent or repository.
@@ -773,7 +773,6 @@ impl AppState {
             }
         }
     }
-
     fn apply_system_message(&mut self, message: SystemMessage) {
         match message {
             SystemMessage::ClearError => self.error_message = None,
@@ -786,7 +785,6 @@ impl AppState {
             auth => self.apply_auth_message(auth),
         }
     }
-
     fn handle_navigate_up(&mut self) {
         match self.pane_focus {
             PaneFocus::Repositories => {
@@ -804,13 +802,11 @@ impl AppState {
                     self.selected_agent_index = None;
                     return;
                 };
-
                 let visible_indices = self.agent_indices_for_repository(&repository_id);
                 if visible_indices.is_empty() {
                     self.selected_agent_index = None;
                     return;
                 }
-
                 let selected_local = self.selected_agent_index.and_then(|selected_idx| {
                     visible_indices
                         .iter()
@@ -854,13 +850,11 @@ impl AppState {
                     self.selected_agent_index = None;
                     return;
                 };
-
                 let visible_indices = self.agent_indices_for_repository(&repository_id);
                 if visible_indices.is_empty() {
                     self.selected_agent_index = None;
                     return;
                 }
-
                 let selected_local = self.selected_agent_index.and_then(|selected_idx| {
                     visible_indices
                         .iter()
@@ -885,6 +879,7 @@ impl AppState {
         }
     }
 }
+
 #[cfg(test)]
 #[path = "auth_ops_tests.rs"]
 mod auth_ops_tests;
@@ -892,6 +887,12 @@ mod auth_ops_tests;
 mod confirm_focus_tests;
 #[cfg(test)]
 mod errors_tests;
+#[cfg(test)]
+#[path = "form_home_end_tests.rs"]
+mod form_home_end_tests;
+#[cfg(test)]
+#[path = "issues_tests_home_end.rs"]
+mod issues_home_end_tests;
 #[cfg(test)]
 mod issues_test_fixtures;
 #[cfg(test)]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -103,26 +103,22 @@ impl AppState {
         self.terminal_viewport_rows = 0;
         self.terminal_total_lines = 0;
     }
-
     #[must_use]
     pub fn selected_repository_id(&self) -> Option<&RepositoryId> {
         self.selected_repository_index
             .and_then(|idx| self.repositories.get(idx).map(|repo| &repo.id))
     }
-
     #[must_use]
     pub fn repository_by_id(&self, repository_id: &RepositoryId) -> Option<&Repository> {
         self.repositories
             .iter()
             .find(|repo| &repo.id == repository_id)
     }
-
     #[must_use]
     pub fn repository_for_agent(&self, agent_id: &AgentId) -> Option<&Repository> {
         let agent = self.agents.iter().find(|agent| &agent.id == agent_id)?;
         self.repository_by_id(&agent.repository_id)
     }
-
     fn remember_selected_agent_for_current_repo(&mut self) {
         let selected_repo_id = self.selected_repository_id().cloned();
         let selected_agent_id = self.selected_agent().map(|agent| agent.id.clone());

--- a/src/state/modal_ops.rs
+++ b/src/state/modal_ops.rs
@@ -104,6 +104,8 @@ impl AppState {
             ModalMessage::FormDelete => self.handle_form_delete(),
             ModalMessage::FormMoveCursorLeft => self.handle_form_move_cursor_left(),
             ModalMessage::FormMoveCursorRight => self.handle_form_move_cursor_right(),
+            ModalMessage::FormMoveCursorStart => self.handle_form_move_cursor_start(),
+            ModalMessage::FormMoveCursorEnd => self.handle_form_move_cursor_end(),
             ModalMessage::FormNextField => self.handle_form_next_field(),
             ModalMessage::FormPrevField => self.handle_form_prev_field(),
             ModalMessage::FormToggleCheckbox => self.handle_form_toggle_checkbox(),

--- a/src/state/prs_inline_ops.rs
+++ b/src/state/prs_inline_ops.rs
@@ -16,7 +16,7 @@
 
 use super::{
     AppEvent, AppState, ComposerTarget, InlineState, PrDetailSubfocus, PrFocus, ReadOnlyHintKind,
-    inline_cursor_vertical,
+    inline_cursor_line_end, inline_cursor_line_start, inline_cursor_vertical,
 };
 use crate::messages::PrInlineMsg;
 
@@ -308,6 +308,20 @@ impl AppState {
             PrInlineMsg::CursorRight => {
                 Self::pr_move_inline_cursor_right(&mut self.prs_state.inline_state);
             }
+            PrInlineMsg::CursorHome => {
+                if let Some((text, cursor)) =
+                    Self::pr_active_inline_text(&mut self.prs_state.inline_state)
+                {
+                    inline_cursor_line_start(text, cursor);
+                }
+            }
+            PrInlineMsg::CursorEnd => {
+                if let Some((text, cursor)) =
+                    Self::pr_active_inline_text(&mut self.prs_state.inline_state)
+                {
+                    inline_cursor_line_end(text, cursor);
+                }
+            }
             PrInlineMsg::Submit => {
                 self.pr_inline_submit();
             }
@@ -357,6 +371,8 @@ impl AppState {
                 | PrInlineMsg::CursorRight
                 | PrInlineMsg::CursorUp
                 | PrInlineMsg::CursorDown
+                | PrInlineMsg::CursorHome
+                | PrInlineMsg::CursorEnd
         )
     }
 

--- a/src/state/prs_ops.rs
+++ b/src/state/prs_ops.rs
@@ -668,6 +668,8 @@ impl AppState {
             AppEvent::PrInlineCursorRight => PrInlineMsg::CursorRight,
             AppEvent::PrInlineCursorUp => PrInlineMsg::CursorUp,
             AppEvent::PrInlineCursorDown => PrInlineMsg::CursorDown,
+            AppEvent::PrInlineCursorHome => PrInlineMsg::CursorHome,
+            AppEvent::PrInlineCursorEnd => PrInlineMsg::CursorEnd,
             AppEvent::PrInlineSubmit => PrInlineMsg::Submit,
             AppEvent::PrInlineCancelOrEsc => PrInlineMsg::CancelOrEsc,
             _ => return false,

--- a/src/state/prs_property_ops.rs
+++ b/src/state/prs_property_ops.rs
@@ -24,7 +24,9 @@ impl AppState {
             | AppEvent::PrPropertyEditorTitleBackspace
             | AppEvent::PrPropertyEditorTitleDelete
             | AppEvent::PrPropertyEditorTitleCursorLeft
-            | AppEvent::PrPropertyEditorTitleCursorRight => self.apply_pr_property_editor_ui(event),
+            | AppEvent::PrPropertyEditorTitleCursorRight
+            | AppEvent::PrPropertyEditorTitleCursorHome
+            | AppEvent::PrPropertyEditorTitleCursorEnd => self.apply_pr_property_editor_ui(event),
             AppEvent::PrPropertyEditorOptionsLoaded { .. }
             | AppEvent::PrPropertyEditorOptionsFailed { .. }
             | AppEvent::PrPropertyEditSucceeded { .. }
@@ -82,6 +84,14 @@ impl AppState {
             }
             AppEvent::PrPropertyEditorTitleCursorRight => {
                 self.pr_property_title_cursor_right();
+                true
+            }
+            AppEvent::PrPropertyEditorTitleCursorHome => {
+                self.pr_property_title_cursor_home();
+                true
+            }
+            AppEvent::PrPropertyEditorTitleCursorEnd => {
+                self.pr_property_title_cursor_end();
                 true
             }
             _ => false,
@@ -354,6 +364,22 @@ impl AppState {
                 .next()
                 .map_or(0, char::len_utf8);
             editor.title_cursor += next;
+        }
+    }
+
+    fn pr_property_title_cursor_home(&mut self) {
+        if let Some(editor) = &mut self.prs_state.property_editor
+            && editor.kind == PrPropertyKind::Title
+        {
+            editor.title_cursor = 0;
+        }
+    }
+
+    fn pr_property_title_cursor_end(&mut self) {
+        if let Some(editor) = &mut self.prs_state.property_editor
+            && editor.kind == PrPropertyKind::Title
+        {
+            editor.title_cursor = editor.title_text.len();
         }
     }
 

--- a/src/state/prs_property_ops_tests.rs
+++ b/src/state/prs_property_ops_tests.rs
@@ -146,6 +146,11 @@ fn title_home_moves_to_start() {
     for _ in 0..title_len {
         state = state.apply(AppEvent::PrPropertyEditorTitleCursorRight);
     }
+    assert_eq!(
+        require_pr_editor(&state).title_cursor,
+        title_len,
+        "cursor must be at the end after walking right"
+    );
     state = state.apply(AppEvent::PrPropertyEditorTitleCursorHome);
     let editor = require_pr_editor(&state);
     assert_eq!(editor.title_cursor, 0, "Home must move the cursor to 0");
@@ -180,6 +185,11 @@ fn title_home_end_utf8_safe() {
     for _ in 0..title_len {
         state = state.apply(AppEvent::PrPropertyEditorTitleCursorRight);
     }
+    assert_eq!(
+        require_pr_editor(&state).title_cursor,
+        title_len,
+        "cursor must be at the byte length after walking right on multibyte text"
+    );
     state = state.apply(AppEvent::PrPropertyEditorTitleCursorHome);
     let editor = require_pr_editor(&state);
     assert_eq!(

--- a/src/state/prs_property_ops_tests.rs
+++ b/src/state/prs_property_ops_tests.rs
@@ -133,6 +133,68 @@ fn title_cursor_move() {
     assert_eq!(editor.title_cursor, 0);
 }
 
+// ── H1: Title Home/End (issue #406) ─────────────────────────────────
+
+#[test]
+fn title_home_moves_to_start() {
+    let mut state = make_state_with_detail();
+    state = state.apply(AppEvent::PrOpenPropertyEditor {
+        kind: PrPropertyKind::Title,
+    });
+    // Walk to the end of the title text.
+    let title_len = require_pr_editor(&state).title_text.len();
+    for _ in 0..title_len {
+        state = state.apply(AppEvent::PrPropertyEditorTitleCursorRight);
+    }
+    state = state.apply(AppEvent::PrPropertyEditorTitleCursorHome);
+    let editor = require_pr_editor(&state);
+    assert_eq!(editor.title_cursor, 0, "Home must move the cursor to 0");
+}
+
+#[test]
+fn title_end_moves_to_end() {
+    let mut state = make_state_with_detail();
+    state = state.apply(AppEvent::PrOpenPropertyEditor {
+        kind: PrPropertyKind::Title,
+    });
+    // Cursor starts at 0; End must jump to the byte length of the title.
+    state = state.apply(AppEvent::PrPropertyEditorTitleCursorEnd);
+    let editor = require_pr_editor(&state);
+    assert_eq!(
+        editor.title_cursor,
+        editor.title_text.len(),
+        "End must move the cursor to the title byte length"
+    );
+}
+
+#[test]
+fn title_home_end_utf8_safe() {
+    let mut state = make_state_with_detail();
+    state = state.apply(AppEvent::PrOpenPropertyEditor {
+        kind: PrPropertyKind::Title,
+    });
+    // Insert a multibyte char at the start ("éTest PR" — cursor at byte 2).
+    state = state.apply(AppEvent::PrPropertyEditorTitleChar('é'));
+    // Walk to the end, then Home -> 0, then End -> byte length.
+    let title_len = require_pr_editor(&state).title_text.len();
+    for _ in 0..title_len {
+        state = state.apply(AppEvent::PrPropertyEditorTitleCursorRight);
+    }
+    state = state.apply(AppEvent::PrPropertyEditorTitleCursorHome);
+    let editor = require_pr_editor(&state);
+    assert_eq!(
+        editor.title_cursor, 0,
+        "Home on multibyte text must land on 0"
+    );
+    state = state.apply(AppEvent::PrPropertyEditorTitleCursorEnd);
+    let editor = require_pr_editor(&state);
+    assert_eq!(
+        editor.title_cursor,
+        editor.title_text.len(),
+        "End on multibyte text must land on the byte length"
+    );
+}
+
 // ── H3: Single-select uses selected_index ──────────────────────────
 
 #[test]

--- a/src/state/prs_tests_cursor_arrows.rs
+++ b/src/state/prs_tests_cursor_arrows.rs
@@ -423,3 +423,102 @@ fn text_box_view_shows_current_text_and_caret_for_tall_draft() {
         "caret must be visible on the current line 'l8'"
     );
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// Issue #406: Home/End cursor movement for the PR inline composer/editor.
+//
+// Home moves the caret to the start of the current logical line; End moves it
+// to the end of the current logical line. These mirror the Issues-mode
+// behavior and reuse the shared UTF-8-safe line-start/line-end helpers.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Home on a single-line PR composer moves the caret to byte 0.
+#[test]
+fn home_on_single_line_moves_to_start() {
+    let mut state = prs_state_with_detail("repo-1", 1);
+    state.prs_state.detail_viewport_rows = 20;
+    let state = state.apply(AppEvent::PrOpenNewCommentComposer);
+    let state = type_into_composer(state, "abcdef");
+    // Caret at end (byte 6); Home must jump to byte 0.
+    let state = state.apply(AppEvent::PrInlineCursorHome);
+    let (_text, cursor) = composer_text_cursor(&state);
+    assert_eq!(
+        cursor, 0,
+        "Home must move the caret to byte 0 on a single line"
+    );
+}
+
+/// End on a single-line PR composer moves the caret to text.len().
+#[test]
+fn end_on_single_line_moves_to_end() {
+    let mut state = prs_state_with_detail("repo-1", 1);
+    state.prs_state.detail_viewport_rows = 20;
+    let state = state.apply(AppEvent::PrOpenNewCommentComposer);
+    let state = type_into_composer(state, "abcdef");
+    // Walk back to the middle, then End must return to the end.
+    let state = state.apply(AppEvent::PrInlineCursorLeft);
+    let state = state.apply(AppEvent::PrInlineCursorLeft);
+    let state = state.apply(AppEvent::PrInlineCursorLeft);
+    let state = state.apply(AppEvent::PrInlineCursorEnd);
+    let (text, cursor) = composer_text_cursor(&state);
+    assert_eq!(cursor, text.len(), "End must move the caret to text.len()");
+}
+
+/// Home on a multi-line PR composer moves the caret to the start of the
+/// CURRENT line (not the whole document).
+#[test]
+fn home_on_multiline_moves_to_current_line_start() {
+    let mut state = prs_state_with_detail("repo-1", 1);
+    state.prs_state.detail_viewport_rows = 20;
+    let state = state.apply(AppEvent::PrOpenNewCommentComposer);
+    // "abcd\nefgh" — caret lands at byte 9 (end of second line).
+    let state = type_into_composer(state, "abcd\nefgh");
+    // Home must move to byte 5 (start of "efgh"), NOT byte 0.
+    let state = state.apply(AppEvent::PrInlineCursorHome);
+    let (_text, cursor) = composer_text_cursor(&state);
+    assert_eq!(
+        cursor, 5,
+        "Home must move to the start of the current line (byte 5), not the document start"
+    );
+}
+
+/// End on a multi-line PR composer moves the caret to the end of the CURRENT
+/// line (not the whole document).
+#[test]
+fn end_on_multiline_moves_to_current_line_end() {
+    let mut state = prs_state_with_detail("repo-1", 1);
+    state.prs_state.detail_viewport_rows = 20;
+    let state = state.apply(AppEvent::PrOpenNewCommentComposer);
+    // "abcd\nefgh" — caret lands at byte 9.
+    let state = type_into_composer(state, "abcd\nefgh");
+    // Move to the first line (CursorUp), then End must land at byte 4 (end of
+    // "abcd"), NOT byte 9.
+    let state = state.apply(AppEvent::PrInlineCursorUp);
+    let state = state.apply(AppEvent::PrInlineCursorEnd);
+    let (_text, cursor) = composer_text_cursor(&state);
+    assert_eq!(
+        cursor, 4,
+        "End must move to the end of the current line (byte 4), not the document end"
+    );
+}
+
+/// Home/End must be UTF-8 safe: a multibyte caret never lands mid-codepoint.
+#[test]
+fn home_end_are_utf8_safe() {
+    let mut state = prs_state_with_detail("repo-1", 1);
+    state.prs_state.detail_viewport_rows = 20;
+    let state = state.apply(AppEvent::PrOpenNewCommentComposer);
+    let state = type_into_composer(state, "héllo");
+    // Caret at byte 6; Home -> 0.
+    let state = state.apply(AppEvent::PrInlineCursorHome);
+    let (_text, cursor) = composer_text_cursor(&state);
+    assert_eq!(cursor, 0, "Home on multibyte text must land on byte 0");
+    // End -> byte length (6).
+    let state = state.apply(AppEvent::PrInlineCursorEnd);
+    let (text, cursor) = composer_text_cursor(&state);
+    assert_eq!(
+        cursor,
+        text.len(),
+        "End on multibyte text must land on the byte length"
+    );
+}

--- a/src/state/util.rs
+++ b/src/state/util.rs
@@ -58,6 +58,16 @@ pub(super) fn move_cursor_right(s: &str, cursor: usize) -> usize {
     clamp_cursor(s, cursor).saturating_add(1).min(len)
 }
 
+/// Move a form-field cursor to the start of the field (char index 0).
+pub(super) fn move_cursor_start() -> usize {
+    0
+}
+
+/// Move a form-field cursor to the end of the field (char count).
+pub(super) fn move_cursor_end(s: &str) -> usize {
+    s.chars().count()
+}
+
 /// Move the inline editor cursor up or down by `direction` lines (-1 = up, 1 = down).
 /// Attempts to land on the same column in the target line, clamping to line length.
 ///
@@ -117,4 +127,41 @@ pub fn inline_cursor_vertical(text: &str, cursor: &mut usize, direction: i32) {
         .map_or(target_slice.len(), |(byte_idx, _)| byte_idx);
 
     *cursor = target_byte_start + target_byte_offset;
+}
+
+/// Move the inline editor cursor to the START of its current logical line
+/// (issue #406).
+///
+/// UTF-8 safe: `cursor` is floored to a char boundary before the line lookup
+/// so a mid-codepoint offset can never panic.
+pub fn inline_cursor_line_start(text: &str, cursor: &mut usize) {
+    let clamped = floor_to_char_boundary(text, *cursor);
+    let newline = char::from(0x0Au8);
+    let line_start = text[..clamped].rfind(newline).map_or(0, |p| p + 1);
+    *cursor = line_start;
+}
+
+/// Move the inline editor cursor to the END of its current logical line
+/// (issue #406).
+///
+/// The end is the byte just before the next newline, or `text.len()` when the
+/// line is the last one. UTF-8 safe: `cursor` is floored to a char boundary.
+pub fn inline_cursor_line_end(text: &str, cursor: &mut usize) {
+    let clamped = floor_to_char_boundary(text, *cursor);
+    let newline = char::from(0x0Au8);
+    let line_end = text[clamped..]
+        .find(newline)
+        .map_or(text.len(), |p| clamped + p);
+    *cursor = line_end;
+}
+
+/// Walk `idx` down to the nearest UTF-8 char boundary at or before `idx`.
+/// Shared by the line-start/line-end helpers so a mid-codepoint cursor offset
+/// never panics during slicing.
+fn floor_to_char_boundary(text: &str, idx: usize) -> usize {
+    let mut i = idx.min(text.len());
+    while i > 0 && !text.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
 }

--- a/src/state/util.rs
+++ b/src/state/util.rs
@@ -145,14 +145,16 @@ pub fn inline_cursor_line_start(text: &str, cursor: &mut usize) {
 /// (issue #406).
 ///
 /// The end is the byte just before the next newline, or `text.len()` when the
-/// line is the last one. UTF-8 safe: `cursor` is floored to a char boundary.
+/// line is the last one. UTF-8 safe: `cursor` is floored to a char boundary,
+/// and the resulting `line_end` is also floored so the invariant holds even if
+/// the line-end calculation is ever extended to non-newline delimiters.
 pub fn inline_cursor_line_end(text: &str, cursor: &mut usize) {
     let clamped = floor_to_char_boundary(text, *cursor);
     let newline = char::from(0x0Au8);
     let line_end = text[clamped..]
         .find(newline)
         .map_or(text.len(), |p| clamped + p);
-    *cursor = line_end;
+    *cursor = floor_to_char_boundary(text, line_end);
 }
 
 /// Walk `idx` down to the nearest UTF-8 char boundary at or before `idx`.


### PR DESCRIPTION
## Summary

Adds Home/End key support across all text-editing surfaces in the TUI, addressing issue #406 where users could not jump to the start or end of a line while editing.

## Changes

### Inline composers/editors (Issues + PRs)
- **Home** jumps the caret to the start of the current logical line
- **End** jumps the caret to the end of the current logical line
- Uses UTF-8-safe byte-cursor helpers (`inline_cursor_line_start` / `inline_cursor_line_end`) so multibyte text never lands mid-codepoint
- New events: `InlineCursorHome` / `InlineCursorEnd` (Issues), `PrInlineCursorHome` / `PrInlineCursorEnd` (PRs)
- New `PrInlineMsg::CursorHome` / `CursorEnd` variants with full bidirectional conversion

### Property editor title fields (Issues + PRs)
- **Home/End** jump to start/end of the single-line title text
- New events: `IssuePropertyEditorTitleCursorHome` / `End`, `PrPropertyEditorTitleCursorHome` / `End`

### Form text fields (repository, agent, workflow-dispatch forms)
- **Home/End** jump to start/end of the focused field using char-count cursors
- New events: `FormMoveCursorStart` / `FormMoveCursorEnd`
- New cursor movement functions in `form_cursor.rs` and `form_workflow_dispatch.rs`

## Test coverage

- **Issues inline composer**: 7 tests (single-line, multi-line, UTF-8 safety, editor vs composer, empty no-op)
- **PRs inline composer**: 5 tests in `prs_tests_cursor_arrows.rs` (multi-line, UTF-8, editor)
- **Issues property title**: 3 tests (Home/End, UTF-8)
- **PRs property title**: 3 tests (Home/End, UTF-8)
- **Form fields**: 4 tests (agent name, repository base-dir, UTF-8 safety)

## Verification

- `cargo fmt --all --check` — pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — pass
- `cargo build --workspace --all-features --locked` — pass
- `cargo test --workspace --all-features --locked` — 2151 passed, 0 failed
- `cargo llvm-cov --fail-under-lines 30` — 71.43% coverage (pass)
- Architecture boundary checks — pass
- Source file size checks — pass

Fixes #406