### PR TITLE
Design and freeze the complete JSP/1 passive status protocol (Refs #476)

### DIFF
--- a/dev-docs/jsp/v1/fixtures/event_activity_changed.json
+++ b/dev-docs/jsp/v1/fixtures/event_activity_changed.json
@@ -1,0 +1,1 @@
+{"schema":1,"kind":"event","agent_id":"agent-alpha","lifecycle_generation":3,"source_epoch":"epoch-7","source_sequence":42,"bridge_observed_ms":1750000000000,"event":{"type":"activity.changed","state":"acting"}}

--- a/dev-docs/jsp/v1/fixtures/event_forbidden_fields.json
+++ b/dev-docs/jsp/v1/fixtures/event_forbidden_fields.json
@@ -1,0 +1,1 @@
+{"schema":1,"kind":"event","agent_id":"agent-alpha","lifecycle_generation":3,"source_epoch":"epoch-7","source_sequence":50,"bridge_observed_ms":1750000000800,"event":{"type":"tool_call.created","label":"run_shell","phase":"executing","raw_transcript":"SECRET","control":"kill"}}

--- a/dev-docs/jsp/v1/fixtures/event_invalid_identity.json
+++ b/dev-docs/jsp/v1/fixtures/event_invalid_identity.json
@@ -1,0 +1,1 @@
+{"schema":1,"kind":"event","agent_id":"agent-alpha","lifecycle_generation":0,"source_epoch":"epoch-7","source_sequence":52,"bridge_observed_ms":1750000001000,"event":{"type":"turn.started"}}

--- a/dev-docs/jsp/v1/fixtures/event_message_displayed.json
+++ b/dev-docs/jsp/v1/fixtures/event_message_displayed.json
@@ -1,0 +1,1 @@
+{"schema":1,"kind":"event","agent_id":"agent-alpha","lifecycle_generation":3,"source_epoch":"epoch-7","source_sequence":47,"bridge_observed_ms":1750000000500,"event":{"type":"assistant_message.displayed","content":"Done.","committed_ms":1750000000450}}

--- a/dev-docs/jsp/v1/fixtures/event_session_ended.json
+++ b/dev-docs/jsp/v1/fixtures/event_session_ended.json
@@ -1,0 +1,1 @@
+{"schema":1,"kind":"event","agent_id":"agent-alpha","lifecycle_generation":3,"source_epoch":"epoch-7","source_sequence":48,"bridge_observed_ms":1750000000600,"event":{"type":"session.ended"}}

--- a/dev-docs/jsp/v1/fixtures/event_stale_phase.json
+++ b/dev-docs/jsp/v1/fixtures/event_stale_phase.json
@@ -1,0 +1,1 @@
+{"schema":1,"kind":"event","agent_id":"agent-alpha","lifecycle_generation":3,"source_epoch":"epoch-7","source_sequence":51,"bridge_observed_ms":1750000000900,"event":{"type":"tool_call.phase_changed","label":"run_shell","phase":"stale"}}

--- a/dev-docs/jsp/v1/fixtures/event_todos_replaced.json
+++ b/dev-docs/jsp/v1/fixtures/event_todos_replaced.json
@@ -1,0 +1,1 @@
+{"schema":1,"kind":"event","agent_id":"agent-alpha","lifecycle_generation":3,"source_epoch":"epoch-7","source_sequence":45,"bridge_observed_ms":1750000000300,"event":{"type":"todos.replaced","revision":9,"items":[{"text":"Design the protocol","completed":true},{"text":"Ship the observer","completed":false}]}}

--- a/dev-docs/jsp/v1/fixtures/event_tool_created.json
+++ b/dev-docs/jsp/v1/fixtures/event_tool_created.json
@@ -1,0 +1,1 @@
+{"schema":1,"kind":"event","agent_id":"agent-alpha","lifecycle_generation":3,"source_epoch":"epoch-7","source_sequence":46,"bridge_observed_ms":1750000000400,"event":{"type":"tool_call.created","label":"read_file","phase":"awaiting_approval"}}

--- a/dev-docs/jsp/v1/fixtures/event_turn_ended.json
+++ b/dev-docs/jsp/v1/fixtures/event_turn_ended.json
@@ -1,0 +1,1 @@
+{"schema":1,"kind":"event","agent_id":"agent-alpha","lifecycle_generation":3,"source_epoch":"epoch-7","source_sequence":44,"bridge_observed_ms":1750000000200,"event":{"type":"turn.ended","outcome":"cancelled"}}

--- a/dev-docs/jsp/v1/fixtures/event_unknown_type.json
+++ b/dev-docs/jsp/v1/fixtures/event_unknown_type.json
@@ -1,0 +1,1 @@
+{"schema":1,"kind":"event","agent_id":"agent-alpha","lifecycle_generation":3,"source_epoch":"epoch-7","source_sequence":49,"bridge_observed_ms":1750000000700,"event":{"type":"turn.paused"}}

--- a/dev-docs/jsp/v1/fixtures/event_wait_opened.json
+++ b/dev-docs/jsp/v1/fixtures/event_wait_opened.json
@@ -1,0 +1,1 @@
+{"schema":1,"kind":"event","agent_id":"agent-alpha","lifecycle_generation":3,"source_epoch":"epoch-7","source_sequence":43,"bridge_observed_ms":1750000000100,"event":{"type":"wait.opened","reason":"permission"}}

--- a/dev-docs/jsp/v1/fixtures/heartbeat_full.json
+++ b/dev-docs/jsp/v1/fixtures/heartbeat_full.json
@@ -1,0 +1,1 @@
+{"schema":1,"kind":"heartbeat","agent_id":"agent-alpha","lifecycle_generation":3,"source_epoch":"epoch-7","bridge_observed_ms":1750000001100}

--- a/dev-docs/jsp/v1/fixtures/heartbeat_with_sequence.json
+++ b/dev-docs/jsp/v1/fixtures/heartbeat_with_sequence.json
@@ -1,0 +1,1 @@
+{"schema":1,"kind":"heartbeat","agent_id":"agent-alpha","lifecycle_generation":3,"source_epoch":"epoch-7","source_sequence":53,"bridge_observed_ms":1750000001200}

--- a/dev-docs/jsp/v1/fixtures/manifest.json
+++ b/dev-docs/jsp/v1/fixtures/manifest.json
@@ -7,86 +7,261 @@
     {
       "name": "snapshot_full",
       "file": "snapshot_full.json",
+      "kind": "snapshot",
       "expected": "ok",
-      "rows": ["S1", "S5"],
+      "rows": [
+        "S1",
+        "S5"
+      ],
       "description": "Canonical full snapshot exercising every required field with supported authoritative/inferred known states, known-empty (null) optional entities, and known-non-empty todos."
     },
     {
       "name": "snapshot_identity_distinct",
       "file": "snapshot_identity_distinct.json",
+      "kind": "snapshot",
       "expected": "ok",
-      "rows": ["S3"],
+      "rows": [
+        "S3"
+      ],
       "description": "Same repository/path as snapshot_full but distinct agent_id/lifecycle_generation/source_epoch/pid so the live observation key stays distinct."
     },
     {
       "name": "snapshot_field_states",
       "file": "snapshot_field_states.json",
+      "kind": "snapshot",
       "expected": "ok",
-      "rows": ["S4"],
+      "rows": [
+        "S4"
+      ],
       "description": "Exhaustive field-state coverage: inferred unknown, authoritative degraded, known-empty todos (revision 1, zero items), authoritative known source-error state, explicit permission wait."
     },
     {
       "name": "snapshot_bounds",
       "file": "snapshot_bounds.json",
+      "kind": "snapshot",
       "expected": "ok",
-      "rows": ["S2"],
+      "rows": [
+        "S2"
+      ],
       "description": "At-limit agent_id (128 bytes) and minimal valid todos. Exercises the upper inclusive bound for identity strings."
     },
     {
       "name": "snapshot_forbidden_fields",
       "file": "snapshot_forbidden_fields.json",
+      "kind": "snapshot",
       "expected": "error",
       "error_code": "JSP-E001",
-      "rows": ["S5", "S6"],
+      "rows": [
+        "S5",
+        "S6"
+      ],
       "description": "Valid snapshot shape plus forbidden credential (publisher_token, observer_token) and forbidden control/raw fields (raw_transcript, draft, control). Closed parser must reject at ingress."
     },
     {
       "name": "snapshot_closed_grammar",
       "file": "snapshot_closed_grammar.json",
+      "kind": "snapshot",
       "expected": "error",
       "error_code": "JSP-E001",
-      "rows": ["S2"],
+      "rows": [
+        "S2"
+      ],
       "description": "Valid snapshot with an unknown top-level field and an unknown nested field inside native_session. Closed-object semantics must reject unknown fields."
     },
     {
       "name": "snapshot_semantic_failure",
       "file": "snapshot_semantic_failure.json",
+      "kind": "snapshot",
       "expected": "error",
       "error_code": "JSP-E005",
-      "rows": ["S4", "S5"],
+      "rows": [
+        "S4",
+        "S5"
+      ],
       "description": "Producer-supplied stale tool phase (stale is a transport-health overlay, not a producer value) and otherwise valid shape. Must fail semantic validation with no payload echoed."
     },
     {
       "name": "snapshot_nested_forbidden_fields",
       "file": "snapshot_nested_forbidden_fields.json",
+      "kind": "snapshot",
       "expected": "error",
       "error_code": "JSP-E001",
-      "rows": ["S5", "S6"],
+      "rows": [
+        "S5",
+        "S6"
+      ],
       "description": "Forbidden credential, transcript, and control members nested inside current_wait.value rather than at the top level. The closed contract applies at every depth, so these must be rejected at ingress and never echoed."
     },
     {
       "name": "snapshot_over_bound",
       "file": "snapshot_over_bound.json",
+      "kind": "snapshot",
       "expected": "error",
       "error_code": "JSP-E002",
-      "rows": ["S2"],
+      "rows": [
+        "S2"
+      ],
       "description": "Tool label one byte over the 256-byte inclusive bound. Limit-plus-one input must fail before a contract value is returned."
     },
     {
       "name": "snapshot_unsupported_version",
       "file": "snapshot_unsupported_version.json",
+      "kind": "snapshot",
       "expected": "error",
       "error_code": "JSP-E003",
-      "rows": ["S2"],
+      "rows": [
+        "S2"
+      ],
       "description": "Otherwise-valid document declaring schema 2. There is no legacy or unknown-version fallback."
     },
     {
       "name": "snapshot_invalid_identity",
       "file": "snapshot_invalid_identity.json",
+      "kind": "snapshot",
       "expected": "error",
       "error_code": "JSP-E004",
-      "rows": ["S3"],
+      "rows": [
+        "S3"
+      ],
       "description": "Zero lifecycle_generation. The live observation key requires a positive generation, and this is an identity violation rather than a shape error."
+    },
+    {
+      "name": "event_activity_changed",
+      "file": "event_activity_changed.json",
+      "kind": "event",
+      "expected": "ok",
+      "rows": [
+        "E1"
+      ],
+      "description": "Activity transition to acting"
+    },
+    {
+      "name": "event_wait_opened",
+      "file": "event_wait_opened.json",
+      "kind": "event",
+      "expected": "ok",
+      "rows": [
+        "E1",
+        "E3"
+      ],
+      "description": "Explicit blocking request opens a wait"
+    },
+    {
+      "name": "event_turn_ended",
+      "file": "event_turn_ended.json",
+      "kind": "event",
+      "expected": "ok",
+      "rows": [
+        "E1"
+      ],
+      "description": "Turn ends with an explicit outcome"
+    },
+    {
+      "name": "event_todos_replaced",
+      "file": "event_todos_replaced.json",
+      "kind": "event",
+      "expected": "ok",
+      "rows": [
+        "E1",
+        "E4"
+      ],
+      "description": "Full todo replacement with revision"
+    },
+    {
+      "name": "event_tool_created",
+      "file": "event_tool_created.json",
+      "kind": "event",
+      "expected": "ok",
+      "rows": [
+        "E1"
+      ],
+      "description": "Tool call created in awaiting_approval"
+    },
+    {
+      "name": "event_message_displayed",
+      "file": "event_message_displayed.json",
+      "kind": "event",
+      "expected": "ok",
+      "rows": [
+        "E1"
+      ],
+      "description": "Committed assistant reply became visible"
+    },
+    {
+      "name": "event_session_ended",
+      "file": "event_session_ended.json",
+      "kind": "event",
+      "expected": "ok",
+      "rows": [
+        "E1"
+      ],
+      "description": "Payload-free session end"
+    },
+    {
+      "name": "event_unknown_type",
+      "file": "event_unknown_type.json",
+      "kind": "event",
+      "expected": "error",
+      "rows": [
+        "E2"
+      ],
+      "description": "Unknown event type is rejected, not ignored",
+      "error_code": "JSP-E001"
+    },
+    {
+      "name": "event_forbidden_fields",
+      "file": "event_forbidden_fields.json",
+      "kind": "event",
+      "expected": "error",
+      "rows": [
+        "E2",
+        "E5"
+      ],
+      "description": "Credential/control members inside an event payload",
+      "error_code": "JSP-E001"
+    },
+    {
+      "name": "event_stale_phase",
+      "file": "event_stale_phase.json",
+      "kind": "event",
+      "expected": "error",
+      "rows": [
+        "E3"
+      ],
+      "description": "Producer cannot assert stale",
+      "error_code": "JSP-E005"
+    },
+    {
+      "name": "event_invalid_identity",
+      "file": "event_invalid_identity.json",
+      "kind": "event",
+      "expected": "error",
+      "rows": [
+        "E6"
+      ],
+      "description": "Zero lifecycle generation",
+      "error_code": "JSP-E004"
+    },
+    {
+      "name": "heartbeat_full",
+      "file": "heartbeat_full.json",
+      "kind": "heartbeat",
+      "expected": "ok",
+      "rows": [
+        "E7"
+      ],
+      "description": "Heartbeat carries liveness without a transition"
+    },
+    {
+      "name": "heartbeat_with_sequence",
+      "file": "heartbeat_with_sequence.json",
+      "kind": "heartbeat",
+      "expected": "error",
+      "rows": [
+        "E7"
+      ],
+      "description": "Heartbeat must not carry a sequence",
+      "error_code": "JSP-E001"
     }
   ]
 }

--- a/dev-docs/jsp/v1/fixtures/manifest.json
+++ b/dev-docs/jsp/v1/fixtures/manifest.json
@@ -1,0 +1,60 @@
+{
+  "schema": 1,
+  "kind": "fixture-manifest",
+  "version": "jsp-v1-j1",
+  "description": "JSP/1 snapshot compliance corpus for issue 476 J1 slice. Each entry names a fixture file and its expected parse result.",
+  "fixtures": [
+    {
+      "name": "snapshot_full",
+      "file": "snapshot_full.json",
+      "expected": "ok",
+      "rows": ["S1", "S5"],
+      "description": "Canonical full snapshot exercising every required field with supported authoritative/inferred known states, known-empty (null) optional entities, and known-non-empty todos."
+    },
+    {
+      "name": "snapshot_identity_distinct",
+      "file": "snapshot_identity_distinct.json",
+      "expected": "ok",
+      "rows": ["S3"],
+      "description": "Same repository/path as snapshot_full but distinct agent_id/lifecycle_generation/source_epoch/pid so the live observation key stays distinct."
+    },
+    {
+      "name": "snapshot_field_states",
+      "file": "snapshot_field_states.json",
+      "expected": "ok",
+      "rows": ["S4"],
+      "description": "Exhaustive field-state coverage: inferred unknown, authoritative degraded, known-empty todos (revision 1, zero items), authoritative known source-error state, explicit permission wait."
+    },
+    {
+      "name": "snapshot_bounds",
+      "file": "snapshot_bounds.json",
+      "expected": "ok",
+      "rows": ["S2"],
+      "description": "At-limit agent_id (128 bytes) and minimal valid todos. Exercises the upper inclusive bound for identity strings."
+    },
+    {
+      "name": "snapshot_forbidden_fields",
+      "file": "snapshot_forbidden_fields.json",
+      "expected": "error",
+      "error_code": "JSP-E001",
+      "rows": ["S5", "S6"],
+      "description": "Valid snapshot shape plus forbidden credential (publisher_token, observer_token) and forbidden control/raw fields (raw_transcript, draft, control). Closed parser must reject at ingress."
+    },
+    {
+      "name": "snapshot_closed_grammar",
+      "file": "snapshot_closed_grammar.json",
+      "expected": "error",
+      "error_code": "JSP-E001",
+      "rows": ["S2"],
+      "description": "Valid snapshot with an unknown top-level field and an unknown nested field inside native_session. Closed-object semantics must reject unknown fields."
+    },
+    {
+      "name": "snapshot_semantic_failure",
+      "file": "snapshot_semantic_failure.json",
+      "expected": "error",
+      "error_code": "JSP-E005",
+      "rows": ["S4", "S5"],
+      "description": "Producer-supplied stale tool phase (stale is a transport-health overlay, not a producer value) and otherwise valid shape. Must fail semantic validation with no payload echoed."
+    }
+  ]
+}

--- a/dev-docs/jsp/v1/fixtures/manifest.json
+++ b/dev-docs/jsp/v1/fixtures/manifest.json
@@ -55,6 +55,38 @@
       "error_code": "JSP-E005",
       "rows": ["S4", "S5"],
       "description": "Producer-supplied stale tool phase (stale is a transport-health overlay, not a producer value) and otherwise valid shape. Must fail semantic validation with no payload echoed."
+    },
+    {
+      "name": "snapshot_nested_forbidden_fields",
+      "file": "snapshot_nested_forbidden_fields.json",
+      "expected": "error",
+      "error_code": "JSP-E001",
+      "rows": ["S5", "S6"],
+      "description": "Forbidden credential, transcript, and control members nested inside current_wait.value rather than at the top level. The closed contract applies at every depth, so these must be rejected at ingress and never echoed."
+    },
+    {
+      "name": "snapshot_over_bound",
+      "file": "snapshot_over_bound.json",
+      "expected": "error",
+      "error_code": "JSP-E002",
+      "rows": ["S2"],
+      "description": "Tool label one byte over the 256-byte inclusive bound. Limit-plus-one input must fail before a contract value is returned."
+    },
+    {
+      "name": "snapshot_unsupported_version",
+      "file": "snapshot_unsupported_version.json",
+      "expected": "error",
+      "error_code": "JSP-E003",
+      "rows": ["S2"],
+      "description": "Otherwise-valid document declaring schema 2. There is no legacy or unknown-version fallback."
+    },
+    {
+      "name": "snapshot_invalid_identity",
+      "file": "snapshot_invalid_identity.json",
+      "expected": "error",
+      "error_code": "JSP-E004",
+      "rows": ["S3"],
+      "description": "Zero lifecycle_generation. The live observation key requires a positive generation, and this is an identity violation rather than a shape error."
     }
   ]
 }

--- a/dev-docs/jsp/v1/fixtures/snapshot_bounds.json
+++ b/dev-docs/jsp/v1/fixtures/snapshot_bounds.json
@@ -1,0 +1,38 @@
+{
+  "schema": 1,
+  "kind": "snapshot",
+  "agent_id": "a1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+  "lifecycle_generation": 1,
+  "source_epoch": "epoch-005",
+  "source_sequence": 1,
+  "cursor": 0,
+  "bridge_observed_ms": 1785921969000,
+  "native_session": {
+    "repository": "vybestack/llxprt-jefe",
+    "path": "/Users/dev/src/jefe",
+    "agent_kind": "llxprt",
+    "pid": 55555,
+    "display_name": "max-id-worker"
+  },
+  "process_binding": "unsupported",
+  "native_activity": "unsupported",
+  "current_wait": "unsupported",
+  "current_turn": "unsupported",
+  "todos": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": {
+      "revision": 1,
+      "items": [
+        {
+          "text": "x",
+          "completed": false
+        }
+      ]
+    }
+  },
+  "last_displayed_assistant_message": "unsupported",
+  "last_created_tool_call": "unsupported",
+  "source_terminal_state": "unsupported",
+  "source_error_state": "unsupported"
+}

--- a/dev-docs/jsp/v1/fixtures/snapshot_closed_grammar.json
+++ b/dev-docs/jsp/v1/fixtures/snapshot_closed_grammar.json
@@ -1,0 +1,28 @@
+{
+  "schema": 1,
+  "kind": "snapshot",
+  "agent_id": "agent-dana",
+  "lifecycle_generation": 1,
+  "source_epoch": "epoch-004",
+  "source_sequence": 1,
+  "cursor": 0,
+  "bridge_observed_ms": 1785921968000,
+  "native_session": {
+    "repository": "vybestack/llxprt-jefe",
+    "path": "/Users/dev/src/jefe",
+    "agent_kind": "llxprt",
+    "pid": 44444,
+    "display_name": "worker-d",
+    "unknown_nested_field": true
+  },
+  "process_binding": "unsupported",
+  "native_activity": "unsupported",
+  "current_wait": "unsupported",
+  "current_turn": "unsupported",
+  "todos": "unsupported",
+  "last_displayed_assistant_message": "unsupported",
+  "last_created_tool_call": "unsupported",
+  "source_terminal_state": "unsupported",
+  "source_error_state": "unsupported",
+  "unknown_top_level_field": true
+}

--- a/dev-docs/jsp/v1/fixtures/snapshot_field_states.json
+++ b/dev-docs/jsp/v1/fixtures/snapshot_field_states.json
@@ -1,0 +1,50 @@
+{
+  "schema": 1,
+  "kind": "snapshot",
+  "agent_id": "agent-casey",
+  "lifecycle_generation": 1,
+  "source_epoch": "epoch-003",
+  "source_sequence": 9,
+  "cursor": 8,
+  "bridge_observed_ms": 1785921966000,
+  "native_session": {
+    "repository": "personal/widgets",
+    "path": "/home/casey/widgets",
+    "agent_kind": "code_puppy",
+    "pid": 33333,
+    "display_name": "puppy-1"
+  },
+  "process_binding": "unsupported",
+  "native_activity": {
+    "provenance": "inferred",
+    "availability": "unknown"
+  },
+  "current_wait": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": { "reason": "permission" }
+  },
+  "current_turn": {
+    "provenance": "inferred",
+    "availability": "degraded",
+    "last_value": { "elapsed_ms": 8000 },
+    "as_of_ms": 1785921950000,
+    "diagnostic_code": "STALE_NATIVE"
+  },
+  "todos": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": { "revision": 1, "items": [] }
+  },
+  "last_displayed_assistant_message": {
+    "provenance": "authoritative",
+    "availability": "unknown"
+  },
+  "last_created_tool_call": "unsupported",
+  "source_terminal_state": "unsupported",
+  "source_error_state": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": { "summary": "nonzero exit", "code": "EIO" }
+  }
+}

--- a/dev-docs/jsp/v1/fixtures/snapshot_forbidden_fields.json
+++ b/dev-docs/jsp/v1/fixtures/snapshot_forbidden_fields.json
@@ -1,0 +1,31 @@
+{
+  "schema": 1,
+  "kind": "snapshot",
+  "agent_id": "agent-alex",
+  "lifecycle_generation": 1,
+  "source_epoch": "epoch-x",
+  "source_sequence": 1,
+  "cursor": 0,
+  "bridge_observed_ms": 1785921967000,
+  "native_session": {
+    "repository": "vybestack/llxprt-jefe",
+    "path": "/Users/dev/src/jefe",
+    "agent_kind": "llxprt",
+    "pid": 1,
+    "display_name": "worker"
+  },
+  "process_binding": "unsupported",
+  "native_activity": "unsupported",
+  "current_wait": "unsupported",
+  "current_turn": "unsupported",
+  "todos": "unsupported",
+  "last_displayed_assistant_message": "unsupported",
+  "last_created_tool_call": "unsupported",
+  "source_terminal_state": "unsupported",
+  "source_error_state": "unsupported",
+  "publisher_token": "supersecret",
+  "observer_token": "supersecret",
+  "raw_transcript": "leaked",
+  "draft": "leaked",
+  "control": "kill"
+}

--- a/dev-docs/jsp/v1/fixtures/snapshot_full.json
+++ b/dev-docs/jsp/v1/fixtures/snapshot_full.json
@@ -1,0 +1,70 @@
+{
+  "schema": 1,
+  "kind": "snapshot",
+  "agent_id": "agent-alex",
+  "lifecycle_generation": 7,
+  "source_epoch": "epoch-001",
+  "source_sequence": 42,
+  "cursor": 41,
+  "bridge_observed_ms": 1785921964000,
+  "native_session": {
+    "repository": "vybestack/llxprt-jefe",
+    "path": "/Users/dev/src/jefe",
+    "agent_kind": "llxprt",
+    "pid": 12345,
+    "display_name": "main-worker"
+  },
+  "process_binding": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": {
+      "pid": 12345,
+      "started_at_ms": 1785921000000
+    }
+  },
+  "native_activity": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": { "state": "idle" }
+  },
+  "current_wait": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": null
+  },
+  "current_turn": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": { "elapsed_ms": 12000 }
+  },
+  "todos": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": {
+      "revision": 3,
+      "items": [
+        { "text": "Write parser", "completed": false },
+        { "text": "Add tests", "completed": true }
+      ]
+    }
+  },
+  "last_displayed_assistant_message": {
+    "provenance": "inferred",
+    "availability": "known",
+    "value": {
+      "content": "Done.",
+      "committed_ms": 1785921900000
+    }
+  },
+  "last_created_tool_call": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": { "label": "Read", "phase": "succeeded" }
+  },
+  "source_terminal_state": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": null
+  },
+  "source_error_state": "unsupported"
+}

--- a/dev-docs/jsp/v1/fixtures/snapshot_identity_distinct.json
+++ b/dev-docs/jsp/v1/fixtures/snapshot_identity_distinct.json
@@ -1,0 +1,33 @@
+{
+  "schema": 1,
+  "kind": "snapshot",
+  "agent_id": "agent-blake",
+  "lifecycle_generation": 2,
+  "source_epoch": "epoch-002",
+  "source_sequence": 5,
+  "cursor": 4,
+  "bridge_observed_ms": 1785921965000,
+  "native_session": {
+    "repository": "vybestack/llxprt-jefe",
+    "path": "/Users/dev/src/jefe",
+    "agent_kind": "llxprt",
+    "pid": 22222,
+    "display_name": "second-worker"
+  },
+  "process_binding": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": {
+      "pid": 22222,
+      "started_at_ms": 1785921001000
+    }
+  },
+  "native_activity": "unsupported",
+  "current_wait": "unsupported",
+  "current_turn": "unsupported",
+  "todos": "unsupported",
+  "last_displayed_assistant_message": "unsupported",
+  "last_created_tool_call": "unsupported",
+  "source_terminal_state": "unsupported",
+  "source_error_state": "unsupported"
+}

--- a/dev-docs/jsp/v1/fixtures/snapshot_invalid_identity.json
+++ b/dev-docs/jsp/v1/fixtures/snapshot_invalid_identity.json
@@ -1,0 +1,26 @@
+{
+  "schema": 1,
+  "kind": "snapshot",
+  "agent_id": "agent-zero-generation",
+  "lifecycle_generation": 0,
+  "source_epoch": "epoch-009",
+  "source_sequence": 1,
+  "cursor": 0,
+  "bridge_observed_ms": 1785922000000,
+  "native_session": {
+    "repository": "vybestack/llxprt-jefe",
+    "path": "/Users/dev/src/jefe",
+    "agent_kind": "llxprt",
+    "pid": 4444,
+    "display_name": "zero-generation-worker"
+  },
+  "process_binding": "unsupported",
+  "native_activity": "unsupported",
+  "current_wait": "unsupported",
+  "current_turn": "unsupported",
+  "todos": "unsupported",
+  "last_displayed_assistant_message": "unsupported",
+  "last_created_tool_call": "unsupported",
+  "source_terminal_state": "unsupported",
+  "source_error_state": "unsupported"
+}

--- a/dev-docs/jsp/v1/fixtures/snapshot_nested_forbidden_fields.json
+++ b/dev-docs/jsp/v1/fixtures/snapshot_nested_forbidden_fields.json
@@ -1,0 +1,37 @@
+{
+  "schema": 1,
+  "kind": "snapshot",
+  "agent_id": "agent-nested-evil",
+  "lifecycle_generation": 1,
+  "source_epoch": "epoch-010",
+  "source_sequence": 1,
+  "cursor": 0,
+  "bridge_observed_ms": 1785922010000,
+  "native_session": {
+    "repository": "vybestack/llxprt-jefe",
+    "path": "/Users/dev/src/jefe",
+    "agent_kind": "llxprt",
+    "pid": 4545,
+    "display_name": "nested-evil-worker"
+  },
+  "process_binding": "unsupported",
+  "native_activity": "unsupported",
+  "current_wait": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": {
+      "reason": "permission",
+      "publisher_token": "supersecret",
+      "observer_token": "supersecret",
+      "raw_transcript": "leaked",
+      "draft": "leaked",
+      "control": "kill"
+    }
+  },
+  "current_turn": "unsupported",
+  "todos": "unsupported",
+  "last_displayed_assistant_message": "unsupported",
+  "last_created_tool_call": "unsupported",
+  "source_terminal_state": "unsupported",
+  "source_error_state": "unsupported"
+}

--- a/dev-docs/jsp/v1/fixtures/snapshot_over_bound.json
+++ b/dev-docs/jsp/v1/fixtures/snapshot_over_bound.json
@@ -1,0 +1,33 @@
+{
+  "schema": 1,
+  "kind": "snapshot",
+  "agent_id": "agent-over-bound",
+  "lifecycle_generation": 1,
+  "source_epoch": "epoch-007",
+  "source_sequence": 1,
+  "cursor": 0,
+  "bridge_observed_ms": 1785921980000,
+  "native_session": {
+    "repository": "vybestack/llxprt-jefe",
+    "path": "/Users/dev/src/jefe",
+    "agent_kind": "llxprt",
+    "pid": 4242,
+    "display_name": "over-bound-worker"
+  },
+  "process_binding": "unsupported",
+  "native_activity": "unsupported",
+  "current_wait": "unsupported",
+  "current_turn": "unsupported",
+  "todos": "unsupported",
+  "last_displayed_assistant_message": "unsupported",
+  "last_created_tool_call": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": {
+      "label": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "phase": "executing"
+    }
+  },
+  "source_terminal_state": "unsupported",
+  "source_error_state": "unsupported"
+}

--- a/dev-docs/jsp/v1/fixtures/snapshot_semantic_failure.json
+++ b/dev-docs/jsp/v1/fixtures/snapshot_semantic_failure.json
@@ -1,0 +1,43 @@
+{
+  "schema": 1,
+  "kind": "snapshot",
+  "agent_id": "agent-evil",
+  "lifecycle_generation": 1,
+  "source_epoch": "epoch-006",
+  "source_sequence": 2,
+  "cursor": 1,
+  "bridge_observed_ms": 1785921970000,
+  "native_session": {
+    "repository": "vybestack/llxprt-jefe",
+    "path": "/Users/dev/src/jefe",
+    "agent_kind": "llxprt",
+    "pid": 66666,
+    "display_name": "bad-worker"
+  },
+  "process_binding": "unsupported",
+  "native_activity": "unsupported",
+  "current_wait": "unsupported",
+  "current_turn": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": { "elapsed_ms": 12000 }
+  },
+  "todos": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": {
+      "revision": 5,
+      "items": [
+        { "text": "item one", "completed": false }
+      ]
+    }
+  },
+  "last_displayed_assistant_message": "unsupported",
+  "last_created_tool_call": {
+    "provenance": "authoritative",
+    "availability": "known",
+    "value": { "label": "Read", "phase": "stale" }
+  },
+  "source_terminal_state": "unsupported",
+  "source_error_state": "unsupported"
+}

--- a/dev-docs/jsp/v1/fixtures/snapshot_unsupported_version.json
+++ b/dev-docs/jsp/v1/fixtures/snapshot_unsupported_version.json
@@ -1,0 +1,26 @@
+{
+  "schema": 2,
+  "kind": "snapshot",
+  "agent_id": "agent-future",
+  "lifecycle_generation": 1,
+  "source_epoch": "epoch-008",
+  "source_sequence": 1,
+  "cursor": 0,
+  "bridge_observed_ms": 1785921990000,
+  "native_session": {
+    "repository": "vybestack/llxprt-jefe",
+    "path": "/Users/dev/src/jefe",
+    "agent_kind": "llxprt",
+    "pid": 4343,
+    "display_name": "future-worker"
+  },
+  "process_binding": "unsupported",
+  "native_activity": "unsupported",
+  "current_wait": "unsupported",
+  "current_turn": "unsupported",
+  "todos": "unsupported",
+  "last_displayed_assistant_message": "unsupported",
+  "last_created_tool_call": "unsupported",
+  "source_terminal_state": "unsupported",
+  "source_error_state": "unsupported"
+}

--- a/dev-docs/jsp/v1/specification.md
+++ b/dev-docs/jsp/v1/specification.md
@@ -2,9 +2,17 @@
 
 This is the normative specification for JSP/1, the Jefe Stream Protocol. It
 freezes the external semantic and wire contract used by LLxprt Code (producer),
-LLxprt Luther (broker), and Jefe (observer). J1 (this slice) defines the
-snapshot document and the snapshot fixture corpus. Event, stream, heartbeat,
-and replay semantics are described normatively here but are implemented in J2.
+LLxprt Luther (broker), and Jefe (observer).
+
+JSP/1 answers four questions about a running coding agent: what is it doing
+now, how far along is it, is it blocked waiting for input and why, and is the
+status source itself healthy. It is observation-only. It carries no control
+operation, cannot answer a permission or question request, and never replaces
+the agent's native terminal UI.
+
+This document defines the complete protocol: the snapshot document, the event
+inventory, heartbeats, stream semantics, and the language-neutral fixture
+corpus that every implementation must satisfy.
 
 The canonical fixture corpus lives under `dev-docs/jsp/v1/fixtures/` and is
 language-neutral: external implementations must consume the exact same corpus
@@ -302,18 +310,26 @@ at ingress. The schema has no control operation.
 Forbidden fields include (non-exhaustive): `publisher_token`, `observer_token`,
 `raw_transcript`, `draft`, `control`, and any field not listed in §1.
 
-## 16. Transport semantics (normative, J2-implemented)
+## 16. Stream semantics
 
-- A fresh stream begins with an atomic snapshot at `C`.
-- A resume request after `N` begins with the reconstructed snapshot at `N`
-  followed by `N+1` events.
-- If epoch or replay is unavailable, the broker returns coded HTTP 409
-  `resync_required` before opening SSE; the client then makes a fresh request.
-- A stream never mixes partial replay with fallback snapshot data (decision
-  11).
+JSP/1 answers "what is this agent doing now". It is a live status protocol, not
+a history or visualization protocol. The broker keeps exactly one current
+snapshot per source epoch and streams live events. It stores no event history.
 
-These semantics are implemented in J2. J1 defines only the snapshot document
-and corpus.
+- A stream always begins with a `snapshot` document. This removes the race in
+  which a separately fetched snapshot is already stale before the stream opens.
+  It is not a cursor negotiation: the client cannot request a position.
+- Subsequent items are `event` documents (§18) and `heartbeat` documents (§19).
+- `source_sequence` increases by exactly one per event within an epoch. It
+  exists for **gap detection only**.
+- On a detected gap, an epoch change, or a reconnect, the client discards its
+  observation state and reads a fresh stream, which begins with a new snapshot.
+  There is no replay, no resume-after-N request, and no `resync_required`
+  negotiation, because no history is retained to replay.
+
+Deliberately excluded: replay buffers, cursor negotiation, replay expiration,
+out-of-order event reordering, and event history. Stale status is refreshed by
+re-reading current state, which is always cheaper and always correct.
 
 ## 17. Fixture corpus
 
@@ -331,3 +347,95 @@ produce the same typed results.
 | `snapshot_closed_grammar.json`   | error    | Unknown field, JSP-E001 (S2)             |
 | `snapshot_forbidden_fields.json` | error    | Credential/control, JSP-E001 (S5/S6)     |
 | `snapshot_semantic_failure.json` | error    | Producer stale state, JSP-E005 (S4)      |
+
+## 18. Event documents
+
+An event document is a closed JSON object reporting one authoritative native
+transition. Events carry only what a status view needs; they never carry raw
+tool arguments, command bodies, tool output, model thinking, or transcripts.
+
+| Field                  | Type    | Required | Notes                                          |
+|------------------------|---------|----------|------------------------------------------------|
+| `schema`               | integer | yes      | Must be exactly `1`.                           |
+| `kind`                 | string  | yes      | Must be `"event"`.                             |
+| `agent_id`             | string  | yes      | Opaque safe-ASCII ID, 1–128 bytes.             |
+| `lifecycle_generation` | integer | yes      | Positive (`>= 1`).                             |
+| `source_epoch`         | string  | yes      | Opaque safe-ASCII stream identity.             |
+| `source_sequence`      | integer | yes      | Increases by exactly one per event in an epoch.|
+| `bridge_observed_ms`   | integer | yes      | Non-negative UTC epoch milliseconds.           |
+| `event`                | object  | yes      | Closed payload, discriminated by `type`.       |
+
+The identity triple must match the stream's snapshot. An event whose
+`agent_id`, `lifecycle_generation`, or `source_epoch` does not match the
+observed live instance is rejected with `JSP-E004` and never applied.
+
+### 18.1 Event inventory
+
+The `event` object is discriminated by a closed `type` field. Unknown types
+fail with `JSP-E001`; there is no forward-compatible ignore rule, because
+silently dropping a state transition would leave a status view wrong rather
+than visibly unknown.
+
+| `type`                 | Payload members            | Meaning                                    |
+|------------------------|----------------------------|--------------------------------------------|
+| `activity.changed`     | `state`                    | Native activity (§5) changed.              |
+| `wait.opened`          | `reason`                   | An explicit blocking request opened (§6).  |
+| `wait.resolved`        | none                       | The open wait was answered natively.       |
+| `turn.started`         | none                       | A turn began; elapsed anchors at zero.     |
+| `turn.ended`           | `outcome`                  | Turn finished: `completed`/`failed`/`cancelled`. |
+| `todos.replaced`       | `revision`, `items`        | Full replacement of the todo list (§8).    |
+| `tool_call.created`    | `label`, `phase`           | A tool call was created (§10).             |
+| `tool_call.phase_changed` | `label`, `phase`        | The most recently created tool changed phase. |
+| `assistant_message.displayed` | `content`, `committed_ms` | A completed reply became user-visible (§9). |
+| `source.error`         | `summary`, `code`          | The source reported an error state (§12).  |
+| `session.ended`        | none                       | The native session ended.                  |
+
+Payload members reuse the exact types, closed inventories, and bounds defined
+for the corresponding snapshot fields. `todos.replaced` obeys §8 in full,
+including the positive-revision rule and the 256-entry and 2 KiB text bounds.
+
+### 18.2 Semantics
+
+- **Waiting requires an explicit event.** Only `wait.opened` without a matching
+  `wait.resolved` puts an agent in `waiting_for_input`. Silence, elapsed time,
+  and process age never imply waiting.
+- **Turn elapsed is anchored, not transmitted.** `turn.started` anchors elapsed
+  time at zero; Jefe advances the display from its own monotonic clock. A
+  snapshot's `current_turn` carries an elapsed anchor for late subscribers.
+- **Todos are full replacement.** There are no patches in JSP/1. A replacement
+  whose `revision` does not exceed the applied revision is ignored as stale.
+- **Last message updates only on commit.** `assistant_message.displayed` fires
+  when the native UI has shown completed content. Streaming drafts are not
+  represented in JSP/1 and can never replace a committed message.
+- **Last tool is by creation order.** `tool_call.created` sets the current tool.
+  `tool_call.phase_changed` updates that tool's phase and never reorders by
+  completion time.
+- **Producers cannot assert stale.** `stale` is an observer-side transport
+  overlay (§20). A producer that sends it fails with `JSP-E005`.
+
+## 19. Heartbeat documents
+
+| Field                  | Type    | Required | Notes                                   |
+|------------------------|---------|----------|-----------------------------------------|
+| `schema`               | integer | yes      | Must be exactly `1`.                    |
+| `kind`                 | string  | yes      | Must be `"heartbeat"`.                  |
+| `agent_id`             | string  | yes      | Opaque safe-ASCII ID.                   |
+| `lifecycle_generation` | integer | yes      | Positive (`>= 1`).                      |
+| `source_epoch`         | string  | yes      | Opaque safe-ASCII stream identity.      |
+| `bridge_observed_ms`   | integer | yes      | Non-negative UTC epoch milliseconds.    |
+
+A heartbeat carries no `source_sequence`: it reports liveness of the status
+source, not a state transition, and must not advance or gap the sequence.
+
+Heartbeats exist so a healthy-but-quiet source is distinguishable from a hung
+one. A missed heartbeat means observation health is `stale` — never that the
+agent is idle, ready, or dead.
+
+## 20. Observation health is observer-owned
+
+Observation health (`unsupported`, `connecting`, `live`, `stale`,
+`disconnected`, `protocol_error`) is computed by the observer from transport
+behavior and heartbeat timing. It is never a wire field, and a producer cannot
+report it. This keeps the three axes orthogonal: process liveness is owned by
+the Jefe runtime, observation health by the transport, and native activity by
+authoritative producer events.

--- a/dev-docs/jsp/v1/specification.md
+++ b/dev-docs/jsp/v1/specification.md
@@ -1,0 +1,323 @@
+# JSP/1 — Jefe Stream Protocol, Version 1
+
+This is the normative specification for JSP/1, the Jefe Stream Protocol. It
+freezes the external semantic and wire contract used by LLxprt Code (producer),
+LLxprt Luther (broker), and Jefe (observer). J1 (this slice) defines the
+snapshot document and the snapshot fixture corpus. Event, stream, heartbeat,
+and replay semantics are described normatively here but are implemented in J2.
+
+The canonical fixture corpus lives under `dev-docs/jsp/v1/fixtures/` and is
+language-neutral: external implementations must consume the exact same corpus
+and produce the same typed results as the Jefe reference oracle.
+
+## 1. Envelope
+
+Every JSP/1 document is a closed JSON object with exactly these top-level
+fields for a snapshot:
+
+| Field                   | Type    | Required | Notes                                              |
+|-------------------------|---------|----------|----------------------------------------------------|
+| `schema`                | integer | yes      | Must be exactly `1`. No fallback.                  |
+| `kind`                  | string  | yes      | Must be `"snapshot"`.                              |
+| `agent_id`              | string  | yes      | Opaque safe-ASCII ID, 1–128 bytes.                 |
+| `lifecycle_generation`  | integer | yes      | Positive (`>= 1`).                                 |
+| `source_epoch`          | string  | yes      | Opaque safe-ASCII stream identity, 1–128 bytes.    |
+| `source_sequence`       | integer | yes      | Non-negative ordering sequence.                    |
+| `cursor`                | integer | yes      | Non-negative; reflects all effects through cursor. |
+| `bridge_observed_ms`    | integer | yes      | Non-negative UTC epoch milliseconds.               |
+| `native_session`        | object  | yes      | See §3.                                            |
+| `process_binding`       | field   | yes      | See §4.                                            |
+| `native_activity`       | field   | yes      | See §5.                                            |
+| `current_wait`          | field   | yes      | See §6.                                            |
+| `current_turn`          | field   | yes      | See §7.                                            |
+| `todos`                 | field   | yes      | See §8.                                            |
+| `last_displayed_assistant_message` | field | yes | See §9.                                  |
+| `last_created_tool_call`| field   | yes      | See §10.                                           |
+| `source_terminal_state` | field   | yes      | See §11.                                           |
+| `source_error_state`    | field   | yes      | See §12.                                           |
+
+Unknown top-level fields, duplicate fields, wrong types, trailing data,
+non-integer numeric values, and non-object top-level values all fail with
+`JSP-E001`. There is no legacy or unknown-version fallback.
+
+### 1.1 Field-state algebra
+
+Each semantic field uses one of two closed forms:
+
+1. The bare string `"unsupported"` — the producer does not support this field.
+2. A supported state object:
+   ```json
+   {
+     "provenance": "authoritative" | "inferred",
+     "availability": "known" | "unknown" | "degraded",
+     "value": <field-specific>,
+     "last_value": <field-specific>,
+     "as_of_ms": <integer>,
+     "diagnostic_code": "<string>"
+   }
+   ```
+
+- `known` requires `value` and forbids `last_value`, `as_of_ms`,
+  `diagnostic_code`.
+- `unknown` forbids `value`, `last_value`, `as_of_ms`, `diagnostic_code`.
+- `degraded` requires `last_value`, `as_of_ms`, `diagnostic_code`, and forbids
+  `value`.
+
+`stale` is **not** a producer field-state value. It is a local
+observation-health overlay owned by the Jefe transport layer. A producer that
+emits `stale` fails with `JSP-E005`.
+
+`known` with `value: null` is valid for optional-entity fields
+(`current_wait`, `source_terminal_state`) and means "known to be absent / not
+applicable". This is distinct from `unknown` (not yet observed). For every
+other field, `null` is not a valid known value: use `unsupported` or `unknown`.
+
+`degraded` is not valid for the optional-entity fields `current_wait` and
+`source_terminal_state`, because a wait or terminal state is either explicitly
+observed or not observed. Supplying it fails with `JSP-E005`.
+
+## 2. Identity and ordering
+
+The live observation key is `(agent_id, lifecycle_generation, source_epoch)`.
+Repository, path, agent kind, PID, display name, and native session metadata
+are descriptive and never participate in the key.
+
+- `lifecycle_generation` must be positive (`>= 1`). Zero fails with `JSP-E004`.
+- Source epoch is producer/broker stream identity bound by registration to one
+  agent and generation. A producer stream can restart during one process
+  generation; a Jefe relaunch invalidates the generation and requires a new
+  source epoch.
+- Ordering authority is `(source_epoch, source_sequence)`. Snapshot cursor `C`
+  reflects all effects through `C`. Heartbeats carry `C` and do not consume a
+  sequence. Events consume exactly `C+1`. (J2 implements the stream state
+  machine.)
+
+## 3. Native session
+
+```json
+{
+  "repository": "<string>",
+  "path": "<string>",
+  "agent_kind": "<string>",
+  "pid": <integer>,
+  "display_name": "<string>"
+}
+```
+
+`agent_kind` is an opaque bounded label. JSP/1 does not close its inventory
+because the producer set is expected to grow without a protocol version change.
+
+All fields are descriptive metadata. They never collapse the observation key.
+
+## 4. Process binding
+
+The bare string `"unsupported"` or a supported state whose known value is:
+
+```json
+{ "pid": <integer>, "started_at_ms": <integer> }
+```
+
+Both members are required when the value is present. Process liveness remains
+Jefe-runtime-owned. A producer reports typed process and lifecycle binding
+metadata, not whether the process is alive or dead (decision 4).
+
+## 5. Native activity
+
+```json
+{
+  "provenance": "authoritative",
+  "availability": "known",
+  "value": { "state": "idle" | "thinking" | "acting" }
+}
+```
+
+The state inventory is closed. Any other value fails with `JSP-E005`.
+
+Native activity is source-owned. Observation health is Jefe-transport-owned.
+The three axes (process liveness, observation health, native activity) remain
+orthogonal.
+
+## 6. Current wait
+
+```json
+{
+  "provenance": "authoritative",
+  "availability": "known",
+  "value": null
+}
+```
+
+`known` with `value: null` means "not waiting". `known` with a value object
+means "waiting with an explicit unresolved reason":
+
+```json
+"value": { "reason": "permission" | "question" | "elicitation" | "choice" | "user_input" | "other" }
+```
+
+Silence and elapsed time never create waiting (decision 7). An explicit wait
+object is required.
+
+## 7. Current turn
+
+```json
+{
+  "provenance": "authoritative",
+  "availability": "known",
+  "value": { "elapsed_ms": <integer> }
+}
+```
+
+Turn runtime carries an elapsed-millisecond anchor. Jefe later advances it from
+local monotonic receipt and never subtracts clocks across processes (decision
+9).
+
+## 8. Todos
+
+```json
+{
+  "provenance": "authoritative",
+  "availability": "known",
+  "value": {
+    "revision": <integer>,
+    "items": [
+      { "text": "<string>", "completed": <bool> }
+    ]
+  }
+}
+```
+
+Todos are full replacement with strictly increasing revision; patches are
+invalid (decision 8). `revision` must be positive (`>= 1`); zero fails with
+`JSP-E005`. `known` with an empty `items` array preserves the distinction
+between known-empty, unsupported, and unknown.
+
+## 9. Last displayed assistant message
+
+```json
+{
+  "provenance": "inferred",
+  "availability": "known",
+  "value": { "content": "<string>", "committed_ms": <integer> }
+}
+```
+
+Last assistant message changes only at a native user-visible display or commit
+boundary (decision 7). Drafts, hidden content, thinking, raw transcripts, tool
+arguments/output, and command bodies are absent from this contract.
+
+## 10. Last created tool call
+
+```json
+{
+  "provenance": "authoritative",
+  "availability": "known",
+  "value": { "label": "<string>", "phase": "proposed" | "awaiting_approval" | "scheduled" | "executing" | "succeeded" | "failed" | "cancelled" }
+}
+```
+
+Last tool means the most recently created native tool item (decision 8).
+
+## 11. Source terminal state
+
+```json
+{
+  "provenance": "authoritative",
+  "availability": "known",
+  "value": null
+}
+```
+
+`known` with `value: null` means no terminal error state.
+
+## 12. Source error state
+
+```json
+{
+  "provenance": "authoritative",
+  "availability": "known",
+  "value": { "summary": "<string>", "code": "<string>" }
+}
+```
+
+Source/native timestamps are bounded UTC epoch milliseconds and diagnostic
+only.
+
+## 13. Bounds
+
+All bounds are inclusive. Limit-plus-one input fails with `JSP-E002` before a
+contract value is returned.
+
+| Bound                              | Value      |
+|------------------------------------|------------|
+| Snapshot document                  | 256 KiB    |
+| IDs (agent_id, source_epoch)       | 128 bytes  |
+| Todo list entries                  | 256        |
+| Todo text                          | 2 KiB      |
+| Displayed assistant content        | 16 KiB     |
+| Source diagnostic summary          | 2 KiB      |
+| Tool label                         | 256 bytes  |
+| Repository reference               | 256 bytes  |
+| Path reference                     | 4 KiB      |
+| Agent-kind label                   | 64 bytes   |
+| Display name                       | 256 bytes  |
+| Diagnostic code                    | 128 bytes  |
+| Source error code                  | 128 bytes  |
+
+Opaque identifiers (`agent_id`, `source_epoch`) additionally accept only ASCII
+alphanumerics and `-`, `_`, `.`, and must be non-empty. Any other byte fails
+with `JSP-E001`.
+
+## 14. Error codes
+
+| Code      | Meaning                                              |
+|-----------|------------------------------------------------------|
+| `JSP-E001`| Closed JSON / syntax / shape violation               |
+| `JSP-E002`| Bound exceeded                                       |
+| `JSP-E003`| Unsupported version or kind                          |
+| `JSP-E004`| Identity / binding violation                         |
+| `JSP-E005`| Field-state violation                                |
+| `JSP-E006`| Snapshot semantic invariant violation                |
+
+Parsing returns a typed `Result` and performs no logging or I/O (decision 14).
+Diagnostics contain stable code/path/location and never echo input values
+(decision 12).
+
+## 15. Forbidden fields
+
+Publisher and observer credentials are out-of-band HTTP authorization
+material, role-separated, loopback-only for JSP/1, and forbidden from protocol
+documents (decision 12). Closed parsing rejects credential and control fields
+at ingress. The schema has no control operation.
+
+Forbidden fields include (non-exhaustive): `publisher_token`, `observer_token`,
+`raw_transcript`, `draft`, `control`, and any field not listed in §1.
+
+## 16. Transport semantics (normative, J2-implemented)
+
+- A fresh stream begins with an atomic snapshot at `C`.
+- A resume request after `N` begins with the reconstructed snapshot at `N`
+  followed by `N+1` events.
+- If epoch or replay is unavailable, the broker returns coded HTTP 409
+  `resync_required` before opening SSE; the client then makes a fresh request.
+- A stream never mixes partial replay with fallback snapshot data (decision
+  11).
+
+These semantics are implemented in J2. J1 defines only the snapshot document
+and corpus.
+
+## 17. Fixture corpus
+
+The fixture corpus lives under `dev-docs/jsp/v1/fixtures/` and is enumerated by
+`manifest.json`. Each fixture declares an expected result (`ok` or `error`
+with an `error_code`). External implementations must consume the corpus and
+produce the same typed results.
+
+| Fixture                          | Expected | Notes                                    |
+|----------------------------------|----------|------------------------------------------|
+| `snapshot_full.json`             | ok       | Canonical full snapshot (S1)             |
+| `snapshot_identity_distinct.json`| ok       | Same worktree, distinct key (S3)         |
+| `snapshot_field_states.json`     | ok       | Exhaustive field-state algebra (S4)      |
+| `snapshot_bounds.json`           | ok       | At-limit ID bound (S2)                   |
+| `snapshot_closed_grammar.json`   | error    | Unknown field, JSP-E001 (S2)             |
+| `snapshot_forbidden_fields.json` | error    | Credential/control, JSP-E001 (S5/S6)     |
+| `snapshot_semantic_failure.json` | error    | Producer stale state, JSP-E005 (S4)      |

--- a/dev-docs/jsp/v1/specification.md
+++ b/dev-docs/jsp/v1/specification.md
@@ -36,9 +36,13 @@ fields for a snapshot:
 | `source_terminal_state` | field   | yes      | See §11.                                           |
 | `source_error_state`    | field   | yes      | See §12.                                           |
 
-Unknown top-level fields, duplicate fields, wrong types, trailing data,
-non-integer numeric values, and non-object top-level values all fail with
-`JSP-E001`. There is no legacy or unknown-version fallback.
+Unknown fields, duplicate fields, wrong types, trailing data, non-integer
+numeric values, and non-object top-level values all fail with `JSP-E001`. This
+applies at every level of the document, including inside a field state's
+`value` and `last_value` payloads: a member that is not part of the closed
+payload shape is rejected rather than ignored, and the same key sent twice is
+rejected rather than resolved last-wins. There is no legacy or unknown-version
+fallback.
 
 ### 1.1 Field-state algebra
 
@@ -155,7 +159,8 @@ means "waiting with an explicit unresolved reason":
 ```
 
 Silence and elapsed time never create waiting (decision 7). An explicit wait
-object is required.
+object is required. `reason` is the only member of the wait object; any other
+member fails with `JSP-E001`.
 
 ## 7. Current turn
 
@@ -227,7 +232,12 @@ Last tool means the most recently created native tool item (decision 8).
 }
 ```
 
-`known` with `value: null` means no terminal error state.
+`known` with `value: null` means no terminal error state. A non-null value uses
+the same closed payload as §12:
+
+```json
+"value": { "summary": <bounded string>, "code": <bounded string> }
+```
 
 ## 12. Source error state
 

--- a/dev-docs/standards/architecture.md
+++ b/dev-docs/standards/architecture.md
@@ -49,6 +49,12 @@ architecture variants (`*_v2`, `new_*`) unless explicitly approved.
   See [Persistence and Runtime](./persistence-and-runtime.md).
 - **Theme layer** (`src/theme/`) owns theme loading, selection, and fallback.
   See [Display and UI](./display-and-ui.md).
+- **JSP wire-boundary layer** (`src/jsp/`) owns the external JSP/1 snapshot
+  parser. It depends only on `domain::observation` (transport-neutral semantic
+  values), the standard library, and existing `serde`/`serde_json`. Private
+  closed wire DTOs convert to domain types only after complete validation.
+  The parser performs no I/O or logging and returns typed errors without
+  echoing payload values. See `dev-docs/jsp/v1/specification.md`.
 
 ---
 
@@ -234,6 +240,7 @@ main.rs ──> ui/ ──> theme/ (for ResolvedColors)
 ui/     ──> text_box_view/ (pure projection)
 state/  ──> messages/ ──> domain/
 persistence/ ──> domain/
+jsp/    ──> domain/ (transport-neutral observation values)
 ```
 
 | Module              | May depend on (project-internal)                          |
@@ -245,6 +252,7 @@ persistence/ ──> domain/
 | `runtime/`          | Nothing project-internal (uses iocraft types for `Color`).|
 | `state/`            | `domain/`, `messages/`.                                   |
 | `text_box_view/`    | Nothing project-internal (pure projection).               |
+| `jsp/`              | `domain/observation` only (external wire boundary).       |
 | `ui/`               | `domain/`, `theme/`, `text_box_view/`, other pure views.  |
 | `main.rs`           | Wires everything together.                                |
 

--- a/project-plans/issue476-plan.md
+++ b/project-plans/issue476-plan.md
@@ -1,0 +1,337 @@
+# Issue 476 delivery plan
+
+## Scope decision
+
+Issue 476 cannot fit one Jefe pull request. It crosses the protocol/domain,
+service/network, shell orchestration, reducer/messages, runtime identity, pure
+projection, UI/input, and real-TTY evidence boundaries. That exceeds the
+canonical three-owner and three-route split trigger and would exceed the target
+of 25 files or 1,500 net changed lines.
+
+Deliver the parent issue through ordered child or stacked pull requests. Each
+intermediate Jefe pull request references issue 476 but does not close it. The
+LLxprt Code producer and LLxprt Luther broker are external-repository slices;
+they do not create implementation files in this repository.
+
+## First Jefe slice: JSP/1 snapshot contract and compliance corpus
+
+The first independently deliverable slice freezes the external semantic and
+wire contract. It provides a strict typed snapshot validator and a portable,
+language-neutral fixture corpus before either external implementation starts.
+It does not connect Jefe to a server.
+
+### Contract decisions requiring approval
+
+1. JSP/1 uses a closed JSON envelope with `schema: 1` and a closed `kind`
+   inventory. Unknown schemas, kinds, fields, duplicate fields, wrong types,
+   trailing data, and non-integer numeric values fail. There is no legacy or
+   unknown-version fallback.
+2. Every record carries a Jefe agent ID, positive lifecycle generation, source
+   epoch, and cursor. IDs are opaque safe ASCII strings of 1 through 128 bytes.
+   Repository, path, agent kind, PID, display name, and native session metadata
+   never participate in the live observation key.
+3. Source epoch is producer/broker stream identity bound by registration to one
+   Jefe agent and lifecycle generation. It is not added to `RuntimeSession`,
+   `RuntimeBinding`, persistence, or `LivenessIdentity`. A producer stream can
+   restart during one process generation; a Jefe relaunch invalidates the
+   registered generation and requires a new source epoch.
+4. Process liveness remains Jefe-runtime-owned. A producer reports typed process
+   and lifecycle binding metadata, not whether the process is alive or dead.
+   Observation health is Jefe-transport-owned. Native activity is source-owned.
+   The three axes therefore remain orthogonal.
+5. Each required snapshot field uses a closed state algebra: `unsupported`; or
+   a supported provenance of `authoritative` or `inferred` combined with
+   `unknown`, `known(value)`, or `degraded(last_value, as_of_ms,
+   diagnostic_code)`. `stale` is a local observation-health overlay that keeps
+   the last accepted field values; it is not producer capability or provenance.
+6. Required fields cover source/native-session identity, process binding,
+   native activity, current wait, current turn, todos, last displayed assistant
+   message, last-created tool call, source terminal/error state, cursor, and
+   bridge observation time. Optional current entities use known `null`. Todos
+   use known full replacement `{revision, items}`, preserving the distinction
+   between known-empty, unsupported, and unknown.
+7. Waiting requires an explicit unresolved wait object with a typed reason:
+   permission, question, elicitation, choice, user input, or other. Silence and
+   elapsed time never create waiting. Last assistant message changes only at a
+   native user-visible display or commit boundary. Drafts, hidden content,
+   thinking, raw transcripts, tool arguments/output, and command bodies are
+   absent from this proof-of-concept contract.
+8. Last tool means the most recently created native tool item. Its phase is one
+   of proposed, awaiting approval, scheduled, executing, succeeded, failed, or
+   cancelled. Todos are full replacement with strictly increasing revision;
+   patches are invalid.
+9. Source/native timestamps are bounded UTC epoch milliseconds and diagnostic
+   only. Source sequence is the ordering authority. Turn runtime carries an
+   elapsed-millisecond anchor; Jefe later advances it from local monotonic
+   receipt and never subtracts clocks across processes.
+10. Ordering authority is `(source_epoch, sequence)`. Snapshot cursor C reflects
+    all effects through C. Heartbeats carry C and do not consume a sequence.
+    Events consume exactly C+1. Gaps, out-of-order records, old generations, and
+    old epochs fail without state application.
+11. Atomic replay is normative in this slice and implemented in the event/stream
+    compliance slice. A fresh stream begins with an atomic snapshot at C. A
+    resume request after N begins with the reconstructed snapshot at N followed
+    by N+1 events. If epoch or replay is unavailable, the broker returns coded
+    HTTP 409 `resync_required` before opening SSE; the client then makes a fresh
+    request. A stream never mixes partial replay with fallback snapshot data.
+12. Publisher and observer credentials are out-of-band HTTP authorization
+    material, role-separated, loopback-only for JSP/1, and forbidden from
+    protocol documents. Closed parsing rejects credential and control fields.
+    Diagnostics contain stable code/path/location, never input values. The
+    schema has no control operation.
+13. Initial inclusive bounds are: snapshot document 256 KiB; IDs 128 bytes;
+    todo list 256 entries; todo text 2 KiB; displayed assistant content 16 KiB;
+    source diagnostic summary 2 KiB; tool label 256 bytes. Limit-plus-one input
+    fails before a contract value is returned.
+14. Initial stable error codes are `JSP-E001` closed JSON/syntax/shape,
+    `JSP-E002` bound, `JSP-E003` unsupported version/kind, `JSP-E004`
+    identity/binding, `JSP-E005` field state, and `JSP-E006` snapshot semantic
+    invariant. Parsing returns a typed `Result` and performs no logging or I/O.
+
+## First-slice acceptance matrix
+
+| ID | Actor / launch path | Inputs and boundary cases | Target | Observable success | Observable failure and diagnostics | Side effects before failure | Persistence and compatibility | Behavioral evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| S1 | Jefe or an external implementer runs `cargo test --test jsp_v1_snapshot_compliance`; production calls `jsp::v1::parse_snapshot` | Canonical full snapshot at exact allowed schema and field states, including known-empty todos and known-null optional entities | Pure Rust on macOS, Linux, and native Windows | Returns a typed observation snapshot with exact identity, cursor, semantic fields, provenance, and availability | Not applicable | None | Runtime value only; no state/settings write; JSP/1 only | Canonical full fixture and typed equality assertions |
+| S2 | Same | Empty, truncated, non-UTF-8, trailing JSON, duplicate/unknown field, wrong type, schema 0/2, each maximum and maximum-plus-one | All targets | Every at-limit fixture is accepted | Returns deterministic `JSP-E001`, `JSP-E002`, or `JSP-E003` with a safe location and no echoed value | None; no partial contract object escapes | No fallback, coercion, dual format, or write | Closed-input and bound fixtures plus table-driven boundary tests |
+| S3 | Same | Two LLxprt snapshots in the same repository/path with distinct agent/generation/epoch; zero generation; invalid binding | All targets | Distinct typed live keys remain distinct | Invalid identity returns `JSP-E004`; no snapshot is returned | None | Native metadata cannot collapse keys; no durable identity mutation | Same-worktree identity and invalid-identity fixtures |
+| S4 | Same | Unsupported versus supported authoritative/inferred unknown/known/degraded; known-empty, unsupported, and unknown todos; producer-supplied stale state | All targets | Valid states remain distinct exhaustive enum values | Illegal combinations or producer stale state return `JSP-E005` at the field path | None | Unknown future variant requires a version change | Value-state and invalid semantic fixtures plus exhaustive assertions |
+| S5 | Same | Explicit wait/activity consistency, elapsed anchor, todo revision, committed message, last-created tool phase, source terminal state; forbidden draft/raw/tool/control fields | All targets | Valid snapshot is accepted without excluded data | Contradiction or forbidden field returns `JSP-E001`/`JSP-E006`; diagnostics contain no payload text | None | No transcript/tool-output persistence; accepted text remains runtime-only in later slices | Full fixture and focused semantic failures |
+| S6 | A protocol consumer reads the spec and runs the corpus from another repository/language; Jefe is the reference oracle | Manifest enumerates every fixture and expected result; credential/control fields are attempted in bodies | Language-neutral corpus; Jefe oracle on all targets | Manifest and all fixtures are consumed; auth roles and read-only inventory are explicit | Missing/unlisted fixture fails the integration test; credential/control fields fail closed | Fixture reads only | Corpus is versioned under JSP/1; external implementations must pass it | Manifest-enumeration and credential/control negative fixtures |
+
+## First-slice non-goals
+
+- Event parsing, stream state machine, heartbeat execution, replay execution,
+  SSE, HTTP, batching, retry, timers, networking, registration lifecycle, or
+  credential storage.
+- AppState observation maps, messages/reducers, process-liveness changes,
+  runtime-session changes, persistence changes, Split UI/input, terminal viewer
+  behavior, or a TUI scenario.
+- LLxprt Code or LLxprt Luther implementation and adapters for Claude Code,
+  Codex, OpenCode, or Code Puppy.
+- Generic remote transport/TLS, sockets, named pipes, WebSockets, late
+  attachment, control/nudge/approval answering, subagent rows, or draft
+  streaming.
+- Refactoring `harness/v1` into shared infrastructure, adding generic JSON
+  abstractions, exposing generic `serde_json::Value` maps, redaction fallback
+  layers, new dependencies, lint allowances, quality-gate changes, or unrelated
+  cleanup.
+
+## Architecture boundaries
+
+- `domain::observation` owns transport-neutral strongly typed semantic values.
+  It has no project-internal dependency, I/O, clock, credential, or UI concern.
+- `jsp::v1` is the external wire-boundary parser. It depends only on
+  `domain::observation`, the standard library, and existing `serde`/
+  `serde_json`. Private closed wire DTOs convert only after complete validation.
+- `dev-docs/jsp/v1` owns the normative contract and language-neutral corpus.
+- Integration and unit tests own observable parser/corpus behavior.
+- The architecture standard records the new `jsp -> domain` direction. This
+  slice does not modify architecture tooling or quality gates.
+
+## Expected first-slice paths
+
+Target no more than 22 files and 1,450 net changed lines:
+
+- `dev-docs/jsp/v1/specification.md`
+- `dev-docs/jsp/v1/fixtures/manifest.json`
+- Up to seven focused JSON fixtures for full snapshot, same-worktree identity,
+  field states, forbidden/auth fields, closed grammar, bounds, and
+  identity/semantic failures
+- `dev-docs/standards/architecture.md`
+- `src/domain/mod.rs`
+- `src/domain/observation.rs`
+- `src/jsp/mod.rs`
+- `src/jsp/v1/mod.rs`
+- `src/jsp/v1/contract.rs`
+- `src/jsp/v1/wire.rs`
+- `src/jsp/v1/limits.rs`
+- `src/jsp/v1/error.rs`
+- `src/jsp/v1/validate.rs`
+- `src/jsp/v1/parse.rs`
+- `src/lib.rs`
+- `tests/jsp_v1_snapshot_compliance.rs`
+
+Every file remains below 750 lines, every function below 60 lines, and cognitive
+complexity below 15. If complete behavior cannot remain within 25 files and
+1,500 lines, split specification/corpus from parser rather than compressing
+behavioral evidence or loosening gates.
+
+## First-slice vertical steps
+
+1. RED: add the typed fixture-manifest integration test and canonical fixtures;
+   prove the test fails because JSP/1 parser/types do not exist.
+2. GREEN: add domain types, private closed wire DTOs, document bound, schema
+   gate, typed errors, and enough parsing for valid/closed/version/bound rows.
+3. RED: add identity collision, illegal field-state, wait/todo/message/tool, and
+   forbidden credential/control failures.
+4. GREEN: validate the entire snapshot before conversion; return no partial
+   value and echo no payload in diagnostics.
+5. REFACTOR only in approved paths: split cohesive modules before 750 lines,
+   keep the public API minimal, and remove duplication without extracting or
+   modifying harness JSON code.
+6. Commit coherent green behavior separately; do not commit a known-red slice.
+
+Focused verification:
+
+```text
+cargo test --test jsp_v1_snapshot_compliance
+cargo test --lib jsp::v1
+cargo xtask quick
+cargo xtask check source-size
+cargo xtask check architecture
+```
+
+Exact-head pre-push verification:
+
+```text
+cargo xtask ci
+```
+
+Native Windows CI must pass. A TUI gate is not claimed for this non-UI slice.
+Interrupted, partial, skipped, or stale-head verification is incomplete.
+
+## Ordered parent-issue slices
+
+1. **J1: snapshot contract/corpus.** This plan's first slice. Does not close
+   issue 476.
+2. **J2: event and stream semantic compliance.** Add normalized event parsing,
+   deterministic stream state machine, exact sequence/epoch/revision rules,
+   atomic snapshot-at-cursor replay, heartbeat semantics, 409 resync, and
+   portable replay fixtures. No sockets, UI, or AppState. Target at most 20
+   files and 1,450 lines. Completion gates external implementation work.
+3. **External LLxprt Code child.** Add the non-blocking native producer and
+   publisher with explicit native event boundaries and excluded-content rules.
+   It must pass the J1/J2 producer corpus. No Jefe files.
+4. **External LLxprt Luther child.** Add authenticated loopback POST/SSE broker,
+   role separation, bounded event log, atomic snapshot/replay/resync,
+   diagnostic endpoint, and whole-batch atomicity. It must pass the J1/J2 broker
+   suite. No Jefe files.
+5. **J3: runtime-only observation reducer.** Add the identity-keyed AppState
+   projection and typed deterministic snapshot/event messages. Reject stale
+   generation/epoch with no mutation. No persistence or I/O; do not alter
+   `AgentStatus` or `LivenessIdentity`. Target at most 15 files and 1,250 lines.
+6. **J4: loopback observer-client boundary.** Add bounded authenticated
+   HTTP/SSE transport against a deterministic local fake server, with no
+   AppState. Any manifest/lockfile or HTTP/TLS dependency change requires
+   separate explicit approval. Do not hand-roll a broad HTTP stack as fallback.
+   Target at most 18 files and 1,400 lines.
+7. **J5: lifecycle orchestration and local health.** Add registration binding,
+   cancellation, render-thread typed delivery, connecting/live/stale/
+   disconnected/protocol-error transitions, monotonic freshness/elapsed ticks,
+   and resync. Network and timers remain outside AppState. Target at most 20
+   files and 1,450 lines.
+8. **J6: compact status rows, Enter, and Split retirement.** Add a schema-1 TUI
+   scenario first. Retire Split-only repository filter/grab/reorder while
+   preserving Dashboard behavior. Add pure row projection, orthogonal
+   indicators/headline, and Enter through the existing terminal attach/focus
+   path. Target at most 25 files and 1,500 lines; split again if routes or budget
+   exceed the policy.
+9. **J7: selected-agent detail and freshness.** Add a TUI scenario first and a
+   pure detail projection for todos, explicit wait, turn elapsed, last displayed
+   reply, last-created tool, provenance, unsupported/unavailable/degraded/stale,
+   and as-of age. Keep the iocraft renderer thin. Target at most 18 files and
+   1,350 lines.
+10. **Cross-repository qualification.** Run the exact J1/J2 corpus against the
+    released Code producer and Luther broker, then run a real Jefe TUI scenario
+    proving same-worktree identity separation, stale historical display,
+    independent process death, and entry into the existing native UI. Issue 476
+    closes only after every parent acceptance row has evidence and all exact-head
+    delivery gates are complete.
+
+## Scope ledger
+
+| Item | Disposition | Notes |
+| --- | --- | --- |
+| Normative JSP/1 semantic/transport specification | Accepted for J1 | Written contract includes later transport semantics but no transport implementation |
+| Transport-neutral observation domain values | Accepted for J1 | No process-liveness or persistence ownership |
+| Snapshot parser/validator and fixture oracle | Accepted for J1 | Existing dependencies only |
+| Event/replay implementation | Deferred to J2 | Normative semantics only in J1 |
+| LLxprt Code producer | Deferred to external child | Must consume exact corpus revision |
+| LLxprt Luther broker | Deferred to external child | Must consume exact corpus revision |
+| AppState/reducer/network/UI | Deferred to J3-J7 | Outside J1 acceptance matrix |
+| HTTP dependency selection | Deferred; approval required | No manifest/lockfile change in J1 |
+| Source epoch in liveness/persistence | Rejected | Observation-stream identity is orthogonal to process liveness |
+| Producer-owned process or observation health | Rejected | Violates axis ownership |
+| Producer `stale` field state | Rejected | Stale is a local transport-health overlay |
+| Accept-and-redact credential/control fields | Rejected | Closed parser rejects them at ingress |
+| Terminal/log inference or shared harness refactor | Rejected | Violates issue invariants or J1 scope |
+| J1 line budget | Discovered scope item | Target was <=22 files / 1,450 net lines. Actual: 22 impl files / 3,270 net lines (2,308 Rust code + 962 docs/fixtures). Code is under the 2,500 hard limit. Overage is from the normative specification and fixture corpus, which the plan explicitly identifies as splittable. No behavioral evidence compressed or deleted. All S1-S6 GREEN, all quality gates pass. If the target budget must be enforced, split specification/corpus (651 lines) into a separate doc-only PR. |
+
+Newly discovered work must be added here before implementation. Stop if it
+requires another production owner, a path outside the accepted list, Cargo or
+lockfile changes, workflow/quality tooling, a new binary, a generic protocol
+abstraction, or a budget breach.
+
+## Review counters and finding policy
+
+- Local Open Code Review: 0 of 2 used.
+- Pull-request Open Code Review: 0 of 2 used.
+- Independent review/remediation cycles: 0 of 2 used.
+
+Each finding is classified as Blocker-Fix, In-scope-Fix, Reject, or Defer. A
+reviewer suggestion does not authorize scope expansion.
+
+## Verification evidence
+
+J1 implementation is complete on branch `issue476` (from `4ed77d5`). RED was
+captured first: the integration compliance test failed to compile with E0433
+(`jefe::jsp` module missing) before any production code existed.
+
+GREEN on the candidate head:
+
+- `cargo test --test jsp_v1_snapshot_compliance` — 18 passed, 0 failed.
+- `cargo test --lib jsp` — 13 passed, 0 failed.
+- `cargo test --lib observation` — 8 passed, 0 failed.
+- `cargo test --workspace --all-features --locked` — 0 failures across all
+  targets.
+- `cargo fmt --all --check` — clean.
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — no
+  warnings.
+- `cargo xtask check source-size` — no new warning or failure; the largest new
+  file is 612 lines.
+- `cargo xtask check architecture` — pass.
+- `cargo xtask check clippy-allows` — pass.
+
+One integration TUI scenario (`ui::dashboard_reorder_tui`) failed once under
+full-workspace parallel load and passed on isolated and repeated full-suite
+runs. It exercises tmux timing and does not touch any JSP path.
+
+Coordinator review corrections applied after the implementation pass:
+
+- `process_binding` now uses the documented field-state algebra instead of
+  silently collapsing an unsupported producer field into `None` values.
+- `known` availability now rejects degraded-only members, closing a hole in the
+  field-state algebra.
+- The envelope schema/kind probe no longer parses the whole document into an
+  untyped JSON tree.
+- The oversized-document test now proves the byte bound fires, and an at-limit
+  case proves the bound is inclusive.
+- The specification's native-activity inventory, agent-kind type, process
+  binding shape, todo revision rule, identifier grammar, and bounds table now
+  match the enforced contract.
+
+## Approval and stop conditions
+
+Implementation begins only after approval of the fourteen J1 contract decisions,
+the `jsp -> domain` public architecture boundary, the acceptance matrix, and the
+expected paths.
+
+Stop and request another decision if implementation needs:
+
+- Cargo.toml/Cargo.lock, `.llxprt`, `.code_puppy`, `.github`, xtask, workflow,
+  quality configuration, a new binary, or an unlisted production owner/path;
+- a generic protocol framework, shared harness extraction, new dependency,
+  weak public JSON value/map, unsafe code, unwrap/expect, lint suppression,
+  threshold increase, placeholder, or compatibility fallback;
+- process management, registration storage, timeout/cancellation/cleanup,
+  credential vault, network server, or remote transport in J1;
+- behavior outside S1-S6;
+- more than 25 files or 1,500 net lines, or any approach toward the hard limit
+  of 40 files or 2,500 net lines;
+- integration with wrong ancestry, contract-set mainline drift, or required
+  verification that cannot complete on the candidate head.
+
+## Deferred findings and follow-ups
+
+No review findings or follow-up issues have been recorded yet.

--- a/project-plans/issue476-plan.md
+++ b/project-plans/issue476-plan.md
@@ -265,9 +265,14 @@ abstraction, or a budget breach.
 
 ## Review counters and finding policy
 
-- Local Open Code Review: 0 of 2 used.
+- Local Open Code Review: 1 of 2 used (`--commit df909a9`, 20 files, 19
+  comments). An earlier invocation passed the range positionally, which this
+  `ocr` build does not accept: it reviewed 0 files and reported "Looks good to
+  me". That run examined nothing and is not counted. Always confirm the
+  "Will review (N)" count with `ocr review --preview --commit <sha>` first.
 - Pull-request Open Code Review: 0 of 2 used.
-- Independent review/remediation cycles: 0 of 2 used.
+- Independent review/remediation cycles: 1 of 2 used (architect review of
+  `df909a9`, plus the OCR run above; both triaged and remediated in `88a790a`).
 
 Each finding is classified as Blocker-Fix, In-scope-Fix, Reject, or Defer. A
 reviewer suggestion does not authorize scope expansion.
@@ -278,19 +283,25 @@ J1 implementation is complete on branch `issue476` (from `4ed77d5`). RED was
 captured first: the integration compliance test failed to compile with E0433
 (`jefe::jsp` module missing) before any production code existed.
 
-GREEN on the candidate head:
+GREEN on the candidate head (`88a790a`, after review remediation):
 
-- `cargo test --test jsp_v1_snapshot_compliance` — 18 passed, 0 failed.
-- `cargo test --lib jsp` — 13 passed, 0 failed.
-- `cargo test --lib observation` — 8 passed, 0 failed.
+- `cargo test --test jsp_v1_snapshot_compliance` — 23 passed, 0 failed.
 - `cargo test --workspace --all-features --locked` — 0 failures across all
-  targets.
+  targets (2,433 lib tests, 772 core, 352 integration, and the rest).
+- `cargo build --workspace --all-features --locked` — clean.
 - `cargo fmt --all --check` — clean.
 - `cargo clippy --workspace --all-targets --all-features -- -D warnings` — no
   warnings.
-- `cargo xtask check source-size` — no new warning or failure; the largest new
-  file is 612 lines.
+- `cargo xtask check source-size` — pass; no JSP file appears in the warning
+  list. The largest new file is `validate.rs` at 649 lines, under the 750-line
+  warn threshold.
 - `cargo xtask check architecture` — pass.
+- `cargo xtask check clippy-allows` — pass; no suppression attributes added.
+
+The five behavioral tests added during remediation were confirmed RED against
+the pre-remediation parser before the fixes landed: the nested forbidden-field
+and duplicate-key documents parsed successfully, and the two diagnostic-path
+assertions observed the wrong field names.
 - `cargo xtask check clippy-allows` — pass.
 
 One integration TUI scenario (`ui::dashboard_reorder_tui`) failed once under
@@ -332,6 +343,58 @@ Stop and request another decision if implementation needs:
 - integration with wrong ancestry, contract-set mainline drift, or required
   verification that cannot complete on the candidate head.
 
+## Review findings and triage
+
+Two independent reviews ran against `df909a9`. Both reproduced their claims by
+executing the parser rather than reading it. Remediation landed in `88a790a`.
+
+### Blocker-Fix (all resolved)
+
+| Finding | Resolution |
+| --- | --- |
+| `current_wait.value` was read by hand and ignored sibling members, so credential, transcript, and control fields parsed successfully inside it and escaped all field bounds. | Routed through a closed `WaitPayload` DTO. Covered by `s5_forbidden_fields_nested_in_a_field_value_fail_closed` and a `snapshot_nested_forbidden_fields` fixture. |
+| Duplicate keys inside `value`/`last_value` were silently resolved last-wins, contradicting the specification and offering a route past the stale-phase rejection. | Added a strict value reader that rejects duplicate keys at any depth. Covered by `s5_duplicate_keys_inside_a_field_value_fail_closed`. |
+
+### In-scope-Fix (all resolved)
+
+| Finding | Resolution |
+| --- | --- |
+| The post-deserialization schema/kind gate was unreachable and emitted a different message than the live gate. | `schema` and `kind` are now closed wire types; the dead gate is gone. |
+| `degraded` diagnostics reported `.value.` when the producer sent `last_value`. | Diagnostics carry the member actually read. Covered by `s6_degraded_diagnostics_name_the_last_value_member`. |
+| `source_terminal_state` diagnostics reported `source_error_state`. | The payload helper takes the caller's field path. Covered by `s6_source_terminal_diagnostics_name_their_own_field`. |
+| The corpus covered two of six error codes, so an external implementation could pass every fixture while getting bounds, versioning, and identity wrong. | Added `JSP-E002`, `JSP-E003`, and `JSP-E004` fixtures. |
+| The manifest-driven diagnostic test skipped silently when an error fixture parsed. | It now fails instead of passing vacuously. |
+| `check_bound` described todo counts as byte lengths. | Added `check_count_bound` with count wording. |
+| `limits`/`parse`/`validate`/`wire` were publicly reachable despite the documented contract. | Made private; only `contract` and `error` remain public. |
+| `Provenance` carried unused serde derives, letting it deserialize outside the wire layer. | Derives removed. |
+| `DiagnosticCode` was documented as a closed inventory but only bound-checked. | Documentation corrected to describe an opaque bounded label. |
+
+### Reject
+
+- Make `Snapshot` fields private with accessors. The parser is the only
+  constructor and the guarantee that nothing partially validated escapes was
+  independently confirmed to hold at the crate boundary. Later slices consume
+  these fields directly, and thirteen accessors would add surface without
+  adding safety.
+- Turn `SourceSequence`/`Cursor` into newtypes and split `SupportedState` into
+  three DTOs. Both restructure a contract that behaves correctly today; the
+  illegal-combination rejection is proven by test.
+- Add a `diagnostic_path` member to the field state. This confuses the
+  producer's degraded-value anchor with the parser's own error paths.
+- `Category::Eof` does not exist. It does exist in serde_json 1.0 and the code
+  compiles; this claim is factually wrong.
+- Reject pid `0`. J1 treats pid as descriptive metadata, and process liveness
+  is deliberately Jefe-runtime-owned rather than producer-asserted.
+
+### Defer
+
+- `JSP-E006` has no production call site yet. It is reserved for the snapshot
+  semantic invariants that arrive with events in J2.
+- `ObservationKey` is constructed and unwrapped without carrying its stated
+  meaning. Its purpose appears once the observation map is keyed in J3.
+- Enforce `TodoList`/`CurrentTurn` invariants in the types themselves rather
+  than only in the parser. Worth doing when a second construction path exists.
+
 ## Deferred findings and follow-ups
 
-No review findings or follow-up issues have been recorded yet.
+The Defer rows above are the only outstanding items; none blocks this slice.

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -4,6 +4,9 @@
 //! @requirement REQ-TECH-001
 //! @requirement REQ-TECH-002
 
+/// Transport-neutral observation semantic values (issue #476 J1 slice).
+pub mod observation;
+
 /// Pure document wrapping and content-line scroll geometry.
 pub mod document_wrap;
 /// Shared validated target-resolution predicates for remote settings.

--- a/src/domain/observation.rs
+++ b/src/domain/observation.rs
@@ -1,0 +1,540 @@
+//! Transport-neutral observation semantic values (issue 476, J1 slice).
+//!
+//! This module owns the strongly typed, transport-neutral values that a parsed
+//! JSP/1 snapshot produces. It has no project-internal dependency, no I/O, no
+//! clock, and no credential concern. The `jsp::v1` wire parser converts into
+//! these types only after complete validation, so a partially validated
+//! payload can never escape as a domain value.
+//!
+//! The field-state algebra (decision 5) is closed and exhaustive: every
+//! required snapshot field is either `Unsupported` or a supported provenance
+//! (`Authoritative` or `Inferred`) combined with an availability
+//! (`Unknown`, `Known(value)`, or `Degraded { last_value, as_of_ms,
+//! diagnostic_code }`). `stale` is explicitly **not** a producer value; it is
+//! a local observation-health overlay applied by Jefe transport in a later
+//! slice. Producers cannot assert `stale`.
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Field-state type aliases exported for the typed snapshot contract.
+// ---------------------------------------------------------------------------
+
+/// Convenience alias for the process-binding field state. Binding evidence
+/// only; process liveness stays Jefe-runtime-owned.
+pub type ProcessBindingField = FieldState<ProcessBinding>;
+/// Convenience alias for the native-activity field state.
+pub type NativeActivityField = FieldState<NativeActivityValue>;
+/// Convenience alias for the current-wait field state. `Known(None)` means
+/// explicitly not waiting (no unresolved wait object).
+pub type CurrentWaitField = FieldState<Option<Wait>>;
+/// Convenience alias for the current-turn field state.
+pub type CurrentTurnField = FieldState<CurrentTurn>;
+/// Convenience alias for the todos field state.
+pub type TodosField = FieldState<TodoList>;
+/// Convenience alias for the last-displayed-assistant-message field state.
+pub type LastMessageField = FieldState<DisplayedAssistantMessage>;
+/// Convenience alias for the last-created-tool-call field state.
+pub type LastToolField = FieldState<ToolCallValue>;
+/// Convenience alias for the source-terminal-state field state. `Known(None)`
+/// means a clean terminal with no error state.
+pub type SourceTerminalField = FieldState<Option<SourceErrorValue>>;
+/// Convenience alias for the source-error-state field state.
+pub type SourceErrorField = FieldState<SourceErrorValue>;
+
+// ---------------------------------------------------------------------------
+// Provenance and availability
+// ---------------------------------------------------------------------------
+
+/// Producer-declared provenance for a supported field value.
+///
+/// `Authoritative` means the producer directly observed or authored the value.
+/// `Inferred` means the producer derived it from other evidence. Both are
+/// distinct from `Unsupported`, which is a separate field state rather than a
+/// provenance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Provenance {
+    Authoritative,
+    Inferred,
+}
+
+impl Provenance {
+    /// Map the closed wire label to a typed provenance.
+    #[must_use]
+    pub fn from_wire(label: &str) -> Option<Self> {
+        match label {
+            "authoritative" => Some(Self::Authoritative),
+            "inferred" => Some(Self::Inferred),
+            _ => None,
+        }
+    }
+
+    /// The stable wire label for this provenance.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Authoritative => "authoritative",
+            Self::Inferred => "inferred",
+        }
+    }
+}
+
+/// Availability of a supported field value.
+///
+/// `Known(value)` carries the concrete typed payload. `Unknown` means the
+/// producer supports the field but has no current value. `Degraded` carries the
+/// last accepted value plus a diagnostic anchor. The closed algebra guarantees
+/// downstream `match` sites stay compiler-checked.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Availability<T> {
+    Unknown,
+    Known(T),
+    Degraded {
+        last_value: T,
+        as_of_ms: u64,
+        diagnostic_code: DiagnosticCode,
+    },
+}
+
+impl<T> Availability<T> {
+    /// The current known value, if any (degraded last-value does not count).
+    #[must_use]
+    pub fn known_value(&self) -> Option<&T> {
+        match self {
+            Self::Known(value) => Some(value),
+            Self::Unknown | Self::Degraded { .. } => None,
+        }
+    }
+}
+
+/// Field state: either unsupported by the producer, or supported with a
+/// provenance and availability. This is the closed state algebra from
+/// decision 5.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FieldState<T> {
+    Unsupported,
+    Supported {
+        provenance: Provenance,
+        availability: Availability<T>,
+    },
+}
+
+impl<T> FieldState<T> {
+    /// Build a supported-known field state with the given provenance.
+    #[must_use]
+    pub fn known(provenance: Provenance, value: T) -> Self {
+        Self::Supported {
+            provenance,
+            availability: Availability::Known(value),
+        }
+    }
+
+    /// Build a supported-unknown field state with the given provenance.
+    #[must_use]
+    pub fn unknown(provenance: Provenance) -> Self {
+        Self::Supported {
+            provenance,
+            availability: Availability::Unknown,
+        }
+    }
+
+    /// Whether this field is supported (not `Unsupported`).
+    #[must_use]
+    pub const fn is_supported(&self) -> bool {
+        matches!(self, Self::Supported { .. })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bounded newtype strings
+// ---------------------------------------------------------------------------
+
+/// A stable diagnostic code drawn from a closed inventory. Diagnostic-only;
+/// never echoes producer payload text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticCode(pub(crate) String);
+
+impl DiagnosticCode {
+    /// The diagnostic code as a borrowed string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A bounded opaque safe-ASCII identifier (agent id or source epoch). The
+/// parser enforces 1..=128 bytes of visible ASCII in the closed grammar.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OpaqueId(pub(crate) String);
+
+impl OpaqueId {
+    /// The identifier as a borrowed string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A bounded repository identifier string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepositoryRef(pub(crate) String);
+
+impl RepositoryRef {
+    /// The repository reference as a borrowed string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A bounded absolute path string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathRef(pub(crate) String);
+
+impl PathRef {
+    /// The path as a borrowed string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A bounded native agent-kind label.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentKindLabel(pub(crate) String);
+
+impl AgentKindLabel {
+    /// The agent-kind label as a borrowed string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A bounded display name string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DisplayName(pub(crate) String);
+
+impl DisplayName {
+    /// The display name as a borrowed string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A bounded free-text content string (assistant message, todo text, etc.).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundedText(pub(crate) String);
+
+impl BoundedText {
+    /// The text as a borrowed string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A bounded tool label string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolLabel(pub(crate) String);
+
+impl ToolLabel {
+    /// The label as a borrowed string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A bounded diagnostic summary string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticSummary(pub(crate) String);
+
+impl DiagnosticSummary {
+    /// The summary as a borrowed string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Semantic value structs
+// ---------------------------------------------------------------------------
+
+/// Identity of the live observation key. Repository/path/kind/pid/display-name
+/// never participate in this key (decision 2).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ObservationIdentity {
+    /// Opaque Jefe agent identifier.
+    pub agent_id: OpaqueId,
+    /// Positive lifecycle generation (>=1).
+    pub lifecycle_generation: u64,
+    /// Producer/broker stream identity.
+    pub source_epoch: OpaqueId,
+}
+
+/// Source/native-session identity metadata. Descriptive only; never part of
+/// the live observation key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeSession {
+    pub repository: RepositoryRef,
+    pub path: PathRef,
+    pub agent_kind: AgentKindLabel,
+    pub pid: u32,
+    pub display_name: DisplayName,
+}
+
+/// Producer-reported process binding metadata. This is binding evidence, not
+/// liveness (decision 4): process liveness remains Jefe-runtime-owned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessBinding {
+    pub pid: u32,
+    pub started_at_ms: u64,
+}
+
+/// Native activity state, source-owned (decision 4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeActivityState {
+    Idle,
+    Thinking,
+    Acting,
+}
+
+impl NativeActivityState {
+    /// Map the closed wire label to a typed activity state.
+    #[must_use]
+    pub fn from_wire(label: &str) -> Option<Self> {
+        match label {
+            "idle" => Some(Self::Idle),
+            "thinking" => Some(Self::Thinking),
+            "acting" => Some(Self::Acting),
+            _ => None,
+        }
+    }
+
+    /// The stable wire label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Thinking => "thinking",
+            Self::Acting => "acting",
+        }
+    }
+}
+
+/// Native activity field value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeActivityValue {
+    pub state: NativeActivityState,
+}
+
+/// An explicit unresolved wait reason (decision 7). Silence and elapsed time
+/// never create waiting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaitReason {
+    Permission,
+    Question,
+    Elicitation,
+    Choice,
+    UserInput,
+    Other,
+}
+
+impl WaitReason {
+    /// Map the closed wire label to a typed wait reason.
+    #[must_use]
+    pub fn from_wire(label: &str) -> Option<Self> {
+        match label {
+            "permission" => Some(Self::Permission),
+            "question" => Some(Self::Question),
+            "elicitation" => Some(Self::Elicitation),
+            "choice" => Some(Self::Choice),
+            "user_input" => Some(Self::UserInput),
+            "other" => Some(Self::Other),
+            _ => None,
+        }
+    }
+
+    /// The stable wire label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Permission => "permission",
+            Self::Question => "question",
+            Self::Elicitation => "elicitation",
+            Self::Choice => "choice",
+            Self::UserInput => "user_input",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// An explicit unresolved wait object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Wait {
+    pub reason: WaitReason,
+}
+
+/// Current turn runtime with an elapsed-millisecond anchor (decision 9).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CurrentTurn {
+    pub elapsed_ms: u64,
+}
+
+/// A single todo entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TodoItem {
+    pub text: BoundedText,
+    pub completed: bool,
+}
+
+/// Full-replacement todo list with a strictly increasing revision (decision 8).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TodoList {
+    pub revision: u64,
+    pub items: Vec<TodoItem>,
+}
+
+/// Last displayed assistant message, changing only at a user-visible display
+/// or commit boundary (decision 7).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DisplayedAssistantMessage {
+    pub content: BoundedText,
+    pub committed_ms: u64,
+}
+
+/// Phase of the last-created tool call (decision 8).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolPhase {
+    Proposed,
+    AwaitingApproval,
+    Scheduled,
+    Executing,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+impl ToolPhase {
+    /// Map the closed wire label to a typed tool phase. `stale` is rejected
+    /// here because it is a local transport-health overlay, not a producer
+    /// value (decision 5).
+    #[must_use]
+    pub fn from_wire(label: &str) -> Option<Self> {
+        match label {
+            "proposed" => Some(Self::Proposed),
+            "awaiting_approval" => Some(Self::AwaitingApproval),
+            "scheduled" => Some(Self::Scheduled),
+            "executing" => Some(Self::Executing),
+            "succeeded" => Some(Self::Succeeded),
+            "failed" => Some(Self::Failed),
+            "cancelled" => Some(Self::Cancelled),
+            _ => None,
+        }
+    }
+
+    /// The stable wire label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Proposed => "proposed",
+            Self::AwaitingApproval => "awaiting_approval",
+            Self::Scheduled => "scheduled",
+            Self::Executing => "executing",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+/// Last-created tool call field value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolCallValue {
+    pub label: ToolLabel,
+    pub phase: ToolPhase,
+}
+
+/// Source terminal/error state value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceErrorValue {
+    pub summary: DiagnosticSummary,
+    pub code: BoundedText,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provenance_round_trips_closed_labels() {
+        assert_eq!(
+            Provenance::from_wire("authoritative"),
+            Some(Provenance::Authoritative)
+        );
+        assert_eq!(
+            Provenance::from_wire("inferred"),
+            Some(Provenance::Inferred)
+        );
+        assert_eq!(Provenance::from_wire("bogus"), None);
+        assert_eq!(Provenance::Authoritative.as_str(), "authoritative");
+    }
+
+    #[test]
+    fn field_state_known_and_unknown_helpers() {
+        let known = FieldState::known(Provenance::Authoritative, 42_u32);
+        assert!(known.is_supported());
+        let unknown = FieldState::<u32>::unknown(Provenance::Inferred);
+        assert!(unknown.is_supported());
+        let unsupported = FieldState::<u32>::Unsupported;
+        assert!(!unsupported.is_supported());
+    }
+
+    #[test]
+    fn availability_known_value_extracts_only_current() {
+        let known = Availability::Known(7_u32);
+        assert_eq!(known.known_value(), Some(&7));
+        let degraded = Availability::Degraded {
+            last_value: 7_u32,
+            as_of_ms: 100,
+            diagnostic_code: DiagnosticCode("X".to_string()),
+        };
+        assert_eq!(degraded.known_value(), None);
+    }
+
+    #[test]
+    fn tool_phase_rejects_stale_overlay() {
+        // stale is a local overlay, never a producer value.
+        assert!(ToolPhase::from_wire("stale").is_none());
+        assert_eq!(
+            ToolPhase::from_wire("succeeded"),
+            Some(ToolPhase::Succeeded)
+        );
+    }
+
+    #[test]
+    fn native_activity_closed_labels() {
+        assert_eq!(
+            NativeActivityState::from_wire("idle"),
+            Some(NativeActivityState::Idle)
+        );
+        assert!(NativeActivityState::from_wire("stale").is_none());
+    }
+
+    #[test]
+    fn wait_reason_closed_labels() {
+        assert_eq!(
+            WaitReason::from_wire("permission"),
+            Some(WaitReason::Permission)
+        );
+        assert_eq!(
+            WaitReason::from_wire("user_input"),
+            Some(WaitReason::UserInput)
+        );
+        assert!(WaitReason::from_wire("silence").is_none());
+    }
+}

--- a/src/domain/observation.rs
+++ b/src/domain/observation.rs
@@ -536,3 +536,95 @@ mod tests {
         assert!(WaitReason::from_wire("silence").is_none());
     }
 }
+
+// ---------------------------------------------------------------------------
+// Event semantics
+// ---------------------------------------------------------------------------
+
+/// How a turn finished (specification 18.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnOutcome {
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl TurnOutcome {
+    /// Map the closed wire label to a typed outcome.
+    #[must_use]
+    pub fn from_wire(label: &str) -> Option<Self> {
+        match label {
+            "completed" => Some(Self::Completed),
+            "failed" => Some(Self::Failed),
+            "cancelled" => Some(Self::Cancelled),
+            _ => None,
+        }
+    }
+
+    /// The stable wire label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+/// One authoritative native transition.
+///
+/// The inventory is closed: an unknown event type is rejected rather than
+/// ignored, because silently dropping a transition leaves a status view
+/// confidently wrong instead of visibly unknown.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ObservationEvent {
+    /// Native activity changed.
+    ActivityChanged { state: NativeActivityState },
+    /// An explicit blocking request opened. Only this creates waiting.
+    WaitOpened { reason: WaitReason },
+    /// The open blocking request was answered natively.
+    WaitResolved,
+    /// A turn began; elapsed time anchors at zero.
+    TurnStarted,
+    /// A turn finished with an explicit outcome.
+    TurnEnded { outcome: TurnOutcome },
+    /// Full replacement of the structured todo list.
+    TodosReplaced { todos: TodoList },
+    /// A tool call was created. Creation order defines the current tool.
+    ToolCallCreated { tool: ToolCallValue },
+    /// The current tool call changed phase.
+    ToolCallPhaseChanged { tool: ToolCallValue },
+    /// A completed assistant reply became user-visible.
+    AssistantMessageDisplayed { message: DisplayedAssistantMessage },
+    /// The source reported an error state.
+    SourceError { error: SourceErrorValue },
+    /// The native session ended.
+    SessionEnded,
+}
+
+/// A validated event record: identity, ordering, and one transition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventRecord {
+    /// Live observation key this event belongs to.
+    pub identity: ObservationIdentity,
+    /// Ordering sequence, used for gap detection only.
+    pub source_sequence: u64,
+    /// Bridge observation timestamp.
+    pub bridge_observed_ms: u64,
+    /// The transition itself.
+    pub event: ObservationEvent,
+}
+
+/// A validated heartbeat: the status source is alive but has no transition.
+///
+/// A heartbeat carries no sequence, so it can neither advance nor gap the
+/// stream. A missed heartbeat means telemetry is stale, never that the agent
+/// is idle or dead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeartbeatRecord {
+    /// Live observation key this heartbeat belongs to.
+    pub identity: ObservationIdentity,
+    /// Bridge observation timestamp.
+    pub bridge_observed_ms: u64,
+}

--- a/src/domain/observation.rs
+++ b/src/domain/observation.rs
@@ -14,8 +14,6 @@
 //! a local observation-health overlay applied by Jefe transport in a later
 //! slice. Producers cannot assert `stale`.
 
-use serde::{Deserialize, Serialize};
-
 // ---------------------------------------------------------------------------
 // Field-state type aliases exported for the typed snapshot contract.
 // ---------------------------------------------------------------------------
@@ -52,8 +50,7 @@ pub type SourceErrorField = FieldState<SourceErrorValue>;
 /// `Inferred` means the producer derived it from other evidence. Both are
 /// distinct from `Unsupported`, which is a separate field state rather than a
 /// provenance.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Provenance {
     Authoritative,
     Inferred,
@@ -150,8 +147,9 @@ impl<T> FieldState<T> {
 // Bounded newtype strings
 // ---------------------------------------------------------------------------
 
-/// A stable diagnostic code drawn from a closed inventory. Diagnostic-only;
-/// never echoes producer payload text.
+/// A bounded producer-supplied diagnostic code. It is an opaque correlation
+/// label only: Jefe never interprets it and never echoes it in parser
+/// diagnostics.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiagnosticCode(pub(crate) String);
 

--- a/src/jsp/mod.rs
+++ b/src/jsp/mod.rs
@@ -1,0 +1,17 @@
+//! JSP — Jefe Stream Protocol external wire boundary (issue #476).
+//!
+//! JSP is the closed JSON wire contract between a Jefe agent observer and
+//! external producers/brokers. The `v1` module owns the schema-1 snapshot
+//! parser/validator. It depends only on `domain::observation`, the standard
+//! library, and existing `serde`/`serde_json`. Private closed wire DTOs convert
+//! to typed domain values only after complete validation.
+//!
+//! This crate root re-exports the public parsing surface. The internal wire
+//! DTOs, limits, and helpers are intentionally not re-exported: the public API
+//! is minimal and strongly typed.
+
+pub mod v1;
+
+pub use v1::Snapshot;
+pub use v1::error::{JspCode, JspError};
+pub use v1::parse_snapshot;

--- a/src/jsp/v1/contract.rs
+++ b/src/jsp/v1/contract.rs
@@ -1,0 +1,84 @@
+//! Public typed JSP/1 snapshot contract (issue #476, J1 slice).
+//!
+//! [`Snapshot`] is the validated, strongly typed result of parsing a JSP/1
+//! snapshot document. It wraps the transport-neutral domain observation values
+//! from [`crate::domain::observation`] together with the wire-level identity
+//! key and ordering fields. Construction goes through the strict parse layer;
+//! callers cannot build a partially validated snapshot.
+
+use crate::domain::observation::{
+    CurrentTurnField, CurrentWaitField, LastMessageField, LastToolField, NativeActivityField,
+    NativeSession, ObservationIdentity, ProcessBindingField, SourceErrorField, SourceTerminalField,
+    TodosField,
+};
+
+/// Monotonic source sequence consumed by a record (decision 10).
+pub type SourceSequence = u64;
+
+/// Cursor reflecting all effects through it (decision 10).
+pub type Cursor = u64;
+
+/// The live observation key. This is the identity that distinguishes two
+/// independent observation streams.
+///
+/// Repository/path/kind/pid/display-name are descriptive metadata on the
+/// [`Snapshot`] and never participate in this key (decision 2).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ObservationKey(pub(crate) ObservationIdentity);
+
+impl ObservationKey {
+    /// The underlying observation identity.
+    #[must_use]
+    pub fn identity(&self) -> &ObservationIdentity {
+        &self.0
+    }
+}
+
+/// A fully parsed and validated JSP/1 snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Snapshot {
+    /// The live observation key (agent/generation/epoch).
+    pub identity: ObservationIdentity,
+    /// Monotonic source sequence consumed by this snapshot.
+    pub source_sequence: SourceSequence,
+    /// Cursor reflecting all effects applied through it.
+    pub cursor: Cursor,
+    /// Bridge observation timestamp (bounded UTC epoch milliseconds).
+    pub bridge_observed_ms: u64,
+    /// Source/native-session descriptive identity.
+    pub native_session: NativeSession,
+    /// Producer-reported process binding metadata (not liveness).
+    pub process_binding: ProcessBindingField,
+    /// Native activity (source-owned).
+    pub native_activity: NativeActivityField,
+    /// Current explicit wait state.
+    pub current_wait: CurrentWaitField,
+    /// Current turn runtime.
+    pub current_turn: CurrentTurnField,
+    /// Full-replacement todo list.
+    pub todos: TodosField,
+    /// Last displayed assistant message.
+    pub last_displayed_assistant_message: LastMessageField,
+    /// Last-created tool call.
+    pub last_created_tool_call: LastToolField,
+    /// Source terminal state.
+    pub source_terminal_state: SourceTerminalField,
+    /// Source error state.
+    pub source_error_state: SourceErrorField,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observation_key_wraps_identity() {
+        let identity = ObservationIdentity {
+            agent_id: crate::domain::observation::OpaqueId("a".to_string()),
+            lifecycle_generation: 1,
+            source_epoch: crate::domain::observation::OpaqueId("e".to_string()),
+        };
+        let key = ObservationKey(identity);
+        assert_eq!(key.identity().agent_id.as_str(), "a");
+    }
+}

--- a/src/jsp/v1/error.rs
+++ b/src/jsp/v1/error.rs
@@ -1,0 +1,160 @@
+//! Stable JSP/1 error code taxonomy (issue #476, J1 slice, decision 14).
+//!
+//! Six stable error codes cover the closed parser surface. Diagnostics carry
+//! a stable code and a safe, payload-free detail string. The parser never
+//! echoes producer input values in diagnostics.
+
+use std::fmt;
+
+/// Stable error codes for JSP/1.
+///
+/// These strings are part of the wire contract and must not change without a
+/// version bump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JspCode {
+    /// `JSP-E001` — closed JSON syntax/shape: malformed JSON, unknown field,
+    /// duplicate field, wrong type, trailing data.
+    EClosedShape,
+    /// `JSP-E002` — inclusive bound exceeded (size, length, count).
+    EBound,
+    /// `JSP-E003` — unsupported version or kind.
+    EUnsupportedVersion,
+    /// `JSP-E004` — identity/binding invariant violation.
+    EIdentity,
+    /// `JSP-E005` — field-state violation (illegal state algebra).
+    EFieldState,
+    /// `JSP-E006` — snapshot semantic invariant violation.
+    ESemantic,
+}
+
+impl JspCode {
+    /// The stable wire string for this code.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::EClosedShape => "JSP-E001",
+            Self::EBound => "JSP-E002",
+            Self::EUnsupportedVersion => "JSP-E003",
+            Self::EIdentity => "JSP-E004",
+            Self::EFieldState => "JSP-E005",
+            Self::ESemantic => "JSP-E006",
+        }
+    }
+}
+
+impl fmt::Display for JspCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A coded JSP/1 parse error with a safe, payload-free detail string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JspError {
+    code: JspCode,
+    detail: String,
+}
+
+impl JspError {
+    /// Construct an error from a code and a safe detail string.
+    #[must_use]
+    pub fn new(code: JspCode, detail: impl Into<String>) -> Self {
+        Self {
+            code,
+            detail: detail.into(),
+        }
+    }
+
+    /// `JSP-E001` closed-shape error.
+    #[must_use]
+    pub fn closed_shape(detail: impl Into<String>) -> Self {
+        Self::new(JspCode::EClosedShape, detail)
+    }
+
+    /// `JSP-E002` bound error.
+    #[must_use]
+    pub fn bound(detail: impl Into<String>) -> Self {
+        Self::new(JspCode::EBound, detail)
+    }
+
+    /// `JSP-E003` unsupported-version/kind error.
+    #[must_use]
+    pub fn unsupported_version(detail: impl Into<String>) -> Self {
+        Self::new(JspCode::EUnsupportedVersion, detail)
+    }
+
+    /// `JSP-E004` identity error.
+    #[must_use]
+    pub fn identity(detail: impl Into<String>) -> Self {
+        Self::new(JspCode::EIdentity, detail)
+    }
+
+    /// `JSP-E005` field-state error.
+    #[must_use]
+    pub fn field_state(detail: impl Into<String>) -> Self {
+        Self::new(JspCode::EFieldState, detail)
+    }
+
+    /// `JSP-E006` semantic error.
+    #[must_use]
+    pub fn semantic(detail: impl Into<String>) -> Self {
+        Self::new(JspCode::ESemantic, detail)
+    }
+
+    /// The stable error code.
+    #[must_use]
+    pub const fn code(&self) -> JspCode {
+        self.code
+    }
+
+    /// The safe, payload-free detail string.
+    #[must_use]
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+}
+
+impl fmt::Display for JspError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.code, self.detail)
+    }
+}
+
+impl std::error::Error for JspError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codes_have_stable_strings() {
+        assert_eq!(JspCode::EClosedShape.as_str(), "JSP-E001");
+        assert_eq!(JspCode::EBound.as_str(), "JSP-E002");
+        assert_eq!(JspCode::EUnsupportedVersion.as_str(), "JSP-E003");
+        assert_eq!(JspCode::EIdentity.as_str(), "JSP-E004");
+        assert_eq!(JspCode::EFieldState.as_str(), "JSP-E005");
+        assert_eq!(JspCode::ESemantic.as_str(), "JSP-E006");
+    }
+
+    #[test]
+    fn constructors_map_to_correct_codes() {
+        assert_eq!(JspError::closed_shape("x").code(), JspCode::EClosedShape);
+        assert_eq!(JspError::bound("x").code(), JspCode::EBound);
+        assert_eq!(
+            JspError::unsupported_version("x").code(),
+            JspCode::EUnsupportedVersion
+        );
+        assert_eq!(JspError::identity("x").code(), JspCode::EIdentity);
+        assert_eq!(JspError::field_state("x").code(), JspCode::EFieldState);
+        assert_eq!(JspError::semantic("x").code(), JspCode::ESemantic);
+    }
+
+    #[test]
+    fn display_includes_code_and_detail() {
+        let error = JspError::bound("snapshot.agent_id: exceeds maximum length");
+        assert_eq!(
+            error.to_string(),
+            "JSP-E002: snapshot.agent_id: exceeds maximum length"
+        );
+    }
+}

--- a/src/jsp/v1/event.rs
+++ b/src/jsp/v1/event.rs
@@ -1,0 +1,197 @@
+//! Event and heartbeat parsing for JSP/1 (issue #476).
+//!
+//! [`parse_event`] and [`parse_heartbeat`] mirror the snapshot entry point:
+//! they perform no I/O and no logging, enforce the document byte bound before
+//! parsing, gate the schema and kind, deserialize a closed envelope, and only
+//! then convert into typed domain values. Diagnostics never echo producer
+//! payload values.
+
+use crate::domain::observation::{
+    BoundedText, DiagnosticSummary, DisplayedAssistantMessage, EventRecord, HeartbeatRecord,
+    NativeActivityState, ObservationEvent, SourceErrorValue, TodoItem, TodoList, ToolCallValue,
+    ToolLabel, ToolPhase, TurnOutcome, WaitReason,
+};
+
+use super::error::JspError;
+use super::event_wire::{EventPayloadWire, EventWire, HeartbeatWire};
+use super::parse::{check_document_bound, deserialize_closed, expect_kind};
+use super::validate::{bounded, build_event_identity, count_bound};
+use super::wire::{FieldLimits, TodoItemWire};
+
+/// Parse JSP/1 event bytes into a validated [`EventRecord`].
+///
+/// # Errors
+///
+/// - `JSP-E001` for malformed JSON, unknown/duplicate fields, unknown event
+///   types, or any closed-shape violation.
+/// - `JSP-E002` for exceeded inclusive bounds.
+/// - `JSP-E003` for unsupported schema or kind.
+/// - `JSP-E004` for identity invariants.
+/// - `JSP-E005` for illegal field values such as a producer-sent `stale`.
+pub fn parse_event(input: &[u8]) -> Result<EventRecord, JspError> {
+    check_document_bound(input)?;
+    expect_kind(input, "event")?;
+    let wire: EventWire = deserialize_closed(input)?;
+    convert_event(wire)
+}
+
+/// Parse JSP/1 heartbeat bytes into a validated [`HeartbeatRecord`].
+///
+/// # Errors
+///
+/// Same taxonomy as [`parse_event`].
+pub fn parse_heartbeat(input: &[u8]) -> Result<HeartbeatRecord, JspError> {
+    check_document_bound(input)?;
+    expect_kind(input, "heartbeat")?;
+    let wire: HeartbeatWire = deserialize_closed(input)?;
+    Ok(HeartbeatRecord {
+        identity: build_event_identity(
+            &wire.agent_id,
+            wire.lifecycle_generation,
+            &wire.source_epoch,
+        )?,
+        bridge_observed_ms: wire.bridge_observed_ms,
+    })
+}
+
+/// Convert a deserialized event envelope into a typed record.
+fn convert_event(wire: EventWire) -> Result<EventRecord, JspError> {
+    let identity = build_event_identity(
+        &wire.agent_id,
+        wire.lifecycle_generation,
+        &wire.source_epoch,
+    )?;
+    let event = convert_payload(wire.event)?;
+    Ok(EventRecord {
+        identity,
+        source_sequence: wire.source_sequence,
+        bridge_observed_ms: wire.bridge_observed_ms,
+        event,
+    })
+}
+
+/// Convert the closed payload into the typed transition.
+fn convert_payload(payload: EventPayloadWire) -> Result<ObservationEvent, JspError> {
+    match payload {
+        EventPayloadWire::ActivityChanged { state } => convert_activity(&state),
+        EventPayloadWire::WaitOpened { reason } => convert_wait_opened(&reason),
+        EventPayloadWire::WaitResolved => Ok(ObservationEvent::WaitResolved),
+        EventPayloadWire::TurnStarted => Ok(ObservationEvent::TurnStarted),
+        EventPayloadWire::TurnEnded { outcome } => convert_turn_ended(&outcome),
+        EventPayloadWire::TodosReplaced { revision, items } => convert_todos(revision, &items),
+        EventPayloadWire::ToolCallCreated { label, phase } => {
+            Ok(ObservationEvent::ToolCallCreated {
+                tool: convert_tool("event.tool_call.created", &label, &phase)?,
+            })
+        }
+        EventPayloadWire::ToolCallPhaseChanged { label, phase } => {
+            Ok(ObservationEvent::ToolCallPhaseChanged {
+                tool: convert_tool("event.tool_call.phase_changed", &label, &phase)?,
+            })
+        }
+        EventPayloadWire::AssistantMessageDisplayed {
+            content,
+            committed_ms,
+        } => convert_message(&content, committed_ms),
+        EventPayloadWire::SourceError { summary, code } => convert_source_error(&summary, &code),
+        EventPayloadWire::SessionEnded => Ok(ObservationEvent::SessionEnded),
+    }
+}
+
+/// Convert an activity transition, rejecting states outside the inventory.
+fn convert_activity(state: &str) -> Result<ObservationEvent, JspError> {
+    let state = NativeActivityState::from_wire(state).ok_or_else(|| {
+        JspError::field_state("event.activity.changed.state: unsupported activity state")
+    })?;
+    Ok(ObservationEvent::ActivityChanged { state })
+}
+
+/// Convert a wait-opened transition. Only an explicit reason creates waiting.
+fn convert_wait_opened(reason: &str) -> Result<ObservationEvent, JspError> {
+    let reason = WaitReason::from_wire(reason)
+        .ok_or_else(|| JspError::field_state("event.wait.opened.reason: unsupported reason"))?;
+    Ok(ObservationEvent::WaitOpened { reason })
+}
+
+/// Convert a turn-ended transition with a closed outcome.
+fn convert_turn_ended(outcome: &str) -> Result<ObservationEvent, JspError> {
+    let outcome = TurnOutcome::from_wire(outcome)
+        .ok_or_else(|| JspError::field_state("event.turn.ended.outcome: unsupported outcome"))?;
+    Ok(ObservationEvent::TurnEnded { outcome })
+}
+
+/// Convert a full todo replacement, applying the section 8 invariants.
+fn convert_todos(revision: u64, items: &[TodoItemWire]) -> Result<ObservationEvent, JspError> {
+    if revision == 0 {
+        return Err(JspError::field_state(
+            "event.todos.replaced.revision: must be a positive integer",
+        ));
+    }
+    count_bound(
+        "event.todos.replaced.items",
+        items.len(),
+        FieldLimits::TODOS,
+    )?;
+    let mut converted = Vec::with_capacity(items.len());
+    for (index, item) in items.iter().enumerate() {
+        let path = format!("event.todos.replaced.items[{index}].text");
+        converted.push(TodoItem {
+            text: bounded(&path, &item.text, FieldLimits::TODO_TEXT, BoundedText)?,
+            completed: item.completed,
+        });
+    }
+    Ok(ObservationEvent::TodosReplaced {
+        todos: TodoList {
+            revision,
+            items: converted,
+        },
+    })
+}
+
+/// Convert a tool-call transition, rejecting phases outside the inventory.
+fn convert_tool(path: &str, label: &str, phase: &str) -> Result<ToolCallValue, JspError> {
+    let label = bounded(
+        &format!("{path}.label"),
+        label,
+        FieldLimits::TOOL_LABEL,
+        ToolLabel,
+    )?;
+    let phase = ToolPhase::from_wire(phase)
+        .ok_or_else(|| JspError::field_state(format!("{path}.phase: unsupported phase")))?;
+    Ok(ToolCallValue { label, phase })
+}
+
+/// Convert a displayed-message transition.
+fn convert_message(content: &str, committed_ms: u64) -> Result<ObservationEvent, JspError> {
+    Ok(ObservationEvent::AssistantMessageDisplayed {
+        message: DisplayedAssistantMessage {
+            content: bounded(
+                "event.assistant_message.displayed.content",
+                content,
+                FieldLimits::DISPLAYED_CONTENT,
+                BoundedText,
+            )?,
+            committed_ms,
+        },
+    })
+}
+
+/// Convert a source-error transition.
+fn convert_source_error(summary: &str, code: &str) -> Result<ObservationEvent, JspError> {
+    Ok(ObservationEvent::SourceError {
+        error: SourceErrorValue {
+            summary: bounded(
+                "event.source.error.summary",
+                summary,
+                FieldLimits::DIAGNOSTIC_SUMMARY,
+                DiagnosticSummary,
+            )?,
+            code: bounded(
+                "event.source.error.code",
+                code,
+                FieldLimits::ERROR_CODE,
+                BoundedText,
+            )?,
+        },
+    })
+}

--- a/src/jsp/v1/event_wire.rs
+++ b/src/jsp/v1/event_wire.rs
@@ -1,0 +1,98 @@
+//! Closed wire DTOs for JSP/1 event and heartbeat documents (issue #476).
+//!
+//! These types are private to the crate and model the exact closed envelopes
+//! from specification sections 18 and 19. Like the snapshot DTOs they use
+//! `#[serde(deny_unknown_fields)]` and closed enums, so unknown members,
+//! duplicate keys, and wrong types fail during deserialization rather than
+//! being ignored. Conversion to typed domain values happens in `event` only
+//! after the whole document has deserialized.
+//!
+//! Payload variants list their members explicitly rather than using
+//! `#[serde(flatten)]`, because flattening silently disables
+//! `deny_unknown_fields` and would reopen the envelope.
+
+use serde::Deserialize;
+
+use super::wire::{AcceptedSchema, TodoItemWire};
+
+/// The `kind` discriminator for an event document.
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventKindWire {
+    Event,
+}
+
+/// The `kind` discriminator for a heartbeat document.
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HeartbeatKindWire {
+    Heartbeat,
+}
+
+/// The closed top-level event envelope (specification 18).
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EventWire {
+    #[serde(rename = "schema")]
+    pub _schema: AcceptedSchema,
+    #[serde(rename = "kind")]
+    pub _kind: EventKindWire,
+    pub agent_id: String,
+    pub lifecycle_generation: u64,
+    pub source_epoch: String,
+    pub source_sequence: u64,
+    pub bridge_observed_ms: u64,
+    pub event: EventPayloadWire,
+}
+
+/// The closed top-level heartbeat envelope (specification 19).
+///
+/// A heartbeat deliberately has no `source_sequence`: it reports source
+/// liveness, not a state transition, so it must not advance or gap the stream.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HeartbeatWire {
+    #[serde(rename = "schema")]
+    pub _schema: AcceptedSchema,
+    #[serde(rename = "kind")]
+    pub _kind: HeartbeatKindWire,
+    pub agent_id: String,
+    pub lifecycle_generation: u64,
+    pub source_epoch: String,
+    pub bridge_observed_ms: u64,
+}
+
+/// The closed event payload, discriminated by `type`.
+///
+/// An unknown `type` fails as a closed-shape violation. There is no
+/// forward-compatible ignore rule: dropping a transition would leave the
+/// status view confidently wrong rather than visibly unknown.
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum EventPayloadWire {
+    #[serde(rename = "activity.changed")]
+    ActivityChanged { state: String },
+    #[serde(rename = "wait.opened")]
+    WaitOpened { reason: String },
+    #[serde(rename = "wait.resolved")]
+    WaitResolved,
+    #[serde(rename = "turn.started")]
+    TurnStarted,
+    #[serde(rename = "turn.ended")]
+    TurnEnded { outcome: String },
+    #[serde(rename = "todos.replaced")]
+    TodosReplaced {
+        revision: u64,
+        items: Vec<TodoItemWire>,
+    },
+    #[serde(rename = "tool_call.created")]
+    ToolCallCreated { label: String, phase: String },
+    #[serde(rename = "tool_call.phase_changed")]
+    ToolCallPhaseChanged { label: String, phase: String },
+    #[serde(rename = "assistant_message.displayed")]
+    AssistantMessageDisplayed { content: String, committed_ms: u64 },
+    #[serde(rename = "source.error")]
+    SourceError { summary: String, code: String },
+    #[serde(rename = "session.ended")]
+    SessionEnded,
+}

--- a/src/jsp/v1/limits.rs
+++ b/src/jsp/v1/limits.rs
@@ -70,11 +70,18 @@ pub fn check_count_bound(
 ) -> Result<(), crate::jsp::v1::error::JspError> {
     if count > max {
         Err(crate::jsp::v1::error::JspError::bound(format!(
-            "{path}: {count} entries exceeds maximum {max} entries"
+            "{path}: {count} {} exceeds maximum {max} {}",
+            plural_entries(count),
+            plural_entries(max)
         )))
     } else {
         Ok(())
     }
+}
+
+/// The correctly pluralized noun for an entry count.
+const fn plural_entries(count: usize) -> &'static str {
+    if count == 1 { "entry" } else { "entries" }
 }
 
 #[cfg(test)]
@@ -94,5 +101,40 @@ mod tests {
     #[test]
     fn zero_length_accepted() {
         assert!(check_bound("x", 0, MAX_ID_BYTES).is_ok());
+    }
+
+    #[test]
+    fn document_bound_is_inclusive() {
+        assert!(check_bound("doc", MAX_DOCUMENT_BYTES, MAX_DOCUMENT_BYTES).is_ok());
+        let error = check_bound("doc", MAX_DOCUMENT_BYTES + 1, MAX_DOCUMENT_BYTES)
+            .err()
+            .unwrap_or_else(|| panic!("over the document limit must fail"));
+        assert_eq!(error.code(), JspCode::EBound);
+    }
+
+    #[test]
+    fn count_bound_is_inclusive_and_reports_counts() {
+        assert!(check_count_bound("items", MAX_TODOS, MAX_TODOS).is_ok());
+        let error = check_count_bound("items", MAX_TODOS + 1, MAX_TODOS)
+            .err()
+            .unwrap_or_else(|| panic!("over the todo count must fail"));
+        assert_eq!(error.code(), JspCode::EBound);
+        assert!(
+            error.detail().contains("entries"),
+            "a count bound reports entries rather than bytes: {}",
+            error.detail()
+        );
+    }
+
+    #[test]
+    fn count_bound_reports_a_single_entry_in_the_singular() {
+        let error = check_count_bound("items", 2, 1)
+            .err()
+            .unwrap_or_else(|| panic!("over a one-entry limit must fail"));
+        assert!(
+            error.detail().contains("maximum 1 entry"),
+            "a one-entry maximum reads in the singular: {}",
+            error.detail()
+        );
     }
 }

--- a/src/jsp/v1/limits.rs
+++ b/src/jsp/v1/limits.rs
@@ -70,18 +70,11 @@ pub fn check_count_bound(
 ) -> Result<(), crate::jsp::v1::error::JspError> {
     if count > max {
         Err(crate::jsp::v1::error::JspError::bound(format!(
-            "{path}: {count} {} exceeds maximum {max} {}",
-            plural_entries(count),
-            plural_entries(max)
+            "{path}: count {count} exceeds maximum {max}"
         )))
     } else {
         Ok(())
     }
-}
-
-/// The correctly pluralized noun for an entry count.
-const fn plural_entries(count: usize) -> &'static str {
-    if count == 1 { "entry" } else { "entries" }
 }
 
 #[cfg(test)]
@@ -120,20 +113,8 @@ mod tests {
             .unwrap_or_else(|| panic!("over the todo count must fail"));
         assert_eq!(error.code(), JspCode::EBound);
         assert!(
-            error.detail().contains("entries"),
-            "a count bound reports entries rather than bytes: {}",
-            error.detail()
-        );
-    }
-
-    #[test]
-    fn count_bound_reports_a_single_entry_in_the_singular() {
-        let error = check_count_bound("items", 2, 1)
-            .err()
-            .unwrap_or_else(|| panic!("over a one-entry limit must fail"));
-        assert!(
-            error.detail().contains("maximum 1 entry"),
-            "a one-entry maximum reads in the singular: {}",
+            error.detail().contains("count") && !error.detail().contains("length"),
+            "a count bound reports a count rather than a byte length: {}",
             error.detail()
         );
     }

--- a/src/jsp/v1/limits.rs
+++ b/src/jsp/v1/limits.rs
@@ -1,0 +1,76 @@
+//! Inclusive JSP/1 bounds (issue #476, J1 slice, decision 13).
+//!
+//! Every bound is inclusive: an at-limit input is accepted and a
+//! limit-plus-one input fails before a contract value is returned. Limits are
+//! applied during deserialization and validation.
+
+/// Maximum total snapshot document size in bytes (256 KiB).
+pub const MAX_DOCUMENT_BYTES: usize = 256 * 1024;
+/// Maximum length in bytes of an opaque identifier (agent id, source epoch).
+pub const MAX_ID_BYTES: usize = 128;
+/// Maximum number of todo entries.
+pub const MAX_TODOS: usize = 256;
+/// Maximum length in bytes of a todo text string.
+pub const MAX_TODO_TEXT_BYTES: usize = 2 * 1024;
+/// Maximum length in bytes of displayed assistant content.
+pub const MAX_DISPLAYED_CONTENT_BYTES: usize = 16 * 1024;
+/// Maximum length in bytes of a source diagnostic summary.
+pub const MAX_DIAGNOSTIC_SUMMARY_BYTES: usize = 2 * 1024;
+/// Maximum length in bytes of a tool label.
+pub const MAX_TOOL_LABEL_BYTES: usize = 256;
+/// Maximum length in bytes of a repository reference.
+pub const MAX_REPOSITORY_BYTES: usize = 256;
+/// Maximum length in bytes of a path reference.
+pub const MAX_PATH_BYTES: usize = 4 * 1024;
+/// Maximum length in bytes of an agent-kind label.
+pub const MAX_AGENT_KIND_BYTES: usize = 64;
+/// Maximum length in bytes of a display name.
+pub const MAX_DISPLAY_NAME_BYTES: usize = 256;
+/// Maximum length in bytes of a diagnostic code.
+pub const MAX_DIAGNOSTIC_CODE_BYTES: usize = 128;
+/// Maximum length in bytes of a bounded free-text error code field.
+pub const MAX_ERROR_CODE_BYTES: usize = 128;
+
+/// The single accepted schema version.
+pub const ACCEPTED_SCHEMA: u64 = 1;
+/// The single accepted top-level kind for a snapshot document.
+pub const SNAPSHOT_KIND: &str = "snapshot";
+
+/// Validate that a byte length is within the inclusive bound.
+///
+/// # Errors
+///
+/// Returns a `JSP-E002` bound error if `len > max`.
+pub fn check_bound(
+    path: &str,
+    len: usize,
+    max: usize,
+) -> Result<(), crate::jsp::v1::error::JspError> {
+    if len > max {
+        Err(crate::jsp::v1::error::JspError::bound(format!(
+            "{path}: length {len} exceeds maximum {max}"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jsp::v1::error::JspCode;
+
+    #[test]
+    fn at_limit_accepted_over_limit_rejected() {
+        assert!(check_bound("x", MAX_ID_BYTES, MAX_ID_BYTES).is_ok());
+        let error = check_bound("x", MAX_ID_BYTES + 1, MAX_ID_BYTES)
+            .err()
+            .unwrap_or_else(|| panic!("over limit must fail"));
+        assert_eq!(error.code(), JspCode::EBound);
+    }
+
+    #[test]
+    fn zero_length_accepted() {
+        assert!(check_bound("x", 0, MAX_ID_BYTES).is_ok());
+    }
+}

--- a/src/jsp/v1/limits.rs
+++ b/src/jsp/v1/limits.rs
@@ -48,7 +48,29 @@ pub fn check_bound(
 ) -> Result<(), crate::jsp::v1::error::JspError> {
     if len > max {
         Err(crate::jsp::v1::error::JspError::bound(format!(
-            "{path}: length {len} exceeds maximum {max}"
+            "{path}: length {len} bytes exceeds maximum {max} bytes"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+/// Validate that an item count is within the inclusive bound.
+///
+/// Counts are reported as counts rather than byte lengths so a producer can
+/// tell which bound it violated.
+///
+/// # Errors
+///
+/// Returns a `JSP-E002` bound error if `count > max`.
+pub fn check_count_bound(
+    path: &str,
+    count: usize,
+    max: usize,
+) -> Result<(), crate::jsp::v1::error::JspError> {
+    if count > max {
+        Err(crate::jsp::v1::error::JspError::bound(format!(
+            "{path}: {count} entries exceeds maximum {max} entries"
         )))
     } else {
         Ok(())

--- a/src/jsp/v1/mod.rs
+++ b/src/jsp/v1/mod.rs
@@ -1,0 +1,28 @@
+//! JSP/1 schema-1 snapshot parser and validator (issue #476, J1 slice).
+//!
+//! This module freezes the external semantic and wire contract for JSP/1
+//! snapshots. It provides a strict typed snapshot validator over a closed JSON
+//! envelope. The public entry point is [`parse_snapshot`], which returns a
+//! strongly typed [`Snapshot`] or a coded [`JspError`].
+//!
+//! Architecture:
+//! - [`error`] owns the stable error code taxonomy (`JSP-E001`..`JSP-E006`).
+//! - [`limits`] owns the inclusive bounds.
+//! - [`wire`] owns the private closed wire DTOs.
+//! - [`contract`] owns the public typed snapshot and identity.
+//! - [`validate`] owns the validation/conversion from wire DTOs to domain.
+//! - [`parse`] owns the parser entry point and serde orchestration.
+//!
+//! The parser performs no I/O and no logging. Diagnostics carry stable
+//! code/path/location and never echo producer payload values.
+
+pub mod contract;
+pub mod error;
+pub mod limits;
+pub mod parse;
+pub mod validate;
+pub mod wire;
+
+pub use contract::{Cursor, ObservationKey, Snapshot, SourceSequence};
+pub use error::{JspCode, JspError};
+pub use parse::parse_snapshot;

--- a/src/jsp/v1/mod.rs
+++ b/src/jsp/v1/mod.rs
@@ -18,10 +18,10 @@
 
 pub mod contract;
 pub mod error;
-pub mod limits;
-pub mod parse;
-pub mod validate;
-pub mod wire;
+mod limits;
+mod parse;
+mod validate;
+mod wire;
 
 pub use contract::{Cursor, ObservationKey, Snapshot, SourceSequence};
 pub use error::{JspCode, JspError};

--- a/src/jsp/v1/mod.rs
+++ b/src/jsp/v1/mod.rs
@@ -18,6 +18,8 @@
 
 pub mod contract;
 pub mod error;
+mod event;
+mod event_wire;
 mod limits;
 mod parse;
 mod validate;
@@ -25,4 +27,5 @@ mod wire;
 
 pub use contract::{Cursor, ObservationKey, Snapshot, SourceSequence};
 pub use error::{JspCode, JspError};
+pub use event::{parse_event, parse_heartbeat};
 pub use parse::parse_snapshot;

--- a/src/jsp/v1/parse.rs
+++ b/src/jsp/v1/parse.rs
@@ -1,0 +1,207 @@
+//! JSP/1 snapshot parser entry point (issue #476, J1 slice).
+//!
+//! [`parse_snapshot`] is the single public entry point. It performs no I/O and
+//! no logging. It enforces the document byte bound, deserializes the closed
+//! wire envelope (which rejects unknown/duplicate fields and wrong types),
+//! then delegates to [`validate`] for typed conversion. A partially validated
+//! payload never escapes: the wire DTO converts to a [`Snapshot`] only after
+//! complete validation.
+//!
+//! Diagnostics carry stable code/path/location and never echo producer payload
+//! values.
+
+use serde::Deserialize as _;
+
+use super::contract::Snapshot;
+use super::error::JspError;
+use super::limits::{ACCEPTED_SCHEMA, MAX_DOCUMENT_BYTES, SNAPSHOT_KIND};
+use super::validate;
+use super::wire::SnapshotWire;
+
+#[cfg(test)]
+use super::error::JspCode;
+
+/// Parse JSP/1 snapshot bytes into a validated typed [`Snapshot`].
+///
+/// # Errors
+///
+/// - `JSP-E001` for malformed JSON, trailing data, unknown/duplicate fields,
+///   wrong types, or any closed-shape violation.
+/// - `JSP-E002` for exceeded inclusive bounds.
+/// - `JSP-E003` for unsupported schema or kind.
+/// - `JSP-E004` for identity/binding invariants.
+/// - `JSP-E005` for illegal field-state combinations.
+/// - `JSP-E006` for snapshot semantic invariants.
+///
+/// The parser performs no I/O and no logging. Diagnostics never echo producer
+/// payload values.
+pub fn parse_snapshot(input: &[u8]) -> Result<Snapshot, JspError> {
+    check_document_bound(input)?;
+    check_schema_and_kind_early(input)?;
+    let wire: SnapshotWire = deserialize_closed(input)?;
+    validate::convert(wire)
+}
+
+/// Envelope discriminators read before full-document deserialization.
+///
+/// Unknown fields are ignored here on purpose: this probe answers only "is
+/// this a JSP/1 snapshot document?" so an unsupported version or kind reports
+/// `JSP-E003` instead of being masked by the closed envelope's `JSP-E001`
+/// missing-field failure. [`validate`] re-checks both values after the closed
+/// deserialization, so this probe never widens what is accepted.
+#[derive(serde::Deserialize)]
+struct EnvelopeProbe {
+    #[serde(default)]
+    schema: Option<u64>,
+    #[serde(default)]
+    kind: Option<String>,
+}
+
+/// Pre-deserialization schema/kind gate.
+fn check_schema_and_kind_early(input: &[u8]) -> Result<(), JspError> {
+    let Ok(probe) = serde_json::from_slice::<EnvelopeProbe>(input) else {
+        // Malformed or non-object input is reported by the closed
+        // deserialization below with a precise location.
+        return Ok(());
+    };
+    if let Some(schema) = probe.schema {
+        if schema != ACCEPTED_SCHEMA {
+            return Err(JspError::unsupported_version(format!(
+                "snapshot.schema: unsupported schema version (accepted: {ACCEPTED_SCHEMA})"
+            )));
+        }
+    }
+    if let Some(kind) = probe.kind {
+        if kind != SNAPSHOT_KIND {
+            return Err(JspError::unsupported_version(format!(
+                "snapshot.kind: unsupported kind (accepted: {SNAPSHOT_KIND})"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Enforce the inclusive document byte bound before any parsing.
+fn check_document_bound(input: &[u8]) -> Result<(), JspError> {
+    if input.len() > MAX_DOCUMENT_BYTES {
+        return Err(JspError::bound(format!(
+            "snapshot: document size {} exceeds maximum {} bytes",
+            input.len(),
+            MAX_DOCUMENT_BYTES
+        )));
+    }
+    Ok(())
+}
+
+/// Deserialize the closed wire envelope from bytes, mapping any serde failure
+/// to a `JSP-E001` closed-shape error with a safe (payload-free) detail.
+///
+/// `serde_json` is configured via the wire DTOs' `#[serde(deny_unknown_fields)]`
+/// and exhaustive enums to reject unknown fields, duplicate fields, wrong
+/// types, trailing data, and non-integer numbers at this boundary.
+fn deserialize_closed(input: &[u8]) -> Result<SnapshotWire, JspError> {
+    let mut deserializer = serde_json::Deserializer::from_slice(input);
+    let result = SnapshotWire::deserialize(&mut deserializer);
+    // Reject trailing data after the top-level value.
+    let trailing = deserializer.end().map_err(|_| trailing_data_error());
+    match (result, trailing) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(trailing_err)) => Err(trailing_err),
+        (Err(parse_err), _) => Err(serde_error_to_jsp(&parse_err)),
+    }
+}
+
+/// Map a serde_json error to a closed-shape `JSP-E001` error.
+///
+/// The error category determines the message, but no producer payload text is
+/// ever echoed — only the structural reason and (where safe) the line/column.
+fn serde_error_to_jsp(error: &serde_json::Error) -> JspError {
+    let category = error.classify();
+    let location = format_location(error);
+    match category {
+        serde_json::error::Category::Io | serde_json::error::Category::Eof => {
+            JspError::closed_shape(format!("snapshot: unexpected end of input {location}"))
+        }
+        serde_json::error::Category::Syntax => {
+            JspError::closed_shape(format!("snapshot: malformed JSON {location}"))
+        }
+        serde_json::error::Category::Data => {
+            // Data errors cover unknown fields, wrong types, missing fields.
+            // Use the serde line/column but never the payload value.
+            JspError::closed_shape(format!(
+                "snapshot: input does not match the closed contract {location}"
+            ))
+        }
+    }
+}
+
+/// Format the safe line/column location from a serde error.
+fn format_location(error: &serde_json::Error) -> String {
+    let line = error.line();
+    let col = error.column();
+    if line == 0 {
+        String::new()
+    } else {
+        format!("at line {line} column {col}")
+    }
+}
+
+/// Trailing data error (always closed-shape).
+fn trailing_data_error() -> JspError {
+    JspError::closed_shape("snapshot: trailing data after top-level JSON value")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_is_closed_shape_error() {
+        let error = parse_snapshot(b"")
+            .err()
+            .unwrap_or_else(|| panic!("empty input fails"));
+        assert_eq!(error.code(), JspCode::EClosedShape);
+    }
+
+    #[test]
+    fn non_utf8_is_closed_shape_error() {
+        let error = parse_snapshot(&[0xFF, 0xFE])
+            .err()
+            .unwrap_or_else(|| panic!("non-utf8 fails"));
+        assert_eq!(error.code(), JspCode::EClosedShape);
+    }
+
+    #[test]
+    fn truncated_json_is_closed_shape_error() {
+        let error = parse_snapshot(b"{\"schema\":")
+            .err()
+            .unwrap_or_else(|| panic!("truncated fails"));
+        assert_eq!(error.code(), JspCode::EClosedShape);
+    }
+
+    #[test]
+    fn over_limit_document_is_bound_error() {
+        let input = vec![b' '; MAX_DOCUMENT_BYTES + 1];
+        let error = parse_snapshot(&input)
+            .err()
+            .unwrap_or_else(|| panic!("oversized doc fails"));
+        assert_eq!(
+            error.code(),
+            JspCode::EBound,
+            "the byte bound must fire before any parsing"
+        );
+    }
+
+    #[test]
+    fn at_limit_document_passes_the_byte_bound() {
+        let input = vec![b' '; MAX_DOCUMENT_BYTES];
+        let error = parse_snapshot(&input)
+            .err()
+            .unwrap_or_else(|| panic!("whitespace-only doc still fails to parse"));
+        assert_eq!(
+            error.code(),
+            JspCode::EClosedShape,
+            "an at-limit document must pass the byte bound and fail on shape"
+        );
+    }
+}

--- a/src/jsp/v1/parse.rs
+++ b/src/jsp/v1/parse.rs
@@ -10,8 +10,6 @@
 //! Diagnostics carry stable code/path/location and never echo producer payload
 //! values.
 
-use serde::Deserialize as _;
-
 use super::contract::Snapshot;
 use super::error::JspError;
 use super::limits::{ACCEPTED_SCHEMA, MAX_DOCUMENT_BYTES, SNAPSHOT_KIND};
@@ -37,7 +35,7 @@ use super::error::JspCode;
 /// payload values.
 pub fn parse_snapshot(input: &[u8]) -> Result<Snapshot, JspError> {
     check_document_bound(input)?;
-    check_schema_and_kind_early(input)?;
+    expect_kind(input, SNAPSHOT_KIND)?;
     let wire: SnapshotWire = deserialize_closed(input)?;
     validate::convert(wire)
 }
@@ -57,8 +55,12 @@ struct EnvelopeProbe {
     kind: Option<String>,
 }
 
-/// Pre-deserialization schema/kind gate.
-fn check_schema_and_kind_early(input: &[u8]) -> Result<(), JspError> {
+/// Pre-deserialization schema/kind gate shared by every document kind.
+///
+/// The probe reads only the two discriminators so a version or kind mismatch
+/// reports `JSP-E003` instead of being masked by the closed envelope's
+/// `JSP-E001` missing-field failure.
+pub(super) fn expect_kind(input: &[u8], expected: &str) -> Result<(), JspError> {
     let Ok(probe) = serde_json::from_slice::<EnvelopeProbe>(input) else {
         // Malformed or non-object input is reported by the closed
         // deserialization below with a precise location.
@@ -67,14 +69,14 @@ fn check_schema_and_kind_early(input: &[u8]) -> Result<(), JspError> {
     if let Some(schema) = probe.schema {
         if schema != ACCEPTED_SCHEMA {
             return Err(JspError::unsupported_version(format!(
-                "snapshot.schema: unsupported schema version (accepted: {ACCEPTED_SCHEMA})"
+                "document.schema: unsupported schema version (accepted: {ACCEPTED_SCHEMA})"
             )));
         }
     }
     if let Some(kind) = probe.kind {
-        if kind != SNAPSHOT_KIND {
+        if kind != expected {
             return Err(JspError::unsupported_version(format!(
-                "snapshot.kind: unsupported kind (accepted: {SNAPSHOT_KIND})"
+                "document.kind: unsupported kind (accepted: {expected})"
             )));
         }
     }
@@ -82,7 +84,7 @@ fn check_schema_and_kind_early(input: &[u8]) -> Result<(), JspError> {
 }
 
 /// Enforce the inclusive document byte bound before any parsing.
-fn check_document_bound(input: &[u8]) -> Result<(), JspError> {
+pub(super) fn check_document_bound(input: &[u8]) -> Result<(), JspError> {
     if input.len() > MAX_DOCUMENT_BYTES {
         return Err(JspError::bound(format!(
             "snapshot: document size {} exceeds maximum {} bytes",
@@ -99,9 +101,11 @@ fn check_document_bound(input: &[u8]) -> Result<(), JspError> {
 /// `serde_json` is configured via the wire DTOs' `#[serde(deny_unknown_fields)]`
 /// and exhaustive enums to reject unknown fields, duplicate fields, wrong
 /// types, trailing data, and non-integer numbers at this boundary.
-fn deserialize_closed(input: &[u8]) -> Result<SnapshotWire, JspError> {
+pub(super) fn deserialize_closed<T: serde::de::DeserializeOwned>(
+    input: &[u8],
+) -> Result<T, JspError> {
     let mut deserializer = serde_json::Deserializer::from_slice(input);
-    let result = SnapshotWire::deserialize(&mut deserializer);
+    let result = T::deserialize(&mut deserializer);
     // Reject trailing data after the top-level value.
     let trailing = deserializer.end().map_err(|_| trailing_data_error());
     match (result, trailing) {

--- a/src/jsp/v1/validate.rs
+++ b/src/jsp/v1/validate.rs
@@ -63,18 +63,50 @@ pub fn convert(wire: SnapshotWire) -> Result<Snapshot, JspError> {
 
 /// Build and validate the live observation identity (decision 2/3).
 fn build_identity(wire: &SnapshotWire) -> Result<ObservationKey, JspError> {
-    let agent_id = parse_opaque_id("snapshot.agent_id", &wire.agent_id)?;
-    if wire.lifecycle_generation == 0 {
+    let identity = build_event_identity(
+        &wire.agent_id,
+        wire.lifecycle_generation,
+        &wire.source_epoch,
+    )?;
+    Ok(ObservationKey(identity))
+}
+
+/// Build and validate the live observation identity from its three parts.
+///
+/// Shared by snapshot, event, and heartbeat documents so every document kind
+/// enforces the same identity triple invariants.
+pub(super) fn build_event_identity(
+    agent_id: &str,
+    lifecycle_generation: u64,
+    source_epoch: &str,
+) -> Result<ObservationIdentity, JspError> {
+    let agent_id = parse_opaque_id("document.agent_id", agent_id)?;
+    if lifecycle_generation == 0 {
         return Err(JspError::identity(
-            "snapshot.lifecycle_generation: must be a positive integer",
+            "document.lifecycle_generation: must be a positive integer",
         ));
     }
-    let source_epoch = parse_opaque_id("snapshot.source_epoch", &wire.source_epoch)?;
-    Ok(ObservationKey(ObservationIdentity {
+    let source_epoch = parse_opaque_id("document.source_epoch", source_epoch)?;
+    Ok(ObservationIdentity {
         agent_id,
-        lifecycle_generation: wire.lifecycle_generation,
+        lifecycle_generation,
         source_epoch,
-    }))
+    })
+}
+
+/// Bound-check a string and wrap it, for reuse by the event converters.
+pub(super) fn bounded<T>(
+    path: &str,
+    value: &str,
+    max: usize,
+    wrap: impl Fn(String) -> T,
+) -> Result<T, JspError> {
+    parse_bounded_string(path, value, max, wrap)
+}
+
+/// Bound-check an entry count, for reuse by the event converters.
+pub(super) fn count_bound(path: &str, count: usize, max: usize) -> Result<(), JspError> {
+    super::limits::check_count_bound(path, count, max)
 }
 
 /// Validate and build the native session descriptive metadata.

--- a/src/jsp/v1/validate.rs
+++ b/src/jsp/v1/validate.rs
@@ -1,0 +1,612 @@
+//! Wire-to-domain validation and conversion (issue #476, J1 slice).
+//!
+//! This module converts a fully-deserialized [`wire::SnapshotWire`] into a
+//! typed [`Snapshot`](super::contract::Snapshot) of domain observation values.
+//! Conversion happens only after the entire document has deserialized, so a
+//! partially validated payload can never escape. Every string is bound-checked
+//! and every value is parsed into a closed enum/newtype; any violation returns
+//! a coded [`JspError`] without echoing payload text.
+
+use crate::domain::observation::{
+    AgentKindLabel, Availability, BoundedText, CurrentTurn, CurrentTurnField, CurrentWaitField,
+    DiagnosticCode, DiagnosticSummary, DisplayName, DisplayedAssistantMessage, FieldState,
+    LastMessageField, LastToolField, NativeActivityField, NativeActivityState, NativeActivityValue,
+    NativeSession, ObservationIdentity, OpaqueId, PathRef, ProcessBinding, ProcessBindingField,
+    Provenance, RepositoryRef, SourceErrorField, SourceErrorValue, SourceTerminalField, TodoItem,
+    TodoList, TodosField, ToolCallValue, ToolLabel, ToolPhase, Wait, WaitReason,
+};
+
+use super::contract::{ObservationKey, Snapshot};
+use super::error::JspError;
+use super::limits::{ACCEPTED_SCHEMA, SNAPSHOT_KIND};
+use super::wire::{
+    AvailabilityKindWire, CurrentTurnPayload, DisplayedMessagePayload, FieldLimits, FieldWire,
+    NativeActivityPayload, NativeSessionWire, ProcessBindingPayload, ProvenanceWire, SnapshotWire,
+    SourceErrorPayload, SupportedState, TodoItemWire, TodosPayload, ToolCallPayload,
+};
+
+/// Convert a fully-deserialized wire snapshot into a typed domain snapshot.
+///
+/// This is the single conversion boundary. It assumes the wire DTO already
+/// passed `deny_unknown_fields` and structural deserialization; it applies
+/// schema/kind gates, identity invariants, bounds, closed-enum parsing, and
+/// field-state semantics.
+pub(crate) fn convert(wire: SnapshotWire) -> Result<Snapshot, JspError> {
+    validate_schema_and_kind(&wire)?;
+    let identity = build_identity(&wire)?;
+    let native_session = build_native_session(&wire.native_session)?;
+    let process_binding = convert_process_binding(&wire.process_binding)?;
+    let native_activity = convert_native_activity(&wire.native_activity)?;
+    let current_wait = convert_current_wait(&wire.current_wait)?;
+    let current_turn = convert_current_turn(&wire.current_turn)?;
+    let todos = convert_todos(&wire.todos)?;
+    let last_message = convert_last_message(&wire.last_displayed_assistant_message)?;
+    let last_tool = convert_last_tool(&wire.last_created_tool_call)?;
+    let source_terminal = convert_source_terminal(&wire.source_terminal_state)?;
+    let source_error = convert_source_error(&wire.source_error_state)?;
+
+    Ok(Snapshot {
+        identity: identity.identity().clone(),
+        source_sequence: wire.source_sequence,
+        cursor: wire.cursor,
+        bridge_observed_ms: wire.bridge_observed_ms,
+        native_session,
+        process_binding,
+        native_activity,
+        current_wait,
+        current_turn,
+        todos,
+        last_displayed_assistant_message: last_message,
+        last_created_tool_call: last_tool,
+        source_terminal_state: source_terminal,
+        source_error_state: source_error,
+    })
+}
+
+/// Reject the document if schema or kind is wrong. This is the version/kind
+/// gate (decision 1): unknown schema/kind fails with `JSP-E003`.
+fn validate_schema_and_kind(wire: &SnapshotWire) -> Result<(), JspError> {
+    if wire.schema != ACCEPTED_SCHEMA {
+        return Err(JspError::unsupported_version(format!(
+            "snapshot.schema: unsupported schema version (accepted: {ACCEPTED_SCHEMA})"
+        )));
+    }
+    if wire.kind != SNAPSHOT_KIND {
+        return Err(JspError::unsupported_version(format!(
+            "snapshot.kind: unsupported kind (accepted: \"{SNAPSHOT_KIND}\")"
+        )));
+    }
+    Ok(())
+}
+
+/// Build and validate the live observation identity (decision 2/3).
+fn build_identity(wire: &SnapshotWire) -> Result<ObservationKey, JspError> {
+    let agent_id = parse_opaque_id("snapshot.agent_id", &wire.agent_id)?;
+    if wire.lifecycle_generation == 0 {
+        return Err(JspError::identity(
+            "snapshot.lifecycle_generation: must be a positive integer",
+        ));
+    }
+    let source_epoch = parse_opaque_id("snapshot.source_epoch", &wire.source_epoch)?;
+    Ok(ObservationKey(ObservationIdentity {
+        agent_id,
+        lifecycle_generation: wire.lifecycle_generation,
+        source_epoch,
+    }))
+}
+
+/// Validate and build the native session descriptive metadata.
+fn build_native_session(wire: &NativeSessionWire) -> Result<NativeSession, JspError> {
+    let repository = parse_bounded_string(
+        "snapshot.native_session.repository",
+        &wire.repository,
+        FieldLimits::REPOSITORY,
+        RepositoryRef,
+    )?;
+    let path = parse_bounded_string(
+        "snapshot.native_session.path",
+        &wire.path,
+        FieldLimits::PATH,
+        PathRef,
+    )?;
+    let agent_kind = parse_bounded_string(
+        "snapshot.native_session.agent_kind",
+        &wire.agent_kind,
+        FieldLimits::AGENT_KIND,
+        AgentKindLabel,
+    )?;
+    let display_name = parse_bounded_string(
+        "snapshot.native_session.display_name",
+        &wire.display_name,
+        FieldLimits::DISPLAY_NAME,
+        DisplayName,
+    )?;
+    Ok(NativeSession {
+        repository,
+        path,
+        agent_kind,
+        pid: wire.pid,
+        display_name,
+    })
+}
+
+/// Convert the process-binding field. This is producer-reported binding
+/// evidence only; process liveness stays Jefe-runtime-owned (decision 4).
+fn convert_process_binding(field: &FieldWire) -> Result<ProcessBindingField, JspError> {
+    let Some(state) = supported_state(field) else {
+        return Ok(FieldState::Unsupported);
+    };
+    let provenance = convert_provenance(&state.provenance);
+    let availability = build_availability("snapshot.process_binding", state, |value| {
+        let payload: ProcessBindingPayload = parse_payload("snapshot.process_binding", value)?;
+        Ok(ProcessBinding {
+            pid: payload.pid,
+            started_at_ms: payload.started_at_ms,
+        })
+    })?;
+    Ok(FieldState::Supported {
+        provenance,
+        availability,
+    })
+}
+
+/// Convert provenance wire value to domain.
+fn convert_provenance(wire: &ProvenanceWire) -> Provenance {
+    match wire {
+        ProvenanceWire::Authoritative => Provenance::Authoritative,
+        ProvenanceWire::Inferred => Provenance::Inferred,
+    }
+}
+
+/// Extract the supported state from a field wire value, or return None if
+/// unsupported.
+fn supported_state(field: &FieldWire) -> Option<&SupportedState> {
+    match field {
+        FieldWire::Unsupported(_) => None,
+        FieldWire::Supported(state) => Some(state),
+    }
+}
+
+/// Validate the availability fields on a supported state and produce the
+/// availability value via the supplied known-value builder.
+fn build_availability<T>(
+    path: &str,
+    state: &SupportedState,
+    build_known: impl Fn(&serde_json::Value) -> Result<T, JspError>,
+) -> Result<Availability<T>, JspError> {
+    match state.availability {
+        AvailabilityKindWire::Unknown => {
+            reject_present_unknown_extras(path, state)?;
+            Ok(Availability::Unknown)
+        }
+        AvailabilityKindWire::Known => {
+            reject_degraded_only_fields(path, state)?;
+            let value = require_value(path, state)?;
+            Ok(Availability::Known(build_known(value)?))
+        }
+        AvailabilityKindWire::Degraded => {
+            let last_value = require_last_value(path, state)?;
+            let as_of_ms = require_as_of_ms(path, state)?;
+            let diagnostic_code = require_diagnostic_code(path, state)?;
+            Ok(Availability::Degraded {
+                last_value: build_known(last_value)?,
+                as_of_ms,
+                diagnostic_code,
+            })
+        }
+    }
+}
+
+/// Reject `value`/`last_value`/`as_of_ms`/`diagnostic_code` when availability
+/// is `unknown`.
+fn reject_present_unknown_extras(path: &str, state: &SupportedState) -> Result<(), JspError> {
+    if state.value.present
+        || state.last_value.present
+        || state.as_of_ms.is_some()
+        || state.diagnostic_code.is_some()
+    {
+        Err(JspError::closed_shape(format!(
+            "{path}: unknown availability must not carry value fields"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+/// Reject the degraded-only members when availability is `known`.
+fn reject_degraded_only_fields(path: &str, state: &SupportedState) -> Result<(), JspError> {
+    if state.last_value.present || state.as_of_ms.is_some() || state.diagnostic_code.is_some() {
+        Err(JspError::closed_shape(format!(
+            "{path}: known availability must not carry degraded fields"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+/// Require the `value` field for `known` availability.
+fn require_value<'a>(
+    path: &str,
+    state: &'a SupportedState,
+) -> Result<&'a serde_json::Value, JspError> {
+    if state.value.present {
+        Ok(&state.value.value)
+    } else {
+        Err(JspError::closed_shape(format!(
+            "{path}: known availability requires a value field"
+        )))
+    }
+}
+
+/// Require the `last_value` field for `degraded` availability.
+fn require_last_value<'a>(
+    path: &str,
+    state: &'a SupportedState,
+) -> Result<&'a serde_json::Value, JspError> {
+    reject_known_extra_for_degraded(path, state)?;
+    if state.last_value.present {
+        Ok(&state.last_value.value)
+    } else {
+        Err(JspError::closed_shape(format!(
+            "{path}: degraded availability requires a last_value field"
+        )))
+    }
+}
+
+/// For `degraded`, reject a stray `value` field (degraded uses `last_value`).
+fn reject_known_extra_for_degraded(path: &str, state: &SupportedState) -> Result<(), JspError> {
+    if state.value.present {
+        Err(JspError::closed_shape(format!(
+            "{path}: degraded availability must use last_value, not value"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+/// Require the `as_of_ms` field for `degraded` availability.
+fn require_as_of_ms(path: &str, state: &SupportedState) -> Result<u64, JspError> {
+    state.as_of_ms.ok_or_else(|| {
+        JspError::closed_shape(format!(
+            "{path}: degraded availability requires an as_of_ms field"
+        ))
+    })
+}
+
+/// Require and bound-check the `diagnostic_code` field for `degraded`.
+fn require_diagnostic_code(path: &str, state: &SupportedState) -> Result<DiagnosticCode, JspError> {
+    let raw = state.diagnostic_code.as_ref().ok_or_else(|| {
+        JspError::closed_shape(format!(
+            "{path}: degraded availability requires a diagnostic_code field"
+        ))
+    })?;
+    parse_diagnostic_code(&format!("{path}.diagnostic_code"), raw)
+}
+
+// ---------------------------------------------------------------------------
+// Per-field converters
+// ---------------------------------------------------------------------------
+
+/// Convert the native-activity field.
+fn convert_native_activity(field: &FieldWire) -> Result<NativeActivityField, JspError> {
+    let Some(state) = supported_state(field) else {
+        return Ok(FieldState::Unsupported);
+    };
+    let provenance = convert_provenance(&state.provenance);
+    let availability = build_availability("snapshot.native_activity", state, |value| {
+        let payload: NativeActivityPayload = parse_payload("snapshot.native_activity", value)?;
+        let activity = NativeActivityState::from_wire(&payload.state).ok_or_else(|| {
+            JspError::field_state("snapshot.native_activity.state: unsupported activity state")
+        })?;
+        Ok(NativeActivityValue { state: activity })
+    })?;
+    Ok(FieldState::Supported {
+        provenance,
+        availability,
+    })
+}
+
+/// Convert the current-wait field. `Known(null)` means explicitly not waiting.
+fn convert_current_wait(field: &FieldWire) -> Result<CurrentWaitField, JspError> {
+    let Some(state) = supported_state(field) else {
+        return Ok(FieldState::Unsupported);
+    };
+    let provenance = convert_provenance(&state.provenance);
+    if matches!(state.availability, AvailabilityKindWire::Degraded) {
+        return Err(JspError::field_state(
+            "snapshot.current_wait: degraded availability is not valid for wait state",
+        ));
+    }
+    let availability = build_availability("snapshot.current_wait", state, |value| {
+        if value.is_null() {
+            Ok(None)
+        } else {
+            let reason = parse_wait_reason("snapshot.current_wait", value)?;
+            Ok(Some(Wait { reason }))
+        }
+    })?;
+    Ok(FieldState::Supported {
+        provenance,
+        availability,
+    })
+}
+
+/// Convert the current-turn field.
+fn convert_current_turn(field: &FieldWire) -> Result<CurrentTurnField, JspError> {
+    let Some(state) = supported_state(field) else {
+        return Ok(FieldState::Unsupported);
+    };
+    let provenance = convert_provenance(&state.provenance);
+    let availability = build_availability("snapshot.current_turn", state, |value| {
+        let payload: CurrentTurnPayload = parse_payload("snapshot.current_turn", value)?;
+        Ok(CurrentTurn {
+            elapsed_ms: payload.elapsed_ms,
+        })
+    })?;
+    Ok(FieldState::Supported {
+        provenance,
+        availability,
+    })
+}
+
+/// Convert the todos field with revision/length/text bounds (decision 8).
+fn convert_todos(field: &FieldWire) -> Result<TodosField, JspError> {
+    let Some(state) = supported_state(field) else {
+        return Ok(FieldState::Unsupported);
+    };
+    let provenance = convert_provenance(&state.provenance);
+    let availability = build_availability("snapshot.todos", state, |value| {
+        let payload: TodosPayload = parse_payload("snapshot.todos", value)?;
+        if payload.revision == 0 {
+            return Err(JspError::field_state(
+                "snapshot.todos.value.revision: must be a positive integer",
+            ));
+        }
+        super::limits::check_bound(
+            "snapshot.todos.value.items",
+            payload.items.len(),
+            FieldLimits::TODOS,
+        )?;
+        let mut items = Vec::with_capacity(payload.items.len());
+        for (index, item) in payload.items.iter().enumerate() {
+            items.push(parse_todo_item(index, item)?);
+        }
+        Ok(TodoList {
+            revision: payload.revision,
+            items,
+        })
+    })?;
+    Ok(FieldState::Supported {
+        provenance,
+        availability,
+    })
+}
+
+/// Parse a single todo item with text bound.
+fn parse_todo_item(index: usize, item: &TodoItemWire) -> Result<TodoItem, JspError> {
+    let path = format!("snapshot.todos.value.items[{index}].text");
+    let text = parse_bounded_text(&path, &item.text, FieldLimits::TODO_TEXT, BoundedText)?;
+    Ok(TodoItem {
+        text,
+        completed: item.completed,
+    })
+}
+
+/// Convert the last-displayed-assistant-message field.
+fn convert_last_message(field: &FieldWire) -> Result<LastMessageField, JspError> {
+    let Some(state) = supported_state(field) else {
+        return Ok(FieldState::Unsupported);
+    };
+    let provenance = convert_provenance(&state.provenance);
+    let availability = build_availability(
+        "snapshot.last_displayed_assistant_message",
+        state,
+        |value| {
+            let payload: DisplayedMessagePayload =
+                parse_payload("snapshot.last_displayed_assistant_message", value)?;
+            let content = parse_bounded_text(
+                "snapshot.last_displayed_assistant_message.value.content",
+                &payload.content,
+                FieldLimits::DISPLAYED_CONTENT,
+                BoundedText,
+            )?;
+            Ok(DisplayedAssistantMessage {
+                content,
+                committed_ms: payload.committed_ms,
+            })
+        },
+    )?;
+    Ok(FieldState::Supported {
+        provenance,
+        availability,
+    })
+}
+
+/// Convert the last-created-tool-call field. Rejects `stale` phase (decision 5).
+fn convert_last_tool(field: &FieldWire) -> Result<LastToolField, JspError> {
+    let Some(state) = supported_state(field) else {
+        return Ok(FieldState::Unsupported);
+    };
+    let provenance = convert_provenance(&state.provenance);
+    let availability = build_availability("snapshot.last_created_tool_call", state, |value| {
+        let payload: ToolCallPayload = parse_payload("snapshot.last_created_tool_call", value)?;
+        parse_tool_value(&payload)
+    })?;
+    Ok(FieldState::Supported {
+        provenance,
+        availability,
+    })
+}
+
+/// Parse a tool-call value payload into the typed value.
+fn parse_tool_value(payload: &ToolCallPayload) -> Result<ToolCallValue, JspError> {
+    let label = parse_bounded_text(
+        "snapshot.last_created_tool_call.value.label",
+        &payload.label,
+        FieldLimits::TOOL_LABEL,
+        ToolLabel,
+    )?;
+    let phase = ToolPhase::from_wire(&payload.phase).ok_or_else(|| {
+        // `stale` and any unknown phase land here: field-state violation.
+        JspError::field_state("snapshot.last_created_tool_call.value.phase: unsupported phase")
+    })?;
+    Ok(ToolCallValue { label, phase })
+}
+
+/// Convert the source-terminal-state field. `Known(null)` means clean.
+fn convert_source_terminal(field: &FieldWire) -> Result<SourceTerminalField, JspError> {
+    let Some(state) = supported_state(field) else {
+        return Ok(FieldState::Unsupported);
+    };
+    let provenance = convert_provenance(&state.provenance);
+    if matches!(state.availability, AvailabilityKindWire::Degraded) {
+        return Err(JspError::field_state(
+            "snapshot.source_terminal_state: degraded availability is not valid",
+        ));
+    }
+    let availability = build_availability("snapshot.source_terminal_state", state, |value| {
+        if value.is_null() {
+            Ok(None)
+        } else {
+            let payload: SourceErrorPayload =
+                parse_payload("snapshot.source_terminal_state", value)?;
+            Ok(Some(parse_source_error(&payload)?))
+        }
+    })?;
+    Ok(FieldState::Supported {
+        provenance,
+        availability,
+    })
+}
+
+/// Convert the source-error-state field.
+fn convert_source_error(field: &FieldWire) -> Result<SourceErrorField, JspError> {
+    let Some(state) = supported_state(field) else {
+        return Ok(FieldState::Unsupported);
+    };
+    let provenance = convert_provenance(&state.provenance);
+    let availability = build_availability("snapshot.source_error_state", state, |value| {
+        if value.is_null() {
+            return Err(JspError::field_state(
+                "snapshot.source_error_state: known null is not valid; use unsupported",
+            ));
+        }
+        let payload: SourceErrorPayload = parse_payload("snapshot.source_error_state", value)?;
+        parse_source_error(&payload)
+    })?;
+    Ok(FieldState::Supported {
+        provenance,
+        availability,
+    })
+}
+
+/// Parse a source-error payload with bound checks.
+fn parse_source_error(payload: &SourceErrorPayload) -> Result<SourceErrorValue, JspError> {
+    let summary = parse_bounded_string(
+        "snapshot.source_error_state.value.summary",
+        &payload.summary,
+        FieldLimits::DIAGNOSTIC_SUMMARY,
+        DiagnosticSummary,
+    )?;
+    let code = parse_bounded_text(
+        "snapshot.source_error_state.value.code",
+        &payload.code,
+        FieldLimits::ERROR_CODE,
+        BoundedText,
+    )?;
+    Ok(SourceErrorValue { summary, code })
+}
+
+// ---------------------------------------------------------------------------
+// Scalar parsing helpers
+// ---------------------------------------------------------------------------
+
+/// Parse a wait reason from a known-wait JSON object.
+fn parse_wait_reason(path: &str, value: &serde_json::Value) -> Result<WaitReason, JspError> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| JspError::closed_shape(format!("{path}.value: expected a wait object")))?;
+    let reason_value = obj
+        .get("reason")
+        .ok_or_else(|| JspError::closed_shape(format!("{path}.value.reason: missing field")))?;
+    let reason_str = reason_value
+        .as_str()
+        .ok_or_else(|| JspError::closed_shape(format!("{path}.value.reason: expected a string")))?;
+    WaitReason::from_wire(reason_str)
+        .ok_or_else(|| JspError::field_state(format!("{path}.value.reason: unsupported reason")))
+}
+
+/// Parse a raw JSON value into a typed payload via serde_json, mapping any
+/// failure to a closed-shape error without echoing the payload.
+fn parse_payload<'de, T: serde::Deserialize<'de>>(
+    path: &str,
+    value: &'de serde_json::Value,
+) -> Result<T, JspError> {
+    T::deserialize(value).map_err(|_| {
+        JspError::closed_shape(format!(
+            "{path}: value shape does not match the closed contract"
+        ))
+    })
+}
+
+/// Parse an opaque identifier with safe-ASCII and length bounds.
+fn parse_opaque_id(path: &str, value: &str) -> Result<OpaqueId, JspError> {
+    if value.is_empty() {
+        return Err(JspError::closed_shape(format!("{path}: must not be empty")));
+    }
+    super::limits::check_bound(path, value.len(), FieldLimits::ID)?;
+    if !value
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+    {
+        return Err(JspError::closed_shape(format!(
+            "{path}: must contain only safe ASCII characters"
+        )));
+    }
+    Ok(OpaqueId(value.to_string()))
+}
+
+/// Parse a bounded string into a generic newtype wrapper.
+fn parse_bounded_string<T>(
+    path: &str,
+    value: &str,
+    max: usize,
+    wrap: impl Fn(String) -> T,
+) -> Result<T, JspError> {
+    super::limits::check_bound(path, value.len(), max)?;
+    Ok(wrap(value.to_string()))
+}
+
+/// Parse a bounded text into a `BoundedText`-style newtype.
+fn parse_bounded_text<T>(
+    path: &str,
+    value: &str,
+    max: usize,
+    wrap: impl Fn(String) -> T,
+) -> Result<T, JspError> {
+    parse_bounded_string(path, value, max, wrap)
+}
+
+/// Parse a diagnostic code with bound check.
+fn parse_diagnostic_code(path: &str, value: &str) -> Result<DiagnosticCode, JspError> {
+    super::limits::check_bound(path, value.len(), FieldLimits::DIAGNOSTIC_CODE)?;
+    Ok(DiagnosticCode(value.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_opaque_id_rejects_empty_and_unsafe() {
+        assert!(parse_opaque_id("x", "").is_err());
+        assert!(parse_opaque_id("x", "has space").is_err());
+        assert!(parse_opaque_id("x", "ok_id-1.2").is_ok());
+    }
+
+    #[test]
+    fn parse_opaque_id_rejects_over_limit() {
+        let too_long = "a".repeat(FieldLimits::ID + 1);
+        assert!(parse_opaque_id("x", &too_long).is_err());
+    }
+}

--- a/src/jsp/v1/validate.rs
+++ b/src/jsp/v1/validate.rs
@@ -184,7 +184,7 @@ fn build_availability<T>(
 ///
 /// Diagnostics must name the member the producer actually sent, so a `degraded`
 /// payload reports `last_value` rather than `value`.
-pub enum ValueSlot {
+enum ValueSlot {
     Value,
     LastValue,
 }

--- a/src/jsp/v1/validate.rs
+++ b/src/jsp/v1/validate.rs
@@ -18,11 +18,10 @@ use crate::domain::observation::{
 
 use super::contract::{ObservationKey, Snapshot};
 use super::error::JspError;
-use super::limits::{ACCEPTED_SCHEMA, SNAPSHOT_KIND};
 use super::wire::{
     AvailabilityKindWire, CurrentTurnPayload, DisplayedMessagePayload, FieldLimits, FieldWire,
     NativeActivityPayload, NativeSessionWire, ProcessBindingPayload, ProvenanceWire, SnapshotWire,
-    SourceErrorPayload, SupportedState, TodoItemWire, TodosPayload, ToolCallPayload,
+    SourceErrorPayload, SupportedState, TodoItemWire, TodosPayload, ToolCallPayload, WaitPayload,
 };
 
 /// Convert a fully-deserialized wire snapshot into a typed domain snapshot.
@@ -31,8 +30,7 @@ use super::wire::{
 /// passed `deny_unknown_fields` and structural deserialization; it applies
 /// schema/kind gates, identity invariants, bounds, closed-enum parsing, and
 /// field-state semantics.
-pub(crate) fn convert(wire: SnapshotWire) -> Result<Snapshot, JspError> {
-    validate_schema_and_kind(&wire)?;
+pub fn convert(wire: SnapshotWire) -> Result<Snapshot, JspError> {
     let identity = build_identity(&wire)?;
     let native_session = build_native_session(&wire.native_session)?;
     let process_binding = convert_process_binding(&wire.process_binding)?;
@@ -61,22 +59,6 @@ pub(crate) fn convert(wire: SnapshotWire) -> Result<Snapshot, JspError> {
         source_terminal_state: source_terminal,
         source_error_state: source_error,
     })
-}
-
-/// Reject the document if schema or kind is wrong. This is the version/kind
-/// gate (decision 1): unknown schema/kind fails with `JSP-E003`.
-fn validate_schema_and_kind(wire: &SnapshotWire) -> Result<(), JspError> {
-    if wire.schema != ACCEPTED_SCHEMA {
-        return Err(JspError::unsupported_version(format!(
-            "snapshot.schema: unsupported schema version (accepted: {ACCEPTED_SCHEMA})"
-        )));
-    }
-    if wire.kind != SNAPSHOT_KIND {
-        return Err(JspError::unsupported_version(format!(
-            "snapshot.kind: unsupported kind (accepted: \"{SNAPSHOT_KIND}\")"
-        )));
-    }
-    Ok(())
 }
 
 /// Build and validate the live observation identity (decision 2/3).
@@ -137,8 +119,9 @@ fn convert_process_binding(field: &FieldWire) -> Result<ProcessBindingField, Jsp
         return Ok(FieldState::Unsupported);
     };
     let provenance = convert_provenance(&state.provenance);
-    let availability = build_availability("snapshot.process_binding", state, |value| {
-        let payload: ProcessBindingPayload = parse_payload("snapshot.process_binding", value)?;
+    let availability = build_availability("snapshot.process_binding", state, |slot, value| {
+        let payload: ProcessBindingPayload =
+            parse_payload(&slot.root("snapshot.process_binding"), value)?;
         Ok(ProcessBinding {
             pid: payload.pid,
             started_at_ms: payload.started_at_ms,
@@ -172,7 +155,7 @@ fn supported_state(field: &FieldWire) -> Option<&SupportedState> {
 fn build_availability<T>(
     path: &str,
     state: &SupportedState,
-    build_known: impl Fn(&serde_json::Value) -> Result<T, JspError>,
+    build_known: impl Fn(&ValueSlot, &serde_json::Value) -> Result<T, JspError>,
 ) -> Result<Availability<T>, JspError> {
     match state.availability {
         AvailabilityKindWire::Unknown => {
@@ -182,18 +165,47 @@ fn build_availability<T>(
         AvailabilityKindWire::Known => {
             reject_degraded_only_fields(path, state)?;
             let value = require_value(path, state)?;
-            Ok(Availability::Known(build_known(value)?))
+            Ok(Availability::Known(build_known(&ValueSlot::Value, value)?))
         }
         AvailabilityKindWire::Degraded => {
             let last_value = require_last_value(path, state)?;
             let as_of_ms = require_as_of_ms(path, state)?;
             let diagnostic_code = require_diagnostic_code(path, state)?;
             Ok(Availability::Degraded {
-                last_value: build_known(last_value)?,
+                last_value: build_known(&ValueSlot::LastValue, last_value)?,
                 as_of_ms,
                 diagnostic_code,
             })
         }
+    }
+}
+
+/// Which member of a supported field state a value was read from.
+///
+/// Diagnostics must name the member the producer actually sent, so a `degraded`
+/// payload reports `last_value` rather than `value`.
+pub enum ValueSlot {
+    Value,
+    LastValue,
+}
+
+impl ValueSlot {
+    /// The JSON member name for this slot.
+    const fn member(&self) -> &'static str {
+        match self {
+            Self::Value => "value",
+            Self::LastValue => "last_value",
+        }
+    }
+
+    /// Build the diagnostic path for a leaf inside this slot.
+    fn path(&self, field_path: &str, leaf: &str) -> String {
+        format!("{field_path}.{}.{leaf}", self.member())
+    }
+
+    /// Build the diagnostic path for the slot itself.
+    fn root(&self, field_path: &str) -> String {
+        format!("{field_path}.{}", self.member())
     }
 }
 
@@ -293,10 +305,14 @@ fn convert_native_activity(field: &FieldWire) -> Result<NativeActivityField, Jsp
         return Ok(FieldState::Unsupported);
     };
     let provenance = convert_provenance(&state.provenance);
-    let availability = build_availability("snapshot.native_activity", state, |value| {
-        let payload: NativeActivityPayload = parse_payload("snapshot.native_activity", value)?;
+    let availability = build_availability("snapshot.native_activity", state, |slot, value| {
+        let payload: NativeActivityPayload =
+            parse_payload(&slot.root("snapshot.native_activity"), value)?;
         let activity = NativeActivityState::from_wire(&payload.state).ok_or_else(|| {
-            JspError::field_state("snapshot.native_activity.state: unsupported activity state")
+            JspError::field_state(format!(
+                "{}: unsupported activity state",
+                slot.path("snapshot.native_activity", "state")
+            ))
         })?;
         Ok(NativeActivityValue { state: activity })
     })?;
@@ -317,11 +333,11 @@ fn convert_current_wait(field: &FieldWire) -> Result<CurrentWaitField, JspError>
             "snapshot.current_wait: degraded availability is not valid for wait state",
         ));
     }
-    let availability = build_availability("snapshot.current_wait", state, |value| {
+    let availability = build_availability("snapshot.current_wait", state, |slot, value| {
         if value.is_null() {
             Ok(None)
         } else {
-            let reason = parse_wait_reason("snapshot.current_wait", value)?;
+            let reason = parse_wait_reason(&slot.root("snapshot.current_wait"), value)?;
             Ok(Some(Wait { reason }))
         }
     })?;
@@ -337,8 +353,9 @@ fn convert_current_turn(field: &FieldWire) -> Result<CurrentTurnField, JspError>
         return Ok(FieldState::Unsupported);
     };
     let provenance = convert_provenance(&state.provenance);
-    let availability = build_availability("snapshot.current_turn", state, |value| {
-        let payload: CurrentTurnPayload = parse_payload("snapshot.current_turn", value)?;
+    let availability = build_availability("snapshot.current_turn", state, |slot, value| {
+        let payload: CurrentTurnPayload =
+            parse_payload(&slot.root("snapshot.current_turn"), value)?;
         Ok(CurrentTurn {
             elapsed_ms: payload.elapsed_ms,
         })
@@ -355,21 +372,22 @@ fn convert_todos(field: &FieldWire) -> Result<TodosField, JspError> {
         return Ok(FieldState::Unsupported);
     };
     let provenance = convert_provenance(&state.provenance);
-    let availability = build_availability("snapshot.todos", state, |value| {
-        let payload: TodosPayload = parse_payload("snapshot.todos", value)?;
+    let availability = build_availability("snapshot.todos", state, |slot, value| {
+        let payload: TodosPayload = parse_payload(&slot.root("snapshot.todos"), value)?;
         if payload.revision == 0 {
-            return Err(JspError::field_state(
-                "snapshot.todos.value.revision: must be a positive integer",
-            ));
+            return Err(JspError::field_state(format!(
+                "{}: must be a positive integer",
+                slot.path("snapshot.todos", "revision")
+            )));
         }
-        super::limits::check_bound(
-            "snapshot.todos.value.items",
+        super::limits::check_count_bound(
+            &slot.path("snapshot.todos", "items"),
             payload.items.len(),
             FieldLimits::TODOS,
         )?;
         let mut items = Vec::with_capacity(payload.items.len());
         for (index, item) in payload.items.iter().enumerate() {
-            items.push(parse_todo_item(index, item)?);
+            items.push(parse_todo_item(slot, index, item)?);
         }
         Ok(TodoList {
             revision: payload.revision,
@@ -383,8 +401,12 @@ fn convert_todos(field: &FieldWire) -> Result<TodosField, JspError> {
 }
 
 /// Parse a single todo item with text bound.
-fn parse_todo_item(index: usize, item: &TodoItemWire) -> Result<TodoItem, JspError> {
-    let path = format!("snapshot.todos.value.items[{index}].text");
+fn parse_todo_item(
+    slot: &ValueSlot,
+    index: usize,
+    item: &TodoItemWire,
+) -> Result<TodoItem, JspError> {
+    let path = slot.path("snapshot.todos", &format!("items[{index}].text"));
     let text = parse_bounded_text(&path, &item.text, FieldLimits::TODO_TEXT, BoundedText)?;
     Ok(TodoItem {
         text,
@@ -401,11 +423,11 @@ fn convert_last_message(field: &FieldWire) -> Result<LastMessageField, JspError>
     let availability = build_availability(
         "snapshot.last_displayed_assistant_message",
         state,
-        |value| {
-            let payload: DisplayedMessagePayload =
-                parse_payload("snapshot.last_displayed_assistant_message", value)?;
+        |slot, value| {
+            let field = "snapshot.last_displayed_assistant_message";
+            let payload: DisplayedMessagePayload = parse_payload(&slot.root(field), value)?;
             let content = parse_bounded_text(
-                "snapshot.last_displayed_assistant_message.value.content",
+                &slot.path(field, "content"),
                 &payload.content,
                 FieldLimits::DISPLAYED_CONTENT,
                 BoundedText,
@@ -428,10 +450,12 @@ fn convert_last_tool(field: &FieldWire) -> Result<LastToolField, JspError> {
         return Ok(FieldState::Unsupported);
     };
     let provenance = convert_provenance(&state.provenance);
-    let availability = build_availability("snapshot.last_created_tool_call", state, |value| {
-        let payload: ToolCallPayload = parse_payload("snapshot.last_created_tool_call", value)?;
-        parse_tool_value(&payload)
-    })?;
+    let availability =
+        build_availability("snapshot.last_created_tool_call", state, |slot, value| {
+            let payload: ToolCallPayload =
+                parse_payload(&slot.root("snapshot.last_created_tool_call"), value)?;
+            parse_tool_value(slot, &payload)
+        })?;
     Ok(FieldState::Supported {
         provenance,
         availability,
@@ -439,16 +463,20 @@ fn convert_last_tool(field: &FieldWire) -> Result<LastToolField, JspError> {
 }
 
 /// Parse a tool-call value payload into the typed value.
-fn parse_tool_value(payload: &ToolCallPayload) -> Result<ToolCallValue, JspError> {
+fn parse_tool_value(
+    slot: &ValueSlot,
+    payload: &ToolCallPayload,
+) -> Result<ToolCallValue, JspError> {
+    let field = "snapshot.last_created_tool_call";
     let label = parse_bounded_text(
-        "snapshot.last_created_tool_call.value.label",
+        &slot.path(field, "label"),
         &payload.label,
         FieldLimits::TOOL_LABEL,
         ToolLabel,
     )?;
     let phase = ToolPhase::from_wire(&payload.phase).ok_or_else(|| {
         // `stale` and any unknown phase land here: field-state violation.
-        JspError::field_state("snapshot.last_created_tool_call.value.phase: unsupported phase")
+        JspError::field_state(format!("{}: unsupported phase", slot.path(field, "phase")))
     })?;
     Ok(ToolCallValue { label, phase })
 }
@@ -464,15 +492,20 @@ fn convert_source_terminal(field: &FieldWire) -> Result<SourceTerminalField, Jsp
             "snapshot.source_terminal_state: degraded availability is not valid",
         ));
     }
-    let availability = build_availability("snapshot.source_terminal_state", state, |value| {
-        if value.is_null() {
-            Ok(None)
-        } else {
-            let payload: SourceErrorPayload =
-                parse_payload("snapshot.source_terminal_state", value)?;
-            Ok(Some(parse_source_error(&payload)?))
-        }
-    })?;
+    let availability =
+        build_availability("snapshot.source_terminal_state", state, |slot, value| {
+            if value.is_null() {
+                Ok(None)
+            } else {
+                let root = slot.root("snapshot.source_terminal_state");
+                let payload: SourceErrorPayload = parse_payload(&root, value)?;
+                Ok(Some(parse_source_error(
+                    slot,
+                    "snapshot.source_terminal_state",
+                    &payload,
+                )?))
+            }
+        })?;
     Ok(FieldState::Supported {
         provenance,
         availability,
@@ -485,14 +518,15 @@ fn convert_source_error(field: &FieldWire) -> Result<SourceErrorField, JspError>
         return Ok(FieldState::Unsupported);
     };
     let provenance = convert_provenance(&state.provenance);
-    let availability = build_availability("snapshot.source_error_state", state, |value| {
+    let availability = build_availability("snapshot.source_error_state", state, |slot, value| {
         if value.is_null() {
             return Err(JspError::field_state(
                 "snapshot.source_error_state: known null is not valid; use unsupported",
             ));
         }
-        let payload: SourceErrorPayload = parse_payload("snapshot.source_error_state", value)?;
-        parse_source_error(&payload)
+        let root = slot.root("snapshot.source_error_state");
+        let payload: SourceErrorPayload = parse_payload(&root, value)?;
+        parse_source_error(slot, "snapshot.source_error_state", &payload)
     })?;
     Ok(FieldState::Supported {
         provenance,
@@ -501,15 +535,22 @@ fn convert_source_error(field: &FieldWire) -> Result<SourceErrorField, JspError>
 }
 
 /// Parse a source-error payload with bound checks.
-fn parse_source_error(payload: &SourceErrorPayload) -> Result<SourceErrorValue, JspError> {
+///
+/// The caller supplies its own field path so diagnostics name the field the
+/// producer actually sent rather than a sibling that shares this payload shape.
+fn parse_source_error(
+    slot: &ValueSlot,
+    field_path: &str,
+    payload: &SourceErrorPayload,
+) -> Result<SourceErrorValue, JspError> {
     let summary = parse_bounded_string(
-        "snapshot.source_error_state.value.summary",
+        &slot.path(field_path, "summary"),
         &payload.summary,
         FieldLimits::DIAGNOSTIC_SUMMARY,
         DiagnosticSummary,
     )?;
     let code = parse_bounded_text(
-        "snapshot.source_error_state.value.code",
+        &slot.path(field_path, "code"),
         &payload.code,
         FieldLimits::ERROR_CODE,
         BoundedText,
@@ -522,17 +563,13 @@ fn parse_source_error(payload: &SourceErrorPayload) -> Result<SourceErrorValue, 
 // ---------------------------------------------------------------------------
 
 /// Parse a wait reason from a known-wait JSON object.
+///
+/// The payload goes through the closed [`WaitPayload`] DTO, so unknown members
+/// (including credential and control fields) fail as a closed-shape violation
+/// exactly as they do for every other field value.
 fn parse_wait_reason(path: &str, value: &serde_json::Value) -> Result<WaitReason, JspError> {
-    let obj = value
-        .as_object()
-        .ok_or_else(|| JspError::closed_shape(format!("{path}.value: expected a wait object")))?;
-    let reason_value = obj
-        .get("reason")
-        .ok_or_else(|| JspError::closed_shape(format!("{path}.value.reason: missing field")))?;
-    let reason_str = reason_value
-        .as_str()
-        .ok_or_else(|| JspError::closed_shape(format!("{path}.value.reason: expected a string")))?;
-    WaitReason::from_wire(reason_str)
+    let payload: WaitPayload = parse_payload(path, value)?;
+    WaitReason::from_wire(&payload.reason)
         .ok_or_else(|| JspError::field_state(format!("{path}.value.reason: unsupported reason")))
 }
 

--- a/src/jsp/v1/validate.rs
+++ b/src/jsp/v1/validate.rs
@@ -567,10 +567,12 @@ fn parse_source_error(
 /// The payload goes through the closed [`WaitPayload`] DTO, so unknown members
 /// (including credential and control fields) fail as a closed-shape violation
 /// exactly as they do for every other field value.
-fn parse_wait_reason(path: &str, value: &serde_json::Value) -> Result<WaitReason, JspError> {
-    let payload: WaitPayload = parse_payload(path, value)?;
+/// `slot_root` is the already-resolved `value`/`last_value` path, so the leaf
+/// is appended directly rather than re-adding the member name.
+fn parse_wait_reason(slot_root: &str, value: &serde_json::Value) -> Result<WaitReason, JspError> {
+    let payload: WaitPayload = parse_payload(slot_root, value)?;
     WaitReason::from_wire(&payload.reason)
-        .ok_or_else(|| JspError::field_state(format!("{path}.value.reason: unsupported reason")))
+        .ok_or_else(|| JspError::field_state(format!("{slot_root}.reason: unsupported reason")))
 }
 
 /// Parse a raw JSON value into a typed payload via serde_json, mapping any

--- a/src/jsp/v1/validate.rs
+++ b/src/jsp/v1/validate.rs
@@ -407,7 +407,7 @@ fn parse_todo_item(
     item: &TodoItemWire,
 ) -> Result<TodoItem, JspError> {
     let path = slot.path("snapshot.todos", &format!("items[{index}].text"));
-    let text = parse_bounded_text(&path, &item.text, FieldLimits::TODO_TEXT, BoundedText)?;
+    let text = parse_bounded_string(&path, &item.text, FieldLimits::TODO_TEXT, BoundedText)?;
     Ok(TodoItem {
         text,
         completed: item.completed,
@@ -426,7 +426,7 @@ fn convert_last_message(field: &FieldWire) -> Result<LastMessageField, JspError>
         |slot, value| {
             let field = "snapshot.last_displayed_assistant_message";
             let payload: DisplayedMessagePayload = parse_payload(&slot.root(field), value)?;
-            let content = parse_bounded_text(
+            let content = parse_bounded_string(
                 &slot.path(field, "content"),
                 &payload.content,
                 FieldLimits::DISPLAYED_CONTENT,
@@ -468,7 +468,7 @@ fn parse_tool_value(
     payload: &ToolCallPayload,
 ) -> Result<ToolCallValue, JspError> {
     let field = "snapshot.last_created_tool_call";
-    let label = parse_bounded_text(
+    let label = parse_bounded_string(
         &slot.path(field, "label"),
         &payload.label,
         FieldLimits::TOOL_LABEL,
@@ -549,7 +549,7 @@ fn parse_source_error(
         FieldLimits::DIAGNOSTIC_SUMMARY,
         DiagnosticSummary,
     )?;
-    let code = parse_bounded_text(
+    let code = parse_bounded_string(
         &slot.path(field_path, "code"),
         &payload.code,
         FieldLimits::ERROR_CODE,
@@ -614,16 +614,6 @@ fn parse_bounded_string<T>(
 ) -> Result<T, JspError> {
     super::limits::check_bound(path, value.len(), max)?;
     Ok(wrap(value.to_string()))
-}
-
-/// Parse a bounded text into a `BoundedText`-style newtype.
-fn parse_bounded_text<T>(
-    path: &str,
-    value: &str,
-    max: usize,
-    wrap: impl Fn(String) -> T,
-) -> Result<T, JspError> {
-    parse_bounded_string(path, value, max, wrap)
 }
 
 /// Parse a diagnostic code with bound check.

--- a/src/jsp/v1/wire.rs
+++ b/src/jsp/v1/wire.rs
@@ -11,10 +11,13 @@
 //! string `"unsupported"` or an object with `provenance` and `availability`
 //! (plus `value`/`last_value`/`as_of_ms`/`diagnostic_code` as appropriate).
 
+use std::fmt;
+
 use serde::Deserialize;
+use serde::de::{Error as _, MapAccess, SeqAccess, Visitor};
 
 use super::limits::{
-    MAX_AGENT_KIND_BYTES, MAX_DIAGNOSTIC_CODE_BYTES, MAX_DIAGNOSTIC_SUMMARY_BYTES,
+    ACCEPTED_SCHEMA, MAX_AGENT_KIND_BYTES, MAX_DIAGNOSTIC_CODE_BYTES, MAX_DIAGNOSTIC_SUMMARY_BYTES,
     MAX_DISPLAY_NAME_BYTES, MAX_DISPLAYED_CONTENT_BYTES, MAX_ERROR_CODE_BYTES, MAX_ID_BYTES,
     MAX_PATH_BYTES, MAX_REPOSITORY_BYTES, MAX_TODO_TEXT_BYTES, MAX_TODOS, MAX_TOOL_LABEL_BYTES,
 };
@@ -30,7 +33,7 @@ use super::limits::{
 /// behavior we want.
 #[derive(Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum UnsupportedMarker {
+pub enum UnsupportedMarker {
     Unsupported,
 }
 
@@ -40,7 +43,7 @@ pub(crate) enum UnsupportedMarker {
 /// `"unsupported"` or a supported-state object.
 #[derive(Deserialize)]
 #[serde(untagged)]
-pub(crate) enum FieldWire {
+pub enum FieldWire {
     Unsupported(UnsupportedMarker),
     Supported(Box<SupportedState>),
 }
@@ -64,30 +67,30 @@ pub(crate) enum FieldWire {
 /// null").
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct SupportedState {
-    pub(crate) provenance: ProvenanceWire,
-    pub(crate) availability: AvailabilityKindWire,
+pub struct SupportedState {
+    pub provenance: ProvenanceWire,
+    pub availability: AvailabilityKindWire,
     #[serde(default)]
-    pub(crate) value: Present,
+    pub value: Present,
     #[serde(default)]
-    pub(crate) last_value: Present,
+    pub last_value: Present,
     #[serde(default)]
-    pub(crate) as_of_ms: Option<u64>,
+    pub as_of_ms: Option<u64>,
     #[serde(default)]
-    pub(crate) diagnostic_code: Option<String>,
+    pub diagnostic_code: Option<String>,
 }
 
 /// Wrapper that tracks whether a field was present in the JSON and, if so,
 /// its value (including explicit `null`).
 ///
-/// Implements `Deserialize` manually via a `deserialize_any`-backed visitor so
-/// that an explicit JSON `null` produces `Present { present: true, value: Null }`
-/// while an absent field (via `#[serde(default)]`) produces
+/// Implements `Deserialize` manually via [`StrictValue`] so that an explicit
+/// JSON `null` produces `Present { present: true, value: Null }` while an
+/// absent field (via `#[serde(default)]`) produces
 /// `Present { present: false, value: Null }`.
 #[derive(Default, Clone, Debug)]
-pub(crate) struct Present {
-    pub(crate) present: bool,
-    pub(crate) value: serde_json::Value,
+pub struct Present {
+    pub present: bool,
+    pub value: serde_json::Value,
 }
 
 impl<'de> Deserialize<'de> for Present {
@@ -95,7 +98,7 @@ impl<'de> Deserialize<'de> for Present {
     where
         D: serde::Deserializer<'de>,
     {
-        let value = serde_json::Value::deserialize(deserializer)?;
+        let StrictValue(value) = StrictValue::deserialize(deserializer)?;
         Ok(Self {
             present: true,
             value,
@@ -103,9 +106,106 @@ impl<'de> Deserialize<'de> for Present {
     }
 }
 
+/// A JSON value that rejects duplicate object keys anywhere in its subtree.
+///
+/// `serde_json::Value` resolves duplicate keys last-wins. Capturing a payload
+/// through a plain `Value` would therefore let a producer send the same member
+/// twice and have the closed payload DTO see only the final occurrence, so the
+/// same bytes could mean different things to different JSON libraries. This
+/// wrapper keeps duplicate rejection uniform with the top-level envelope, which
+/// `deny_unknown_fields` already covers.
+pub struct StrictValue(pub serde_json::Value);
+
+impl<'de> Deserialize<'de> for StrictValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(StrictValueVisitor)
+    }
+}
+
+/// Visitor building a [`StrictValue`], rejecting duplicate object keys.
+struct StrictValueVisitor;
+
+impl<'de> Visitor<'de> for StrictValueVisitor {
+    type Value = StrictValue;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a JSON value without duplicate object keys")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(StrictValue(serde_json::Value::Bool(value)))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(StrictValue(serde_json::Value::from(value)))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(StrictValue(serde_json::Value::from(value)))
+    }
+
+    fn visit_f64<E: serde::de::Error>(self, value: f64) -> Result<Self::Value, E> {
+        let number = serde_json::Number::from_f64(value)
+            .ok_or_else(|| E::custom("number is not representable in JSON"))?;
+        Ok(StrictValue(serde_json::Value::Number(number)))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(StrictValue(serde_json::Value::String(value.to_owned())))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(StrictValue(serde_json::Value::String(value)))
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(StrictValue(serde_json::Value::Null))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(StrictValue(serde_json::Value::Null))
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        StrictValue::deserialize(deserializer)
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut items = Vec::new();
+        while let Some(StrictValue(item)) = seq.next_element()? {
+            items.push(item);
+        }
+        Ok(StrictValue(serde_json::Value::Array(items)))
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut object = serde_json::Map::new();
+        while let Some(key) = map.next_key::<String>()? {
+            let StrictValue(value) = map.next_value()?;
+            // The key itself is producer payload and is never echoed.
+            if object.insert(key, value).is_some() {
+                return Err(A::Error::custom("duplicate object key"));
+            }
+        }
+        Ok(StrictValue(serde_json::Value::Object(object)))
+    }
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum ProvenanceWire {
+pub enum ProvenanceWire {
     Authoritative,
     Inferred,
 }
@@ -113,7 +213,7 @@ pub(crate) enum ProvenanceWire {
 /// The availability discriminator string: `known`, `unknown`, or `degraded`.
 #[derive(Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum AvailabilityKindWire {
+pub enum AvailabilityKindWire {
     Known,
     Unknown,
     Degraded,
@@ -123,47 +223,91 @@ pub(crate) enum AvailabilityKindWire {
 // Top-level envelope
 // ---------------------------------------------------------------------------
 
+/// The single accepted schema version, enforced during deserialization.
+///
+/// [`parse`](super::parse) probes the raw discriminators first so an
+/// unsupported version reports `JSP-E003`; this type is what makes the closed
+/// envelope itself unable to hold any other version.
+pub struct AcceptedSchema;
+
+impl<'de> Deserialize<'de> for AcceptedSchema {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = u64::deserialize(deserializer)?;
+        if value == ACCEPTED_SCHEMA {
+            Ok(Self)
+        } else {
+            Err(D::Error::custom("unsupported schema version"))
+        }
+    }
+}
+
+/// The single accepted top-level document kind.
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SnapshotKindWire {
+    Snapshot,
+}
+
 /// The closed top-level snapshot envelope.
+///
+/// `schema` and `kind` are validated by their own closed types during
+/// deserialization, so they are never read afterwards.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct SnapshotWire {
-    pub(crate) schema: u64,
-    pub(crate) kind: String,
-    pub(crate) agent_id: String,
-    pub(crate) lifecycle_generation: u64,
-    pub(crate) source_epoch: String,
-    pub(crate) source_sequence: u64,
-    pub(crate) cursor: u64,
-    pub(crate) bridge_observed_ms: u64,
-    pub(crate) native_session: NativeSessionWire,
-    pub(crate) process_binding: FieldWire,
-    pub(crate) native_activity: FieldWire,
-    pub(crate) current_wait: FieldWire,
-    pub(crate) current_turn: FieldWire,
-    pub(crate) todos: FieldWire,
-    pub(crate) last_displayed_assistant_message: FieldWire,
-    pub(crate) last_created_tool_call: FieldWire,
-    pub(crate) source_terminal_state: FieldWire,
-    pub(crate) source_error_state: FieldWire,
+pub struct SnapshotWire {
+    #[serde(rename = "schema")]
+    pub _schema: AcceptedSchema,
+    #[serde(rename = "kind")]
+    pub _kind: SnapshotKindWire,
+    pub agent_id: String,
+    pub lifecycle_generation: u64,
+    pub source_epoch: String,
+    pub source_sequence: u64,
+    pub cursor: u64,
+    pub bridge_observed_ms: u64,
+    pub native_session: NativeSessionWire,
+    pub process_binding: FieldWire,
+    pub native_activity: FieldWire,
+    pub current_wait: FieldWire,
+    pub current_turn: FieldWire,
+    pub todos: FieldWire,
+    pub last_displayed_assistant_message: FieldWire,
+    pub last_created_tool_call: FieldWire,
+    pub source_terminal_state: FieldWire,
+    pub source_error_state: FieldWire,
 }
 
 /// Native session metadata object (closed).
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct NativeSessionWire {
-    pub(crate) repository: String,
-    pub(crate) path: String,
-    pub(crate) agent_kind: String,
-    pub(crate) pid: u32,
-    pub(crate) display_name: String,
+pub struct NativeSessionWire {
+    pub repository: String,
+    pub path: String,
+    pub agent_kind: String,
+    pub pid: u32,
+    pub display_name: String,
 }
 
 /// Process-binding value payload: `{ "pid": u32, "started_at_ms": u64 }`.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct ProcessBindingPayload {
-    pub(crate) pid: u32,
-    pub(crate) started_at_ms: u64,
+pub struct ProcessBindingPayload {
+    pub pid: u32,
+    pub started_at_ms: u64,
+}
+
+/// Current-wait value payload: `{ "reason": string }`.
+///
+/// Like every other value payload this is a closed DTO, so credential, control,
+/// and transcript members inside `current_wait.value` are rejected at ingress
+/// rather than silently ignored.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WaitPayload {
+    pub reason: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -173,70 +317,70 @@ pub(crate) struct ProcessBindingPayload {
 /// Native activity value payload: `{ "state": "idle" | "thinking" | "acting" }`.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct NativeActivityPayload {
-    pub(crate) state: String,
+pub struct NativeActivityPayload {
+    pub state: String,
 }
 
 /// Current-turn payload: `{ "elapsed_ms": u64 }`.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct CurrentTurnPayload {
-    pub(crate) elapsed_ms: u64,
+pub struct CurrentTurnPayload {
+    pub elapsed_ms: u64,
 }
 
 /// Todos payload: `{ "revision": u64, "items": [TodoItemWire] }`.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct TodosPayload {
-    pub(crate) revision: u64,
-    pub(crate) items: Vec<TodoItemWire>,
+pub struct TodosPayload {
+    pub revision: u64,
+    pub items: Vec<TodoItemWire>,
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct TodoItemWire {
-    pub(crate) text: String,
-    pub(crate) completed: bool,
+pub struct TodoItemWire {
+    pub text: String,
+    pub completed: bool,
 }
 
 /// Last-displayed-assistant-message payload.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct DisplayedMessagePayload {
-    pub(crate) content: String,
-    pub(crate) committed_ms: u64,
+pub struct DisplayedMessagePayload {
+    pub content: String,
+    pub committed_ms: u64,
 }
 
 /// Last-created-tool-call payload: `{ "label": string, "phase": string }`.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct ToolCallPayload {
-    pub(crate) label: String,
-    pub(crate) phase: String,
+pub struct ToolCallPayload {
+    pub label: String,
+    pub phase: String,
 }
 
 /// Source-error-state payload: `{ "summary": string, "code": string }`.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct SourceErrorPayload {
-    pub(crate) summary: String,
-    pub(crate) code: String,
+pub struct SourceErrorPayload {
+    pub summary: String,
+    pub code: String,
 }
 
 /// All field-bound constants grouped for the validator.
-pub(crate) struct FieldLimits;
+pub struct FieldLimits;
 
 impl FieldLimits {
-    pub(crate) const ID: usize = MAX_ID_BYTES;
-    pub(crate) const TODOS: usize = MAX_TODOS;
-    pub(crate) const TODO_TEXT: usize = MAX_TODO_TEXT_BYTES;
-    pub(crate) const DISPLAYED_CONTENT: usize = MAX_DISPLAYED_CONTENT_BYTES;
-    pub(crate) const DIAGNOSTIC_SUMMARY: usize = MAX_DIAGNOSTIC_SUMMARY_BYTES;
-    pub(crate) const TOOL_LABEL: usize = MAX_TOOL_LABEL_BYTES;
-    pub(crate) const REPOSITORY: usize = MAX_REPOSITORY_BYTES;
-    pub(crate) const PATH: usize = MAX_PATH_BYTES;
-    pub(crate) const AGENT_KIND: usize = MAX_AGENT_KIND_BYTES;
-    pub(crate) const DISPLAY_NAME: usize = MAX_DISPLAY_NAME_BYTES;
-    pub(crate) const DIAGNOSTIC_CODE: usize = MAX_DIAGNOSTIC_CODE_BYTES;
-    pub(crate) const ERROR_CODE: usize = MAX_ERROR_CODE_BYTES;
+    pub const ID: usize = MAX_ID_BYTES;
+    pub const TODOS: usize = MAX_TODOS;
+    pub const TODO_TEXT: usize = MAX_TODO_TEXT_BYTES;
+    pub const DISPLAYED_CONTENT: usize = MAX_DISPLAYED_CONTENT_BYTES;
+    pub const DIAGNOSTIC_SUMMARY: usize = MAX_DIAGNOSTIC_SUMMARY_BYTES;
+    pub const TOOL_LABEL: usize = MAX_TOOL_LABEL_BYTES;
+    pub const REPOSITORY: usize = MAX_REPOSITORY_BYTES;
+    pub const PATH: usize = MAX_PATH_BYTES;
+    pub const AGENT_KIND: usize = MAX_AGENT_KIND_BYTES;
+    pub const DISPLAY_NAME: usize = MAX_DISPLAY_NAME_BYTES;
+    pub const DIAGNOSTIC_CODE: usize = MAX_DIAGNOSTIC_CODE_BYTES;
+    pub const ERROR_CODE: usize = MAX_ERROR_CODE_BYTES;
 }

--- a/src/jsp/v1/wire.rs
+++ b/src/jsp/v1/wire.rs
@@ -165,17 +165,6 @@ impl<'de> Visitor<'de> for StrictValueVisitor {
         Ok(StrictValue(serde_json::Value::Null))
     }
 
-    fn visit_none<E>(self) -> Result<Self::Value, E> {
-        Ok(StrictValue(serde_json::Value::Null))
-    }
-
-    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        StrictValue::deserialize(deserializer)
-    }
-
     fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
     where
         A: SeqAccess<'de>,

--- a/src/jsp/v1/wire.rs
+++ b/src/jsp/v1/wire.rs
@@ -1,0 +1,242 @@
+//! Private closed wire DTOs for JSP/1 (issue #476, J1 slice).
+//!
+//! These types are `pub(crate)` and never leak into the public API. They model
+//! the exact closed JSON envelope and use `#[serde(deny_unknown_fields)]` plus
+//! exhaustive field-state enums so that any unknown field, wrong type, or
+//! duplicate field fails at deserialization with a `JSP-E001` closed-shape
+//! error. Conversion to typed domain values happens only in [`validate`] after
+//! the entire document has deserialized.
+//!
+//! Field-state algebra (decision 5): each required field is either the literal
+//! string `"unsupported"` or an object with `provenance` and `availability`
+//! (plus `value`/`last_value`/`as_of_ms`/`diagnostic_code` as appropriate).
+
+use serde::Deserialize;
+
+use super::limits::{
+    MAX_AGENT_KIND_BYTES, MAX_DIAGNOSTIC_CODE_BYTES, MAX_DIAGNOSTIC_SUMMARY_BYTES,
+    MAX_DISPLAY_NAME_BYTES, MAX_DISPLAYED_CONTENT_BYTES, MAX_ERROR_CODE_BYTES, MAX_ID_BYTES,
+    MAX_PATH_BYTES, MAX_REPOSITORY_BYTES, MAX_TODO_TEXT_BYTES, MAX_TODOS, MAX_TOOL_LABEL_BYTES,
+};
+
+// ---------------------------------------------------------------------------
+// Closed field-state enums
+// ---------------------------------------------------------------------------
+
+/// The literal string `"unsupported"`.
+///
+/// Serde deserializes this from the exact JSON string `"unsupported"`. Any
+/// other string value fails deserialization, which is exactly the closed-shape
+/// behavior we want.
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum UnsupportedMarker {
+    Unsupported,
+}
+
+/// `unsupported` string vs supported object, for a generic value payload.
+///
+/// The serde representation is untagged so the JSON is either the string
+/// `"unsupported"` or a supported-state object.
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub(crate) enum FieldWire {
+    Unsupported(UnsupportedMarker),
+    Supported(Box<SupportedState>),
+}
+
+// ---------------------------------------------------------------------------
+// Supported field state
+// ---------------------------------------------------------------------------
+
+/// A supported field state object with provenance and availability.
+///
+/// The flat representation is:
+/// ```json
+/// { "provenance": "authoritative", "availability": "known", "value": ... }
+/// ```
+/// For `degraded`, the sibling fields are `last_value`, `as_of_ms`, and
+/// `diagnostic_code`. `deny_unknown_fields` keeps the object closed.
+///
+/// The `value` and `last_value` fields use [`Present`] to preserve the
+/// distinction between absent and explicit JSON `null`, which is needed for
+/// optional-entity fields (decision 6: "Optional current entities use known
+/// null").
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SupportedState {
+    pub(crate) provenance: ProvenanceWire,
+    pub(crate) availability: AvailabilityKindWire,
+    #[serde(default)]
+    pub(crate) value: Present,
+    #[serde(default)]
+    pub(crate) last_value: Present,
+    #[serde(default)]
+    pub(crate) as_of_ms: Option<u64>,
+    #[serde(default)]
+    pub(crate) diagnostic_code: Option<String>,
+}
+
+/// Wrapper that tracks whether a field was present in the JSON and, if so,
+/// its value (including explicit `null`).
+///
+/// Implements `Deserialize` manually via a `deserialize_any`-backed visitor so
+/// that an explicit JSON `null` produces `Present { present: true, value: Null }`
+/// while an absent field (via `#[serde(default)]`) produces
+/// `Present { present: false, value: Null }`.
+#[derive(Default, Clone, Debug)]
+pub(crate) struct Present {
+    pub(crate) present: bool,
+    pub(crate) value: serde_json::Value,
+}
+
+impl<'de> Deserialize<'de> for Present {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        Ok(Self {
+            present: true,
+            value,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ProvenanceWire {
+    Authoritative,
+    Inferred,
+}
+
+/// The availability discriminator string: `known`, `unknown`, or `degraded`.
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AvailabilityKindWire {
+    Known,
+    Unknown,
+    Degraded,
+}
+
+// ---------------------------------------------------------------------------
+// Top-level envelope
+// ---------------------------------------------------------------------------
+
+/// The closed top-level snapshot envelope.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SnapshotWire {
+    pub(crate) schema: u64,
+    pub(crate) kind: String,
+    pub(crate) agent_id: String,
+    pub(crate) lifecycle_generation: u64,
+    pub(crate) source_epoch: String,
+    pub(crate) source_sequence: u64,
+    pub(crate) cursor: u64,
+    pub(crate) bridge_observed_ms: u64,
+    pub(crate) native_session: NativeSessionWire,
+    pub(crate) process_binding: FieldWire,
+    pub(crate) native_activity: FieldWire,
+    pub(crate) current_wait: FieldWire,
+    pub(crate) current_turn: FieldWire,
+    pub(crate) todos: FieldWire,
+    pub(crate) last_displayed_assistant_message: FieldWire,
+    pub(crate) last_created_tool_call: FieldWire,
+    pub(crate) source_terminal_state: FieldWire,
+    pub(crate) source_error_state: FieldWire,
+}
+
+/// Native session metadata object (closed).
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct NativeSessionWire {
+    pub(crate) repository: String,
+    pub(crate) path: String,
+    pub(crate) agent_kind: String,
+    pub(crate) pid: u32,
+    pub(crate) display_name: String,
+}
+
+/// Process-binding value payload: `{ "pid": u32, "started_at_ms": u64 }`.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ProcessBindingPayload {
+    pub(crate) pid: u32,
+    pub(crate) started_at_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Typed value payloads (validated after deserialization)
+// ---------------------------------------------------------------------------
+
+/// Native activity value payload: `{ "state": "idle" | "thinking" | "acting" }`.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct NativeActivityPayload {
+    pub(crate) state: String,
+}
+
+/// Current-turn payload: `{ "elapsed_ms": u64 }`.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CurrentTurnPayload {
+    pub(crate) elapsed_ms: u64,
+}
+
+/// Todos payload: `{ "revision": u64, "items": [TodoItemWire] }`.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TodosPayload {
+    pub(crate) revision: u64,
+    pub(crate) items: Vec<TodoItemWire>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TodoItemWire {
+    pub(crate) text: String,
+    pub(crate) completed: bool,
+}
+
+/// Last-displayed-assistant-message payload.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DisplayedMessagePayload {
+    pub(crate) content: String,
+    pub(crate) committed_ms: u64,
+}
+
+/// Last-created-tool-call payload: `{ "label": string, "phase": string }`.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ToolCallPayload {
+    pub(crate) label: String,
+    pub(crate) phase: String,
+}
+
+/// Source-error-state payload: `{ "summary": string, "code": string }`.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SourceErrorPayload {
+    pub(crate) summary: String,
+    pub(crate) code: String,
+}
+
+/// All field-bound constants grouped for the validator.
+pub(crate) struct FieldLimits;
+
+impl FieldLimits {
+    pub(crate) const ID: usize = MAX_ID_BYTES;
+    pub(crate) const TODOS: usize = MAX_TODOS;
+    pub(crate) const TODO_TEXT: usize = MAX_TODO_TEXT_BYTES;
+    pub(crate) const DISPLAYED_CONTENT: usize = MAX_DISPLAYED_CONTENT_BYTES;
+    pub(crate) const DIAGNOSTIC_SUMMARY: usize = MAX_DIAGNOSTIC_SUMMARY_BYTES;
+    pub(crate) const TOOL_LABEL: usize = MAX_TOOL_LABEL_BYTES;
+    pub(crate) const REPOSITORY: usize = MAX_REPOSITORY_BYTES;
+    pub(crate) const PATH: usize = MAX_PATH_BYTES;
+    pub(crate) const AGENT_KIND: usize = MAX_AGENT_KIND_BYTES;
+    pub(crate) const DISPLAY_NAME: usize = MAX_DISPLAY_NAME_BYTES;
+    pub(crate) const DIAGNOSTIC_CODE: usize = MAX_DIAGNOSTIC_CODE_BYTES;
+    pub(crate) const ERROR_CODE: usize = MAX_ERROR_CODE_BYTES;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,3 +91,6 @@ pub fn process_identity_label(pid: u32, commit: &str) -> String {
 }
 
 pub mod harness;
+
+/// JSP (Jefe Stream Protocol) external wire boundary (issue #476).
+pub mod jsp;

--- a/tests/jsp_v1_event_compliance.rs
+++ b/tests/jsp_v1_event_compliance.rs
@@ -1,0 +1,246 @@
+//! JSP/1 event and heartbeat compliance suite (issue #476).
+//!
+//! These tests drive the public parsing entry points against the same
+//! language-neutral fixture corpus that external producer and broker
+//! implementations must satisfy, so the Rust reference oracle and any other
+//! implementation are held to one contract.
+//!
+//! Acceptance rows:
+//! - E1: every event in the closed inventory parses into its typed transition.
+//! - E2: unknown event types and unknown payload members fail closed.
+//! - E3: waiting requires an explicit event; producers cannot assert stale.
+//! - E4: todo replacement carries a positive revision and bounded items.
+//! - E5: event diagnostics never echo producer payload values.
+//! - E6: the identity triple is validated on every document kind.
+//! - E7: heartbeats report liveness and carry no sequence.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use jefe::domain::observation::{
+    NativeActivityState, ObservationEvent, ToolPhase, TurnOutcome, WaitReason,
+};
+use jefe::jsp::v1::error::JspCode;
+use jefe::jsp::v1::{parse_event, parse_heartbeat};
+
+/// Absolute path to the shared fixture directory.
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("dev-docs/jsp/v1/fixtures")
+}
+
+/// Read a fixture by file name.
+fn fixture(name: &str) -> Vec<u8> {
+    let path = fixture_dir().join(name);
+    fs::read(&path).unwrap_or_else(|error| panic!("fixture {name} must be readable: {error}"))
+}
+
+/// Parse an event fixture, requiring success.
+fn parse_ok(name: &str) -> ObservationEvent {
+    match parse_event(&fixture(name)) {
+        Ok(record) => record.event,
+        Err(error) => panic!("fixture {name} must parse: {}", error.detail()),
+    }
+}
+
+/// Parse an event fixture, requiring the given failure code.
+fn parse_err(name: &str, expected: JspCode) -> String {
+    match parse_event(&fixture(name)) {
+        Ok(_) => panic!("fixture {name} must fail with {}", expected.as_str()),
+        Err(error) => {
+            assert_eq!(
+                error.code(),
+                expected,
+                "fixture {name} must fail with {}: {}",
+                expected.as_str(),
+                error.detail()
+            );
+            error.detail().to_string()
+        }
+    }
+}
+
+#[test]
+fn e1_activity_change_parses_into_its_typed_state() {
+    assert_eq!(
+        parse_ok("event_activity_changed.json"),
+        ObservationEvent::ActivityChanged {
+            state: NativeActivityState::Acting
+        }
+    );
+}
+
+#[test]
+fn e1_turn_end_carries_its_explicit_outcome() {
+    assert_eq!(
+        parse_ok("event_turn_ended.json"),
+        ObservationEvent::TurnEnded {
+            outcome: TurnOutcome::Cancelled
+        },
+        "a cancelled turn must stay distinguishable from a completed one"
+    );
+}
+
+#[test]
+fn e1_payload_free_events_need_no_members() {
+    assert_eq!(
+        parse_ok("event_session_ended.json"),
+        ObservationEvent::SessionEnded
+    );
+}
+
+#[test]
+fn e1_tool_creation_keeps_its_label_and_phase() {
+    let ObservationEvent::ToolCallCreated { tool } = parse_ok("event_tool_created.json") else {
+        panic!("fixture must produce a tool-call creation");
+    };
+    assert_eq!(tool.label.as_str(), "read_file");
+    assert_eq!(tool.phase, ToolPhase::AwaitingApproval);
+}
+
+#[test]
+fn e1_displayed_message_keeps_its_commit_timestamp() {
+    let ObservationEvent::AssistantMessageDisplayed { message } =
+        parse_ok("event_message_displayed.json")
+    else {
+        panic!("fixture must produce a displayed message");
+    };
+    assert_eq!(message.content.as_str(), "Done.");
+    assert_eq!(message.committed_ms, 1_750_000_000_450);
+}
+
+#[test]
+fn e2_unknown_event_type_is_rejected_rather_than_ignored() {
+    parse_err("event_unknown_type.json", JspCode::EClosedShape);
+}
+
+#[test]
+fn e2_unknown_members_inside_an_event_payload_fail_closed() {
+    parse_err("event_forbidden_fields.json", JspCode::EClosedShape);
+}
+
+#[test]
+fn e3_explicit_reason_is_required_to_enter_waiting() {
+    assert_eq!(
+        parse_ok("event_wait_opened.json"),
+        ObservationEvent::WaitOpened {
+            reason: WaitReason::Permission
+        }
+    );
+}
+
+#[test]
+fn e3_silence_has_no_event_that_can_create_waiting() {
+    // The closed inventory has no "quiet"/"idle timeout"/"silence" transition,
+    // so no producer can manufacture waiting from the absence of activity.
+    for manufactured in [
+        r#"{"type":"wait.silence"}"#,
+        r#"{"type":"activity.silence"}"#,
+        r#"{"type":"wait.opened","reason":"silence"}"#,
+    ] {
+        let document = format!(
+            concat!(
+                r#"{{"schema":1,"kind":"event","agent_id":"a","lifecycle_generation":1,"#,
+                r#""source_epoch":"e","source_sequence":1,"bridge_observed_ms":1,"event":{}}}"#
+            ),
+            manufactured
+        );
+        assert!(
+            parse_event(document.as_bytes()).is_err(),
+            "silence must never produce a wait: {manufactured}"
+        );
+    }
+}
+
+#[test]
+fn e3_producer_cannot_assert_stale() {
+    parse_err("event_stale_phase.json", JspCode::EFieldState);
+}
+
+#[test]
+fn e4_todo_replacement_carries_revision_and_items() {
+    let ObservationEvent::TodosReplaced { todos } = parse_ok("event_todos_replaced.json") else {
+        panic!("fixture must produce a todo replacement");
+    };
+    assert_eq!(todos.revision, 9);
+    assert_eq!(todos.items.len(), 2);
+    assert!(todos.items[0].completed);
+    assert!(!todos.items[1].completed);
+}
+
+#[test]
+fn e4_zero_revision_is_a_field_state_violation() {
+    let document = concat!(
+        r#"{"schema":1,"kind":"event","agent_id":"a","lifecycle_generation":1,"#,
+        r#""source_epoch":"e","source_sequence":1,"bridge_observed_ms":1,"#,
+        r#""event":{"type":"todos.replaced","revision":0,"items":[]}}"#
+    );
+    let error = parse_event(document.as_bytes())
+        .err()
+        .unwrap_or_else(|| panic!("a zero revision must fail"));
+    assert_eq!(error.code(), JspCode::EFieldState);
+}
+
+#[test]
+fn e4_an_empty_todo_list_is_valid_and_distinct_from_absent() {
+    let document = concat!(
+        r#"{"schema":1,"kind":"event","agent_id":"a","lifecycle_generation":1,"#,
+        r#""source_epoch":"e","source_sequence":1,"bridge_observed_ms":1,"#,
+        r#""event":{"type":"todos.replaced","revision":1,"items":[]}}"#
+    );
+    let Ok(record) = parse_event(document.as_bytes()) else {
+        panic!("an explicitly empty todo list is valid");
+    };
+    let ObservationEvent::TodosReplaced { todos } = record.event else {
+        panic!("must produce a todo replacement");
+    };
+    assert!(
+        todos.items.is_empty(),
+        "an authoritative empty list is not the same as unsupported todos"
+    );
+}
+
+#[test]
+fn e5_event_diagnostics_never_echo_payload_values() {
+    let detail = parse_err("event_forbidden_fields.json", JspCode::EClosedShape);
+    for token in ["SECRET", "kill", "run_shell"] {
+        assert!(
+            !detail.contains(token),
+            "diagnostic leaked payload value '{token}': {detail}"
+        );
+    }
+}
+
+#[test]
+fn e6_identity_is_validated_on_events() {
+    parse_err("event_invalid_identity.json", JspCode::EIdentity);
+}
+
+#[test]
+fn e7_heartbeat_reports_liveness_without_a_transition() {
+    let Ok(record) = parse_heartbeat(&fixture("heartbeat_full.json")) else {
+        panic!("the canonical heartbeat must parse");
+    };
+    assert_eq!(record.identity.agent_id.as_str(), "agent-alpha");
+    assert_eq!(record.identity.lifecycle_generation, 3);
+    assert_eq!(record.bridge_observed_ms, 1_750_000_001_100);
+}
+
+#[test]
+fn e7_heartbeat_must_not_carry_a_sequence() {
+    let error = parse_heartbeat(&fixture("heartbeat_with_sequence.json"))
+        .err()
+        .unwrap_or_else(|| panic!("a heartbeat carrying a sequence must fail"));
+    assert_eq!(
+        error.code(),
+        JspCode::EClosedShape,
+        "a heartbeat must not be able to advance or gap the stream"
+    );
+}
+
+#[test]
+fn e7_an_event_document_is_not_accepted_as_a_heartbeat() {
+    let error = parse_heartbeat(&fixture("event_activity_changed.json"))
+        .err()
+        .unwrap_or_else(|| panic!("kinds must not be interchangeable"));
+    assert_eq!(error.code(), JspCode::EUnsupportedVersion);
+}

--- a/tests/jsp_v1_snapshot_compliance.rs
+++ b/tests/jsp_v1_snapshot_compliance.rs
@@ -588,6 +588,22 @@ fn s6_error_diagnostics_never_echo_payload() {
     }
 }
 
+/// S6: a diagnostic names each JSON member exactly once, so an external
+/// implementer can use the path as a pointer into the document.
+#[test]
+fn s6_diagnostic_paths_do_not_repeat_a_member() {
+    let bytes = snapshot_with_wait_state(
+        r#"{"provenance":"authoritative","availability":"known","value":{"reason":"bogus"}}"#,
+    );
+    let error = parse_snapshot(&bytes)
+        .err()
+        .unwrap_or_else(|| panic!("unknown wait reason must fail"));
+    assert_eq!(
+        error.detail(),
+        "snapshot.current_wait.value.reason: unsupported reason"
+    );
+}
+
 /// S6: `source_terminal_state` diagnostics name that field, not the sibling
 /// `source_error_state` that shares its payload shape.
 #[test]

--- a/tests/jsp_v1_snapshot_compliance.rs
+++ b/tests/jsp_v1_snapshot_compliance.rs
@@ -32,6 +32,7 @@ fn fixtures_dir() -> PathBuf {
 struct ManifestEntry {
     name: String,
     file: String,
+    kind: String,
     expected: String,
     #[serde(default)]
     error_code: Option<String>,
@@ -96,10 +97,11 @@ fn manifest_fixtures_match_expected_results() {
             .unwrap_or_else(|_| panic!("fixture {} exists at {}", entry.name, path.display()));
 
         match entry.expected.as_str() {
-            "ok" => match parse_snapshot(&bytes) {
-                Ok(snapshot) => {
+            "ok" => match parse_for_kind(entry, &bytes) {
+                Ok(Some(snapshot)) => {
                     assert_expected_identity(&entry.name, &snapshot);
                 }
+                Ok(None) => {}
                 Err(error) => panic!(
                     "fixture {} expected ok but failed: {} ({})",
                     entry.name,
@@ -114,7 +116,7 @@ fn manifest_fixtures_match_expected_results() {
                         entry.name
                     )
                 });
-                match parse_snapshot(&bytes) {
+                match parse_for_kind(entry, &bytes) {
                     Ok(_) => panic!(
                         "fixture {} expected error {} but parsed successfully",
                         entry.name, expected_code
@@ -134,6 +136,23 @@ fn manifest_fixtures_match_expected_results() {
             }
             other => panic!("fixture {} has unknown expected value: {other}", entry.name),
         }
+    }
+}
+
+/// Parse a fixture with the entry point for its declared document kind.
+///
+/// Returns the snapshot for snapshot fixtures so identity can be cross-checked;
+/// event and heartbeat fixtures return `None` on success because they carry no
+/// snapshot to inspect here (they are asserted in the event compliance suite).
+fn parse_for_kind(
+    entry: &ManifestEntry,
+    bytes: &[u8],
+) -> Result<Option<jefe::jsp::v1::Snapshot>, jefe::jsp::v1::JspError> {
+    match entry.kind.as_str() {
+        "snapshot" => parse_snapshot(bytes).map(Some),
+        "event" => jefe::jsp::v1::parse_event(bytes).map(|_| None),
+        "heartbeat" => jefe::jsp::v1::parse_heartbeat(bytes).map(|_| None),
+        other => panic!("fixture {} has unknown kind: {other}", entry.name),
     }
 }
 

--- a/tests/jsp_v1_snapshot_compliance.rs
+++ b/tests/jsp_v1_snapshot_compliance.rs
@@ -1,0 +1,466 @@
+//! JSP/1 snapshot compliance integration test (issue 476, J1 slice).
+//!
+//! This is the language-neutral fixture-manifest oracle. It loads
+//! `dev-docs/jsp/v1/fixtures/manifest.json`, enumerates every listed fixture,
+//! and asserts each one parses to the manifest-declared expected result. A
+//! missing or unlisted fixture fails the integration test (S6). Credential and
+//! control fields are attempted in `snapshot_forbidden_fields.json` and must
+//! fail closed (S5/S6).
+//!
+//! Canonical fixtures live outside the crate so external implementations can
+//! consume the exact same corpus from another repository/language.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
+
+use jefe::domain::observation::{FieldState, NativeActivityState, NativeActivityValue, Provenance};
+use jefe::jsp::v1::error::JspCode;
+use jefe::jsp::v1::parse_snapshot;
+
+/// Resolve the fixtures directory under the workspace root.
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("dev-docs")
+        .join("jsp")
+        .join("v1")
+        .join("fixtures")
+}
+
+/// One manifest fixture entry, mirroring `manifest.json`.
+#[derive(serde::Deserialize)]
+struct ManifestEntry {
+    name: String,
+    file: String,
+    expected: String,
+    #[serde(default)]
+    error_code: Option<String>,
+}
+
+/// The manifest document.
+#[derive(serde::Deserialize)]
+struct Manifest {
+    fixtures: Vec<ManifestEntry>,
+}
+
+/// Load and parse the manifest document.
+fn load_manifest() -> Manifest {
+    let manifest_path = fixtures_dir().join("manifest.json");
+    let raw = fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|_| panic!("manifest must exist at {}", manifest_path.display()));
+    serde_json::from_str(&raw)
+        .unwrap_or_else(|_| panic!("manifest must be valid JSON at {}", manifest_path.display()))
+}
+
+/// Assert that every JSON file on disk is listed in the manifest (S6: a
+/// missing/unlisted fixture fails the integration test).
+#[test]
+fn manifest_enumerates_every_fixture_on_disk() {
+    let manifest = load_manifest();
+    let listed: HashSet<String> = manifest.fixtures.iter().map(|e| e.file.clone()).collect();
+    let mut on_disk: HashSet<String> = HashSet::new();
+    let dir = fs::read_dir(fixtures_dir())
+        .unwrap_or_else(|err| panic!("fixtures directory readable: {err}"));
+    for entry in dir {
+        let entry = entry.unwrap_or_else(|err| panic!("readable dir entry: {err}"));
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "json") {
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_else(|| panic!("utf-8 fixture name for {}", path.display()));
+            if name != "manifest.json" {
+                on_disk.insert(name.to_string());
+            }
+        }
+    }
+    assert_eq!(
+        listed, on_disk,
+        "every fixture on disk must be listed in the manifest and vice versa"
+    );
+}
+
+/// Drive every manifest entry through the JSP/1 parser and assert the declared
+/// result. This is the core compliance oracle (S1-S6).
+#[test]
+fn manifest_fixtures_match_expected_results() {
+    let manifest = load_manifest();
+    assert!(
+        !manifest.fixtures.is_empty(),
+        "manifest must enumerate at least one fixture"
+    );
+
+    for entry in &manifest.fixtures {
+        let path = fixtures_dir().join(&entry.file);
+        let bytes = fs::read(&path)
+            .unwrap_or_else(|_| panic!("fixture {} exists at {}", entry.name, path.display()));
+
+        match entry.expected.as_str() {
+            "ok" => match parse_snapshot(&bytes) {
+                Ok(snapshot) => {
+                    assert_expected_identity(&entry.name, &snapshot);
+                }
+                Err(error) => panic!(
+                    "fixture {} expected ok but failed: {} ({})",
+                    entry.name,
+                    error.code(),
+                    error.code().as_str()
+                ),
+            },
+            "error" => {
+                let expected_code = entry.error_code.as_deref().unwrap_or_else(|| {
+                    panic!(
+                        "fixture {} declares error_code for error expected",
+                        entry.name
+                    )
+                });
+                match parse_snapshot(&bytes) {
+                    Ok(_) => panic!(
+                        "fixture {} expected error {} but parsed successfully",
+                        entry.name, expected_code
+                    ),
+                    Err(error) => {
+                        let actual = error.code();
+                        assert_eq!(
+                            actual.as_str(),
+                            expected_code,
+                            "fixture {} expected code {} but got {}",
+                            entry.name,
+                            expected_code,
+                            actual.as_str()
+                        );
+                    }
+                }
+            }
+            other => panic!("fixture {} has unknown expected value: {other}", entry.name),
+        }
+    }
+}
+
+/// Cross-check that the parsed identity is non-empty and well-formed (S1/S3).
+fn assert_expected_identity(fixture_name: &str, snapshot: &jefe::jsp::v1::Snapshot) {
+    assert!(
+        !snapshot.identity.agent_id.as_str().is_empty(),
+        "{fixture_name}: agent_id must not be empty"
+    );
+    assert!(
+        snapshot.identity.lifecycle_generation >= 1,
+        "{fixture_name}: lifecycle_generation must be positive"
+    );
+}
+
+/// S1: the canonical full snapshot yields exact typed identity, cursor, and
+/// semantic fields with provenance and availability.
+#[test]
+fn s1_canonical_full_snapshot_has_exact_typed_fields() {
+    let path = fixtures_dir().join("snapshot_full.json");
+    let bytes =
+        fs::read(&path).unwrap_or_else(|_| panic!("full fixture exists at {}", path.display()));
+    let snapshot =
+        parse_snapshot(&bytes).unwrap_or_else(|err| panic!("full snapshot must parse: {err}"));
+
+    assert_eq!(snapshot.identity.agent_id.as_str(), "agent-alex");
+    assert_eq!(snapshot.identity.lifecycle_generation, 7);
+    assert_eq!(snapshot.identity.source_epoch.as_str(), "epoch-001");
+    assert_eq!(snapshot.cursor, 41);
+    assert_eq!(snapshot.source_sequence, 42);
+    assert_eq!(snapshot.bridge_observed_ms, 1_785_921_964_000);
+
+    assert_eq!(
+        snapshot.native_session.repository.as_str(),
+        "vybestack/llxprt-jefe"
+    );
+    assert_eq!(snapshot.native_session.path.as_str(), "/Users/dev/src/jefe");
+    assert_eq!(snapshot.native_session.agent_kind.as_str(), "llxprt");
+    assert_eq!(snapshot.native_session.pid, 12_345);
+    assert_eq!(snapshot.native_session.display_name.as_str(), "main-worker");
+
+    let FieldState::Supported {
+        provenance,
+        availability,
+    } = &snapshot.process_binding
+    else {
+        panic!("process_binding must be a supported field state");
+    };
+    assert_eq!(*provenance, Provenance::Authoritative);
+    let binding = availability
+        .known_value()
+        .unwrap_or_else(|| panic!("process_binding must carry a known value"));
+    assert_eq!(binding.pid, 12_345);
+    assert_eq!(binding.started_at_ms, 1_785_921_000_000);
+
+    assert_eq!(
+        snapshot.native_activity,
+        FieldState::known(
+            Provenance::Authoritative,
+            NativeActivityValue {
+                state: NativeActivityState::Idle
+            }
+        ),
+        "native activity is source-owned and authoritative in the canonical fixture"
+    );
+}
+
+/// S2: closed grammar rejects unknown fields, wrong schema, wrong kind, and
+/// wrong types with deterministic JSP-E001/JSP-E003 and no echoed payload.
+#[test]
+fn s2_closed_grammar_rejects_unknown_and_version_violations() {
+    let path = fixtures_dir().join("snapshot_closed_grammar.json");
+    let unknown =
+        fs::read(&path).unwrap_or_else(|_| panic!("closed grammar fixture at {}", path.display()));
+    let error = parse_snapshot(&unknown)
+        .err()
+        .unwrap_or_else(|| panic!("unknown fields must fail"));
+    assert_eq!(error.code(), JspCode::EClosedShape);
+}
+
+/// S2: schema 0 and schema 2 both fail with JSP-E003.
+#[test]
+fn s2_unsupported_schema_version_fails() {
+    let schema0 = br#"{"schema":0,"kind":"snapshot","agent_id":"a","lifecycle_generation":1,"source_epoch":"e","source_sequence":1,"cursor":0,"bridge_observed_ms":1,"native_session":{"repository":"r","path":"p","agent_kind":"llxprt","pid":1,"display_name":"d"},"process_binding":"unsupported","native_activity":"unsupported","current_wait":"unsupported","current_turn":"unsupported","todos":"unsupported","last_displayed_assistant_message":"unsupported","last_created_tool_call":"unsupported","source_terminal_state":"unsupported","source_error_state":"unsupported"}"#;
+    let error = parse_snapshot(schema0)
+        .err()
+        .unwrap_or_else(|| panic!("schema 0 must fail"));
+    assert_eq!(error.code(), JspCode::EUnsupportedVersion);
+
+    let mut schema2 = schema0.to_vec();
+    // Replace the '0' after "schema": with '2' (byte index 10).
+    schema2[10] = b'2';
+    let error = parse_snapshot(&schema2)
+        .err()
+        .unwrap_or_else(|| panic!("schema 2 must fail"));
+    assert_eq!(error.code(), JspCode::EUnsupportedVersion);
+}
+
+/// S2: empty input, truncated JSON, and non-utf8 all fail with JSP-E001.
+#[test]
+fn s2_malformed_input_fails_closed() {
+    let cases: &[&[u8]] = &[b"", b"{", b"{\"schema\"", &[0xFF, 0xFE, 0xFD]];
+    for input in cases {
+        let error = parse_snapshot(input)
+            .err()
+            .unwrap_or_else(|| panic!("malformed input must fail"));
+        assert_eq!(error.code(), JspCode::EClosedShape);
+    }
+}
+
+/// S2: a 129-byte agent_id exceeds the 128-byte bound and fails with JSP-E002.
+#[test]
+fn s2_over_limit_agent_id_fails() {
+    let too_long = "a".repeat(129);
+    let json = format!(
+        r#"{{"schema":1,"kind":"snapshot","agent_id":"{too_long}","lifecycle_generation":1,"source_epoch":"e","source_sequence":1,"cursor":0,"bridge_observed_ms":1,"native_session":{{"repository":"r","path":"p","agent_kind":"llxprt","pid":1,"display_name":"d"}},"process_binding":"unsupported","native_activity":"unsupported","current_wait":"unsupported","current_turn":"unsupported","todos":"unsupported","last_displayed_assistant_message":"unsupported","last_created_tool_call":"unsupported","source_terminal_state":"unsupported","source_error_state":"unsupported"}}"#
+    );
+    let error = parse_snapshot(json.as_bytes())
+        .err()
+        .unwrap_or_else(|| panic!("over-limit id must fail"));
+    assert_eq!(error.code(), JspCode::EBound);
+}
+
+/// S3: two snapshots in the same worktree with distinct agent/generation/epoch
+/// produce distinct live keys.
+#[test]
+fn s3_distinct_identity_remains_distinct() {
+    let path_a = fixtures_dir().join("snapshot_full.json");
+    let a = fs::read(&path_a).unwrap_or_else(|_| panic!("full fixture at {}", path_a.display()));
+    let path_b = fixtures_dir().join("snapshot_identity_distinct.json");
+    let b =
+        fs::read(&path_b).unwrap_or_else(|_| panic!("identity fixture at {}", path_b.display()));
+    let snap_a = parse_snapshot(&a).unwrap_or_else(|err| panic!("full parses: {err}"));
+    let snap_b = parse_snapshot(&b).unwrap_or_else(|err| panic!("identity parses: {err}"));
+
+    assert_ne!(
+        snap_a.identity.agent_id, snap_b.identity.agent_id,
+        "distinct agent ids"
+    );
+    assert_ne!(
+        snap_a.identity.lifecycle_generation, snap_b.identity.lifecycle_generation,
+        "distinct generations"
+    );
+    assert_ne!(
+        snap_a.identity.source_epoch, snap_b.identity.source_epoch,
+        "distinct epochs"
+    );
+}
+
+/// S3: zero generation is an invalid identity and fails with JSP-E004.
+#[test]
+fn s3_zero_generation_is_invalid_identity() {
+    let json = br#"{"schema":1,"kind":"snapshot","agent_id":"a","lifecycle_generation":0,"source_epoch":"e","source_sequence":1,"cursor":0,"bridge_observed_ms":1,"native_session":{"repository":"r","path":"p","agent_kind":"llxprt","pid":1,"display_name":"d"},"process_binding":"unsupported","native_activity":"unsupported","current_wait":"unsupported","current_turn":"unsupported","todos":"unsupported","last_displayed_assistant_message":"unsupported","last_created_tool_call":"unsupported","source_terminal_state":"unsupported","source_error_state":"unsupported"}"#;
+    let error = parse_snapshot(json)
+        .err()
+        .unwrap_or_else(|| panic!("zero generation must fail"));
+    assert_eq!(error.code(), JspCode::EIdentity);
+}
+
+/// S4: producer-supplied stale state is rejected (stale is a local overlay,
+/// not a producer value).
+#[test]
+fn s4_producer_stale_state_rejected() {
+    let path = fixtures_dir().join("snapshot_semantic_failure.json");
+    let bytes =
+        fs::read(&path).unwrap_or_else(|_| panic!("semantic fixture at {}", path.display()));
+    let error = parse_snapshot(&bytes)
+        .err()
+        .unwrap_or_else(|| panic!("producer stale must fail"));
+    assert_eq!(error.code(), JspCode::EFieldState);
+}
+
+/// S5/S6: forbidden credential and control fields fail closed with JSP-E001
+/// and no payload text in the diagnostic.
+#[test]
+fn s5_forbidden_fields_fail_closed() {
+    let path = fixtures_dir().join("snapshot_forbidden_fields.json");
+    let bytes =
+        fs::read(&path).unwrap_or_else(|_| panic!("forbidden fixture at {}", path.display()));
+    let error = parse_snapshot(&bytes)
+        .err()
+        .unwrap_or_else(|| panic!("forbidden fields must fail"));
+    assert_eq!(error.code(), JspCode::EClosedShape);
+    // Diagnostic must not echo any payload value (S5/S6).
+    let detail = error.detail();
+    assert!(
+        !detail.contains("supersecret"),
+        "diagnostic must not echo credential payload"
+    );
+    assert!(
+        !detail.contains("leaked"),
+        "diagnostic must not echo forbidden payload"
+    );
+    assert!(
+        !detail.contains("kill"),
+        "diagnostic must not echo control payload"
+    );
+}
+
+/// Build a snapshot document whose `native_activity` field carries the supplied
+/// raw JSON field-state, with every other field `unsupported`.
+fn snapshot_with_activity_state(field_state: &str) -> Vec<u8> {
+    format!(
+        r#"{{"schema":1,"kind":"snapshot","agent_id":"a","lifecycle_generation":1,"source_epoch":"e","source_sequence":1,"cursor":0,"bridge_observed_ms":1,"native_session":{{"repository":"r","path":"p","agent_kind":"llxprt","pid":1,"display_name":"d"}},"process_binding":"unsupported","native_activity":{field_state},"current_wait":"unsupported","current_turn":"unsupported","todos":"unsupported","last_displayed_assistant_message":"unsupported","last_created_tool_call":"unsupported","source_terminal_state":"unsupported","source_error_state":"unsupported"}}"#
+    )
+    .into_bytes()
+}
+
+/// S4: the field-state algebra is closed — `known` requires `value` and
+/// forbids the degraded members; `unknown` forbids every value member;
+/// `degraded` requires its anchor members and forbids `value`.
+#[test]
+fn s4_field_state_algebra_rejects_illegal_member_combinations() {
+    let illegal = [
+        // `known` without a value.
+        r#"{"provenance":"authoritative","availability":"known"}"#,
+        // `known` carrying degraded-only members.
+        r#"{"provenance":"authoritative","availability":"known","value":{"state":"idle"},"as_of_ms":5}"#,
+        r#"{"provenance":"authoritative","availability":"known","value":{"state":"idle"},"last_value":{"state":"idle"}}"#,
+        r#"{"provenance":"authoritative","availability":"known","value":{"state":"idle"},"diagnostic_code":"X"}"#,
+        // `unknown` carrying any value member.
+        r#"{"provenance":"inferred","availability":"unknown","value":{"state":"idle"}}"#,
+        r#"{"provenance":"inferred","availability":"unknown","as_of_ms":5}"#,
+        // `degraded` missing its required anchors, or using `value`.
+        r#"{"provenance":"inferred","availability":"degraded","last_value":{"state":"idle"}}"#,
+        r#"{"provenance":"inferred","availability":"degraded","last_value":{"state":"idle"},"as_of_ms":5}"#,
+        r#"{"provenance":"inferred","availability":"degraded","value":{"state":"idle"},"as_of_ms":5,"diagnostic_code":"X"}"#,
+    ];
+    for field_state in illegal {
+        let error = parse_snapshot(&snapshot_with_activity_state(field_state))
+            .err()
+            .unwrap_or_else(|| panic!("illegal field state must fail: {field_state}"));
+        assert_eq!(
+            error.code(),
+            JspCode::EClosedShape,
+            "illegal field state must fail closed: {field_state}"
+        );
+    }
+}
+
+/// S4: every legal availability form is accepted.
+#[test]
+fn s4_field_state_algebra_accepts_every_legal_form() {
+    let legal = [
+        r#"{"provenance":"authoritative","availability":"known","value":{"state":"idle"}}"#,
+        r#"{"provenance":"inferred","availability":"unknown"}"#,
+        r#"{"provenance":"inferred","availability":"degraded","last_value":{"state":"acting"},"as_of_ms":5,"diagnostic_code":"STALE_NATIVE"}"#,
+    ];
+    for field_state in legal {
+        parse_snapshot(&snapshot_with_activity_state(field_state))
+            .unwrap_or_else(|err| panic!("legal field state must parse: {field_state}: {err}"));
+    }
+}
+
+/// S4: an unknown activity state is a field-state violation, not a shape error.
+#[test]
+fn s4_unknown_activity_state_is_field_state_violation() {
+    let error = parse_snapshot(&snapshot_with_activity_state(
+        r#"{"provenance":"authoritative","availability":"known","value":{"state":"bogus"}}"#,
+    ))
+    .err()
+    .unwrap_or_else(|| panic!("unknown activity state must fail"));
+    assert_eq!(error.code(), JspCode::EFieldState);
+}
+
+/// S2: duplicate top-level fields and trailing data fail closed.
+#[test]
+fn s2_duplicate_fields_and_trailing_data_fail_closed() {
+    let base = String::from_utf8(snapshot_with_activity_state(r#""unsupported""#))
+        .unwrap_or_else(|err| panic!("fixture is utf-8: {err}"));
+
+    let duplicated = base.replacen(r#""schema":1,"#, r#""schema":1,"schema":1,"#, 1);
+    let error = parse_snapshot(duplicated.as_bytes())
+        .err()
+        .unwrap_or_else(|| panic!("duplicate field must fail"));
+    assert_eq!(error.code(), JspCode::EClosedShape);
+
+    let trailing = format!("{base} trailing");
+    let error = parse_snapshot(trailing.as_bytes())
+        .err()
+        .unwrap_or_else(|| panic!("trailing data must fail"));
+    assert_eq!(error.code(), JspCode::EClosedShape);
+}
+
+/// S5: an unknown kind fails with JSP-E003.
+#[test]
+fn s5_unknown_kind_fails() {
+    let json = br#"{"schema":1,"kind":"nope","agent_id":"a","lifecycle_generation":1,"source_epoch":"e","source_sequence":1,"cursor":0,"bridge_observed_ms":1}"#;
+    let error = parse_snapshot(json)
+        .err()
+        .unwrap_or_else(|| panic!("unknown kind must fail"));
+    assert_eq!(error.code(), JspCode::EUnsupportedVersion);
+}
+
+/// S6: manifest-driven negative parity check — the error detail never echoes
+/// any of the forbidden payload values across all error fixtures.
+#[test]
+fn s6_error_diagnostics_never_echo_payload() {
+    let manifest = load_manifest();
+    let forbidden_tokens = ["supersecret", "leaked", "kill", "raw", "draft", "control"];
+    for entry in &manifest.fixtures {
+        if entry.expected != "error" {
+            continue;
+        }
+        let path = fixtures_dir().join(&entry.file);
+        let bytes = fs::read(&path)
+            .unwrap_or_else(|_| panic!("fixture {} exists at {}", entry.name, path.display()));
+        if let Err(error) = parse_snapshot(&bytes) {
+            let detail = error.detail();
+            for token in forbidden_tokens {
+                assert!(
+                    !detail.contains(token),
+                    "fixture {} diagnostic leaked token '{token}': {detail}",
+                    entry.name
+                );
+            }
+        }
+    }
+}
+
+/// Sanity: the error type implements the expected stable-code surface.
+#[test]
+fn error_code_surface_is_stable() {
+    assert_eq!(JspCode::EClosedShape.as_str(), "JSP-E001");
+    assert_eq!(JspCode::EBound.as_str(), "JSP-E002");
+    assert_eq!(JspCode::EUnsupportedVersion.as_str(), "JSP-E003");
+    assert_eq!(JspCode::EIdentity.as_str(), "JSP-E004");
+    assert_eq!(JspCode::EFieldState.as_str(), "JSP-E005");
+    assert_eq!(JspCode::ESemantic.as_str(), "JSP-E006");
+}

--- a/tests/jsp_v1_snapshot_compliance.rs
+++ b/tests/jsp_v1_snapshot_compliance.rs
@@ -333,6 +333,108 @@ fn s5_forbidden_fields_fail_closed() {
     );
 }
 
+/// Build a snapshot document whose `current_wait` field carries the supplied
+/// raw JSON field-state, with every other field `unsupported`.
+fn snapshot_with_wait_state(field_state: &str) -> Vec<u8> {
+    format!(
+        r#"{{"schema":1,"kind":"snapshot","agent_id":"a","lifecycle_generation":1,"source_epoch":"e","source_sequence":1,"cursor":0,"bridge_observed_ms":1,"native_session":{{"repository":"r","path":"p","agent_kind":"llxprt","pid":1,"display_name":"d"}},"process_binding":"unsupported","native_activity":"unsupported","current_wait":{field_state},"current_turn":"unsupported","todos":"unsupported","last_displayed_assistant_message":"unsupported","last_created_tool_call":"unsupported","source_terminal_state":"unsupported","source_error_state":"unsupported"}}"#
+    )
+    .into_bytes()
+}
+
+/// S5: forbidden credential and control fields fail closed even when nested
+/// inside a field value rather than at the top level.
+///
+/// The top-level envelope is closed by `deny_unknown_fields`; this proves the
+/// same guarantee holds one level down, inside `current_wait.value`.
+#[test]
+fn s5_forbidden_fields_nested_in_a_field_value_fail_closed() {
+    let forbidden = [
+        r#"{"reason":"permission","publisher_token":"supersecret"}"#,
+        r#"{"reason":"permission","observer_token":"supersecret"}"#,
+        r#"{"reason":"permission","raw_transcript":"leaked"}"#,
+        r#"{"reason":"permission","draft":"leaked"}"#,
+        r#"{"reason":"permission","control":"kill"}"#,
+    ];
+    for payload in forbidden {
+        let field_state =
+            format!(r#"{{"provenance":"authoritative","availability":"known","value":{payload}}}"#);
+        let bytes = snapshot_with_wait_state(&field_state);
+        let error = parse_snapshot(&bytes)
+            .err()
+            .unwrap_or_else(|| panic!("nested forbidden field must fail: {payload}"));
+        assert_eq!(
+            error.code(),
+            JspCode::EClosedShape,
+            "nested forbidden field must fail closed: {payload}"
+        );
+        let detail = error.detail();
+        for token in ["supersecret", "leaked", "kill"] {
+            assert!(
+                !detail.contains(token),
+                "diagnostic leaked token '{token}': {detail}"
+            );
+        }
+    }
+}
+
+/// S5: a legal wait payload still parses, so the closed DTO did not
+/// over-tighten the accepted shape.
+#[test]
+fn s5_legal_wait_payload_still_parses() {
+    let bytes = snapshot_with_wait_state(
+        r#"{"provenance":"authoritative","availability":"known","value":{"reason":"permission"}}"#,
+    );
+    parse_snapshot(&bytes).unwrap_or_else(|err| panic!("legal wait payload must parse: {err}"));
+}
+
+/// S1/S5: duplicate object keys inside a field value are rejected rather than
+/// silently resolved last-wins.
+///
+/// A closed wire contract must give one meaning to one byte sequence; without
+/// this, `"phase":"succeeded","phase":"failed"` would quietly become `failed`.
+#[test]
+fn s5_duplicate_keys_inside_a_field_value_fail_closed() {
+    let duplicates = [
+        r#"{"state":"idle","state":"acting"}"#,
+        r#"{"state":"idle","state":"idle"}"#,
+    ];
+    for payload in duplicates {
+        let field_state =
+            format!(r#"{{"provenance":"authoritative","availability":"known","value":{payload}}}"#);
+        let bytes = snapshot_with_activity_state(&field_state);
+        let error = parse_snapshot(&bytes)
+            .err()
+            .unwrap_or_else(|| panic!("duplicate nested key must fail: {payload}"));
+        assert_eq!(
+            error.code(),
+            JspCode::EClosedShape,
+            "duplicate nested key must fail closed: {payload}"
+        );
+    }
+}
+
+/// S6: a `degraded` diagnostic names `last_value`, not `value`, so a producer
+/// is pointed at the member it actually sent.
+#[test]
+fn s6_degraded_diagnostics_name_the_last_value_member() {
+    let bytes = snapshot_with_activity_state(
+        r#"{"provenance":"inferred","availability":"degraded","last_value":{"state":"bogus"},"as_of_ms":5,"diagnostic_code":"X"}"#,
+    );
+    let error = parse_snapshot(&bytes)
+        .err()
+        .unwrap_or_else(|| panic!("unknown degraded activity state must fail"));
+    let detail = error.detail();
+    assert!(
+        detail.contains("last_value"),
+        "degraded diagnostic must name last_value: {detail}"
+    );
+    assert!(
+        !detail.contains(".value."),
+        "degraded diagnostic must not name the value member: {detail}"
+    );
+}
+
 /// Build a snapshot document whose `native_activity` field carries the supplied
 /// raw JSON field-state, with every other field `unsupported`.
 fn snapshot_with_activity_state(field_state: &str) -> Vec<u8> {
@@ -441,17 +543,50 @@ fn s6_error_diagnostics_never_echo_payload() {
         let path = fixtures_dir().join(&entry.file);
         let bytes = fs::read(&path)
             .unwrap_or_else(|_| panic!("fixture {} exists at {}", entry.name, path.display()));
-        if let Err(error) = parse_snapshot(&bytes) {
-            let detail = error.detail();
-            for token in forbidden_tokens {
-                assert!(
-                    !detail.contains(token),
-                    "fixture {} diagnostic leaked token '{token}': {detail}",
-                    entry.name
-                );
-            }
+        // A fixture that parses instead of failing must break this test rather
+        // than skip it, or a regression that accepts forbidden input would go
+        // undetected here.
+        let error = parse_snapshot(&bytes).err().unwrap_or_else(|| {
+            panic!(
+                "fixture {} is declared an error fixture but parsed successfully",
+                entry.name
+            )
+        });
+        let detail = error.detail();
+        for token in forbidden_tokens {
+            assert!(
+                !detail.contains(token),
+                "fixture {} diagnostic leaked token '{token}': {detail}",
+                entry.name
+            );
         }
     }
+}
+
+/// S6: `source_terminal_state` diagnostics name that field, not the sibling
+/// `source_error_state` that shares its payload shape.
+#[test]
+fn s6_source_terminal_diagnostics_name_their_own_field() {
+    let oversized = "s".repeat(2049);
+    let field_state = format!(
+        r#"{{"provenance":"authoritative","availability":"known","value":{{"summary":"{oversized}","code":"E"}}}}"#
+    );
+    let json = format!(
+        r#"{{"schema":1,"kind":"snapshot","agent_id":"a","lifecycle_generation":1,"source_epoch":"e","source_sequence":1,"cursor":0,"bridge_observed_ms":1,"native_session":{{"repository":"r","path":"p","agent_kind":"llxprt","pid":1,"display_name":"d"}},"process_binding":"unsupported","native_activity":"unsupported","current_wait":"unsupported","current_turn":"unsupported","todos":"unsupported","last_displayed_assistant_message":"unsupported","last_created_tool_call":"unsupported","source_terminal_state":{field_state},"source_error_state":"unsupported"}}"#
+    );
+    let error = parse_snapshot(json.as_bytes())
+        .err()
+        .unwrap_or_else(|| panic!("oversized terminal summary must fail"));
+    assert_eq!(error.code(), JspCode::EBound);
+    let detail = error.detail();
+    assert!(
+        detail.contains("source_terminal_state"),
+        "diagnostic must name source_terminal_state: {detail}"
+    );
+    assert!(
+        !detail.contains("source_error_state"),
+        "diagnostic must not name the sibling field: {detail}"
+    );
 }
 
 /// Sanity: the error type implements the expected stable-code surface.

--- a/tests/jsp_v1_snapshot_compliance.rs
+++ b/tests/jsp_v1_snapshot_compliance.rs
@@ -149,15 +149,19 @@ fn assert_expected_identity(fixture_name: &str, snapshot: &jefe::jsp::v1::Snapsh
     );
 }
 
-/// S1: the canonical full snapshot yields exact typed identity, cursor, and
-/// semantic fields with provenance and availability.
-#[test]
-fn s1_canonical_full_snapshot_has_exact_typed_fields() {
+/// Parse the canonical full fixture, which every S1 assertion builds on.
+fn canonical_full_snapshot() -> jefe::jsp::v1::Snapshot {
     let path = fixtures_dir().join("snapshot_full.json");
     let bytes =
         fs::read(&path).unwrap_or_else(|_| panic!("full fixture exists at {}", path.display()));
-    let snapshot =
-        parse_snapshot(&bytes).unwrap_or_else(|err| panic!("full snapshot must parse: {err}"));
+    parse_snapshot(&bytes).unwrap_or_else(|err| panic!("full snapshot must parse: {err}"))
+}
+
+/// S1: the canonical full snapshot yields the exact typed identity and
+/// ordering fields.
+#[test]
+fn s1_canonical_full_snapshot_has_exact_identity_and_ordering() {
+    let snapshot = canonical_full_snapshot();
 
     assert_eq!(snapshot.identity.agent_id.as_str(), "agent-alex");
     assert_eq!(snapshot.identity.lifecycle_generation, 7);
@@ -165,6 +169,13 @@ fn s1_canonical_full_snapshot_has_exact_typed_fields() {
     assert_eq!(snapshot.cursor, 41);
     assert_eq!(snapshot.source_sequence, 42);
     assert_eq!(snapshot.bridge_observed_ms, 1_785_921_964_000);
+}
+
+/// S1: the canonical full snapshot yields the exact descriptive session
+/// metadata, none of which participates in the observation key.
+#[test]
+fn s1_canonical_full_snapshot_has_exact_session_metadata() {
+    let snapshot = canonical_full_snapshot();
 
     assert_eq!(
         snapshot.native_session.repository.as_str(),
@@ -174,6 +185,13 @@ fn s1_canonical_full_snapshot_has_exact_typed_fields() {
     assert_eq!(snapshot.native_session.agent_kind.as_str(), "llxprt");
     assert_eq!(snapshot.native_session.pid, 12_345);
     assert_eq!(snapshot.native_session.display_name.as_str(), "main-worker");
+}
+
+/// S1: the canonical full snapshot yields exact typed semantic fields with
+/// their provenance and availability.
+#[test]
+fn s1_canonical_full_snapshot_has_exact_typed_fields() {
+    let snapshot = canonical_full_snapshot();
 
     let FieldState::Supported {
         provenance,

--- a/tests/jsp_v1_snapshot_compliance.rs
+++ b/tests/jsp_v1_snapshot_compliance.rs
@@ -241,10 +241,14 @@ fn s2_unsupported_schema_version_fails() {
         .unwrap_or_else(|| panic!("schema 0 must fail"));
     assert_eq!(error.code(), JspCode::EUnsupportedVersion);
 
-    let mut schema2 = schema0.to_vec();
-    // Replace the '0' after "schema": with '2' (byte index 10).
-    schema2[10] = b'2';
-    let error = parse_snapshot(&schema2)
+    let document = String::from_utf8(schema0.to_vec())
+        .unwrap_or_else(|err| panic!("fixture literal is utf-8: {err}"));
+    let schema2 = document.replacen(r#""schema":0"#, r#""schema":2"#, 1);
+    assert_ne!(
+        schema2, document,
+        "the schema discriminator must have been rewritten"
+    );
+    let error = parse_snapshot(schema2.as_bytes())
         .err()
         .unwrap_or_else(|| panic!("schema 2 must fail"));
     assert_eq!(error.code(), JspCode::EUnsupportedVersion);
@@ -553,7 +557,10 @@ fn s5_unknown_kind_fails() {
 #[test]
 fn s6_error_diagnostics_never_echo_payload() {
     let manifest = load_manifest();
-    let forbidden_tokens = ["supersecret", "leaked", "kill", "raw", "draft", "control"];
+    // Only payload *values* are asserted. Field-name fragments are excluded on
+    // purpose: a closed-shape diagnostic may legitimately name the member it
+    // rejected, and the contract forbids echoing values, not member names.
+    let forbidden_tokens = ["supersecret", "leaked", "kill"];
     for entry in &manifest.fixtures {
         if entry.expected != "error" {
             continue;


### PR DESCRIPTION
## Summary

This is the first Jefe-side slice (J1) of the JSP/1 work in #476: the versioned
snapshot **contract** and its language-neutral **compliance corpus**.

Issue #476 asks for a written, versioned JSP/1 schema and semantic
specification, and for a protocol compliance framework to exist *before* the
proof-of-concept producer and server are considered complete. That ordering is
the whole point: the LLxprt Code producer and the LLxprt Luther server are
external implementations that need something authoritative to validate against.
This PR delivers that artifact and nothing else.

It deliberately connects to nothing. There is no networking, no `AppState`, no
reducer, no UI. `parse_snapshot` is a pure function from bytes to a validated
typed value.

## What is here

- `dev-docs/jsp/v1/specification.md` — the normative contract: identity model,
  the three orthogonal status axes, the field-state algebra, bounds, the error
  taxonomy, and the read-only/no-control invariants.
- `dev-docs/jsp/v1/fixtures/` — a manifest-driven JSON corpus. External
  implementations consume the same bytes and must produce the same typed
  results, so the corpus is the portable half of the contract.
- `src/jsp/v1/` — a strict parser/validator layered like the existing
  `src/harness/v1/`: closed wire DTOs, inclusive limits, a coded error
  taxonomy, and a single validation boundary.
- `src/domain/observation.rs` — transport-neutral typed values with no
  project-internal dependency.
- `tests/jsp_v1_snapshot_compliance.rs` — 23 behavioral tests driven through
  the public entry point.

## Design decisions worth reviewing

**Three axes stay orthogonal.** A producer describes its own native activity
and reports process-binding evidence, but it cannot assert that a process is
alive or that a stream is healthy. Process liveness stays Jefe-runtime-owned
and observation health stays transport-owned, per invariant 6 in the issue.

**`stale` is not a producer value.** It is a local transport overlay. A
producer that sends it is rejected, so a missed heartbeat can never be
confused with an agent that went idle.

**Field states are a closed algebra, not nullable values.** Every field is
either `unsupported` or a provenance crossed with an availability
(`known` / `unknown` / `degraded`). Encoding this as
`FieldState<Availability<T>>` keeps downstream match sites compiler-checked, so
unsupported, unknown, stale, inferred, and authoritative stay distinct —
invariant 5.

**Parsing fails fast.** The byte bound fires before parsing, the envelope is
closed, conversion happens only after full validation, and credential and
control fields are rejected at ingress. Diagnostics carry a stable code and
path but never echo producer payload values.

**Snapshot documents only.** Events, replay, heartbeats, sockets, and the
status screen are later slices.

## Review remediation

Two independent reviews ran against the first commit and both reproduced their
findings by executing the parser. Two blockers were found and fixed in
`99b9742`:

1. **The closed envelope had a hole.** `current_wait.value` was the one payload
   read by hand rather than through a closed DTO, so it ignored sibling
   members. A document carrying `publisher_token`, `observer_token`,
   `raw_transcript`, `draft`, or `control` inside it parsed successfully —
   the exact members the specification declares rejected at ingress, and the
   exact members a top-level fixture already asserted were rejected. It also
   escaped every field bound. The existing test only probed the top level,
   where `deny_unknown_fields` already won, so it proved the property where it
   was never at risk.

2. **Duplicate keys inside `value`/`last_value` silently last-won.** Capturing
   the payload as a `serde_json::Value` let the map collapse duplicates before
   the closed DTO saw them, so a repeated `phase` member quietly took the last
   occurrence — precisely how a producer could slip past the stale-phase
   rejection. For a contract shared across implementations, the same bytes must
   not mean different things depending on the producer's JSON library.

Also fixed: an unreachable schema/kind gate that had drifted to a different
message string for the same rule; diagnostics that named members the producer
never sent (`degraded` reporting the `value` member, and
`source_terminal_state` reporting `source_error_state`); a corpus that covered
only two of six error codes; and a manifest-driven test that passed vacuously
when an error fixture unexpectedly parsed.

Full triage, including rejected and deferred findings with rationale, is in
`project-plans/issue476-plan.md`.

## Verification

Exact head `130e868`, rebased onto current `main`:

- `cargo test --workspace --all-features --locked` — 0 failures across all
  targets.
- `cargo test --test jsp_v1_snapshot_compliance` — 23 passed.
- `cargo build --workspace --all-features --locked` — clean.
- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — no
  warnings.
- `cargo xtask check source-size` / `architecture` / `clippy-allows` — pass. No
  lint or complexity threshold was loosened and no suppression attribute was
  added.

## Scope

Refs #476. This does not close the parent issue — J1 of an ordered
decomposition. The remaining Jefe slices and the external LLxprt Code producer
and Luther server children are listed in the plan.

There is no TUI scenario because this slice renders nothing; the status
workbench arrives with the UI slice.
