### PR TITLE
Stop bare Enter from submitting the New Issue form (Fixes #480)

### DIFF
--- a/project-plans/issue480-plan.md
+++ b/project-plans/issue480-plan.md
@@ -1,0 +1,91 @@
+# Issue #480 — New issue now submits on enter
+
+## Problem
+
+In the inline New Issue form (issue #407), pressing plain Enter while the
+**Title** field is focused dispatches `NewIssueSubmit`, immediately creating
+the issue on GitHub. Every other field in the form advances focus on Enter
+(Template/Type/Labels/Milestone/Project/Assignees → `NewIssueFocusNext`;
+Body → `NewIssueBodyNewline`), and the form's own rendered hint advertises
+`Alt+Enter submit`. Only Alt+Enter (and the Ctrl+Enter compatibility key) is
+supposed to submit. This is a regression from the pre-#407 composer where
+bare Enter always inserted a newline.
+
+## Root cause
+
+`src/app_input/issues.rs::resolve_new_issue_enter` maps
+`NewIssueFormFocus::Title => AppEvent::NewIssueSubmit`. Plain Enter in the
+title submits instead of advancing to the next field (Body). The Alt+Enter /
+Ctrl+Enter submit path is already handled earlier in
+`resolve_new_issue_inline_key_event` and is unaffected.
+
+## Decision (accepted approach)
+
+Change **only** the `Title` arm of `resolve_new_issue_enter` to dispatch
+`NewIssueFocusNext` (advance to Body), matching every other selection/text
+field. Alt+Enter and Ctrl+Enter continue to submit via the existing
+modifier-aware early return. This restores the "Enter never submits" contract
+that the rest of the form and the inline editor already honor.
+
+## Acceptance matrix
+
+| ID | Behavior | Evidence |
+|----|----------|----------|
+| A1 | Plain Enter (no modifiers) while the New Issue form Title field is focused dispatches `NewIssueFocusNext` (advances to Body), **not** `NewIssueSubmit`. | Behavioral key-routing test. |
+| A2 | Alt+Enter while the New Issue form Title field is focused still dispatches `NewIssueSubmit` (regression guard). | Behavioral key-routing test. |
+| A3 | Ctrl+Enter while the New Issue form Title field is focused still dispatches `NewIssueSubmit` (regression guard, terminal-portable compat). | Behavioral key-routing test. |
+| A4 | Plain Enter while the New Issue form Body field is focused still dispatches `NewIssueBodyNewline` (unchanged). | Behavioral key-routing test. |
+| A5 | Plain Enter on selection fields (Template/Type/Labels/Milestone/Project/Assignees) still dispatches `NewIssueFocusNext` (unchanged). | Behavioral key-routing test. |
+
+## Non-goals
+
+- Do not change the Alt+Enter / Ctrl+Enter submit contract.
+- Do not change the inline editor / inline composer (non-new-issue) Enter
+  behavior — that path is already correct (issue #265).
+- Do not change the rendered hint text (`Alt+Enter submit` is accurate).
+- Do not add a new event type or public abstraction.
+- Do not touch the submit pipeline, property-apply pipeline, or persistence.
+- Do not modify `.llxprt/`, dependencies, quality-gate scripts, or CI config.
+- Do not refactor unrelated key-routing code.
+
+## Vertical slices
+
+1. **Title Enter no longer submits** (A1–A5) — single RED→GREEN slice:
+   - Add behavioral tests in `src/app_input/issues_key_tests.rs` proving
+     plain Enter in Title advances focus (not submit), and that Alt/Ctrl+Enter
+     and Body/selection-field Enter are unchanged.
+   - Fix the `Title` arm of `resolve_new_issue_enter` to return
+     `AppEvent::NewIssueFocusNext`.
+
+## Expected files
+
+| File | Change | Est. net lines |
+|------|--------|----------------|
+| `src/app_input/issues.rs` | Title arm → `NewIssueFocusNext` | +1 / -1 |
+| `src/app_input/issues_key_tests.rs` | new behavioral tests + helper | ~+90 |
+
+**Estimated total: 2 files, ~90 net added lines.** Well under the 25-file /
+1,500-line target; no scope-review trigger.
+
+## Scope ledger
+
+| File | Change | Reason |
+|------|--------|--------|
+| `src/app_input/issues.rs` | 1-line fix in `resolve_new_issue_enter` | A1 root cause |
+| `src/app_input/issues_key_tests.rs` | add New Issue form Enter tests | A1–A5 evidence |
+
+No newly discovered work. No out-of-scope files.
+
+## Review counters
+
+- OCR before PR: 0 / 2
+- OCR after PR: 0 / 2
+
+## Verification
+
+- `cargo xtask quick` (fmt + check + test) during iteration.
+- Full `cargo xtask ci` (fmt check, clippy-allow policy, source-size,
+  architecture, strict + complexity clippy, coverage ≥ 30%, locked
+  all-feature build + test) on the green checkpoint.
+- New behavioral tests pass; existing `issues_key_265_tests.rs` and
+  `new_issue_form_ops_tests.rs` still pass.

--- a/src/app_input/issues.rs
+++ b/src/app_input/issues.rs
@@ -172,16 +172,19 @@ fn resolve_new_issue_inline_key_event(state: &AppState, key_event: &KeyEvent) ->
 
 fn resolve_new_issue_enter(focus: NewIssueFormFocus) -> AppEvent {
     match focus {
-        // In the body, Enter inserts a newline; selection fields advance to
-        // the next field so Enter is not a dangerous accidental submit.
+        // In the body, Enter inserts a newline; every other field advances to
+        // the next field so a bare Enter is never an accidental submit. Only
+        // Alt+Enter / Ctrl+Enter submit (handled earlier in
+        // resolve_new_issue_inline_key_event). Issue #480: Title previously
+        // submitted on bare Enter, contradicting the "Alt+Enter submit" hint.
         NewIssueFormFocus::Body => AppEvent::NewIssueBodyNewline,
         NewIssueFormFocus::Template
         | NewIssueFormFocus::Type
+        | NewIssueFormFocus::Title
         | NewIssueFormFocus::Labels
         | NewIssueFormFocus::Milestone
         | NewIssueFormFocus::Project
         | NewIssueFormFocus::Assignees => AppEvent::NewIssueFocusNext,
-        NewIssueFormFocus::Title => AppEvent::NewIssueSubmit,
     }
 }
 

--- a/src/app_input/issues_key_480_tests.rs
+++ b/src/app_input/issues_key_480_tests.rs
@@ -1,0 +1,100 @@
+//! Issue #480: New Issue form bare-Enter must not submit.
+//!
+//! Extracted from `issues_key_tests.rs` to keep that file under the
+//! source-size hard limit. Compiled as a submodule via
+//! `#[path = "..."] mod ...;`, so `use super::*;` re-imports the parent
+//! module's helpers (`key`, `key_with_mods`, `resolve_issues_key_event`).
+
+use jefe::state::{NewIssueFormFocus, NewIssueFormState};
+
+use super::*;
+
+/// Build an Issues-mode state with the inline New Issue form open and the
+/// given field focused. The form coexists with the NewIssue composer
+/// `InlineState` (issue #407), which is what routes keys through
+/// `resolve_new_issue_inline_key_event`.
+fn issues_state_with_new_issue_form(focus: NewIssueFormFocus) -> AppState {
+    AppState {
+        screen_mode: ScreenMode::DashboardIssues,
+        issues_state: IssuesState {
+            active: true,
+            issue_focus: IssueFocus::IssueDetail,
+            inline_state: InlineState::Composer {
+                target: ComposerTarget::NewIssue,
+                text: String::new(),
+                cursor: 0,
+            },
+            new_issue_form: Some(NewIssueFormState {
+                focus,
+                ..NewIssueFormState::default()
+            }),
+            ..IssuesState::default()
+        },
+        ..AppState::default()
+    }
+}
+
+/// Plain Enter on the Title field must advance focus to the next field,
+/// NOT submit (issue #480). Only Alt+Enter / Ctrl+Enter submit.
+#[test]
+fn bare_enter_on_new_issue_title_advances_focus_not_submit() {
+    let state = issues_state_with_new_issue_form(NewIssueFormFocus::Title);
+    let event = resolve_issues_key_event(&state, &key(KeyCode::Enter));
+    assert!(
+        matches!(event, Some(AppEvent::NewIssueFocusNext)),
+        "bare Enter on Title must dispatch NewIssueFocusNext (advance to Body), got {event:?}"
+    );
+    assert!(
+        !matches!(event, Some(AppEvent::NewIssueSubmit)),
+        "bare Enter on Title must NOT dispatch NewIssueSubmit, got {event:?}"
+    );
+}
+
+/// Alt+Enter on the Title field still submits (regression guard, issue #480).
+#[test]
+fn alt_enter_on_new_issue_title_submits() {
+    let state = issues_state_with_new_issue_form(NewIssueFormFocus::Title);
+    let event = resolve_issues_key_event(&state, &key_with_mods(KeyCode::Enter, KeyModifiers::ALT));
+    assert!(
+        matches!(event, Some(AppEvent::NewIssueSubmit)),
+        "Alt+Enter on Title must dispatch NewIssueSubmit, got {event:?}"
+    );
+}
+
+/// Ctrl+Enter on the Title field still submits (terminal-portable compat,
+/// regression guard, issue #480).
+#[test]
+fn ctrl_enter_on_new_issue_title_submits() {
+    let state = issues_state_with_new_issue_form(NewIssueFormFocus::Title);
+    let event = resolve_issues_key_event(
+        &state,
+        &key_with_mods(KeyCode::Enter, KeyModifiers::CONTROL),
+    );
+    assert!(
+        matches!(event, Some(AppEvent::NewIssueSubmit)),
+        "Ctrl+Enter on Title must dispatch NewIssueSubmit, got {event:?}"
+    );
+}
+
+/// Plain Enter on the Body field still inserts a newline (unchanged, issue #480).
+#[test]
+fn bare_enter_on_new_issue_body_inserts_newline() {
+    let state = issues_state_with_new_issue_form(NewIssueFormFocus::Body);
+    let event = resolve_issues_key_event(&state, &key(KeyCode::Enter));
+    assert!(
+        matches!(event, Some(AppEvent::NewIssueBodyNewline)),
+        "bare Enter on Body must dispatch NewIssueBodyNewline, got {event:?}"
+    );
+}
+
+/// Plain Enter on a selection field (Template) still advances focus
+/// (unchanged, issue #480).
+#[test]
+fn bare_enter_on_new_issue_template_advances_focus() {
+    let state = issues_state_with_new_issue_form(NewIssueFormFocus::Template);
+    let event = resolve_issues_key_event(&state, &key(KeyCode::Enter));
+    assert!(
+        matches!(event, Some(AppEvent::NewIssueFocusNext)),
+        "bare Enter on Template must dispatch NewIssueFocusNext, got {event:?}"
+    );
+}

--- a/src/app_input/issues_key_tests.rs
+++ b/src/app_input/issues_key_tests.rs
@@ -991,3 +991,6 @@ mod close_delete;
 
 #[path = "issues_key_265_tests.rs"]
 mod issue265;
+
+#[path = "issues_key_480_tests.rs"]
+mod issue480;


### PR DESCRIPTION
## Summary

Plain Enter on the New Issue form **Title** field was dispatching `NewIssueSubmit`, immediately creating the issue on GitHub. This regressed the pre-#407 behavior (Enter only inserts a newline) and contradicts the form's own rendered hint: `Alt+Enter submit`. Every other field in the form already advances focus on Enter; only Alt+Enter / Ctrl+Enter are supposed to submit.

Fixes #480.

## Root cause

`src/app_input/issues.rs::resolve_new_issue_enter` mapped `NewIssueFormFocus::Title => AppEvent::NewIssueSubmit`. The modifier-aware submit path (Alt+Enter / Ctrl+Enter) is handled earlier in `resolve_new_issue_inline_key_event` and was unaffected — the bug was only the bare-Enter case.

## Change

Move `Title` into the `NewIssueFocusNext` group in `resolve_new_issue_enter`, so a bare Enter on Title advances focus to Body (matching Template/Type/Labels/Milestone/Project/Assignees). The Alt+Enter / Ctrl+Enter submit path is unchanged.

Single-line production logic change (+6/-3 in `issues.rs`, including the updated comment).

## Acceptance matrix

| ID | Behavior | Evidence |
|----|----------|----------|
| A1 | Bare Enter on Title dispatches `NewIssueFocusNext` (advance to Body), NOT `NewIssueSubmit` | `bare_enter_on_new_issue_title_advances_focus_not_submit` |
| A2 | Alt+Enter on Title still dispatches `NewIssueSubmit` (regression guard) | `alt_enter_on_new_issue_title_submits` |
| A3 | Ctrl+Enter on Title still dispatches `NewIssueSubmit` (terminal-portable compat) | `ctrl_enter_on_new_issue_title_submits` |
| A4 | Bare Enter on Body still dispatches `NewIssueBodyNewline` (unchanged) | `bare_enter_on_new_issue_body_inserts_newline` |
| A5 | Bare Enter on selection fields still dispatches `NewIssueFocusNext` (unchanged) | `bare_enter_on_new_issue_template_advances_focus` |

## Non-goals

- No change to the Alt+Enter / Ctrl+Enter submit contract.
- No change to the inline editor / non-new-issue composer Enter behavior (already correct, issue #265).
- No change to the rendered hint text (`Alt+Enter submit` is accurate).
- No new event type or public abstraction.

## Verification

- `cargo xtask quick` — fmt + check + test pass.
- `cargo xtask ci` equivalent (fmt, clippy-allow policy, source-size, architecture, strict + complexity clippy, coverage 71.34% >= 30%, locked build + test) — all green.
- Local Open Code Review (1/2 pre-PR cap): 3 files reviewed, 0 comments.
- New behavioral tests extracted into `issues_key_480_tests.rs` to keep `issues_key_tests.rs` under the 1000-line source-size hard limit (matches the existing `issues_key_265_tests.rs` extraction pattern).

## Scope

4 files, +200/-3 net. Well under the 25-file / 1,500-line target. Scope ledger in `project-plans/issue480-plan.md`.