### PR TITLE
Bound and trust local Unix process probe subprocesses (Fixes #400)

### DIFF
--- a/project-plans/issue400-plan.md
+++ b/project-plans/issue400-plan.md
@@ -76,14 +76,21 @@ the render-path liveness poll indefinitely).
 
 | Item | Status |
 |---|---|
-| `src/local_command.rs` — Kill/Ps + `run_bounded` | Slice 1 |
+| `src/local_command.rs` — Kill/Ps + `run_bounded` + trusted-path policy | Slices 1, 3, 4 |
 | `src/runtime/process.rs` — resolve + bound probes | Slice 2 |
 | `src/runtime/process_tests.rs` — updated structural + new boundary tests | Slice 2 |
 
-Changed files: 3 (target well under 25). Estimated net lines: ~250 (well under
-1500).
+Changed files: 4 (incl. plan). Net lines: +538 / -20 (well under 25-file and
+1,500-line budgets).
 
 ## Review counters
 
-- OCR local (pre-PR): 0 / 2
+- OCR local (pre-PR): 2 / 2 used
+  - Run #1: 3 findings — 1 Blocker-Fix (trusted-path, fixed in Slice 3),
+    2 Defer (macOS `.ok()?` observability — pre-existing pattern; shared
+    `PROBE_TIMEOUT` — non-critical).
+  - Run #2: 4 findings — 2 In-scope-Fix (Unix-only trust gate, `Stdio::null`
+    stdin — fixed in Slice 4), 1 Defer (macOS `.ok()?` observability — same
+    as run #1), 1 Reject (process-group kill — speculative for leaf probe
+    tools, out of scope).
 - OCR post-PR: 0 / 2

--- a/project-plans/issue400-plan.md
+++ b/project-plans/issue400-plan.md
@@ -1,0 +1,89 @@
+# Issue #400 — Bound and trust local Unix process probe subprocesses
+
+## Problem
+
+`src/runtime/process.rs` invokes the external `kill` and macOS `ps` utilities
+synchronously via `std::process::Command::new("kill")` / `Command::new("ps")`.
+Those invocations inherit executable resolution from `PATH` (no explicit
+resolution) and impose no subprocess deadline (a hung probe blocks startup and
+the render-path liveness poll indefinitely).
+
+## Acceptance matrix
+
+| # | Actor / launch path | Input / boundary | Success behavior | Failure behavior | Test evidence |
+|---|---|---|---|---|---|
+| A1 | Unix `probe_process` (startup + render-path liveness) | live PID, trusted `kill` on PATH | `Running`/`Exited`/`Inaccessible` classified as today | resolution failure → `ProbeFailed` (fail open) | `local_command` Kill resolution test; `process_tests` resolution-failure test |
+| A2 | Unix `probe_process` | hung / manipulated `kill` executable | n/a | spawn or timeout deadline fires → child killed+reaped → `ProbeFailed` | `local_command` `run_bounded` timeout test |
+| A3 | macOS `unix_process_start_time` | live PID, trusted `ps` on PATH | UTC epoch seconds parsed as today | resolution/spawn/timeout failure → `None` (identity-less, fail open) | macOS structural command test updated; existing timezone-stability test covers end-to-end |
+| A4 | `JEFE_KILL_BIN` / `JEFE_PS_BIN` override | explicit trusted executable path | override used verbatim | invalid override → typed `LocalToolError` → `ProbeFailed` | `local_command` override tests (Kill/Ps) |
+| A5 | Windows `probe_process` | any PID | **unchanged** — native `OpenProcess`/`GetProcessTimes` | **unchanged** | existing Windows tests; `#[cfg(windows)]` branch untouched |
+| A6 | structural command contracts | resolved executable + pid | args and controlled env (`LC_ALL=C`, `TZ=UTC`) preserved | n/a | `process_tests` structural tests updated for new builder signatures |
+
+## Non-goals
+
+- Changing issue #305 process classification semantics (`classify_unix_probe`,
+  `classify_process_observation`, `ProcessObservation`, `ProcessLiveness`
+  unchanged).
+- Adding unsafe system calls (`unsafe_code = "forbid"` preserved).
+- Changing remote SSH probing (`src/ssh.rs` execution path unchanged — no
+  refactor to share the bounded-run helper; noted as a potential follow-up).
+- Changing Windows native probe behavior.
+- Adding new dependencies.
+
+## Vertical slices
+
+### Slice 1 — Extend `local_command` with Kill/Ps resolution and a bounded runner
+
+**Files:** `src/local_command.rs`
+
+- Add `LocalTool::Kill` (`"kill"`, `JEFE_KILL_BIN`) and `LocalTool::Ps`
+  (`"ps"`, `JEFE_PS_BIN`).
+- Add `BoundedRunError` (spawn / timeout / io / pipe-unavailable) and
+  `pub fn run_bounded(command, timeout) -> Result<Output, BoundedRunError>`.
+  Pattern mirrors `ssh.rs::execute_command`: spawn → piped stdout/stderr read
+  on threads → `try_wait` poll with `Instant` deadline (25 ms sleep) → kill +
+  reap on timeout. No stdin, no cancellation (simpler than ssh).
+
+**RED tests** (in `local_command.rs` test module):
+- Kill/Ps resolve from PATH and from explicit override (structural, like
+  existing Git/Gh/Ssh tests).
+- Invalid override → `InvalidOverride`.
+- `run_bounded` returns `Output` for a fast-exiting command.
+- `run_bounded` returns `Timeout` and reaps the child for a hanging command.
+
+### Slice 2 — Route Unix/macOS probes through the bounded boundary
+
+**Files:** `src/runtime/process.rs`, `src/runtime/process_tests.rs`
+
+- Add `const PROBE_TIMEOUT: Duration = Duration::from_secs(5);`
+- Split `unix_probe_command(pid)` into
+  `unix_probe_command_for(executable: &Path, pid: u32) -> Command` (pure
+  builder, preserves args + `LC_ALL=C`) and have `probe_process` resolve +
+  run-bounded.
+- Split `macos_start_time_command(pid)` into
+  `macos_start_time_command_for(executable: &Path, pid: u32) -> Command` and
+  have `unix_process_start_time` resolve + run-bounded.
+- Map resolution, spawn, timeout, and pipe failures → `ProcessObservation::ProbeFailed`
+  (Unix probe) / `None` (macOS start time).
+
+**RED/updated tests** (in `process_tests.rs`):
+- Structural command tests updated to call `*_for(Path, pid)` and verify args
+  + env are unchanged.
+- New test: empty-PATH resolution failure for Kill → `ProbeFailed` via
+  `probe_process`.
+
+## Scope ledger
+
+| Item | Status |
+|---|---|
+| `src/local_command.rs` — Kill/Ps + `run_bounded` | Slice 1 |
+| `src/runtime/process.rs` — resolve + bound probes | Slice 2 |
+| `src/runtime/process_tests.rs` — updated structural + new boundary tests | Slice 2 |
+
+Changed files: 3 (target well under 25). Estimated net lines: ~250 (well under
+1500).
+
+## Review counters
+
+- OCR local (pre-PR): 0 / 2
+- OCR post-PR: 0 / 2

--- a/src/local_command.rs
+++ b/src/local_command.rs
@@ -44,6 +44,17 @@ impl LocalTool {
             Self::Ps => "JEFE_PS_BIN",
         }
     }
+
+    /// Whether this tool must resolve from trusted system directories rather
+    /// than the full `PATH`.
+    ///
+    /// Security-sensitive probe tools (`kill`, `ps`) participate in process
+    /// liveness decisions, so a manipulated `PATH` must not silently
+    /// substitute an untrusted executable under the selected deployment
+    /// policy.
+    const fn requires_trusted_path(self) -> bool {
+        matches!(self, Self::Kill | Self::Ps)
+    }
 }
 
 /// Host executable-resolution policy.
@@ -96,14 +107,18 @@ impl std::error::Error for LocalToolError {}
 /// Resolve a local tool to an explicit executable path.
 pub fn resolve(tool: LocalTool) -> Result<PathBuf, LocalToolError> {
     let override_path = std::env::var_os(tool.override_name()).map(PathBuf::from);
-    let paths = std::env::var_os("PATH")
-        .filter(|value| !value.is_empty())
-        .map(|value| {
-            std::env::split_paths(&value)
-                .filter(|path| !path.as_os_str().is_empty())
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
+    let paths = if tool.requires_trusted_path() {
+        trusted_unix_directories()
+    } else {
+        std::env::var_os("PATH")
+            .filter(|value| !value.is_empty())
+            .map(|value| {
+                std::env::split_paths(&value)
+                    .filter(|path| !path.as_os_str().is_empty())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+    };
     resolve_in(
         tool,
         ToolPlatform::current(),
@@ -111,6 +126,22 @@ pub fn resolve(tool: LocalTool) -> Result<PathBuf, LocalToolError> {
         std::env::var_os("PATHEXT"),
         override_path,
     )
+}
+
+/// Return the portable set of trusted system directories used to resolve
+/// security-sensitive probe executables.
+///
+/// Only canonical absolute system directories are searched, never the full
+/// `PATH`, so a manipulated `PATH` cannot substitute an untrusted `kill` or
+/// `ps` under the selected deployment policy.
+fn trusted_unix_directories() -> Vec<PathBuf> {
+    [
+        PathBuf::from("/bin"),
+        PathBuf::from("/usr/bin"),
+        PathBuf::from("/sbin"),
+        PathBuf::from("/usr/sbin"),
+    ]
+    .into()
 }
 
 /// Construct a command using an explicitly resolved executable.
@@ -519,5 +550,49 @@ mod tests {
         let command = std::process::Command::new(&missing);
         let result = run_bounded(command, std::time::Duration::from_secs(1));
         assert!(matches!(result, Err(BoundedRunError::Spawn(_))));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_probe_tools_resolve_only_from_trusted_system_directories() {
+        // Kill and Ps are security-sensitive probe tools: they must resolve
+        // only from canonical system directories, never from arbitrary PATH
+        // entries that an attacker could influence. This is the trust policy
+        // that prevents a manipulated PATH from silently substituting an
+        // untrusted probe executable under the selected deployment policy.
+        assert!(LocalTool::Kill.requires_trusted_path());
+        assert!(LocalTool::Ps.requires_trusted_path());
+
+        // Non-security tools continue to use the full PATH.
+        assert!(!LocalTool::Git.requires_trusted_path());
+        assert!(!LocalTool::Gh.requires_trusted_path());
+        assert!(!LocalTool::Ssh.requires_trusted_path());
+
+        // The trusted directory list contains only canonical absolute system
+        // directories — never user-writable or PATH-injected locations.
+        let trusted = trusted_unix_directories();
+        assert!(trusted.iter().all(|dir| dir.is_absolute()));
+        assert!(trusted.iter().any(|dir| dir == &PathBuf::from("/bin")));
+        assert!(trusted.iter().any(|dir| dir == &PathBuf::from("/usr/bin")));
+
+        // An untrusted directory is never in the trusted list, so a malicious
+        // executable placed there cannot be resolved through resolve().
+        let untrusted = tempfile::Builder::new()
+            .prefix("jefe untrusted probe ")
+            .tempdir()
+            .unwrap_or_else(|error| panic!("create untrusted probe directory: {error}"));
+        assert!(!trusted.contains(&untrusted.path().to_path_buf()));
+
+        // The real system kill binary resolves from the trusted list when it
+        // exists there (CI and dev hosts have /bin/kill or /usr/bin/kill).
+        let resolved = resolve_in(LocalTool::Kill, ToolPlatform::Unix, &trusted, None, None);
+        if let Ok(path) = resolved {
+            let parent = path.parent().map(Path::to_path_buf).unwrap_or_default();
+            assert!(
+                trusted.contains(&parent),
+                "kill must resolve from a trusted directory, got {}",
+                path.display()
+            );
+        }
     }
 }

--- a/src/local_command.rs
+++ b/src/local_command.rs
@@ -51,9 +51,10 @@ impl LocalTool {
     /// Security-sensitive probe tools (`kill`, `ps`) participate in process
     /// liveness decisions, so a manipulated `PATH` must not silently
     /// substitute an untrusted executable under the selected deployment
-    /// policy.
+    /// policy. This applies only on Unix where the probe tools shell out; on
+    /// Windows the native Win32 probe path does not resolve `kill` or `ps`.
     const fn requires_trusted_path(self) -> bool {
-        matches!(self, Self::Kill | Self::Ps)
+        cfg!(unix) && matches!(self, Self::Kill | Self::Ps)
     }
 }
 
@@ -198,7 +199,10 @@ const BOUNDED_POLL_INTERVAL: Duration = Duration::from_millis(25);
 /// [`BoundedRunError::Io`] / [`BoundedRunError::Pipe`] if the captured output
 /// cannot be collected.
 pub fn run_bounded(mut command: Command, timeout: Duration) -> Result<Output, BoundedRunError> {
-    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
     let mut child = command.spawn().map_err(BoundedRunError::Spawn)?;
     let stdout = take_pipe(child.stdout.take(), &mut child, "stdout")?;
     let stderr = take_pipe(child.stderr.take(), &mut child, "stderr")?;

--- a/src/local_command.rs
+++ b/src/local_command.rs
@@ -599,4 +599,55 @@ mod tests {
             );
         }
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_kill_resolution_ignores_untrusted_path_entries() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // The security invariant: resolve(LocalTool::Kill) searches ONLY
+        // trusted_unix_directories(), never PATH. A fake kill in an untrusted
+        // directory must not be resolved even if that directory exists on disk
+        // and contains an executable named "kill".
+        //
+        // We cannot mutate PATH (Rust 2024 forbids set_var), but we can prove
+        // the decision logic: requires_trusted_path() gates Kill/Ps to the
+        // trusted list, and resolve_in over the trusted list never visits any
+        // temp directory.
+        let untrusted = tempfile::Builder::new()
+            .prefix("jefe path-injection ")
+            .tempdir()
+            .unwrap_or_else(|error| panic!("create path-injection directory: {error}"));
+        let fake_kill = untrusted.path().join("kill");
+        std::fs::write(&fake_kill, b"#!/bin/sh
+echo pwned
+")
+            .unwrap_or_else(|error| panic!("write fake kill: {error}"));
+        std::fs::set_permissions(&fake_kill, std::fs::Permissions::from_mode(0o755))
+            .unwrap_or_else(|error| panic!("chmod fake kill: {error}"));
+
+        // requires_trusted_path() is the gate that makes resolve() use
+        // trusted_unix_directories() instead of PATH for Kill/Ps.
+        assert!(LocalTool::Kill.requires_trusted_path());
+
+        // The trusted list never contains a temp directory.
+        let trusted = trusted_unix_directories();
+        assert!(
+            !trusted.contains(&untrusted.path().to_path_buf()),
+            "temp directory must not appear in the trusted list"
+        );
+
+        // Searching only the trusted list never resolves the fake kill. If a
+        // real kill exists in /bin or /usr/bin it resolves; otherwise NotFound.
+        // Either way the fake is never selected.
+        let resolved = resolve_in(LocalTool::Kill, ToolPlatform::Unix, &trusted, None, None);
+        match resolved {
+            Ok(path) => assert_ne!(
+                path, fake_kill,
+                "fake kill in untrusted directory must not be resolved"
+            ),
+            Err(LocalToolError::NotFound { tool }) => assert_eq!(tool, LocalTool::Kill),
+            Err(other) => panic!("expected NotFound or trusted kill, got {other:?}"),
+        }
+    }
 }

--- a/src/local_command.rs
+++ b/src/local_command.rs
@@ -231,7 +231,11 @@ fn join_reader(
 ) -> Result<Vec<u8>, BoundedRunError> {
     reader
         .join()
-        .map_err(|_| BoundedRunError::Io(std::io::Error::other("output reader terminated unexpectedly")))?
+        .map_err(|_| {
+            BoundedRunError::Io(std::io::Error::other(
+                "output reader terminated unexpectedly",
+            ))
+        })?
         .map_err(BoundedRunError::Io)
 }
 
@@ -492,10 +496,8 @@ mod tests {
     fn run_bounded_returns_output_for_a_fast_exiting_command() {
         let mut command = std::process::Command::new("sh");
         command.args(["-c", "printf hello; exit 0"]);
-        let output =
-            run_bounded(command, std::time::Duration::from_secs(2)).unwrap_or_else(|error| {
-                panic!("run_bounded fast-path failed: {error}")
-            });
+        let output = run_bounded(command, std::time::Duration::from_secs(2))
+            .unwrap_or_else(|error| panic!("run_bounded fast-path failed: {error}"));
         assert!(output.status.success());
         assert_eq!(output.stdout, b"hello");
     }

--- a/src/local_command.rs
+++ b/src/local_command.rs
@@ -619,10 +619,13 @@ mod tests {
             .tempdir()
             .unwrap_or_else(|error| panic!("create path-injection directory: {error}"));
         let fake_kill = untrusted.path().join("kill");
-        std::fs::write(&fake_kill, b"#!/bin/sh
+        std::fs::write(
+            &fake_kill,
+            b"#!/bin/sh
 echo pwned
-")
-            .unwrap_or_else(|error| panic!("write fake kill: {error}"));
+",
+        )
+        .unwrap_or_else(|error| panic!("write fake kill: {error}"));
         std::fs::set_permissions(&fake_kill, std::fs::Permissions::from_mode(0o755))
             .unwrap_or_else(|error| panic!("chmod fake kill: {error}"));
 

--- a/src/local_command.rs
+++ b/src/local_command.rs
@@ -2,8 +2,10 @@
 
 use std::ffi::{OsStr, OsString};
 use std::fmt;
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
 
 const WINDOWS_DEFAULT_PATHEXT: &str = ".COM;.EXE;.BAT;.CMD";
 
@@ -16,6 +18,10 @@ pub enum LocalTool {
     Gh,
     /// OpenSSH command-line client.
     Ssh,
+    /// Unix `kill` utility used by the local process-identity probe.
+    Kill,
+    /// Unix `ps` utility used by the macOS process-identity probe.
+    Ps,
 }
 
 impl LocalTool {
@@ -24,6 +30,8 @@ impl LocalTool {
             Self::Git => "git",
             Self::Gh => "gh",
             Self::Ssh => "ssh",
+            Self::Kill => "kill",
+            Self::Ps => "ps",
         }
     }
 
@@ -32,6 +40,8 @@ impl LocalTool {
             Self::Git => "JEFE_GIT_BIN",
             Self::Gh => "JEFE_GH_BIN",
             Self::Ssh => "JEFE_SSH_BIN",
+            Self::Kill => "JEFE_KILL_BIN",
+            Self::Ps => "JEFE_PS_BIN",
         }
     }
 }
@@ -106,6 +116,140 @@ pub fn resolve(tool: LocalTool) -> Result<PathBuf, LocalToolError> {
 /// Construct a command using an explicitly resolved executable.
 pub fn command(tool: LocalTool) -> Result<Command, LocalToolError> {
     resolve(tool).map(Command::new)
+}
+
+/// Failure from a bounded subprocess invocation.
+#[derive(Debug)]
+pub enum BoundedRunError {
+    /// The subprocess could not be spawned.
+    Spawn(std::io::Error),
+    /// The deadline elapsed before the subprocess exited; the child was killed.
+    Timeout,
+    /// The subprocess exited but its output could not be captured.
+    Io(std::io::Error),
+    /// A piped standard stream was unexpectedly missing.
+    Pipe(&'static str),
+}
+
+impl fmt::Display for BoundedRunError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Spawn(error) => write!(formatter, "spawn failed: {error}"),
+            Self::Timeout => write!(formatter, "subprocess exceeded its deadline"),
+            Self::Io(error) => write!(formatter, "subprocess I/O failed: {error}"),
+            Self::Pipe(name) => write!(formatter, "{name} pipe was unavailable"),
+        }
+    }
+}
+
+impl std::error::Error for BoundedRunError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Spawn(error) | Self::Io(error) => Some(error),
+            Self::Timeout | Self::Pipe(_) => None,
+        }
+    }
+}
+
+const BOUNDED_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Run a command to completion, killing and reaping it once `timeout` elapses.
+///
+/// Mirrors the bounded executor in `ssh.rs`: spawn with piped stdout/stderr,
+/// poll `try_wait` against an `Instant` deadline, then kill and reap the child
+/// on timeout. No stdin is written. Used by the local process-identity probe so
+/// a hung or manipulated `kill`/`ps` cannot block startup or the render-path
+/// liveness poll indefinitely.
+///
+/// # Errors
+/// Returns [`BoundedRunError::Spawn`] if the child cannot be spawned,
+/// [`BoundedRunError::Timeout`] if the deadline elapses, or
+/// [`BoundedRunError::Io`] / [`BoundedRunError::Pipe`] if the captured output
+/// cannot be collected.
+pub fn run_bounded(mut command: Command, timeout: Duration) -> Result<Output, BoundedRunError> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command.spawn().map_err(BoundedRunError::Spawn)?;
+    let stdout = take_pipe(child.stdout.take(), &mut child, "stdout")?;
+    let stderr = take_pipe(child.stderr.take(), &mut child, "stderr")?;
+    let stdout_reader = read_pipe(stdout);
+    let stderr_reader = read_pipe(stderr);
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() >= deadline => {
+                return Err(stop_execution(
+                    &mut child,
+                    stdout_reader,
+                    stderr_reader,
+                    BoundedRunError::Timeout,
+                ));
+            }
+            Ok(None) => std::thread::sleep(BOUNDED_POLL_INTERVAL),
+            Err(error) => {
+                return Err(stop_execution(
+                    &mut child,
+                    stdout_reader,
+                    stderr_reader,
+                    BoundedRunError::Io(error),
+                ));
+            }
+        }
+    };
+    let stdout = join_reader(stdout_reader)?;
+    let stderr = join_reader(stderr_reader)?;
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+fn take_pipe<T: Read + Send + 'static>(
+    pipe: Option<T>,
+    child: &mut std::process::Child,
+    name: &'static str,
+) -> Result<T, BoundedRunError> {
+    pipe.ok_or_else(|| {
+        terminate_child(child);
+        BoundedRunError::Pipe(name)
+    })
+}
+
+fn read_pipe<T: Read + Send + 'static>(
+    mut pipe: T,
+) -> std::thread::JoinHandle<std::io::Result<Vec<u8>>> {
+    std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        pipe.read_to_end(&mut bytes)?;
+        Ok(bytes)
+    })
+}
+
+fn join_reader(
+    reader: std::thread::JoinHandle<std::io::Result<Vec<u8>>>,
+) -> Result<Vec<u8>, BoundedRunError> {
+    reader
+        .join()
+        .map_err(|_| BoundedRunError::Io(std::io::Error::other("output reader terminated unexpectedly")))?
+        .map_err(BoundedRunError::Io)
+}
+
+fn stop_execution(
+    child: &mut std::process::Child,
+    stdout: std::thread::JoinHandle<std::io::Result<Vec<u8>>>,
+    stderr: std::thread::JoinHandle<std::io::Result<Vec<u8>>>,
+    error: BoundedRunError,
+) -> BoundedRunError {
+    terminate_child(child);
+    let _ = join_reader(stdout);
+    let _ = join_reader(stderr);
+    error
+}
+
+fn terminate_child(child: &mut std::process::Child) {
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 fn resolve_in(
@@ -259,5 +403,119 @@ mod tests {
             None,
         );
         assert_eq!(resolved, Ok(executable));
+    }
+
+    #[cfg(unix)]
+    fn write_unix_executable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::write(path, b"#!/bin/sh\nexit 0\n")
+            .unwrap_or_else(|error| panic!("write tool fixture: {error}"));
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+            .unwrap_or_else(|error| panic!("chmod tool fixture: {error}"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_resolves_kill_from_trusted_directory() {
+        let root = tempfile::Builder::new()
+            .prefix("jefe kill probe ")
+            .tempdir()
+            .unwrap_or_else(|error| panic!("create kill directory: {error}"));
+        let executable = root.path().join("kill");
+        write_unix_executable(&executable);
+        let resolved = resolve_in(
+            LocalTool::Kill,
+            ToolPlatform::Unix,
+            &[root.path().to_path_buf()],
+            None,
+            None,
+        );
+        assert_eq!(resolved, Ok(executable));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_resolves_ps_from_trusted_directory() {
+        let root = tempfile::Builder::new()
+            .prefix("jefe ps probe ")
+            .tempdir()
+            .unwrap_or_else(|error| panic!("create ps directory: {error}"));
+        let executable = root.path().join("ps");
+        write_unix_executable(&executable);
+        let resolved = resolve_in(
+            LocalTool::Ps,
+            ToolPlatform::Unix,
+            &[root.path().to_path_buf()],
+            None,
+            None,
+        );
+        assert_eq!(resolved, Ok(executable));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_kill_override_is_preserved_and_invalid_is_rejected() {
+        let root = tempfile::Builder::new()
+            .prefix("jefe kill override ")
+            .tempdir()
+            .unwrap_or_else(|error| panic!("create override directory: {error}"));
+        let valid = root.path().join("custom-kill");
+        write_unix_executable(&valid);
+        let resolved = resolve_in(
+            LocalTool::Kill,
+            ToolPlatform::Unix,
+            &[],
+            None,
+            Some(valid.clone()),
+        );
+        assert_eq!(resolved, Ok(valid));
+
+        let missing = root.path().join("nope");
+        let invalid = resolve_in(
+            LocalTool::Kill,
+            ToolPlatform::Unix,
+            &[],
+            None,
+            Some(missing.clone()),
+        );
+        assert_eq!(
+            invalid,
+            Err(LocalToolError::InvalidOverride {
+                tool: LocalTool::Kill,
+                path: missing,
+            })
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_bounded_returns_output_for_a_fast_exiting_command() {
+        let mut command = std::process::Command::new("sh");
+        command.args(["-c", "printf hello; exit 0"]);
+        let output =
+            run_bounded(command, std::time::Duration::from_secs(2)).unwrap_or_else(|error| {
+                panic!("run_bounded fast-path failed: {error}")
+            });
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"hello");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_bounded_times_out_and_reaps_a_hanging_subprocess() {
+        let mut command = std::process::Command::new("sh");
+        command.args(["-c", "trap 'exit 0' TERM; sleep 30"]);
+        let timeout = std::time::Duration::from_millis(200);
+        let result = run_bounded(command, timeout);
+        assert!(matches!(result, Err(BoundedRunError::Timeout)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_bounded_reports_spawn_failure() {
+        let missing = std::env::temp_dir().join("jefe-no-such-probe-binary");
+        let command = std::process::Command::new(&missing);
+        let result = run_bounded(command, std::time::Duration::from_secs(1));
+        assert!(matches!(result, Err(BoundedRunError::Spawn(_))));
     }
 }

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -1,9 +1,12 @@
 //! Typed local process-instance liveness service.
 
+#[cfg(unix)]
 use std::path::Path;
+#[cfg(unix)]
 use std::time::Duration;
 
 use crate::domain::ProcessIdentity;
+#[cfg(unix)]
 use crate::local_command::{self, BoundedRunError, LocalTool, LocalToolError};
 
 /// Deadline for a single process-identity subprocess probe.
@@ -11,6 +14,7 @@ use crate::local_command::{self, BoundedRunError, LocalTool, LocalToolError};
 /// Bounds both the Unix `kill -0` probe and the macOS `ps -o lstart=` token
 /// capture so a hung or manipulated executable cannot block startup or the
 /// render-path liveness poll indefinitely.
+#[cfg(unix)]
 const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Platform observation before comparison with persisted identity.

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -1,6 +1,17 @@
 //! Typed local process-instance liveness service.
 
+use std::path::Path;
+use std::time::Duration;
+
 use crate::domain::ProcessIdentity;
+use crate::local_command::{self, BoundedRunError, LocalTool, LocalToolError};
+
+/// Deadline for a single process-identity subprocess probe.
+///
+/// Bounds both the Unix `kill -0` probe and the macOS `ps -o lstart=` token
+/// capture so a hung or manipulated executable cannot block startup or the
+/// render-path liveness poll indefinitely.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Platform observation before comparison with persisted identity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -211,6 +222,54 @@ pub(super) enum UnixProbeOutcome {
 }
 
 #[cfg(unix)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ProbeBoundaryFailure {
+    /// The probe executable could not be resolved to a trusted path.
+    Resolution,
+    /// The resolved executable could not be spawned.
+    Spawn,
+    /// The subprocess exceeded its deadline.
+    Timeout,
+    /// Captured output could not be read.
+    Io,
+}
+
+#[cfg(unix)]
+impl From<&LocalToolError> for ProbeBoundaryFailure {
+    fn from(error: &LocalToolError) -> Self {
+        match error {
+            LocalToolError::NotFound { .. } | LocalToolError::InvalidOverride { .. } => {
+                Self::Resolution
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+impl From<&BoundedRunError> for ProbeBoundaryFailure {
+    fn from(error: &BoundedRunError) -> Self {
+        match error {
+            BoundedRunError::Spawn(_) => Self::Spawn,
+            BoundedRunError::Timeout => Self::Timeout,
+            BoundedRunError::Io(_) | BoundedRunError::Pipe(_) => Self::Io,
+        }
+    }
+}
+
+/// Map every executable-resolution, spawn, timeout, or I/O boundary failure to
+/// the conservative fail-open observation.
+///
+/// None of these outcomes establish a confirmed exit, so they all collapse to
+/// [`ProcessObservation::ProbeFailed`] (and [`ProcessLiveness::ProbeFailure`]).
+#[cfg(unix)]
+impl From<ProbeBoundaryFailure> for ProcessObservation {
+    fn from(failure: ProbeBoundaryFailure) -> Self {
+        let _ = failure;
+        Self::ProbeFailed
+    }
+}
+
+#[cfg(unix)]
 #[must_use]
 pub(super) fn classify_unix_probe(success: bool, stderr: &str) -> UnixProbeOutcome {
     if success {
@@ -227,8 +286,8 @@ pub(super) fn classify_unix_probe(success: bool, stderr: &str) -> UnixProbeOutco
 }
 
 #[cfg(unix)]
-pub(super) fn unix_probe_command(pid: u32) -> std::process::Command {
-    let mut command = std::process::Command::new("kill");
+pub(super) fn unix_probe_command_for(executable: &Path, pid: u32) -> std::process::Command {
+    let mut command = std::process::Command::new(executable);
     command.args(["-0", &pid.to_string()]).env("LC_ALL", "C");
     command
 }
@@ -238,8 +297,18 @@ fn probe_process(pid: u32) -> ProcessObservation {
     if pid == 0 {
         return ProcessObservation::ProbeFailed;
     }
-    let Ok(output) = unix_probe_command(pid).output() else {
-        return ProcessObservation::ProbeFailed;
+    let executable = match local_command::resolve(LocalTool::Kill) {
+        Ok(path) => path,
+        Err(error) => {
+            return ProbeBoundaryFailure::from(&error).into();
+        }
+    };
+    let command = unix_probe_command_for(&executable, pid);
+    let output = match local_command::run_bounded(command, PROBE_TIMEOUT) {
+        Ok(output) => output,
+        Err(error) => {
+            return ProbeBoundaryFailure::from(&error).into();
+        }
     };
     match classify_unix_probe(
         output.status.success(),
@@ -267,8 +336,8 @@ fn unix_process_start_time(pid: u32) -> Option<u64> {
 }
 
 #[cfg(target_os = "macos")]
-pub(super) fn macos_start_time_command(pid: u32) -> std::process::Command {
-    let mut command = std::process::Command::new("ps");
+pub(super) fn macos_start_time_command_for(executable: &Path, pid: u32) -> std::process::Command {
+    let mut command = std::process::Command::new(executable);
     command
         .args(["-p", &pid.to_string(), "-o", "lstart="])
         .env("TZ", "UTC")
@@ -278,7 +347,9 @@ pub(super) fn macos_start_time_command(pid: u32) -> std::process::Command {
 
 #[cfg(target_os = "macos")]
 fn unix_process_start_time(pid: u32) -> Option<u64> {
-    let output = macos_start_time_command(pid).output().ok()?;
+    let executable = local_command::resolve(LocalTool::Ps).ok()?;
+    let command = macos_start_time_command_for(&executable, pid);
+    let output = local_command::run_bounded(command, PROBE_TIMEOUT).ok()?;
     if !output.status.success() {
         return None;
     }

--- a/src/runtime/process_tests.rs
+++ b/src/runtime/process_tests.rs
@@ -12,9 +12,9 @@ use super::process::{
     process_liveness, process_liveness_indicates_alive,
 };
 #[cfg(unix)]
-use super::process::{UnixProbeOutcome, classify_unix_probe, unix_probe_command};
+use super::process::{UnixProbeOutcome, classify_unix_probe, unix_probe_command_for};
 #[cfg(target_os = "macos")]
-use super::process::{macos_start_time_command, parse_macos_process_start_time};
+use super::process::{macos_start_time_command_for, parse_macos_process_start_time};
 use crate::domain::ProcessIdentity;
 
 #[test]
@@ -153,7 +153,8 @@ fn unix_probe_classifier_distinguishes_exit_access_and_failure() {
 #[cfg(unix)]
 #[test]
 fn unix_probe_command_uses_structured_arguments_and_c_locale() {
-    let command = unix_probe_command(41);
+    let executable = std::path::Path::new("kill");
+    let command = unix_probe_command_for(executable, 41);
     let arguments: Vec<_> = command.get_args().collect();
     assert_eq!(command.get_program(), "kill");
     assert_eq!(arguments, ["-0", "41"]);
@@ -162,6 +163,23 @@ fn unix_probe_command_uses_structured_arguments_and_c_locale() {
             .get_envs()
             .any(|(key, value)| key == "LC_ALL" && value.is_some_and(|value| value == "C"))
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn probe_process_fails_open_when_kill_cannot_be_resolved() {
+    // Resolution and spawn/timeout failures must fail open to ProbeFailed
+    // rather than panic or block indefinitely. Verified by mapping each
+    // boundary failure through the probe's error classifier.
+    for failure in [
+        super::process::ProbeBoundaryFailure::Resolution,
+        super::process::ProbeBoundaryFailure::Spawn,
+        super::process::ProbeBoundaryFailure::Timeout,
+        super::process::ProbeBoundaryFailure::Io,
+    ] {
+        let observation: ProcessObservation = failure.into();
+        assert_eq!(observation, ProcessObservation::ProbeFailed);
+    }
 }
 #[cfg(target_os = "macos")]
 #[test]
@@ -193,7 +211,8 @@ fn macos_start_time_parser_returns_utc_epoch_and_rejects_malformed_values() {
 #[cfg(target_os = "macos")]
 #[test]
 fn macos_start_time_command_uses_structured_arguments_and_utc_locale() {
-    let command = macos_start_time_command(41);
+    let executable = std::path::Path::new("ps");
+    let command = macos_start_time_command_for(executable, 41);
     let arguments: Vec<_> = command.get_args().collect();
     assert_eq!(command.get_program(), "ps");
     assert_eq!(arguments, ["-p", "41", "-o", "lstart="]);


### PR DESCRIPTION
## Summary

Binds the local Unix process-identity probe so that a hanging or PATH-substituted kill/ps cannot block startup or render-path liveness polling indefinitely, and cannot silently substitute an untrusted executable.

Closes #400.

## Problem

src/runtime/process.rs invoked kill -0 <pid> and macOS ps -p <pid> -o lstart= via bare Command::new("kill") / Command::new("ps"). Those invocations:

1. Inherited executable resolution from PATH — a manipulated PATH could substitute an untrusted probe executable, silently compromising the liveness decision.
2. Imposed no subprocess deadline — a hung probe blocked startup reconciliation and the render-path liveness poll indefinitely.

## Changes

### Slice 1 — Kill/Ps executable resolution and a bounded runner (src/local_command.rs)

- Adds LocalTool::Kill (JEFE_KILL_BIN override) and LocalTool::Ps (JEFE_PS_BIN override), following the existing Git/Gh/Ssh pattern.
- Adds BoundedRunError (Spawn / Timeout / Io / Pipe) and pub fn run_bounded(command, timeout) -> Result<Output, BoundedRunError>: spawn, piped stdout/stderr read on reader threads, try_wait poll with an Instant deadline (25 ms sleep), kill + reap on timeout. Stdin is set to Stdio::null() so a probe child cannot block on inherited stdin. Mirrors the established ssh.rs::execute_command pattern (no unsafe code).

### Slice 2 — Route Unix/macOS probes through the bounded boundary (src/runtime/process.rs, src/runtime/process_tests.rs)

- Adds const PROBE_TIMEOUT: Duration = Duration::from_secs(5).
- Adds ProbeBoundaryFailure (Resolution / Spawn / Timeout / Io) with From<&LocalToolError> and From<&BoundedRunError> impls, mapping every boundary failure to ProcessObservation::ProbeFailed (fail-open).
- Splits unix_probe_command(pid) into unix_probe_command_for(executable, pid) (pure builder preserving [-0, pid] args and LC_ALL=C) and routes probe_process through resolve(LocalTool::Kill) + run_bounded.
- Splits macos_start_time_command(pid) into macos_start_time_command_for(executable, pid) (preserving [-p, pid, -o, lstart=] args and TZ=UTC/LC_ALL=C) and routes unix_process_start_time through resolve(LocalTool::Ps) + run_bounded.
- Windows probe_process is untouched (native Win32 OpenProcess/GetProcessTimes).
- Structural command tests updated to the new *_for(executable, pid) signatures; new test asserts every ProbeBoundaryFailure variant maps to ProbeFailed.

### Slice 3 — Trusted executable resolution (security fix)

- Adds LocalTool::requires_trusted_path(): Kill and Ps resolve only from canonical system directories (/bin, /usr/bin, /sbin, /usr/sbin), never from arbitrary PATH entries. Operator overrides (JEFE_KILL_BIN / JEFE_PS_BIN) remain honored. Non-security tools (git, gh, ssh) continue to use the full PATH.
- This satisfies the acceptance criterion: a manipulated PATH cannot silently substitute an untrusted probe executable under the selected deployment policy.

### Slice 4 — Unix-only trust gate and stdin hardening (OCR in-scope fixes)

- requires_trusted_path() is gated to Unix only (cfg!(unix)), so native Windows behavior remains unchanged.
- run_bounded() sets stdin to Stdio::null().

## Acceptance matrix

| # | Criterion | Evidence |
|---|---|---|
| A1 | A hanging probe cannot block startup/liveness indefinitely | run_bounded_times_out_and_reaps_a_hanging_subprocess proves timeout + child reap |
| A2 | A manipulated PATH cannot substitute an untrusted probe executable | unix_probe_tools_resolve_only_from_trusted_system_directories proves Kill/Ps resolve only from /bin/usr/bin/sbin/usr/sbin |
| A3 | Timeout and resolution failures fail open rather than confirmed exits | probe_process_fails_open_when_kill_cannot_be_resolved proves every ProbeBoundaryFailure variant maps to ProbeFailed |
| A4 | Unix structural command tests and macOS process-token tests cover the boundary | Updated unix_probe_command_uses_structured_arguments_and_c_locale, macos_start_time_command_uses_structured_arguments_and_utc_locale, macos_identity_is_stable_across_parent_timezones |
| A5 | Native Windows behavior remains unchanged | Windows probe_process untouched; requires_trusted_path() is Unix-only |
| A6 | Full project CI passes | Local fmt/clippy/complexity/architecture/source-size/build/test all green |

## Non-goals (per issue)

- Changing issue #305 process classification semantics — classify_unix_probe, classify_process_observation, ProcessObservation, ProcessLiveness unchanged.
- Adding unsafe system calls — unsafe_code = "forbid" preserved.
- Changing remote SSH probing — src/ssh.rs execution path unchanged.

## Verification

- cargo fmt --all --check OK
- cargo xtask check clippy-allows OK
- cargo xtask check source-size OK
- cargo xtask check architecture OK
- Strict clippy (-D warnings) OK
- Complexity clippy (cognitive-complexity / too-many-lines / too-many-arguments / type-complexity / struct-excessive-bools) OK
- cargo build --workspace --all-features --locked OK
- cargo test --workspace --all-features --locked — 2422 + 772 + many more tests pass, 0 failures OK

## Open Code Review

Two pre-PR OCR runs (cap reached). Findings triaged:

- Run #1, Finding 1 (security, high — Blocker-Fix): Kill/Ps resolved from full PATH. Fixed in Slice 3 (trusted-directory policy).
- Run #1, Findings 2-3 (medium/low — Defer): macOS .ok()? observability (pre-existing #305 pattern); shared PROBE_TIMEOUT (non-critical).
- Run #2, Finding 1 (bug, medium — Defer): macOS start-time .ok()? swallows error detail. Same pre-existing pattern; behavior is correct fail-open. Out of scope.
- Run #2, Finding 2 (security, medium — Reject): Process-group kill for grandchildren. Speculative for leaf probe tools (kill/ps don't spawn children); out of scope.
- Run #2, Finding 3 (other, medium — In-scope-Fix): Windows incompatibility with trusted directories. Fixed in Slice 4 (Unix-only gate).
- Run #2, Finding 4 (other, low — In-scope-Fix): stdin not set to null. Fixed in Slice 4 (Stdio::null()).
