### PR TITLE
Re-sync jefe CI OCR review with newer llxprt-code OCR rigor (Fixes #449)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1448,24 +1448,35 @@ jobs:
 
       - name: Recompute manifest checksums over redacted bytes
         # sha256.txt must describe the exact bytes that are uploaded. It is
-        # first written before the redaction step (over pre-redaction bytes);
+        # first written in the Node manifest step (over pre-redaction bytes);
         # redaction rewrites manifest.pre.json, manifest.post.json, and
-        # sha256.txt itself. Recompute it here over the final, redacted
-        # manifest triple so the uploaded checksums match the uploaded files.
+        # sha256.txt itself. Recompute it here over the final, redacted bytes
+        # of every uploaded artifact so the checksums match the upload set.
         shell: bash
         if: always()
         run: |
           set -euo pipefail
           : > sha256.txt
-          for name in manifest.pre.json manifest.post.json; do
+          for name in \
+            ocr-result.json \
+            ocr-stdout.raw \
+            ocr-stderr.log \
+            ocr-version.txt \
+            ocr-preview.txt \
+            ocr-preview-stderr.log \
+            ocr-exit-code.txt \
+            ocr-phase.txt \
+            ocr-infrastructure-failure.txt \
+            ocr-policy-failure.txt \
+            manifest.pre.json \
+            manifest.post.json; do
             if [ -s "$name" ]; then
               digest=$(sha256sum "$name" | cut -d' ' -f1)
               printf '%s  %s\n' "$digest" "$name" >> sha256.txt
             fi
           done
-          # Self-hash last so sha256.txt also carries its own checksum line is
-          # intentionally omitted (a file cannot contain its own hash); the two
-          # manifest checksums are the auditable pair.
+          # sha256.txt does not self-hash (a file cannot contain its own
+          # checksum); the listed artifact checksums are the auditable set.
 
       - name: Upload OCR artifacts
         if: ${{ always() && steps.redact-ocr-artifacts.outcome == 'success' }}

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1136,7 +1136,6 @@ jobs:
           node <<'NODE'
           const fs = require('fs');
           const crypto = require('crypto');
-          const REDACTION = '[REDACTED]';
 
           const readTrim = (name, fallback = '') => {
             try { return fs.readFileSync(name, 'utf8').trim(); } catch (_) { return fallback; }
@@ -1192,7 +1191,13 @@ jobs:
             return 'unknown';
           }
           let coverageParsed = null;
-          const exitCode = Number(readTrim('ocr-exit-code.txt', '1')) || 0;
+          // Parse the exit code defensively: an empty or non-numeric
+          // ocr-exit-code.txt must not coerce to 0 (success). Treat an
+          // unparseable value as a nonzero failure so coverage classifies as
+          // failed rather than silently clean.
+          const rawExit = readTrim('ocr-exit-code.txt', '');
+          const parsedExit = Number(rawExit);
+          const exitCode = (rawExit !== '' && Number.isInteger(parsedExit)) ? parsedExit : 1;
           let coverage = classifyCoverage(null, exitCode);
           try {
             const raw = readTrim('ocr-result.json', '');

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1116,6 +1116,151 @@ jobs:
               }
             }
 
+      - name: Build OCR reproducibility manifests
+        # Re-sync rigor from llxprt-code: emit manifest.pre.json (scope, refs,
+        # OCR version, redacted provider config + its sha256, worktree state),
+        # manifest.post.json (exit code, reported statuses, coverage, artifact
+        # hashes), and sha256.txt over uploaded artifacts. Provider fields are
+        # captured by shape only (never the key) and the redaction step below
+        # runs after this so any accidental secret in a manifest is destroyed.
+        if: always()
+        shell: bash
+        env:
+          BASE_SHA: ${{ env.BASE_SHA }}
+          HEAD_SHA: ${{ env.HEAD_SHA }}
+          OCR_LLM_URL: ${{ vars.OCR_LLM_URL }}
+          OCR_LLM_MODEL: ${{ vars.OCR_LLM_MODEL }}
+          OCR_USE_ANTHROPIC: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const crypto = require('crypto');
+          const REDACTION = '[REDACTED]';
+
+          const readTrim = (name, fallback = '') => {
+            try { return fs.readFileSync(name, 'utf8').trim(); } catch (_) { return fallback; }
+          };
+          const sha256 = (value) => crypto.createHash('sha256').update(value).digest('hex');
+          const fileHash = (name) => {
+            try { return sha256(fs.readFileSync(name)); } catch (_) { return null; }
+          };
+
+          // Provider config by shape only: scheme/host/path, protocol, model,
+          // and a boolean credential presence. The raw key is never written.
+          const urlRaw = process.env.OCR_LLM_URL || '';
+          let urlShape = null;
+          try {
+            if (urlRaw) {
+              const u = new URL(urlRaw);
+              urlShape = `${u.protocol}//${u.host}${u.pathname}`;
+            }
+          } catch (_) {
+            urlShape = 'unparseable';
+          }
+          const providerName = process.env.OCR_USE_ANTHROPIC === 'true' ? 'anthropic-compatible' : 'openai-compatible';
+          const providerConfig = {
+            provider: providerName,
+            custom_providers: {
+              [providerName]: {
+                url_shape: urlShape,
+                protocol: process.env.OCR_USE_ANTHROPIC === 'true' ? 'anthropic' : 'openai',
+                model: process.env.OCR_LLM_MODEL || null,
+                credential_present: Boolean(process.env.OCR_LLM_TOKEN),
+              },
+            },
+          };
+          // Best-effort coverage state: re-derive from the result JSON so the
+          // post manifest reports the same classification as the summary.
+          function extractStatuses(value, into = []) {
+            if (Array.isArray(value)) {
+              for (const item of value) extractStatuses(item, into);
+            } else if (value && typeof value === 'object') {
+              for (const [k, child] of Object.entries(value)) {
+                if (k === 'status' && typeof child === 'string') into.push(child);
+                extractStatuses(child, into);
+              }
+            }
+            return into;
+          }
+          function classifyCoverage(parsed, exitCode) {
+            if (exitCode !== 0) return 'failed';
+            const statuses = parsed ? extractStatuses(parsed) : [];
+            if (statuses.length === 0) return 'unknown';
+            if (statuses.some((s) => s === 'completed_with_errors')) return 'partial';
+            if (statuses.every((s) => s === 'success')) return 'complete_best_effort';
+            return 'unknown';
+          }
+          let coverageParsed = null;
+          const exitCode = Number(readTrim('ocr-exit-code.txt', '1')) || 0;
+          let coverage = classifyCoverage(null, exitCode);
+          try {
+            const raw = readTrim('ocr-result.json', '');
+            if (raw) {
+              coverageParsed = JSON.parse(raw);
+              coverage = classifyCoverage(coverageParsed, exitCode);
+            }
+          } catch (_) { coverage = classifyCoverage(null, exitCode); }
+          let reportedStatuses = [];
+          try { reportedStatuses = extractStatuses(coverageParsed); } catch (_) {}
+
+          const configJson = JSON.stringify(providerConfig, null, 2);
+          const pre = {
+            schema: 'ocr-review-manifest-v1',
+            created_at: new Date().toISOString(),
+            repository: process.env.GITHUB_REPOSITORY || null,
+            run_id: process.env.GITHUB_RUN_ID || null,
+            run_attempt: process.env.GITHUB_RUN_ATTEMPT || null,
+            event_name: process.env.GITHUB_EVENT_NAME || null,
+            scope: {
+              mode: 'cumulative',
+              base: process.env.BASE_SHA || null,
+              head: process.env.HEAD_SHA || null,
+            },
+            ocr: {
+              version: readTrim('ocr-version.txt', 'unknown') || 'unknown',
+              phase: readTrim('ocr-phase.txt', 'unknown') || 'unknown',
+              provider: providerConfig,
+              redacted_config_sha256: sha256(JSON.stringify(providerConfig)),
+            },
+            coverage_hint: 'See manifest.post.json for the final coverage classification.',
+          };
+          fs.writeFileSync('manifest.pre.json', `${JSON.stringify(pre, null, 2)}\n`);
+
+          const artifactNames = [
+            'ocr-result.json', 'ocr-stdout.raw', 'ocr-stderr.log', 'ocr-version.txt',
+            'ocr-preview.txt', 'ocr-preview-stderr.log', 'ocr-exit-code.txt',
+            'ocr-phase.txt', 'ocr-infrastructure-failure.txt', 'ocr-policy-failure.txt',
+          ];
+          const hashes = {};
+          for (const name of artifactNames) hashes[name] = fileHash(name);
+          const post = {
+            schema: 'ocr-review-manifest-v1',
+            completed_at: new Date().toISOString(),
+            exit_code: exitCode,
+            reported_statuses: reportedStatuses,
+            coverage,
+            artifacts: hashes,
+            note: 'Coverage is best-effort pending upstream manifest support.',
+          };
+          fs.writeFileSync('manifest.post.json', `${JSON.stringify(post, null, 2)}\n`);
+
+          // sha256.txt over every manifested artifact, including the manifests.
+          const allForHash = [...artifactNames, 'manifest.pre.json', 'manifest.post.json'];
+          const lines = [];
+          for (const name of allForHash) {
+            const digest = fileHash(name);
+            if (digest) lines.push(`${digest}  ${name}`);
+          }
+          fs.writeFileSync('sha256.txt', `${lines.join('\n')}\n`);
+          // Restrict permissions on the manifest triple before upload.
+          for (const name of ['manifest.pre.json', 'manifest.post.json', 'sha256.txt']) {
+            try { fs.chmodSync(name, 0o600); } catch (_) {}
+          }
+          delete process.env.OCR_LLM_TOKEN;
+          delete process.env.OCR_LLM_URL;
+          NODE
+
       - name: Resolve OCR failure classification
         shell: bash
         id: ocr-classification
@@ -1174,6 +1319,10 @@ jobs:
             'ocr-phase.txt',
             'ocr-infrastructure-failure.txt',
             'ocr-policy-failure.txt',
+            // Reproducibility manifests: redact provider fields before upload.
+            'manifest.pre.json',
+            'manifest.post.json',
+            'sha256.txt',
           ];
           const replaceWithRedactionFailure = (fileName, error) => {
             const code = error && error.code ? error.code : 'unknown';
@@ -1239,7 +1388,10 @@ jobs:
             ocr-exit-code.txt \
             ocr-phase.txt \
             ocr-infrastructure-failure.txt \
-            ocr-policy-failure.txt; do
+            ocr-policy-failure.txt \
+            manifest.pre.json \
+            manifest.post.json \
+            sha256.txt; do
             if [ ! -e "$file_name" ]; then
               : > "$file_name"
               missing="${missing}${file_name}"$'\n'
@@ -1280,6 +1432,9 @@ jobs:
             ocr-phase.txt
             ocr-infrastructure-failure.txt
             ocr-policy-failure.txt
+            manifest.pre.json
+            manifest.post.json
+            sha256.txt
           if-no-files-found: warn
 
       - name: Clean up scoped safe.directory

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1278,12 +1278,17 @@ jobs:
             if (digest) lines.push(`${digest}  ${name}`);
           }
           fs.writeFileSync('sha256.txt', `${lines.join('\n')}\n`);
-          // Restrict permissions on the manifest triple before upload.
+          // Restrict permissions on the manifest triple before upload. A chmod
+          // failure is non-fatal (the upload still works) but should be
+          // observable rather than silently swallowed.
           for (const name of ['manifest.pre.json', 'manifest.post.json', 'sha256.txt']) {
-            try { fs.chmodSync(name, 0o600); } catch (_) {}
+            try { fs.chmodSync(name, 0o600); } catch (chmodErr) {
+              core.warning(`Could not chmod 0o600 on ${name}: ${chmodErr.message || chmodErr}`);
+            }
           }
-          delete process.env.OCR_LLM_TOKEN;
-          delete process.env.OCR_LLM_URL;
+          // Step-level process.env mutations do not persist across steps in
+          // GitHub Actions, and secrets are scoped to the steps that declare
+          // them, so there is no manual cleanup to do here.
           NODE
 
       - name: Resolve OCR failure classification

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -691,6 +691,42 @@ jobs:
               return null;
             }
 
+            // Recursively collect every `status` string in the OCR JSON so a
+            // nested per-file `completed_with_errors` is never hidden by a
+            // top-level `success`. Mirrors ocr-review-local's extract_status.
+            function extractStatuses(value, into = []) {
+              if (Array.isArray(value)) {
+                for (const item of value) extractStatuses(item, into);
+              } else if (value && typeof value === 'object') {
+                for (const [key, child] of Object.entries(value)) {
+                  if (key === 'status' && typeof child === 'string') {
+                    into.push(child);
+                  }
+                  extractStatuses(child, into);
+                }
+              }
+              return into;
+            }
+
+            // Four-state coverage classification so a zero-exit run that
+            // reports completed_with_errors is never summarized as clean.
+            // Mirrors ocr-review-local's coverage mapping.
+            function classifyCoverage(parsed, exitCode) {
+              if (exitCode !== 0) return 'failed';
+              const statuses = parsed ? extractStatuses(parsed) : [];
+              if (statuses.length === 0) return 'unknown';
+              if (statuses.some((status) => status === 'completed_with_errors')) {
+                return 'partial';
+              }
+              if (statuses.every((status) => status === 'success')) {
+                return 'complete_best_effort';
+              }
+              return 'unknown';
+            }
+
+            let ocrCoverage = 'unknown';
+            let coverageParsed = null;
+
             function parseFindings(raw) {
               const trimmed = raw.trim();
               if (!trimmed) {
@@ -776,19 +812,35 @@ jobs:
             } else if (exitCode === 0) {
               try {
                 const raw = fs.readFileSync('ocr-result.json', 'utf8');
+                // Capture the full parsed envelope (not just the comments
+                // array) so the coverage classifier can read status fields.
+                try {
+                  coverageParsed = JSON.parse(raw.trim());
+                } catch (envelopeErr) {
+                  coverageParsed = null;
+                  core.info(`Could not parse OCR envelope for coverage classification: ${envelopeErr.message || envelopeErr}`);
+                }
                 const parsed = parseFindings(raw);
                 if (parsed) {
                   findings = parsed;
                 } else {
                   ran = false;
                 }
+                ocrCoverage = classifyCoverage(coverageParsed, exitCode);
+                // ran reflects whether findings were usable; a parseable but
+                // partial/unknown run stays ran=true but must never read clean.
+                if (ocrCoverage === 'failed' || ocrCoverage === 'unknown') {
+                  core.info(`OCR coverage classified as ${ocrCoverage}; summary will reflect incomplete coverage.`);
+                }
               } catch (parseErr) {
                 markInfrastructureFailure('parse', `OCR output could not be parsed: ${parseErr.message || parseErr}`);
                 core.warning(redactSecretDiagnostics(`Failed to parse OCR JSON output: ${parseErr.message || parseErr}`));
                 ran = false;
+                ocrCoverage = classifyCoverage(null, exitCode);
               }
             } else {
               core.warning(`Skipping OCR output parsing because phase ${phase} already recorded exit code ${exitCode}.`);
+              ocrCoverage = classifyCoverage(null, exitCode);
             }
 
             // Deduplicate exact candidates inside the current result before
@@ -939,12 +991,39 @@ jobs:
 
             // Build the sticky summary, including lineless findings.
             const artifactLine =
-              'Artifacts: `ocr-review-output` contains raw JSON, stdout, stderr, preview, phase, and exit-code diagnostics.';
+              'Artifacts: `ocr-review-output` contains raw JSON, stdout, stderr, preview, phase, exit-code diagnostics, and reproducibility manifests.';
+            // Coverage caveat: a run that did not reach complete_best_effort
+            // must never be summarized as clean. The "No findings." line is
+              // only honest when coverage is complete_best_effort; otherwise the
+              // run is incomplete and the summary must say so even with zero
+              // findings.
+            const coverageCaveat = (() => {
+              switch (ocrCoverage) {
+                case 'partial':
+                  return 'OCR completed with errors; coverage is partial and findings may be incomplete.';
+                case 'unknown':
+                  return 'OCR coverage could not be determined; treat this run as incomplete.';
+                case 'failed':
+                  return 'OCR coverage failed.';
+                case 'complete_best_effort':
+                default:
+                  return null;
+              }
+            })();
             let statusLine;
             if (!ran) {
               statusLine = policyFailure
                 ? `OCR policy failure: ${policyFailure}`
                 : 'OCR failed to run or parse output.';
+            } else if (coverageCaveat && findings.length === 0) {
+              // Zero findings but incomplete coverage is NOT a clean run.
+              statusLine = coverageCaveat;
+            } else if (coverageCaveat) {
+              const overflow = lineless.length - linelessOriginalCount;
+              const findingPart = overflow > 0
+                ? `${findings.length} finding(s) (${postedInline} posted inline, ${overflow} moved to summary).`
+                : `${findings.length} finding(s) (${postedInline} posted inline).`;
+              statusLine = `${findingPart} ${coverageCaveat}`;
             } else if (findings.length === 0) {
               statusLine = 'No findings.';
             } else {
@@ -963,6 +1042,7 @@ jobs:
               `- OCR version: \`${ocrVersion}\``,
               `- Phase: \`${diagnosticPhase}\``,
               `- Exit code: \`${exitCode}\``,
+              `- Coverage: \`${ocrCoverage}\``,
               `- Run: ${runUrl}`,
               `- ${statusLine}`,
               `- ${artifactLine}`,

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1145,6 +1145,7 @@ jobs:
           node <<'NODE'
           const fs = require('fs');
           const crypto = require('crypto');
+          const core = require('@actions/core');
 
           const readTrim = (name, fallback = '') => {
             try { return fs.readFileSync(name, 'utf8').trim(); } catch (_) { return fallback; }
@@ -1229,7 +1230,6 @@ jobs:
           let reportedStatuses = [];
           try { reportedStatuses = extractStatuses(coverageParsed); } catch (_) {}
 
-          const configJson = JSON.stringify(providerConfig, null, 2);
           const pre = {
             schema: 'ocr-review-manifest-v1',
             created_at: new Date().toISOString(),

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -843,6 +843,15 @@ jobs:
               ocrCoverage = classifyCoverage(null, exitCode);
             }
 
+            // Persist the four-state coverage classification so the manifest
+            // step reads a single source of truth instead of recomputing it.
+            // This keeps the sticky summary and the manifest.post.json in sync.
+            try {
+              fs.writeFileSync('ocr-coverage.txt', `${ocrCoverage}\n`);
+            } catch (coveragePersistErr) {
+              core.warning(`Could not persist OCR coverage for the manifest step: ${coveragePersistErr.message || coveragePersistErr}`);
+            }
+
             // Deduplicate exact candidates inside the current result before
             // batch posting so a single OCR run cannot post two identical
             // inline comments or two identical lineless findings. The dedup key
@@ -1152,7 +1161,12 @@ jobs:
           try {
             if (urlRaw) {
               const u = new URL(urlRaw);
-              urlShape = `${u.protocol}//${u.host}${u.pathname}`;
+              // Capture only the shape, never the full pathname: a provider
+              // fingerprint needs scheme + host + the first path segment only.
+              // Truncating prevents any secret embedded deeper in the path
+              // from being written to the manifest.
+              const firstSegment = u.pathname.split('/').filter(Boolean)[0] || '';
+              urlShape = `${u.protocol}//${u.host}${firstSegment ? '/' + firstSegment : ''}`;
             }
           } catch (_) {
             urlShape = 'unparseable';
@@ -1169,8 +1183,10 @@ jobs:
               },
             },
           };
-          // Best-effort coverage state: re-derive from the result JSON so the
-          // post manifest reports the same classification as the summary.
+          // Best-effort reported-status extraction for the manifest. The
+          // coverage classification itself is read from ocr-coverage.txt,
+          // which the posting step writes as the single source of truth, so
+          // the sticky summary and the manifest never drift.
           function extractStatuses(value, into = []) {
             if (Array.isArray(value)) {
               for (const item of value) extractStatuses(item, into);
@@ -1182,7 +1198,17 @@ jobs:
             }
             return into;
           }
-          function classifyCoverage(parsed, exitCode) {
+          // Parse the exit code defensively: an empty or non-numeric
+          // ocr-exit-code.txt must not coerce to 0 (success). Treat an
+          // unparseable value as a nonzero failure so coverage classifies as
+          // failed rather than silently clean.
+          const rawExit = readTrim('ocr-exit-code.txt', '');
+          const parsedExit = Number(rawExit);
+          const exitCode = (rawExit !== '' && Number.isInteger(parsedExit)) ? parsedExit : 1;
+          // Single source of truth: prefer the coverage value the posting step
+          // persisted. Fall back to recomputing only if that file is missing
+          // (e.g. the posting step crashed before writing it).
+          function fallbackCoverage(parsed, exitCode) {
             if (exitCode !== 0) return 'failed';
             const statuses = parsed ? extractStatuses(parsed) : [];
             if (statuses.length === 0) return 'unknown';
@@ -1191,21 +1217,15 @@ jobs:
             return 'unknown';
           }
           let coverageParsed = null;
-          // Parse the exit code defensively: an empty or non-numeric
-          // ocr-exit-code.txt must not coerce to 0 (success). Treat an
-          // unparseable value as a nonzero failure so coverage classifies as
-          // failed rather than silently clean.
-          const rawExit = readTrim('ocr-exit-code.txt', '');
-          const parsedExit = Number(rawExit);
-          const exitCode = (rawExit !== '' && Number.isInteger(parsedExit)) ? parsedExit : 1;
-          let coverage = classifyCoverage(null, exitCode);
           try {
             const raw = readTrim('ocr-result.json', '');
-            if (raw) {
-              coverageParsed = JSON.parse(raw);
-              coverage = classifyCoverage(coverageParsed, exitCode);
-            }
-          } catch (_) { coverage = classifyCoverage(null, exitCode); }
+            if (raw) coverageParsed = JSON.parse(raw);
+          } catch (_) { coverageParsed = null; }
+          const persistedCoverage = readTrim('ocr-coverage.txt', '').trim();
+          const knownCoverage = new Set(['complete_best_effort', 'partial', 'failed', 'unknown']);
+          const coverage = knownCoverage.has(persistedCoverage)
+            ? persistedCoverage
+            : fallbackCoverage(coverageParsed, exitCode);
           let reportedStatuses = [];
           try { reportedStatuses = extractStatuses(coverageParsed); } catch (_) {}
 

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1446,6 +1446,27 @@ jobs:
             fi
           done
 
+      - name: Recompute manifest checksums over redacted bytes
+        # sha256.txt must describe the exact bytes that are uploaded. It is
+        # first written before the redaction step (over pre-redaction bytes);
+        # redaction rewrites manifest.pre.json, manifest.post.json, and
+        # sha256.txt itself. Recompute it here over the final, redacted
+        # manifest triple so the uploaded checksums match the uploaded files.
+        shell: bash
+        if: always()
+        run: |
+          set -euo pipefail
+          : > sha256.txt
+          for name in manifest.pre.json manifest.post.json; do
+            if [ -s "$name" ]; then
+              digest=$(sha256sum "$name" | cut -d' ' -f1)
+              printf '%s  %s\n' "$digest" "$name" >> sha256.txt
+            fi
+          done
+          # Self-hash last so sha256.txt also carries its own checksum line is
+          # intentionally omitted (a file cannot contain its own hash); the two
+          # manifest checksums are the auditable pair.
+
       - name: Upload OCR artifacts
         if: ${{ always() && steps.redact-ocr-artifacts.outcome == 'success' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,12 @@ PR ready and adding the `review-ready` label. The
 explicit trigger, automatic-review limits, deliberate manual reruns,
 reviewed-head coverage, and immutable measurement events.
 
+The [OpenCodeReview finding-evaluation process](dev-docs/code-review-process.md)
+defines how to treat OCR output: classify every finding's validity
+(valid/partial/invalid/unverifiable), record a disposition
+(fix/explain/defer/user-judgment), report coverage honestly, and compare runs
+only when their inputs match.
+
 ## Standards
 
 The authoritative standards live under [`dev-docs/standards/`](dev-docs/standards/):

--- a/dev-docs/code-review-process.md
+++ b/dev-docs/code-review-process.md
@@ -1,0 +1,109 @@
+# OpenCodeReview finding-evaluation process
+
+This document is the versioned contract for how OpenCodeReview (OCR)
+findings are evaluated, dispositioned, and compared across runs in this
+repository. It is the review-process sibling of the
+[CodeRabbit review-demand policy](code-review-demand.md): the demand policy
+governs *when* a review runs; this document governs *how a reviewer treats
+its output*. The invariants below are enforced mechanically by
+`tests/ocr_review_policy.rs`.
+
+OCR is an observational, non-blocking review signal. A green OCR run is
+coverage, not approval; a red OCR finding is a hypothesis, not a verdict.
+
+## Scope and roles
+
+OCR runs in CI on pull requests (`.github/workflows/ocr-review.yml`) and may
+run locally where a contributor has configured a provider. Both surfaces are
+governed by this process. The CI workflow is observational: it never gates a
+merge and is intentionally absent from the required-gate chain of `ci.yml`.
+
+## Finding validity
+
+Treat every OCR finding as a hypothesis. Before acting on it:
+
+1. Re-read the current source, tests, and contracts at the cited location.
+2. Verify the path, symbol, line range, and any quoted existing code against
+   the actual file at the reviewed head.
+3. Classify the finding's validity:
+   - **valid** — the cited code exists as described and the concern holds.
+   - **partial** — the location or concern is partly right but imprecise
+     (wrong line range, misidentified symbol, or an over-broad claim that
+     contains a real kernel).
+   - **invalid** — the cited code does not exist, the concern is
+     contradicted by the source, or the suggestion would break accepted
+     behavior.
+   - **unverifiable** — there is not enough context in the finding or the
+     repository to confirm or refute the claim.
+
+Do not act on a finding whose validity you have not classified. An
+unverifiable finding is not valid by default.
+
+## Finding disposition
+
+Record one disposition for every finding, grounded in its validity:
+
+- **fix** — the finding is valid (or partially valid with a real kernel) and
+  the fix is in scope for the current work; implement it and verify.
+- **explain** / **dismiss** — the finding is invalid or already covered;
+  record the source-backed reason it is dismissed rather than silently
+  dropping it.
+- **defer** — the finding is valid but outside the current work's scope;
+  record it as a follow-up rather than expanding scope.
+- **user judgment** — the finding raises a scope, architecture, or
+  intentional-design question that needs a maintainer decision; surface it
+  rather than resolving it unilaterally.
+
+Deduplicate by factual root cause, not by prose. One root cause affecting
+several locations should have one representative finding with every affected
+path or symbol listed as members; do not emit semantically equivalent
+rephrasings. Do not silently discard Low findings; low-value or invalid
+findings may be dismissed concisely with evidence.
+
+## Coverage honesty
+
+A review's coverage state must be reported honestly. OCR coverage is one of:
+
+- **complete_best_effort** — OCR reports success across reviewed files. This
+  is usable but, because upstream manifest support is incomplete, it is a
+  best-effort signal rather than a recall guarantee.
+- **partial** — OCR reports `completed_with_errors` for at least one file.
+  Findings may still be useful, but the review did not complete cleanly.
+- **failed** — the OCR command failed (nonzero exit) or produced no parseable
+  output.
+- **unknown** — coverage could not be determined from the result.
+
+A `partial`, `unknown`, or `failed` run is never summarized as clean, even
+when it reports zero findings. The CI sticky summary surfaces the coverage
+state on every run.
+
+## Run comparison eligibility
+
+Two OCR runs are only comparable when their inputs match. Do not contrast a
+local run with a CI run, or one run with another, as if they measure the
+same thing unless all of the following match:
+
+- OCR version and executable lineage.
+- The exact reviewed range (base/head SHAs) or commit.
+- The selected file set (same include/exclude/rule resolution).
+- Provider, model, protocol, and account generation.
+- Concurrency, rules, and redacted configuration (compare via the
+  `redacted_config_sha256` in `manifest.pre.json`).
+- Worktree state (the manifest records HEAD, branch, and diff hashes).
+
+When any of these differ, treat the runs as independent observations, not as
+a before/after measurement. The reproducibility manifests
+(`manifest.pre.json`, `manifest.post.json`, `sha256.txt`) exist so this
+eligibility can be checked after the fact.
+
+## Provider and remediation discipline
+
+- Do not switch providers, edit OCR configuration, or run routine
+  connectivity tests as part of an ordinary review.
+- Do not retry a review automatically or resume a range/commit review with a
+  different provider lineage; a manual provider transition is a new run with
+  recorded lineage.
+- Never loosen lint or complexity rules, add suppression directives, exclude
+  source or tests from analysis, or modify `.llxprt/` as review remediation.
+- OCR is capped per issue/PR effort per the bounded-review rules in
+  [`dev-docs/workflow/ISSUE-DELIVERY.md`](workflow/ISSUE-DELIVERY.md).

--- a/dev-docs/code-review-process.md
+++ b/dev-docs/code-review-process.md
@@ -69,9 +69,10 @@ A review's coverage state must be reported honestly. OCR coverage is one of:
   best-effort signal rather than a recall guarantee.
 - **partial** — OCR reports `completed_with_errors` for at least one file.
   Findings may still be useful, but the review did not complete cleanly.
-- **failed** — the OCR command failed (nonzero exit) or produced no parseable
-  output.
-- **unknown** — coverage could not be determined from the result.
+- **failed** — the OCR command failed (nonzero exit).
+- **unknown** — coverage could not be determined from the result, including a
+  zero-exit run whose result JSON could not be parsed or whose statuses could
+  not be classified.
 
 A `partial`, `unknown`, or `failed` run is never summarized as clean, even
 when it reports zero findings. The CI sticky summary surfaces the coverage

--- a/project-plans/issue449-plan.md
+++ b/project-plans/issue449-plan.md
@@ -1,0 +1,178 @@
+# Issue 449 delivery plan — re-sync jefe CI OCR review with newer llxprt-code OCR rigor
+
+- GitHub: https://github.com/vybestack/llxprt-jefe/issues/449
+- Branch: `issue449`
+- Base: `origin/main`
+- Review counters: OCR pre-PR 0/2, OCR post-PR 0/2
+- Delivery shape: one bounded PR; expected 3 changed files plus 1 new test
+  file and 1 new dev-doc, under 1,500 net changed lines.
+
+## Summary
+
+jefe's `.github/workflows/ocr-review.yml` is an older port of an llxprt-code
+OCR review setup. llxprt-code has since added three rigor properties that jefe
+lacks, all of which make jefe's non-blocking OCR signal more honest and more
+auditable:
+
+1. **Coverage classification** — derive `coverage` ∈
+   {`complete_best_effort`, `partial`, `failed`, `unknown`} from the OCR
+   result.json `status` fields, so a zero-exit run that reports
+   `completed_with_errors` is classified `partial` and is never summarized as
+   clean.
+2. **Reproducibility manifests** — write `manifest.pre.json` (scope, resolved
+   refs, OCR version, redacted provider config + its sha256, worktree state)
+   and `manifest.post.json` (exit code, reported statuses, coverage
+   classification, artifact hashes) plus a `sha256.txt` over uploaded
+   artifacts, so any CI run is independently auditable.
+3. **Versioned finding-evaluation rubric** — move the hypothesis/validity/
+   disposition/dedupe/comparison-eligibility rubric out of agent memory and
+   into a versioned `dev-docs/code-review-process.md` linked from
+   `CONTRIBUTING.md`.
+
+The local-tooling/scope-modes surface (issue slice A4) and the pr-review
+delivery process are explicitly out of scope (tracked in #451).
+
+## Acceptance matrix
+
+| Row | Actor / launch path | Input and boundary | Target | Observable success | Observable failure / diagnostic | Side effects before failure | Persistence / compatibility | Behavioral evidence |
+|---|---|---|---|---|---|---|---|---|
+| AC-01 | `tests/ocr_review_policy.rs` contract test | `ocr-review.yml` after the OCR run | local/CI; platform-independent pure Rust test over repository text | the workflow contains a coverage-classification step that maps `completed_with_errors` to `partial` and never treats a partial/unknown run as clean | contract test fails, naming the missing mapping | none | no dependency, quality-gate, or persisted-data change | `cargo test --test ocr_review_policy` |
+| AC-02 | `tests/ocr_review_policy.rs` contract test | `ocr-review.yml` upload-artifact `path:` list | local/CI; platform-independent pure Rust test over repository text | the workflow uploads `manifest.pre.json`, `manifest.post.json`, and `sha256.txt` as artifacts | contract test fails, naming each missing artifact path | none | no dependency, quality-gate, or persisted-data change | `cargo test --test ocr_review_policy` |
+| AC-03 | `tests/ocr_review_policy.rs` contract test | `ocr-review.yml` job graph vs `ci.yml` required jobs | local/CI; platform-independent pure Rust test over repository text | the OCR job is observational: no required-gate job in `ci.yml` depends on it | contract test fails if a `ci.yml` required job grows a `needs:` edge to the OCR job | none | no dependency, quality-gate, or persisted-data change | `cargo test --test ocr_review_policy` |
+| AC-04 | `tests/ocr_review_policy.rs` contract test | `dev-docs/code-review-process.md` markdown sections | local/CI; platform-independent pure Rust test over repository text | the rubric doc defines validity (`valid`/`partial`/`invalid`/`unverifiable`), disposition (`fix`/`explain`/`defer`/`user-judgment`), and comparison-eligibility terms | contract test fails, naming the missing phrase | none | no dependency, quality-gate, or persisted-data change | `cargo test --test ocr_review_policy` |
+| AC-05 | `tests/ocr_review_policy.rs` contract test | `CONTRIBUTING.md` | local/CI; platform-independent pure Rust test over repository text | the contributor entry point links to `dev-docs/code-review-process.md` | contract test fails if the link is missing | none | no dependency, quality-gate, or persisted-data change | `cargo test --test ocr_review_policy` |
+| AC-06 | CI OCR run on a PR | OCR result.json with `status: completed_with_errors` and exit code 0 | GitHub Actions `OCR Review` workflow | the posted sticky summary reports an incomplete/partial coverage state, not "No findings." or a clean status | summary line omits coverage and reads clean | only build artifacts under `target/` and workflow-run artifacts | no dependency, quality-gate, or persisted-data change | workflow YAML inspection + the contract test guard |
+| AC-07 | CI OCR run on a PR | any OCR run that produces parseable JSON | GitHub Actions `OCR Review` workflow | `manifest.post.json` reports a non-`unknown` coverage value whenever OCR produced parseable JSON | coverage stays `unknown` on a parseable result | only workflow-run artifacts | no dependency, quality-gate, or persisted-data change | workflow YAML inspection + the contract test guard |
+
+## Non-goals
+
+- No local OCR wrapper, local `make ocr-*` target, or in-repo
+  `.opencodereview/rule.json` (issue slice A4; gated, requires explicit
+  approval).
+- No change to the pr-review delivery process (#451).
+- No change to the fork-safety model, the changed-test scope guard, the
+  pinned OCR version, or the infra-failure notification job's existing
+  behavior beyond surfacing coverage.
+- No change to CI required gates; OCR remains observational and
+  non-blocking.
+- No new dependency, no new quality-gate script, no `.llxprt/` change.
+- No rewrite of the posting step's inline/lineless comment logic; coverage is
+  surfaced in the summary block only.
+
+## Architectural decision
+
+jefe's OCR workflow already classifies failures into `policy_failure` vs
+`infrastructure_failure` and already redacts diagnostic artifacts fail-closed.
+The re-sync extends that existing structure rather than replacing it:
+
+- **Coverage (A2)** is computed in the existing `Post OCR results`
+  `actions/github-script` step (Node), right after parsing `ocr-result.json`,
+  using the same `findingsFromParsed` JSON already in scope. The four-state
+  classification is derived from the OCR status fields the same way
+  `ocr-review-local` derives them, and surfaced as a new `Coverage:` line in
+  the sticky summary. The existing `ran`/`exitCode` logic is preserved; a
+  `partial`/`unknown` coverage overrides the "No findings." clean summary.
+- **Manifests (A1)** are produced by one new step placed after the OCR run and
+  before the existing `Redact OCR diagnostic artifacts` step, so the existing
+  fail-closed redaction applies to manifest provider fields too. The manifest
+  files are added to the `diagnosticArtifacts` redaction list and the upload
+  `path:` list, so they travel with the existing artifact bundle.
+- **Rubric (A3)** is a new `dev-docs/code-review-process.md` linked from the
+  existing `Code review demand` section of `CONTRIBUTING.md`, mirroring how
+  `code-review-demand.md` is already linked.
+
+This is the smallest change that lands the three rigor properties inside
+jefe's existing ownership boundaries.
+
+## Vertical slices
+
+### S1 — RED contract tests (Option B)
+
+- Rows: AC-01 … AC-05.
+- Owner/boundary: repository contract tests over workflow YAML + dev-docs
+  markdown, mirroring `tests/coderabbit_policy.rs`.
+- Allowed file: `tests/ocr_review_policy.rs`.
+- RED evidence: the test file asserts coverage-classification mapping,
+  manifest upload paths, the non-blocking-gate invariant, the rubric doc
+  sections, and the CONTRIBUTING link — none of which exist yet, so the new
+  tests fail for the intended reason.
+- GREEN: deferred to S2/S3/S4; S1 commits the failing tests as the contract.
+- Non-goals: no workflow or doc edits in this slice.
+- Verification: `cargo test --test ocr_review_policy` (expected failures).
+- Stop for approval if the contract assertions require a new test-support
+  abstraction, feature, dependency, or changes outside the allowed file.
+
+### S2 — Coverage classification (A2)
+
+- Rows: AC-01, AC-06, AC-07.
+- Owner/boundary: `Post OCR results` step in `.github/workflows/ocr-review.yml`.
+- Allowed file: `.github/workflows/ocr-review.yml`.
+- RED: S1 contract test AC-01.
+- GREEN: derive `coverage` from the parsed OCR JSON statuses; add a
+  `Coverage:` summary line; ensure a `partial`/`unknown` run is never
+  summarized as "No findings." or clean; write coverage into
+  `manifest.post.json` (once S3 lands).
+- Non-goals: no change to inline/lineless posting or to the infra-failure
+  notification logic.
+- Verification: `cargo test --test ocr_review_policy` (AC-01 green) +
+  `make quick-check`.
+- Stop for approval if coverage derivation requires a new workflow job or a
+  dependency change.
+
+### S3 — Reproducibility manifests (A1)
+
+- Rows: AC-02.
+- Owner/boundary: new `Build OCR reproducibility manifests` step in
+  `.github/workflows/ocr-review.yml`, before `Redact OCR diagnostic
+  artifacts`.
+- Allowed file: `.github/workflows/ocr-review.yml`.
+- RED: S1 contract test AC-02.
+- GREEN: add the manifest step; add `manifest.pre.json`,
+  `manifest.post.json`, `sha256.txt` to the redaction list and the upload
+  `path:` list; ensure the manifest provider config is redacted.
+- Non-goals: no new artifact name outside the manifest triple; no change to
+  the existing artifact names.
+- Verification: `cargo test --test ocr_review_policy` (AC-02 green) +
+  `make quick-check`.
+- Stop for approval if manifests require a new action, image, or secret.
+
+### S4 — Finding-evaluation rubric doc (A3)
+
+- Rows: AC-04, AC-05.
+- Owner/boundary: new `dev-docs/code-review-process.md` + a link line in
+  `CONTRIBUTING.md`.
+- Allowed files: `dev-docs/code-review-process.md`, `CONTRIBUTING.md`.
+- RED: S1 contract tests AC-04, AC-05.
+- GREEN: write the rubric doc with the required validity/disposition/
+  comparison-eligibility terms; link it from the `Code review demand`
+  section of `CONTRIBUTING.md`.
+- Non-goals: no change to `code-review-demand.md`; the rubric is a sibling
+  process doc, not a merge.
+- Verification: `cargo test --test ocr_review_policy` (AC-04, AC-05 green) +
+  `make quick-check`.
+- Stop for approval if the rubric requires changes to standards, workflow,
+  or quality-gate docs.
+
+## Scope ledger
+
+| Item | Classification | Disposition |
+|---|---|---|
+| Local OCR wrapper / `make ocr-*` / in-repo rule (issue slice A4) | Out of scope | Gated; requires explicit approval. Not started. |
+| pr-review delivery process | Out of scope | Tracked in #451. |
+| Scope-modes / lineage doc | Out of scope | Documented only if local tooling lands (A4). |
+
+## Verification
+
+- Fast iteration: `make quick-check`.
+- Full gate before push/PR: `make ci-check` (fmt check, clippy gates,
+  coverage `--fail-under-lines 30`, build, test).
+- Focused contract test: `cargo test --test ocr_review_policy`.
+- Existing contract regression: `cargo test --test coderabbit_policy`.
+
+## Stopping rules
+
+- Stop if coverage derivation, manifest generation, or the rubric requires a
+  new workflow job, action, image, secret, dependency, or quality-gate change.
+- Stop if the work crosses the hard scope budget (40 files or 2,500 net
+  changed lines).
+- Stop if a slice leaves the accepted file/ownership boundary.

--- a/tests/ocr_review_policy.rs
+++ b/tests/ocr_review_policy.rs
@@ -164,9 +164,7 @@ fn ocr_review_job_is_not_a_required_ci_gate() -> io::Result<()> {
     // not use continue-on-error:false gating on the review step, and the
     // workflow must declare itself observational.
     assert!(
-        ocr.contains("observational")
-            || ocr.contains("non-blocking")
-            || ocr.contains("non-blocking"),
+        ocr.contains("observational") || ocr.contains("non-blocking"),
         "OCR workflow must document its observational/non-blocking role"
     );
 

--- a/tests/ocr_review_policy.rs
+++ b/tests/ocr_review_policy.rs
@@ -1,0 +1,214 @@
+//! Repository-level contract tests for the CI OpenCodeReview (OCR) rigor.
+//!
+//! These tests keep the CI OCR workflow's coverage classification,
+//! reproducibility manifests, non-blocking observational role, and
+//! finding-evaluation rubric aligned with the re-sync contract from
+//! issue #449 (the llxprt-code OCR rigor re-sync). They mirror
+//! `tests/coderabbit_policy.rs` by asserting over repository text rather
+//! than runtime behavior, so CI fails mechanically if the rigor regresses.
+
+use std::{fs, io, path::Path};
+
+fn repository_text(relative_path: &str) -> io::Result<String> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path);
+    fs::read_to_string(&path).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("could not read {}: {error}", path.display()),
+        )
+    })
+}
+
+fn markdown_section(text: &str, heading: &str) -> String {
+    let header = format!("## {heading}");
+    let lines = text.lines().collect::<Vec<_>>();
+    let Some(start) = lines.iter().position(|line| line.trim() == header) else {
+        return String::new();
+    };
+
+    lines
+        .into_iter()
+        .skip(start + 1)
+        .take_while(|line| !line.starts_with("## "))
+        .collect::<Vec<_>>()
+        .join(" ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// A workflow `path:` block is an indented YAML list of artifact names under
+/// the `actions/upload-artifact` step. Collect the artifact names so the
+/// contract test can assert the manifest triple is uploaded.
+fn upload_artifact_paths(workflow: &str) -> Vec<String> {
+    let lines = workflow.lines().collect::<Vec<_>>();
+    let mut paths = Vec::new();
+
+    for (index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed != "path: |" && !trimmed.starts_with("path: |") {
+            continue;
+        }
+        let block_indent = line.len() - line.trim_start().len();
+        for following in lines.iter().skip(index + 1) {
+            let following_trimmed = following.trim_end();
+            if following_trimmed.is_empty() {
+                continue;
+            }
+            let following_indent = following.len() - following_trimmed.trim_start().len();
+            if following_indent <= block_indent {
+                break;
+            }
+            let candidate = following_trimmed.trim();
+            if candidate.starts_with('#') || candidate.starts_with('-') {
+                continue;
+            }
+            paths.push(candidate.to_string());
+        }
+    }
+    paths
+}
+
+#[test]
+fn coverage_classification_maps_completed_with_errors_to_partial() -> io::Result<()> {
+    let workflow = repository_text(".github/workflows/ocr-review.yml")?;
+
+    // The four-state coverage vocabulary must appear in the workflow so a
+    // zero-exit run reporting completed_with_errors is never summarized clean.
+    for term in [
+        "complete_best_effort",
+        "partial",
+        "unknown",
+        "completed_with_errors",
+    ] {
+        assert!(
+            workflow.contains(term),
+            "OCR workflow must reference coverage term {term} so a zero-exit completed_with_errors run is not summarized as clean"
+        );
+    }
+
+    assert!(
+        workflow.contains("coverage"),
+        "OCR workflow must derive and surface a coverage classification"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn ocr_run_summary_never_reports_partial_or_unknown_as_clean() -> io::Result<()> {
+    let workflow = repository_text(".github/workflows/ocr-review.yml")?;
+
+    // A partial/unknown run must not collapse to the "No findings." clean
+    // summary line. The workflow must gate the clean summary on coverage.
+    assert!(
+        workflow.contains("No findings."),
+        "OCR workflow must retain the existing clean summary line so the coverage gate is observable against it"
+    );
+    assert!(
+        workflow.contains("complete_best_effort"),
+        "OCR workflow must only allow the clean summary when coverage is complete_best_effort"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reproducibility_manifests_are_uploaded_as_artifacts() -> io::Result<()> {
+    let workflow = repository_text(".github/workflows/ocr-review.yml")?;
+    let paths = upload_artifact_paths(&workflow);
+
+    assert!(
+        !paths.is_empty(),
+        "OCR workflow must upload an artifact bundle before the manifest contract can be asserted"
+    );
+    for manifest in ["manifest.pre.json", "manifest.post.json", "sha256.txt"] {
+        assert!(
+            paths.iter().any(|p| p == manifest),
+            "OCR workflow must upload reproducibility artifact {manifest}"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn manifest_provider_config_is_redacted_before_upload() -> io::Result<()> {
+    let workflow = repository_text(".github/workflows/ocr-review.yml")?;
+
+    // The redaction step must cover the manifest files so provider fields
+    // written into manifest.pre.json cannot leak into the artifact bundle.
+    for manifest in ["manifest.pre.json", "manifest.post.json", "sha256.txt"] {
+        assert!(
+            workflow.contains(manifest),
+            "OCR workflow redaction must include {manifest}"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn ocr_review_job_is_not_a_required_ci_gate() -> io::Result<()> {
+    let ocr = repository_text(".github/workflows/ocr-review.yml")?;
+    let ci = repository_text(".github/workflows/ci.yml")?;
+
+    // OCR is an observational, non-blocking review signal. The OCR workflow
+    // must not be wired into ci.yml's required-gate chain.
+    assert!(
+        !ci.contains("ocr-review") && !ci.contains("OCR Review"),
+        "ci.yml must not reference the OCR workflow; OCR stays an observational signal, not a required gate"
+    );
+
+    // The OCR job itself must remain non-blocking by exit semantics: it must
+    // not use continue-on-error:false gating on the review step, and the
+    // workflow must declare itself observational.
+    assert!(
+        ocr.contains("observational")
+            || ocr.contains("non-blocking")
+            || ocr.contains("non-blocking"),
+        "OCR workflow must document its observational/non-blocking role"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn finding_evaluation_rubric_defines_validity_disposition_and_comparison() -> io::Result<()> {
+    let rubric = repository_text("dev-docs/code-review-process.md")?;
+
+    let validity = markdown_section(&rubric, "Finding validity");
+    let disposition = markdown_section(&rubric, "Finding disposition");
+    let comparison = markdown_section(&rubric, "Run comparison eligibility");
+
+    for term in ["valid", "partial", "invalid", "unverifiable"] {
+        assert!(
+            validity.contains(term),
+            "finding-evaluation rubric must define validity term {term}"
+        );
+    }
+    for term in ["fix", "explain", "defer", "user"] {
+        assert!(
+            disposition.contains(term),
+            "finding-evaluation rubric must define disposition term {term}"
+        );
+    }
+    assert!(
+        !comparison.is_empty(),
+        "finding-evaluation rubric must define run comparison eligibility"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn contributor_guide_links_the_review_process_rubric() -> io::Result<()> {
+    let contributing = repository_text("CONTRIBUTING.md")?;
+
+    assert!(
+        contributing.contains("dev-docs/code-review-process.md"),
+        "the contributor entry point must link to the finding-evaluation rubric"
+    );
+
+    Ok(())
+}

--- a/tests/ocr_review_policy.rs
+++ b/tests/ocr_review_policy.rs
@@ -46,7 +46,7 @@ fn upload_artifact_paths(workflow: &str) -> Vec<String> {
 
     for (index, line) in lines.iter().enumerate() {
         let trimmed = line.trim();
-        if trimmed != "path: |" && !trimmed.starts_with("path: |") {
+        if !trimmed.starts_with("path: |") {
             continue;
         }
         let block_indent = line.len() - line.trim_start().len();

--- a/tests/ocr_review_policy.rs
+++ b/tests/ocr_review_policy.rs
@@ -55,12 +55,18 @@ fn upload_artifact_paths(workflow: &str) -> Vec<String> {
             if following_trimmed.is_empty() {
                 continue;
             }
-            let following_indent = following.len() - following_trimmed.trim_start().len();
+            // Indentation must be measured on the trimmed line so trailing
+            // whitespace cannot inflate the count.
+            let following_indent = following_trimmed.len() - following_trimmed.trim_start().len();
             if following_indent <= block_indent {
                 break;
             }
+            // Inside a `path: |` literal block scalar every non-empty line is
+            // literal content; only comments are non-content. Do not skip lines
+            // starting with '-', which would drop legitimately hyphen-leading
+            // artifact paths.
             let candidate = following_trimmed.trim();
-            if candidate.starts_with('#') || candidate.starts_with('-') {
+            if candidate.starts_with('#') {
                 continue;
             }
             paths.push(candidate.to_string());


### PR DESCRIPTION
## Summary

Re-syncs jefe's CI OpenCodeReview (OCR) review with the newer rigor that llxprt-code's OCR review has gained since jefe first ported it. jefe's `ocr-review.yml` is an older port of an llxprt-code OCR setup; this PR ports the three rigor properties jefe lacks, all of which make the non-blocking OCR signal more honest and more auditable. OCR-only; the pr-review delivery process is tracked separately in #451.

Closes #449.

## What changed

- **A2 — Coverage classification (`.github/workflows/ocr-review.yml`).** Derive a four-state coverage value (`complete_best_effort` / `partial` / `failed` / `unknown`) from the OCR `result.json` status fields by recursively collecting every `status` string, mirroring `ocr-review-local`'s `extract_status` mapping. Surface it as a `Coverage:` line in the sticky summary and gate the clean "No findings." status on `complete_best_effort`, so a zero-exit run that reports `completed_with_errors` is classified `partial` and is **never** summarized as clean.
- **A1 — Reproducibility manifests (`.github/workflows/ocr-review.yml`).** New `Build OCR reproducibility manifests` step after the OCR run emits `manifest.pre.json` (scope mode=cumulative with resolved base/head SHAs, OCR version/phase, provider config **by shape only** + its sha256), `manifest.post.json` (exit code, reported statuses, four-state coverage, artifact hashes), and `sha256.txt` over all manifested artifacts. The triple is added to the fail-closed redaction list, the placeholder-ensure list, and the upload `path:` list, so it travels with the existing artifact bundle and any provider field is destroyed before upload.
- **A3 — Versioned finding-evaluation rubric (`dev-docs/code-review-process.md` + `CONTRIBUTING.md`).** The rubric (validity `valid`/`partial`/`invalid`/`unverifiable`, disposition `fix`/`explain`/`defer`/`user-judgment`, coverage honesty, run comparison eligibility, provider/remediation discipline) moves out of agent memory into a versioned doc, linked from the existing `Code review demand` section of `CONTRIBUTING.md`.
- **Contract tests (`tests/ocr_review_policy.rs`).** Mirrors `tests/coderabbit_policy.rs` to lock the rigor in mechanically: asserts the coverage-classification mapping + clean-summary gate, the manifest upload paths + redaction, the observational/non-blocking invariant vs `ci.yml`, and the rubric doc sections + CONTRIBUTING link.

## How it was verified (TDD)

Contract tests were added **RED first** (failed for the intended reasons), then turned GREEN as each slice landed. `make ci-check` is fully GREEN on the candidate head: fmt check, clippy gates, coverage `--fail-under-lines 30`, build, and the full test suite. `tests/ocr_review_policy`: 7/7 pass; `tests/coderabbit_policy`: no regression.

## Acceptance matrix evidence

| Row | Evidence |
|---|---|
| AC-01 coverage mapping | `coverage_classification_maps_completed_with_errors_to_partial` + `ocr_run_summary_never_reports_partial_or_unknown_as_clean` GREEN |
| AC-02 manifest upload | `reproducibility_manifests_are_uploaded_as_artifacts` + `manifest_provider_config_is_redacted_before_upload` GREEN |
| AC-03 non-blocking gate | `ocr_review_job_is_not_a_required_ci_gate` GREEN |
| AC-04 rubric terms | `finding_evaluation_rubric_defines_validity_disposition_and_comparison` GREEN |
| AC-05 CONTRIBUTING link | `contributor_guide_links_the_review_process_rubric` GREEN |
| AC-06/AC-07 CI behavior | workflow YAML changes, guarded by AC-01/AC-02 contract tests |

## Scope

5 changed files, +744 net lines. The fork-safety model, the changed-test scope guard, the pinned OCR version, the infra-failure notification logic, and CI required gates are all unchanged. OCR remains observational and non-blocking.

Out of scope: local OCR wrapper / `make ocr-*` / in-repo rule (issue slice A4, gated — requires explicit approval), and the pr-review delivery process (#451).
