### PR TITLE
Make OCR manifests independent of action runtime

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1145,7 +1145,14 @@ jobs:
           node <<'NODE'
           const fs = require('fs');
           const crypto = require('crypto');
-          const core = require('@actions/core');
+
+          const escapeWorkflowCommand = (value) => String(value)
+            .replaceAll('%', '%25')
+            .replaceAll('\r', '%0D')
+            .replaceAll('\n', '%0A');
+          const warning = (message) => {
+            process.stdout.write(`::warning::${escapeWorkflowCommand(message)}\n`);
+          };
 
           const readTrim = (name, fallback = '') => {
             try { return fs.readFileSync(name, 'utf8').trim(); } catch (_) { return fallback; }
@@ -1283,7 +1290,7 @@ jobs:
           // observable rather than silently swallowed.
           for (const name of ['manifest.pre.json', 'manifest.post.json', 'sha256.txt']) {
             try { fs.chmodSync(name, 0o600); } catch (chmodErr) {
-              core.warning(`Could not chmod 0o600 on ${name}: ${chmodErr.message || chmodErr}`);
+              warning(`Could not chmod 0o600 on ${name}: ${chmodErr.message || chmodErr}`);
             }
           }
           // Step-level process.env mutations do not persist across steps in

--- a/project-plans/issue464-plan.md
+++ b/project-plans/issue464-plan.md
@@ -1,0 +1,74 @@
+# Issue #464 — Restore OCR reproducibility manifest execution
+
+## Scope
+
+Issue #464 already owns OCR reproducibility-manifest integrity. PR #475 proved that
+`Build OCR reproducibility manifests` always fails because a plain `node` heredoc
+imports undeclared package `@actions/core`.
+
+## Acceptance matrix
+
+| # | Boundary | Success | Failure | Proof |
+|---|---|---|---|---|
+| AC1 | `Build OCR reproducibility manifests` plain-shell Node process | Runs using only Node built-ins and repository-declared inputs | Missing runtime package cannot abort manifest generation | Scoped repository contract test |
+| AC2 | GitHub Actions diagnostics | Manifest chmod failures remain visible as Actions warnings | Diagnostic emission does not require an npm package | Contract test for dependency-free workflow command encoding |
+| AC3 | Existing manifest/redaction/upload contract | Manifest triple, redaction, checksums, and upload paths are unchanged | No provider secret or unredacted artifact is uploaded | Existing OCR policy tests |
+| AC4 | Exact-head OCR workflow | Manifest-build step passes after OCR result posting | Infrastructure failure remains classified by existing downstream steps | PR workflow evidence |
+
+## Non-goals
+
+- No OCR coverage-classification, model/provider, review-scope, or finding-posting changes.
+- No new npm or Rust dependency.
+- No redesign of the broader manifest schema tracked by issue #464.
+- No workflow-gating change.
+
+## Vertical slice
+
+1. Add a contract test scoped to the manifest-build step proving it does not
+   import `@actions/core` and emits dependency-free Actions warning commands.
+2. Prove RED against current main.
+3. Replace the single `core.warning` use with safe workflow-command emission.
+4. Run focused OCR policy tests and full required verification.
+5. Open an issue-linked PR and verify the exact-head OCR manifest step.
+
+## Expected paths
+
+- `.github/workflows/ocr-review.yml`
+- `tests/core/ocr_workflow_contracts.rs`
+- `project-plans/issue464-plan.md`
+
+## Scope ledger
+
+| Date | Item | Disposition |
+|---|---|---|
+| 2026-07-27 | Existing issue #464 confirmed as owner | Accepted |
+| 2026-07-27 | Exact PR #475 failure added to issue #464 | Accepted |
+| 2026-07-27 | Dedicated branch `issue464` created from merged main `eaba9f2` | Accepted |
+
+## Review counters
+
+- OCR pre-PR: 0/2 (one bounded GLM review completed; no OCR run requested)
+- OCR post-PR: 0/2
+
+## Review triage
+
+- **Blocker—Fix:** none.
+- **In-scope—Fix:** none. The dependency-free warning command escapes `%`, CR,
+  and LF before writing to the GitHub Actions command channel.
+- **Reject:** broader YAML/dependency restructuring is unnecessary for the
+  two-line runtime defect and would expand issue scope.
+- **Defer:** broader manifest-schema completeness remains tracked by issue #464.
+
+## Verification evidence
+
+- RED: focused integration contract failed because the manifest step imported
+  unavailable `@actions/core`.
+- GREEN: focused contract passed after replacement with built-in Node output.
+- All 19 scoped OCR workflow contracts passed.
+- All 7 repository OCR policy tests passed.
+- `cargo fmt --all --check`, policy checks, strict Clippy, and complexity checks
+  passed in the full `cargo xtask ci` attempt.
+- Full local coverage/test completion is blocked by the pre-existing native
+  `tests/psmux_attach.rs` terminal-input assertion; this workflow-only diff does
+  not touch that route. Required exact-head Linux and Windows CI will provide
+  authoritative full-suite evidence.

--- a/tests/core/ocr_workflow_contracts.rs
+++ b/tests/core/ocr_workflow_contracts.rs
@@ -382,6 +382,25 @@ fn ocr_deduplicates_findings_before_posting() {
 }
 
 // ---------------------------------------------------------------------------
+// Issue #464: manifest builder has no undeclared action-runtime dependencies
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ocr_manifest_builder_uses_dependency_free_workflow_commands() {
+    let content = read_workflow();
+    let step = step_body(&content, "Build OCR reproducibility manifests");
+
+    assert!(
+        !step.contains("require('@actions/core')") && !step.contains("require(\"@actions/core\")"),
+        "Plain-shell manifest Node must not import @actions/core, which is not installed in the repository module path"
+    );
+    assert!(
+        step.contains("::warning::"),
+        "Manifest diagnostics must retain GitHub Actions warning semantics without @actions/core"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Criterion 10: preserve existing protections
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- remove the undeclared `@actions/core` import from the plain-shell OCR manifest builder
- emit safely escaped GitHub Actions warnings using Node built-ins
- add a scoped workflow contract preventing regression

Refs #464. This fixes the demonstrated runtime blocker; the broader manifest-integrity work in #464 remains open.

## Acceptance evidence

- RED: the new manifest-builder contract failed against merged main because the step imported unavailable `@actions/core`
- GREEN: focused contract passes
- all 19 OCR workflow contracts pass
- all 7 OCR policy tests pass
- format, policy, strict Clippy, and complexity gates pass locally

## Verification

```text
cargo test -p jefe --test integration core::ocr_workflow_contracts::ocr_manifest_builder_uses_dependency_free_workflow_commands -- --exact
cargo test -p jefe --test integration core::ocr_workflow_contracts
cargo test -p jefe --test ocr_review_policy
cargo fmt --all --check
```

The full local `cargo xtask ci` reached coverage after format, policy, Clippy, and complexity passed, then encountered the existing native `tests/psmux_attach.rs` terminal-input assertion on Windows. This workflow-only change does not touch that path; exact-head Linux and native Windows CI remain authoritative.

## Scope

No dependency, OCR provider/model, coverage classification, finding posting, manifest schema, or required-gate changes.
