### PR TITLE
Make Windows agent sessions rebuild-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width 0.2.2",
  "whoami",
+ "win32job",
  "winsafe",
 ]
 
@@ -905,7 +906,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1823,6 +1824,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "win32job"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6a6724ccfbf34154a8691bd868b0fcd2be2ca3f7b47b32614654f1a01b191c"
+dependencies = [
+ "thiserror 1.0.69",
+ "windows",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,10 +1856,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1865,7 +1978,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1882,6 +1995,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ tempfile = "3.0"
 
 [target.'cfg(windows)'.dependencies]
 winsafe = { version = "0.0.27", features = ["kernel"] }
+win32job = "2.0.3"
 whoami = "2.1.2"
 
 [target.'cfg(unix)'.dependencies]
@@ -94,6 +95,11 @@ required-features = ["psmux-smoke"]
 [[bin]]
 name = "jefe-psmux-orphan-fixture"
 path = "tests/fixtures/psmux_orphan_fixture.rs"
+required-features = ["psmux-smoke"]
+
+[[bin]]
+name = "jefe-psmux-session-host-fixture"
+path = "tests/fixtures/psmux_session_host_fixture.rs"
 required-features = ["psmux-smoke"]
 
 [[bin]]

--- a/project-plans/issue467-plan.md
+++ b/project-plans/issue467-plan.md
@@ -1,0 +1,295 @@
+# Issue #467 — Make Windows agent sessions rebuild-safe and reliably reconnectable
+
+## Problem
+
+Native Windows psmux sessions use the currently running dashboard image as each
+pane's long-lived launcher (`jefe.exe --jefe-internal-agent-launch`). Ctrl-Q and
+dashboard crashes correctly leave those sessions alive, but the surviving
+launchers lock the rebuild target. Killing the launchers to unblock a build kills
+the panes and can strand Bun/Node descendants, making terminal reconnection
+impossible. Issue #332/#416 added orphan recovery but not prevention.
+
+## Architecture decision
+
+On Windows, stage an immutable **per-session, content-addressed copy** of the Jefe
+image below the resolved state root and use that copy as the psmux pane host:
+
+```text
+<state-root>/session-hosts/<sanitized-session>/<sha256>/jefe-session-host.exe
+```
+
+The copy—not the build/install target—runs the existing private launch-plan
+entrypoint. The host creates and owns a kill-on-close Windows Job Object before
+spawning the agent worker. The dashboard never owns the Job handle, so dashboard
+quit/crash leaves the psmux host and worker alive. Host death closes the handle
+and terminates the owned worker tree.
+
+The session name makes artifact ownership deterministic, so no state schema
+change is required: restart/kill/delete derive the session directory from the
+existing `RuntimeBinding.session_name`. The binary digest allows old and new
+host images to coexist without overwriting a running Windows image. Existing
+#416 PID-identity-validated orphan reaping remains defense in depth.
+
+The resolved state-file parent is passed to `TmuxRuntimeManager`; production,
+`--config`, `JEFE_STATE_DIR`, and isolated tests therefore use the same path
+authority without process-environment mutation.
+
+### Dependency decision — approved
+
+The existing `winsafe = 0.0.27` kernel feature does **not** expose Job Object
+creation, limit configuration, or process assignment (confirmed against the
+installed crate source). Project source forbids `unsafe`, so direct Win32 FFI is
+not allowed. Completing AC6 requires adding the Windows-only safe wrapper:
+
+```toml
+win32job = "2.0.3"
+```
+
+This crate provides safe `Job::create`, `ExtendedLimitInfo::limit_kill_on_job_close`,
+`Job::set_extended_limit_info`, and `Job::assign_current_process` APIs. The user
+explicitly approved this Windows-target-only dependency on 2026-07-27; Unix and
+remote execution paths remain unchanged.
+
+## Acceptance matrix
+
+| # | Path / boundary | Success | Failure / diagnostic | Proof |
+|---|---|---|---|---|
+| AC1 | Windows local launch | psmux pane command uses immutable copied host outside build target; argv/env/cwd unchanged | typed staging error names operation and safe path; no pane spawned | planner/staging/command tests + native psmux |
+| AC2 | Ctrl-Q, one or multiple agents | dashboard exits; all original panes/workers remain healthy and attachable | no healthy binding is cleared | native lifecycle regression |
+| AC3 | dashboard forced termination | same survival/reconnect behavior as Ctrl-Q | stale/dead pane is diagnosed, not called healthy | native lifecycle regression |
+| AC4 | rebuild/replace after dashboard exit | source `jefe.exe` can be overwritten while sessions run | diagnostics identify source/host/pane when replacement fails | native image-replacement test |
+| AC5 | restart | exact original pane is restored, exactly one worker, no duplicate `--continue` | typed restore result; binding retained when pane is live | manager/startup + native regression |
+| AC6 | pane-host death | Job Object closes and worker descendants terminate; #416 reaper remains fallback | survivors are boundedly detected and reported | native Job Object process-tree test |
+| AC7 | explicit kill/delete | target psmux session and its session-host directory are cleaned; unrelated sessions untouched | cleanup is best effort and retained for retry | cleanup truth table + runtime integration |
+| AC8 | startup cleanup/legacy state | unreferenced, non-running staged versions and interrupted temp files are removed; legacy bindings load unchanged | live/ambiguous artifacts retained and logged | cleanup tests + existing serde suite |
+| AC9 | Unix/remote | existing tmux/remote launch path unchanged | Windows host path never selected | structural tests + full CI |
+| AC10 | end-to-end Windows | multiple agents → quit/crash → replace binary → restart → reconnect all; no duplicate, lock, dead binding, orphan, or unrelated cleanup | namespace-scoped transcript retained | required real-psmux regression |
+
+## Non-goals
+
+- Killing healthy agents when the dashboard exits.
+- Reattaching to arbitrary Bun/Node processes after their PTY pane is dead.
+- Changing remote process ownership or Unix/tmux lifecycle.
+- Replacing existing #416 orphan safeguards.
+- Adding a daemon/supervisor subsystem.
+- Unrelated persistence, UI, or runtime refactoring.
+
+## Vertical slices
+
+### Slice 1 — RED: host staging and command contract
+
+**Rows:** AC1, AC4, AC8, AC9.
+
+**Expected paths:**
+- `src/runtime/session_host.rs` (new)
+- `src/runtime/session_host_tests.rs` (new)
+- `src/runtime/multiplexer.rs`
+- `src/runtime/multiplexer_tests.rs`
+- `src/runtime/mod.rs`
+
+**RED:** tests prove deterministic sanitized/content-addressed paths, copy rather
+than hardlink, idempotent staging, atomic temp cleanup, typed errors, Windows pane
+uses the copy, Unix uses its existing direct command, and a staged running-copy
+fixture does not lock the source image.
+
+**GREEN:** implement pure path planning and Windows staging. Use the repository's
+dependency-free `domain::sha256::Sha256`; no hashing dependency.
+
+### Slice 2 — RED: lifecycle root ownership and cleanup
+
+**Rows:** AC5, AC7, AC8.
+
+**Expected paths:**
+- `src/runtime/manager.rs`
+- `src/runtime/commands.rs`
+- `src/runtime/session_host.rs`
+- `src/main.rs`
+- focused runtime tests
+
+**RED:** explicit resolved state-root reaches local creation; reattach does not
+stage/replace an existing host; kill removes only the target session directory;
+startup cleanup retains referenced/live session directories and removes only
+unreferenced/dead versions.
+
+**GREEN:** add a manager constructor accepting the resolved session-host root,
+thread the session name/root through local launch, and perform bounded,
+agent-scoped cleanup. No `RuntimeBinding` schema change.
+
+### Slice 3 — RED: host-owned Job Object containment
+
+**Rows:** AC3, AC6.
+
+**Expected paths:**
+- `Cargo.toml` / `Cargo.lock` (only after explicit dependency approval)
+- `src/runtime/job_object.rs` (new)
+- `src/runtime/agent_launcher.rs`
+- focused Windows test/fixture
+
+**RED:** a host launches a long-lived child, host termination closes the Job, and
+the child exits within the bound. Dashboard process lifetime is absent from this
+ownership chain.
+
+**GREEN:** create/configure/assign the Job from the private host entrypoint and
+hold its safe handle for the full worker lifetime. Existing Unix code is
+unchanged.
+
+### Slice 4 — RED: native psmux quit/crash/rebuild/reconnect
+
+**Rows:** AC2–AC7, AC10.
+
+**Expected paths:**
+- `tests/psmux_session_host.rs` (new or bounded extension of smoke suite)
+- deterministic fixture under `tests/fixtures/`
+- `Cargo.toml` fixture target if needed
+- `dev-docs/testing/psmux-smoke.md`
+
+**RED:** with a unique `-L` namespace, prove the current source launcher locks the
+source and host death strands a child. Test owns cleanup via Drop and retains a
+transcript.
+
+**GREEN:** two or more staged hosts survive simulated dashboard quit/crash;
+source executable is replaced; same pane PIDs/session names remain; exactly one
+worker per pane; killing one host reaps only its tree; explicit cleanup removes
+only its artifact directory.
+
+## Scope ledger
+
+| Date | Item | Disposition |
+|---|---|---|
+| 2026-07-27 | Issue #467 filed with complete prevention + containment scope | Accepted |
+| 2026-07-27 | Branch `issue467` created from current `origin/main` (`d391efe`) | Accepted |
+| 2026-07-27 | Deep architecture subagent timed out; GLM implementation analysis completed | Recorded |
+| 2026-07-27 | Corrected proposed persistence expansion: session-name-derived ownership avoids a new persisted host-image field | Accepted, reduces scope |
+| 2026-07-27 | Installed winsafe has no Job Object API; safe wrapper dependency is required because repository source forbids unsafe | **Approved by user; Windows target only** |
+| 2026-07-27 | Mandatory scope count: 20 files, 2,693 net lines; complete lifecycle and native regression exceeded the 2,500-line hard threshold | **Approved by user to continue** |
+
+## Expected budget
+
+- Target: 12–18 files, approximately 700–1,200 net lines.
+- Mandatory scope review above 25 files or 1,500 net lines.
+- Hard stop without explicit approval above 40 files or 2,500 net lines.
+- No `.llxprt/`, `.code_puppy/`, `.github/`, workflow, or quality-gate changes.
+
+## Review counters
+
+- OCR pre-PR: 1/2
+- OCR post-PR: 0/2
+
+## Verification evidence
+
+### Slice 3 — host-owned Job Object containment (AC3, AC6)
+
+**Status:** RED → GREEN complete for the in-crate containment boundary.
+
+**Files (within Slice 3 allowlist):**
+- `src/runtime/job_object.rs` (new) — narrow boundary owning every safe
+  `win32job` call: `JobObjectError` (typed create/query/configure/assign),
+  `JobContainment::enable_for_current_process` (create + configure
+  `KILL_ON_JOB_CLOSE` + assign current process), `contain_handle` (cfg(test)
+  helper to contain a spawned child without assigning the test runner).
+- `src/runtime/job_object_tests.rs` (new, `cfg(all(test, windows))`) — three
+  behavioral contracts.
+- `src/runtime/agent_launcher.rs` — `run_launch_plan` establishes containment on
+  Windows before `.status()` and holds the guard for the full worker lifetime;
+  new `AgentLauncherError::ContainmentUnavailable` (cfg(windows)) refuses spawn
+  on failure; Unix path byte-for-byte unchanged.
+- `src/runtime/agent_executable_tests.rs` — contract test asserting the typed
+  containment refusal diagnostic on Windows and the absence of any containment
+  mention on Unix.
+- `src/runtime/mod.rs` — module wiring (`#[cfg(windows)] mod job_object;` and
+  the cfg-gated test module).
+- `Cargo.toml` / `Cargo.lock` — `win32job = "2.0.3"` under
+  `[target.'cfg(windows)'.dependencies]` (pre-approved dependency, unchanged).
+
+**RED evidence:** the two behavioral tests
+(`enabling_containment_for_current_process_yields_kill_on_job_close_guard`,
+`native_kill_on_job_close_terminates_a_contained_descendant_within_bound`)
+failed against the stub with
+`failed to create windows job object` before the win32job-backed GREEN landed.
+
+**GREEN evidence (native Windows, `CARGO_TARGET_DIR=target/issue467`):**
+```
+test runtime::job_object_tests::enabling_containment_for_current_process_yields_kill_on_job_close_guard ... ok
+test runtime::job_object_tests::job_object_error_variants_are_typed_and_name_the_failing_operation ... ok
+test runtime::job_object_tests::native_kill_on_job_close_terminates_a_contained_descendant_within_bound ... ok
+test result: ok. 3 passed; 0 failed
+```
+The native containment proof spawns a long-lived `ping` child, contains ONLY the
+spawned child (never the test runner — the guard's `enable_for_current_process`
+path is invoked with `mem::forget` so its handle never closes mid-suite), then
+drops the guard and asserts the child exits within a 5s bound — proving
+`KILL_ON_JOB_CLOSE` reaps the descendant tree on handle release.
+
+Full runtime lib suite green (339 passed, 0 failed) confirms the
+`run_launch_plan` wiring introduced no regressions.
+
+**AC3 ownership:** the dashboard process is absent from the Job ownership chain.
+The Job handle lives only inside `run_launch_plan` (the private pane host
+entrypoint), so a dashboard quit/crash cannot close it. AC3 native lifecycle
+proof is owned by Slice 4.
+
+**Safety:** no `unsafe` in Jefe source (crate-level `unsafe_code = "forbid"`);
+all Win32 interaction is via the safe `win32job` wrapper.
+
+**Native host-death proof (full AC6 end-to-end):** the in-crate test proves the
+kernel mechanism (Job handle release → contained descendant termination within
+bound). A dedicated subprocess fixture proving *host-process-exit* closes the
+owned handle and reaps the worker tree is deferred to Slice 4, which owns the
+native psmux regression; Slice 3 must not add a Cargo bin fixture outside its
+allowlist.
+
+### Slice 3 verification gap (pre-existing, not introduced here)
+
+`cargo fmt --all --check` and
+`cargo clippy --workspace --all-targets --all-features -- -D warnings` do not
+pass on the current working tree because of **pre-existing Slice 1/2** fmt diffs
+and one clippy `too many arguments` error in `src/runtime/commands.rs` /
+`session_host.rs` / `session_host_tests.rs` / `main.rs`. Slice 3 is forbidden
+from modifying Slice 2 files, so those gates cannot be cleared from this slice.
+Slice 3's own files (`job_object.rs`, `job_object_tests.rs`, `agent_launcher.rs`,
+`agent_executable_tests.rs`, `mod.rs` additions) are individually fmt- and
+clippy-clean.
+
+Required exact-head gates:
+
+```text
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo build --workspace --all-features --locked
+cargo test --workspace --all-features --locked
+```
+
+Native Windows proof:
+
+```text
+JEFE_REQUIRE_PSMUX=1 cargo test --features psmux-smoke --test psmux_session_host -- --nocapture
+```
+
+### Slice 4 and exact-head evidence
+
+- Native Windows psmux lifecycle: `JEFE_REQUIRE_PSMUX=1 cargo test --features
+  psmux-smoke --test psmux_session_host -- --nocapture` — **1 passed, 0 failed**.
+- `cargo fmt --all --check` — passed.
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passed.
+- `cargo build --workspace --all-features --locked` — passed with
+  `CARGO_TARGET_DIR=target/issue467` so legacy running Jefe images do not lock
+  the candidate build output.
+- `cargo test --workspace --all-features --locked` — all issue-relevant and
+  library targets passed; the pre-existing native `tests/psmux_attach.rs`
+  input-byte contract fails in isolation with unrelated extra terminal input.
+  No issue #467 file modifies that test or its attach/input route.
+
+### Pre-PR review 1 triage
+
+- **In-scope—Fix:** preserve staging failures as typed
+  `RuntimeError::SessionHostStaging(SessionHostError)` — fixed.
+- **In-scope—Fix:** remove unused no-Job fixture/test-driver scaffolding — fixed.
+- **Reject:** Job-guard `mem::forget` in the isolated test and fixture — required
+  to keep the kill-on-close handle alive until host process termination.
+- **Reject:** startup/kill cleanup concurrency and scoping concerns — retained
+  directories are live, referenced, unprobeable, or ambiguous; removal is only
+  for missing unreferenced sessions and target-session explicit cleanup.
+
+## Deferred findings
+
+None. Every accepted behavior AC1–AC10 is in scope; no prevention work is deferred.

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -38,6 +38,34 @@ fn append_warning(state: &mut AppState, warning: String) {
     });
 }
 
+/// Run the issue #467 AC8 startup session-host cleanup.
+///
+/// Supplies the persisted `RuntimeBinding.session_name` references for every
+/// Running agent and probes live local sessions before any directory is
+/// deleted. Remote sessions never own a local host image and are excluded
+/// from the reference set because their session-host directory is never
+/// staged. A cleanup failure is logged and never aborts startup.
+fn run_startup_session_host_cleanup(state: &AppState, runtime: &TmuxRuntimeManager) {
+    let Some(root) = runtime.session_host_root() else {
+        return;
+    };
+    let persisted_references: Vec<String> = state
+        .agents
+        .iter()
+        .filter(|agent| agent.status == AgentStatus::Running)
+        .filter_map(|agent| agent.runtime_binding.as_ref())
+        .map(|binding| binding.session_name.clone())
+        .collect();
+    // The manager probes live local sessions before deletion; a session whose
+    // probe cannot be classified is retained rather than risk deleting a live
+    // session whose probe transiently failed.
+    let probe = jefe::runtime::session_liveness;
+    let _ = jefe::runtime::startup_cleanup_session_hosts(root, &persisted_references, probe)
+        .map_err(|error| {
+            warn!(error = %error, "session-host startup cleanup failed; retained for next startup");
+        });
+}
+
 fn normalize_persisted_sandbox_engines(state: &mut AppState) -> bool {
     let caps = PlatformCapabilities::current();
     let mut normalized_agent_count = 0usize;
@@ -282,6 +310,12 @@ pub fn init_app_state(app_state: &mut HookState<AppState>, ctx: &SharedContext) 
     let normalized_engines = normalize_persisted_sandbox_engines(&mut state);
 
     let dead_ids = reconcile_running_agents(&state, &ctx_guard.runtime);
+    // Issue #467 AC8: sweep the session-host root before applying
+    // reconciliations so unreferenced/dead directories and interrupted staging
+    // temps are reclaimed, while live psmux sessions and persisted-reference
+    // directories are retained. Best-effort: a failure is logged and never
+    // aborts startup.
+    run_startup_session_host_cleanup(&state, &ctx_guard.runtime);
     let should_persist = apply_dead_reconciliations(&mut state, dead_ids, normalized_engines);
     // The persist worker is not running yet, so startup reconciliation writes
     // its candidate synchronously through the manager.

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,19 @@ fn dispatch_recovery_command(cli_args: &jefe::cli::CliArgs) -> bool {
     true
 }
 
+fn runtime_manager(rows: u16, cols: u16, state_path: &std::path::Path) -> TmuxRuntimeManager {
+    state_path.parent().map_or_else(
+        || TmuxRuntimeManager::new(rows, cols),
+        |parent| {
+            TmuxRuntimeManager::with_session_host_root(
+                rows,
+                cols,
+                parent.join(jefe::runtime::SESSION_HOST_ROOT_SEGMENT),
+            )
+        },
+    )
+}
+
 fn main() {
     run_internal_agent_launch_if_requested();
     let Some(cli_args) = parse_cli_or_exit() else {
@@ -230,7 +243,7 @@ fn main() {
 
     let mut theme_manager = FileThemeManager::new();
     theme_manager.load_from_dir(&themes_dir);
-    let runtime = TmuxRuntimeManager::new(pty_rows, pty_cols);
+    let runtime = runtime_manager(pty_rows, pty_cols, &startup.paths.state.path);
 
     let persist_handle =
         jefe::services::persist_worker::PersistHandle::new(build_persist_fn(persist_paths));

--- a/src/runtime/agent_executable_tests.rs
+++ b/src/runtime/agent_executable_tests.rs
@@ -367,3 +367,52 @@ fn windows_oversized_marked_llxprt_wrapper_is_not_treated_as_official() {
     assert_eq!(executable.wrapper_kind(), AgentWrapperKind::CommandScript);
     assert!(executable.script_launch_plan().is_none());
 }
+
+// Issue #467 Slice 3 (AC6): the private pane host must establish Windows Job
+// Object containment before spawning the worker, and any failure to do so must
+// surface as a typed refusal that names containment so the host never starts a
+// descendant tree it cannot reliably reap.
+#[test]
+fn agent_launcher_error_names_windows_containment_refusal() {
+    use super::agent_launcher::AgentLauncherError;
+
+    #[cfg(windows)]
+    {
+        let message = AgentLauncherError::ContainmentUnavailable.to_string();
+        assert!(
+            message.contains("containment"),
+            "containment refusal must name the failing concern: got {message}"
+        );
+        assert!(
+            message.contains("job object"),
+            "containment refusal must name the job object: got {message}"
+        );
+        assert!(
+            !message.contains("0x"),
+            "containment refusal must not leak raw handle values: got {message}"
+        );
+    }
+
+    #[cfg(not(windows))]
+    {
+        // Unix keeps the launch path exactly as before: containment is absent
+        // from both the error surface and the spawn path.
+        let variants = [
+            AgentLauncherError::InvalidPlan,
+            AgentLauncherError::PlanSerializationFailed,
+            AgentLauncherError::PlanCreateFailed,
+            AgentLauncherError::PlanWriteFailed,
+            AgentLauncherError::PlanReadFailed,
+            AgentLauncherError::InvalidPlanPayload,
+            AgentLauncherError::CleanupFailed,
+            AgentLauncherError::LaunchFailed,
+        ];
+        for variant in variants {
+            assert!(
+                !variant.to_string().contains("containment"),
+                "Unix launch errors must not mention containment: {}",
+                variant
+            );
+        }
+    }
+}

--- a/src/runtime/agent_executable_tests.rs
+++ b/src/runtime/agent_executable_tests.rs
@@ -410,8 +410,7 @@ fn agent_launcher_error_names_windows_containment_refusal() {
         for variant in variants {
             assert!(
                 !variant.to_string().contains("containment"),
-                "Unix launch errors must not mention containment: {}",
-                variant
+                "Unix launch errors must not mention containment: {variant}"
             );
         }
     }

--- a/src/runtime/agent_launcher.rs
+++ b/src/runtime/agent_launcher.rs
@@ -105,9 +105,31 @@ pub fn run_launch_plan(path: &Path) -> Result<ExitStatus, AgentLauncherError> {
         command.env_remove(variable);
     }
     command.envs(payload.environment);
+
+    // Issue #467 Slice 3 (AC6): on Windows the private pane host owns a
+    // kill-on-close Job Object and assigns itself before spawning the worker so
+    // the whole descendant tree inherits containment. The guard is held until
+    // `status()` returns; host death closes the handle and the kernel reaps the
+    // tree, while normal worker completion still returns the exit status. A
+    // failure to establish containment is typed and refuses spawn so a host can
+    // never start a tree it cannot contain. Unix behaviour is unchanged.
+    #[cfg(windows)]
+    let _containment = establish_worker_containment()?;
+
     command
         .status()
         .map_err(|_| AgentLauncherError::LaunchFailed)
+}
+
+#[cfg(windows)]
+fn establish_worker_containment() -> Result<super::job_object::JobContainment, AgentLauncherError> {
+    super::job_object::JobContainment::enable_for_current_process().map_err(|error| {
+        tracing::error!(
+            error = %error,
+            "windows job object containment unavailable; refusing to spawn agent worker"
+        );
+        AgentLauncherError::ContainmentUnavailable
+    })
 }
 fn valid_launch_plan_path(path: &Path) -> bool {
     let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
@@ -210,6 +232,11 @@ pub enum AgentLauncherError {
     InvalidPlanPayload,
     CleanupFailed,
     LaunchFailed,
+    /// Windows Job Object containment could not be established before spawning
+    /// the worker (issue #467 Slice 3). Worker spawn is refused so a host can
+    /// never start a descendant tree it cannot reliably contain.
+    #[cfg(windows)]
+    ContainmentUnavailable,
 }
 
 impl std::fmt::Display for AgentLauncherError {
@@ -233,6 +260,10 @@ impl std::fmt::Display for AgentLauncherError {
             }
             Self::CleanupFailed => formatter.write_str("internal agent launch plan cleanup failed"),
             Self::LaunchFailed => formatter.write_str("agent process could not be started"),
+            #[cfg(windows)]
+            Self::ContainmentUnavailable => formatter.write_str(
+                "windows job object containment could not be established for agent worker",
+            ),
         }
     }
 }

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -717,6 +717,7 @@ fn local_launch_command(
     session_name: &str,
     work_dir: &Path,
     launch: &LocalLaunchPlan,
+    session_host_root: Option<&Path>,
 ) -> Result<Command, RuntimeError> {
     let multiplexer = MultiplexerPlan::current().map_err(RuntimeError::Multiplexer)?;
     let mut cmd = multiplexer.command();
@@ -726,12 +727,9 @@ fn local_launch_command(
         .arg(session_name)
         .arg("-c")
         .arg(work_dir);
-
     let executable = if let Some(bin_dir) = &launch.managed_bin_dir {
         // Issue #425: resolve the cached `llxprt` binary from the jefe-managed
-        // install dir so the work directory's `node_modules` cannot shadow
-        // the pinned version. `try_local_create_session` already ran
-        // `ensure_installed` so the bin dir exists.
+        // install dir so the work directory's `node_modules` cannot shadow it.
         super::llxprt_install::resolve_managed_executable(bin_dir, launch.executable)?
     } else {
         AgentExecutableResolver::current()
@@ -743,34 +741,44 @@ fn local_launch_command(
         &executable,
         &launch.env,
         &launch.args,
+        session_host_root.map(|root| (root, session_name)),
         &mut cmd,
     )?;
     Ok(cmd)
 }
 
-/// Drive `MultiplexerPlan::agent_pane_command_args`, converting env and args
-/// to `OsString` and forwarding them to `cmd`. Split out so `local_launch_command`
-/// stays compact.
+/// Build the multiplexer pane-command argv. Issue #467: on Windows with an
+/// explicit session-host root, stage `current_exe()` and launch the staged
+/// copy; otherwise the direct agent launch path is preserved (AC9).
 fn multiplexer_pane_args(
     multiplexer: &MultiplexerPlan,
     executable: &super::agent_executable::ResolvedAgentExecutable,
     env: &[(String, String)],
     args: &[String],
+    session_host: Option<(&Path, &str)>,
     cmd: &mut Command,
 ) -> Result<(), RuntimeError> {
-    let pane_args = args.iter().map(OsString::from).collect::<Vec<_>>();
-    let environment = env
+    let pane_args: Vec<OsString> = args.iter().map(OsString::from).collect();
+    let environment: Vec<(OsString, OsString)> = env
         .iter()
-        .map(|(key, value)| (OsString::from(key), OsString::from(value)))
-        .collect::<Vec<_>>();
-    for arg in multiplexer
-        .agent_pane_command_args(executable, &pane_args, &environment)
-        .map_err(RuntimeError::Multiplexer)?
-    {
+        .map(|(k, v)| (OsString::from(k), OsString::from(v)))
+        .collect();
+    let pane_command = super::session_host::resolve_local_pane_command(
+        multiplexer,
+        executable,
+        &pane_args,
+        &environment,
+        session_host,
+    )?;
+    for arg in pane_command {
         cmd.arg(arg);
     }
     Ok(())
 }
+
+// Re-exported for the local-launch staging-decision test.
+#[cfg(test)]
+use super::session_host::session_host_stage_request;
 
 /// Build the Unix pane-command argv for remote shell construction and
 /// regression tests. Local runtime launch uses `MultiplexerPlan::pane_command_args`
@@ -802,19 +810,17 @@ fn try_local_create_session(
     work_dir: &Path,
     signature: &LaunchSignature,
     attempt: u8,
+    session_host_root: Option<&Path>,
 ) -> Result<(), LocalCreateFailure> {
     let plan = local_launch_plan(signature);
     if let Some(selector) = commands_launch_parts::versioned_local_selector(signature) {
         // Issue #425: ensure the jefe-managed install exists before resolving
-        // the cached binary. The install happens here (not in
-        // `local_launch_command`) so a failure surfaces as a launch failure
-        // with the typed install error rather than a missing-binary
-        // SpawnFailed.
+        // the cached binary so a failure surfaces as a typed install error.
         super::llxprt_install::ensure_installed(selector)
             .map_err(|error| LocalCreateFailure::Runtime(RuntimeError::LlxprtInstall(error)))?;
     }
-    let mut cmd =
-        local_launch_command(session_name, work_dir, &plan).map_err(LocalCreateFailure::Runtime)?;
+    let mut cmd = local_launch_command(session_name, work_dir, &plan, session_host_root)
+        .map_err(LocalCreateFailure::Runtime)?;
     debug!(session_name = %session_name, attempt, "create_session invoking local multiplexer new-session");
 
     let output = cmd
@@ -851,16 +857,13 @@ fn local_spawn_error(session_name: &str, attempt: u8, stderr: String) -> Runtime
     RuntimeError::SpawnFailed(format!("tmux new-session failed: {stderr}"))
 }
 
-/// Create a new detached tmux session running llxprt.
-///
-/// The session runs `llxprt` directly (not a shell), so when llxprt exits,
-/// the tmux session becomes "dead" until explicit relaunch.
-///
-/// @pseudocode component-002 lines 01-06
+/// Create a detached agent session, staging the Windows pane host below the
+/// supplied root while leaving remote and Unix launch paths unchanged.
 pub fn create_session(
     session_name: &str,
     work_dir: &Path,
     signature: &LaunchSignature,
+    session_host_root: Option<&Path>,
 ) -> Result<(), RuntimeError> {
     debug!(session_name = %session_name, work_dir = %work_dir.display(), "create_session start");
     if remote_is_enabled(&signature.remote) {
@@ -877,13 +880,11 @@ pub fn create_session(
         .map_err(RuntimeError::Multiplexer)?;
 
     let _ = kill_session(session_name);
-    match try_local_create_session(session_name, work_dir, signature, 0) {
+    match try_local_create_session(session_name, work_dir, signature, 0, session_host_root) {
         Ok(()) => return Ok(()),
         Err(LocalCreateFailure::Runtime(error)) => return Err(error),
         Err(LocalCreateFailure::Command(stderr)) if is_tmux_fork_broken(&stderr) => {
             debug!(session_name = %session_name, attempt = 0, stderr = %stderr, "create_session retrying after multiplexer fork failure");
-            // Scoped recovery: kill only this one target session in Jefe's
-            // private isolation handle. Never terminate the whole server.
             let _ = kill_session(session_name);
         }
         Err(LocalCreateFailure::Command(stderr)) => {
@@ -891,7 +892,7 @@ pub fn create_session(
         }
     }
 
-    match try_local_create_session(session_name, work_dir, signature, 1) {
+    match try_local_create_session(session_name, work_dir, signature, 1, session_host_root) {
         Ok(()) => Ok(()),
         Err(LocalCreateFailure::Runtime(error)) => Err(error),
         Err(LocalCreateFailure::Command(stderr)) => Err(local_spawn_error(session_name, 1, stderr)),

--- a/src/runtime/commands_tests.rs
+++ b/src/runtime/commands_tests.rs
@@ -15,7 +15,7 @@ fn remote_attach_plan_uses_direct_ssh_and_excludes_local_psmux_namespace() {
         login_user: "ubuntu".to_owned(),
         host: "linux.example".to_owned(),
         port: Some(2222),
-        identity_file: std::path::PathBuf::from(r"C:\Keys Ω\agent key"),
+        identity_file: std::path::PathBuf::from(r"C:\Keys Î©\agent key"),
         options: vec!["Compression=yes".to_owned()],
         ..crate::domain::RemoteRepositorySettings::default()
     };
@@ -183,7 +183,7 @@ fn code_puppy_fresh_prompt_keeps_model_before_instruction() {
 /// [`local_pane_command_args`] so the llxprt child never sees a stale debug
 /// flag.
 ///
-/// Drives the real production path (`local_launch_plan` →
+/// Drives the real production path (`local_launch_plan` â†’
 /// `local_pane_command_args`) rather than re-deriving the env vector inline,
 /// so a regression in the env-building logic (a new condition, a renamed key)
 /// is caught here (#173).
@@ -324,7 +324,7 @@ fn command_capture_timeout_terminates_descendant_process_group() {
 /// [`local_pane_command_args`] verbatim (single argv entry, no extra quoting),
 /// so the llxprt child inherits the intended debug level.
 ///
-/// Drives the real production path (`local_launch_plan` →
+/// Drives the real production path (`local_launch_plan` â†’
 /// `local_pane_command_args`) instead of re-deriving the env vector inline
 /// (#173).
 #[test]
@@ -604,10 +604,10 @@ fn remote_launch_command_scrubs_tmux_env_from_pane() {
 /// `SANDBOX_FLAGS` must reach the local pane command as a single raw
 /// `SANDBOX_FLAGS=--cpus=2 --memory=12288m --pids-limit=256` argv entry (no
 /// shell quoting), because tmux passes each argv element to `sh -c` as one
-/// token — shell-quoting the value would embed literal quote chars in the env
+/// token â€” shell-quoting the value would embed literal quote chars in the env
 /// var the agent child sees.
 ///
-/// Drives the real production path (`local_launch_plan` →
+/// Drives the real production path (`local_launch_plan` â†’
 /// `local_pane_command_args`) with `sandbox_enabled: true` and asserts the raw
 /// argv entry appears, rather than re-deriving `format!` output (#173).
 #[test]
@@ -738,7 +738,7 @@ fn code_puppy_launch_uses_only_supported_args() {
     assert!(!pane_args.iter().any(|arg| arg == "--profile-load"));
 }
 
-// ── Code Puppy strict args (issue #184) ───────────────────────────────────
+// â”€â”€ Code Puppy strict args (issue #184) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 //
 // Code Puppy outputs interactive mode plus its typed YOLO value for normal
 // launches, and appends one positional instruction for fresh sends. Arbitrary
@@ -817,7 +817,7 @@ fn code_puppy_discards_unrecognized_positional_flags() {
     assert_eq!(launch_args(&signature), vec!["-i", "--yolo", "false"]);
 }
 
-// ── Issue #198: history-aware capture-pane argv builder ───────────────────
+// â”€â”€ Issue #198: history-aware capture-pane argv builder â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 //
 // `capture-pane -p -S -<N> -E -` captures the last N lines of tmux scrollback
 // history including the visible pane. The argv builder is a pure function so
@@ -883,7 +883,7 @@ fn capture_pane_history_argv_zero_lines_clamps_to_one() {
     };
     assert_eq!(*s_value, "-1", "zero lines should clamp to -S -1");
 }
-// ── Issue #465: Windows psmux root-table PageUp unbind ────────────────────
+// â”€â”€ Issue #465: Windows psmux root-table PageUp unbind â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 //
 // `configure_prefix_with` must unbind `PageUp` from the psmux root table on
 // Windows so the default `PageUp -> copy-mode -u` binding cannot consume bare
@@ -925,4 +925,69 @@ fn windows_configure_prefix_unbinds_page_up_from_root_table() {
             "Unix configure_prefix_with must not emit any unbind-key command; calls: {calls:?}"
         );
     }
+}
+
+// â”€â”€ Issue #467 Slice 2: local launch host-staging decision (AC1, AC9) â”€â”€â”€â”€â”€â”€
+//
+// On native Windows, a fresh local creation with an explicit session-host root
+// stages std::env::current_exe() below the manager's root and the psmux pane
+// launches the staged copy through the existing private launch-plan entrypoint
+// (never the agent argv directly). On Unix, or whenever no root is supplied,
+// staging must not occur so the structurally unchanged tmux/SSH launch path is
+// preserved.
+//
+// The decision is pure so it can be exercised deterministically on every CI
+// platform; the Windows-only staging side effect is covered by the cfg(windows)
+// integration test below.
+
+/// Pure decision helper that returns whether the local launch should stage a
+/// session host, and if so, the (root, session_name) pair to stage under.
+fn session_host_stage_request<'a>(
+    root: Option<&'a std::path::Path>,
+    session_name: Option<&'a str>,
+) -> Option<(&'a std::path::Path, &'a str)> {
+    super::session_host_stage_request(root, session_name)
+}
+
+#[test]
+fn stage_request_is_none_when_no_root_is_supplied() {
+    assert!(
+        session_host_stage_request(None, Some("jefe-agent-1")).is_none(),
+        "no session-host root means staging must not occur"
+    );
+}
+
+#[test]
+fn stage_request_is_none_when_no_session_name_is_supplied() {
+    let root = std::path::PathBuf::from("/state/session-hosts");
+    assert!(
+        session_host_stage_request(Some(&root), None).is_none(),
+        "no session name means staging must not occur"
+    );
+}
+
+#[test]
+fn stage_request_is_none_on_unix_even_when_root_and_name_are_supplied() {
+    // AC9: Unix and remote launch paths never stage a host. The decision helper
+    // is platform-gated so the Windows-only staging code path is compiled out of
+    // Unix targets entirely.
+    if !cfg!(windows) {
+        let root = std::path::PathBuf::from("/state/session-hosts");
+        assert!(
+            session_host_stage_request(Some(&root), Some("jefe-agent-1")).is_none(),
+            "Unix local launch must never stage a session host"
+        );
+    }
+}
+
+#[test]
+#[cfg(windows)]
+fn stage_request_returns_root_and_name_on_windows_when_both_supplied() {
+    // AC1: on Windows the manager's explicit session-host root reaches local
+    // creation, and staging is requested for the resolved session name.
+    let root = std::path::PathBuf::from("C:/State/session-hosts");
+    let request = session_host_stage_request(Some(&root), Some("jefe-agent-1"))
+        .unwrap_or_else(|| panic!("Windows local launch with a root must request staging"));
+    assert_eq!(request.0, std::path::Path::new("C:/State/session-hosts"));
+    assert_eq!(request.1, "jefe-agent-1");
 }

--- a/src/runtime/commands_tests.rs
+++ b/src/runtime/commands_tests.rs
@@ -15,7 +15,7 @@ fn remote_attach_plan_uses_direct_ssh_and_excludes_local_psmux_namespace() {
         login_user: "ubuntu".to_owned(),
         host: "linux.example".to_owned(),
         port: Some(2222),
-        identity_file: std::path::PathBuf::from(r"C:\Keys Î©\agent key"),
+        identity_file: std::path::PathBuf::from(r"C:\Keys Ω\agent key"),
         options: vec!["Compression=yes".to_owned()],
         ..crate::domain::RemoteRepositorySettings::default()
     };
@@ -183,7 +183,7 @@ fn code_puppy_fresh_prompt_keeps_model_before_instruction() {
 /// [`local_pane_command_args`] so the llxprt child never sees a stale debug
 /// flag.
 ///
-/// Drives the real production path (`local_launch_plan` â†’
+/// Drives the real production path (`local_launch_plan` →
 /// `local_pane_command_args`) rather than re-deriving the env vector inline,
 /// so a regression in the env-building logic (a new condition, a renamed key)
 /// is caught here (#173).
@@ -324,7 +324,7 @@ fn command_capture_timeout_terminates_descendant_process_group() {
 /// [`local_pane_command_args`] verbatim (single argv entry, no extra quoting),
 /// so the llxprt child inherits the intended debug level.
 ///
-/// Drives the real production path (`local_launch_plan` â†’
+/// Drives the real production path (`local_launch_plan` →
 /// `local_pane_command_args`) instead of re-deriving the env vector inline
 /// (#173).
 #[test]
@@ -604,10 +604,10 @@ fn remote_launch_command_scrubs_tmux_env_from_pane() {
 /// `SANDBOX_FLAGS` must reach the local pane command as a single raw
 /// `SANDBOX_FLAGS=--cpus=2 --memory=12288m --pids-limit=256` argv entry (no
 /// shell quoting), because tmux passes each argv element to `sh -c` as one
-/// token â€” shell-quoting the value would embed literal quote chars in the env
+/// token — shell-quoting the value would embed literal quote chars in the env
 /// var the agent child sees.
 ///
-/// Drives the real production path (`local_launch_plan` â†’
+/// Drives the real production path (`local_launch_plan` →
 /// `local_pane_command_args`) with `sandbox_enabled: true` and asserts the raw
 /// argv entry appears, rather than re-deriving `format!` output (#173).
 #[test]
@@ -738,7 +738,7 @@ fn code_puppy_launch_uses_only_supported_args() {
     assert!(!pane_args.iter().any(|arg| arg == "--profile-load"));
 }
 
-// â”€â”€ Code Puppy strict args (issue #184) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Code Puppy strict args (issue #184) ───────────────────────────────────
 //
 // Code Puppy outputs interactive mode plus its typed YOLO value for normal
 // launches, and appends one positional instruction for fresh sends. Arbitrary
@@ -817,7 +817,7 @@ fn code_puppy_discards_unrecognized_positional_flags() {
     assert_eq!(launch_args(&signature), vec!["-i", "--yolo", "false"]);
 }
 
-// â”€â”€ Issue #198: history-aware capture-pane argv builder â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Issue #198: history-aware capture-pane argv builder ───────────────────
 //
 // `capture-pane -p -S -<N> -E -` captures the last N lines of tmux scrollback
 // history including the visible pane. The argv builder is a pure function so
@@ -883,7 +883,7 @@ fn capture_pane_history_argv_zero_lines_clamps_to_one() {
     };
     assert_eq!(*s_value, "-1", "zero lines should clamp to -S -1");
 }
-// â”€â”€ Issue #465: Windows psmux root-table PageUp unbind â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Issue #465: Windows psmux root-table PageUp unbind ────────────────────
 //
 // `configure_prefix_with` must unbind `PageUp` from the psmux root table on
 // Windows so the default `PageUp -> copy-mode -u` binding cannot consume bare
@@ -927,7 +927,7 @@ fn windows_configure_prefix_unbinds_page_up_from_root_table() {
     }
 }
 
-// â”€â”€ Issue #467 Slice 2: local launch host-staging decision (AC1, AC9) â”€â”€â”€â”€â”€â”€
+// Issue #467 Slice 2: local launch host-staging decision (AC1, AC9)
 //
 // On native Windows, a fresh local creation with an explicit session-host root
 // stages std::env::current_exe() below the manager's root and the psmux pane

--- a/src/runtime/errors.rs
+++ b/src/runtime/errors.rs
@@ -9,6 +9,7 @@ use super::agent_executable::AgentExecutableError;
 use super::llxprt_install::LlxprtInstallError;
 use super::multiplexer::MultiplexerError;
 use super::package_probe::NpmPackageAvailabilityError;
+use super::session_host::SessionHostError;
 
 /// Errors from runtime operations.
 #[derive(Debug, Clone)]
@@ -19,6 +20,8 @@ pub enum RuntimeError {
     AttachFailed(String),
     /// Failed to spawn session.
     SpawnFailed(String),
+    /// The immutable Windows pane host could not be staged.
+    SessionHostStaging(SessionHostError),
     /// Local agent executable resolution or launch-strategy failure.
     AgentExecutable(AgentExecutableError),
     /// npm or the requested LLxprt package is unavailable on the effective target.
@@ -58,6 +61,7 @@ impl std::fmt::Display for RuntimeError {
             Self::SessionNotFound(name) => write!(f, "session not found: {name}"),
             Self::AttachFailed(msg) => write!(f, "attach failed: {msg}"),
             Self::SpawnFailed(msg) => write!(f, "spawn failed: {msg}"),
+            Self::SessionHostStaging(error) => write!(f, "session host staging failed: {error}"),
             Self::AgentExecutable(error) => write!(f, "agent launch unavailable: {error}"),
             Self::NpmPackageAvailability(error) => write!(f, "agent launch unavailable: {error}"),
             Self::LlxprtInstall(error) => write!(f, "llxprt install failed: {error}"),
@@ -80,4 +84,11 @@ impl std::fmt::Display for RuntimeError {
     }
 }
 
-impl std::error::Error for RuntimeError {}
+impl std::error::Error for RuntimeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::SessionHostStaging(error) => Some(error),
+            _ => None,
+        }
+    }
+}

--- a/src/runtime/job_object.rs
+++ b/src/runtime/job_object.rs
@@ -91,7 +91,6 @@ pub struct JobContainment {
     // Written on construction; read by `is_kill_on_job_close_active`, which is a
     // public contract asserted by the test suite (the lib path trusts the flag
     // unconditionally once construction succeeds).
-    #[allow(dead_code)]
     kill_on_job_close_active: bool,
 }
 

--- a/src/runtime/job_object.rs
+++ b/src/runtime/job_object.rs
@@ -1,0 +1,148 @@
+//! Windows Job Object containment boundary (issue #467 Slice 3).
+//!
+//! Native Windows psmux panes run a staged host copy of the Jefe image as the
+//! long-lived launcher. The host creates and owns a kill-on-close Job Object
+//! before spawning the agent worker and holds the handle for the worker's whole
+//! lifetime, so a host crash/exit closes the handle and the kernel terminates
+//! the owned descendant tree. The dashboard never owns this handle, so a
+//! dashboard quit/crash leaves the host and worker alive (AC3); only host death
+//! reaps the tree (AC6).
+//!
+//! This module is the narrow boundary that owns every `win32job` call so the
+//! rest of the runtime depends only on the typed `JobContainment` /
+//! `JobObjectError` contract. The crate forbids `unsafe` in Jefe source; all
+//! Win32 interaction stays inside the safe `win32job` wrapper.
+
+#![cfg(windows)]
+
+use std::io;
+
+use win32job::Job;
+
+/// Typed failure for Job Object create/query/configure/assign operations.
+///
+/// Each variant names the failing operation so callers can surface an actionable
+/// diagnostic without leaking raw Win32 HANDLE values.
+#[derive(Debug)]
+pub enum JobObjectError {
+    /// `CreateJobObjectW` failed.
+    Create(io::Error),
+    /// `QueryInformationJobObject` failed.
+    Query(io::Error),
+    /// `SetInformationJobObject` (kill-on-close configuration) failed.
+    Configure(io::Error),
+    /// `AssignProcessToJobObject` failed.
+    Assign(io::Error),
+}
+
+impl From<win32job::JobError> for JobObjectError {
+    fn from(error: win32job::JobError) -> Self {
+        match error {
+            win32job::JobError::CreateFailed(inner) => Self::Create(inner),
+            win32job::JobError::GetInfoFailed(inner) => Self::Query(inner),
+            win32job::JobError::SetInfoFailed(inner) => Self::Configure(inner),
+            win32job::JobError::AssignFailed(inner) => Self::Assign(inner),
+            // `JobError` is non_exhaustive; future variants are still job-setup
+            // failures and surface as a configuration error so callers always see
+            // a typed, actionable diagnostic.
+            other => Self::Configure(io::Error::other(other.to_string())),
+        }
+    }
+}
+
+impl std::fmt::Display for JobObjectError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Create(_) => formatter.write_str("failed to create windows job object"),
+            Self::Query(_) => formatter.write_str("failed to query windows job object limits"),
+            Self::Configure(_) => {
+                formatter.write_str("failed to configure windows job object kill-on-close")
+            }
+            Self::Assign(_) => {
+                formatter.write_str("failed to assign process to windows job object")
+            }
+        }
+    }
+}
+
+impl std::error::Error for JobObjectError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Create(inner)
+            | Self::Query(inner)
+            | Self::Configure(inner)
+            | Self::Assign(inner) => Some(inner),
+        }
+    }
+}
+
+/// Owns a kill-on-close Windows Job Object handle for the lifetime of a host
+/// process tree.
+///
+/// Dropping the guard closes the underlying Job handle. When
+/// `KILL_ON_JOB_CLOSE` is configured, the kernel terminates every process still
+/// assigned to the Job at that point, which is the containment guarantee relied
+/// on by the private pane-host entrypoint.
+pub struct JobContainment {
+    // Held solely for its Drop side-effect: dropping the Job closes the kernel
+    // handle and, with KILL_ON_JOB_CLOSE set, terminates the contained tree.
+    #[allow(dead_code)]
+    job: Job,
+    // Written on construction; read by `is_kill_on_job_close_active`, which is a
+    // public contract asserted by the test suite (the lib path trusts the flag
+    // unconditionally once construction succeeds).
+    #[allow(dead_code)]
+    kill_on_job_close_active: bool,
+}
+
+impl JobContainment {
+    /// Create and configure a kill-on-close Job, then assign the current
+    /// process so spawned descendants inherit containment.
+    ///
+    /// This is the production entrypoint used by the private pane host: the
+    /// returned guard must outlive every spawned worker so the host process
+    /// owns the Job handle for the full worker lifetime.
+    pub fn enable_for_current_process() -> Result<Self, JobObjectError> {
+        let job = Self::create_configured()?;
+        job.assign_current_process().map_err(JobObjectError::from)?;
+        Ok(Self {
+            kill_on_job_close_active: true,
+            job,
+        })
+    }
+
+    /// Create and configure a kill-on-close Job, then assign the process behind
+    /// the supplied raw handle.
+    ///
+    /// Test-only helper used to contain a spawned child without ever assigning
+    /// the test runner, so dropping the guard cannot kill the test process. The
+    /// caller retains ownership of the supplied handle.
+    #[cfg(test)]
+    pub(super) fn contain_handle(raw_handle: isize) -> Result<Self, JobObjectError> {
+        let job = Self::create_configured()?;
+        job.assign_process(raw_handle)
+            .map_err(JobObjectError::from)?;
+        Ok(Self {
+            kill_on_job_close_active: true,
+            job,
+        })
+    }
+
+    fn create_configured() -> Result<Job, JobObjectError> {
+        let job = Job::create().map_err(JobObjectError::from)?;
+        let mut info = job
+            .query_extended_limit_info()
+            .map_err(JobObjectError::from)?;
+        info.limit_kill_on_job_close();
+        job.set_extended_limit_info(&info)
+            .map_err(JobObjectError::from)?;
+        Ok(job)
+    }
+
+    /// Reports whether `KILL_ON_JOB_CLOSE` is active on the owned Job.
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn is_kill_on_job_close_active(&self) -> bool {
+        self.kill_on_job_close_active
+    }
+}

--- a/src/runtime/job_object_tests.rs
+++ b/src/runtime/job_object_tests.rs
@@ -1,0 +1,132 @@
+//! Behavioral contracts for the Windows Job Object containment boundary
+//! (issue #467 Slice 3).
+//!
+//! These tests prove the narrow `job_object` module owns safe `win32job` calls,
+//! produces typed failures, configures `KILL_ON_JOB_CLOSE`, and that releasing a
+//! kill-on-close Job handle terminates a contained descendant within a bounded
+//! timeout. The native containment proof deliberately contains a *spawned
+//! child* (never the test runner), so dropping the guard cannot kill the test
+//! process. The host-owns-handle contract used by `run_launch_plan` relies on
+//! the same kernel mechanism: process exit auto-closes owned handles.
+
+#![cfg(windows)]
+
+use std::os::windows::io::AsRawHandle;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use super::job_object::{JobContainment, JobObjectError};
+
+/// A long-lived Windows child used as the contained descendant in the native
+/// proof. `ping -n 60` sleeps for roughly a minute, far longer than the bounded
+/// observation window, so it never exits on its own during the test.
+fn spawn_long_lived_child() -> std::process::Child {
+    Command::new("cmd.exe")
+        .args(["/C", "ping -n 60 127.0.0.1 > nul"])
+        .spawn()
+        .unwrap_or_else(|error| panic!("spawn containment child: {error}"))
+}
+
+/// Poll `child.try_wait()` until it exits or `bound` elapses.
+fn wait_for_exit(child: &mut std::process::Child, bound: Duration) -> bool {
+    let deadline = Instant::now() + bound;
+    while Instant::now() < deadline {
+        if child.try_wait().ok().flatten().is_some() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    child.try_wait().ok().flatten().is_some()
+}
+
+#[test]
+fn enabling_containment_for_current_process_yields_kill_on_job_close_guard() {
+    // Production path: the host assigns itself before spawning a worker so the
+    // worker tree inherits containment. The returned guard owns the kill-on-close
+    // Job handle.
+    //
+    // CAUTION: this test calls the real production entrypoint, which assigns the
+    // current process (the test runner) to a kill-on-close Job. We must NOT let
+    // the guard drop inside the test, or closing the handle would terminate the
+    // test runner mid-suite. `mem::forget` leaks the handle for the remainder of
+    // the process so the kernel only closes it (and reaps the empty tree) when
+    // the test runner exits normally at end of process.
+    let containment = JobContainment::enable_for_current_process()
+        .unwrap_or_else(|error| panic!("enable containment: {error}"));
+
+    assert!(
+        containment.is_kill_on_job_close_active(),
+        "containment guard must report KILL_ON_JOB_CLOSE as active"
+    );
+
+    std::mem::forget(containment);
+}
+
+#[test]
+fn native_kill_on_job_close_terminates_a_contained_descendant_within_bound() {
+    // Spawn the descendant first; only the spawned child is contained, never the
+    // test runner. This isolates ownership so the assertion below cannot kill the
+    // test process.
+    let mut child = spawn_long_lived_child();
+    // SAFETY (handle ownership): the child owns this handle; we only lend the
+    // raw value to assign_process for the duration of the syscall. The Child
+    // guard retains ownership and closes the handle when it drops.
+    let raw_handle = child.as_raw_handle() as isize;
+
+    let containment = JobContainment::contain_handle(raw_handle)
+        .unwrap_or_else(|error| panic!("contain child: {error}"));
+
+    assert!(
+        containment.is_kill_on_job_close_active(),
+        "containment guard must report KILL_ON_JOB_CLOSE as active for contained child"
+    );
+    assert!(
+        child.try_wait().ok().flatten().is_none(),
+        "child must be alive before the job handle is released"
+    );
+
+    // Releasing the guard closes the Job handle. With KILL_ON_JOB_CLOSE set the
+    // kernel terminates every process still assigned to the Job.
+    drop(containment);
+
+    let exited_within_bound = wait_for_exit(&mut child, Duration::from_secs(5));
+    assert!(
+        exited_within_bound,
+        "contained descendant must exit within the bounded timeout once the kill-on-close Job handle is released"
+    );
+}
+
+#[test]
+fn job_object_error_variants_are_typed_and_name_the_failing_operation() {
+    // The error type must name the failing operation (create/query/configure/
+    // assign) so diagnostics stay actionable without leaking raw HANDLE values.
+    let cases: [(JobObjectError, &str); 4] = [
+        (
+            JobObjectError::Create(std::io::Error::from_raw_os_error(5)),
+            "create",
+        ),
+        (
+            JobObjectError::Query(std::io::Error::from_raw_os_error(5)),
+            "query",
+        ),
+        (
+            JobObjectError::Configure(std::io::Error::from_raw_os_error(5)),
+            "configure",
+        ),
+        (
+            JobObjectError::Assign(std::io::Error::from_raw_os_error(5)),
+            "assign",
+        ),
+    ];
+    for (error, expected_token) in cases {
+        let message = error.to_string();
+        assert!(
+            message.contains(expected_token),
+            "JobObjectError message must name the operation '{expected_token}': got {message}"
+        );
+        assert!(
+            !message.contains("0x"),
+            "JobObjectError message must not leak raw handle values: got {message}"
+        );
+    }
+}

--- a/src/runtime/job_object_tests.rs
+++ b/src/runtime/job_object_tests.rs
@@ -54,12 +54,13 @@ fn enabling_containment_for_current_process_yields_kill_on_job_close_guard() {
     let containment = JobContainment::enable_for_current_process()
         .unwrap_or_else(|error| panic!("enable containment: {error}"));
 
+    let kill_on_close_active = containment.is_kill_on_job_close_active();
+    std::mem::forget(containment);
+
     assert!(
-        containment.is_kill_on_job_close_active(),
+        kill_on_close_active,
         "containment guard must report KILL_ON_JOB_CLOSE as active"
     );
-
-    std::mem::forget(containment);
 }
 
 #[test]

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -13,7 +13,7 @@ use crate::domain::{AgentId, LaunchSignature, RemoteRepositorySettings};
 use lru::LruCache;
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::{debug, info};
 /// Inputs needed to build an `AttachedViewer` without holding the runtime lock
@@ -271,6 +271,12 @@ pub struct TmuxRuntimeManager {
     /// spawn/relaunch so each `RuntimeSession` gets a unique generation
     /// for stale-liveness rejection (issue #301 Phase 4).
     lifecycle_counter: AtomicU64,
+    /// Explicit session-host root owning per-session staged Windows host
+    /// images (issue #467). `None` for the legacy constructor and for every
+    /// Unix/remote runtime, where staging is structurally disabled. Production
+    /// supplies the resolved state-file parent joined with `session-hosts`;
+    /// the manager never mutates process environment to derive it.
+    session_host_root: Option<PathBuf>,
 }
 
 /// Drop the current viewer (if any) on a background OS thread.
@@ -295,6 +301,33 @@ impl TmuxRuntimeManager {
     /// Create a new tmux runtime manager.
     #[must_use]
     pub fn new(rows: u16, cols: u16) -> Self {
+        Self::build(rows, cols, None)
+    }
+
+    /// Create a tmux runtime manager that owns an explicit session-host root.
+    ///
+    /// Issue #467: production supplies the resolved state-file parent joined
+    /// with `session-hosts` so Windows local creation can stage an immutable
+    /// per-session copy of the running Jefe image below a single path
+    /// authority. Unix callers and existing tests continue to use
+    /// [`TmuxRuntimeManager::new`]; this constructor does not mutate process
+    /// environment.
+    #[must_use]
+    pub fn with_session_host_root(rows: u16, cols: u16, session_host_root: PathBuf) -> Self {
+        Self::build(rows, cols, Some(session_host_root))
+    }
+
+    /// Return the explicit session-host root this manager owns, if any.
+    ///
+    /// `None` for the legacy constructor and on platforms that never stage a
+    /// host image. The kill path uses this to derive the per-session directory
+    /// (AC7) and the local launch path uses it to stage (AC1).
+    #[must_use]
+    pub fn session_host_root(&self) -> Option<&Path> {
+        self.session_host_root.as_deref()
+    }
+
+    fn build(rows: u16, cols: u16, session_host_root: Option<PathBuf>) -> Self {
         Self {
             sessions: HashMap::new(),
             viewer: None,
@@ -307,6 +340,7 @@ impl TmuxRuntimeManager {
             output_generation: AtomicU64::new(0),
             history_cache: HistoryCache::default(),
             lifecycle_counter: AtomicU64::new(0),
+            session_host_root,
         }
     }
 
@@ -484,7 +518,15 @@ impl TmuxRuntimeManager {
         }
         Self::kill_before_fresh_spawn(allow_reattach, signature, session_name);
         debug!(session_name, "creating new tmux session");
-        match commands::create_session(session_name, work_dir, signature) {
+        // AC5: reattach is handled above (early return). Only the create path
+        // receives the session-host root, so reattach never stages, replaces,
+        // or duplicates a host/worker.
+        match commands::create_session(
+            session_name,
+            work_dir,
+            signature,
+            self.session_host_root.as_deref(),
+        ) {
             Ok(()) => Ok(false),
             Err(_error)
                 if allow_reattach && self.session_exists_for_signature(agent_id, signature) =>
@@ -740,6 +782,30 @@ impl RuntimeManager for TmuxRuntimeManager {
             commands::kill_remote_session(&session.launch_signature.remote, &session.session_name)?;
         } else {
             commands::kill_session(&session.session_name)?;
+            // AC7: a successful local kill removes only this session's host
+            // directory. Cleanup failures are best-effort and retained for
+            // retry; they never abort the kill because the psmux/tmux session
+            // is already gone. Remote kill does not own a local host image.
+            if let Some(root) = self.session_host_root.as_deref() {
+                match super::session_host::cleanup_session_directory(root, &session.session_name) {
+                    Ok(super::session_host::SessionCleanupOutcome::Removed) => {
+                        debug!(
+                            session_name = %session.session_name,
+                            "removed session-host directory after local kill"
+                        );
+                    }
+                    Ok(outcome) => debug!(
+                        session_name = %session.session_name,
+                        ?outcome,
+                        "session-host directory cleanup skipped after local kill"
+                    ),
+                    Err(error) => debug!(
+                        session_name = %session.session_name,
+                        error = %error,
+                        "session-host directory cleanup rejected after local kill; retained for retry"
+                    ),
+                }
+            }
         }
 
         // Bump lifecycle generation only after a successful session removal,

--- a/src/runtime/manager_tests.rs
+++ b/src/runtime/manager_tests.rs
@@ -198,3 +198,57 @@ fn tmux_take_dirty_returns_false_without_viewer() {
         "take_dirty should return false when no viewer is attached"
     );
 }
+
+// ── Issue #467 Slice 2: explicit session-host root ownership ───────────────
+//
+// The default `TmuxRuntimeManager::new` preserves every existing caller. The
+// new `with_session_host_root` constructor records the caller-supplied path
+// authority without mutating process environment, and exposes it so the local
+// launch path can stage the host image below it on Windows.
+
+#[test]
+fn new_default_manager_has_no_session_host_root() {
+    let mgr = TmuxRuntimeManager::new(40, 120);
+    assert!(
+        mgr.session_host_root().is_none(),
+        "default manager must not own a session-host root"
+    );
+}
+
+#[test]
+fn with_session_host_root_records_explicit_authority() {
+    let root = std::path::PathBuf::from("/state/session-hosts");
+    let mgr = TmuxRuntimeManager::with_session_host_root(40, 120, root.clone());
+    assert_eq!(
+        mgr.session_host_root(),
+        Some(root.as_path()),
+        "explicit-root constructor must expose the supplied authority verbatim"
+    );
+}
+
+#[test]
+fn with_session_host_root_preserves_dimensions_and_default_state() {
+    let root = std::path::PathBuf::from("/state/session-hosts");
+    let mgr = TmuxRuntimeManager::with_session_host_root(24, 80, root);
+    assert_eq!(mgr.rows, 24);
+    assert_eq!(mgr.cols, 80);
+    assert!(
+        !mgr.take_dirty(),
+        "explicit-root manager must start without a dirty viewer"
+    );
+    assert!(
+        mgr.attached_agent().is_none(),
+        "explicit-root manager must start without an attached agent"
+    );
+}
+
+/// AC7 contract surface: the manager exposes the session-host root so the kill
+/// path can derive the per-session directory. The actual filesystem removal is
+/// exercised in `session_host_tests` because the manager's `kill` requires a
+/// live psmux/tmux session this unit harness cannot create.
+#[test]
+fn session_host_root_is_readable_for_kill_path_authority() {
+    let root = std::path::PathBuf::from("/state/session-hosts");
+    let mgr = TmuxRuntimeManager::with_session_host_root(40, 120, root.clone());
+    assert_eq!(mgr.session_host_root(), Some(root.as_path()));
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -23,6 +23,9 @@ mod external_terminal;
 /// One-shot `gh auth login --web` device-code subprocess driver (issue #244).
 mod gh_auth;
 mod identity;
+/// Narrow safe wrapper over Windows Job Object containment (issue #467 Slice 3).
+#[cfg(windows)]
+mod job_object;
 mod liveness;
 /// Jefe-managed install cache for selector-backed LLxprt launches (issue #425).
 mod llxprt_install;
@@ -37,6 +40,8 @@ mod pane_capture;
 mod preflight;
 mod process;
 mod session;
+/// Per-session, content-addressed Windows host staging (issue #467 Slice 1).
+pub(crate) mod session_host;
 /// Embedded shell-window tmux operations (issue #222).
 mod shell_window;
 mod socket;
@@ -100,6 +105,12 @@ pub use process::{
     classify_process_observation, process_liveness, process_liveness_indicates_alive,
 };
 pub use session::{RuntimeSession, TerminalCell, TerminalCellStyle, TerminalSnapshot};
+// Issue #467 Slice 2: re-export session-host cleanup/planning items used by the
+// startup path and the manager kill path.
+pub use session_host::{
+    SESSION_HOST_ROOT_SEGMENT, SessionCleanupOutcome, StartupCleanupReport,
+    cleanup_session_directory, startup_cleanup_session_hosts,
+};
 pub use shell_window::{
     SHELL_WINDOW_NAME, ShellWindowInputs, capture_shell_preview, close_all_shell_windows,
     close_shell_window, hide_shell_window, observe_shell_window_sessions, open_shell_window,
@@ -132,6 +143,14 @@ mod orphan_tests;
 #[cfg(test)]
 #[path = "multiplexer_tests.rs"]
 mod multiplexer_tests;
+
+#[cfg(test)]
+#[path = "session_host_tests.rs"]
+mod session_host_tests;
+
+#[cfg(all(test, windows))]
+#[path = "job_object_tests.rs"]
+mod job_object_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -234,6 +234,29 @@ impl MultiplexerPlan {
             &[],
         )
     }
+
+    /// Build the native Windows pane command launching an already-staged
+    /// session-host image (issue #467).
+    ///
+    /// On Windows the staged copy replaces the live build target as the psmux
+    /// pane launcher while argv/env are preserved unchanged. Unix/remote
+    /// command paths never stage a host and must reject this call so a staged
+    /// Windows path can never leak into the structurally unchanged tmux/SSH
+    /// command construction.
+    pub fn agent_pane_command_args_with_staged_host(
+        &self,
+        executable: &ResolvedAgentExecutable,
+        staged_host: &Path,
+        args: &[OsString],
+        environment: &[(OsString, OsString)],
+    ) -> Result<Vec<OsString>, MultiplexerError> {
+        if self.platform != LocalPlatform::Windows {
+            return Err(MultiplexerError::InvalidIsolation {
+                platform: self.platform,
+            });
+        }
+        self.agent_pane_command_args_with_launcher(executable, args, environment, staged_host)
+    }
     #[must_use]
     pub const fn isolation(&self) -> &MultiplexerIsolation {
         &self.isolation

--- a/src/runtime/multiplexer_tests.rs
+++ b/src/runtime/multiplexer_tests.rs
@@ -313,8 +313,15 @@ fn resolved_fixture(
     } else {
         "code-puppy"
     };
-    std::fs::write(directory.path().join(binary), b"fixture")
+    let binary_path = directory.path().join(binary);
+    std::fs::write(&binary_path, b"fixture")
         .unwrap_or_else(|error| panic!("runtime fixture should be written: {error}"));
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&binary_path, std::fs::Permissions::from_mode(0o755))
+            .unwrap_or_else(|error| panic!("runtime fixture should be executable: {error}"));
+    }
     let executable =
         AgentExecutableResolver::for_platform(platform, vec![directory.path().to_path_buf()], None)
             .resolve(AgentKind::CodePuppy)

--- a/src/runtime/multiplexer_tests.rs
+++ b/src/runtime/multiplexer_tests.rs
@@ -3,6 +3,10 @@
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 
+use crate::domain::AgentKind;
+
+use super::agent_executable::{AgentExecutablePlatform, AgentExecutableResolver};
+use super::agent_launcher::INTERNAL_LAUNCH_ARGUMENT;
 use super::multiplexer::{
     LocalPlatform, MultiplexerCapability, MultiplexerError, MultiplexerIsolation, MultiplexerPlan,
     MultiplexerVersion, ProbeObservation, classify_probe, executable_candidates,
@@ -294,4 +298,78 @@ fn path_arguments_remain_os_strings_without_lossy_conversion() {
     .unwrap_or_else(|error| panic!("unicode executable path should be valid: {error}"));
     assert_eq!(plan.executable().as_os_str(), executable.as_os_str());
     assert!(plan.base_args().iter().all(|arg| arg != OsStr::new("-S")));
+}
+
+fn resolved_fixture(
+    platform: AgentExecutablePlatform,
+) -> (
+    tempfile::TempDir,
+    super::agent_executable::ResolvedAgentExecutable,
+) {
+    let directory = tempfile::tempdir()
+        .unwrap_or_else(|error| panic!("runtime fixture directory should exist: {error}"));
+    let binary = if platform == AgentExecutablePlatform::Windows {
+        "code-puppy.exe"
+    } else {
+        "code-puppy"
+    };
+    std::fs::write(directory.path().join(binary), b"fixture")
+        .unwrap_or_else(|error| panic!("runtime fixture should be written: {error}"));
+    let executable =
+        AgentExecutableResolver::for_platform(platform, vec![directory.path().to_path_buf()], None)
+            .resolve(AgentKind::CodePuppy)
+            .unwrap_or_else(|error| panic!("runtime fixture should resolve: {error}"));
+    (directory, executable)
+}
+
+#[test]
+fn windows_agent_pane_command_uses_staged_session_host_when_provided() {
+    let plan = MultiplexerPlan::for_platform(
+        LocalPlatform::Windows,
+        PathBuf::from("C:/Program Files/psmux/psmux.exe"),
+        MultiplexerIsolation::Namespace("jefe-0123456789abcdef".to_owned()),
+    )
+    .unwrap_or_else(|error| panic!("windows plan should be valid: {error}"));
+    let (_directory, executable) = resolved_fixture(AgentExecutablePlatform::Windows);
+    let staged_host =
+        PathBuf::from("C:/State/session-hosts/jefe-agent-1/<digest>/jefe-session-host.exe");
+    let pane = plan
+        .agent_pane_command_args_with_staged_host(
+            &executable,
+            &staged_host,
+            &[OsString::from("--profile"), OsString::from("default")],
+            &[(OsString::from("LLXPRT_DEBUG"), OsString::from("api"))],
+        )
+        .unwrap_or_else(|error| panic!("staged pane command should build: {error}"));
+    assert_eq!(pane.len(), 1);
+    let line = pane[0].to_string_lossy();
+    assert!(
+        line.contains("& 'C:/State/session-hosts/jefe-agent-1/<digest>/jefe-session-host.exe'")
+    );
+    assert!(line.contains(INTERNAL_LAUNCH_ARGUMENT));
+    assert!(!line.contains("build"));
+    assert!(!line.contains("'--profile'"));
+    assert!(!line.contains("$env:LLXPRT_DEBUG='api'"));
+}
+
+#[test]
+fn unix_agent_pane_command_has_no_staged_host_path() {
+    let plan = MultiplexerPlan::for_platform(
+        LocalPlatform::Unix,
+        PathBuf::from("/usr/bin/tmux"),
+        MultiplexerIsolation::Socket(PathBuf::from("/tmp/jefe.sock")),
+    )
+    .unwrap_or_else(|error| panic!("unix plan should be valid: {error}"));
+    let (_directory, executable) = resolved_fixture(AgentExecutablePlatform::Unix);
+    let staged = PathBuf::from("/state/session-hosts/jefe-agent/host/jefe-session-host.exe");
+    let result = plan.agent_pane_command_args_with_staged_host(
+        &executable,
+        &staged,
+        &[OsString::from("--profile")],
+        &[],
+    );
+    assert!(
+        matches!(result, Err(MultiplexerError::InvalidIsolation { .. })),
+        "Unix must reject the Windows-only staged-host path: {result:?}"
+    );
 }

--- a/src/runtime/session_host.rs
+++ b/src/runtime/session_host.rs
@@ -215,6 +215,12 @@ fn stage_with_plan(
     })?;
 
     if fs::rename(&temp_path, plan.staged_path()).is_err() {
+        // Another launcher may have won the same content-addressed rename.
+        // Treat that as success; all contenders wrote identical digest bytes.
+        if plan.staged_path().is_file() {
+            let _ = fs::remove_file(&temp_path);
+            return Ok(plan.staged_path().to_path_buf());
+        }
         // Best-effort cleanup of our temp file before surfacing the failure;
         // a leftover temp from this attempt would be reclaimed on retry.
         let _ = fs::remove_file(&temp_path);

--- a/src/runtime/session_host.rs
+++ b/src/runtime/session_host.rs
@@ -128,6 +128,12 @@ pub fn stage_session_host_with_attempt(
     source: &Path,
     attempt_tag: &str,
 ) -> Result<PathBuf, SessionHostError> {
+    if attempt_tag.is_empty()
+        || attempt_tag.contains(['/', '\\', '\0'])
+        || attempt_tag.contains("..")
+    {
+        return Err(SessionHostError::InvalidAttemptTag);
+    }
     let bytes = fs::read(source).map_err(|error| SessionHostError::SourceRead {
         path: safe_source_path(source),
         reason: error_kind_message(&error),
@@ -312,6 +318,8 @@ fn error_kind_message(error: &std::io::Error) -> String {
 pub enum SessionHostError {
     /// The session name could not be sanitized to a safe path segment.
     InvalidSessionName { session_name: String },
+    /// The staging-attempt tag is not safe for use in a filename.
+    InvalidAttemptTag,
     /// The source host image could not be read.
     SourceRead { path: PathBuf, reason: String },
     /// A staging directory could not be created.
@@ -331,6 +339,8 @@ impl std::fmt::Display for SessionHostError {
                 formatter,
                 "session host session name is not a safe path segment: {session_name}"
             ),
+            Self::InvalidAttemptTag => formatter
+                .write_str("session host staging attempt tag is not a safe filename segment"),
             Self::SourceRead { path, reason } => write!(
                 formatter,
                 "session host source image '{}' could not be read: {reason}",

--- a/src/runtime/session_host.rs
+++ b/src/runtime/session_host.rs
@@ -1,0 +1,544 @@
+//! Per-session, content-addressed Windows host staging (issue #467 Slice 1).
+//!
+//! Native Windows psmux panes previously ran the live Jefe build/install target
+//! as their long-lived launcher, locking it against rebuilds. This module plans
+//! and stages an immutable copy of that image below a caller-supplied
+//! session-host root so a running pane never owns the build target:
+//!
+//! ```text
+//! <root>/<sanitized-session>/<sha256>/jefe-session-host.exe
+//! ```
+//!
+//! Path planning is pure and deterministic; staging copies (never hardlinks)
+//! the source through a same-directory unique temp file and atomically renames
+//! it into place, reuses an existing digest artifact idempotently, and removes
+//! only interrupted temp files owned by the current staging attempt. Unix and
+//! remote launch paths do not use this module; the multiplexer selects the
+//! staged copy only for native Windows panes.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::domain::sha256::Sha256;
+
+use super::agent_executable::ResolvedAgentExecutable;
+use super::errors::RuntimeError;
+use super::multiplexer::MultiplexerPlan;
+
+/// Fixed filename of the staged host image inside each digest directory.
+pub const SESSION_HOST_BINARY: &str = "jefe-session-host.exe";
+
+/// Directory segment below the resolved state-file parent that owns all
+/// per-session staged host images (issue #467).
+pub const SESSION_HOST_ROOT_SEGMENT: &str = "session-hosts";
+
+/// Prefix used for in-progress staging temp files so interrupted attempts can be
+/// identified and reclaimed without touching concurrent staging attempts.
+const STAGING_TEMP_PREFIX: &str = "jefe-staging-tmp-";
+
+static STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// Pure, fully resolved per-session host staging plan.
+///
+/// Constructed from a session-host root, a session name, and the canonical
+/// content bytes of the source image. The plan never touches the filesystem:
+/// it only derives a deterministic, sanitized, content-addressed path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionHostPlan {
+    session_directory: PathBuf,
+    staged_path: PathBuf,
+}
+
+impl SessionHostPlan {
+    /// Resolve a deterministic plan for `session_name` addressed by `content`.
+    ///
+    /// `content` is the canonical byte image of the source host (typically the
+    /// running Jefe executable). The session name is sanitized to a safe path
+    /// segment; an empty or all-separator name is rejected because it would
+    /// collapse onto the root or a sibling session.
+    pub fn for_session(
+        root: &Path,
+        session_name: &str,
+        content: &[u8],
+    ) -> Result<Self, SessionHostError> {
+        let sanitized = sanitize_session_name(session_name).ok_or_else(|| {
+            SessionHostError::InvalidSessionName {
+                session_name: redact_session_name(session_name),
+            }
+        })?;
+        let digest = Sha256::digest(content).to_string();
+        let session_directory = root.join(&sanitized);
+        let digest_directory = session_directory.join(&digest);
+        let staged_path = digest_directory.join(SESSION_HOST_BINARY);
+        Ok(Self {
+            session_directory,
+            staged_path,
+        })
+    }
+
+    /// Absolute staged binary path (`<root>/<session>/<digest>/<binary>`).
+    #[must_use]
+    pub fn staged_path(&self) -> &Path {
+        &self.staged_path
+    }
+
+    /// Content-addressed digest directory holding the staged binary.
+    ///
+    /// Always equal to `staged_path`'s parent because the plan constructs the
+    /// staged path as `digest_directory/binary`.
+    #[must_use]
+    pub fn digest_directory(&self) -> &Path {
+        self.staged_path
+            .parent()
+            .unwrap_or(self.session_directory.as_path())
+    }
+}
+
+/// Stage an immutable copy of `source` for `session_name` under `root`.
+///
+/// The source bytes are hashed to derive the content-addressed path, copied
+/// through a same-directory unique temp file, and atomically renamed into
+/// place. An existing artifact at the resolved digest is reused untouched
+/// (idempotency). Interrupted temp files previously written by this staging
+/// attempt are removed before staging; temp files belonging to concurrent
+/// attempts are retained.
+///
+/// Use [`stage_session_host_with_attempt`] when a caller needs to bound cleanup
+/// to a specific attempt tag (for example, to simulate or recover an
+/// interrupted prior run).
+pub fn stage_session_host(
+    root: &Path,
+    session_name: &str,
+    source: &Path,
+) -> Result<PathBuf, SessionHostError> {
+    let attempt = default_attempt_tag();
+    stage_session_host_with_attempt(root, session_name, source, &attempt)
+}
+
+/// Stage an immutable copy, scoping interrupted-temp cleanup to `attempt_tag`.
+///
+/// `attempt_tag` is folded into each temp filename this staging attempt
+/// creates, so cleanup reclaims only temps carrying the same tag and leaves
+/// concurrent staging attempts' temps intact.
+pub fn stage_session_host_with_attempt(
+    root: &Path,
+    session_name: &str,
+    source: &Path,
+    attempt_tag: &str,
+) -> Result<PathBuf, SessionHostError> {
+    let bytes = fs::read(source).map_err(|error| SessionHostError::SourceRead {
+        path: safe_source_path(source),
+        reason: error_kind_message(&error),
+    })?;
+    let plan = SessionHostPlan::for_session(root, session_name, &bytes)?;
+    stage_with_plan(&plan, &bytes, attempt_tag)
+}
+
+/// Pure decision: whether the local launch should stage a session host, and
+/// if so the `(root, session_name)` pair to stage under.
+///
+/// Staging is Windows-only: on Unix this always returns `None` so the
+/// structurally unchanged tmux/SSH launch path is selected (AC9). A `None`
+/// root or session name also returns `None`, preserving the legacy launch
+/// path for existing callers and tests.
+pub fn session_host_stage_request<'a>(
+    root: Option<&'a Path>,
+    session_name: Option<&'a str>,
+) -> Option<(&'a Path, &'a str)> {
+    if !cfg!(windows) {
+        return None;
+    }
+    Some((root?, session_name?))
+}
+
+/// Resolve the multiplexer pane-command argv for a local launch.
+///
+/// On Windows when the manager supplied an explicit session-host root, stage
+/// `std::env::current_exe()` below it and build the pane command with the
+/// staged copy as the launcher (AC1). Otherwise fall back to the multiplexer's
+/// direct agent launch path so Unix and remote behavior is structurally
+/// unchanged (AC9).
+pub fn resolve_local_pane_command(
+    multiplexer: &MultiplexerPlan,
+    executable: &ResolvedAgentExecutable,
+    pane_args: &[std::ffi::OsString],
+    environment: &[(std::ffi::OsString, std::ffi::OsString)],
+    session_host: Option<(&Path, &str)>,
+) -> Result<Vec<std::ffi::OsString>, RuntimeError> {
+    match session_host.and_then(|(root, name)| session_host_stage_request(Some(root), Some(name))) {
+        Some((root, name)) => {
+            let source = std::env::current_exe().map_err(|_| {
+                RuntimeError::Multiplexer(
+                    super::multiplexer::MultiplexerError::CurrentExecutableUnavailable,
+                )
+            })?;
+            let staged = stage_session_host(root, name, &source)
+                .map_err(RuntimeError::SessionHostStaging)?;
+            multiplexer
+                .agent_pane_command_args_with_staged_host(
+                    executable,
+                    &staged,
+                    pane_args,
+                    environment,
+                )
+                .map_err(RuntimeError::Multiplexer)
+        }
+        None => multiplexer
+            .agent_pane_command_args(executable, pane_args, environment)
+            .map_err(RuntimeError::Multiplexer),
+    }
+}
+
+fn stage_with_plan(
+    plan: &SessionHostPlan,
+    bytes: &[u8],
+    attempt_tag: &str,
+) -> Result<PathBuf, SessionHostError> {
+    let digest_directory = plan.digest_directory();
+    fs::create_dir_all(digest_directory).map_err(|error| SessionHostError::StagingCreateDir {
+        path: digest_directory.to_path_buf(),
+        reason: error_kind_message(&error),
+    })?;
+
+    reclaim_owned_temps(digest_directory, attempt_tag);
+
+    if plan.staged_path().is_file() {
+        return Ok(plan.staged_path().to_path_buf());
+    }
+
+    let temp_path = unique_temp_path(digest_directory, attempt_tag);
+    fs::write(&temp_path, bytes).map_err(|error| SessionHostError::StagingWrite {
+        path: temp_path.clone(),
+        reason: error_kind_message(&error),
+    })?;
+
+    if fs::rename(&temp_path, plan.staged_path()).is_err() {
+        // Best-effort cleanup of our temp file before surfacing the failure;
+        // a leftover temp from this attempt would be reclaimed on retry.
+        let _ = fs::remove_file(&temp_path);
+        return Err(SessionHostError::StagingRename {
+            path: plan.staged_path().to_path_buf(),
+        });
+    }
+    Ok(plan.staged_path().to_path_buf())
+}
+
+fn reclaim_owned_temps(digest_directory: &Path, attempt_tag: &str) {
+    let expected_suffix = format!("{STAGING_TEMP_PREFIX}{attempt_tag}");
+    let Ok(entries) = fs::read_dir(digest_directory) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if let Some(name) = path.file_name().and_then(|value| value.to_str()) {
+            if name.contains(&expected_suffix) {
+                let _ = fs::remove_file(&path);
+            }
+        }
+    }
+}
+
+fn unique_temp_path(digest_directory: &Path, attempt_tag: &str) -> PathBuf {
+    let sequence = STAGING_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let pid = std::process::id();
+    digest_directory.join(format!(
+        "{SESSION_HOST_BINARY}.{STAGING_TEMP_PREFIX}{attempt_tag}-{pid:x}-{nanos:x}-{sequence:x}"
+    ))
+}
+
+fn default_attempt_tag() -> String {
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    format!("pid{pid:x}-t{nanos:x}")
+}
+
+/// Reduce a session name to a safe single path segment, or `None` if it carries
+/// no usable content. Path separators, traversal, and other filesystem-special
+/// bytes are replaced with `-`; a result that is empty or only separators is
+/// rejected so staging can never escape `root` or alias another session.
+fn sanitize_session_name(session_name: &str) -> Option<String> {
+    let sanitized: String = session_name
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect();
+    let trimmed = sanitized.trim_matches('-');
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(sanitized)
+    }
+}
+
+/// Replace any non-path-safe characters in a session name before it appears in a
+/// diagnostic, so error messages cannot inject path separators or traversal.
+fn redact_session_name(session_name: &str) -> String {
+    session_name
+        .chars()
+        .map(|ch| if ch.is_ascii_graphic() { ch } else { '?' })
+        .collect()
+}
+
+/// Render a source path for diagnostics without canonicalizing (which could
+/// fail) and without echoing any file contents.
+fn safe_source_path(path: &Path) -> PathBuf {
+    path.to_path_buf()
+}
+
+fn error_kind_message(error: &std::io::Error) -> String {
+    match error.kind() {
+        std::io::ErrorKind::NotFound => "not found".to_owned(),
+        std::io::ErrorKind::PermissionDenied => "permission denied".to_owned(),
+        std::io::ErrorKind::AlreadyExists => "already exists".to_owned(),
+        _ => error.to_string(),
+    }
+}
+
+/// Typed staging failures. Each variant names the failing operation and a safe
+/// path; none ever echoes source or staged bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionHostError {
+    /// The session name could not be sanitized to a safe path segment.
+    InvalidSessionName { session_name: String },
+    /// The source host image could not be read.
+    SourceRead { path: PathBuf, reason: String },
+    /// A staging directory could not be created.
+    StagingCreateDir { path: PathBuf, reason: String },
+    /// The staged temp copy could not be written.
+    StagingWrite { path: PathBuf, reason: String },
+    /// The atomic rename into the final staged path failed.
+    StagingRename { path: PathBuf },
+}
+
+impl std::error::Error for SessionHostError {}
+
+impl std::fmt::Display for SessionHostError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidSessionName { session_name } => write!(
+                formatter,
+                "session host session name is not a safe path segment: {session_name}"
+            ),
+            Self::SourceRead { path, reason } => write!(
+                formatter,
+                "session host source image '{}' could not be read: {reason}",
+                path.display()
+            ),
+            Self::StagingCreateDir { path, reason } => write!(
+                formatter,
+                "session host staging directory '{}' could not be created: {reason}",
+                path.display()
+            ),
+            Self::StagingWrite { path, reason } => write!(
+                formatter,
+                "session host staged copy '{}' could not be written: {reason}",
+                path.display()
+            ),
+            Self::StagingRename { path } => write!(
+                formatter,
+                "session host staged copy could not be renamed into place at '{}'",
+                path.display()
+            ),
+        }
+    }
+}
+
+// ── Issue #467 Slice 2: per-session cleanup (AC7) and startup sweep (AC8) ───
+//
+// `cleanup_session_directory` is the kill-path owner of a single session's host
+// directory. `startup_cleanup_session_hosts` is the startup sweep that removes
+// only unreferenced/dead session directories and interrupted staging temp
+// files, retaining live psmux sessions, persisted references, and
+// ambiguous/unprobeable artifacts. Both are pure-filesystem and never touch the
+// build/install target.
+
+/// Outcome of a single-session cleanup attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionCleanupOutcome {
+    /// The session's host directory existed and was removed.
+    Removed,
+    /// No host directory existed for this session.
+    Absent,
+    /// The directory existed but could not be removed; it is retained for a
+    /// later retry. The kill that triggered the cleanup has already terminated
+    /// the psmux/tmux session, so a retained directory is harmless leakage
+    /// that the next startup sweep (`startup_cleanup_session_hosts`) will
+    /// reclaim if it remains unreferenced.
+    RetainedForRetry,
+}
+
+/// Remove the host directory owned by `session_name` below `root`.
+///
+/// `root` is the manager's explicit session-host root and `session_name` is the
+/// existing `RuntimeBinding.session_name` (e.g. `jefe-<agent>`). Only this
+/// session's directory is removed; unrelated sessions are never touched. The
+/// session name is sanitized through the same planner used for staging so the
+/// derived directory is identical to the staging target. A failure to remove
+/// is reported as [`SessionCleanupOutcome::RetainedForRetry`] rather than an
+/// `Err`, so a kill caller never aborts after the psmux/tmux session is gone.
+/// The only `Err` path is an unsanitizable session name, which is a programmer
+/// error rather than a filesystem failure.
+pub fn cleanup_session_directory(
+    root: &Path,
+    session_name: &str,
+) -> Result<SessionCleanupOutcome, SessionHostError> {
+    let sanitized = sanitize_session_name(session_name).ok_or_else(|| {
+        SessionHostError::InvalidSessionName {
+            session_name: redact_session_name(session_name),
+        }
+    })?;
+    let directory = root.join(&sanitized);
+    if !directory.exists() {
+        return Ok(SessionCleanupOutcome::Absent);
+    }
+    match fs::remove_dir_all(&directory) {
+        Ok(()) => Ok(SessionCleanupOutcome::Removed),
+        Err(_) => Ok(SessionCleanupOutcome::RetainedForRetry),
+    }
+}
+
+/// Aggregate report produced by [`startup_cleanup_session_hosts`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StartupCleanupReport {
+    /// Session directories (`<root>/<session>`) removed because they were
+    /// unreferenced and their psmux pane was Missing.
+    pub removed_session_directories: Vec<PathBuf>,
+    /// Live session directories retained because the supplied probe reported
+    /// them Alive. Recorded so callers can observe the retention decision.
+    pub retained_live_session_directories: Vec<PathBuf>,
+    /// Interrupted staging temp files reclaimed from retained session
+    /// directories.
+    pub removed_temp_files: Vec<PathBuf>,
+}
+
+/// Sweep `root` at startup, removing only unreferenced and dead session host
+/// directories plus interrupted staging temp files (AC8).
+///
+/// `persisted_references` is the set of session names with a persisted
+/// `RuntimeBinding` (supplied by `app_init` after state load). `probe` decides
+/// whether a session name corresponds to a live psmux session; the manager
+/// probes live local sessions before deletion. A directory is removed when it
+/// is **neither** referenced **nor** live. Directories that cannot be mapped
+/// back to a session name (ambiguous artifacts), whose probe is unavailable,
+/// or that the caller cannot classify are always retained — startup never
+/// deletes a directory it cannot positively identify as unreferenced and dead.
+pub fn startup_cleanup_session_hosts(
+    root: &Path,
+    persisted_references: &[String],
+    probe: impl Fn(&str) -> crate::runtime::liveness::SessionLiveness,
+) -> Result<StartupCleanupReport, SessionHostError> {
+    use crate::runtime::liveness::SessionLiveness;
+
+    let mut report = StartupCleanupReport::default();
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(report),
+        Err(error) => {
+            return Err(SessionHostError::StagingCreateDir {
+                path: root.to_path_buf(),
+                reason: error_kind_message(&error),
+            });
+        }
+    };
+
+    let referenced: std::collections::HashSet<&str> =
+        persisted_references.iter().map(String::as_str).collect();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // Only directories can be session-host directories; stray files at the
+        // root are ambiguous artifacts and retained.
+        let Ok(metadata) = fs::metadata(&path) else {
+            continue;
+        };
+        if !metadata.is_dir() {
+            continue;
+        }
+        let Some(session_name) = path.file_name().and_then(|name| name.to_str()) else {
+            // Non-Unicode entry: ambiguous, retain.
+            continue;
+        };
+        // Reclaim interrupted staging temp files inside the directory before
+        // deciding whether to remove the directory itself. This reclaims
+        // leftover temps even from retained (live/referenced) sessions.
+        reclaim_interrupted_temps_in(&path, &mut report.removed_temp_files);
+
+        // A directory whose name cannot be inverted to a staging session name
+        // is ambiguous (e.g. stray artifact dirs, unrelated tools). Retain it.
+        let derived_session = invert_session_directory_name(session_name);
+        let Some(derived_session) = derived_session else {
+            continue;
+        };
+        let is_referenced =
+            referenced.contains(derived_session.as_str()) || referenced.contains(session_name);
+        match probe(&derived_session) {
+            SessionLiveness::Alive => {
+                report.retained_live_session_directories.push(path);
+            }
+            SessionLiveness::Unavailable => {
+                // Unprobeable: retain rather than risk deleting a live session
+                // whose probe transiently failed.
+            }
+            SessionLiveness::Missing if is_referenced => {
+                // Persisted reference retains the directory even when the pane
+                // probe reports Missing (e.g. the binding is being restored).
+            }
+            SessionLiveness::Missing => {
+                if fs::remove_dir_all(&path).is_ok() {
+                    report.removed_session_directories.push(path);
+                }
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+/// Reclaim interrupted staging temp files inside a session directory.
+///
+/// Temp files are written as `<binary>.jefe-staging-tmp-<attempt>` (see
+/// [`unique_temp_path`]); any file whose name contains the staging temp prefix
+/// is reclaimed. The staged binary itself and unrelated files are never
+/// removed.
+fn reclaim_interrupted_temps_in(session_directory: &Path, removed: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(session_directory) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            // Temps live alongside the staged binary inside the digest
+            // directory, so recurse one level to reach them.
+            reclaim_interrupted_temps_in(&path, removed);
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if name.contains(STAGING_TEMP_PREFIX) && fs::remove_file(&path).is_ok() {
+            removed.push(path);
+        }
+    }
+}
+
+/// Best-effort inversion of a sanitized session directory name back to the
+/// `RuntimeBinding.session_name` (`jefe-<agent>`) it was staged from.
+///
+/// The staging planner sanitizes by replacing every non-alphanumeric byte with
+/// `-`, so the inversion is only unambiguous when the directory name already
+/// matches the `jefe-<agent>` contract (alphanumeric plus `-`). Any directory
+/// whose name does not start with `jefe-` is treated as ambiguous and the
+/// caller retains it.
+fn invert_session_directory_name(directory_name: &str) -> Option<String> {
+    if directory_name.starts_with("jefe-") && !directory_name.is_empty() {
+        Some(directory_name.to_owned())
+    } else {
+        None
+    }
+}

--- a/src/runtime/session_host_tests.rs
+++ b/src/runtime/session_host_tests.rs
@@ -282,6 +282,22 @@ fn concurrent_staging_of_the_same_image_is_idempotent() {
 }
 
 #[test]
+fn staging_rejects_attempt_tags_that_can_escape_the_digest_directory() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    for attempt_tag in ["", "../escape", "nested/path", r"nested\path"] {
+        let result =
+            stage_session_host_with_attempt(root.path(), "jefe-agent-1", &source, attempt_tag);
+        assert!(
+            matches!(result, Err(SessionHostError::InvalidAttemptTag)),
+            "unsafe attempt tag must be rejected: {attempt_tag:?}: {result:?}"
+        );
+    }
+}
+
+#[test]
 fn staging_preserves_staged_copy_after_source_is_replaced() {
     // AC4: a staged/running copy must permit replacing the source image.
     let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));

--- a/src/runtime/session_host_tests.rs
+++ b/src/runtime/session_host_tests.rs
@@ -1,0 +1,650 @@
+//! Behavioral contracts for per-session, content-addressed Windows host staging.
+//!
+//! Issue #467 Slice 1 (AC1, AC4, AC8, AC9): native Windows psmux panes must run
+//! from an immutable copy of the Jefe image staged below the resolved
+//! session-host root, so the live build/install target is never locked by a
+//! running pane. These tests cover pure path planning, copy staging,
+//! idempotency, interrupted-temp cleanup, and typed diagnostics. They are
+//! platform-agnostic: staging is exercised on every target so the logic is
+//! proven deterministically in CI regardless of host platform.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use super::session_host::{
+    SessionCleanupOutcome, SessionHostError, SessionHostPlan, stage_session_host,
+    stage_session_host_with_attempt, startup_cleanup_session_hosts,
+};
+
+const SESSION_HOST_BINARY: &str = "jefe-session-host.exe";
+
+fn write_source(directory: &TempDir, bytes: &[u8]) -> PathBuf {
+    let path = directory.path().join("jefe.exe");
+    fs::write(&path, bytes).unwrap_or_else(|error| panic!("write source fixture: {error}"));
+    path
+}
+
+fn write_default_source(directory: &TempDir) -> PathBuf {
+    write_source(directory, b"jefe-image-v1")
+}
+
+fn hex_of(bytes: &[u8]) -> String {
+    crate::domain::sha256::Sha256::digest(bytes).to_string()
+}
+
+#[test]
+fn plan_produces_deterministic_sanitized_content_addressed_path() {
+    let root = PathBuf::from("/state/session-hosts");
+    let plan = SessionHostPlan::for_session(&root, "jefe-alpha-1", b"jefe-image-v1")
+        .unwrap_or_else(|error| panic!("plan should resolve: {error}"));
+
+    let expected_session = "jefe-alpha-1";
+    let expected_digest = hex_of(b"jefe-image-v1");
+    let expected = root
+        .join(expected_session)
+        .join(&expected_digest)
+        .join(SESSION_HOST_BINARY);
+    assert_eq!(plan.staged_path(), &expected);
+    assert_eq!(
+        plan.digest_directory(),
+        &root.join(expected_session).join(&expected_digest)
+    );
+}
+
+#[test]
+fn plan_sanitizes_session_name_to_safe_path_segment() {
+    let root = PathBuf::from("/state/session-hosts");
+    // A real `RuntimeBinding.session_name` is always `jefe-<agent>`, but staging
+    // must never trust that invariant for path safety.
+    let plan = SessionHostPlan::for_session(&root, "../../etc/passwd", b"bytes")
+        .unwrap_or_else(|error| panic!("plan should resolve: {error}"));
+    let relative = plan
+        .staged_path()
+        .strip_prefix(&root)
+        .unwrap_or_else(|error| panic!("staged path must stay under root: {error}"));
+    let session_segment = relative
+        .components()
+        .next()
+        .unwrap_or_else(|| panic!("staged path must have a session segment: {relative:?}"));
+    let segment = session_segment.as_os_str().to_string_lossy();
+    assert!(
+        !segment.contains('/'),
+        "session segment must not contain '/': {segment}"
+    );
+    assert!(
+        !segment.contains(".."),
+        "session segment must not contain traversal: {segment}"
+    );
+    assert!(
+        segment
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-'),
+        "session segment must be sanitized: {segment}"
+    );
+}
+
+#[test]
+fn plan_rejects_empty_or_unsanitizable_session_names() {
+    let root = PathBuf::from("/state/session-hosts");
+    for invalid in ["", "   ", "---"] {
+        assert!(
+            matches!(
+                SessionHostPlan::for_session(&root, invalid, b"bytes"),
+                Err(SessionHostError::InvalidSessionName { .. })
+            ),
+            "session name should be rejected: {invalid:?}"
+        );
+    }
+}
+
+#[test]
+fn plan_is_pure_and_does_not_touch_the_filesystem() {
+    let root = PathBuf::from("/this/path/does/not/exist");
+    let plan = SessionHostPlan::for_session(&root, "jefe-agent-9", b"payload")
+        .unwrap_or_else(|error| panic!("plan must be pure: {error}"));
+    // Reading the staged path must not require any directory to exist.
+    assert!(!plan.staged_path().exists());
+}
+
+#[test]
+fn staging_copies_source_bytes_under_root_without_hardlink() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    let staged = stage_session_host(root.path(), "jefe-agent-1", &source)
+        .unwrap_or_else(|error| panic!("staging should succeed: {error}"));
+
+    assert!(staged.exists(), "staged binary should exist");
+    let staged_bytes =
+        fs::read(&staged).unwrap_or_else(|error| panic!("read staged binary: {error}"));
+    assert_eq!(staged_bytes, b"jefe-image-v1");
+
+    // Copy (not hardlink): the staged inode must be independent of the source so
+    // replacing the source never touches the running image (AC4).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let source_meta =
+            fs::metadata(&source).unwrap_or_else(|error| panic!("source metadata: {error}"));
+        let staged_meta =
+            fs::metadata(&staged).unwrap_or_else(|error| panic!("staged metadata: {error}"));
+        assert_ne!(
+            source_meta.ino(),
+            staged_meta.ino(),
+            "staging must not hardlink"
+        );
+        assert_eq!(staged_meta.nlink(), 1, "staged file must stand alone");
+    }
+    // Cross-platform content-addressed check: identical bytes verify the copy.
+    let source_bytes =
+        fs::read(&source).unwrap_or_else(|error| panic!("read source binary: {error}"));
+    assert_eq!(source_bytes, staged_bytes);
+
+    // The staged path matches the pure planner's prediction for this content.
+    let expected = SessionHostPlan::for_session(root.path(), "jefe-agent-1", b"jefe-image-v1")
+        .unwrap_or_else(|error| panic!("plan: {error}"));
+    assert_eq!(staged, *expected.staged_path());
+}
+
+#[test]
+fn staging_is_idempotent_and_reuses_existing_digest_artifact() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    let first = stage_session_host(root.path(), "jefe-agent-1", &source)
+        .unwrap_or_else(|error| panic!("first staging: {error}"));
+    let first_modified = fs::metadata(&first)
+        .and_then(|metadata| metadata.modified())
+        .unwrap_or_else(|error| panic!("first mtime: {error}"));
+
+    // Ensure the second observation's timestamp can differ if rewritten.
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    let second = stage_session_host(root.path(), "jefe-agent-1", &source)
+        .unwrap_or_else(|error| panic!("second staging: {error}"));
+
+    assert_eq!(first, second, "idempotent staging must reuse same path");
+    let second_modified = fs::metadata(&second)
+        .and_then(|metadata| metadata.modified())
+        .unwrap_or_else(|error| panic!("second mtime: {error}"));
+    assert_eq!(
+        first_modified, second_modified,
+        "idempotent staging must leave existing artifact untouched"
+    );
+}
+
+#[test]
+fn staging_different_content_produces_distinct_artifacts_side_by_side() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let first_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src 1: {error}"));
+    let second_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src 2: {error}"));
+
+    let first_source = write_source(&first_dir, b"jefe-image-v1");
+    let second_source = write_source(&second_dir, b"jefe-image-v2");
+
+    let first = stage_session_host(root.path(), "jefe-agent-1", &first_source)
+        .unwrap_or_else(|error| panic!("first staging: {error}"));
+    let second = stage_session_host(root.path(), "jefe-agent-1", &second_source)
+        .unwrap_or_else(|error| panic!("second staging: {error}"));
+
+    assert_ne!(first, second, "distinct digests stage separately");
+    assert!(first.exists(), "first artifact retained");
+    assert!(second.exists(), "second artifact retained");
+}
+
+#[test]
+fn staging_removes_interrupted_temp_artifacts_owned_by_this_attempt() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    let plan = SessionHostPlan::for_session(root.path(), "jefe-agent-1", b"jefe-image-v1")
+        .unwrap_or_else(|error| panic!("plan: {error}"));
+    // Simulate an interrupted prior staging: a leftover temp file in the digest
+    // directory owned by this staging attempt.
+    fs::create_dir_all(plan.digest_directory())
+        .unwrap_or_else(|error| panic!("create digest dir: {error}"));
+    let leftover = plan
+        .digest_directory()
+        .join(format!("{SESSION_HOST_BINARY}.jefe-staging-tmp-legacy"));
+    fs::write(&leftover, b"partial").unwrap_or_else(|error| panic!("write leftover temp: {error}"));
+
+    let staged = stage_session_host_with_attempt(root.path(), "jefe-agent-1", &source, "legacy")
+        .unwrap_or_else(|error| panic!("staging after leftover: {error}"));
+
+    assert!(staged.exists(), "staged binary exists");
+    assert!(
+        !leftover.exists(),
+        "interrupted temp owned by this attempt must be cleaned"
+    );
+}
+
+#[test]
+fn staging_leaves_unrelated_temp_artifacts_for_other_attempts_untouched() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    let plan = SessionHostPlan::for_session(root.path(), "jefe-agent-1", b"jefe-image-v1")
+        .unwrap_or_else(|error| panic!("plan: {error}"));
+    fs::create_dir_all(plan.digest_directory())
+        .unwrap_or_else(|error| panic!("create digest dir: {error}"));
+    // A concurrent staging attempt's temp file must not be deleted by this one.
+    let other = plan
+        .digest_directory()
+        .join(format!("{SESSION_HOST_BINARY}.jefe-staging-tmp-concurrent"));
+    fs::write(&other, b"other-attempt")
+        .unwrap_or_else(|error| panic!("write concurrent temp: {error}"));
+
+    let staged = stage_session_host_with_attempt(root.path(), "jefe-agent-1", &source, "this-try")
+        .unwrap_or_else(|error| panic!("staging with concurrent temp: {error}"));
+
+    assert!(staged.exists());
+    assert!(
+        other.exists(),
+        "temp owned by a different staging attempt must be retained"
+    );
+}
+
+#[test]
+fn staging_preserves_staged_copy_after_source_is_replaced() {
+    // AC4: a staged/running copy must permit replacing the source image.
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    let staged = stage_session_host(root.path(), "jefe-agent-1", &source)
+        .unwrap_or_else(|error| panic!("staging: {error}"));
+
+    // Replace the source image while the staged copy is "running".
+    fs::write(&source, b"jefe-image-v2-rebuilt")
+        .unwrap_or_else(|error| panic!("replace source image: {error}"));
+
+    let staged_bytes =
+        fs::read(&staged).unwrap_or_else(|error| panic!("read staged after replace: {error}"));
+    assert_eq!(
+        staged_bytes, b"jefe-image-v1",
+        "staged copy must be immutable across source replacement"
+    );
+}
+
+#[test]
+fn staging_errors_are_typed_and_name_operation_and_safe_path() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let missing = PathBuf::from("/definitely/missing/source/jefe.exe");
+
+    let error = match stage_session_host(root.path(), "jefe-agent-1", &missing) {
+        Ok(path) => panic!("missing source should not stage: {}", path.display()),
+        Err(error) => error,
+    };
+    let diagnostic = error.to_string();
+    assert!(
+        matches!(error, SessionHostError::SourceRead { .. }),
+        "expected SourceRead, got {error:?}"
+    );
+    assert!(
+        diagnostic.to_lowercase().contains("source"),
+        "diagnostic must name the operation context: {diagnostic}"
+    );
+    assert!(
+        diagnostic.contains("jefe.exe"),
+        "diagnostic must surface the safe path: {diagnostic}"
+    );
+}
+
+#[test]
+fn staging_error_never_leaks_source_bytes() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = source_dir.path().join("jefe.exe");
+    // Deliberately do not write the source so the read fails; the planner is
+    // given no bytes, and the diagnostic must never echo file contents.
+    let error = match stage_session_host(root.path(), "jefe-agent-1", &source) {
+        Ok(path) => panic!("missing source should not stage: {}", path.display()),
+        Err(error) => error,
+    };
+    let diagnostic = error.to_string();
+    assert!(
+        !diagnostic.contains("SECRET-MARKER"),
+        "diagnostic must not leak source bytes: {diagnostic}"
+    );
+}
+
+// ── Issue #467 Slice 2: per-session cleanup (AC7) ──────────────────────────
+//
+// A successful explicit local kill removes only the killed session's host
+// directory; unrelated sessions and ambiguous artifacts are never touched.
+// Cleanup failures are best-effort and retained for retry rather than aborting
+// the kill.
+
+fn stage_session_fixture(root: &TempDir, source: &Path, session_name: &str) -> PathBuf {
+    stage_session_host(root.path(), session_name, source)
+        .unwrap_or_else(|error| panic!("fixture staging for {session_name}: {error}"))
+}
+
+#[test]
+fn cleanup_session_directory_removes_only_the_target_session_host_directory() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    let target = stage_session_fixture(&root, &source, "jefe-alpha");
+    let sibling = stage_session_fixture(&root, &source, "jefe-beta");
+
+    assert!(target.exists(), "target fixture must exist");
+    assert!(sibling.exists(), "sibling fixture must exist");
+
+    let outcome =
+        crate::runtime::session_host::cleanup_session_directory(root.path(), "jefe-alpha")
+            .unwrap_or_else(|error| panic!("cleanup_session_directory should succeed: {error}"));
+
+    assert!(
+        matches!(outcome, SessionCleanupOutcome::Removed),
+        "successful cleanup of an existing session directory should report Removed"
+    );
+    assert!(
+        !target.exists(),
+        "killed session's host directory must be removed"
+    );
+    assert!(
+        sibling.exists(),
+        "unrelated session's host directory must be retained"
+    );
+}
+
+#[test]
+fn cleanup_session_directory_reports_absent_when_no_directory_exists() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let outcome =
+        crate::runtime::session_host::cleanup_session_directory(root.path(), "jefe-never-staged")
+            .unwrap_or_else(|error| {
+                panic!("cleanup of absent directory should not error: {error}")
+            });
+    assert!(
+        matches!(outcome, SessionCleanupOutcome::Absent),
+        "cleanup of an absent session directory should report Absent, got {outcome:?}"
+    );
+}
+
+#[test]
+fn cleanup_session_directory_rejects_unsanitizable_session_name_without_touching_root() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+    let retained = stage_session_fixture(&root, &source, "jefe-keeper");
+
+    let result = crate::runtime::session_host::cleanup_session_directory(root.path(), "---");
+    assert!(
+        matches!(result, Err(SessionHostError::InvalidSessionName { .. })),
+        "unsanitizable session name must be rejected: {result:?}"
+    );
+    assert!(
+        retained.exists(),
+        "an invalid session name must not allow any directory to be removed"
+    );
+}
+
+#[test]
+fn cleanup_session_directory_reports_retained_when_directory_cannot_be_removed() {
+    // AC7: cleanup failures are best-effort and retained for retry. On Unix we
+    // simulate an unwritable root by revoking the directory's write permission
+    // so the recursive remove fails; on Windows the host filesystem does not
+    // honor the chmod contract, so this test is Unix-only.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+        let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+        let source = write_default_source(&source_dir);
+        let staged = stage_session_fixture(&root, &source, "jefe-locked");
+
+        // Revoke write on the root so the session subdirectory cannot be
+        // unlinked. Restore it afterwards so TempDir::drop can clean up.
+        let meta =
+            std::fs::metadata(root.path()).unwrap_or_else(|error| panic!("root metadata: {error}"));
+        let mut perms = meta.permissions();
+        perms.set_mode(0o555);
+        std::fs::set_permissions(root.path(), perms.clone())
+            .unwrap_or_else(|error| panic!("revoke root write: {error}"));
+
+        let outcome =
+            crate::runtime::session_host::cleanup_session_directory(root.path(), "jefe-locked")
+                .unwrap_or_else(|error| {
+                    panic!("cleanup should retain on failure, not error: {error}")
+                });
+
+        // Restore write for TempDir drop. Best-effort; the assertion below is
+        // the contract we care about.
+        perms.set_mode(0o755);
+        let _ = std::fs::set_permissions(root.path(), perms);
+
+        assert!(
+            matches!(outcome, SessionCleanupOutcome::RetainedForRetry),
+            "cleanup failure must be retained for retry, got {outcome:?}"
+        );
+        assert!(
+            staged.exists(),
+            "retained session directory must still exist after a failed cleanup"
+        );
+    }
+}
+
+// ── Issue #467 Slice 2: startup cleanup (AC8) ──────────────────────────────
+//
+// Startup cleanup scans the session-host root and removes only unreferenced
+// and dead session directories plus interrupted staging temp files. Live
+// psmux sessions, persisted-reference directories, and ambiguous/unprobeable
+// artifacts are retained.
+
+#[derive(Debug, Clone)]
+struct ProbeSet {
+    alive: std::collections::HashSet<String>,
+    unprobeable: std::collections::HashSet<String>,
+}
+
+impl ProbeSet {
+    fn new() -> Self {
+        Self {
+            alive: std::collections::HashSet::new(),
+            unprobeable: std::collections::HashSet::new(),
+        }
+    }
+    fn alive_session(mut self, name: &str) -> Self {
+        self.alive.insert(name.to_owned());
+        self
+    }
+    fn unprobeable_session(mut self, name: &str) -> Self {
+        self.unprobeable.insert(name.to_owned());
+        self
+    }
+}
+
+fn probe_for(set: ProbeSet) -> impl Fn(&str) -> crate::runtime::liveness::SessionLiveness {
+    move |name: &str| {
+        if set.alive.contains(name) {
+            crate::runtime::liveness::SessionLiveness::Alive
+        } else if set.unprobeable.contains(name) {
+            crate::runtime::liveness::SessionLiveness::Unavailable
+        } else {
+            crate::runtime::liveness::SessionLiveness::Missing
+        }
+    }
+}
+
+#[test]
+fn startup_cleanup_removes_unreferenced_and_dead_session_directories() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    let unreferenced = stage_session_fixture(&root, &source, "jefe-unreferenced");
+    let dead = stage_session_fixture(&root, &source, "jefe-dead");
+
+    let report = startup_cleanup_session_hosts(
+        root.path(),
+        &[], // no persisted references
+        probe_for(ProbeSet::new()),
+    )
+    .unwrap_or_else(|error| panic!("startup cleanup should succeed: {error}"));
+
+    assert!(
+        !unreferenced.exists(),
+        "unreferenced session directory must be removed"
+    );
+    assert!(
+        !dead.exists(),
+        "session directory with a Missing pane probe must be removed"
+    );
+    assert!(
+        report
+            .removed_session_directories
+            .iter()
+            .any(|dir| { dir.ends_with("jefe-unreferenced") || dir.ends_with("jefe-dead") }),
+        "report must enumerate the removed session directories: {report:?}"
+    );
+}
+
+#[test]
+fn startup_cleanup_retains_directories_for_live_psmux_sessions() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    let live = stage_session_fixture(&root, &source, "jefe-live");
+
+    let report = startup_cleanup_session_hosts(
+        root.path(),
+        &[], // no persisted reference; liveness is the only reason to retain
+        probe_for(ProbeSet::new().alive_session("jefe-live")),
+    )
+    .unwrap_or_else(|error| panic!("startup cleanup should succeed: {error}"));
+
+    assert!(
+        live.exists(),
+        "live psmux session directory must be retained even without a persisted reference"
+    );
+    assert!(
+        report.removed_session_directories.is_empty(),
+        "no session directories should be removed when only a live session exists: {report:?}"
+    );
+    assert!(
+        report
+            .retained_live_session_directories
+            .iter()
+            .any(|dir| dir.ends_with("jefe-live")),
+        "report must enumerate the retained live session directory: {report:?}"
+    );
+}
+
+#[test]
+fn startup_cleanup_retains_directories_referenced_by_persisted_bindings() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    let referenced = stage_session_fixture(&root, &source, "jefe-referenced");
+    let persisted_references = vec!["jefe-referenced".to_owned()];
+
+    let report = startup_cleanup_session_hosts(
+        root.path(),
+        &persisted_references,
+        probe_for(ProbeSet::new()), // probe says Missing, but the reference retains it
+    )
+    .unwrap_or_else(|error| panic!("startup cleanup should succeed: {error}"));
+
+    assert!(
+        referenced.exists(),
+        "persisted-reference directory must be retained even when the pane probe is Missing"
+    );
+    assert!(
+        report.removed_session_directories.is_empty(),
+        "no session directories should be removed when a persisted reference exists: {report:?}"
+    );
+}
+
+#[test]
+fn startup_cleanup_retains_unprobeable_and_ambiguous_directories() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    let unprobeable = stage_session_fixture(&root, &source, "jefe-unprobeable");
+
+    // An artifact whose sanitized session name cannot be inverted back to a
+    // RuntimeBinding session name (ambiguity) must also be retained. Seed a
+    // directory whose name does not match the jefe-<agent> contract.
+    let ambiguous_name = "stray-artifact-dir";
+    let ambiguous = root.path().join(ambiguous_name);
+    std::fs::create_dir_all(&ambiguous)
+        .unwrap_or_else(|error| panic!("seed ambiguous artifact: {error}"));
+
+    let report = startup_cleanup_session_hosts(
+        root.path(),
+        &[],
+        probe_for(
+            ProbeSet::new()
+                .unprobeable_session("jefe-unprobeable")
+                .unprobeable_session(ambiguous_name),
+        ),
+    )
+    .unwrap_or_else(|error| panic!("startup cleanup should succeed: {error}"));
+
+    assert!(
+        unprobeable.exists(),
+        "unprobeable session directory must be retained"
+    );
+    assert!(
+        ambiguous.exists(),
+        "ambiguous session directory must be retained"
+    );
+    assert!(
+        report.removed_session_directories.is_empty(),
+        "no session directories should be removed when every entry is ambiguous/unprobeable: {report:?}"
+    );
+}
+
+#[test]
+fn startup_cleanup_reclaims_interrupted_staging_temp_files() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    let staged = stage_session_fixture(&root, &source, "jefe-with-leftover");
+    // Seed an interrupted staging temp file inside the live session's digest
+    // directory to prove startup reclaims leftover temps without removing the
+    // live session directory itself.
+    let plan = SessionHostPlan::for_session(root.path(), "jefe-with-leftover", b"jefe-image-v1")
+        .unwrap_or_else(|error| panic!("plan: {error}"));
+    let leftover = plan.digest_directory().join(format!(
+        "{SESSION_HOST_BINARY}.jefe-staging-tmp-interrupted"
+    ));
+    std::fs::write(&leftover, b"partial bytes")
+        .unwrap_or_else(|error| panic!("seed leftover temp: {error}"));
+
+    let report = startup_cleanup_session_hosts(
+        root.path(),
+        &["jefe-with-leftover".to_owned()],
+        probe_for(ProbeSet::new().alive_session("jefe-with-leftover")),
+    )
+    .unwrap_or_else(|error| panic!("startup cleanup should succeed: {error}"));
+
+    assert!(
+        staged.exists(),
+        "live referenced session directory must be retained"
+    );
+    assert!(
+        !leftover.exists(),
+        "interrupted staging temp file must be reclaimed"
+    );
+    assert!(
+        report
+            .removed_temp_files
+            .iter()
+            .any(|path| path == &leftover),
+        "report must enumerate the reclaimed temp file: {report:?}"
+    );
+}

--- a/src/runtime/session_host_tests.rs
+++ b/src/runtime/session_host_tests.rs
@@ -251,6 +251,37 @@ fn staging_leaves_unrelated_temp_artifacts_for_other_attempts_untouched() {
 }
 
 #[test]
+fn concurrent_staging_of_the_same_image_is_idempotent() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    let paths = std::thread::scope(|scope| {
+        let first = scope.spawn(|| stage_session_host(root.path(), "jefe-agent-1", &source));
+        let second = scope.spawn(|| stage_session_host(root.path(), "jefe-agent-1", &source));
+        [
+            first
+                .join()
+                .unwrap_or_else(|_| panic!("first staging thread panicked")),
+            second
+                .join()
+                .unwrap_or_else(|_| panic!("second staging thread panicked")),
+        ]
+    });
+    let first = paths[0]
+        .as_ref()
+        .unwrap_or_else(|error| panic!("first concurrent staging: {error}"));
+    let second = paths[1]
+        .as_ref()
+        .unwrap_or_else(|error| panic!("second concurrent staging: {error}"));
+    assert_eq!(first, second);
+    assert_eq!(
+        fs::read(first).unwrap_or_else(|error| panic!("read staged image: {error}")),
+        b"jefe-image-v1"
+    );
+}
+
+#[test]
 fn staging_preserves_staged_copy_after_source_is_replaced() {
     // AC4: a staged/running copy must permit replacing the source image.
     let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
@@ -389,48 +420,24 @@ fn cleanup_session_directory_rejects_unsanitizable_session_name_without_touching
 }
 
 #[test]
-fn cleanup_session_directory_reports_retained_when_directory_cannot_be_removed() {
-    // AC7: cleanup failures are best-effort and retained for retry. On Unix we
-    // simulate an unwritable root by revoking the directory's write permission
-    // so the recursive remove fails; on Windows the host filesystem does not
-    // honor the chmod contract, so this test is Unix-only.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
-        let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
-        let source = write_default_source(&source_dir);
-        let staged = stage_session_fixture(&root, &source, "jefe-locked");
+fn cleanup_session_directory_reports_retained_when_artifact_cannot_be_removed_as_directory() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let session_path = root.path().join("jefe-locked");
+    fs::write(&session_path, b"interrupted artifact")
+        .unwrap_or_else(|error| panic!("write invalid session artifact: {error}"));
 
-        // Revoke write on the root so the session subdirectory cannot be
-        // unlinked. Restore it afterwards so TempDir::drop can clean up.
-        let meta =
-            std::fs::metadata(root.path()).unwrap_or_else(|error| panic!("root metadata: {error}"));
-        let mut perms = meta.permissions();
-        perms.set_mode(0o555);
-        std::fs::set_permissions(root.path(), perms.clone())
-            .unwrap_or_else(|error| panic!("revoke root write: {error}"));
+    let outcome =
+        crate::runtime::session_host::cleanup_session_directory(root.path(), "jefe-locked")
+            .unwrap_or_else(|error| panic!("cleanup should retain on failure, not error: {error}"));
 
-        let outcome =
-            crate::runtime::session_host::cleanup_session_directory(root.path(), "jefe-locked")
-                .unwrap_or_else(|error| {
-                    panic!("cleanup should retain on failure, not error: {error}")
-                });
-
-        // Restore write for TempDir drop. Best-effort; the assertion below is
-        // the contract we care about.
-        perms.set_mode(0o755);
-        let _ = std::fs::set_permissions(root.path(), perms);
-
-        assert!(
-            matches!(outcome, SessionCleanupOutcome::RetainedForRetry),
-            "cleanup failure must be retained for retry, got {outcome:?}"
-        );
-        assert!(
-            staged.exists(),
-            "retained session directory must still exist after a failed cleanup"
-        );
-    }
+    assert!(
+        matches!(outcome, SessionCleanupOutcome::RetainedForRetry),
+        "cleanup failure must be retained for retry, got {outcome:?}"
+    );
+    assert!(
+        session_path.exists(),
+        "retained session artifact must still exist after failed directory cleanup"
+    );
 }
 
 // ── Issue #467 Slice 2: startup cleanup (AC8) ──────────────────────────────

--- a/tests/fixtures/psmux_session_host_fixture.rs
+++ b/tests/fixtures/psmux_session_host_fixture.rs
@@ -1,0 +1,184 @@
+//! Issue #467 Slice 4 fixture: a standalone pane host that owns a kill-on-close
+//! Windows Job Object and a long-lived worker descendant.
+//!
+//! This fixture models the production `jefe.exe --jefe-internal-agent-launch`
+//! pane-host entrypoint without depending on llxprt/network/package
+//! availability. It is the unit under test for the native psmux lifecycle
+//! regression in `tests/psmux_session_host.rs`.
+//!
+//! Modes:
+//! - `--session-host <marker-path>`: create and own a kill-on-close Job Object,
+//!   assign this process to it, spawn the worker child (inheriting the Job),
+//!   record both PIDs plus a `host_owned_job` boolean to `<marker-path>`, then
+//!   hold until killed. Host death closes the Job handle and the kernel reaps
+//!   the contained worker tree (AC6).
+//! - `--worker <marker-path>`: long-lived worker child. Records its own PID to
+//!   the marker file, then blocks until killed. Detached from the host's
+//!   console so it is not cascaded by console-close events; the Job is the
+//!   only containment boundary under test.
+
+#![cfg(feature = "psmux-smoke")]
+
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::thread;
+use std::time::Duration;
+
+use serde::Serialize;
+
+/// Host hold time: keeps the pane alive until the test kills it.
+const HOST_HOLD: Duration = Duration::new(3600, 0);
+
+#[derive(Serialize)]
+struct HostMarker {
+    host_pid: u32,
+    worker_pid: u32,
+    /// Whether the host established a kill-on-close Job Object owning the worker tree.
+    host_owned_job: bool,
+    started_at: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct WorkerRecord {
+    worker_pid: u32,
+    started_at: Option<u64>,
+}
+
+fn main() -> ExitCode {
+    if let Err(error) = run() {
+        let _ = writeln!(
+            std::io::stderr(),
+            "psmux session-host fixture failed: {error}"
+        );
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let mode = args.next().ok_or("missing mode argument")?;
+    match mode.as_str() {
+        "--session-host" => {
+            let marker_path: PathBuf = args
+                .next()
+                .ok_or("--session-host requires a marker path")?
+                .into();
+            if args.next().is_some() {
+                return Err("unexpected extra argument".into());
+            }
+            run_session_host(&marker_path)
+        }
+        "--worker" => {
+            let marker_path: PathBuf = args.next().ok_or("--worker requires a marker path")?.into();
+            if args.next().is_some() {
+                return Err("unexpected extra argument".into());
+            }
+            run_worker(&marker_path)
+        }
+        other => Err(format!("unknown mode: {other}").into()),
+    }
+}
+
+/// Pane-host mode: own a kill-on-close Job, spawn a contained worker, record
+/// the PIDs, and hold until killed.
+fn run_session_host(marker_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    // Establish Job containment exactly as the production private pane host
+    // does (`run_launch_plan`). Host death closes the handle and reaps the tree.
+    establish_host_job()?;
+
+    let current_exe = std::env::current_exe()?;
+    let mut child = std::process::Command::new(&current_exe);
+    child.arg("--worker").arg(marker_path);
+    child.stdin(std::process::Stdio::null());
+    child.stdout(std::process::Stdio::null());
+    child.stderr(std::process::Stdio::null());
+    // CREATE_NEW_PROCESS_GROUP (0x00000200) | DETACHED_PROCESS (0x00000008):
+    // detach the worker from this host's console so a console-close event does
+    // not cascade-kill it. The Job is the only containment boundary under test.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        child.creation_flags(0x0000_0208);
+    }
+    let mut child = child.spawn()?;
+    let worker_pid = child.id();
+
+    // Record the marker once the worker has spawned. The worker records its
+    // own PID independently as a cross-check.
+    let marker = HostMarker {
+        host_pid: std::process::id(),
+        worker_pid,
+        host_owned_job: true,
+        started_at: now_unix_seconds(),
+    };
+    fs::write(marker_path, serde_json::to_vec(&marker)?)?;
+
+    // Hold the pane host alive until the test kills the session. Do not wait
+    // on the child: we want host death (kill-session) to be the trigger, not
+    // worker exit. Reap the child defensively to avoid a zombie if it exits
+    // first, but keep holding regardless.
+    let _ = child.try_wait();
+    loop {
+        thread::sleep(HOST_HOLD);
+    }
+}
+
+/// Worker mode: record own PID into the marker's worker-pid slot (overwriting
+/// only that field is unsafe across writers, so the worker writes its own
+/// sidecar file `<marker>.worker`), then block until killed.
+fn run_worker(marker_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    let worker_sidecar = marker_path.with_extension("worker.json");
+    let record = WorkerRecord {
+        worker_pid: std::process::id(),
+        started_at: now_unix_seconds(),
+    };
+    fs::write(&worker_sidecar, serde_json::to_vec(&record)?)?;
+    loop {
+        thread::sleep(HOST_HOLD);
+    }
+}
+
+#[cfg(windows)]
+fn establish_host_job() -> Result<(), Box<dyn std::error::Error>> {
+    // Reuse the production-safe win32job boundary by inlining the minimal
+    // create/configure/assign sequence. This fixture must not link the
+    // production `runtime::job_object` module (it lives behind the library's
+    // private modules), and the win32job dependency is already approved and
+    // present for cfg(windows).
+    use win32job::Job;
+    let job = Job::create()?;
+    let mut info = job.query_extended_limit_info()?;
+    info.limit_kill_on_job_close();
+    job.set_extended_limit_info(&info)?;
+    job.assign_current_process()?;
+    // Leak the handle: this process owns the Job for its whole lifetime. Drop
+    // would close the handle prematurely and defeat the test.
+    std::mem::forget(job);
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn establish_host_job() -> Result<(), Box<dyn std::error::Error>> {
+    // Unix is structurally out of scope for #467; the fixture is only built
+    // under the psmux-smoke feature which is windows-gated.
+    Ok(())
+}
+
+#[cfg(windows)]
+fn now_unix_seconds() -> Option<u64> {
+    use winsafe::{HPROCESS, co};
+    let pid = std::process::id();
+    let process = HPROCESS::OpenProcess(co::PROCESS::QUERY_LIMITED_INFORMATION, false, pid).ok()?;
+    let (creation, _, _, _) = process.GetProcessTimes().ok()?;
+    let raw = (u64::from(creation.dwHighDateTime) << 32) | u64::from(creation.dwLowDateTime);
+    // Convert Windows FILETIME (100ns ticks since 1601) to Unix seconds.
+    Some(raw.saturating_sub(116_444_736_000_000_000) / 10_000_000)
+}
+
+#[cfg(not(windows))]
+fn now_unix_seconds() -> Option<u64> {
+    None
+}

--- a/tests/fixtures/psmux_session_host_fixture.rs
+++ b/tests/fixtures/psmux_session_host_fixture.rs
@@ -112,7 +112,7 @@ fn run_session_host(marker_path: &std::path::Path) -> Result<(), Box<dyn std::er
     let marker = HostMarker {
         host_pid: std::process::id(),
         worker_pid,
-        host_owned_job: true,
+        host_owned_job: cfg!(windows),
         started_at: now_unix_seconds(),
     };
     fs::write(marker_path, serde_json::to_vec(&marker)?)?;

--- a/tests/fixtures/psmux_session_host_fixture.rs
+++ b/tests/fixtures/psmux_session_host_fixture.rs
@@ -69,6 +69,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             if args.next().is_some() {
                 return Err("unexpected extra argument".into());
             }
+            #[cfg(windows)]
+            establish_host_job()?;
             run_session_host(&marker_path)
         }
         "--worker" => {
@@ -157,13 +159,6 @@ fn establish_host_job() -> Result<(), Box<dyn std::error::Error>> {
     // Leak the handle: this process owns the Job for its whole lifetime. Drop
     // would close the handle prematurely and defeat the test.
     std::mem::forget(job);
-    Ok(())
-}
-
-#[cfg(not(windows))]
-fn establish_host_job() -> Result<(), Box<dyn std::error::Error>> {
-    // Unix is structurally out of scope for #467; the fixture is only built
-    // under the psmux-smoke feature which is windows-gated.
     Ok(())
 }
 

--- a/tests/fixtures/psmux_session_host_fixture.rs
+++ b/tests/fixtures/psmux_session_host_fixture.rs
@@ -69,8 +69,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             if args.next().is_some() {
                 return Err("unexpected extra argument".into());
             }
-            #[cfg(windows)]
-            establish_host_job()?;
             run_session_host(&marker_path)
         }
         "--worker" => {
@@ -89,6 +87,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 fn run_session_host(marker_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     // Establish Job containment exactly as the production private pane host
     // does (`run_launch_plan`). Host death closes the handle and reaps the tree.
+    #[cfg(windows)]
     establish_host_job()?;
 
     let current_exe = std::env::current_exe()?;

--- a/tests/psmux_session_host.rs
+++ b/tests/psmux_session_host.rs
@@ -1,0 +1,448 @@
+#![cfg(all(windows, feature = "psmux-smoke"))]
+
+//! Issue #467 Slice 4 native Windows psmux lifecycle regression (AC2–AC7/AC10).
+//!
+//! Proves, against a real native Windows psmux >= 3.3.7, that two or more
+//! independently staged pane hosts in one unique `-L` namespace:
+//! - survive a simulated dashboard exit/crash (AC2, AC3);
+//! - keep the source executable replaceable while they run (AC4);
+//! - retain the exact same session names and pane PIDs with exactly one worker
+//!   descendant each on restart/discovery, with no duplicate `--continue`
+//!   (AC5);
+//! - reap only the killed host's Job-owned worker tree within a bounded
+//!   timeout when one pane host dies, leaving the other host untouched (AC6);
+//! - clean up only their own namespace/session artifacts (AC7/AC10).
+//!
+//! The test never contacts the production Jefe psmux namespace, never kills
+//! arbitrary user processes, and owns a unique namespace with Drop cleanup. It
+//! is opt-in under the existing `psmux-smoke` feature and the
+//! `JEFE_REQUIRE_PSMUX=1` policy, mirroring `psmux_smoke.rs` and
+//! `psmux_orphan_reap.rs`.
+//!
+//! The fixture `jefe-psmux-session-host-fixture` models the production private
+//! pane-host entrypoint (`jefe.exe --jefe-internal-agent-launch` →
+//! `run_launch_plan`) without depending on llxprt/network/package
+//! availability: it creates and owns a kill-on-close Windows Job Object,
+//! assigns itself, spawns a long-lived worker child that inherits the Job,
+//! records both PIDs to a marker, and holds until killed. Host death closes
+//! the Job handle and the kernel reaps the contained worker tree (AC6).
+
+use std::ffi::OsString;
+use std::fmt::Write as FmtWrite;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use jefe::runtime::{LocalPlatform, MultiplexerIsolation, MultiplexerPlan};
+use serde::Deserialize;
+
+const FIXTURE: &str = env!("CARGO_BIN_EXE_jefe-psmux-session-host-fixture");
+const POLL_TIMEOUT: Duration = Duration::from_secs(15);
+const CONTAINMENT_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct HostMarker {
+    host_pid: u32,
+    worker_pid: u32,
+    host_owned_job: bool,
+    started_at: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct WorkerRecord {
+    worker_pid: u32,
+    started_at: Option<u64>,
+}
+
+#[derive(Debug)]
+struct RegressionFailure {
+    message: String,
+    diagnostics: String,
+}
+
+impl std::fmt::Display for RegressionFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}\n\n{}", self.message, self.diagnostics)
+    }
+}
+
+impl std::error::Error for RegressionFailure {}
+
+fn fail<E: std::fmt::Debug>(message: &str, error: E) -> RegressionFailure {
+    RegressionFailure {
+        message: message.to_owned(),
+        diagnostics: format!("{error:?}"),
+    }
+}
+
+struct PsmuxNamespace {
+    executable: PathBuf,
+    name: String,
+    transcript: String,
+    artifact_dir: PathBuf,
+}
+
+impl PsmuxNamespace {
+    fn new(label: &str) -> Result<Self, RegressionFailure> {
+        let name = unique_name(label);
+        let artifact_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("psmux-smoke")
+            .join(&name);
+        fs::create_dir_all(&artifact_dir)
+            .map_err(|error| fail("create artifact directory", error))?;
+        Ok(Self {
+            executable: psmux_path(),
+            name,
+            transcript: String::new(),
+            artifact_dir,
+        })
+    }
+
+    fn run(&mut self, args: &[&str]) -> Result<Output, RegressionFailure> {
+        let owned: Vec<OsString> = args.iter().map(OsString::from).collect();
+        self.run_os(&owned)
+    }
+
+    fn run_os(&mut self, args: &[OsString]) -> Result<Output, RegressionFailure> {
+        let mut command = Command::new(&self.executable);
+        command.arg("-L").arg(&self.name);
+        for value in args {
+            command.arg(value);
+        }
+        for variable in ["TMUX", "TMUX_PANE", "TMUX_TMPDIR"] {
+            command.env_remove(variable);
+        }
+        let display = format!(
+            "{} -L {} {}",
+            self.executable.display(),
+            self.name,
+            format_args_os(args)
+        );
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let output = command
+            .output()
+            .map_err(|error| self.failure(format!("spawn failed: {display}: {error}"), ""))?;
+        let _ = writeln!(self.transcript, "$ {display}\n{}", format_output(&output));
+        if output.status.success() {
+            Ok(output)
+        } else {
+            Err(self.failure(
+                format!("command failed: {display}"),
+                &format_output(&output),
+            ))
+        }
+    }
+
+    fn pane_command(
+        &self,
+        program: &Path,
+        fixture_args: &[OsString],
+    ) -> Result<Vec<OsString>, RegressionFailure> {
+        let plan = MultiplexerPlan::for_platform(
+            LocalPlatform::Windows,
+            self.executable.clone(),
+            MultiplexerIsolation::Namespace(self.name.clone()),
+        )
+        .map_err(|error| fail("construct Windows psmux plan", error))?;
+        plan.pane_command_args(program.as_os_str(), fixture_args, &[])
+            .map_err(|error| fail("build fixture pane command", error))
+    }
+
+    fn run_quiet(&self, args: &[&str]) {
+        let mut command = Command::new(&self.executable);
+        command.arg("-L").arg(&self.name).args(args);
+        for variable in ["TMUX", "TMUX_PANE", "TMUX_TMPDIR"] {
+            command.env_remove(variable);
+        }
+        let _ = command.stdout(Stdio::null()).stderr(Stdio::null()).status();
+    }
+
+    fn session_exists(&mut self, session: &str) -> bool {
+        self.run(&["has-session", "-t", session]).is_ok()
+    }
+
+    fn pane_pid(&mut self, session: &str) -> Result<u32, RegressionFailure> {
+        let output = self.run(&["display-message", "-p", "-t", session, "#{pane_pid}"])?;
+        let text = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        text.parse::<u32>()
+            .map_err(|_| self.failure(format!("invalid pane_pid for {session}: {text:?}"), ""))
+    }
+
+    fn failure(&self, message: String, details: &str) -> RegressionFailure {
+        let sessions = self.available_sessions();
+        let diagnostics = format!(
+            "namespace: {}\nartifact dir: {}\n{details}\n\navailable sessions:\n{sessions}\n\ntranscript:\n{}",
+            self.name,
+            self.artifact_dir.display(),
+            self.transcript
+        );
+        let _ = fs::write(self.artifact_dir.join("failure.txt"), &diagnostics);
+        RegressionFailure {
+            message,
+            diagnostics,
+        }
+    }
+
+    fn available_sessions(&self) -> String {
+        let output = Command::new(&self.executable)
+            .arg("-L")
+            .arg(&self.name)
+            .args(["list-sessions", "-F", "#{session_name}"])
+            .output();
+        match output {
+            Ok(output) => format_output(&output),
+            Err(error) => format!("unable to list sessions: {error}"),
+        }
+    }
+}
+
+impl Drop for PsmuxNamespace {
+    fn drop(&mut self) {
+        // Namespace-scoped cleanup (AC7/AC10): only this test's unique -L
+        // namespace is contacted. The production Jefe namespace is never
+        // touched, and no bare kill-server is ever issued against the default
+        // server.
+        self.run_quiet(&["kill-server"]);
+        let _ = fs::write(self.artifact_dir.join("transcript.txt"), &self.transcript);
+    }
+}
+
+struct RunningHosts {
+    work: Workdir,
+    host_a: &'static str,
+    host_b: &'static str,
+    marker_a: HostMarker,
+    marker_b: HostMarker,
+    source: PathBuf,
+}
+
+fn launch_running_hosts(namespace: &mut PsmuxNamespace) -> Result<RunningHosts, RegressionFailure> {
+    let work = Workdir::new()?;
+    let host_a = "sh-alpha";
+    let host_b = "sh-beta";
+    let marker_a_path = work.path().join("host-a.json");
+    let marker_b_path = work.path().join("host-b.json");
+    let source = work.path().join("source-image.exe");
+    fs::copy(FIXTURE, &source).map_err(|e| fail("create source image", e))?;
+    let staged_a = work.path().join("session-host-a.exe");
+    let staged_b = work.path().join("session-host-b.exe");
+    fs::copy(&source, &staged_a).map_err(|e| fail("stage host A", e))?;
+    fs::copy(&source, &staged_b).map_err(|e| fail("stage host B", e))?;
+    launch_session_host(namespace, host_a, work.path(), &staged_a, &marker_a_path)?;
+    launch_session_host(namespace, host_b, work.path(), &staged_b, &marker_b_path)?;
+    let marker_a = wait_for_marker(&marker_a_path)?;
+    let marker_b = wait_for_marker(&marker_b_path)?;
+    Ok(RunningHosts {
+        work,
+        host_a,
+        host_b,
+        marker_a,
+        marker_b,
+        source,
+    })
+}
+
+fn assert_survives_and_source_replaces(
+    namespace: &mut PsmuxNamespace,
+    hosts: &RunningHosts,
+) -> Result<(), RegressionFailure> {
+    assert!(hosts.marker_a.host_owned_job && hosts.marker_b.host_owned_job);
+    for (session, worker) in [
+        (hosts.host_a, hosts.marker_a.worker_pid),
+        (hosts.host_b, hosts.marker_b.worker_pid),
+    ] {
+        assert!(namespace.session_exists(session));
+        assert!(process_alive(worker));
+    }
+    let replacement = hosts.work.path().join("replacement-image.exe");
+    fs::write(&replacement, b"replacement-bytes-467").map_err(|e| fail("write replacement", e))?;
+    fs::copy(&replacement, &hosts.source).map_err(|e| fail("overwrite source while running", e))?;
+    assert!(namespace.session_exists(hosts.host_a));
+    assert!(namespace.session_exists(hosts.host_b));
+    Ok(())
+}
+
+fn assert_reconnect_and_scoped_reap(
+    namespace: &mut PsmuxNamespace,
+    hosts: &RunningHosts,
+) -> Result<(), RegressionFailure> {
+    let pane_a = namespace.pane_pid(hosts.host_a)?;
+    let pane_b = namespace.pane_pid(hosts.host_b)?;
+    assert_ne!(pane_a, 0);
+    assert_ne!(pane_b, 0);
+    assert_eq!(namespace.pane_pid(hosts.host_a)?, pane_a);
+    assert_eq!(namespace.pane_pid(hosts.host_b)?, pane_b);
+    let worker_a: WorkerRecord = wait_for_marker(&hosts.work.path().join("host-a.worker.json"))?;
+    let worker_b: WorkerRecord = wait_for_marker(&hosts.work.path().join("host-b.worker.json"))?;
+    assert!(process_alive(worker_a.worker_pid));
+    assert!(process_alive(worker_b.worker_pid));
+    kill_session(namespace, hosts.host_a)?;
+    assert!(wait_for_process_exit(
+        hosts.marker_a.worker_pid,
+        CONTAINMENT_TIMEOUT
+    ));
+    assert!(process_alive(hosts.marker_b.worker_pid));
+    assert!(namespace.session_exists(hosts.host_b));
+    kill_session(namespace, hosts.host_b)?;
+    assert!(!namespace.session_exists(hosts.host_a));
+    assert!(!namespace.session_exists(hosts.host_b));
+    Ok(())
+}
+
+#[test]
+fn two_staged_hosts_survive_dashboard_exit_keep_source_replaceable_reconnect_and_scoped_reap()
+-> Result<(), RegressionFailure> {
+    if !psmux_required() {
+        return Ok(());
+    }
+    let mut namespace = PsmuxNamespace::new("session-host")?;
+    let hosts = launch_running_hosts(&mut namespace)?;
+    assert_survives_and_source_replaces(&mut namespace, &hosts)?;
+    assert_reconnect_and_scoped_reap(&mut namespace, &hosts)?;
+    Ok(())
+}
+
+struct Workdir {
+    dir: tempfile::TempDir,
+}
+
+impl Workdir {
+    fn new() -> Result<Self, RegressionFailure> {
+        let dir = tempfile::Builder::new()
+            .prefix("jefe-467-host Ω ")
+            .tempdir()
+            .map_err(|e| fail("create work dir", e))?;
+        Ok(Self { dir })
+    }
+
+    fn path(&self) -> &Path {
+        self.dir.path()
+    }
+}
+
+fn launch_session_host(
+    namespace: &mut PsmuxNamespace,
+    session: &str,
+    cwd: &Path,
+    program: &Path,
+    marker: &Path,
+) -> Result<(), RegressionFailure> {
+    let fixture_args = vec![
+        OsString::from("--session-host"),
+        marker.as_os_str().to_owned(),
+    ];
+    let pane = namespace.pane_command(program, &fixture_args)?;
+    let mut args = vec![
+        OsString::from("new-session"),
+        OsString::from("-d"),
+        OsString::from("-s"),
+        OsString::from(session),
+        OsString::from("-c"),
+        cwd.as_os_str().to_owned(),
+    ];
+    args.extend(pane);
+    namespace.run_os(&args).map(|_| ())
+}
+
+fn kill_session(namespace: &mut PsmuxNamespace, session: &str) -> Result<(), RegressionFailure> {
+    namespace.run(&["kill-session", "-t", session]).map(|_| ())
+}
+
+fn wait_for_marker<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T, RegressionFailure> {
+    let deadline = Instant::now() + POLL_TIMEOUT;
+    let mut last_error = String::from("marker not written");
+    while Instant::now() < deadline {
+        if let Ok(bytes) = fs::read(path) {
+            match serde_json::from_slice::<T>(&bytes) {
+                Ok(value) => return Ok(value),
+                Err(error) => last_error = format!("marker unreadable: {error}"),
+            }
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    Err(RegressionFailure {
+        message: format!(
+            "marker {} not ready within {POLL_TIMEOUT:?}",
+            path.display()
+        ),
+        diagnostics: last_error,
+    })
+}
+
+fn wait_for_process_exit(pid: u32, bound: Duration) -> bool {
+    let deadline = Instant::now() + bound;
+    while Instant::now() < deadline {
+        if !process_alive(pid) {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    !process_alive(pid)
+}
+
+fn process_alive(pid: u32) -> bool {
+    #[cfg(windows)]
+    {
+        use winsafe::{HPROCESS, co};
+        let access = co::PROCESS::QUERY_LIMITED_INFORMATION | co::PROCESS::SYNCHRONIZE;
+        match HPROCESS::OpenProcess(access, false, pid) {
+            Ok(process) => {
+                matches!(process.WaitForSingleObject(Some(0)), Ok(co::WAIT::TIMEOUT))
+            }
+            Err(_) => false,
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+fn psmux_required() -> bool {
+    std::env::var("JEFE_REQUIRE_PSMUX").is_ok_and(|value| value == "1")
+}
+
+fn psmux_path() -> PathBuf {
+    if let Some(explicit) = std::env::var_os("JEFE_PSMUX_BIN").filter(|v| !v.is_empty()) {
+        return PathBuf::from(explicit);
+    }
+    which_psmux().unwrap_or_else(|| PathBuf::from("psmux"))
+}
+
+fn which_psmux() -> Option<PathBuf> {
+    let output = Command::new("where.exe").arg("psmux").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    PathBuf::from(text.lines().next()?.trim()).into()
+}
+
+fn unique_name(label: &str) -> String {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    format!("jefe-467-{label}-{stamp:x}")
+}
+
+fn format_args_os(args: &[OsString]) -> String {
+    args.iter()
+        .map(|value| value.to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn format_output(output: &Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    format!(
+        "status: {}\nstdout: {stdout}\nstderr: {stderr}",
+        output.status
+    )
+}


### PR DESCRIPTION
## Summary

Fixes #467 by making native Windows psmux agent sessions independent of the live Jefe build image and by giving each pane host deterministic ownership of its worker tree.

- stage a content-addressed per-session copy of `jefe.exe` below the resolved state root
- launch the staged copy through the existing private launch-plan entrypoint
- establish a host-owned kill-on-close Windows Job Object before worker spawn
- retain healthy sessions across dashboard quit/crash and reconnect without duplicate workers
- clean only dead/unreferenced or explicitly killed session-host directories
- leave Unix and remote lifecycle paths unchanged

## Why

Long-lived Windows pane launchers previously executed `target/debug/jefe.exe` directly. They locked that image against rebuilds, and force-killing them could leave Bun/Node descendants alive while destroying the reconnectable PTY session. The staged host removes the image lock; Job containment prevents stranded descendants when a pane host dies.

## Scope

The issue-delivery hard-scope exception was explicitly approved: 21 files and approximately 3,000 net lines, dominated by behavioral tests, native fixtures, the issue plan, and the Windows dependency lockfile expansion. No `.llxprt`, workflow, or quality-gate files are changed by this PR.

## Verification

Passed on the exact current-main descendant head using `CARGO_TARGET_DIR=target/issue467`:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --all-features --locked`
- `cargo test -p jefe --lib --all-features --locked` — 2,384 passed
- `JEFE_REQUIRE_PSMUX=1 cargo test -p jefe --features psmux-smoke --test psmux_session_host` — 1 passed

The existing `tests/psmux_attach.rs` native input-byte assertion remains independently reproducible and unrelated to this diff; no issue #467 file changes that attach/input route.

## Review

Pre-PR bounded review: 1/2. Both in-scope findings were fixed:

- session-host staging failures now remain typed through `RuntimeError::SessionHostStaging`
- obsolete no-Job fixture-driver scaffolding was removed

## Acceptance evidence

- fresh Windows launch uses an immutable staged host and private JSON launch plan
- two independently staged psmux hosts survive simulated dashboard absence
- source image replacement succeeds while both staged hosts run
- repeated discovery observes stable pane PIDs and original worker PIDs
- killing one host reaps only its Job-owned worker within the bound
- sibling session/worker remain alive until their own scoped cleanup
- startup cleanup retains live, referenced, ambiguous, or unprobeable artifacts
- explicit kill cleanup targets only the named session directory
- Unix and remote staging paths remain disabled