### PR TITLE
Bypass cmd.exe for official Windows LLxprt launches

### DIFF
--- a/dev-docs/testing/psmux-smoke.md
+++ b/dev-docs/testing/psmux-smoke.md
@@ -48,6 +48,7 @@ the suite never contacts the default server and never invokes bare
 | Screen/history capture | `capture-pane -p -S <start> -E - -t <session>` | Returns visible output and bounded scrollback |
 | Resize request | `resize-window -t <session> -x 90 -y 28` | Command succeeds; detached 3.3.7 retains its initial `100x32` geometry until an attached client supplies size |
 | Session cleanup | `kill-session -t <session>` | Terminates only the selected session |
+| Official LLxprt agent launch (#433) | `jefe --jefe-internal-agent-launch <plan>` through `new-session`, resolving marked `llxprt.cmd` to bundled Bun + `index.ts` | Delivers a #425-sized 8,092-byte prompt as one intact process argument without crossing `cmd.exe`'s line limit |
 | Namespace cleanup | `psmux -L <name> kill-server` | Terminates only the explicitly named namespace |
 | Mouse-mode advertisement observation (#296) | `AttachedViewer::spawn_with_plan` over a fixture emitting `\x1b[?1000h ?1002h ?1006h` | Jefe's embedded terminal model observes the advertised DEC private mouse modes and reports `mouse_reporting_active() == true` after attach |
 | Page-key byte delivery (#296) | `AttachedViewer::write_input(b"\x1b[5~")` / `b"\x1b[6~")` | The exact `CSI 5~` / `CSI 6~` byte sequences reach the child (not arrow sequences `CSI A` / `CSI B`) |

--- a/project-plans/issue433-plan.md
+++ b/project-plans/issue433-plan.md
@@ -1,0 +1,125 @@
+# Issue 433 delivery plan
+
+## Issue and baseline
+
+- GitHub: https://github.com/vybestack/llxprt-jefe/issues/433
+- Branch: `issue433`
+- Base: `origin/main` at `20f6e764433946c0916bb4bf5878ff47212705cc`
+- Concrete reproduction: send issue #425 (8,092 UTF-8 body bytes) from the Issues screen to direct LLxprt on native Windows with psmux 3.3.6; the launched pane reports `line too long`.
+- Related work: #409/#410 compact large Unix tmux prompts; #253 owns native Windows parity; #277 already transports Windows agent argv/environment out of band through a consumed launch-plan file.
+- Discussion: the user approved generalizing the existing canonical script launch abstraction to launch the official LLxprt bundled Bun runtime and `index.ts` entrypoint directly. Generic command-script compaction/error handling, PowerShell wrappers, and #425 package-version behavior remain deferred.
+
+## Corrected root cause and approved architecture
+
+Current main does not pass the full prompt through psmux. `MultiplexerPlan::agent_pane_command_args_with_launcher` writes the full argv/environment to a private temporary plan and gives psmux only `jefe.exe --jefe-internal-agent-launch <plan-path>`.
+
+The private launcher later reconstructs a `CommandScript` as `cmd.exe /D /S /C llxprt.cmd <args>`. The official installed LLxprt wrapper then invokes its bundled Bun runtime and `index.ts`, but the complete #425-sized instruction has already crossed `cmd.exe`'s approximately 8,191-character command-line boundary.
+
+Approved fix:
+
+- recognize only the official wrapper marker `LLXPRT_NATIVE_LAUNCHER owned by @vybestack/llxprt-code`;
+- validate and canonicalize the documented bundled Bun and `index.ts` paths relative to the wrapper;
+- generalize the existing typed canonical script launch plan from npm-specific Node/CLI names to runtime/entrypoint names;
+- have the consumed private launch plan execute the runtime plus entrypoint and preserve every original argument as a structural process argument;
+- preserve unrecognized `.cmd`/`.bat` wrappers and all Unix paths unchanged.
+
+This removes the binding `cmd.exe` shell from the supported LLxprt path rather than lowering prompt thresholds or changing psmux.
+
+## Acceptance matrix
+
+| ID | Actor / launch path | Inputs and boundary cases | Target | Observable success | Observable failure / diagnostics | Permitted side effects | Compatibility | Proof |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| A1 | User presses uppercase `S`, chooses direct LLxprt, and Jefe launches the resolved agent | #425-sized instruction (8,092-byte body plus metadata/workflow), quotes and shell metacharacters | Native Windows, psmux 3.3.6, official `llxprt.cmd` | Session starts and the full instruction reaches LLxprt as one unchanged argv value; no `line too long` | Resolver/launcher returns a prompt-free typed diagnostic if the marked official layout is incomplete | Existing private launch-plan file is created and consumed; owned psmux namespace/session only | Existing issue prompt and LLxprt flags remain unchanged | resolver/launcher regression plus real psmux smoke with official-layout fixture |
+| A2 | Windows resolver examines a marked official LLxprt command wrapper | Bundled Bun and `index.ts` both exist; one is missing; wrapper marker absent | Native Windows | Complete marked layout yields a canonical runtime/entrypoint plan | Marked but incomplete layout fails safely with reinstall guidance; unmarked wrapper retains existing `CommandScript` behavior | Read-only wrapper/layout inspection | Other agents and third-party wrappers are unchanged | deterministic resolver unit tests |
+| A3 | Private launcher consumes a canonical script launch plan | Long prompt, empty args, Unicode, quotes, shell metacharacters | Windows process boundary | Runtime executable is the process program; entrypoint is the first child argument; original args remain separate and ordered | Existing safe `AgentLauncherError` behavior remains prompt-free | Plan file is removed before child execution as today | Existing canonical npm launch remains behaviorally identical after type generalization | command structure tests and existing npm tests |
+| A4 | Unix/macOS or Windows pinned npm launch executes | Direct Unix LLxprt; canonical Windows npm; selector-backed LLxprt | Unix/macOS and Windows | Existing executable selection, prompt compaction, and npm direct launch remain unchanged | Existing diagnostics unchanged | No new side effects | Serialized persistence schema and public CLI are unchanged | existing suites plus focused regression guards |
+
+## Explicit non-goals
+
+- No psmux pane-command or namespace changes.
+- No lower platform-specific prompt-compaction threshold and no change to #409/#410 behavior.
+- No generic `.cmd`/`.bat` command-length budgeting, compaction, or new fallback error subsystem.
+- No PowerShell-wrapper generalization without evidence of an LLxprt `.ps1` failure.
+- No change to issue #425's npm version selection, cache, locking, or install strategy.
+- No change to issue/PR content, keybindings, reducer behavior, persistence, dependencies, workflow/agent-memory files, `.llxprt/`, `.code_puppy/`, `.github/`, or quality-gate configuration.
+- No broad parser for arbitrary command scripts; only the explicit official marker and canonical package-relative layout are accepted.
+
+## Bounded vertical slice
+
+### S1: canonical official LLxprt script launch
+
+- Acceptance rows: A1-A4.
+- Architecture owner: runtime executable resolution and private process launcher; integration boundary is `ResolvedAgentExecutable -> AgentLaunchPayload -> Command`.
+- Allowed production paths: `src/runtime/agent_executable.rs`, `src/runtime/agent_launcher.rs`, plus directly required public re-export/exhaustive error consumers in `src/runtime/mod.rs` and `src/runtime/package_probe.rs`.
+- Allowed evidence paths: `src/runtime/agent_executable_tests.rs`, `src/runtime/npm_launch_tests.rs`, `tests/psmux_smoke.rs`, `tests/fixtures/psmux_smoke_fixture.rs`, `dev-docs/testing/psmux-smoke.md`, and this plan.
+- Planned approved public-contract change: rename/generalize `CanonicalNpmLaunchPlan` to a canonical script-runtime plan with `runtime` and `entrypoint`, and generalize the corresponding private serialized payload. No new module or subsystem.
+- RED: first add deterministic resolver/launcher assertions and a real psmux smoke using an official-layout fixture with an 8,092-byte prompt. Current main must resolve the wrapper without a canonical plan and fail the real launch at the command-shell boundary.
+- GREEN: the official marker plus complete canonical layout resolves to bundled Bun + `index.ts`; the private launcher bypasses `cmd.exe`; the native psmux smoke records the full prompt.
+- REFACTOR: keep wrapper recognition/layout validation in the resolver boundary and process construction in the launcher boundary; retain safe prompt-free errors.
+- Verification: focused runtime unit tests; `cargo test --features psmux-smoke --test psmux_smoke -- --nocapture`; `make quick-check`; exact-head `make ci-check`.
+- Stop conditions: parsing arbitrary wrapper syntax, a new process/cleanup subsystem, prompt-layer changes, dependencies, quality-tool changes, paths outside the allowed set, or scope above 15 files/800 lines for the slice.
+
+## TUI evidence decision
+
+The observable UI route from uppercase `S` through issue prompt construction and `spawn_session_fresh` is existing covered behavior; this issue changes only the post-resolution Windows process boundary. New schema-1 scenarios cannot target Windows because the closed grammar permits only `macos|linux`, and changing that harness is an unapproved quality-tool expansion. Adding a new legacy scenario is prohibited by the schema-1 migration contract. Therefore the bounded native proof is the established real-psmux smoke suite using production resolver, private launcher, and session creation, while existing app-input tests retain the uppercase-`S` route. A full Windows schema-1 TUI scenario is deferred to the harness Windows-platform effort rather than weakening either contract.
+
+## Expected paths by layer
+
+| Layer | Expected paths | Acceptance mapping |
+| --- | --- | --- |
+| Windows executable resolution | `src/runtime/agent_executable.rs` | A1, A2, A4 |
+| Private launch-plan execution | `src/runtime/agent_launcher.rs` | A1, A3, A4 |
+| Runtime public re-export | `src/runtime/mod.rs` | A3, A4 |
+| Exhaustive probe error classification | `src/runtime/package_probe.rs` | A2, A4 |
+| Resolver behavior evidence | `src/runtime/agent_executable_tests.rs` | A2, A4 |
+| Launcher/npm regression evidence | `src/runtime/npm_launch_tests.rs` | A3, A4 |
+| Native Windows process scenario | `tests/psmux_smoke.rs` | A1, A3 |
+| Native fixture support, only if needed | `tests/fixtures/psmux_smoke_fixture.rs` | A1 |
+| Compatibility documentation | `dev-docs/testing/psmux-smoke.md` | A1 |
+| Delivery record | `project-plans/issue433-plan.md` | all rows |
+
+Expected scope: at most 14 changed files and under 700 net changed lines. Two files are user-approved one-line prerequisite Clippy corrections; the native regression was split into a child module and a test-module declaration was reordered to satisfy the repository's 1,000-line hard gate.
+
+## Scope ledger
+
+| Discovery | Disposition | Rationale / follow-up |
+| --- | --- | --- |
+| PR #277 already removes full argv from the psmux pane command | In-scope correction | Do not alter psmux or add final-pane-command budgeting; diagnose the subsequent wrapper boundary. |
+| Official installed `llxprt.cmd` carries an explicit native-launcher marker and invokes bundled Bun + `index.ts` | In-scope fix | Use the marker and canonical package-relative paths; do not parse arbitrary shell syntax. |
+| Existing canonical npm plan already bypasses `cmd.exe` | In-scope refactor | Generalize the type/payload while preserving npm behavior. User explicitly approved this public abstraction change. |
+| Generalized public type and new typed error require runtime re-export and exhaustive probe classification updates | In-scope fix | `src/runtime/mod.rs` and `src/runtime/package_probe.rs` are direct compile-time consumers of the approved contract, not new behavior or scope expansion. |
+| Current Rust/Clippy flags `input.len() % 4 != 0` in `src/harness/v1/validate.rs` | Blocker-Fix | User approved the one-line prerequisite correction so the PR has no Clippy failure; behavior is unchanged. |
+| Current Rust/Clippy flags a one-hour capture-shim sleep expressed as 3,600 seconds | Blocker-Fix | Use `Duration::from_hours(1)` in `src/bin/jefe-capture-shim.rs`; user required clearing all PR Clippy failures and behavior is unchanged. |
+| Issue #425 concerns npm package-version reliability | Reject | #425 supplies the size fixture only; its install/cache/version requirements remain separate. |
+| Generic unrecognized command wrappers may retain the same command-shell limit | Defer | No evidence for other agents in #433; generic compaction/error handling would add a broader subsystem. |
+| PowerShell wrappers use a different process boundary | Defer | No reproduced failure; preserve existing behavior. |
+| Schema-1 harness excludes Windows and new legacy scenarios are prohibited | Defer | Changing the quality tool requires separate approval/issue; use the established real psmux smoke at the changed boundary. |
+| Adding the native regression made `tests/psmux_smoke.rs` exceed the 1,000-line hard gate | In-scope fix | Keep behavior unchanged and place the new regression in `tests/psmux_smoke/official_llxprt.rs` as a child module. |
+| Current main has `src/runtime/manager.rs` at 1,002 lines | Blocker-Fix | Reorder the two private test-module declarations without behavior change, removing separator lines so the exact-head hard gate passes at 1,000 lines. |
+| Pre-PR audit: resolver contracts were Windows-gated, wrapper marker read was unbounded, and marked-corrupt fallback intent was implicit | In-scope fix | Run pure injected-platform resolver tests on all hosts, cap marker reads at 8 KiB with regression coverage, and document authoritative marked-wrapper failure behavior. |
+| Pre-PR audit: fixture filename sniffing could become fragile if reused | Defer | Test-only behavior is bounded to the new native regression; revisit if the fixture gains callers. |
+| Pre-PR audit: marker trust model | Reject | PATH is already trusted and package-relative runtime/entrypoint paths are canonicalized; no privilege boundary is added. |
+
+## Review counters
+
+- Local OCR runs before PR: 1 / 2 (GLM Rust audit; pass, three low in-scope findings addressed, two informational findings deferred).
+- OCR runs after PR: 0 / 2.
+
+## Verification evidence
+
+| Check | Result | Head |
+| --- | --- | --- |
+| Baseline branch/status/main drift | `issue433`, clean, `main...origin/main` 0/0 | `20f6e76` |
+| RED focused tests | Reconstructed against isolated base source: `cargo test --lib issue433_red_official_llxprt_wrapper_requires_canonical_launch_plan -- --nocapture` failed at the behavioral assertion because the official LLxprt wrapper had no canonical direct plan and would use `cmd.exe` | `20f6e76` |
+| GREEN focused tests | Resolver contracts: 11 passed on injected Windows policy, including oversized-marker rejection. `cargo test --lib windows_official_llxprt_script_plan_launches_bun_with_entrypoint_first_argument -- --nocapture`: 1 passed, runtime/entrypoint structural argv preserved | working tree |
+| Native psmux smoke | New #425-sized regression passed through a WMI-created process outside the current nested psmux pseudo-console: 1 passed, full 8,092-byte prompt recorded; exact all-feature test gate also passed all 13 psmux smoke tests | working tree |
+| `make quick-check` | `make` is unavailable on this native Windows host; direct Makefile equivalent `cargo fmt --all; cargo check -q; cargo test -q` passed from a WMI-created process outside nested psmux (all listed suites passed) | working tree |
+| `make ci-check` | Exact constituent gates passed: fmt; all-target/all-feature Clippy `-D warnings`; complexity Clippy; source-size hard gate; locked all-feature build; locked all-feature tests outside nested psmux; coverage 69.63% lines (minimum 30%). Clippy-allow script could not invoke Python on this host; equivalent first-party scan found no attributes and config-threshold comparison passed. | working tree |
+| Exact-head scope/ancestry/conflict review | 14 files, 618 additions / 68 deletions / +550 net lines including untracked plan and child test module; `git diff --check` clean, `main...HEAD` 0/0; within approved 14-file/700-line budget. Remote conflict check is deferred until PR creation. | working tree |
+
+## Deferred findings and follow-ups
+
+- Generic long-argument handling for unrecognized Windows command/PowerShell wrappers, if reproduced.
+- Windows support in the schema-1 real-process TUI harness.
+- Issue #425's jefe-managed exact LLxprt package installation/version strategy.
+- Replace the native fixture's `index.ts` filename sniffing with an explicit protocol marker if the fixture gains more callers.

--- a/src/runtime/agent_executable.rs
+++ b/src/runtime/agent_executable.rs
@@ -1,6 +1,7 @@
 //! Platform-owned resolution of launchable local executables used by agent sessions.
 
 use std::ffi::{OsStr, OsString};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use crate::domain::AgentKind;
@@ -12,6 +13,14 @@ const UNIX_REMEDIATION: &str = "install an executable runtime on PATH and restar
 const NPM_REMEDIATION: &str = "install Node.js with npm on PATH and restart Jefe";
 const UVX_REMEDIATION: &str = "install uv with uvx on PATH and restart Jefe";
 const NPM_LAYOUT_REMEDIATION: &str = "install the official Node.js npm layout (npm.cmd/npm.bat beside node.exe and node_modules/npm/bin/npm-cli.js) or put npm.exe on PATH, then restart Jefe";
+const LLXPRT_OFFICIAL_LAYOUT_REMEDIATION: &str = "reinstall @vybestack/llxprt-code so its bundled bun.exe and index.ts ship beside llxprt.cmd, then restart Jefe";
+const LLXPRT_NATIVE_LAUNCHER_MARKER: &str =
+    "LLXPRT_NATIVE_LAUNCHER owned by @vybestack/llxprt-code";
+const MAX_WRAPPER_MARKER_READ_BYTES: u64 = 8 * 1_024;
+const LLXPRT_BUN_REL: &str = "node_modules/@vybestack/llxprt-code/node_modules/bun/bin/bun.exe";
+const LLXPRT_ENTRYPOINT_REL: &str = "node_modules/@vybestack/llxprt-code/index.ts";
+const NPM_NODE_REL: &str = "node.exe";
+const NPM_CLI_REL: &str = "node_modules/npm/bin/npm-cli.js";
 
 /// Operating-system executable-resolution policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -82,24 +91,28 @@ pub enum AgentWrapperKind {
     PowerShellScript,
 }
 
-/// Direct Node.js invocation retained for an official Windows npm wrapper layout.
+/// Direct script runtime and entrypoint invocation for an official Windows
+/// command-wrapper layout.
+///
+/// This supports npm's Node/npm-cli.js and LLxprt's bundled Bun/index.ts while
+/// bypassing `cmd.exe` so the full argument vector survives intact.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CanonicalNpmLaunchPlan {
-    node: PathBuf,
-    cli: PathBuf,
+pub struct CanonicalScriptLaunchPlan {
+    runtime: PathBuf,
+    entrypoint: PathBuf,
 }
 
-impl CanonicalNpmLaunchPlan {
-    /// Canonical path to the Node.js executable.
+impl CanonicalScriptLaunchPlan {
+    /// Canonical path to the script runtime executable (node.exe or bun.exe).
     #[must_use]
-    pub fn node(&self) -> &Path {
-        &self.node
+    pub fn runtime(&self) -> &Path {
+        &self.runtime
     }
 
-    /// Canonical path to npm's JavaScript CLI entry point.
+    /// Canonical path to the script entry point (npm-cli.js or index.ts).
     #[must_use]
-    pub fn cli(&self) -> &Path {
-        &self.cli
+    pub fn entrypoint(&self) -> &Path {
+        &self.entrypoint
     }
 }
 
@@ -109,7 +122,7 @@ pub struct ResolvedAgentExecutable {
     target: AgentExecutableTarget,
     path: PathBuf,
     wrapper_kind: AgentWrapperKind,
-    npm_launch_plan: Option<CanonicalNpmLaunchPlan>,
+    script_launch_plan: Option<CanonicalScriptLaunchPlan>,
 }
 
 impl ResolvedAgentExecutable {
@@ -140,10 +153,11 @@ impl ResolvedAgentExecutable {
         self.wrapper_kind
     }
 
-    /// Validated direct Node.js launch plan for an official Windows npm script.
+    /// Validated canonical script runtime + entrypoint plan for an official
+    /// Windows wrapper layout, when one was recognized.
     #[must_use]
-    pub fn npm_launch_plan(&self) -> Option<&CanonicalNpmLaunchPlan> {
-        self.npm_launch_plan.as_ref()
+    pub fn script_launch_plan(&self) -> Option<&CanonicalScriptLaunchPlan> {
+        self.script_launch_plan.as_ref()
     }
 }
 
@@ -226,30 +240,32 @@ impl AgentExecutableResolver {
         target: AgentExecutableTarget,
     ) -> Result<ResolvedAgentExecutable, AgentExecutableError> {
         let extensions = windows_extensions(self.pathext.as_deref());
-        let mut rejected_npm_script = false;
+        let mut rejection: Option<AgentExecutableError> = None;
         for directory in &self.directories {
             for (extension, wrapper_kind) in &extensions {
                 let path = directory.join(format!("{}{extension}", target.binary_name()));
                 if path.is_file() {
-                    if target == AgentExecutableTarget::Npm
-                        && *wrapper_kind == AgentWrapperKind::CommandScript
-                    {
-                        if let Some(plan) = canonical_npm_launch_plan(directory) {
-                            return Ok(resolved_npm_script(path, plan));
+                    match canonical_script_plan(target, *wrapper_kind, directory, &path) {
+                        CanonicalScriptOutcome::Plan(plan) => {
+                            return Ok(resolved_script(target, path, *wrapper_kind, plan));
                         }
-                        rejected_npm_script = true;
-                        continue;
+                        CanonicalScriptOutcome::Unmarked => {
+                            return Ok(resolved(target, path, *wrapper_kind));
+                        }
+                        CanonicalScriptOutcome::Reject(error) => {
+                            if target == AgentExecutableTarget::Npm {
+                                rejection = Some(error);
+                                continue;
+                            }
+                            // A marked official wrapper is authoritative: surface package
+                            // corruption instead of silently launching another PATH entry.
+                            return Err(error);
+                        }
                     }
-                    return Ok(resolved(target, path, *wrapper_kind));
                 }
             }
         }
-        if rejected_npm_script {
-            return Err(AgentExecutableError::NonCanonicalNpmWrapper {
-                remediation: NPM_LAYOUT_REMEDIATION,
-            });
-        }
-        Err(self.missing(target))
+        Err(rejection.unwrap_or_else(|| self.missing(target)))
     }
 
     fn missing(&self, target: AgentExecutableTarget) -> AgentExecutableError {
@@ -284,6 +300,11 @@ pub enum AgentExecutableError {
         /// Action the user can take to install a structurally safe npm layout.
         remediation: &'static str,
     },
+    /// A marked official LLxprt wrapper exists but its bundled runtime/entrypoint layout is incomplete.
+    NonCanonicalOfficialLlxprtWrapper {
+        /// Action the user can take to restore the official native-launcher layout.
+        remediation: &'static str,
+    },
 }
 
 impl std::fmt::Display for AgentExecutableError {
@@ -301,6 +322,10 @@ impl std::fmt::Display for AgentExecutableError {
                 formatter,
                 "npm wrapper is not in a supported official Node.js layout; {remediation}"
             ),
+            Self::NonCanonicalOfficialLlxprtWrapper { remediation } => write!(
+                formatter,
+                "LLxprt wrapper is marked as an official native launcher but its layout is incomplete; {remediation}"
+            ),
         }
     }
 }
@@ -316,29 +341,101 @@ fn resolved(
         target,
         path,
         wrapper_kind,
-        npm_launch_plan: None,
+        script_launch_plan: None,
     }
 }
 
-fn resolved_npm_script(
+fn resolved_script(
+    target: AgentExecutableTarget,
     path: PathBuf,
-    npm_launch_plan: CanonicalNpmLaunchPlan,
+    wrapper_kind: AgentWrapperKind,
+    plan: CanonicalScriptLaunchPlan,
 ) -> ResolvedAgentExecutable {
     ResolvedAgentExecutable {
-        target: AgentExecutableTarget::Npm,
+        target,
         path,
-        wrapper_kind: AgentWrapperKind::CommandScript,
-        npm_launch_plan: Some(npm_launch_plan),
+        wrapper_kind,
+        script_launch_plan: Some(plan),
     }
 }
 
-fn canonical_npm_launch_plan(directory: &Path) -> Option<CanonicalNpmLaunchPlan> {
-    let node = std::fs::canonicalize(directory.join("node.exe")).ok()?;
-    let cli = std::fs::canonicalize(directory.join("node_modules/npm/bin/npm-cli.js")).ok()?;
-    if !node.is_file() || !cli.is_file() {
+enum CanonicalScriptOutcome {
+    Plan(CanonicalScriptLaunchPlan),
+    Unmarked,
+    Reject(AgentExecutableError),
+}
+
+fn canonical_script_plan(
+    target: AgentExecutableTarget,
+    wrapper_kind: AgentWrapperKind,
+    directory: &Path,
+    wrapper_path: &Path,
+) -> CanonicalScriptOutcome {
+    if wrapper_kind != AgentWrapperKind::CommandScript {
+        return CanonicalScriptOutcome::Unmarked;
+    }
+    if target == AgentExecutableTarget::Npm {
+        return canonical_npm_outcome(directory);
+    }
+    if matches!(target, AgentExecutableTarget::Agent(AgentKind::Llxprt)) {
+        return official_llxprt_outcome(directory, wrapper_path);
+    }
+    CanonicalScriptOutcome::Unmarked
+}
+
+fn canonical_npm_outcome(directory: &Path) -> CanonicalScriptOutcome {
+    match canonical_script_launch_plan(directory, NPM_NODE_REL, NPM_CLI_REL) {
+        Some(plan) => CanonicalScriptOutcome::Plan(plan),
+        None => CanonicalScriptOutcome::Reject(AgentExecutableError::NonCanonicalNpmWrapper {
+            remediation: NPM_LAYOUT_REMEDIATION,
+        }),
+    }
+}
+
+fn official_llxprt_outcome(directory: &Path, wrapper_path: &Path) -> CanonicalScriptOutcome {
+    if !wrapper_carries_native_launcher_marker(wrapper_path) {
+        return CanonicalScriptOutcome::Unmarked;
+    }
+    match canonical_script_launch_plan(directory, LLXPRT_BUN_REL, LLXPRT_ENTRYPOINT_REL) {
+        Some(plan) => CanonicalScriptOutcome::Plan(plan),
+        None => CanonicalScriptOutcome::Reject(
+            AgentExecutableError::NonCanonicalOfficialLlxprtWrapper {
+                remediation: LLXPRT_OFFICIAL_LAYOUT_REMEDIATION,
+            },
+        ),
+    }
+}
+
+fn canonical_script_launch_plan(
+    directory: &Path,
+    runtime_rel: &str,
+    entrypoint_rel: &str,
+) -> Option<CanonicalScriptLaunchPlan> {
+    let runtime = std::fs::canonicalize(directory.join(runtime_rel)).ok()?;
+    let entrypoint = std::fs::canonicalize(directory.join(entrypoint_rel)).ok()?;
+    if !runtime.is_file() || !entrypoint.is_file() {
         return None;
     }
-    Some(CanonicalNpmLaunchPlan { node, cli })
+    Some(CanonicalScriptLaunchPlan {
+        runtime,
+        entrypoint,
+    })
+}
+
+fn wrapper_carries_native_launcher_marker(wrapper_path: &Path) -> bool {
+    let Ok(file) = std::fs::File::open(wrapper_path) else {
+        return false;
+    };
+    let mut bytes = Vec::new();
+    if file
+        .take(MAX_WRAPPER_MARKER_READ_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .is_err()
+        || bytes.len() as u64 > MAX_WRAPPER_MARKER_READ_BYTES
+    {
+        return false;
+    }
+    std::str::from_utf8(&bytes).is_ok_and(|text| text.contains(LLXPRT_NATIVE_LAUNCHER_MARKER))
 }
 
 fn windows_extensions(pathext: Option<&OsStr>) -> Vec<(String, AgentWrapperKind)> {

--- a/src/runtime/agent_executable_tests.rs
+++ b/src/runtime/agent_executable_tests.rs
@@ -129,7 +129,7 @@ fn windows_npm_resolution_reuses_command_wrapper_policy() {
     let executable = resolver
         .resolve_target(AgentExecutableTarget::Npm)
         .unwrap_or_else(|error| panic!("npm.cmd should resolve: {error}"));
-    let Some(plan) = executable.npm_launch_plan() else {
+    let Some(plan) = executable.script_launch_plan() else {
         panic!("npm.cmd must retain a canonical direct Node.js plan");
     };
 
@@ -137,11 +137,11 @@ fn windows_npm_resolution_reuses_command_wrapper_policy() {
     assert_eq!(executable.wrapper_kind(), AgentWrapperKind::CommandScript);
     assert_eq!(executable.target(), AgentExecutableTarget::Npm);
     assert_eq!(
-        plan.node(),
+        plan.runtime(),
         std::fs::canonicalize(node).unwrap_or_else(|error| panic!("node: {error}"))
     );
     assert_eq!(
-        plan.cli(),
+        plan.entrypoint(),
         std::fs::canonicalize(cli).unwrap_or_else(|error| panic!("cli: {error}"))
     );
 }
@@ -234,4 +234,136 @@ fn windows_npm_resolution_rejects_noncanonical_command_wrapper() {
     assert!(diagnostic.contains("official Node.js layout"));
     assert!(diagnostic.contains("node.exe"));
     assert!(diagnostic.contains("npm-cli.js"));
+}
+
+const LLXPRT_WRAPPER_MARKER: &str = "LLXPRT_NATIVE_LAUNCHER owned by @vybestack/llxprt-code";
+const LLXPRT_BUN_REL: &str = "node_modules/@vybestack/llxprt-code/node_modules/bun/bin/bun.exe";
+const LLXPRT_ENTRYPOINT_REL: &str = "node_modules/@vybestack/llxprt-code/index.ts";
+
+fn write_official_llxprt_wrapper(directory: &TempDir, include_bun: bool, include_entry: bool) {
+    let wrapper = directory.path().join("llxprt.cmd");
+    let body = format!(
+        "@echo off\r\nrem {LLXPRT_WRAPPER_MARKER}\r\nrem official launcher\r\nexit /b 0\r\n"
+    );
+    std::fs::write(&wrapper, body.as_bytes())
+        .unwrap_or_else(|error| panic!("write official wrapper: {error}"));
+    if include_bun {
+        let bun = directory.path().join(LLXPRT_BUN_REL);
+        std::fs::create_dir_all(bun.parent().unwrap_or_else(|| directory.path()))
+            .unwrap_or_else(|error| panic!("create bun dir: {error}"));
+        std::fs::write(&bun, b"fixture")
+            .unwrap_or_else(|error| panic!("write bun fixture: {error}"));
+    }
+    if include_entry {
+        let entry = directory.path().join(LLXPRT_ENTRYPOINT_REL);
+        std::fs::create_dir_all(entry.parent().unwrap_or_else(|| directory.path()))
+            .unwrap_or_else(|error| panic!("create entry dir: {error}"));
+        std::fs::write(&entry, b"fixture")
+            .unwrap_or_else(|error| panic!("write entry fixture: {error}"));
+    }
+}
+
+#[test]
+fn windows_official_llxprt_wrapper_resolves_to_canonical_bun_entrypoint_plan() {
+    let directory = tempfile::tempdir().unwrap_or_else(|error| panic!("temp dir: {error}"));
+    write_official_llxprt_wrapper(&directory, true, true);
+    let resolver = AgentExecutableResolver::for_platform(
+        AgentExecutablePlatform::Windows,
+        vec![directory.path().to_path_buf()],
+        Some(OsString::from(".CMD")),
+    );
+
+    let executable = resolver
+        .resolve(AgentKind::Llxprt)
+        .unwrap_or_else(|error| panic!("official wrapper should resolve: {error}"));
+    let plan = executable
+        .script_launch_plan()
+        .unwrap_or_else(|| panic!("official wrapper must produce a canonical script plan"));
+    let expected_bun = std::fs::canonicalize(directory.path().join(LLXPRT_BUN_REL))
+        .unwrap_or_else(|error| panic!("canonical bun: {error}"));
+    let expected_entry = std::fs::canonicalize(directory.path().join(LLXPRT_ENTRYPOINT_REL))
+        .unwrap_or_else(|error| panic!("canonical entry: {error}"));
+    assert_eq!(executable.path(), directory.path().join("llxprt.cmd"));
+    assert_eq!(executable.wrapper_kind(), AgentWrapperKind::CommandScript);
+    assert_eq!(plan.runtime(), expected_bun);
+    assert_eq!(plan.entrypoint(), expected_entry);
+}
+
+#[test]
+fn windows_official_llxprt_wrapper_missing_bun_fails_safely() {
+    let directory = tempfile::tempdir().unwrap_or_else(|error| panic!("temp dir: {error}"));
+    write_official_llxprt_wrapper(&directory, false, true);
+    let resolver = AgentExecutableResolver::for_platform(
+        AgentExecutablePlatform::Windows,
+        vec![directory.path().to_path_buf()],
+        Some(OsString::from(".CMD")),
+    );
+
+    let error = resolver
+        .resolve(AgentKind::Llxprt)
+        .err()
+        .unwrap_or_else(|| panic!("incomplete official layout must fail"));
+    let diagnostic = error.to_string();
+    assert!(diagnostic.contains("LLxprt"));
+    assert!(diagnostic.contains("reinstall"));
+    assert!(!diagnostic.contains("prompt"));
+}
+
+#[test]
+fn windows_official_llxprt_wrapper_missing_entrypoint_fails_safely() {
+    let directory = tempfile::tempdir().unwrap_or_else(|error| panic!("temp dir: {error}"));
+    write_official_llxprt_wrapper(&directory, true, false);
+    let resolver = AgentExecutableResolver::for_platform(
+        AgentExecutablePlatform::Windows,
+        vec![directory.path().to_path_buf()],
+        Some(OsString::from(".CMD")),
+    );
+
+    let error = resolver
+        .resolve(AgentKind::Llxprt)
+        .err()
+        .unwrap_or_else(|| panic!("incomplete official layout must fail"));
+    assert!(error.to_string().contains("reinstall"));
+}
+
+#[test]
+fn windows_unmarked_llxprt_cmd_retains_command_script_behavior() {
+    let directory = tempfile::tempdir().unwrap_or_else(|error| panic!("temp dir: {error}"));
+    write_candidate(&directory, "llxprt.cmd");
+    let resolver = AgentExecutableResolver::for_platform(
+        AgentExecutablePlatform::Windows,
+        vec![directory.path().to_path_buf()],
+        Some(OsString::from(".CMD")),
+    );
+
+    let executable = resolver
+        .resolve(AgentKind::Llxprt)
+        .unwrap_or_else(|error| panic!("unmarked wrapper should resolve: {error}"));
+    assert_eq!(executable.wrapper_kind(), AgentWrapperKind::CommandScript);
+    assert!(
+        executable.script_launch_plan().is_none(),
+        "unmarked wrapper must not produce a canonical script plan"
+    );
+}
+
+#[test]
+fn windows_oversized_marked_llxprt_wrapper_is_not_treated_as_official() {
+    let directory =
+        TempDir::new().unwrap_or_else(|error| panic!("create oversized wrapper dir: {error}"));
+    let wrapper = directory.path().join("llxprt.cmd");
+    let mut body = format!("@echo off\r\nrem {LLXPRT_WRAPPER_MARKER}\r\n").into_bytes();
+    body.resize(8 * 1_024 + 1, b'x');
+    std::fs::write(&wrapper, body)
+        .unwrap_or_else(|error| panic!("write oversized wrapper: {error}"));
+
+    let executable = AgentExecutableResolver::for_platform(
+        AgentExecutablePlatform::Windows,
+        vec![directory.path().to_path_buf()],
+        Some(OsString::from(".CMD")),
+    )
+    .resolve(AgentKind::Llxprt)
+    .unwrap_or_else(|error| panic!("oversized wrapper should remain launchable: {error}"));
+
+    assert_eq!(executable.wrapper_kind(), AgentWrapperKind::CommandScript);
+    assert!(executable.script_launch_plan().is_none());
 }

--- a/src/runtime/agent_launcher.rs
+++ b/src/runtime/agent_launcher.rs
@@ -21,15 +21,15 @@ static LAUNCH_PLAN_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 struct AgentLaunchPayload {
     path: PathBuf,
     wrapper: AgentWrapperKindPayload,
-    npm_launch: Option<NpmLaunchPayload>,
+    script_launch: Option<ScriptLaunchPayload>,
     args: Vec<OsString>,
     environment: Vec<(OsString, OsString)>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct NpmLaunchPayload {
-    node: PathBuf,
-    cli: PathBuf,
+struct ScriptLaunchPayload {
+    runtime: PathBuf,
+    entrypoint: PathBuf,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -58,7 +58,7 @@ pub fn write_launch_plan(
     let payload = AgentLaunchPayload {
         path: executable.path().to_path_buf(),
         wrapper: executable.wrapper_kind().into(),
-        npm_launch: npm_launch_payload(executable),
+        script_launch: script_launch_payload(executable),
         args: args.to_vec(),
         environment: environment.to_vec(),
     };
@@ -148,23 +148,25 @@ pub(super) fn command_for_executable(
     command_for_payload(&AgentLaunchPayload {
         path: executable.path().to_path_buf(),
         wrapper: executable.wrapper_kind().into(),
-        npm_launch: npm_launch_payload(executable),
+        script_launch: script_launch_payload(executable),
         args: args.to_vec(),
         environment: Vec::new(),
     })
 }
 
-fn npm_launch_payload(executable: &ResolvedAgentExecutable) -> Option<NpmLaunchPayload> {
-    executable.npm_launch_plan().map(|plan| NpmLaunchPayload {
-        node: plan.node().to_path_buf(),
-        cli: plan.cli().to_path_buf(),
-    })
+fn script_launch_payload(executable: &ResolvedAgentExecutable) -> Option<ScriptLaunchPayload> {
+    executable
+        .script_launch_plan()
+        .map(|plan| ScriptLaunchPayload {
+            runtime: plan.runtime().to_path_buf(),
+            entrypoint: plan.entrypoint().to_path_buf(),
+        })
 }
 
 fn command_for_payload(payload: &AgentLaunchPayload) -> Command {
-    if let Some(npm_launch) = &payload.npm_launch {
-        let mut command = Command::new(&npm_launch.node);
-        command.arg(&npm_launch.cli).args(&payload.args);
+    if let Some(script_launch) = &payload.script_launch {
+        let mut command = Command::new(&script_launch.runtime);
+        command.arg(&script_launch.entrypoint).args(&payload.args);
         return command;
     }
     match payload.wrapper {

--- a/src/runtime/llxprt_install.rs
+++ b/src/runtime/llxprt_install.rs
@@ -308,7 +308,8 @@ fn run_npm_install(
             let selector = selector.as_str().to_owned();
             match error {
                 AgentExecutableError::NotFound { .. }
-                | AgentExecutableError::NonCanonicalNpmWrapper { .. } => {
+                | AgentExecutableError::NonCanonicalNpmWrapper { .. }
+                | AgentExecutableError::NonCanonicalOfficialLlxprtWrapper { .. } => {
                     LlxprtInstallError::NpmMissing { selector }
                 }
             }

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -890,11 +890,9 @@ impl RuntimeManager for TmuxRuntimeManager {
         super::shell_window::close_all_manager_shell_windows()
     }
 }
-
-#[cfg(test)]
-#[path = "manager_tests.rs"]
-mod tests;
-
 #[cfg(test)]
 #[path = "history_tests.rs"]
 mod history_tests;
+#[cfg(test)]
+#[path = "manager_tests.rs"]
+mod tests;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -44,7 +44,7 @@ mod stub_manager;
 
 pub use agent_executable::{
     AgentExecutableError, AgentExecutablePlatform, AgentExecutableResolver, AgentExecutableTarget,
-    AgentWrapperKind, CanonicalNpmLaunchPlan, ResolvedAgentExecutable,
+    AgentWrapperKind, CanonicalScriptLaunchPlan, ResolvedAgentExecutable,
 };
 pub use agent_launcher::{AgentLauncherError, INTERNAL_LAUNCH_ARGUMENT, run_launch_plan};
 pub use attach::AttachedViewer;

--- a/src/runtime/npm_launch_tests.rs
+++ b/src/runtime/npm_launch_tests.rs
@@ -371,3 +371,67 @@ fn latest_nightly_sentinel_remote_uses_nightly_dist_tag() {
         .unwrap_or_else(|error| panic!("nightly remote plan: {error}"));
     assert_eq!(plan.args[2], "--package=@vybestack/llxprt-code@nightly");
 }
+
+#[cfg(windows)]
+#[test]
+fn windows_official_llxprt_script_plan_launches_bun_with_entrypoint_first_argument() {
+    use super::super::agent_executable::{AgentExecutablePlatform, AgentExecutableResolver};
+    use std::ffi::{OsStr, OsString};
+
+    const MARKER: &str = "LLXPRT_NATIVE_LAUNCHER owned by @vybestack/llxprt-code";
+    const BUN_REL: &str = "node_modules/@vybestack/llxprt-code/node_modules/bun/bin/bun.exe";
+    const ENTRY_REL: &str = "node_modules/@vybestack/llxprt-code/index.ts";
+
+    let directory = tempfile::tempdir().unwrap_or_else(|error| panic!("temp dir: {error}"));
+    let wrapper = directory.path().join("llxprt.cmd");
+    std::fs::write(
+        &wrapper,
+        format!("@echo off\r\nrem {MARKER}\r\n").as_bytes(),
+    )
+    .unwrap_or_else(|error| panic!("write wrapper: {error}"));
+    let bun = directory.path().join(BUN_REL);
+    let entry = directory.path().join(ENTRY_REL);
+    for path in [&bun, &entry] {
+        std::fs::create_dir_all(path.parent().unwrap_or_else(|| directory.path()))
+            .unwrap_or_else(|error| panic!("create fixture dir: {error}"));
+        std::fs::write(path, b"fixture").unwrap_or_else(|error| panic!("write fixture: {error}"));
+    }
+    let resolver = AgentExecutableResolver::for_platform(
+        AgentExecutablePlatform::Windows,
+        vec![directory.path().to_path_buf()],
+        Some(std::ffi::OsString::from(".CMD")),
+    );
+    let executable = resolver
+        .resolve(crate::domain::AgentKind::Llxprt)
+        .unwrap_or_else(|error| panic!("resolve official wrapper: {error}"));
+    let prompt = OsString::from("x".repeat(8_092));
+    let command = super::super::agent_launcher::command_for_executable(
+        &executable,
+        &[
+            OsString::from("--profile-load"),
+            OsString::from("p"),
+            prompt,
+        ],
+    );
+    let canonical_bun =
+        std::fs::canonicalize(&bun).unwrap_or_else(|error| panic!("canonical bun: {error}"));
+    let canonical_entry =
+        std::fs::canonicalize(&entry).unwrap_or_else(|error| panic!("canonical entry: {error}"));
+    let args = command.get_args().collect::<Vec<_>>();
+    assert_eq!(command.get_program(), canonical_bun.as_path());
+    assert_eq!(args.len(), 4);
+    assert_eq!(args[0], canonical_entry.as_os_str());
+    assert_eq!(args[1], OsStr::new("--profile-load"));
+    assert_eq!(args[2], OsStr::new("p"));
+    assert_eq!(args[3].len(), 8_092);
+    assert!(
+        !args.iter().any(|arg| *arg == wrapper.as_os_str()),
+        "wrapper must not appear in argv"
+    );
+    assert!(
+        !command
+            .get_program()
+            .to_str()
+            .is_some_and(|program| program.eq_ignore_ascii_case("cmd.exe"))
+    );
+}

--- a/src/runtime/package_probe.rs
+++ b/src/runtime/package_probe.rs
@@ -251,7 +251,8 @@ fn local_resolution_error(
             target: "local machine".to_owned(),
             selector: selector.as_str().to_owned(),
         },
-        error @ AgentExecutableError::NonCanonicalNpmWrapper { .. } => {
+        error @ (AgentExecutableError::NonCanonicalNpmWrapper { .. }
+        | AgentExecutableError::NonCanonicalOfficialLlxprtWrapper { .. }) => {
             let (target, selector, diagnostic) =
                 failure_fields("local machine", selector, &error.to_string());
             NpmPackageAvailabilityError::ProbeFailure {

--- a/tests/fixtures/psmux_smoke_fixture.rs
+++ b/tests/fixtures/psmux_smoke_fixture.rs
@@ -13,7 +13,8 @@ fn main() -> ExitCode {
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let mut args = std::env::args().skip(1);
+    let mut args = std::env::args().skip(1).peekable();
+    skip_official_entrypoint(&mut args);
     let marker = fixture_marker(&mut args)?;
     if marker.as_deref() == Some("--record") {
         let output = args.next().ok_or("record mode requires an output path")?;
@@ -70,6 +71,16 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         if byte[0] == 0x04 {
             return Ok(());
         }
+    }
+}
+
+fn skip_official_entrypoint(args: &mut std::iter::Peekable<impl Iterator<Item = String>>) {
+    if args.peek().is_some_and(|first| {
+        Path::new(first)
+            .file_name()
+            .is_some_and(|name| name == "index.ts")
+    }) {
+        let _ = args.next();
     }
 }
 

--- a/tests/psmux_smoke.rs
+++ b/tests/psmux_smoke.rs
@@ -436,6 +436,9 @@ fn psmux_command_contract_rejects_invalid_command_with_diagnostics() {
     assert!(report.contains("psmux version:"), "report: {report}");
 }
 
+#[path = "psmux_smoke/official_llxprt.rs"]
+mod official_llxprt;
+
 #[test]
 fn psmux_supports_jefe_runtime_and_harness_command_surface() {
     let Some((executable, version_text)) = qualified_psmux() else {

--- a/tests/psmux_smoke/official_llxprt.rs
+++ b/tests/psmux_smoke/official_llxprt.rs
@@ -1,0 +1,116 @@
+use super::*;
+
+const OFFICIAL_WRAPPER_MARKER: &str = "LLXPRT_NATIVE_LAUNCHER owned by @vybestack/llxprt-code";
+const OFFICIAL_BUN_REL: &str = "node_modules/@vybestack/llxprt-code/node_modules/bun/bin/bun.exe";
+const OFFICIAL_ENTRY_REL: &str = "node_modules/@vybestack/llxprt-code/index.ts";
+
+struct OfficialLlxprtFixture {
+    work_dir: tempfile::TempDir,
+    agent_executable: jefe::runtime::ResolvedAgentExecutable,
+    record: PathBuf,
+    prompt: String,
+}
+
+fn prepare_official_llxprt_fixture() -> OfficialLlxprtFixture {
+    let work_dir =
+        tempfile::tempdir().unwrap_or_else(|error| panic!("create official fixture dir: {error}"));
+    let runtime_dir = work_dir.path().join("runtime");
+    fs::create_dir_all(&runtime_dir).unwrap_or_else(|error| panic!("create runtime dir: {error}"));
+    let wrapper = runtime_dir.join("llxprt.cmd");
+    let body = format!("@echo off\r\nrem {OFFICIAL_WRAPPER_MARKER}\r\nexit /b 0\r\n");
+    fs::write(&wrapper, body.as_bytes())
+        .unwrap_or_else(|error| panic!("write official wrapper: {error}"));
+    let bun = runtime_dir.join(OFFICIAL_BUN_REL);
+    let entry = runtime_dir.join(OFFICIAL_ENTRY_REL);
+    for path in [&bun, &entry] {
+        fs::create_dir_all(path.parent().unwrap_or(runtime_dir.as_path()))
+            .unwrap_or_else(|error| panic!("create official layout dir: {error}"));
+        fs::copy(FIXTURE, path).unwrap_or_else(|error| panic!("copy fixture binary: {error}"));
+    }
+    let agent_executable = AgentExecutableResolver::for_platform(
+        AgentExecutablePlatform::Windows,
+        vec![runtime_dir],
+        Some(OsString::from(".CMD")),
+    )
+    .resolve(AgentKind::Llxprt)
+    .unwrap_or_else(|error| panic!("resolve official LLxprt layout: {error}"));
+    let record = work_dir.path().join("official observation.json");
+    let prompt = "x".repeat(8_092);
+    OfficialLlxprtFixture {
+        work_dir,
+        agent_executable,
+        record,
+        prompt,
+    }
+}
+
+#[test]
+fn psmux_official_llxprt_launch_bypasses_cmd_and_delivers_full_prompt() {
+    let Some((executable, version_text)) = qualified_psmux() else {
+        return;
+    };
+    let mut namespace = namespace_or_panic(executable.clone(), "official-llxprt", &version_text);
+    let fixture = prepare_official_llxprt_fixture();
+    let plan = MultiplexerPlan::for_platform(
+        LocalPlatform::Windows,
+        executable,
+        MultiplexerIsolation::Namespace(namespace.name.clone()),
+    )
+    .unwrap_or_else(|error| panic!("construct psmux plan: {error}"));
+    let launch_args = vec![
+        OsString::from("--record"),
+        fixture.record.as_os_str().to_owned(),
+        OsString::from("--profile-load"),
+        OsString::from("profile"),
+        OsString::from(fixture.prompt.clone()),
+    ];
+    let pane = plan
+        .agent_pane_command_args_with_launcher(
+            &fixture.agent_executable,
+            &launch_args,
+            &[],
+            Path::new(JEFE),
+        )
+        .unwrap_or_else(|error| panic!("build official pane command: {error}"));
+    let mut command = vec![
+        OsString::from("new-session"),
+        OsString::from("-d"),
+        OsString::from("-s"),
+        OsString::from("official-llxprt"),
+        OsString::from("-c"),
+        fixture.work_dir.path().as_os_str().to_owned(),
+    ];
+    command.extend(pane);
+    namespace
+        .run_os(&command)
+        .unwrap_or_else(|error| panic!("launch official fixture through psmux: {error}"));
+    let deadline = Instant::now() + POLL_TIMEOUT;
+    while !fixture.record.is_file() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(50));
+    }
+    assert_official_llxprt_observation(&fixture);
+    if namespace
+        .run(&["has-session", "-t", "official-llxprt"])
+        .is_ok()
+    {
+        namespace
+            .run(&["kill-session", "-t", "official-llxprt"])
+            .unwrap_or_else(|error| panic!("clean up official session: {error}"));
+    }
+}
+
+fn assert_official_llxprt_observation(fixture: &OfficialLlxprtFixture) {
+    let bytes = fs::read(&fixture.record)
+        .unwrap_or_else(|error| panic!("read official observation: {error}"));
+    let observation: LaunchObservation = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|error| panic!("decode official observation: {error}"));
+    assert_eq!(
+        observation.args,
+        ["--profile-load", "profile", &fixture.prompt]
+    );
+    assert!(observation.args.iter().all(|arg| {
+        !Path::new(arg)
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("ts"))
+    }));
+}


### PR DESCRIPTION
## Summary

- recognize the official marked Windows `llxprt.cmd` installation layout
- validate and canonicalize bundled Bun plus `index.ts`, then launch them with structural argv instead of crossing `cmd.exe`
- preserve npm, unmarked command-wrapper, and other agent behavior
- add resolver, launcher, and native psmux coverage using an 8,092-byte prompt

## Why

Sending an issue to LLxprt with `S` on Windows could fail with `The command line is too long`. The prompt had already been removed from the psmux pane command, but the internal launcher still invoked the official `llxprt.cmd`, crossing Windows `cmd.exe`'s command-line limit. This change bypasses that wrapper only when its official native-launcher marker and bundled package layout are both present.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- dedicated complexity Clippy gate
- source-file-size hard gate
- `cargo build --workspace --all-features --locked`
- `cargo test --workspace --all-features --locked`
- coverage: 69.63% lines (minimum 30%)
- native psmux regression: full 8,092-byte prompt delivered intact
- bounded pre-PR Rust audit passed; all in-scope findings addressed

Fixes #433