### PR TITLE
Surface PR merge-methods fetch failures instead of allowing all methods

### DIFF
--- a/src/app_input/prs_merge_dispatch.rs
+++ b/src/app_input/prs_merge_dispatch.rs
@@ -202,11 +202,10 @@ fn pr_merge_failure_context_from_state(state: &jefe::state::AppState) -> (Reposi
 ///
 /// Resolves the repo owner/name from state and spawns
 /// `GhClient::get_repo_merge_methods` OFF the UI thread, delivering
-/// `PrMergeMethodsLoaded` on success. On failure, nothing is delivered — the
-/// chooser treats `allowed_methods: None` as "all available" (graceful
-/// degradation). A malformed nonblank override surfaces the typed error
-/// as a `PrMergeMethodsLoadFailed` event rather than collapsing to empty
-/// (issue #266).
+/// `PrMergeMethodsLoaded` on success. On API/client failure, delivers
+/// `PrMergeMethodsLoadFailed` (same typed surface as a malformed tracker
+/// override) so the UI shows why methods could not be loaded instead of
+/// silently treating `allowed_methods: None` as "all available".
 ///
 /// @requirement REQ-PR-009
 pub(super) fn dispatch_pr_merge_methods_load(app_state: &mut AppStateHandle, ctx: &SharedContext) {
@@ -237,8 +236,6 @@ pub(super) fn dispatch_pr_merge_methods_load(app_state: &mut AppStateHandle, ctx
             );
         }
         Ok(Some((scope, owner, name, pr_number))) => {
-            // The chooser keeps its graceful "all available" fallback rather
-            // than surfacing an abandoned merge-methods request.
             let Some(deliveries) = gh_async::delivery_handle_or_report(
                 app_state,
                 ctx,
@@ -262,9 +259,11 @@ pub(super) fn dispatch_pr_merge_methods_load(app_state: &mut AppStateHandle, ctx
     }
 }
 
-/// Build the merge-methods-loaded event, returning `None` on failure so the
-/// chooser keeps `allowed_methods: None` (meaning "all available") rather than
-/// collapsing to an empty list that disables every method.
+/// Build the merge-methods result event.
+///
+/// Success → `PrMergeMethodsLoaded`. Fetch failure → `PrMergeMethodsLoadFailed`
+/// so the chooser does not silently degrade to "all methods allowed" when
+/// GitHub rejected or could not answer the allowlist query.
 ///
 /// @requirement REQ-PR-009
 fn pr_merge_methods_event(
@@ -275,22 +274,25 @@ fn pr_merge_methods_event(
     pr_number: u64,
 ) -> Option<AppEvent> {
     let client = super::github_client(ctx)?;
-    let methods = match client.get_repo_merge_methods(owner, name) {
-        Ok(methods) => methods,
+    match client.get_repo_merge_methods(owner, name) {
+        Ok(methods) => Some(AppEvent::PrMergeMethodsLoaded {
+            scope_repo_id: scope.clone(),
+            pr_number,
+            allowed_methods: methods,
+        }),
         Err(error) => {
             tracing::warn!(
                 error = %error,
                 repository = %format_args!("{owner}/{name}"),
-                "could not load PR merge methods; keeping all methods available"
+                "could not load PR merge methods; surfacing load failure"
             );
-            return None;
+            Some(AppEvent::PrMergeMethodsLoadFailed {
+                scope_repo_id: scope.clone(),
+                pr_number,
+                error: error.to_string(),
+            })
         }
-    };
-    Some(AppEvent::PrMergeMethodsLoaded {
-        scope_repo_id: scope.clone(),
-        pr_number,
-        allowed_methods: methods,
-    })
+    }
 }
 
 /// Resolve `(owner, name, malformed_message)` from the effective tracker.

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -712,6 +712,11 @@ pub enum PullRequestsMessage {
         pr_number: u64,
         allowed_methods: Vec<MergeMethod>,
     },
+    MergeMethodsLoadFailed {
+        scope_repo_id: RepositoryId,
+        pr_number: u64,
+        error: String,
+    },
     // PR Review Threads (issue #119)
     /// Open the inline reply composer for a review thread.
     OpenThreadReply {

--- a/src/messages/message_names.rs
+++ b/src/messages/message_names.rs
@@ -294,6 +294,7 @@ message_names!(PullRequestsMessage {
     Self::Merged { .. } => "PrMerged",
     Self::MergeFailed { .. } => "PrMergeFailed",
     Self::MergeMethodsLoaded { .. } => "PrMergeMethodsLoaded",
+    Self::MergeMethodsLoadFailed { .. } => "PrMergeMethodsLoadFailed",
     Self::OpenThreadReply { .. } => "PrOpenThreadReply",
     Self::ToggleThreadResolve { .. } => "PrToggleThreadResolve",
     Self::ThreadResolveSucceeded { .. } => "PrThreadResolveSucceeded",

--- a/src/messages/names.rs
+++ b/src/messages/names.rs
@@ -338,6 +338,7 @@ message_names!(PullRequestsMessage {
     Self::Merged { .. } => "PrMerged",
     Self::MergeFailed { .. } => "PrMergeFailed",
     Self::MergeMethodsLoaded { .. } => "PrMergeMethodsLoaded",
+    Self::MergeMethodsLoadFailed { .. } => "PrMergeMethodsLoadFailed",
     Self::OpenThreadReply { .. } => "PrOpenThreadReply",
     Self::ToggleThreadResolve { .. } => "PrToggleThreadResolve",
     Self::ThreadResolveSucceeded { .. } => "PrThreadResolveSucceeded",

--- a/src/messages/prs_conversion.rs
+++ b/src/messages/prs_conversion.rs
@@ -460,6 +460,15 @@ impl PullRequestsMessage {
                 pr_number,
                 allowed_methods,
             },
+            AppEvent::PrMergeMethodsLoadFailed {
+                scope_repo_id,
+                pr_number,
+                error,
+            } => Self::MergeMethodsLoadFailed {
+                scope_repo_id,
+                pr_number,
+                error,
+            },
             property if Self::is_pr_property_app_event(&property) => {
                 Self::from_app_event_property(property)
             }
@@ -931,6 +940,15 @@ impl PullRequestsMessage {
                 scope_repo_id,
                 pr_number,
                 allowed_methods,
+            },
+            Self::MergeMethodsLoadFailed {
+                scope_repo_id,
+                pr_number,
+                error,
+            } => AppEvent::PrMergeMethodsLoadFailed {
+                scope_repo_id,
+                pr_number,
+                error,
             },
             Self::OpenPropertyEditor { .. }
             | Self::PropertyEditorNavigateUp

--- a/src/messages/prs_conversion.rs
+++ b/src/messages/prs_conversion.rs
@@ -906,6 +906,9 @@ impl PullRequestsMessage {
         if let Some(event) = self.thread_to_app_event() {
             return event;
         }
+        if Self::is_pr_property_message(&self) {
+            return self.into_app_event_property();
+        }
         match self {
             Self::OpenMergeChooser => AppEvent::PrOpenMergeChooser,
             Self::MergeNavigate(NavDir::Up | NavDir::Prev) => AppEvent::PrMergeNavigateUp,
@@ -950,26 +953,33 @@ impl PullRequestsMessage {
                 pr_number,
                 error,
             },
-            Self::OpenPropertyEditor { .. }
-            | Self::PropertyEditorNavigateUp
-            | Self::PropertyEditorNavigateDown
-            | Self::PropertyEditorToggle
-            | Self::PropertyEditorConfirm
-            | Self::PropertyEditorCancel
-            | Self::PropertyEditorTitleChar(_)
-            | Self::PropertyEditorTitleBackspace
-            | Self::PropertyEditorTitleDelete
-            | Self::PropertyEditorTitleCursorLeft
-            | Self::PropertyEditorTitleCursorRight
-            | Self::PropertyEditorTitleCursorHome
-            | Self::PropertyEditorTitleCursorEnd
-            | Self::PropertyEditorOptionsLoaded { .. }
-            | Self::PropertyEditorOptionsFailed { .. }
-            | Self::PropertyEditSucceeded { .. }
-            | Self::PostMutationRefreshStarted
-            | Self::PropertyEditFailed { .. }
-            | Self::PropertyEditorValidationError { .. } => self.into_app_event_property(),
             _ => unreachable!("unrouted PullRequestsMessage variant reached merge converter"),
         }
+    }
+
+    /// Whether a message is a PR property-editor variant (routed out of merge).
+    fn is_pr_property_message(message: &Self) -> bool {
+        matches!(
+            message,
+            Self::OpenPropertyEditor { .. }
+                | Self::PropertyEditorNavigateUp
+                | Self::PropertyEditorNavigateDown
+                | Self::PropertyEditorToggle
+                | Self::PropertyEditorConfirm
+                | Self::PropertyEditorCancel
+                | Self::PropertyEditorTitleChar(_)
+                | Self::PropertyEditorTitleBackspace
+                | Self::PropertyEditorTitleDelete
+                | Self::PropertyEditorTitleCursorLeft
+                | Self::PropertyEditorTitleCursorRight
+                | Self::PropertyEditorTitleCursorHome
+                | Self::PropertyEditorTitleCursorEnd
+                | Self::PropertyEditorOptionsLoaded { .. }
+                | Self::PropertyEditorOptionsFailed { .. }
+                | Self::PropertyEditSucceeded { .. }
+                | Self::PostMutationRefreshStarted
+                | Self::PropertyEditFailed { .. }
+                | Self::PropertyEditorValidationError { .. }
+        )
     }
 }

--- a/src/state/prs_tests_merge.rs
+++ b/src/state/prs_tests_merge.rs
@@ -271,6 +271,46 @@ fn merge_methods_loaded_updates_chooser() {
     }
 }
 
+#[test]
+fn merge_methods_load_failed_sets_scoped_error() {
+    let state = prs_state_with_detail("repo-1", 42);
+    let state = state.apply(AppEvent::PrOpenMergeChooser).committed_pure();
+    assert!(state.prs_state.merge_chooser.is_some());
+    assert!(state.prs_state.error.is_none());
+    let state = state
+        .apply(AppEvent::PrMergeMethodsLoadFailed {
+            scope_repo_id: RepositoryId("repo-1".to_string()),
+            pr_number: 42,
+            error: "API rate limited".to_string(),
+        })
+        .committed_pure();
+    assert!(
+        state.prs_state.merge_chooser.is_some(),
+        "chooser stays open after load failure so the user can still attempt merge"
+    );
+    assert_eq!(
+        state.prs_state.error.as_deref(),
+        Some("Failed to load merge methods: API rate limited")
+    );
+}
+
+#[test]
+fn merge_methods_load_failed_ignored_for_wrong_pr_number() {
+    let state = prs_state_with_detail("repo-1", 42);
+    let state = state.apply(AppEvent::PrOpenMergeChooser).committed_pure();
+    let state = state
+        .apply(AppEvent::PrMergeMethodsLoadFailed {
+            scope_repo_id: RepositoryId("repo-1".to_string()),
+            pr_number: 99,
+            error: "stale".to_string(),
+        })
+        .committed_pure();
+    assert!(
+        state.prs_state.error.is_none(),
+        "stale load-failure for another PR must not clobber current detail"
+    );
+}
+
 // ── Edge cases: list sync, stale responses, pending guard ────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
Fixes #490

When `get_repo_merge_methods` fails, surface `PrMergeMethodsLoadFailed` instead of returning `None` (which silently enabled all merge methods). Fully wire the event through AppMessage conversion so apply does not panic.

## Test plan
- [x] cargo test --lib merge_methods_load_failed / prs_tests_merge
- [x] Open merge chooser when merge-methods API fails; confirm scoped error is shown