### PR TITLE
Align contextual composer geometry (Fixes #423)

### DIFF
--- a/dev-docs/tmux-scenarios/issues-detail-word-wrap.json
+++ b/dev-docs/tmux-scenarios/issues-detail-word-wrap.json
@@ -10,15 +10,15 @@
     { "waitFor": "LLxprt Jefe" },
     { "key": "i" },
     { "waitFor": "Issues" },
-    { "waitFor": "#" },
+    { "waitFor": "Contextual allocation fixture" },
     { "key": "Enter" },
-    { "waitFor": "Body" },
-    { "key": "e" },
-    { "waitFor": "editing" },
-    { "keys": ["a", "l", "p", "h", "a", " ", "b", "r", "a", "v", "o", " ", "c", "h", "a", "r", "l", "i", "e", " ", "d", "e", "l", "t", "a", " ", "e", "c", "h", "o", " ", "f", "o", "x", "t", "r", "o", "t", " ", "g", "o", "l", "f", " ", "h", "o", "t", "e", "l", " ", "i", "n", "d", "i", "a", " ", "j", "u", "l", "i", "e", "t", "t"] },
-    { "waitFor": "juliett" },
+    { "waitFor": "wrapped-context-head" },
+    { "key": "c" },
+    { "waitFor": "New Comment" },
+    { "expect": "wrapped-context-tail" },
+    { "capture": "issues-contextual-wrapped-document" },
     { "key": "Escape" },
-    { "key": "q" },
+    { "key": "C-q" },
     { "waitForExit": 3000 }
   ]
 }

--- a/project-plans/issue423-plan.md
+++ b/project-plans/issue423-plan.md
@@ -1,0 +1,119 @@
+# Issue 423 delivery plan
+
+## Issue and baseline
+
+- GitHub: https://github.com/vybestack/llxprt-jefe/issues/423
+- Branch: `issue423`
+- Base: `origin/main` at `edeff48`
+- Reported behavior: contextual issue and pull-request composers reserve at most five rows, but Issues currently sizes the read-only document from logical line count while `ScrollableText` consumes wrapped display rows. A long logical line can therefore leave usable document rows blank.
+- Origin: deferred intentionally from PR 418 / issue 408 so the contextual scroll/display ownership contract could change independently from New Issue textbox expansion.
+- Discussion: the only issue comment is an automated planning placeholder and adds no behavioral requirements.
+
+## Acceptance matrix
+
+| ID | Actor / launch path | Inputs and boundaries | Target | Observable success | Observable failure / diagnostics | Permitted side effects | Persistence / compatibility | Proof |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| A1 | User opens an Issues New Comment or Reply composer | Narrow detail content; one logical document line wraps to multiple display rows; normal and tiny pane heights | Local TUI; platform-independent projection | The read-only document receives up to its wrapped display-row count within the contextual capacity; available rows are not discarded merely because logical line count is smaller | Existing banner/error paths remain unchanged; zero/tiny dimensions do not panic or overflow | Render only until existing submit/cancel action | Content-line scroll offsets, draft state, submit behavior, and persistence remain unchanged | updated real-TTY Issues scenario plus narrow-width issue projection/render regression |
+| A2 | User opens a PR New Comment, conversation Reply, or review-thread Reply composer | Narrow and wide detail content; short, wrapped, normal, and tiny panes | Local TUI; all platforms | PR and Issues use the same contextual allocation policy: document rows are bounded by wrapped display rows and available capacity; composer remains directly below short context and never exceeds five rows | Existing PR error/loading paths remain unchanged | Render only until existing submit/cancel action | Existing PR draft, reply target, and mutation behavior remain unchanged | narrow-width PR projection/render regression and shared layout tests |
+| A3 | User scrolls or opens a reply composer | Existing content-line scroll offset, bottom clamp, focused comment/thread reply anchor, wrapped content | All platforms | Scroll offsets remain in content-line units; reply anchor remains visible; state maximum offsets continue to agree with the renderer's contextual capacity for Issues and PRs | No new diagnostics; existing no-detail/no-anchor no-op behavior remains | Existing deterministic state transition only | No state schema or event change | existing issue/PR state focus regressions plus focused parity assertions around the shared capacity contract |
+| A4 | User composes in any contextual comment/reply textbox | Normal pane, tiny pane, and content shorter/taller than capacity | All platforms | Composer receives remaining rows after contextual document allocation, preserves at least the existing document reservation on non-empty tiny panes, and is capped at five rows | Zero-row panes render no rows without panic | Render only | Existing caret-following TextBox contract unchanged | shared pure layout tests and issue/PR component tests |
+
+## Explicit non-goals
+
+- No change to New Issue fill-available guidance/textbox allocation from issue 408.
+- No change to `ScrollableText` wrapping, terminal-cell measurement, selection mapping, scrollbar behavior, or content-line scroll-offset units.
+- No manual display-row scroll offset, persisted geometry, new state event, or per-keystroke parent scrolling.
+- No change to comment/reply submission, editing, pagination, GitHub I/O, keybindings, or persistence.
+- No composer expansion beyond the existing five-row contextual cap.
+- No dependency, manifest, workflow, agent-memory, `.llxprt/`, `.code_puppy/`, quality-gate, or harness-runner change.
+- No migration of legacy scenarios to schema 1; update the existing issue detail wrap scenario because schema-1 direct PTY input is already tracked outside this issue.
+
+## Bounded vertical slices
+
+### Slice S1: shared contextual row allocation and Issues behavior
+
+- Acceptance rows: A1, A3, A4.
+- Architecture owner: pure layout/projection layer; integration boundary is `IssueDetailProjectionInputs -> DetailPaneProps`.
+- Allowed production paths: `src/layout.rs`, `src/ui/components/issue_detail.rs`.
+- Allowed evidence paths: `src/ui/components/issue_detail_render_tests.rs`, `dev-docs/tmux-scenarios/issues-detail-word-wrap.json`, this plan.
+- RED: update the existing real-Jefe Issues detail scenario first; add a narrow-width projection/render test requiring wrapped document rows rather than logical-line rows.
+- GREEN: introduce one shared pure contextual allocation value/function and use wrapped document rows in Issues.
+- REFACTOR: keep wrapping in the existing `doc_wrap` projection and allocation in the pure shared layout helper; do not add state or component-local layout variants.
+- Verification: focused layout and issue-detail tests, updated scenario, `make quick-check`.
+- Stop conditions: new state events/fields, a wrapping subsystem, harness production changes, dependency changes, or paths outside this slice.
+
+### Slice S2: shared wrapped scroll geometry and width-aware state
+
+- Acceptance rows: A1-A4.
+- Architecture owner: `domain::document_wrap` as the project-independent geometry layer; state consumes only domain geometry and boundary-supplied dimensions.
+- Allowed production paths: `src/domain/document_wrap.rs`, `src/domain/mod.rs`, Issues/PR state type and operation modules, input orchestration, mouse detail routing, and the UI compatibility re-export.
+- RED: state-level narrow-width tests require nonzero content-line offsets and visible composer help anchors where logical-line bounds returned zero; the strong real-TTY fixture must fail before implementation.
+- GREEN: boundary routes store content width; state maximum offsets and reveal transitions consume the same wrapped rows the renderer consumes; offsets remain logical lines.
+- REFACTOR: remove duplicate PR maximum-bound implementations and retain one shared geometry algorithm.
+- Verification: focused geometry/state tests, strong 13-step real-TTY scenario, `make quick-check`.
+- Stop conditions: new events, persisted geometry, changed offset units, new dependency, or unrelated UI behavior.
+
+### Slice S3: PR policy parity and state-bound evidence
+
+- Acceptance rows: A2, A3, A4.
+- Architecture owner: PR pure detail projection consuming the S1 shared layout contract; state remains content-line based.
+- Allowed production paths: `src/ui/components/pr_detail.rs`; `src/layout.rs` only for S1 contract refinement.
+- Allowed evidence paths: `src/ui/components/pr_detail_render_tests.rs`, focused existing issue/PR state tests when parity needs an explicit regression, this plan.
+- RED: add narrow-width PR tests requiring the same wrapped-row contextual allocation and five-row cap.
+- GREEN: route PR detail projection through the shared allocation helper.
+- REFACTOR: remove duplicated issue-only allocation logic; retain the existing state capacity helper as the single scroll-bound reservation contract.
+- Verification: focused PR projection/render and composer-focus tests, `make quick-check`.
+- Stop conditions: persisted geometry or new state events, changed scroll-offset units, reply-anchor relocation, pagination changes, or any unplanned public abstraction.
+
+## Expected paths by layer
+
+| Layer | Expected paths | Acceptance mapping |
+| --- | --- | --- |
+| Shared pure layout | `src/layout.rs` | A1-A4 |
+| Issues pure projection | `src/ui/components/issue_detail.rs` | A1, A3, A4 |
+| PR pure projection | `src/ui/components/pr_detail.rs` | A2-A4 |
+| Issues component evidence | `src/ui/components/issue_detail_render_tests.rs` | A1, A3, A4 |
+| PR component evidence | `src/ui/components/pr_detail_render_tests.rs` | A2-A4 |
+| State evidence, only if existing tests do not prove parity | existing focused files under `src/state/` | A3 |
+| Real-TTY evidence | `dev-docs/tmux-scenarios/issues-detail-word-wrap.json` | A1, A4 |
+| Delivery record | `project-plans/issue423-plan.md` | all rows |
+
+Approved expanded scope: at most 25 changed files and under 1,500 net changed lines. In addition to one typed contextual row-allocation contract in `layout`, the existing pure document wrapper is promoted below UI so state and rendering share width-aware geometry. The user explicitly approved this expansion after the stronger TUI RED exposed the state/render disagreement.
+
+## Scope ledger
+
+| Discovery | Disposition | Rationale / follow-up |
+| --- | --- | --- |
+| `ScrollableText` already exposes the canonical terminal-cell-aware `doc_wrap::wrap_document` projection | In-scope design constraint | Reuse it; do not duplicate wrapping or convert state offsets to display rows. |
+| Issues shrinks contextual document rows by logical lines while PR always reserves full capacity | In-scope fix | Both projections should consume one wrapped-display-row-aware contextual allocation policy. |
+| Strong TUI RED proved state lacked the content width needed to reveal wrapped tail anchors | Approved in-scope expansion | The user approved promoting the existing pure wrapper to `domain::document_wrap`, storing the latest Issues/PR content width, and using one geometry source for render allocation, state bounds, and anchor reveal while offsets remain content-line based. |
+| Existing issue/PR reply-open tests cover anchor visibility with fixed contextual capacity | In-scope evidence reuse | Keep these tests green and add only focused parity evidence not already covered. |
+| Existing issue detail wrap scenario is pre-schema and externally fixture-backed | In-scope evidence update | Update it in place rather than changing the schema-1 runner, which issue 408 already identified as a separate quality-tool concern. |
+| RED/GREEN scenario with content whose wrapped height exceeded the fixed document capacity exposed an anchor-visibility gap | Approved in-scope expansion | Wrapped allocation alone could not preserve tail anchors. The approved shared domain geometry and width-aware state contract now close that gap. |
+| Approved geometry expansion remained within 25-file target | In-scope | Scope review found 24 changed paths including the wrapper move, about 370 tracked insertions plus the moved 444-line module and plan; no hard-budget trigger. |
+
+No unapproved scope discoveries are open.
+
+## Review counters
+
+- Pre-PR Open Code Review: 2 / 2 (both invocations terminated by external signal 15 with no output; no findings available to triage)
+- Post-PR Open Code Review: 0 / 2
+
+## Verification evidence
+
+| Candidate head | Command / evidence | Result |
+| --- | --- | --- |
+| `edeff48` | source audit | Baseline confirmed: Issues uses logical line count for contextual rows; PR uses fixed document capacity; both state paths use content-line offsets and the shared fixed capacity helper |
+| baseline working tree | focused allocation regressions | RED: Issues allocated 12 logical rows instead of 28 wrapped rows; PR allocated 28 fixed rows instead of 20 wrapped rows |
+| baseline working tree | strong isolated `issues-detail-word-wrap.json` fixture | RED: long wrapped tail/new-comment anchor could not be revealed by logical-line state bounds |
+| working tree | focused domain geometry, layout, Issues state, PR state, and projection tests | PASS |
+| working tree | isolated fail-closed real-Jefe TUI scenario | PASS: 13 steps; wrapped tail and contextual New Comment anchor visible together |
+| working tree | `make quick-check` and `git diff --check` | PASS |
+| working tree | format, allow-policy, source-size, full Clippy, complexity Clippy, locked all-feature build | PASS; source-size emitted recommendation-only warnings |
+| working tree | locked all-feature workspace tests with `--test-threads=1` | PASS; normal parallel gate repeatedly misclassified one one-second package-probe test under unrelated host cargo load |
+| working tree | exact `cargo llvm-cov` workspace/all-feature coverage gate | PASS: 71.57% line coverage, above the required 30% floor |
+| working tree | aggregate `make ci-check` attempts | Aggregate wrapper received external signal 15 during compilation; each required gate passed exactly and individually on the current source |
+
+## Deferred findings and follow-ups
+
+- None at planning time.

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -755,7 +755,7 @@ fn dispatch_issues_lifecycle(
 
 fn update_detail_viewport_rows(app_state: &mut AppStateHandle) {
     let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((120, 40));
-    let (_, render_rows) = jefe::layout::effective_render_size(term_cols, term_rows);
+    let (render_cols, render_rows) = jefe::layout::effective_render_size(term_cols, term_rows);
     let mut state = app_state.write();
     // Issue #265: use the shared banner projection so a notice-only banner
     // reserves the same viewport row as an error banner.
@@ -768,6 +768,8 @@ fn update_detail_viewport_rows(app_state: &mut AppStateHandle) {
         issues_banner_visible,
         state.issues_state.filter_ui.controls_open,
     );
+    state.issues_state.detail_content_width =
+        usize::from(jefe::layout::issues_detail_content_width(render_cols));
 }
 
 fn log_dispatch(message: &AppMessage) {

--- a/src/app_input/prs_comments_dispatch.rs
+++ b/src/app_input/prs_comments_dispatch.rs
@@ -9,7 +9,7 @@
 //! @pseudocode component-004 lines 146-155
 
 use jefe::domain::{PageToken, RepositoryId};
-use jefe::state::{AppEvent, ComposerTarget, InlineState};
+use jefe::state::AppEvent;
 
 use super::prs_dispatch::{current_pr_scope_repo_id, resolve_pr_gh_repo_or_error};
 use super::{AppStateHandle, SharedContext, apply_and_persist, gh_async, github_client};
@@ -94,49 +94,17 @@ enum PrCommentPageRequest {
     Skip,
 }
 
-/// Whether the embedded PR composer TextBox is active for the current state.
-///
-/// @plan PLAN-20260624-PR-MODE.P14
-/// @requirement REQ-PR-009
-/// @pseudocode component-001 lines 169-176
-fn pr_text_box_active(inline_state: &InlineState) -> bool {
-    matches!(
-        inline_state,
-        InlineState::Composer {
-            target: ComposerTarget::NewComment | ComposerTarget::Reply { .. },
-            ..
-        }
-    )
-}
-
-/// Compute the max detail scroll offset using the CANONICAL parity function
-/// `pr_detail_content_line_count` (the exact text the renderer emits for the
-/// current subfocus, inline composer state, and loading flags) minus the
-/// effective read-only document viewport rows. Using the parity function —
-/// rather than a local heuristic — guarantees the comments-dispatch "scrolled
-/// near bottom" check uses the SAME line count and viewport the renderer and
-/// scroll clamp do (MED-8).
+/// Compute the maximum detail offset through the canonical state contract.
+/// State builds the same read-only document as the renderer and projects its
+/// wrapped rows at the boundary-supplied width, so pagination, navigation, and
+/// rendering agree while the stored offset remains content-line based.
 ///
 /// @plan PLAN-20260624-PR-MODE.P11
 /// @requirement REQ-PR-009
 /// @requirement REQ-PR-010
 /// @pseudocode component-004 lines 146-155
 pub(super) fn pr_detail_max_scroll_offset(state: &jefe::state::AppState) -> usize {
-    let Some(detail) = state.prs_state.pr_detail.as_ref() else {
-        return 0;
-    };
-    let document_viewport = jefe::layout::pr_detail_document_viewport_rows(
-        state.prs_state.detail_viewport_rows,
-        pr_text_box_active(&state.prs_state.inline_state),
-    );
-    jefe::pr_detail_content::pr_detail_content_line_count(
-        detail,
-        state.prs_state.detail_subfocus,
-        &state.prs_state.inline_state,
-        state.prs_state.loading.detail,
-        state.prs_state.loading.comments,
-    )
-    .saturating_sub(document_viewport)
+    state.pr_detail_max_scroll_offset()
 }
 
 /// Resolve comment-page params or a Skip/Fail outcome from state.

--- a/src/app_input/prs_orchestration.rs
+++ b/src/app_input/prs_orchestration.rs
@@ -473,24 +473,25 @@ fn refresh_pr_preview_if_changed(app_state: &mut AppStateHandle, prev_pr_idx: Op
 
 /// Update the PR detail viewport row count from the layout module.
 ///
-/// Reads `crossterm::size()` ONCE at the dispatch boundary and writes the
-/// computed viewport rows into `prs_state.detail_viewport_rows` so the
-/// reducers never touch crossterm (#37/#39/#55). The content width for
-/// truncation is computed independently by the screen renderer (it does not
-/// live in reducer state — the reducer never wraps).
+/// Reads `crossterm::size()` once at the dispatch boundary and writes the
+/// computed viewport rows and content width into PR state so reducers never
+/// touch crossterm (#37/#39/#55). State uses that width only for deterministic
+/// wrapped scroll bounds; the screen derives the same geometry for rendering.
 ///
 /// @plan PLAN-20260624-PR-MODE.P11
 /// @requirement REQ-PR-009
 /// @pseudocode component-004 lines 156-159
 fn update_pr_detail_viewport_rows(app_state: &mut AppStateHandle) {
     let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((120, 40));
-    let (_, render_rows) = jefe::layout::effective_render_size(term_cols, term_rows);
+    let (render_cols, render_rows) = jefe::layout::effective_render_size(term_cols, term_rows);
     let mut state = app_state.write();
     state.prs_state.detail_viewport_rows = jefe::layout::prs_detail_viewport_rows(
         usize::from(render_rows),
         state.prs_state.error.is_some(),
         state.prs_state.filter_ui.controls_open,
     );
+    state.prs_state.detail_content_width =
+        usize::from(jefe::layout::prs_detail_content_width(render_cols));
 }
 
 /// Dispatch the PR agent-chooser confirm (send-to-agent) side effects.

--- a/src/domain/document_wrap.rs
+++ b/src/domain/document_wrap.rs
@@ -179,7 +179,7 @@ pub fn max_content_line_scroll_offset(rows: &[DocDisplayRow], viewport_rows: usi
         return 0;
     };
     if viewport_rows == 0 {
-        return last.line.saturating_add(1);
+        return last.line;
     }
     if rows.len() <= viewport_rows {
         return 0;
@@ -389,6 +389,7 @@ mod tests {
         let rows = wrap_document("alpha bravo charlie\nanchor\nhelp", 5);
         assert_eq!(max_content_line_scroll_offset(&rows, 4), 1);
         assert_eq!(max_content_line_scroll_offset(&rows, rows.len()), 0);
+        assert_eq!(max_content_line_scroll_offset(&rows, 0), 2);
     }
 
     #[test]

--- a/src/domain/document_wrap.rs
+++ b/src/domain/document_wrap.rs
@@ -1,7 +1,6 @@
-//! Pure, iocraft-free document wrapping projection for [`ScrollableText`].
+//! Pure, iocraft-free document wrapping and scroll-geometry projection.
 //!
-//! [`ScrollableText`] renders a scrollable text document (issue/PR detail
-//! bodies + comments + the inline editors). Each content *line* may wrap to
+//! Scrollable detail views render text documents whose content *lines* may wrap to
 //! several display *rows* at the pane content width; this module is the single
 //! source of truth for that line→row projection so the render path, the
 //! inline-editor caret placement, and the mouse-selection reverse-map cannot
@@ -169,6 +168,91 @@ pub fn viewport_row_to_content(
     Some((row.line, char_offset))
 }
 
+/// Compute the largest content-line scroll offset that can reveal the document tail.
+///
+/// The returned offset remains in content-line units. It is the earliest line
+/// whose wrapped suffix fits in `viewport_rows`; when no full suffix fits, the
+/// final content line is the best representable line-based offset.
+#[must_use]
+pub fn max_content_line_scroll_offset(rows: &[DocDisplayRow], viewport_rows: usize) -> usize {
+    let Some(last) = rows.last() else {
+        return 0;
+    };
+    if viewport_rows == 0 {
+        return last.line.saturating_add(1);
+    }
+    if rows.len() <= viewport_rows {
+        return 0;
+    }
+
+    let required_first_row = rows.len().saturating_sub(viewport_rows);
+    rows.iter()
+        .enumerate()
+        .find(|(index, row)| {
+            *index >= required_first_row
+                && (*index == 0 || rows[index.saturating_sub(1)].line != row.line)
+        })
+        .map_or(last.line, |(_, row)| row.line)
+}
+
+/// Compute the minimal content-line offset that reveals an inclusive line range.
+///
+/// This preserves the state model's content-line offsets while using wrapped
+/// display rows for visibility. Ranges taller than the viewport anchor at their
+/// first content line, matching the existing line-based reveal policy.
+#[must_use]
+pub fn reveal_content_line_range(
+    rows: &[DocDisplayRow],
+    item_start: usize,
+    item_end: usize,
+    offset: usize,
+    viewport_rows: usize,
+) -> usize {
+    if viewport_rows == 0 || rows.is_empty() {
+        return offset;
+    }
+    let first_visible = line_first_row(rows, offset);
+    let item_first = line_first_row(rows, item_start);
+    let item_last = line_last_row(rows, item_end);
+    let last_visible = first_visible
+        .saturating_add(viewport_rows)
+        .saturating_sub(1);
+    if item_first >= first_visible && item_last <= last_visible {
+        return offset;
+    }
+    if item_last < first_visible || item_first < first_visible {
+        return item_start;
+    }
+    if item_last.saturating_sub(item_first).saturating_add(1) > viewport_rows {
+        return item_start;
+    }
+
+    first_line_revealing_row(rows, item_last, viewport_rows).min(item_start)
+}
+
+fn line_last_row(rows: &[DocDisplayRow], line: usize) -> usize {
+    rows.iter()
+        .enumerate()
+        .rev()
+        .find(|(_, row)| row.line <= line)
+        .map_or(0, |(index, _)| index)
+}
+
+fn first_line_revealing_row(
+    rows: &[DocDisplayRow],
+    target_row: usize,
+    viewport_rows: usize,
+) -> usize {
+    rows.iter()
+        .enumerate()
+        .filter(|(index, row)| *index == 0 || rows[index.saturating_sub(1)].line != row.line)
+        .find(|(index, _)| index.saturating_add(viewport_rows) > target_row)
+        .map_or_else(
+            || rows.last().map_or(0, |row| row.line),
+            |(_, row)| row.line,
+        )
+}
+
 /// Find the display row + relative column that carries the caret at
 /// `(content_line, line_char_col)`, for inline-editor caret placement.
 ///
@@ -298,6 +382,20 @@ mod tests {
     fn caret_row_for_unknown_line_returns_none() {
         let rows = wrap_document("alpha\nbeta", 50);
         assert_eq!(caret_row_for_line_col(&rows, 99, 0), None);
+    }
+
+    #[test]
+    fn wrapped_scroll_bound_stays_in_content_line_units() {
+        let rows = wrap_document("alpha bravo charlie\nanchor\nhelp", 5);
+        assert_eq!(max_content_line_scroll_offset(&rows, 4), 1);
+        assert_eq!(max_content_line_scroll_offset(&rows, rows.len()), 0);
+    }
+
+    #[test]
+    fn reveal_range_uses_wrapped_rows_to_keep_tail_anchor_visible() {
+        let rows = wrap_document("alpha bravo charlie\nanchor\nhelp", 5);
+        assert_eq!(reveal_content_line_range(&rows, 1, 2, 0, 4), 1);
+        assert_eq!(reveal_content_line_range(&rows, 1, 2, 1, 4), 1);
     }
 
     #[test]

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -4,6 +4,8 @@
 //! @requirement REQ-TECH-001
 //! @requirement REQ-TECH-002
 
+/// Pure document wrapping and content-line scroll geometry.
+pub mod document_wrap;
 /// Shared validated target-resolution predicates for remote settings.
 pub mod target;
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -388,6 +388,42 @@ pub const PR_COMPOSER_VIEWPORT_ROWS: usize = DETAIL_COMPOSER_VIEWPORT_ROWS;
 pub const NEW_COMMENT_COMPOSER_PREFIX: &str = "  │ ";
 pub const REPLY_COMPOSER_PREFIX: &str = "    │ ";
 
+/// Contextual detail-pane rows allocated to the read-only document and editor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContextualDetailRows {
+    /// Wrapped display rows allocated to the read-only document.
+    pub document: usize,
+    /// Rows allocated to the embedded composer.
+    pub composer: usize,
+}
+
+/// Allocate contextual detail rows from the wrapped document height.
+///
+/// The document remains scrollable in content-line units; wrapping affects
+/// only how much of the pane the render projection occupies. The fixed
+/// document capacity remains the state scroll-bound contract, while a short
+/// document uses only the display rows it actually renders.
+#[must_use]
+pub fn contextual_detail_rows(
+    detail_viewport_rows: usize,
+    document_display_rows: usize,
+    composer_active: bool,
+) -> ContextualDetailRows {
+    if !composer_active {
+        return ContextualDetailRows {
+            document: detail_viewport_rows,
+            composer: 0,
+        };
+    }
+
+    let document_capacity = detail_document_viewport_rows(detail_viewport_rows, true);
+    let document = document_display_rows.min(document_capacity);
+    ContextualDetailRows {
+        document,
+        composer: DETAIL_COMPOSER_VIEWPORT_ROWS.min(detail_viewport_rows.saturating_sub(document)),
+    }
+}
+
 /// Compute rows available to the read-only PR detail document after embedded
 /// local editors reserve rows inside the detail pane.
 ///

--- a/src/mouse_routing_detail.rs
+++ b/src/mouse_routing_detail.rs
@@ -21,6 +21,8 @@ pub(super) fn refresh_detail_viewport_rows(
                 ),
                 state.issues_state.filter_ui.controls_open,
             );
+            state.issues_state.detail_content_width =
+                usize::from(jefe::layout::issues_detail_content_width(render_cols));
         }
         SelectablePane::PrDetail => {
             state.prs_state.detail_viewport_rows = jefe::layout::prs_detail_viewport_rows(
@@ -28,6 +30,8 @@ pub(super) fn refresh_detail_viewport_rows(
                 state.prs_state.error.is_some(),
                 state.prs_state.filter_ui.controls_open,
             );
+            state.prs_state.detail_content_width =
+                usize::from(jefe::layout::prs_detail_content_width(render_cols));
         }
         SelectablePane::ActionsDetail => {
             let geometry = jefe::layout::actions_detail_geometry(

--- a/src/state/issues_inline_ops.rs
+++ b/src/state/issues_inline_ops.rs
@@ -36,7 +36,19 @@ impl AppState {
             self.issues_state.detail_viewport_rows
         };
         let document_rows = crate::layout::issue_detail_document_viewport_rows(viewport_rows, true);
-        let desired = anchor_line.saturating_add(1).saturating_sub(document_rows);
+        let content_width = if self.issues_state.detail_content_width == 0 {
+            usize::from(crate::layout::issues_detail_content_width(120))
+        } else {
+            self.issues_state.detail_content_width
+        };
+        let rows = crate::domain::document_wrap::wrap_document(&content.text, content_width);
+        let desired = crate::domain::document_wrap::reveal_content_line_range(
+            &rows,
+            anchor_line,
+            anchor_line,
+            self.issues_state.detail_scroll_offset,
+            document_rows,
+        );
         self.issues_state.detail_scroll_offset =
             desired.min(self.issues_state.max_detail_scroll_offset());
     }

--- a/src/state/issues_ops.rs
+++ b/src/state/issues_ops.rs
@@ -185,7 +185,20 @@ impl AppState {
             return;
         };
         let viewport = self.issues_detail_scroll_viewport_rows();
-        let desired = crate::layout::reveal_range_scroll_offset(
+        let content = crate::issue_detail_content::build_detail_content(
+            detail,
+            self.issues_state.detail_subfocus,
+            &self.issues_state.inline_state,
+            self.issues_state.loading.comments,
+        );
+        let content_width = if self.issues_state.detail_content_width == 0 {
+            usize::from(crate::layout::issues_detail_content_width(120))
+        } else {
+            self.issues_state.detail_content_width
+        };
+        let rows = crate::domain::document_wrap::wrap_document(&content.text, content_width);
+        let desired = crate::domain::document_wrap::reveal_content_line_range(
+            &rows,
             item_start,
             item_end,
             self.issues_state.detail_scroll_offset,

--- a/src/state/issues_tests_composer_focus.rs
+++ b/src/state/issues_tests_composer_focus.rs
@@ -154,7 +154,9 @@ fn wrapped_body_new_comment_open_reveals_tail_anchor_with_line_offset() {
     state.issues_state.detail_viewport_rows = 20;
     state.issues_state.detail_content_width = 20;
 
-    let state = state.apply(AppEvent::OpenNewCommentComposer);
+    let state = state
+        .apply(AppEvent::OpenNewCommentComposer)
+        .committed_pure();
     let content = crate::issue_detail_content::build_detail_content(
         state
             .issues_state

--- a/src/state/issues_tests_composer_focus.rs
+++ b/src/state/issues_tests_composer_focus.rs
@@ -143,6 +143,47 @@ fn test_open_new_comment_composer_scrolls_to_bottom() {
     );
 }
 
+#[test]
+fn wrapped_body_new_comment_open_reveals_tail_anchor_with_line_offset() {
+    let repo_id = RepositoryId("repo-1".to_string());
+    let mut state = p15_state_with_loaded_detail(&repo_id, 42);
+    let Some(detail) = state.issues_state.issue_detail.as_mut() else {
+        panic!("expected loaded detail");
+    };
+    detail.body = format!("wrapped head {} wrapped tail", "segment ".repeat(30));
+    state.issues_state.detail_viewport_rows = 20;
+    state.issues_state.detail_content_width = 20;
+
+    let state = state.apply(AppEvent::OpenNewCommentComposer);
+    let content = crate::issue_detail_content::build_detail_content(
+        state
+            .issues_state
+            .issue_detail
+            .as_ref()
+            .unwrap_or_else(|| panic!("expected loaded detail")),
+        state.issues_state.detail_subfocus,
+        &state.issues_state.inline_state,
+        false,
+    );
+    let rows = crate::domain::document_wrap::wrap_document(&content.text, 20);
+    let first = crate::domain::document_wrap::line_first_row(
+        &rows,
+        state.issues_state.detail_scroll_offset,
+    );
+    let help_row = rows
+        .iter()
+        .position(|row| row.text.contains("Alt+Enter submit"))
+        .unwrap_or_else(|| panic!("expected composer help row"));
+    let viewport = crate::layout::issue_detail_document_viewport_rows(20, true);
+
+    assert!(state.issues_state.detail_scroll_offset > 0);
+    assert!(help_row < first + viewport);
+    assert_eq!(
+        state.issues_state.detail_scroll_offset,
+        state.issues_state.max_detail_scroll_offset()
+    );
+}
+
 /// Issue #56: When the composer is blocked by exclusivity (an editor is already
 /// active), opening the new-comment composer must NOT change subfocus or scroll.
 #[test]

--- a/src/state/issues_types.rs
+++ b/src/state/issues_types.rs
@@ -38,6 +38,8 @@ pub struct IssuesState {
     pub detail_scroll_offset: usize,
     /// Last rendered detail viewport height in rows.
     pub detail_viewport_rows: usize,
+    /// Last rendered detail content width in terminal cells.
+    pub detail_content_width: usize,
     pub inline_state: InlineState,
     pub agent_chooser: Option<AgentChooserState>,
     pub filter_ui: IssueFilterUiState,
@@ -246,7 +248,23 @@ impl IssuesState {
                 ..
             }
         );
-        self.detail_content_line_count().saturating_sub(
+        let Some(detail) = &self.issue_detail else {
+            return 0;
+        };
+        let content = crate::issue_detail_content::build_detail_content(
+            detail,
+            self.detail_subfocus,
+            &self.inline_state,
+            self.loading.comments,
+        );
+        let content_width = if self.detail_content_width == 0 {
+            usize::from(crate::layout::issues_detail_content_width(120))
+        } else {
+            self.detail_content_width
+        };
+        let rows = crate::domain::document_wrap::wrap_document(&content.text, content_width);
+        crate::domain::document_wrap::max_content_line_scroll_offset(
+            &rows,
             crate::layout::issue_detail_document_viewport_rows(viewport_rows, composer_active),
         )
     }

--- a/src/state/issues_types.rs
+++ b/src/state/issues_types.rs
@@ -238,9 +238,6 @@ impl IssuesState {
     /// Maximum detail scroll offset for a caller-provided viewport row count.
     #[must_use]
     pub fn max_detail_scroll_offset_for_viewport(&self, viewport_rows: usize) -> usize {
-        if self.issue_detail.is_none() {
-            return 0;
-        }
         let composer_active = matches!(
             self.inline_state,
             InlineState::Composer {

--- a/src/state/pr_types.rs
+++ b/src/state/pr_types.rs
@@ -120,6 +120,8 @@ pub struct PullRequestsState {
     pub detail_scroll_offset: usize,
     /// Last rendered detail viewport height in rows.
     pub detail_viewport_rows: usize,
+    /// Last rendered detail content width in terminal cells.
+    pub detail_content_width: usize,
     pub inline_state: InlineState,
     pub agent_chooser: Option<AgentChooserState>,
     /// Merge-method chooser overlay state (issue #92; mirrors AgentChooser).

--- a/src/state/prs_inline_ops.rs
+++ b/src/state/prs_inline_ops.rs
@@ -32,7 +32,7 @@ impl AppState {
     /// @requirement REQ-PR-010
     /// @pseudocode component-001 lines 169-176
     pub(super) fn scroll_pr_detail_to_bottom(&mut self) {
-        self.prs_state.detail_scroll_offset = self.pr_max_detail_scroll_offset();
+        self.prs_state.detail_scroll_offset = self.pr_detail_max_scroll_offset();
     }
 
     /// Scroll to the stable read-only Reply anchor rendered for the active
@@ -58,43 +58,27 @@ impl AppState {
         if viewport == 0 {
             return;
         }
-        let max_offset = content.text.lines().count().saturating_sub(viewport);
-        if let Some(line_idx) = content
+        let Some(anchor_line) = content
             .text
             .lines()
             .position(|line| line == crate::pr_detail_content::PR_REPLY_ANCHOR)
-        {
-            let desired = line_idx.saturating_sub(viewport.saturating_sub(1));
-            self.prs_state.detail_scroll_offset = desired.min(max_offset);
-        }
-    }
-
-    /// Compute the maximum detail scroll offset from the REAL rendered content
-    /// length (the exact text `build_pr_detail_content` emits for the current
-    /// subfocus and inline composer state) minus the viewport prop.
-    ///
-    /// Using the shared `pr_detail_content_line_count` parity function — rather
-    /// than a heuristic — guarantees that scrolling to the bottom on composer
-    /// open lands on the same offset the scroll clamp uses, so the composer
-    /// stays on-screen and a later page-down does not jump (#56). Like Issues
-    /// mode, the reducer NEVER wraps, so the count is the unwrapped line count
-    /// the renderer also sees (truncation does not change line counts).
-    ///
-    /// @plan PLAN-20260624-PR-MODE.P05
-    /// @requirement REQ-PR-009
-    /// @pseudocode component-001 lines 169-176
-    fn pr_max_detail_scroll_offset(&self) -> usize {
-        let Some(detail) = &self.prs_state.pr_detail else {
-            return 0;
+        else {
+            return;
         };
-        crate::pr_detail_content::pr_detail_content_line_count(
-            detail,
-            self.prs_state.detail_subfocus,
-            &self.prs_state.inline_state,
-            self.prs_state.loading.detail,
-            self.prs_state.loading.comments,
-        )
-        .saturating_sub(self.pr_detail_scroll_viewport_rows())
+        let content_width = if self.prs_state.detail_content_width == 0 {
+            usize::from(crate::layout::prs_detail_content_width(120))
+        } else {
+            self.prs_state.detail_content_width
+        };
+        let rows = crate::domain::document_wrap::wrap_document(&content.text, content_width);
+        let desired = crate::domain::document_wrap::reveal_content_line_range(
+            &rows,
+            anchor_line,
+            anchor_line,
+            self.prs_state.detail_scroll_offset,
+            viewport,
+        );
+        self.prs_state.detail_scroll_offset = desired.min(self.pr_detail_max_scroll_offset());
     }
 
     /// Borrow the active (text, cursor) pair from the inline composer/editor.

--- a/src/state/prs_integration_tests.rs
+++ b/src/state/prs_integration_tests.rs
@@ -402,32 +402,15 @@ fn assert_stale_comments_page_is_discarded(state: &mut AppState) {
     );
 }
 
-/// Compute the expected PR-detail bottom scroll offset by replicating the
-/// production `scroll_pr_detail_to_bottom` → `pr_max_detail_scroll_offset`
-/// path: the REAL rendered line count from the shared
-/// `pr_detail_content::pr_detail_content_line_count` parity function (for the
-/// current subfocus + inline composer state), then
-/// `saturating_sub(detail_viewport_rows)`.  This deliberately uses the same
-/// parity surface production uses so the assertion follows the real rendered
-/// bottom (reviews, checks, separators, section headers, composer block) and
-/// never the old header+body+comments heuristic that under-scrolled (#56).
+/// Compute the expected PR-detail bottom scroll offset from the canonical
+/// width-aware wrapped-row bound used by detail navigation.
 ///
 /// @plan PLAN-20260624-PR-MODE.P15
 /// @requirement REQ-PR-009
 /// @requirement REQ-PR-010
 /// @pseudocode component-001 lines 169-176
 fn pr_expected_detail_bottom_scroll(state: &AppState) -> usize {
-    let Some(detail) = state.prs_state.pr_detail.as_ref() else {
-        return 0;
-    };
-    crate::pr_detail_content::pr_detail_content_line_count(
-        detail,
-        state.prs_state.detail_subfocus,
-        &state.prs_state.inline_state,
-        state.prs_state.loading.detail,
-        state.prs_state.loading.comments,
-    )
-    .saturating_sub(state.prs_state.detail_viewport_rows)
+    state.pr_detail_max_scroll_offset()
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/state/prs_nav_ops.rs
+++ b/src/state/prs_nav_ops.rs
@@ -290,7 +290,21 @@ impl AppState {
             return;
         };
         let viewport = self.pr_detail_scroll_viewport_rows();
-        let desired = crate::layout::reveal_range_scroll_offset(
+        let content = crate::pr_detail_content::build_pr_detail_content(
+            detail,
+            self.prs_state.detail_subfocus,
+            &self.prs_state.inline_state,
+            self.prs_state.loading.detail,
+            self.prs_state.loading.comments,
+        );
+        let content_width = if self.prs_state.detail_content_width == 0 {
+            usize::from(crate::layout::prs_detail_content_width(120))
+        } else {
+            self.prs_state.detail_content_width
+        };
+        let rows = crate::domain::document_wrap::wrap_document(&content.text, content_width);
+        let desired = crate::domain::document_wrap::reveal_content_line_range(
+            &rows,
             item_start,
             item_end,
             self.prs_state.detail_scroll_offset,
@@ -312,14 +326,23 @@ impl AppState {
         let Some(detail) = &self.prs_state.pr_detail else {
             return 0;
         };
-        crate::pr_detail_content::pr_detail_content_line_count(
+        let content = crate::pr_detail_content::build_pr_detail_content(
             detail,
             self.prs_state.detail_subfocus,
             &self.prs_state.inline_state,
             self.prs_state.loading.detail,
             self.prs_state.loading.comments,
+        );
+        let content_width = if self.prs_state.detail_content_width == 0 {
+            usize::from(crate::layout::prs_detail_content_width(120))
+        } else {
+            self.prs_state.detail_content_width
+        };
+        let rows = crate::domain::document_wrap::wrap_document(&content.text, content_width);
+        crate::domain::document_wrap::max_content_line_scroll_offset(
+            &rows,
+            self.pr_detail_scroll_viewport_rows(),
         )
-        .saturating_sub(self.pr_detail_scroll_viewport_rows())
     }
 
     // ---- Navigation dispatch ----

--- a/src/state/prs_nav_ops.rs
+++ b/src/state/prs_nav_ops.rs
@@ -272,6 +272,26 @@ impl AppState {
         true
     }
 
+    fn pr_detail_wrapped_rows(&self) -> Option<Vec<crate::domain::document_wrap::DocDisplayRow>> {
+        let detail = self.prs_state.pr_detail.as_ref()?;
+        let content = crate::pr_detail_content::build_pr_detail_content(
+            detail,
+            self.prs_state.detail_subfocus,
+            &self.prs_state.inline_state,
+            self.prs_state.loading.detail,
+            self.prs_state.loading.comments,
+        );
+        let content_width = if self.prs_state.detail_content_width == 0 {
+            usize::from(crate::layout::prs_detail_content_width(120))
+        } else {
+            self.prs_state.detail_content_width
+        };
+        Some(crate::domain::document_wrap::wrap_document(
+            &content.text,
+            content_width,
+        ))
+    }
+
     /// Scroll the detail pane so the currently-focused subfocus item is
     /// visible, using the pure `reveal_range_scroll_offset` helper and the
     /// fresh viewport row count. Only fires on a subfocus *change* (Tab/j/k),
@@ -290,19 +310,9 @@ impl AppState {
             return;
         };
         let viewport = self.pr_detail_scroll_viewport_rows();
-        let content = crate::pr_detail_content::build_pr_detail_content(
-            detail,
-            self.prs_state.detail_subfocus,
-            &self.prs_state.inline_state,
-            self.prs_state.loading.detail,
-            self.prs_state.loading.comments,
-        );
-        let content_width = if self.prs_state.detail_content_width == 0 {
-            usize::from(crate::layout::prs_detail_content_width(120))
-        } else {
-            self.prs_state.detail_content_width
+        let Some(rows) = self.pr_detail_wrapped_rows() else {
+            return;
         };
-        let rows = crate::domain::document_wrap::wrap_document(&content.text, content_width);
         let desired = crate::domain::document_wrap::reveal_content_line_range(
             &rows,
             item_start,
@@ -323,22 +333,9 @@ impl AppState {
     /// @pseudocode component-001 lines 169-176
     #[must_use]
     pub fn pr_detail_max_scroll_offset(&self) -> usize {
-        let Some(detail) = &self.prs_state.pr_detail else {
+        let Some(rows) = self.pr_detail_wrapped_rows() else {
             return 0;
         };
-        let content = crate::pr_detail_content::build_pr_detail_content(
-            detail,
-            self.prs_state.detail_subfocus,
-            &self.prs_state.inline_state,
-            self.prs_state.loading.detail,
-            self.prs_state.loading.comments,
-        );
-        let content_width = if self.prs_state.detail_content_width == 0 {
-            usize::from(crate::layout::prs_detail_content_width(120))
-        } else {
-            self.prs_state.detail_content_width
-        };
-        let rows = crate::domain::document_wrap::wrap_document(&content.text, content_width);
         crate::domain::document_wrap::max_content_line_scroll_offset(
             &rows,
             self.pr_detail_scroll_viewport_rows(),

--- a/src/state/prs_tests_composer_focus.rs
+++ b/src/state/prs_tests_composer_focus.rs
@@ -479,6 +479,45 @@ fn test_open_composer_scrolls_to_real_rendered_bottom_so_composer_visible() {
     );
 }
 
+#[test]
+fn wrapped_pr_body_new_comment_open_reveals_tail_anchor_with_line_offset() {
+    let mut state = prs_state_with_detail("repo-1", 1);
+    let Some(detail) = state.prs_state.pr_detail.as_mut() else {
+        panic!("expected loaded detail");
+    };
+    detail.body = format!("wrapped head {} wrapped tail", "segment ".repeat(30));
+    state.prs_state.detail_viewport_rows = 20;
+    state.prs_state.detail_content_width = 20;
+
+    let state = state.apply(AppEvent::PrOpenNewCommentComposer);
+    let content = crate::pr_detail_content::build_pr_detail_content(
+        state
+            .prs_state
+            .pr_detail
+            .as_ref()
+            .unwrap_or_else(|| panic!("expected loaded detail")),
+        state.prs_state.detail_subfocus,
+        &state.prs_state.inline_state,
+        false,
+        false,
+    );
+    let rows = crate::domain::document_wrap::wrap_document(&content.text, 20);
+    let first =
+        crate::domain::document_wrap::line_first_row(&rows, state.prs_state.detail_scroll_offset);
+    let help_row = rows
+        .iter()
+        .position(|row| row.text.contains("Alt+Enter submit"))
+        .unwrap_or_else(|| panic!("expected composer help row"));
+    let viewport = crate::layout::pr_detail_document_viewport_rows(20, true);
+
+    assert!(state.prs_state.detail_scroll_offset > 0);
+    assert!(help_row < first + viewport);
+    assert_eq!(
+        state.prs_state.detail_scroll_offset,
+        state.pr_detail_max_scroll_offset()
+    );
+}
+
 /// HIGH-2: While a mutation is pending, pressing Esc/Cancel MUST close the
 /// composer (inline_state → None) and clear mutation_pending — it must NOT be
 /// swallowed by the early-return guard and leave the composer frozen.

--- a/src/state/prs_tests_composer_focus.rs
+++ b/src/state/prs_tests_composer_focus.rs
@@ -489,7 +489,9 @@ fn wrapped_pr_body_new_comment_open_reveals_tail_anchor_with_line_offset() {
     state.prs_state.detail_viewport_rows = 20;
     state.prs_state.detail_content_width = 20;
 
-    let state = state.apply(AppEvent::PrOpenNewCommentComposer);
+    let state = state
+        .apply(AppEvent::PrOpenNewCommentComposer)
+        .committed_pure();
     let content = crate::pr_detail_content::build_pr_detail_content(
         state
             .prs_state

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -213,23 +213,6 @@ fn detail_content_width(available_width: Option<u16>) -> usize {
     }))
 }
 
-/// Compute the document/composer split for a contextual comment or reply.
-fn contextual_issue_composer_rows(
-    detail_viewport_rows: usize,
-    reserved_document_rows: usize,
-    document_line_count: usize,
-    composer_active: bool,
-) -> (usize, usize) {
-    if !composer_active {
-        return (reserved_document_rows, 0);
-    }
-
-    let scroll_rows = reserved_document_rows.min(document_line_count);
-    let composer_rows = crate::layout::DETAIL_COMPOSER_VIEWPORT_ROWS
-        .min(detail_viewport_rows.saturating_sub(scroll_rows));
-    (scroll_rows, composer_rows)
-}
-
 /// Preserve New Issue guidance and give every remaining row to its composer.
 fn new_issue_composer_rows(
     detail_viewport_rows: usize,
@@ -280,20 +263,17 @@ pub fn issue_detail_props(inputs: IssueDetailProjectionInputs<'_>) -> DetailPane
         empty_issue_content()
     };
 
-    let document_line_count = detail_content.text.lines().count().max(1);
+    let document_display_rows =
+        super::doc_wrap::wrap_document(&detail_content.text, content_width).len();
     let (scroll_rows, composer_rows) = if showing_new_issue_composer {
-        let document_display_rows =
-            super::doc_wrap::wrap_document(&detail_content.text, content_width).len();
         new_issue_composer_rows(detail_vp_rows, document_display_rows)
     } else {
-        let reserved_document_rows =
-            crate::layout::issue_detail_document_viewport_rows(detail_vp_rows, composer_active);
-        contextual_issue_composer_rows(
+        let rows = crate::layout::contextual_detail_rows(
             detail_vp_rows,
-            reserved_document_rows,
-            document_line_count,
+            document_display_rows,
             composer_active,
-        )
+        );
+        (rows.document, rows.composer)
     };
     let composer_props = composer.map(|(text, byte_cursor, prefix)| DetailComposerProps {
         text,

--- a/src/ui/components/issue_detail_render_tests.rs
+++ b/src/ui/components/issue_detail_render_tests.rs
@@ -219,6 +219,50 @@ fn active_issue_new_comment_on_short_detail_starts_after_comments() {
     );
 }
 
+/// Contextual allocation follows the same wrapped display rows that
+/// `ScrollableText` renders instead of shrinking to the logical-line count.
+#[test]
+fn contextual_issue_document_uses_wrapped_display_rows_at_narrow_width() {
+    let mut detail = issue_detail_with_comment();
+    detail.body = format!(
+        "wrapped-context-head {} wrapped-context-tail",
+        "narrow body segment ".repeat(8)
+    );
+    let inline = InlineState::Composer {
+        target: ComposerTarget::NewComment,
+        text: String::new(),
+        cursor: 0,
+    };
+    let pane_height = 40;
+    let content_width = 20;
+    let props = issue_detail_props(IssueDetailProjectionInputs {
+        issue_detail: Some(&detail),
+        detail_subfocus: DetailSubfocus::NewComment,
+        inline_state: &inline,
+        comments_loading: false,
+        focused: true,
+        scroll_offset: 0,
+        colors: ThemeColors::default(),
+        available_height: Some(pane_height),
+        available_width: Some(content_width),
+        selection: None,
+    });
+    let detail_rows = crate::layout::detail_body_viewport_rows(usize::from(pane_height));
+    let document_capacity = crate::layout::issue_detail_document_viewport_rows(detail_rows, true);
+    let display_rows =
+        super::doc_wrap::wrap_document(&props.content, usize::from(content_width)).len();
+
+    assert!(
+        display_rows > props.content.lines().count(),
+        "fixture must wrap at the narrow content width"
+    );
+    assert_eq!(props.viewport_rows, document_capacity.min(display_rows));
+    assert_eq!(
+        props.composer_rows,
+        crate::layout::DETAIL_COMPOSER_VIEWPORT_ROWS
+    );
+}
+
 /// Long single-line Issues composer drafts must keep the caret-owned tail visible
 /// through TextBox even when the parent detail scroll offset is stale.
 #[test]

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -23,7 +23,8 @@ mod close_reason_chooser;
 /// helpers (`header_highlight`, `header_row`) live here so both detail panes
 /// share one source of truth.
 pub(crate) mod detail_pane;
-pub mod doc_wrap;
+/// Compatibility re-export for the shared document geometry projection.
+pub use crate::domain::document_wrap as doc_wrap;
 /// Generic bordered filter bar with labeled `[value]` fields and action hints.
 /// Domain layers (`filter_controls` for Issues, `pr_filter_controls` for PRs)
 /// project into [`FilterBarProps`] and delegate rendering through

--- a/src/ui/components/pr_detail.rs
+++ b/src/ui/components/pr_detail.rs
@@ -259,10 +259,6 @@ pub fn pr_detail_props(inputs: PrDetailProjectionInputs<'_>) -> DetailPaneProps 
     let composer = composer_from_inline_state(inputs.inline_state);
     let text_box_active = composer.is_some();
 
-    let scroll_rows =
-        crate::layout::pr_detail_document_viewport_rows(detail_viewport_rows, text_box_active);
-    let composer_rows = detail_viewport_rows.saturating_sub(scroll_rows);
-
     let (header_rows, detail_content) = if let Some(detail) = inputs.detail {
         loaded_pr_content(
             detail,
@@ -275,6 +271,13 @@ pub fn pr_detail_props(inputs: PrDetailProjectionInputs<'_>) -> DetailPaneProps 
         empty_pr_content()
     };
 
+    let document_display_rows =
+        super::doc_wrap::wrap_document(&detail_content.text, inputs.detail_content_width).len();
+    let rows = crate::layout::contextual_detail_rows(
+        detail_viewport_rows,
+        document_display_rows,
+        text_box_active,
+    );
     let composer_props = composer.map(|(text, byte_cursor, prefix)| DetailComposerProps {
         text,
         byte_cursor,
@@ -287,7 +290,7 @@ pub fn pr_detail_props(inputs: PrDetailProjectionInputs<'_>) -> DetailPaneProps 
         content: detail_content.text,
         content_cursor: detail_content.cursor,
         scroll_offset: inputs.scroll_offset,
-        viewport_rows: scroll_rows,
+        viewport_rows: rows.document,
         content_line_offset: HEADER_ROWS,
         max_line_width: inputs.detail_content_width,
         focused: inputs.focused,
@@ -295,6 +298,6 @@ pub fn pr_detail_props(inputs: PrDetailProjectionInputs<'_>) -> DetailPaneProps 
         colors: inputs.colors,
         selection: inputs.selection,
         composer: composer_props,
-        composer_rows,
+        composer_rows: rows.composer,
     }
 }

--- a/src/ui/components/pr_detail_render_tests.rs
+++ b/src/ui/components/pr_detail_render_tests.rs
@@ -229,6 +229,54 @@ fn long_comment_wraps_across_rendered_rows() {
     );
 }
 
+/// PR contextual composers share the wrapped-display-row allocation policy
+/// with Issues, so short wrapped context is not padded to the pane bottom.
+#[test]
+fn contextual_pr_document_uses_wrapped_display_rows_at_narrow_width() {
+    let mut detail = bare_pr_detail();
+    detail.body = format!(
+        "wrapped-context-head {} wrapped-context-tail",
+        "narrow body segment ".repeat(2)
+    );
+    let inline = InlineState::Composer {
+        target: ComposerTarget::NewComment,
+        text: String::new(),
+        cursor: 0,
+    };
+    let pane_height = 40;
+    let content_width = 32;
+    let props = pr_detail_props(PrDetailProjectionInputs {
+        detail: Some(&detail),
+        subfocus: PrDetailSubfocus::NewComment,
+        inline_state: &inline,
+        detail_loading: false,
+        comments_loading: false,
+        focused: true,
+        scroll_offset: 0,
+        detail_content_width: content_width,
+        colors: ThemeColors::default(),
+        viewport_rows: Some(pane_height),
+        selection: None,
+    });
+    let detail_rows = crate::layout::detail_body_viewport_rows(usize::from(pane_height));
+    let document_capacity = crate::layout::pr_detail_document_viewport_rows(detail_rows, true);
+    let display_rows = super::doc_wrap::wrap_document(&props.content, content_width).len();
+
+    assert!(
+        display_rows > props.content.lines().count(),
+        "fixture must wrap at the narrow content width"
+    );
+    assert!(
+        display_rows < document_capacity,
+        "fixture must leave room for contextual allocation to shrink"
+    );
+    assert_eq!(props.viewport_rows, display_rows);
+    assert_eq!(
+        props.composer_rows,
+        crate::layout::DETAIL_COMPOSER_VIEWPORT_ROWS
+    );
+}
+
 /// Count the background-color SGR sequences (`48;2;` truecolor or `48;5;`
 /// indexed) in a component's ANSI output. Used to prove the caret's
 /// reverse-video cell adds background fills beyond the baseline chrome.

--- a/tests/layout/layout_tests.rs
+++ b/tests/layout/layout_tests.rs
@@ -304,6 +304,38 @@ fn issue_detail_document_viewport_reserves_composer_rows_but_preserves_document_
 }
 
 #[test]
+fn contextual_detail_rows_follow_wrapped_document_and_cap_composer() {
+    assert_eq!(
+        contextual_detail_rows(20, 12, true),
+        ContextualDetailRows {
+            document: 12,
+            composer: 5,
+        }
+    );
+    assert_eq!(
+        contextual_detail_rows(20, 30, true),
+        ContextualDetailRows {
+            document: 15,
+            composer: 5,
+        }
+    );
+    assert_eq!(
+        contextual_detail_rows(4, 10, true),
+        ContextualDetailRows {
+            document: 1,
+            composer: 3,
+        }
+    );
+    assert_eq!(
+        contextual_detail_rows(20, 1, false),
+        ContextualDetailRows {
+            document: 20,
+            composer: 0,
+        }
+    );
+}
+
+#[test]
 fn issue_list_content_width_excludes_sidebar_and_border() {
     assert_eq!(issue_list_content_width(120), 96);
     assert_eq!(issue_list_content_width(10), 0);


### PR DESCRIPTION
## Summary

Fixes #423.

- allocates contextual issue and pull-request document rows from wrapped display height instead of logical-line count or an unconditional capacity
- preserves logical content-line scroll offsets while sharing terminal-cell-aware wrapping geometry between state and rendering
- keeps reply anchors visible and contextual composers capped at five rows
- adds narrow-width Issues and PR regressions plus an isolated real-Jefe scenario

## Verification

- [x] Format — cargo fmt --all --check
- [x] Clippy allow policy — scripts/check-clippy-allows.sh
- [x] Source file length — scripts/check-source-file-size.sh
- [x] Lint — full workspace/all-target/all-feature Clippy gate
- [x] Complexity — dedicated complexity Clippy gate
- [x] Coverage — exact-head GitHub coverage gate passed
- [x] Build — locked workspace all-feature build passed locally and in GitHub CI
- [x] Tests — locked workspace all-feature tests passed locally and in GitHub CI
- [x] Native Windows — GitHub CI passed
- [x] TUI behavior — isolated fail-closed 13-step contextual allocation scenario passed

## Testing notes

- focused document-wrap geometry tests passed, including the zero-height content-line bound regression
- Issues composer-focus tests: 12 passed
- PR composer-focus tests: 13 passed
- layout tests: 46 passed
- isolated real-Jefe scenario: 13 steps passed
- exact-head GitHub format, policy, source-size, Clippy, complexity, coverage, build, test, and Windows checks passed
- all Open Code Review findings were evaluated, answered, and resolved; valid scroll-bound, duplicate-guard, and shared-geometry findings were fixed
- CodeRabbit reported success with review skipped by repository label configuration and posted no findings

The aggregate local make wrapper was interrupted by external signal 15. Its exact constituent gates were run separately; formatting, policies, Clippy, complexity, build, and locked workspace tests passed locally, while exact-head GitHub CI independently passed the full coverage and test gates. A host-sensitive guarded tmux test failed once during the first local aggregate test run, then passed individually and in the complete locked workspace retry.

## Scope

- 24 files, 609 insertions, 157 deletions
- no dependency, persistence-schema, workflow, quality-tool, or keybinding changes
- delivery plan: project-plans/issue423-plan.md
