### PR TITLE
Isolate native psmux commands from inherited sessions (Fixes #456)

### DIFF
--- a/project-plans/issue456-plan.md
+++ b/project-plans/issue456-plan.md
@@ -1,0 +1,401 @@
+# Issue #456: Stabilize the Windows psmux mouse smoke test
+
+## Problem and investigation result
+
+The Windows-only integration test
+`psmux_attached_viewer_observes_mouse_modes_and_delivers_page_keys` remains
+non-deterministic on current `main` (`a38f763`) after issue #465 removed
+psmux 3.3.7's `PageUp -> copy-mode -u` root binding.
+
+A required local psmux 3.3.7 run on current main failed before Page-key input:
+`AttachedViewer never observed mouse reporting after fixture advertised
+1000/1002/1006`. The fixture emits those DEC private modes once, before the
+detached session's ready marker; the test waits for that marker before creating
+`AttachedViewer`. A fresh viewer starts with a blank terminal model, so whether
+it observes the earlier one-shot mode advertisement depends on psmux/ConPTY
+attach timing. The pane capture was healthy and contained
+`PSMUX_SMOKE_READY`, and the failed run left no
+`jefe-psmux-smoke-fixture` process.
+
+Issue #465/#468 correctly fixed the separate PageUp interception failure. Its
+single-write Page-key behavior remains part of this plan. Increasing the timeout
+or re-injecting semantic Page keys cannot fix either a missed one-shot mode
+advertisement or a key consumed by a root binding.
+
+### Discovered root cause (post-DeepThinker)
+
+The three-sequential-candidate architecture still failed to forward any probe
+input on the original machine because Jefe itself was running **inside** an
+existing psmux session. The inherited `PSMUX_SESSION`/`PSMUX_TARGET_SESSION`
+environment variables made every psmux command appear nested, so psmux refused
+setup with `psmux: sessions should be nested with care, unset PSMUX_SESSION to
+force`, and the attaching client never established an input relay. The
+one-shot mouse-mode timing was a symptom, not the cause.
+
+The fix is a related production isolation change (authorized by the user's
+demand to continue):
+
+- `MultiplexerPlan::command()` scrubs `PSMUX_SESSION`/`PSMUX_TARGET_SESSION`
+  on native Windows (Unix is unaffected), via a shared `pub(super)` constant
+  `PSMUX_INHERITED_SESSION_VARS`.
+- `attach_command` scrubs `TMUX`/`TMUX_PANE`/`TMUX_TMPDIR` plus the same two
+  psmux session variables on every platform, and always emits the explicit
+  `attach-session -t <session>` form (psmux 3.3.7 accepts it; the stale 3.3.6
+  compatibility comment is removed).
+- `PSMUX_CLAUDE_TEAMMATE_MODE` and `PSMUX_CONFIG_FILE` are intentionally
+  retained (team mode is not session routing; the plan already carries `-f NUL`).
+
+With both isolation changes, the real psmux smoke passes on the **first**
+candidate in ~2.7s. The bounded three-candidate retry is retained as defense
+against genuine attach-timing variance on loaded CI runners, but the candidate
+deadline accounting is fixed so marker + mouse-mode are polled conjunctively
+under one shared per-candidate ceiling (see AC1).
+
+## Acceptance matrix
+
+| ID | Actor / launch path | Input and boundary cases | Target | Observable success | Observable failure / diagnostic | Side effects permitted before failure | Persistence / compatibility | Behavioral evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| AC1 | `psmux_attached_viewer_observes_mouse_modes_and_delivers_page_keys` creates a detached fixture session, then attaches up to three sequential `AttachedViewer` candidates through `attach_viewer_until_input_and_mouse_ready` against the same established session | The fixture's startup mode advertisement may occur before any single viewer exists; a unique readiness probe (`j`/`k`/`l`) is the first confirmed post-attach child input for each candidate; the fixture emits the DEC private mouse modes *before* the probe's byte marker | Native Windows, psmux >= 3.3.7, `psmux-smoke` feature | A candidate's own unique marker (`PSMUX_BYTE_6A`/`6B`/`6C`) appears in capture **and** that same viewer reports `mouse_reporting_active`, polled conjunctively under one shared per-candidate ceiling (10s), within one shared 30-second overall deadline; the qualifier is kept for AC2 | The assertion lists per-candidate diagnostics distinguishing marker/mode/liveness; the namespace transcript remains under `target/psmux-smoke/<namespace>` | One unique psmux namespace, one fixture process, one temporary working directory, and test artifacts only | Related production isolation: `MultiplexerPlan::command` and `attach_command` scrub inherited `PSMUX_SESSION`/`PSMUX_TARGET_SESSION` (Windows/all-platform attach respectively) and always emit explicit `attach-session -t`; startup advertisement remains compatible with other fixture users | One-client RED recorded; DeepThinker-amended three-sequential-candidate architecture implemented; discovered inherited-PSMUX root cause fixed in production isolation; real psmux smoke GREEN on first candidate ~2.7s (see evidence) |
+| AC2 | The same attached viewer writes PageUp/PageDown and SGR mouse bytes | Input readiness and mouse-mode synchronization have completed; Page keys are written once without retry re-injection | Native Windows, psmux >= 3.3.7 | Exact `CSI 5~`, `CSI 6~`, and `CSI <0;1;1M` constituent byte markers reach the child; `pane_in_mode` stays `0` | Existing bounded capture diagnostics identify the missing exact marker or unexpected pane mode | Only the accepted input bytes are sent to the isolated fixture | The issue #296 byte/mouse contract and issue #465 root-table workaround remain unchanged | Existing exact-byte assertions in `tests/psmux_smoke_mouse.rs` pass in each repeated run |
+| AC3 | `PsmuxNamespace` teardown during normal return or panic unwinding | Success, assertion timeout, or command failure after namespace creation | Native Windows test harness only | Cleanup invokes namespace-scoped `kill-server` through the existing five-second bounded command collector, which waits for psmux 3.3.7 to terminate its owned fixture descendants; transcript collection completes | Cleanup command failure/timeout is recorded in the namespace transcript; teardown never contacts the default server | Only the unique `-L <namespace>` server and its descendants may be terminated | Relies on the already-qualified psmux 3.3.7 namespace-cleanup contract; no process-management subsystem or public API | RED run external process check shows no leaked fixture; focused repetitions complete with bounded teardown transcripts and no fixture survivors |
+
+## Timing, retry, failure, and ownership decisions
+
+- Keep the existing 30-second Windows poll ceiling as one shared overall
+  deadline across all attach attempts. All waits return as soon as their
+  condition holds. This test is Windows-only, so there is no Linux timeout
+  branch to change. The 30-second ceiling is never restarted or made per-attempt.
+- Synchronize on observable post-attach input delivery rather than sleeping or
+  increasing a timeout.
+- A candidate's unique readiness probe (`j`/`k`/`l`) may be sent through that
+  candidate because it is an idempotent ASCII probe. At most three sequential
+  candidates are attempted against the same established session, each capped at
+  ten seconds; failed viewers are dropped before the next spawn. **Per-candidate
+  deadline accounting:** marker delivery and mouse-mode observation are polled
+  **conjunctively** under one shared per-candidate ceiling (`PER_CANDIDATE_TIMEOUT`)
+  via `poll_marker_and_mouse_reporting` — the fixture emits the DEC private mouse
+  modes before the probe's byte marker, so once the marker lands the modes have
+  already traversed the PTY and the loop keeps polling mouse mode without
+  restarting the deadline. The outer 30-second overall deadline is never
+  restarted. PageUp/PageDown remain a single write with capture-only polling;
+  semantic keys are never re-injected, and no retry or reattach occurs after
+  semantic input starts.
+- The fixture owns re-advertisement of the exact `MOUSE_MODE_BYTES` in response
+  to any readiness probe (`READINESS_PROBES b"jkl"`), emitted before that
+  probe's normal byte marker. Production `AttachedViewer` and runtime
+  orchestration remain unchanged; `nudge_for_mode_recovery` is called once per
+  candidate to mirror production but is never used as readiness.
+- Namespace cleanup stays in the private test harness and reuses its existing
+  bounded command collector. If full reaping requires a new process-management
+  or cancellation subsystem, stop for approval instead of adding one.
+
+## DeepThinker amendment record
+
+- **DeepThinker count:** 1.
+- **Trigger:** The one-viewer readiness-probe re-advertisement attempt
+  (single `j` probe against a single attached viewer) remained RED: the pane
+  forwarded fixture output but the probe input never reached the child within
+  the full 30 seconds, even after `nudge_for_mode_recovery`.
+- **User authorization:** The user explicitly authorized continuing issue #456
+  on branch `issue456` and provided the amended bounded architecture below.
+- **Selected architecture:** Replace the single readiness probe with
+  `READINESS_PROBES b"jkl"`; the fixture re-advertises exact `MOUSE_MODE_BYTES`
+  before its normal byte marker for any `j`/`k`/`l`. In the integration test,
+  replace the one-shot viewer spawn plus separate readiness/mouse assertions
+  with a private `attach_viewer_until_input_and_mouse_ready` helper that creates
+  at most three sequential `AttachedViewer` candidates against the same
+  established session, using unique probes `(j, PSMUX_BYTE_6A)`,
+  `(k, PSMUX_BYTE_6B)`, `(l, PSMUX_BYTE_6C)`, one shared 30-second overall
+  deadline and a maximum of ten seconds per candidate. A candidate qualifies
+  only when its own unique marker appears in capture and that same viewer
+  reports `mouse_reporting_active`. `nudge_for_mode_recovery` is called once
+  per candidate to mirror production but is not used as readiness. Each failed
+  viewer is dropped before the next spawn; the qualifier is kept for the
+  existing PageUp/PageDown one-write/no-reinjection assertion and the exact SGR
+  assertion. No retry or reattach after semantic input starts.
+- **Scope impact:** Originally test-only; amended after the inherited-PSMUX
+  root cause was discovered to include the related production isolation changes
+  described above (`MultiplexerPlan::command`, `attach_command`). Allowed files
+  now: `project-plans/issue456-plan.md`,
+  `tests/fixtures/psmux_smoke_fixture.rs`, `tests/psmux_smoke_mouse.rs`,
+  `src/runtime/multiplexer.rs`, `src/runtime/attach.rs`, plus their existing
+  private test modules (`multiplexer_tests.rs`, `attach_tests.rs`).
+
+## Explicit non-goals
+
+- Do not change the asserted PageUp/PageDown or SGR mouse byte sequences.
+- Do not delete, ignore, or gate the smoke test behind a CI skip variable.
+- Do not increase the timeout or retry/re-inject semantic Page keys.
+- Do not change psmux production **routing** behavior, public APIs,
+  dependencies, workflow files, quality tooling, or `.llxprt/`. (The authorized
+  env-scrub isolation fix and explicit `-t` are the only production changes.)
+- Do not normalize the three private psmux test harnesses or move unrelated
+  tests.
+- Do not add a TUI scenario: this is stabilization of an existing native
+  transport integration test, not a new UI-visible behavior.
+- Do not implement issue #465's deferred P1/P3/P4/P6 harness or diagnostic
+  hardening.
+
+## Bounded vertical slices
+
+### Slice 1 — deterministic post-attach mode synchronization
+
+- **Acceptance rows:** AC1, preserves AC2.
+- **Architecture owner:** native-Windows integration fixture/test boundary.
+- **Allowed files:**
+  - `tests/fixtures/psmux_smoke_fixture.rs`
+  - `tests/psmux_smoke_mouse.rs`
+  - `project-plans/issue456-plan.md`
+- **RED (current main):** On current main with `JEFE_REQUIRE_PSMUX=1`,
+  repetition 1 fails after 30 seconds because the attached viewer never
+  observes mouse reporting.
+- **RED (one-client amendment):** The single-`j`-probe/single-viewer
+  re-advertisement path forwarded fixture output but the probe input never
+  reached the child within the full 30 seconds, even after
+  `nudge_for_mode_recovery`. This RED was the DeepThinker trigger.
+- **GREEN (amended architecture):** The fixture exposes
+  `READINESS_PROBES b"jkl"` and re-advertises exact `MOUSE_MODE_BYTES` before
+  any probe's normal byte marker. The test attaches up to three sequential
+  candidates, each with a unique probe and byte marker, keeping the first that
+  both forwards its own unique marker and observes mouse reporting within one
+  shared 30-second deadline (max 10s per candidate). Startup output and exact
+  input assertions stay intact.
+- **Verification:** fixture unit tests (all three probes + non-probes), focused
+  unit/clippy, `cargo fmt --all --check`, and one real psmux smoke with
+  `JEFE_REQUIRE_PSMUX=1`. Repeated runs and the full suite are coordinator-owned.
+- **Stop conditions:** Stop if synchronization requires production runtime
+  changes, a new public abstraction, a new fixture protocol subsystem, a timeout
+  increase, or if all three candidates empirically fail.
+
+### Slice 2 — bounded namespace cleanup fallback
+
+- **Acceptance row:** AC3.
+- **Architecture owner:** private `PsmuxNamespace` RAII test harness.
+- **Allowed files:**
+  - `tests/psmux_smoke_mouse.rs`
+  - `project-plans/issue456-plan.md`
+- **RED evidence:** The current `Drop` path calls unbounded `Command::output()`;
+  source inspection proves it bypasses the harness's five-second collector.
+  The reproduced timeout returned without a fixture survivor, confirming the
+  namespace kill is the correct ownership boundary rather than permission to
+  add a process-management subsystem.
+- **GREEN:** `Drop` routes namespace-scoped `kill-server` through the existing
+  bounded collector and persists its transcript.
+- **Verification:** focused smoke repetitions complete; transcript contains the
+  bounded cleanup command; external process check finds no fixture survivor.
+- **Stop conditions:** Stop if psmux does not reap descendants after a completed
+  namespace `kill-server`, or if proof requires a new process-management,
+  timeout, cancellation, or cleanup subsystem.
+
+## Expected paths and ownership layers
+
+| Path | Layer / owner | Acceptance mapping |
+| --- | --- | --- |
+| `project-plans/issue456-plan.md` | Delivery record | Matrix, scope ledger, evidence, review triage |
+| `tests/fixtures/psmux_smoke_fixture.rs` | Native psmux fixture | AC1 post-attach mode re-advertisement |
+| `tests/psmux_smoke_mouse.rs` | Native psmux integration test/private harness | AC1 ordering, AC2 preserved assertions, AC3 bounded teardown |
+| `src/runtime/multiplexer.rs` | Local multiplexer policy | AC1 isolation: scrub inherited `PSMUX_SESSION`/`PSMUX_TARGET_SESSION` on Windows `command()` via shared `PSMUX_INHERITED_SESSION_VARS` |
+| `src/runtime/attach.rs` | Local attach command builder | AC1 isolation: scrub inherited tmux+psmux session vars on all attaches; explicit `attach-session -t` |
+| `src/runtime/multiplexer_tests.rs` | Multiplexer policy unit tests | Regression coverage for the Windows scrub, base-args preservation, Unix non-scrub, retained vars |
+| `src/runtime/attach_tests.rs` | Attach command unit tests | Regression coverage for the scrub helper and explicit `-t` argv on Windows/Unix plans |
+
+The work crosses the test ownership boundary and the local multiplexer/attach
+policy boundary (authorized related production isolation fix).
+
+## Scope ledger
+
+| Discovered item | Classification | Decision / mapping | Status |
+| --- | --- | --- | --- |
+| Current main already fixes PageUp root interception through issue #465/#468 | In-scope context | Preserve the root unbind and single-write Page-key assertion under AC2 | accepted, no new work |
+| Current main locally misses the fixture's one-shot mouse modes before attach | Blocker-Fix | AC1 / Slice 1 | accepted |
+| One-client readiness-probe path forwarded output but no probe input for full 30s even after nudge | Blocker-Fix | DeepThinker trigger; amended AC1 architecture selected (three sequential candidates, unique probes, one shared deadline) | accepted, DeepThinker count 1 |
+| `READINESS_PROBES b"jkl"` replaces single probe; fixture re-advertises `MOUSE_MODE_BYTES` for any probe | In-scope-Fix | AC1 / Slice 1 (fixture) | implemented; unit tests cover all three probes + non-probes |
+| Three sequential `AttachedViewer` candidates, unique probes/markers, one shared 30s deadline, max 10s per candidate | In-scope-Fix | AC1 / Slice 1 (test) | implemented; per-attempt diagnostics to transcript |
+| Candidate deadline could spend up to `2*cap` (marker then mouse) | Blocker-Fix | AC1 / Slice 1: replaced `forward_probe_until_marker` + `wait_for_mouse_reporting` with conjunctive `poll_marker_and_mouse_reporting` under one shared per-candidate ceiling | implemented; function limits preserved |
+| Inherited `PSMUX_SESSION`/`PSMUX_TARGET_SESSION` made Jefe appear nested inside a parent psmux session (root cause) | Blocker-Fix | Authorized related production isolation: `MultiplexerPlan::command` scrubs both on Windows; `attach_command` scrubs TMUX/TMUX_PANE/TMUX_TMPDIR + both psmux session vars on all platforms; shared `PSMUX_INHERITED_SESSION_VARS` constant | implemented; regression unit tests added |
+| `attach_command` conditional `-t` (Unix-only) was a stale psmux 3.3.6 workaround | In-scope-Fix | Always emit `attach-session -t <session>` (psmux 3.3.7 minimum accepts it); removed stale comment | implemented; argv regression tests on both plans |
+| `PSMUX_CLAUDE_TEAMMATE_MODE` / `PSMUX_CONFIG_FILE` retention | Decision | Retain both: team mode is not session routing, plan already carries `-f NUL` | accepted; regression test asserts retention |
+| `PsmuxNamespace::drop` uses unbounded `Command::output()` | In-scope-Fix | AC3 / Slice 2; reuse existing bounded `run`/`run_os` collector only | implemented; cleanup failure recorded in transcript, never panics, transcript persisted after cleanup |
+| All three candidates empirically failed before the isolation fix (single real run) | Empirical RED (superseded) | Was the stop condition; the inherited-PSMUX root-cause fix made the first candidate pass in ~2.7s | superseded by GREEN |
+| Shared psmux harness, loader retry, readiness diagnostics, and expanded capture diagnostics | Defer | Already recorded as issue #465 P1/P3/P4/P6 follow-ups; not required for AC1-AC3 | deferred |
+| Production attach recovery changes (nudge) | Reject | Existing production nudge is unrelated; only the authorized env-scrub isolation and explicit `-t` are in scope | rejected (except authorized isolation) |
+
+## Scope budget
+
+- Changed files: 7 (`project-plans/issue456-plan.md`,
+  `tests/fixtures/psmux_smoke_fixture.rs`, `tests/psmux_smoke_mouse.rs`,
+  `src/runtime/multiplexer.rs`, `src/runtime/attach.rs`,
+  `src/runtime/multiplexer_tests.rs`, `src/runtime/attach_tests.rs`). The two
+  test modules are existing files, not new modules.
+- Net changed lines: approximately 845 including the delivery plan (production
+  isolation + conjunctive polling + regression tests + plan amendments), below
+  the 1,500-line scope-review trigger.
+- Ownership layers: test fixture, integration test harness, local multiplexer
+  policy, local attach command builder.
+- Hard stop: more than 40 files or 2,500 net lines; mandatory scope review above
+  25 files or 1,500 net lines.
+
+## Review counters
+
+- DeepThinker architecture analysis: 1.
+- Local OCR: 2/2 (both actual CLI sessions were partial/aborted after four of
+  six reviewable files; first reported two findings, second reported none).
+- Independent GLM/zai local audit: pass; all seven changed paths reviewed.
+- PR OCR: 0/2.
+
+## Verification evidence
+
+### RED on current main
+
+- Head: `a38f763d885128955dab7ede309d76c13df5de45`.
+- psmux: `3.3.7`.
+- Command: `JEFE_REQUIRE_PSMUX=1 cargo test --features psmux-smoke --test psmux_smoke_mouse -- --nocapture --test-threads=1`.
+- Result: failed on repetition 1 after 32.40 seconds at
+  `tests/psmux_smoke_mouse.rs:102`:
+  `AttachedViewer never observed mouse reporting after fixture advertised 1000/1002/1006`.
+- Artifact:
+  `target/psmux-smoke/jefe-psmux-mouse-mode-19372-18c628f7cfe19528/transcript.txt`
+  shows a healthy pane containing `ALT_SCREEN` and `PSMUX_SMOKE_READY`.
+- Post-failure process check found no `jefe-psmux-smoke-fixture` process.
+
+### GREEN and exact-head evidence
+
+To be filled after each completed slice. Interrupted, skipped, stale-head, or
+partial commands do not count.
+
+### Amended architecture implementation evidence
+
+- **Branch:** `issue456`.
+- **Allowed files changed:** `src/runtime/attach.rs`,
+  `src/runtime/attach_tests.rs`, `src/runtime/multiplexer.rs`,
+  `src/runtime/multiplexer_tests.rs`, `tests/fixtures/psmux_smoke_fixture.rs`,
+  `tests/psmux_smoke_mouse.rs`, and `project-plans/issue456-plan.md`.
+- **Related production changes:** local attach and native-Windows multiplexer
+  commands scrub inherited psmux session-routing variables; attach uses the
+  explicit psmux 3.3.7 `-t` target form.
+- **RED artifacts preserved:** the one-client readiness-probe transcript
+  (`target/psmux-smoke/jefe-psmux-mouse-mode-19372-18c628f7cfe19528/transcript.txt`)
+  is unchanged working context; the three-candidate transcript is
+  `target/psmux-smoke/jefe-psmux-mouse-mode-22432-18c632ded55cb744/transcript.txt`.
+
+#### Fixture unit tests (GREEN)
+
+- Command: `cargo test --features psmux-smoke --bin jefe-psmux-smoke-fixture`.
+- Result: `test result: ok. 5 passed; 0 failed`, including
+  `readiness_probe_emits_mouse_modes_before_marker` (covers `j`, `k`, `l` in
+  1000/1002/1006 order) and `non_probe_input_emits_nothing_before_marker`.
+
+#### Format and clippy (GREEN)
+
+- `cargo fmt --all --check`: clean after `cargo fmt --all`.
+- `cargo clippy --features psmux-smoke --test psmux_smoke_mouse -- -D warnings`:
+  clean.
+- `cargo clippy --features psmux-smoke --bin jefe-psmux-smoke-fixture -- -D warnings`:
+  clean.
+
+#### Real psmux smoke — three sequential candidates (RED, superseded by GREEN)
+
+- psmux: `3.3.7`.
+- Command: `JEFE_REQUIRE_PSMUX=1 cargo test --features psmux-smoke --test psmux_smoke_mouse -- --nocapture --test-threads=1`.
+- Result (pre-isolation-fix): `FAILED. 0 passed; 1 failed` after 31.56 seconds.
+- All three candidates failed to forward their own unique marker because Jefe
+  itself ran inside a parent psmux session and inherited
+  `PSMUX_SESSION`/`PSMUX_TARGET_SESSION`, so psmux refused the nested attach.
+- This RED is **superseded** by the GREEN run after the authorized production
+  isolation fix (see below). The inherited-PSMUX root cause was the real
+  blocker; the three-candidate retry alone could not fix a refused attach.
+
+### GREEN after authorized production isolation fix (first candidate)
+
+- psmux: `3.3.7`.
+- Command: `JEFE_REQUIRE_PSMUX=1 cargo test --features psmux-smoke --test psmux_smoke_mouse -- --nocapture --test-threads=1`.
+- Result: `test result: ok. 1 passed; 0 failed` in **2.68s** (wall ~4.7s incl.
+  compile). The first candidate qualified: marker + mouse reporting were
+  observed conjunctively under the shared per-candidate ceiling, and the
+  Page-key + SGR semantic assertions followed.
+- AC3 teardown verified: post-run `Get-Process` found **no**
+  `jefe-psmux-smoke-fixture` process, confirming the bounded `kill-server`
+  reaped the fixture descendants. (Lingering `psmux` servers are pre-existing
+  user-environment namespace servers, not test descendants; the test's own
+  unique `-L` namespace is killed.)
+
+### Focused unit tests (GREEN)
+
+- `cargo test --lib multiplexer` → 18 passed (incl. 5 new
+  `*_command_*`/`psmux_inherited_session_vars_*` regression tests).
+- `cargo test --lib "runtime::attach::tests"` → 22 passed (incl. 3 new
+  `scrub_helper_*`/`attach_command_*_plan_*` regression tests).
+- `cargo test --features psmux-smoke --bin jefe-psmux-smoke-fixture` → 5 passed.
+
+### Sibling psmux tests under JEFE_REQUIRE_PSMUX=1 (GREEN)
+
+- `cargo test --features psmux-smoke --test psmux_attach` → 2 passed in 3.62s
+  (exercises the same `attach_command` path with the new explicit `-t` and env
+  scrubbing).
+- `cargo test --features psmux-smoke --test psmux_orphan_reap` → 2 passed in
+  3.68s (confirms the namespace reaping contract).
+
+### Format and clippy (GREEN)
+
+- `cargo fmt --all --check`: clean.
+- `cargo clippy --lib -- -D warnings`: clean.
+- `cargo clippy --tests -- -D warnings`: clean.
+- `cargo clippy --features psmux-smoke --test psmux_smoke_mouse -- -D warnings`:
+  clean.
+- `cargo clippy --features psmux-smoke --bin jefe-psmux-smoke-fixture -- -D warnings`:
+  clean.
+
+### Ten consecutive native-Windows repetitions (GREEN)
+
+- psmux: `3.3.7`.
+- Command: loop ten invocations of
+  `JEFE_REQUIRE_PSMUX=1 cargo test --features psmux-smoke --test psmux_smoke_mouse -- --nocapture --test-threads=1`.
+- Result: **10/10 passed**, each in 2.52–2.84 seconds.
+- Post-loop process check found no `jefe-psmux-smoke-fixture` survivor.
+
+### Quick-check equivalent (GREEN)
+
+- GNU `make` is unavailable on this Windows host, so the Makefile's exact
+  `quick-check` commands were run directly: `cargo fmt --all`,
+  `cargo check -q`, and `cargo test -q`.
+- Result: all passed; primary test targets reported 2,330 and 760 passing tests
+  with no failures, followed by all integration/doctest targets passing.
+
+### Rebased-candidate full local verification (GREEN)
+
+- Candidate base/head before issue commit: `4ed77d5218ff8b119a213f6d30569eb9fceeb640`
+  (`origin/main`, after a clean autostash rebase from the original `a38f763`
+  baseline; all seven issue files restored without conflict).
+- Command: `cargo xtask ci` (current main replaced the former Makefile gate with
+  the cross-platform xtask equivalent).
+- Result: **passed** all 9 steps: format, clippy-allow policy, source-size,
+  architecture, strict all-target/all-feature Clippy, complexity Clippy,
+  coverage (**47.87%**, floor 30%), locked all-feature build, and locked
+  all-feature workspace tests. Elapsed 178.6 seconds.
+- The Windows psmux smoke target passed within the locked all-feature test step.
+
+### Not yet claimed
+
+- Exact committed-head verification and PR CI are not yet claimed.
+
+## Review triage
+
+- Local OCR 1, session `6f9364a1-45bd-4090-bd36-b0b7b9befef5`:
+  **partial/aborted** after four of six reviewable files, with two findings.
+  - **In-scope-Fix (valid):** the Windows attach test name/doc claimed to prove
+    scrubbing while its assertions covered argv and `TERM`; renamed/documented
+    it as explicit-target coverage and pointed to the dedicated scrub test.
+  - **In-scope-Fix (valid):** Unix explicit-target coverage omitted the common
+    `TERM=xterm-256color` assertion; added parity coverage.
+- Local OCR 2, session `63e736f9-bc4e-4c86-8dc9-ee636bd9d505`:
+  **partial/aborted** after the same four production/unit files, with no
+  findings. It is not represented as clean full-diff coverage.
+- Independent GLM/zai local audit: **pass** across all seven changed paths; no
+  additional Blocker-Fix, In-scope-Fix, or Reject findings.
+- **Defer:** duplicated private psmux smoke harness support is pre-existing and
+  already tracked among issue #465 follow-ups; it is not required for AC1-AC3.
+
+## Deferred findings / follow-ups
+
+- Issue #465's P1/P3/P4/P6 items remain deferred and are not absorbed here.
+- No optional hardening will be added after AC1-AC3 and required gates pass.

--- a/src/runtime/attach.rs
+++ b/src/runtime/attach.rs
@@ -499,16 +499,37 @@ fn attach_command(
             cmd.arg(arg);
         }
         cmd.arg("attach-session");
-        if !cfg!(windows) {
-            cmd.arg("-t");
-        }
-        // psmux 3.3.6 ignores `attach-session -t`; its positional target is
-        // resolved correctly. Upstream tmux continues to receive `-t` above.
+        // psmux 3.3.7 (the supported minimum) accepts the explicit `attach-session
+        // -t <session>` target form, so the session name is always passed via `-t`
+        // on every platform. Upstream tmux uses the identical flag.
+        cmd.arg("-t");
         cmd.arg(session_name);
         cmd
     };
+    scrub_inherited_multiplexer_env(&mut cmd);
     cmd.env("TERM", "xterm-256color");
     Ok(cmd)
+}
+
+/// Strip inherited tmux/psmux session-routing variables from an attach
+/// `CommandBuilder` so the attaching client never appears nested inside a
+/// parent multiplexer session. `PSMUX_SESSION`/`PSMUX_TARGET_SESSION` share the
+/// exact same list the native Windows `MultiplexerPlan::command` scrubs; the
+/// tmux variables are always scrubbed because the attach client must run
+/// against Jefe's private socket/namespace regardless of platform.
+/// `PSMUX_CLAUDE_TEAMMATE_MODE` and `PSMUX_CONFIG_FILE` are intentionally
+/// retained: team mode is not session routing and the plan already carries
+/// `-f NUL`.
+fn scrub_inherited_multiplexer_env(cmd: &mut CommandBuilder) {
+    for variable in [
+        "TMUX",
+        "TMUX_PANE",
+        "TMUX_TMPDIR",
+        super::multiplexer::PSMUX_INHERITED_SESSION_VARS[0],
+        super::multiplexer::PSMUX_INHERITED_SESSION_VARS[1],
+    ] {
+        cmd.env_remove(variable);
+    }
 }
 
 fn open_pty(rows: u16, cols: u16) -> Result<PtyPair, RuntimeError> {

--- a/src/runtime/attach_tests.rs
+++ b/src/runtime/attach_tests.rs
@@ -4,6 +4,7 @@
 //! Issue #179 coverage: default-color transparency in `snapshot_cell_style`.
 
 use super::*;
+use std::ffi::OsStr;
 
 /// Build a minimal terminal model for testing `process_pty_read`.
 fn test_term() -> Arc<Mutex<Term<RuntimeListener>>> {
@@ -513,5 +514,137 @@ fn cursor_on_default_cell_keeps_concrete_colors() {
         style.bg,
         iocraft::Color::Reset,
         "cursor cell bg must be concrete (visible cursor)"
+    );
+}
+
+// ── Issue #456 regression: attach command inherits no multiplexer sessions ──
+
+/// The private env-scrub helper must remove every inherited tmux/psmux
+/// session-routing variable even when the builder carried an explicit value.
+/// `CommandBuilder::get_env` reads the merged env map, so injecting first and
+/// scrubbing afterwards proves the removal deterministically without depending
+/// on the test process environment.
+#[test]
+fn scrub_helper_removes_inherited_session_routing_variables() {
+    let mut cmd = CommandBuilder::new("tmux");
+    // Inject every scrubbed variable so the test has something concrete to
+    // prove removed. Without injection an absent variable would also report
+    // `None`, which would not distinguish a real scrub from a no-op.
+    cmd.env("TMUX", "/tmp/jefe.sock,123,0");
+    cmd.env("TMUX_PANE", "%5");
+    cmd.env("TMUX_TMPDIR", "/tmp");
+    cmd.env("PSMUX_SESSION", "parent-session");
+    cmd.env("PSMUX_TARGET_SESSION", "parent-target");
+    // A non-scrubbed psmux variable must survive.
+    cmd.env("PSMUX_CLAUDE_TEAMMATE_MODE", "1");
+
+    scrub_inherited_multiplexer_env(&mut cmd);
+
+    for variable in [
+        "TMUX",
+        "TMUX_PANE",
+        "TMUX_TMPDIR",
+        "PSMUX_SESSION",
+        "PSMUX_TARGET_SESSION",
+    ] {
+        assert!(
+            cmd.get_env(variable).is_none(),
+            "{variable} must be scrubbed from the attach command environment"
+        );
+    }
+    assert_eq!(
+        cmd.get_env("PSMUX_CLAUDE_TEAMMATE_MODE"),
+        Some(OsStr::new("1")),
+        "PSMUX_CLAUDE_TEAMMATE_MODE must be retained"
+    );
+}
+
+/// `attach_command` for a Windows local plan must build the production argv
+/// with the plan's executable, base args, and an explicit
+/// `attach-session -t <session>`. The scrubbed variables are verified separately
+/// by `scrub_helper_removes_inherited_session_routing_variables`.
+#[test]
+fn attach_command_windows_plan_uses_explicit_target_form() {
+    use crate::runtime::multiplexer::{LocalPlatform, MultiplexerIsolation, MultiplexerPlan};
+    use std::path::PathBuf;
+
+    let plan = MultiplexerPlan::for_platform(
+        LocalPlatform::Windows,
+        PathBuf::from("C:/Program Files/psmux/psmux.exe"),
+        MultiplexerIsolation::Namespace("jefe-0123456789abcdef".to_owned()),
+    )
+    .unwrap_or_else(|error| panic!("windows plan should be valid: {error}"));
+
+    let cmd = attach_command("issue456", None, Some(&plan))
+        .unwrap_or_else(|error| panic!("attach_command should build: {error}"));
+
+    let argv: Vec<&OsStr> = cmd
+        .get_argv()
+        .iter()
+        .map(std::ffi::OsString::as_os_str)
+        .collect();
+    assert_eq!(
+        argv,
+        [
+            OsStr::new("C:/Program Files/psmux/psmux.exe"),
+            OsStr::new("-f"),
+            OsStr::new("NUL"),
+            OsStr::new("-L"),
+            OsStr::new("jefe-0123456789abcdef"),
+            OsStr::new("attach-session"),
+            OsStr::new("-t"),
+            OsStr::new("issue456"),
+        ],
+        "attach_command must always emit attach-session -t <session> on Windows"
+    );
+    assert_eq!(
+        cmd.get_env("TERM"),
+        Some(OsStr::new("xterm-256color")),
+        "attach_command must still set TERM"
+    );
+}
+
+/// `attach_command` for a Unix local plan must also use the explicit
+/// `attach-session -t <session>` form. The scrubbed variables are verified
+/// separately by `scrub_helper_removes_inherited_session_routing_variables`
+/// since `attach_command` calls the same private helper.
+#[test]
+fn attach_command_unix_plan_uses_explicit_target_form() {
+    use crate::runtime::multiplexer::{LocalPlatform, MultiplexerIsolation, MultiplexerPlan};
+    use std::path::PathBuf;
+
+    let plan = MultiplexerPlan::for_platform(
+        LocalPlatform::Unix,
+        PathBuf::from("/usr/bin/tmux"),
+        MultiplexerIsolation::Socket(PathBuf::from("/tmp/jefe.sock")),
+    )
+    .unwrap_or_else(|error| panic!("unix plan should be valid: {error}"));
+
+    let cmd = attach_command("issue456", None, Some(&plan))
+        .unwrap_or_else(|error| panic!("attach_command should build: {error}"));
+
+    let argv: Vec<&OsStr> = cmd
+        .get_argv()
+        .iter()
+        .map(std::ffi::OsString::as_os_str)
+        .collect();
+    assert_eq!(
+        argv,
+        [
+            OsStr::new("/usr/bin/tmux"),
+            OsStr::new("-f"),
+            OsStr::new("/dev/null"),
+            OsStr::new("-S"),
+            OsStr::new("/tmp/jefe.sock"),
+            OsStr::new("attach-session"),
+            OsStr::new("-t"),
+            OsStr::new("issue456"),
+        ],
+        "attach_command must always emit attach-session -t <session> on Unix"
+    );
+    assert_eq!(
+        cmd.get_env("TERM"),
+        Some(OsStr::new("xterm-256color")),
+        "attach_command must still set TERM"
     );
 }

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -16,6 +16,15 @@ const WINDOWS_INSTALL_GUIDANCE: &str =
 const UNIX_INSTALL_GUIDANCE: &str =
     "install upstream tmux with your operating system package manager";
 
+/// Inherited psmux session-routing variables that must be scrubbed from any
+/// native Windows local command so Jefe never appears nested inside a parent
+/// psmux session. `PSMUX_CLAUDE_TEAMMATE_MODE` and `PSMUX_CONFIG_FILE` are
+/// intentionally retained: team mode is not session routing, and the plan's
+/// base args already carry `-f NUL`. `pub(super)` so the local attach command
+/// builder can share the exact same list instead of duplicating it.
+pub(super) const PSMUX_INHERITED_SESSION_VARS: [&str; 2] =
+    ["PSMUX_SESSION", "PSMUX_TARGET_SESSION"];
+
 /// Local operating-system policy used to select a multiplexer implementation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LocalPlatform {
@@ -275,10 +284,20 @@ impl MultiplexerPlan {
     }
 
     /// Build a process command carrying this plan's executable and base args.
+    ///
+    /// On native Windows, inherited psmux session-routing variables
+    /// (`PSMUX_SESSION`/`PSMUX_TARGET_SESSION`) are scrubbed so Jefe never
+    /// appears nested inside a parent psmux session even when its own process
+    /// was launched from inside one. Unix is unaffected.
     #[must_use]
     pub fn command(&self) -> Command {
         let mut command = Command::new(&self.executable);
         command.args(&self.base_args);
+        if self.platform == LocalPlatform::Windows {
+            for variable in PSMUX_INHERITED_SESSION_VARS {
+                command.env_remove(variable);
+            }
+        }
         command
     }
 

--- a/src/runtime/multiplexer_tests.rs
+++ b/src/runtime/multiplexer_tests.rs
@@ -380,3 +380,129 @@ fn unix_agent_pane_command_has_no_staged_host_path() {
         "Unix must reject the Windows-only staged-host path: {result:?}"
     );
 }
+// ── Issue #456 regression: scrub inherited psmux session variables ──────
+//
+// Jefe may itself run from inside a psmux session, in which case it inherits
+// `PSMUX_SESSION`/`PSMUX_TARGET_SESSION`. Any native Windows local command
+// must scrub these so psmux does not refuse to start with
+// `sessions should be nested with care`. `std::process::Command::get_envs`
+// reports removed entries as `(key, None)`, which lets the scrub be proven
+// deterministically without touching the test process environment.
+
+#[test]
+fn windows_command_scrubs_inherited_psmux_session_variables() {
+    let plan = MultiplexerPlan::for_platform(
+        LocalPlatform::Windows,
+        PathBuf::from("C:/Program Files/psmux/psmux.exe"),
+        MultiplexerIsolation::Namespace("jefe-0123456789abcdef".to_owned()),
+    )
+    .unwrap_or_else(|error| panic!("windows plan should be valid: {error}"));
+
+    // `command()` rebuilds a fresh `std::process::Command`; `env_remove` marks
+    // the variable as removed regardless of whether it was in the parent env,
+    // and `get_envs` surfaces that removal as `(key, None)`.
+    let command = plan.command();
+    let envs: std::collections::HashMap<&OsStr, Option<&OsStr>> = command.get_envs().collect();
+
+    for variable in ["PSMUX_SESSION", "PSMUX_TARGET_SESSION"] {
+        assert_eq!(
+            envs.get(OsStr::new(variable)),
+            Some(&None),
+            "{variable} must be marked removed on the Windows plan command"
+        );
+    }
+}
+
+#[test]
+fn windows_command_preserves_base_args_and_executable_after_scrub() {
+    let plan = MultiplexerPlan::for_platform(
+        LocalPlatform::Windows,
+        PathBuf::from("C:/Program Files/psmux/psmux.exe"),
+        MultiplexerIsolation::Namespace("jefe-0123456789abcdef".to_owned()),
+    )
+    .unwrap_or_else(|error| panic!("windows plan should be valid: {error}"));
+    let command = plan.command();
+
+    assert_eq!(
+        command.get_program(),
+        Path::new("C:/Program Files/psmux/psmux.exe")
+    );
+    let args: Vec<&OsStr> = command.get_args().collect();
+    assert_eq!(
+        args,
+        [
+            OsStr::new("-f"),
+            OsStr::new("NUL"),
+            OsStr::new("-L"),
+            OsStr::new("jefe-0123456789abcdef")
+        ]
+    );
+}
+
+#[test]
+fn windows_command_retains_non_session_psmux_variables() {
+    // PSMUX_CLAUDE_TEAMMATE_MODE is not session routing and PSMUX_CONFIG_FILE
+    // is already covered by `-f NUL`; both must be retained (not removed).
+    let plan = MultiplexerPlan::for_platform(
+        LocalPlatform::Windows,
+        PathBuf::from("C:/Program Files/psmux/psmux.exe"),
+        MultiplexerIsolation::Namespace("jefe-0123456789abcdef".to_owned()),
+    )
+    .unwrap_or_else(|error| panic!("windows plan should be valid: {error}"));
+    let mut command = plan.command();
+    command.env("PSMUX_CLAUDE_TEAMMATE_MODE", "1");
+    command.env("PSMUX_CONFIG_FILE", "NUL");
+    let envs: std::collections::HashMap<&OsStr, Option<&OsStr>> = command.get_envs().collect();
+    assert_eq!(
+        envs.get(OsStr::new("PSMUX_CLAUDE_TEAMMATE_MODE")),
+        Some(&Some(OsStr::new("1"))),
+        "team-mode variable must not be scrubbed"
+    );
+    assert_eq!(
+        envs.get(OsStr::new("PSMUX_CONFIG_FILE")),
+        Some(&Some(OsStr::new("NUL"))),
+        "config-file variable must not be scrubbed"
+    );
+}
+
+#[test]
+fn unix_command_does_not_scrub_psmux_session_variables() {
+    // Unix uses upstream tmux on a private socket; psmux session variables are
+    // irrelevant there, so the command must not mark any env removals.
+    let plan = MultiplexerPlan::for_platform(
+        LocalPlatform::Unix,
+        PathBuf::from("/usr/bin/tmux"),
+        MultiplexerIsolation::Socket(PathBuf::from("/tmp/jefe.sock")),
+    )
+    .unwrap_or_else(|error| panic!("unix plan should be valid: {error}"));
+    let command = plan.command();
+
+    assert_eq!(command.get_program(), Path::new("/usr/bin/tmux"));
+    let args: Vec<&OsStr> = command.get_args().collect();
+    assert_eq!(
+        args,
+        [
+            OsStr::new("-f"),
+            OsStr::new("/dev/null"),
+            OsStr::new("-S"),
+            OsStr::new("/tmp/jefe.sock")
+        ]
+    );
+    let removed: Vec<&OsStr> = command
+        .get_envs()
+        .filter_map(|(key, value)| value.is_none().then_some(key))
+        .collect();
+    assert!(
+        removed.is_empty(),
+        "unix plan command must not remove any environment variables, got {removed:?}"
+    );
+}
+
+#[test]
+fn psmux_inherited_session_vars_constant_is_exact_session_routing_set() {
+    // Guards against accidental widening of the scrub list.
+    assert_eq!(
+        super::multiplexer::PSMUX_INHERITED_SESSION_VARS,
+        ["PSMUX_SESSION", "PSMUX_TARGET_SESSION"]
+    );
+}

--- a/tests/fixtures/psmux_smoke_fixture.rs
+++ b/tests/fixtures/psmux_smoke_fixture.rs
@@ -4,6 +4,23 @@ use std::process::ExitCode;
 
 use serde::Serialize;
 
+/// DEC private mouse modes advertised so an attaching viewer's terminal model
+/// observes mouse reporting. Re-emitted in response to the readiness probe so
+/// a freshly attached viewer (whose model starts blank) reliably sees them.
+const MOUSE_MODE_BYTES: &[u8] = b"\x1b[?1000h\x1b[?1002h\x1b[?1006h";
+
+/// ASCII bytes the integration test sends as post-attach readiness probes.
+/// On receipt of any probe the fixture re-advertises `MOUSE_MODE_BYTES`
+/// before echoing the byte, giving the attached viewer a post-attach
+/// synchronization barrier. Multiple distinct probes let the integration test
+/// attach fresh viewers in sequence until one both forwards its own unique
+/// marker and observes mouse reporting.
+const READINESS_PROBES: &[u8] = b"jkl";
+
+fn is_readiness_probe(byte: u8) -> bool {
+    READINESS_PROBES.contains(&byte)
+}
+
 fn main() -> ExitCode {
     if let Err(error) = run() {
         let _ = writeln!(std::io::stderr(), "psmux smoke fixture failed: {error}");
@@ -43,7 +60,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     output.write_all(b"\x1b[31mCOLOR_RED\x1b[0m\r\n")?;
     output.write_all("UNICODE_Ω_界_e\u{301}\r\n".as_bytes())?;
     output.write_all(b"CURSOR_AB\x1b[D!\r\n")?;
-    output.write_all(b"\x1b[?1000h\x1b[?1002h\x1b[?1006h\x1b[?2004h\x1b[?1049hALT_SCREEN\r\n")?;
+    output.write_all(MOUSE_MODE_BYTES)?;
+    output.write_all(b"\x1b[?2004h\x1b[?1049hALT_SCREEN\r\n")?;
     output.write_all(b"\x1b[31mCOLOR_RED\x1b[0m\r\n")?;
     output.write_all("UNICODE_Ω_界_e\u{301}\r\n".as_bytes())?;
     output.write_all(b"CURSOR_AB\x1b[D!\r\n")?;
@@ -59,6 +77,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         std::io::stdin().read_exact(&mut byte)?;
         received.push(byte[0]);
+        output.write_all(readiness_response(byte[0]))?;
         writeln!(output, "PSMUX_BYTE_{:02X} BYTE_{:02X}", byte[0], byte[0])?;
         if byte[0] == 0x12 {
             output.write_all(b"\x1b[?1049lMAIN_SCREEN\r\nINPUT_HEX")?;
@@ -110,9 +129,23 @@ fn valid_marker(marker: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 
+/// Bytes to emit before a received input byte's marker line. A readiness
+/// probe triggers a re-advertisement of the DEC private mouse modes so an
+/// attaching viewer's freshly initialized terminal model observes mouse
+/// reporting after attach; any other input emits nothing before its marker.
+fn readiness_response(byte: u8) -> &'static [u8] {
+    if is_readiness_probe(byte) {
+        MOUSE_MODE_BYTES
+    } else {
+        &[]
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::fixture_marker;
+    use super::{
+        MOUSE_MODE_BYTES, READINESS_PROBES, fixture_marker, is_readiness_probe, readiness_response,
+    };
 
     #[test]
     fn marker_accepts_protocol_safe_value() {
@@ -142,6 +175,43 @@ mod tests {
         let result = fixture_marker(&mut args);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn readiness_probe_emits_mouse_modes_before_marker() {
+        for probe in READINESS_PROBES {
+            assert!(
+                is_readiness_probe(*probe),
+                "byte {probe:02X} must be a probe"
+            );
+            assert_response_advertises_modes_in_order(readiness_response(*probe));
+        }
+    }
+
+    fn assert_response_advertises_modes_in_order(response: &[u8]) {
+        assert_eq!(response, MOUSE_MODE_BYTES);
+        let modes = [b"\x1b[?1000h".as_slice(), b"\x1b[?1002h", b"\x1b[?1006h"];
+        let mut cursor = 0;
+        for mode in modes {
+            let offset = response[cursor..]
+                .windows(mode.len())
+                .position(|window| window == mode)
+                .map(|offset| cursor + offset);
+            match offset {
+                Some(index) if index >= cursor => cursor = index + mode.len(),
+                _ => panic!(
+                    "mouse mode {mode:?} must follow the previous one in 1000/1002/1006 order"
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn non_probe_input_emits_nothing_before_marker() {
+        assert!(!is_readiness_probe(0x04));
+        assert!(!is_readiness_probe(0x12));
+        assert!(readiness_response(0x04).is_empty());
+        assert!(readiness_response(0x12).is_empty());
     }
 }
 

--- a/tests/psmux_smoke_mouse.rs
+++ b/tests/psmux_smoke_mouse.rs
@@ -29,6 +29,17 @@ const POLL_TIMEOUT: Duration = Duration::from_secs(30);
 const FIXTURE: &str = env!("CARGO_BIN_EXE_jefe-psmux-smoke-fixture");
 
 #[test]
+fn capture_tail_preserves_reading_order_and_character_boundaries() {
+    let capture = format!("discard-{}-end", "αβ".repeat(90));
+    let expected = capture
+        .chars()
+        .skip(capture.chars().count().saturating_sub(160))
+        .collect::<String>();
+
+    assert_eq!(capture_tail(&capture), expected);
+}
+
+#[test]
 fn psmux_attached_viewer_observes_mouse_modes_and_delivers_page_keys() {
     let Some((executable, version_text)) = qualified_psmux() else {
         return;
@@ -210,10 +221,16 @@ fn poll_marker_and_mouse_reporting(
     } else {
         format!("marker {needle} not seen within {cap:?}")
     };
-    Err(format!(
-        "{stage}; capture tail: {}",
-        last.chars().rev().take(160).collect::<String>()
-    ))
+    Err(format!("{stage}; capture tail: {}", capture_tail(&last)))
+}
+
+fn capture_tail(capture: &str) -> &str {
+    let start = capture
+        .char_indices()
+        .rev()
+        .nth(159)
+        .map_or(0, |(index, _)| index);
+    &capture[start..]
 }
 
 fn write_input_until_captured(

--- a/tests/psmux_smoke_mouse.rs
+++ b/tests/psmux_smoke_mouse.rs
@@ -71,15 +71,14 @@ fn psmux_attached_viewer_observes_mouse_modes_and_delivers_page_keys() {
     configure_prefix_for_passthrough_with_plan(session, &plan)
         .unwrap_or_else(|error| panic!("configure production prefix policy: {error}"));
 
-    let viewer = AttachedViewer::spawn_with_plan(session, 32, 100, &plan)
-        .unwrap_or_else(|error| panic!("spawn AttachedViewer: {error}"));
-    assert!(
-        viewer.is_alive(),
-        "AttachedViewer should be alive after spawn"
-    );
-
-    assert_attached_viewer_observes_mouse_reporting(&viewer);
-    assert_attached_input_ready(&mut namespace, session, &viewer);
+    // The fixture's startup mode advertisement may occur before a given viewer
+    // exists, and a fresh viewer's blank terminal model can miss it depending
+    // on psmux/ConPTY attach timing. Rather than synchronizing on a single
+    // one-shot probe, attach up to three sequential viewers — each with its own
+    // unique probe and byte marker — against the same established session,
+    // keeping the first that both forwards its own unique marker and observes
+    // mouse reporting. One shared 30-second deadline bounds the whole process.
+    let viewer = attach_viewer_until_input_and_mouse_ready(&mut namespace, session, &plan);
     assert_page_keys_delivered_as_csi_tilde(&mut namespace, session, &viewer);
     assert_sgr_mouse_delivered_intact(&mut namespace, session, &viewer);
 
@@ -87,41 +86,134 @@ fn psmux_attached_viewer_observes_mouse_modes_and_delivers_page_keys() {
     let _ = namespace.run(&["kill-session", "-t", session]);
 }
 
-/// Issue #296 (a): poll until the AttachedViewer's embedded terminal model
-/// observes the fixture's advertised DEC private mouse modes.
-fn assert_attached_viewer_observes_mouse_reporting(viewer: &AttachedViewer) {
+/// Readiness probes for sequential attach attempts. Each candidate viewer gets
+/// a unique probe byte so its own unique marker (`PSMUX_BYTE_6A`/`6B`/`6C`)
+/// confirms that specific viewer's input relay reached the child. On receipt of
+/// any probe byte the fixture re-advertises the DEC private mouse modes.
+const ATTACH_PROBES: [(&[u8], &str); 3] = [
+    (b"j", "PSMUX_BYTE_6A"),
+    (b"k", "PSMUX_BYTE_6B"),
+    (b"l", "PSMUX_BYTE_6C"),
+];
+
+/// Per-candidate ceiling. The overall 30-second `POLL_TIMEOUT` deadline is
+/// shared across all attempts and is never restarted, so a single stuck
+/// attach cannot extend the test beyond its existing bound.
+const PER_CANDIDATE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Attach up to three sequential viewers against the same established session.
+/// A candidate qualifies only when its own unique marker appears in the pane
+/// capture and that same viewer reports `mouse_reporting_active`. Each failed
+/// viewer is dropped before the next spawn; the qualifier is returned for the
+/// semantic Page-key and SGR assertions. Mirrors production by calling
+/// `nudge_for_mode_recovery` once per candidate, but never treats the nudge as
+/// readiness.
+fn attach_viewer_until_input_and_mouse_ready(
+    namespace: &mut PsmuxNamespace,
+    session: &str,
+    plan: &MultiplexerPlan,
+) -> AttachedViewer {
     let deadline = Instant::now() + POLL_TIMEOUT;
-    let mut observed = false;
-    while Instant::now() < deadline {
-        if viewer.mouse_reporting_active() {
-            observed = true;
+    let mut transcript: Vec<String> = Vec::new();
+    for (index, (probe, needle)) in ATTACH_PROBES.iter().enumerate() {
+        if Instant::now() >= deadline {
             break;
         }
-        thread::sleep(Duration::from_millis(50));
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let cap = remaining.min(PER_CANDIDATE_TIMEOUT);
+        match try_attach_candidate(namespace, session, plan, probe, needle, cap) {
+            Ok(viewer) => {
+                for line in &transcript {
+                    let _ = writeln!(namespace.transcript, "{line}");
+                }
+                return viewer;
+            }
+            Err(diagnostic) => transcript.push(format!(
+                "candidate {index} (probe {:?}, needle {needle}): {diagnostic}",
+                probe[0] as char
+            )),
+        }
     }
-    assert!(
-        observed,
-        "AttachedViewer never observed mouse reporting after fixture advertised 1000/1002/1006"
+    for line in &transcript {
+        let _ = writeln!(namespace.transcript, "{line}");
+    }
+    panic!(
+        "no candidate attached and observed mouse reporting within {POLL_TIMEOUT:?}:\n{}",
+        transcript.join("\n")
     );
 }
 
-/// Wait for the attached psmux client to forward input before asserting the
-/// semantic key sequences. Output can reach the viewer before psmux's input
-/// relay is ready on a loaded Windows runner, so terminal-mode observation alone
-/// is not an input-readiness barrier.
-fn assert_attached_input_ready(
+/// Spawn one viewer, nudge it once, send its probe, and confirm the candidate
+/// both forwards its unique marker and observes mouse reporting before `cap`.
+/// Marker delivery and mouse-mode observation are polled together under one
+/// shared `cap` deadline so a single candidate can never consume more than
+/// `cap`; the caller's outer 30-second deadline is the only bound that matters.
+/// On failure returns a concise diagnostic; the caller drops the viewer.
+fn try_attach_candidate(
+    namespace: &mut PsmuxNamespace,
+    session: &str,
+    plan: &MultiplexerPlan,
+    probe: &[u8],
+    needle: &str,
+    cap: Duration,
+) -> Result<AttachedViewer, String> {
+    let viewer = AttachedViewer::spawn_with_plan(session, 32, 100, plan)
+        .map_err(|error| format!("spawn failed: {error}"))?;
+    viewer.nudge_for_mode_recovery();
+    poll_marker_and_mouse_reporting(namespace, session, &viewer, probe, needle, cap)
+        .map(|()| viewer)
+}
+
+/// Conjunctively poll until both (a) `needle` appears in the pane capture and
+/// (b) the viewer reports `mouse_reporting_active`, under a single shared
+/// `cap` deadline. The fixture emits the DEC private mouse modes *before* the
+/// probe's byte marker (see `readiness_response`), so once the marker lands the
+/// modes have already traversed the PTY; this loop keeps polling mouse mode
+/// after the marker arrives without restarting the deadline. Returns an error
+/// capturing which condition failed and the capture tail.
+fn poll_marker_and_mouse_reporting(
     namespace: &mut PsmuxNamespace,
     session: &str,
     viewer: &AttachedViewer,
-) {
-    write_input_until_captured(
-        namespace,
-        session,
-        viewer,
-        b"j",
-        "PSMUX_BYTE_6A",
-        "input-readiness probe",
-    );
+    probe: &[u8],
+    needle: &str,
+    cap: Duration,
+) -> Result<(), String> {
+    let deadline = Instant::now() + cap;
+    let mut last = String::new();
+    let mut marker_seen = false;
+    while Instant::now() < deadline {
+        if !viewer.is_alive() {
+            return Err(format!(
+                "viewer exited before forwarding {needle}; tail: {last}"
+            ));
+        }
+        if !marker_seen {
+            viewer
+                .write_input(probe)
+                .map_err(|error| format!("write probe: {error}"))?;
+        }
+        thread::sleep(Duration::from_millis(50));
+        last = namespace
+            .capture(session)
+            .map_err(|error| format!("capture: {error}"))?;
+        if !marker_seen && last.contains(needle) {
+            marker_seen = true;
+        }
+        if marker_seen && viewer.mouse_reporting_active() {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    let stage = if marker_seen {
+        format!("marker {needle} seen but mouse_reporting_active=false")
+    } else {
+        format!("marker {needle} not seen within {cap:?}")
+    };
+    Err(format!(
+        "{stage}; capture tail: {}",
+        last.chars().rev().take(160).collect::<String>()
+    ))
 }
 
 fn write_input_until_captured(
@@ -391,11 +483,13 @@ impl PsmuxNamespace {
 
 impl Drop for PsmuxNamespace {
     fn drop(&mut self) {
-        let _ = Command::new(&self.executable)
-            .arg("-L")
-            .arg(&self.name)
-            .arg("kill-server")
-            .output();
+        // Issue #456 AC3: route namespace-scoped kill-server through the
+        // existing bounded `run` collector (five-second ceiling) instead of an
+        // unbounded `Command::output`, so teardown cannot hang the test runner.
+        // Never contact the default server: `-L <namespace>` scopes the kill.
+        if let Err(error) = self.run(&["kill-server"]) {
+            let _ = writeln!(self.transcript, "namespace cleanup failed: {error}");
+        }
         let _ = fs::write(self.artifact_dir.join("transcript.txt"), &self.transcript);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #456.

The flaky native-Windows psmux smoke was not simply exceeding its timeout. When Jefe itself ran inside psmux, child commands inherited `PSMUX_SESSION` and `PSMUX_TARGET_SESSION`, so supposedly isolated setup and attach commands targeted the parent session. The attached viewer could receive output while its input never reached the fixture.

## Changes

- Scrub inherited psmux session-routing variables from native-Windows multiplexer commands and all local attach commands.
- Use the explicit psmux 3.3.7 `attach-session -t <session>` form on every platform.
- Qualify attached input and DEC mouse-mode observation conjunctively under one existing 30-second deadline, with at most three unique bounded candidates.
- Preserve the issue #465 single-write PageUp/PageDown path and exact `CSI 5~`, `CSI 6~`, `CSI <0;1;1M`, and `pane_in_mode == 0` assertions.
- Route namespace cleanup through the existing five-second bounded command collector and retain teardown diagnostics.
- Add command-structure, cross-platform, fixture, and timeout-diagnostic regression tests.

## Acceptance criteria

- **AC1:** an attached candidate qualifies only after its own unique input marker and mouse-reporting state are both observed under shared bounded deadlines.
- **AC2:** PageUp/PageDown and SGR mouse still use and assert the exact issue #296/#465 byte contract, without semantic reinjection.
- **AC3:** namespace cleanup remains scoped and now uses the existing bounded collector; no fixture descendants survive successful smoke runs.

## Explicit non-goals

No timeout increase, semantic Page-key retry, env-var CI skip, dependency/workflow/quality-tool change, public abstraction, harness normalization, unrelated test move, or issue #465 deferred P1/P3/P4/P6 hardening. Unix multiplexer routing remains unchanged. `.llxprt/` is untouched.

## RED / GREEN evidence

- Current-main RED: attached viewer missed mouse mode; follow-up diagnostics showed the psmux nested-session warning and no readiness marker.
- Intermediate RED: scrubbing only attach allowed readiness but left PageUp setup failing, proving ordinary setup commands also needed isolation.
- GREEN: 10 consecutive psmux 3.3.7 smoke runs passed (2.52–2.84s each), followed by no surviving fixture process.
- Sibling native tests: `psmux_attach` 2/2 and `psmux_orphan_reap` 2/2 passed.

## Exact-head verification

Current head `4e47fe27d9b91f2f04e238d3f57cfbd6015e54ac`:

- `cargo xtask ci` passed all 9 gates: fmt, clippy-allow, source-size, architecture, strict Clippy, complexity, 47.87% coverage (floor 30%), locked all-feature build, and locked all-feature tests.
- Required psmux smoke passed 1/1 in 3.37s with `JEFE_REQUIRE_PSMUX=1`.
- No `jefe-psmux-smoke-fixture` process survived.

## Review and scope

- Initial candidate: 7 files, 911 additions / 46 deletions including the delivery plan; below the bounded workflow trigger.
- Two local OCR runs were partial because the CLI aborted after four of six reviewable files. Both first-pass In-scope-Fix findings were resolved; the second reported no findings in its partial coverage. An independent GLM/zai audit covered all changed paths and passed.
- PR OCR run 1 completed the review phase with `complete_best_effort` coverage and exit code 0, then its manifest-only post-processing failed because the workflow could not load `@actions/core` (repository infrastructure, no issue-source involvement).
- PR OCR findings: one valid reading-order diagnostic issue was fixed with a RED/GREEN regression test; two duplicate suggestions to derive the fixture's expected modes from its own constant were rejected because that would make the order contract tautological.
- LLxprt walkthrough passed. Its template-section suggestion was fixed in this description; its #465 linkage claim was rejected because this PR closes #456 and #465/#468 already delivered the separate root-unbind work.
- CodeRabbit selected all seven files but was rate limited; its status context passed.
- Scope ledger is clean; shared private-harness cleanup remains deferred as already tracked by issue #465.

## Pre-push checklist

- [x] Correct `main` ancestry and issue branch
- [x] RED → GREEN regression evidence
- [x] Exact-head full local verification
- [x] Required real native-Windows smoke and leak check
- [x] Review findings classified and all In-scope-Fix items resolved
- [x] No workflow, dependency, quality-tool, or `.llxprt/` changes

## Testing notes

CI must run the locked all-feature workspace and the Native Windows (MSVC + psmux) job on this exact head. Local psmux evidence uses psmux 3.3.7 with `JEFE_REQUIRE_PSMUX=1` so unavailable psmux cannot silently skip coverage.

## Reviewers / Assignees

No specific reviewer or assignee requested; repository automation and maintainers may review the ready PR.