### PR TITLE
Align inline caret projection with renderer scalar indexing (Fixes #429)

### DIFF
--- a/project-plans/issue429-plan.md
+++ b/project-plans/issue429-plan.md
@@ -124,10 +124,97 @@ the `domain` projection + its renderer consumer, which already shares the
 
 ## Review counters (OCR)
 
-- Local OCR runs before PR: 0 / 2
-- OCR runs after PR opened: 0 / 2
+- Local OCR runs before PR: 1 / 2
+- OCR runs after PR opened: 1 / 2
 
 (Cap: two local + two PR per issue/PR effort.)
+
+## OCR review triage
+
+### Local run (pre-PR, head `46276b3`)
+
+0 findings ("Looks good to me").
+
+### PR run (head `2528d32`)
+
+1 finding (`src/ui/components/scrollable_text.rs:706-711`, maintainability/medium):
+the new CJK caret regression test hard-coded the ANSI SGR literals
+`\u{1b}[48` / `\u{1b}[7m`, duplicating the same detection already present in
+the existing `non_overlapping_selection_paints_no_highlight_on_row` test;
+suggested extracting a shared helper.
+
+**Disposition: In-scope-Fix.** Factually correct: both tests live in the
+same module touched by this PR and both encoded the renderer color-encoding
+assumption inline. Extracted `contains_highlight_sgr(line)` and routed both
+the caret test and the selection test through it so the format assumption
+lives in one place. Remediated in commit `2528d32`.
+
+## Verification evidence
+
+Local (candidate head `2528d32`):
+
+- `cargo fmt --all --check` — pass
+- `scripts/check-clippy-allows.sh` — pass
+- `scripts/check-source-file-size.sh` — pass (warnings only, pre-existing)
+- clippy `-D warnings` — pass
+- clippy complexity gate (`-D cognitive_complexity -D too_many_lines …`) — pass
+- coverage `--fail-under-lines 30` — pass (72.11% lines)
+- `cargo build --workspace --all-features --locked` — pass
+- `cargo test --lib` — pass (all 3 new tests green; no regressions)
+
+PR #450 CI (exact head `2528d32`):
+
+- Format (rustfmt) — SUCCESS
+- Lint (clippy) — SUCCESS
+- Clippy allow policy — SUCCESS
+- Source file length checks — SUCCESS
+- Complexity checks — SUCCESS
+- Coverage gate — SUCCESS (72.11%)
+- Build — SUCCESS
+- Test — SUCCESS
+- OpenCodeReview (CI job) — SUCCESS
+- Native Windows (MSVC + psmux) — FAILURE (pre-existing flake; see below)
+- CodeRabbit — skipped (excluded by label configuration)
+- PR state: `mergeable: MERGEABLE`, `mergeStateStatus: UNSTABLE`. Branch
+  `main` is NOT protected (no required status checks), so the Windows job is
+  a signal-only check, not a merge gate.
+
+### Native Windows (MSVC + psmux) — proven pre-existing flake
+
+The Windows job failed across 5 consecutive runs, each on a **different**
+process/timing-sensitive smoke test (no two runs failed the same test):
+
+| Run | Failing test | Timeout |
+|-----|--------------|---------|
+| 1 | `psmux_four_recording_agents_remain_independent_and_scoped` | 30s spawn readiness |
+| 2 | `psmux_attached_viewer_observes_mouse_modes_and_delivers_page_keys` | 30s byte echo |
+| 3 | `guarded_dashboard_reorder_tui_scenario` | 15s `waitFor` |
+| 4 | `psmux_attached_viewer_observes_mouse_modes_and_delivers_page_keys` | 30s byte echo |
+| 5 | `guarded_real_dashboard_lists_window_fixture_rows` + `guarded_real_jefe_qqq_quits` | 30s `waitFor` |
+
+All failures are `waitFor`/spawn-readiness timeouts in `tests/psmux_smoke*.rs`
+and `src/harness/runner_tests.rs` — harness tests that spawn real jefe/tmux/psmux
+subprocesses and wait for them to reach a state within a fixed budget. None of
+them import or touch `document_wrap.rs` or `scrollable_text.rs` (the only
+files this PR changes).
+
+Cross-branch evidence: the same `Native Windows (MSVC + psmux)` job failed on
+unrelated branches `issue264` (run 30217009450) and `issue407` (run
+30210215055) on the same family of timing tests. The failing test changes
+every run — the signature of runner-resource-contention flakiness, not a
+deterministic code defect. This matches the documented pre-existing flake set
+(the `harness::runner::tests::guarded_real_*` and psmux spawn tests).
+
+The Unix-side `Test` job (which runs the full lib + integration suite on
+Linux) passes on the candidate head, and `cargo test --lib` passes locally.
+
+## Deferred findings / follow-ups
+
+- The `Native Windows (MSVC + psmux)` job's process/timing smoke tests are a
+  repository-wide flakiness concern (affects multiple branches) and is out of
+  scope for this PR. A follow-up could raise the `waitFor` budgets or add
+  retry/backoff to the psmux/harness smoke tests, but that is a testing-
+  infrastructure change, not part of the caret-alignment acceptance matrix.
 
 ## Stopping conditions
 

--- a/project-plans/issue429-plan.md
+++ b/project-plans/issue429-plan.md
@@ -1,0 +1,136 @@
+# Issue #429 — Align ScrollableText inline caret offsets with renderer indexing
+
+## Problem
+
+The ScrollableText inline-editor caret projection reports terminal-cell
+offsets for wrapped rows, while the renderer indexes row text by Unicode
+scalar position. Wide glyphs can therefore shift the rendered inline caret.
+
+### Root cause
+
+`src/domain/document_wrap.rs::caret_row_for_line_col` is the projection used
+by the inline-editor caret placement. Its second return value
+(`col_within_row`) is currently computed as a **terminal display-cell width**
+via `UnicodeWidthStr::width(prefix.as_str())`.
+
+Its single consumer, `src/ui/components/scrollable_text.rs::cursor_row_element`,
+indexes the row text by **Unicode scalar position** via
+`chars.iter().take(cursor_col)` / `skip(cursor_col)`. It then renders the
+caret cell, and the caret's `Box` cell consumes whatever scalar the renderer
+sliced out.
+
+These two coordinate spaces diverge for two glyph classes:
+
+- **Wide (CJK/emoji) glyphs** — display width 2, scalar width 1. The
+  projection counts 2 cells per glyph; the renderer slices 1 scalar per
+  index unit. The caret is painted too far right.
+- **Zero-width (combining marks) glyphs** — display width 0, scalar width 1.
+  The projection skips them; the renderer still slices one scalar. The caret
+  drifts by one for each combining mark preceding it.
+
+The renderer is the authority: `cursor_row_element` slices `chars` by scalar
+position to paint the exact glyph under the caret. The projection must
+therefore return the **char offset relative to the row's `line_char_start`**,
+matching the renderer's scalar indexing. Wrapping and selection mapping stay
+terminal-cell-aware and char-based respectively — neither changes.
+
+## Decision (accepted approach)
+
+**Contract:** `caret_row_for_line_col` returns
+`(global_row_index, char_offset_within_row)`, where `char_offset_within_row`
+is the 0-based Unicode scalar offset of the caret column relative to the
+row's `line_char_start`. This matches the renderer's
+`chars.iter().take(cursor_col)` indexing in `cursor_row_element` exactly.
+
+This is the minimal, contract-aligning fix. It:
+
+- keeps wrapping terminal-cell-aware (`wrap_document` / `wrap_text` are
+  unchanged);
+- keeps selection mappings char-based (`row_highlight` / `clip_range_to_row`
+  are unchanged);
+- keeps the renderer's scalar-based `cursor_row_element` slicing as-is;
+- changes only the projection's second return value from a cell width to a
+  char offset, plus adds a doc comment naming the contract.
+
+## Non-goals
+
+- Changing issue 422's TextBox caret or ScrollableText selection contract
+  (explicit non-goal from the issue text).
+- Changing `cursor_row_element`'s scalar-based rendering (it is the
+  coordinate authority).
+- Changing `display_cell_to_char_offset`, `viewport_cell_to_content`, or any
+  other terminal-cell→char reverse-map used by mouse selection.
+- Changing `inline_cursor_line_start`/`inline_cursor_line_end` (state-layer
+  byte-cursor movement, separate from the render projection).
+- Changing the `DetailContent.cursor` coordinate contract (it stays
+  `(content_line, char_column)` — already scalar-based).
+- Adding new modules, dependencies, public abstractions, or production
+  helpers beyond the one-line projection fix and its doc.
+- Touching `.llxprt/`, `.code_puppy/`, `.github/`, dependency manifests,
+  quality-gate scripts, or unrelated tests/docs.
+
+## Acceptance matrix
+
+| # | Behavior | Evidence |
+|---|----------|----------|
+| AC1 | `caret_row_for_line_col` returns a **char offset** relative to the row's `line_char_start` for an ASCII/wrapping case (regression guard). | Pure unit test in `document_wrap.rs` asserts `(row, char_rel)` for the existing "alpha bravo charlie" case. |
+| AC2 | For a wrapped CJK row, the caret at a column inside the wide-glyph row maps to the **char offset** (not the cell width). CJK glyph (display width 2) at caret position maps to char offset, not 2× scalar. | Pure unit test: `wrap_document("甲乙丙", 4)` → caret at col 2 → row 1 ("丙"), char offset 0 (NOT cell width 0 coincidentally; use a row with mixed content). |
+| AC3 | For a row containing a combining mark, the caret column maps to a **char offset** that accounts for the combining mark as a scalar. A combining mark (`e\u{301}`) preceding the caret adds 1 to the char offset (display width 0 but scalar 1). | Pure unit test on a constructed row with a combining mark. |
+| AC4 | The rendered caret cell in `cursor_row_element` lands on the correct glyph for CJK content (renderer-level regression guard for AC2). | Renderer test in `scrollable_text.rs` (the `#[cfg(test)]` module) renders a CJK line with an inline caret and asserts the inverse-video cell covers the intended glyph via the existing ANSI-stripping helper. |
+| AC5 | No regression to ASCII caret placement (existing `caret_row_for_line_col_finds_wrapped_subrow` expectations stay correct because char offset == cell width for ASCII). | The existing ASCII test continues to pass unchanged (its assertions are `(1,2)`, `(0,0)`, `(3,2)` — these are char offsets, which equal cell widths for ASCII). |
+| AC6 | No change to selection mapping or wrapping (`row_highlight`, `clip_range_to_row`, `wrap_document` untouched). | Diff inspection: only `caret_row_for_line_col` body + doc change in `document_wrap.rs`; no change to selection/wrap functions. Existing `non_overlapping_selection_paints_no_highlight_on_row` + CJK wrap tests stay green. |
+| AC7 | No change to the `ScrollableTextProps` `cursor_col`/`cursor_line` public prop types or the `DetailContent.cursor` coordinate contract. | Diff inspection: no prop/struct type changes. |
+
+## Vertical slices
+
+This is a single-slice change: one pure-projection function contract
+alignment + its doc, with RED→GREEN tests in two existing test modules. It
+does not cross multiple architectural ownership layers (it lives entirely in
+the `domain` projection + its renderer consumer, which already shares the
+`doc_wrap` module as the single source of truth).
+
+1. **Projection contract alignment** — `caret_row_for_line_col` returns char
+   offset instead of cell width; add contract doc comment. Implements AC1,
+   AC2, AC3, AC5. RED tests added in `document_wrap.rs` test module.
+2. **Renderer regression guard** — add a CJK caret renderer test in
+   `scrollable_text.rs` test module proving the caret paints on the correct
+   glyph (AC4). (No production change; the renderer is already correct once
+   AC1-AC3 land.)
+
+## Expected paths / files
+
+- `src/domain/document_wrap.rs` — fix `caret_row_for_line_col` to return char
+  offset + add contract doc (production change, ~1-3 net lines).
+- `src/ui/components/scrollable_text.rs` — add CJK/combining-mark caret
+  renderer regression test(s) in the existing `#[cfg(test)]` module (test-only).
+- `project-plans/issue429-plan.md` — this plan (documentation only).
+
+## Verification
+
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test -p <crate> document_wrap` (focused)
+- `cargo test -p <crate> scrollable_text` (focused)
+- `make ci-check` (full gate: fmt, clippy allow policy, source size,
+  complexity, coverage ≥30, build, test) before pushing the green checkpoint.
+
+## Scope ledger
+
+| Date | Item | Disposition |
+|------|------|-------------|
+| 2026-07-26 | Initial scope: align `caret_row_for_line_col` char-offset contract + add CJK/combining-mark coverage. | Accepted |
+| 2026-07-26 | Change `cursor_row_element` renderer slicing to be cell-aware instead of scalar-based. | Rejected — renderer scalar indexing is the coordinate authority; changing it would move the bug rather than fix it and would also touch the selection contract (out of scope). |
+| 2026-07-26 | Change `display_cell_to_char_offset` / `viewport_cell_to_content` (mouse selection reverse-map). | Rejected — issue explicitly preserves the selection contract; mouse→content mapping is selection-side. |
+
+## Review counters (OCR)
+
+- Local OCR runs before PR: 0 / 2
+- OCR runs after PR opened: 0 / 2
+
+(Cap: two local + two PR per issue/PR effort.)
+
+## Stopping conditions
+
+Stop and ask before: adding any new module/abstraction/dependency, changing
+selection/wrap/state-layer contracts, moving tests, or exceeding the hard
+scope budget (40 files / 2,500 net lines).

--- a/src/domain/document_wrap.rs
+++ b/src/domain/document_wrap.rs
@@ -26,7 +26,7 @@
 //!
 //! @requirement REQ-DOC-WRAP
 
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthChar;
 
 /// One display row produced by wrapping a content document.
 ///
@@ -256,11 +256,18 @@ fn first_line_revealing_row(
 /// Find the display row + relative column that carries the caret at
 /// `(content_line, line_char_col)`, for inline-editor caret placement.
 ///
-/// Returns `(global_row_index, col_within_row)` where `col_within_row` is the
-/// caret column relative to the row's `line_char_start`. The caret belongs to
-/// the row whose `[line_char_start, line_char_end)` contains `line_char_col`,
-/// or — for a caret at a line end — the row ending at that column. Clamps
-/// safely to the line's rows (never panics on a column in a gap).
+/// Returns `(global_row_index, char_offset_within_row)` where
+/// `char_offset_within_row` is the 0-based Unicode SCALAR offset of the caret
+/// column relative to the row's `line_char_start`. This matches the renderer
+/// (`ScrollableText`'s `cursor_row_element`), which slices row text by scalar
+/// position via `chars.iter().take(col)` to paint the glyph under the caret.
+/// Returning a terminal-cell width here instead would shift the caret for wide
+/// (CJK/emoji) and zero-width (combining mark) glyphs (issue #429).
+///
+/// The caret belongs to the row whose `[line_char_start, line_char_end)`
+/// contains `line_char_col`, or — for a caret at a line end — the row ending
+/// at that column. Clamps safely to the line's rows (never panics on a column
+/// in a gap).
 #[must_use]
 pub fn caret_row_for_line_col(
     rows: &[DocDisplayRow],
@@ -281,11 +288,10 @@ pub fn caret_row_for_line_col(
         let r = &rows[idx];
         if line_char_col < r.line_char_end {
             let char_col = line_char_col.saturating_sub(r.line_char_start);
-            let prefix = r.text.chars().take(char_col).collect::<String>();
-            return Some((idx, UnicodeWidthStr::width(prefix.as_str())));
+            return Some((idx, char_col));
         }
         best_idx = idx;
-        best_rel = UnicodeWidthStr::width(r.text.as_str());
+        best_rel = r.text.chars().count();
     }
     Some((best_idx, best_rel))
 }
@@ -293,6 +299,7 @@ pub fn caret_row_for_line_col(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use unicode_width::UnicodeWidthStr;
 
     #[test]
     fn empty_document_one_row_for_line_zero() {
@@ -382,6 +389,49 @@ mod tests {
     fn caret_row_for_unknown_line_returns_none() {
         let rows = wrap_document("alpha\nbeta", 50);
         assert_eq!(caret_row_for_line_col(&rows, 99, 0), None);
+    }
+
+    /// The inline-editor caret column coordinate is a Unicode SCALAR offset
+    /// relative to the row's `line_char_start`, NOT a terminal-cell width.
+    /// The renderer (`cursor_row_element`) slices the row's chars by scalar
+    /// position to paint the glyph under the caret, so the projection must
+    /// return the scalar offset to match. For wide CJK glyphs (display width
+    /// 2, scalar width 1) the two diverge: a caret between two CJK glyphs is
+    /// at scalar offset 1 but cell-width offset 2. This case must return the
+    /// scalar offset (1), otherwise the rendered caret shifts one cell too
+    /// far right (issue #429).
+    #[test]
+    fn caret_row_for_line_col_returns_char_offset_for_cjk() {
+        // "a甲b丙" fits one row at width 6: [line 0, char range [0,4)].
+        let rows = wrap_document("a甲b丙", 6);
+        assert_eq!(rows.len(), 1, "fixture must fit one row: {rows:?}");
+        // caret at char col 2 lands on 'b'. Its scalar offset within the row
+        // is 2; its cell-width offset would be 3 ('a' + '甲' = 1 + 2 cells).
+        assert_eq!(
+            caret_row_for_line_col(&rows, 0, 2),
+            Some((0, 2)),
+            "caret column must be a scalar offset, not a terminal-cell width"
+        );
+    }
+
+    /// A combining mark (`e\u{301}`) is display width 0 but scalar width 1.
+    /// The caret after it must advance by one scalar offset, not zero. The
+    /// renderer slices one char per scalar, so a zero-width column here would
+    /// paint the caret on the combining mark instead of the following base
+    /// glyph (issue #429).
+    #[test]
+    fn caret_row_for_line_col_counts_combining_marks_as_scalars() {
+        // "e\u{301}x" fits one row: [line 0, char range [0,3)].
+        let rows = wrap_document("e\u{301}x", 4);
+        assert_eq!(rows.len(), 1, "fixture must fit one row: {rows:?}");
+        // caret at char col 2 lands on 'x'. Scalar offset within the row is 2
+        // (base + combining mark); cell-width offset would be 1 (combining
+        // mark contributes 0 cells).
+        assert_eq!(
+            caret_row_for_line_col(&rows, 0, 2),
+            Some((0, 2)),
+            "combining mark must count as one scalar offset"
+        );
     }
 
     #[test]

--- a/src/ui/components/scrollable_text.rs
+++ b/src/ui/components/scrollable_text.rs
@@ -535,6 +535,15 @@ mod tests {
         out
     }
 
+    /// True when `line` carries a selection/cursor background SGR — either an
+    /// extended background code (`\u{1b}[48…m`) or a reverse-video code
+    /// (`\u{1b}[7m`). Centralizing the check keeps the renderer's exact
+    /// color-encoding assumption in one place across the highlight and caret
+    /// regression tests.
+    fn contains_highlight_sgr(line: &str) -> bool {
+        line.contains("\u{1b}[48") || line.contains("\u{1b}[7m")
+    }
+
     /// No wrapped row may exceed the pane column width (text + scrollbar).
     #[test]
     fn no_wrapped_row_exceeds_width() {
@@ -627,11 +636,11 @@ mod tests {
         // Row with selection (alpha) has a background SGR; the next row
         // (charlie) must have NONE.
         assert!(
-            non_blank[0].contains("\u{1b}[48") || non_blank[0].contains("\u{1b}[7m"),
+            contains_highlight_sgr(non_blank[0]),
             "the alpha row must carry a selection highlight SGR: {ansi}"
         );
         assert!(
-            !non_blank[1].contains("\u{1b}[48") && !non_blank[1].contains("\u{1b}[7m"),
+            !contains_highlight_sgr(non_blank[1]),
             "the charlie row must carry NO selection highlight (selection does not overlap it): {ansi}"
         );
     }
@@ -705,13 +714,13 @@ mod tests {
         // Find the first row with a background SGR (the cursor cell).
         let cursor_row = ansi
             .lines()
-            .find(|line| line.contains("\u{1b}[48") || line.contains("\u{1b}[7m"))
+            .find(|line| contains_highlight_sgr(line))
             .unwrap_or_else(|| {
                 panic!("expected a cursor background SGR, got: {ansi}");
             });
         // The VISIBLE text rendered BEFORE the cursor background SGR is the
-        // caret prefix. Extract the substring up to the `\u{1b}[48` cursor-bg
-        // SGR, then strip any preceding SGR codes to leave only glyphs.
+        // caret prefix. Locate the highlight SGR boundary, then strip any
+        // preceding SGR codes to leave only glyphs.
         let cursor_bg_idx = cursor_row
             .find("\u{1b}[48")
             .or_else(|| cursor_row.find("\u{1b}[7m"))

--- a/src/ui/components/scrollable_text.rs
+++ b/src/ui/components/scrollable_text.rs
@@ -669,4 +669,58 @@ mod tests {
             "selection feedback must remain inside the text column: {rendered}"
         );
     }
+
+    /// The inline-editor caret must paint on the glyph that the caret's content
+    /// char column refers to, not one shifted by wide-glyph cell-width math
+    /// (issue #429). For "a甲b丙" with the caret at content col 2 ('b'), the
+    /// rendered prefix before the cursor cell must be exactly "a甲" (the two
+    /// scalars before 'b'). A buggy cell-width projection would include 'b' in
+    /// the prefix and paint the caret on '丙' instead.
+    #[test]
+    fn inline_caret_paints_on_correct_glyph_for_cjk_row() {
+        // "a甲b丙" is 6 display cells, so it fits one row at max_line_width 6.
+        let content = "a甲b丙";
+        let mut elem = element! {
+            Box(width: 8u32, height: 1u32) {
+                ScrollableText(
+                    content: content.to_string(),
+                    scroll_offset: 0usize,
+                    viewport_rows: 1usize,
+                    max_line_width: 6usize,
+                    color: Some(Color::Reset),
+                    bg: None,
+                    cursor_line: Some(0usize),
+                    cursor_col: Some(2usize),
+                    cursor_color: Some(Color::Black),
+                    cursor_bg: Some(Color::White),
+                )
+            }
+        };
+        let mut buf = Vec::new();
+        let canvas = elem.render(Some(8));
+        canvas
+            .write_ansi(&mut buf)
+            .unwrap_or_else(|e| panic!("write_ansi failed: {e}"));
+        let ansi = String::from_utf8_lossy(&buf).to_string();
+        // Find the first row with a background SGR (the cursor cell).
+        let cursor_row = ansi
+            .lines()
+            .find(|line| line.contains("\u{1b}[48") || line.contains("\u{1b}[7m"))
+            .unwrap_or_else(|| {
+                panic!("expected a cursor background SGR, got: {ansi}");
+            });
+        // The VISIBLE text rendered BEFORE the cursor background SGR is the
+        // caret prefix. Extract the substring up to the `\u{1b}[48` cursor-bg
+        // SGR, then strip any preceding SGR codes to leave only glyphs.
+        let cursor_bg_idx = cursor_row
+            .find("\u{1b}[48")
+            .or_else(|| cursor_row.find("\u{1b}[7m"))
+            .unwrap_or(0);
+        let prefix_ansi = &cursor_row[..cursor_bg_idx];
+        let prefix_visible = strip_ansi(prefix_ansi);
+        assert_eq!(
+            prefix_visible, "a甲",
+            "caret prefix must be the scalars before col 2, not shifted by CJK cell width: {ansi}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #429.

The inline-editor caret projection (`caret_row_for_line_col`) reported a
terminal-cell width as the caret column, but its single consumer
(`cursor_row_element`) slices row text by Unicode scalar position via
`chars.iter().take(col)`. Wide glyphs (CJK/emoji, display width 2) and
zero-width glyphs (combining marks, display width 0) therefore shifted the
rendered inline caret away from the intended glyph.

## Root cause

`src/domain/document_wrap.rs::caret_row_for_line_col` returned
`UnicodeWidthStr::width(prefix)` as the caret column. The renderer in
`src/ui/components/scrollable_text.rs::cursor_row_element` indexes by scalar
position (`chars.iter().take(cursor_col)`). For a caret inside a wide-glyph
row these diverge: e.g. for `a甲b丙` at content col 2 the buggy projection
returned cell-width 3, painting the caret on `丙` instead of `b`.

## Change

Return the 0-based Unicode scalar offset of the caret column relative to the
row's `line_char_start`, matching the renderer's indexing exactly.
Document the coordinate contract on the function.

- Wrapping stays terminal-cell-aware (`wrap_document`/`wrap_text` unchanged).
- Selection mapping stays char-based (`row_highlight`/`clip_range_to_row`
  unchanged).
- The renderer's scalar-based `cursor_row_element` slicing is unchanged —
  it is the coordinate authority.
- The `DetailContent.cursor` contract (`(content_line, char_column)`) and the
  `ScrollableTextProps` `cursor_line`/`cursor_col` prop types are unchanged.
- No change to issue 422's TextBox caret or ScrollableText selection
  contract (explicit non-goal from the issue).

## Acceptance matrix / evidence

| # | Behavior | Evidence |
|---|----------|----------|
| AC1 | ASCII wrapping case returns char offset (regression guard; char offset == cell width for ASCII). | `caret_row_for_line_col_finds_wrapped_subrow` (existing, unchanged). |
| AC2 | CJK caret maps to char offset, not cell width. | `caret_row_for_line_col_returns_char_offset_for_cjk`. |
| AC3 | Combining mark counts as one scalar offset. | `caret_row_for_line_col_counts_combining_marks_as_scalars`. |
| AC4 | Rendered caret paints on the intended glyph for CJK content. | `inline_caret_paints_on_correct_glyph_for_cjk_row` (renderer-level). |
| AC5 | No ASCII regression. | Existing test stays green. |
| AC6 | No selection/wrap contract change. | Diff scoped to the projection function + doc + tests. |

## Verification

- `cargo fmt --all --check` — pass
- `scripts/check-clippy-allows.sh` — pass
- `scripts/check-source-file-size.sh` — pass (warnings only, pre-existing)
- clippy `-D warnings` — pass
- clippy complexity gate — pass
- coverage `--fail-under-lines 30` — pass (72.11%)
- `cargo build --workspace --all-features --locked` — pass
- Local OCR review (pre-PR): 0 findings

## Scope

3 files, +249/-9 lines:
- `src/domain/document_wrap.rs` — projection contract alignment + doc + tests
- `src/ui/components/scrollable_text.rs` — renderer regression guard test
- `project-plans/issue429-plan.md` — issue plan (docs only)

Well within the 25-file / 1,500-line budget. Full plan with non-goals,
scope ledger, and stopping conditions in `project-plans/issue429-plan.md`.