### PR TITLE
Resolve symlinks in work-dir path comparison (Fixes #424)

### DIFF
--- a/project-plans/issue424-plan.md
+++ b/project-plans/issue424-plan.md
@@ -1,0 +1,58 @@
+# Issue #424 — Symlink-aware path comparison for work-dir collision detection and delete guard
+
+## Acceptance matrix
+
+| ID | Actor / launch path | Input & boundary cases | Platform | Observable success | Observable failure | Side effects permitted | Persistence / compat | Behavioral test |
+|----|---------------------|------------------------|----------|--------------------|--------------------|------------------------|----------------------|-----------------|
+| A1 | `local_paths_equivalent` | Two paths that resolve to the same physical dir via symlink | Unix + Windows | Returns `true` | — | None (pure) | No contract change for non-symlink callers | Unit: create temp dir + symlink, assert equivalent |
+| A2 | `local_paths_equivalent` | One path via symlink, one direct, both exist | Unix + Windows | Returns `true` | — | None | Backward compatible | Unit |
+| A3 | `local_paths_equivalent` | One or both paths do not exist (unmaterialized work dir) | All | Falls back to string-based comparison | — | None | Backward compatible | Unit: nonexistent paths use string comparison |
+| A4 | `local_paths_equivalent` | Canonicalize fails on one path | All | Falls back to string-based comparison | — | None | Backward compatible | Unit |
+| A5 | Form validation (`check_agent_uniqueness`) | New work_dir collides with existing agent via symlink | All | Agent NOT created; error_message set | — | None | — | Covered by existing form_validation tests using the shared comparison |
+| A6 | Delete guard (`work_dir_shared_by_sibling`) | Deleted agent's work_dir shared by sibling via symlink | All | `remove_dir_all` skipped; warn logged | — | None | — | Covered by existing state_ops tests using the shared comparison |
+
+## Non-goals
+
+- Changing `local_paths_equivalent` contract for callers that do not need symlink resolution — the function remains the single shared comparison; it simply canonicalizes when possible.
+- Remote repository work dirs (paths refer to a remote host, cannot be canonicalized locally).
+- Resolving relative paths that do not exist on disk (best-effort: only existing paths are canonicalized).
+
+## Vertical slices
+
+### Slice 1 — Canonicalizing comparison (single behavior)
+
+- **Acceptance rows:** A1, A2, A3, A4
+- **Architecture owner:** `src/services/normalize.rs` (app/domain boundary)
+- **Allowed files:** `src/services/normalize.rs`, `src/services/mod.rs` (re-export if needed)
+- **RED:** Unit test creating a temp dir, creating a symlink to it, asserting `local_paths_equivalent` returns `true` for the symlink path vs the real path. Also a test for the fallback when paths don't exist.
+- **GREEN:** Add `canonicalize_for_comparison` helper using `std::fs::canonicalize`; in `local_paths_equivalent`, attempt to canonicalize both paths; if both succeed, compare canonical forms; otherwise fall back to existing string normalization.
+- **Non-goals:** No changes to form validation or delete guard logic — they already use the shared comparison.
+- **Verification:** `cargo test -p jefe local_paths_equivalent` + `make quick-check`
+
+### Slice 2 — Update documentation comments (behavior proven)
+
+- **Acceptance rows:** A5, A6 (documentation accuracy)
+- **Allowed files:** `src/state/state_ops.rs` (delete doc comment), `src/state/form_validation_issue403.rs` (if needed)
+- **GREEN:** Remove the "known limitation" language from doc comments now that symlink resolution is handled.
+- **Verification:** `cargo clippy --workspace --all-targets --all-features -- -D warnings` + `make quick-check`
+
+## Scope ledger
+
+| Item | Status | Disposition |
+|------|--------|-------------|
+| Initial scope | — | Slices 1–2 |
+
+## Review counters
+
+| Phase | Runs | Cap |
+|-------|------|-----|
+| Pre-PR OCR | 0 | 2 |
+| Post-PR OCR | 0 | 2 |
+
+## Verification evidence
+
+- `cargo test --lib -- services::normalize::tests` — 27/27 pass (including `symlinked_paths_to_same_physical_directory_are_equivalent` and `nonexistent_paths_fall_back_to_string_comparison`)
+- `cargo test --lib -- state::state_ops state::form_validation_issue403 state::form_build` — all caller tests pass
+- `cargo fmt --all` — clean
+- `cargo clippy --lib` — no new warnings from changed files (one pre-existing `manual_is_multiple_of` in unrelated `harness/v1/validate.rs` blocks the gate on this machine due to a newer clippy version; confirmed pre-existing on main)
+- Full `cargo test`: 2127 pass; the only 4 failures are pre-existing `harness::*` integration tests that require a running psmux server (confirmed failing on main)

--- a/src/services/normalize.rs
+++ b/src/services/normalize.rs
@@ -28,13 +28,43 @@ impl LocalPathPlatform {
 }
 
 /// Compare local paths without changing either user-visible value.
+///
+/// When both paths exist on disk, symlinks are resolved via
+/// [`std::fs::canonicalize`] before comparison so that two paths pointing at
+/// the same physical directory through different symlinked routes are
+/// recognized as equivalent (issue #424). If either path does not exist (for
+/// example, a work directory that has not been materialized yet) or
+/// canonicalization otherwise fails, the comparison falls back to the
+/// string-based platform normalizer.
 #[must_use]
 pub fn local_paths_equivalent(left: &Path, right: &Path) -> bool {
-    local_paths_equivalent_for_platform(
-        &left.to_string_lossy(),
-        &right.to_string_lossy(),
-        LocalPathPlatform::current(),
-    )
+    match (
+        canonicalize_for_comparison(left),
+        canonicalize_for_comparison(right),
+    ) {
+        (Some(left_canon), Some(right_canon)) => local_paths_equivalent_for_platform(
+            &left_canon.to_string_lossy(),
+            &right_canon.to_string_lossy(),
+            LocalPathPlatform::current(),
+        ),
+        // Best-effort fallback: at least one path does not exist or cannot be
+        // canonicalized, so symlink resolution is impossible. Use the existing
+        // string-based normalization which still handles separators, case,
+        // `.`/`..`, and Windows extended-path prefixes.
+        _ => local_paths_equivalent_for_platform(
+            &left.to_string_lossy(),
+            &right.to_string_lossy(),
+            LocalPathPlatform::current(),
+        ),
+    }
+}
+
+/// Resolve a path to its canonical filesystem form, stripping any symlinks.
+///
+/// Returns `None` when the path does not exist or canonicalization fails, so
+/// that callers can fall back to a string-based comparison.
+fn canonicalize_for_comparison(path: &Path) -> Option<std::path::PathBuf> {
+    std::fs::canonicalize(path).ok()
 }
 
 #[must_use]
@@ -503,6 +533,55 @@ mod tests {
     #[test]
     fn normalize_profile_trims_surrounding_whitespace() {
         assert_eq!(normalize_profile("  custom  "), "custom");
+    }
+
+    #[test]
+    fn symlinked_paths_to_same_physical_directory_are_equivalent() {
+        let tmp = std::env::temp_dir();
+        let real = tmp.join(format!("jefe-424-real-{}", std::process::id()));
+        let link = tmp.join(format!("jefe-424-link-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&real);
+        let _ = std::fs::remove_dir_all(&link);
+        if std::fs::create_dir_all(&real).is_err() {
+            let _ = std::fs::remove_dir_all(&real);
+            let _ = std::fs::remove_dir_all(&link);
+            return;
+        }
+        // Create a symlink `link` -> `real`. On Windows this requires either
+        // developer mode or admin privileges; if it fails, skip the test
+        // rather than failing, since the capability is environment-dependent.
+        #[cfg(unix)]
+        let created = std::os::unix::fs::symlink(&real, &link).is_ok();
+        #[cfg(windows)]
+        let created = std::os::windows::fs::symlink_dir(&real, &link).is_ok();
+        if !created {
+            let _ = std::fs::remove_dir_all(&real);
+            let _ = std::fs::remove_dir_all(&link);
+            return;
+        }
+        // Both `real` and `link` resolve to the same physical directory.
+        // Without symlink canonicalization a string-based comparison sees
+        // different path components and returns false.
+        assert!(
+            local_paths_equivalent(&real, &link),
+            "a symlink and its target must be recognized as equivalent"
+        );
+        let _ = std::fs::remove_dir_all(&real);
+        let _ = std::fs::remove_dir_all(&link);
+    }
+
+    #[test]
+    fn nonexistent_paths_fall_back_to_string_comparison() {
+        // Neither path exists, so canonicalization is impossible. The
+        // comparison must still work via the existing string normalizer.
+        assert!(local_paths_equivalent(
+            std::path::Path::new("/this/does/not/exist/repo/"),
+            std::path::Path::new("/this/does/not/exist/repo"),
+        ));
+        assert!(!local_paths_equivalent(
+            std::path::Path::new("/this/does/not/exist/repo"),
+            std::path::Path::new("/this/does/not/exist/other"),
+        ));
     }
 
     #[test]

--- a/src/state/state_ops.rs
+++ b/src/state/state_ops.rs
@@ -74,13 +74,11 @@ pub fn delete_selected_repository(state: &mut AppState, repository_id: &Reposito
 ///
 /// The work-directory removal guard uses [`work_dir_shared_by_sibling`] which
 /// compares paths via [`crate::services::local_paths_equivalent`] — a
-/// string-based, platform-aware normalization (separators, case, `.`/`..`,
-/// Windows extended-path prefixes). It does **not** canonicalize symlinks or
-/// resolve relative paths to absolute. Work directories that point to the
-/// same physical directory through different symlinked paths will bypass this
-/// guard. This is a known limitation; the guard protects against the
-/// identical/normalized path collision case which is the common failure mode
-/// from duplicate agent names (issue #403).
+/// platform-aware comparison that resolves symlinks via
+/// [`std::fs::canonicalize`] when both paths exist on disk (issue #424), then
+/// normalizes separators, case, `.`/`..`, and Windows extended-path prefixes.
+/// Paths that do not exist (unmaterialized work directories) fall back to the
+/// string-based normalization.
 pub fn delete_selected_agent(
     state: &mut AppState,
     agent_id: &AgentId,


### PR DESCRIPTION
## Summary

\local_paths_equivalent\ — the shared path comparison used by both the work-dir collision check (form validation, issue #403) and the delete guard (\state_ops.rs\) — was string-based only and did not canonicalize symlinks. Two agents whose \work_dir\ values pointed at the same physical directory through different symlinked paths would bypass both guards, allowing a colliding work dir to be created and allowing \emove_dir_all\ to destroy a directory another agent still depends on.

This change makes \local_paths_equivalent\ attempt \std::fs::canonicalize\ on both paths first. If both succeed, the canonical forms are compared through the existing platform normalizer (so Windows extended-path prefix stripping still applies). If either path does not exist (e.g. an unmaterialized work dir) or canonicalization fails, the comparison falls back to the original string-based normalization, preserving backward compatibility.

Fixes #424.

## Acceptance matrix

| ID | Behavior | Test |
|----|----------|------|
| A1 | Two paths resolving to the same physical dir via symlink are equivalent | \symlinked_paths_to_same_physical_directory_are_equivalent\ |
| A3 | Nonexistent paths fall back to string comparison | \
onexistent_paths_fall_back_to_string_comparison\ |
| A5 | Form validation uniqueness check uses the shared comparison (no change needed) | existing \orm_validation_issue403\ tests |
| A6 | Delete guard uses the shared comparison (no change needed) | existing \state_ops\ tests |

## Non-goals

- Changing the \local_paths_equivalent\ contract for callers that do not need symlink resolution.
- Remote repository work dirs (paths refer to a remote host, cannot be canonicalized locally).
- Resolving relative paths that do not exist on disk.

## Verification

- \cargo fmt --all\ — clean
- \cargo test --lib\ — 2127 pass; 4 pre-existing \harness::*\ failures require a psmux server (confirmed failing on main)
- \cargo clippy\ — no new issues from changed files (one pre-existing \manual_is_multiple_of\ in unrelated \harness/v1/validate.rs\ is present on main)