### PR TITLE
Fix stale-base.sha checkout in LLxprt PR Review (Fixes #474)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -73,7 +73,14 @@ jobs:
       - name: 'Checkout base revision'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
         with:
-          ref: '${{ github.event.pull_request.base.sha }}'
+          # Resolve the base-branch tip, not the recorded pull_request.base.sha.
+          # base.sha can lag behind the commit that introduced this workflow's
+          # supporting scripts (e.g. scripts/ci-quota-check.mjs); checking out a
+          # stale base.sha yields a tree that lacks those scripts and fails with
+          # 'Cannot find module ...'. The base branch tip always contains them.
+          # base.sha is still fetched (fetch-depth: 0) and used as the
+          # git merge-base input below, so PR diff scoping is unchanged.
+          ref: '${{ github.event.pull_request.base.ref }}'
           fetch-depth: 0
 
       - name: 'Prepare review workspace'

--- a/project-plans/issue474-plan.md
+++ b/project-plans/issue474-plan.md
@@ -1,0 +1,88 @@
+# Issue 474 delivery plan
+
+## Problem statement
+
+The `LLxprt PR Review` workflow (`.github/workflows/pr-review.yml`) checks out
+`github.event.pull_request.base.sha` and then runs `node scripts/ci-quota-check.mjs`
+(workflow line ~210) and `node scripts/pr-review-walkthrough.mjs`
+(workflow line ~396) against that working tree. Both scripts (and their three
+helpers) were introduced by commit `8d0c45b` (PR #466). For any PR whose
+recorded `pull_request.base.sha` is a strict ancestor of `8d0c45b`, the
+checked-out tree lacks those scripts and the job fails with
+`Cannot find module .../scripts/ci-quota-check.mjs` (exit 1).
+
+This is a CI/workflow infrastructure defect, not a product bug. The same PR
+fails identically across reruns until `base.sha` advances past `8d0c45b`.
+
+## Root cause (verified)
+
+- All `git diff` operations in the workflow use explicit SHAs
+  (`${MERGE_BASE}` and `${PR_HEAD_SHA}`), never the working tree. The
+  checked-out ref's sole purpose is to provide the workflow-supporting scripts
+  (`scripts/ci-quota-*.mjs`, `scripts/pr-review-*.mjs`).
+- `base.sha` is also read into `base_sha` (line ~108) and consumed only by
+  `git merge-base` (line ~117) for diff scoping. That computation is correct
+  and must be preserved exactly; it does not depend on the checked-out ref.
+- Therefore checking out the base-branch **tip** (guaranteed to contain the
+  scripts) instead of the possibly-stale `base.sha` fixes the failure without
+  altering diff semantics, merge-base accuracy, or fork safety.
+
+## Acceptance matrix
+
+| # | Actor / path | Input / boundary | Observable success | Observable failure / diagnostic | Behavioral test |
+|---|---|---|---|---|---|
+| A1 | `LLxprt PR Review` job, checkout step | `pull_request.base.sha` older than workflow/script introduction commit `8d0c45b` | Checkout ref resolves to the base branch tip (or a ref guaranteed to contain the scripts), not the stale `base.sha` | (pre-fix) `Cannot find module .../scripts/ci-quota-check.mjs`, exit 1 | Structural assertion: checkout step does not use `github.event.pull_request.base.sha` as its `ref` |
+| A2 | `LLxprt PR Review` job, script steps | Workflow references `scripts/ci-quota-check.mjs` and `scripts/pr-review-walkthrough.mjs` | The checked-out ref contains every workflow-referenced script at the base-branch tip | (pre-fix) module resolution failure | Structural assertion: checkout ref targets the base branch / tip; all five `scripts/*.mjs` referenced or imported exist in the workflow's expected tree |
+| A3 | `LLxprt PR Review` job, diff steps | Any PR | Diff scoping unchanged: `git merge-base` still uses the event's `base.sha`; diffs still use `${MERGE_BASE}`..`${PR_HEAD_SHA}` | (regression) diffs would change | Structural assertion: `base_sha` is still read from `github.event.pull_request.base.sha` and still feeds `git merge-base` |
+| A4 | Regression guard | PR whose `base.sha` predates `8d0c45b` | Workflow proceeds past the quota step | (pre-fix) hard failure | `tests/core/pr_review_workflow_contracts.rs` proves the fix structurally |
+
+## Non-goals
+
+- Changes to product code, dependencies, or `ci-quota-check.mjs` script logic.
+- Changes to required product CI (`ci.yml`) — it passed for PR #444 and is unaffected.
+- Hardening of `release.yml` (tracked separately in #471).
+- OCR reproducibility-manifest completeness (#464).
+- OCR config/secrets failures (#158).
+- Changing `pull_request_target` semantics, fork-safety model, or the
+  mergeability gate. The fix must preserve `pull_request_target` and all
+  existing fork-safety and concurrency controls.
+
+## Planned vertical slices
+
+### Slice 1 (only slice): checkout strategy fix + regression test
+
+- **Acceptance rows:** A1, A2, A3, A4
+- **Architecture owner:** CI/review automation (`.github/workflows/pr-review.yml`).
+  Integration boundary: the workflow's checkout `ref` and the event context
+  consumed by `git merge-base`.
+- **Allowed files:**
+  - `.github/workflows/pr-review.yml` (checkout step only)
+  - `tests/core/pr_review_workflow_contracts.rs` (new)
+  - `tests/core/mod.rs` (module wire-up line only)
+- **RED:** new contract test fails on current main because the checkout step
+  still uses `github.event.pull_request.base.sha` as its `ref`.
+- **GREEN completion criteria:** contract test passes; checkout step resolves
+  scripts from the base-branch tip; `base.sha` still feeds `git merge-base`
+  unchanged.
+- **Non-goals for this slice:** everything in the issue-level non-goals above.
+- **Verification commands:**
+  - `cargo test --test integration pr_review_workflow_contracts`
+  - `make quick-check`
+  - `make ci-check` (fmt, clippy, build, coverage, test)
+- **Stopping conditions:** any requirement to touch `ci.yml`, `ci-quota-check.mjs`
+  logic, fork-safety model, or product code requires user approval.
+
+## Scope ledger
+
+- `.github/workflows/pr-review.yml` — checkout step `ref` change (in scope, A1/A2).
+- `tests/core/pr_review_workflow_contracts.rs` — new regression test (in scope, A4).
+- `tests/core/mod.rs` — one module declaration line (in scope, test wire-up).
+
+No newly discovered out-of-scope work. No dependency, agent-memory, or
+quality-tool changes.
+
+## Review counters
+
+- Open Code Review (local, before PR): 0 / 2
+- Open Code Review (after PR): 0 / 2
+- CodeRabbit: pending PR

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -9,6 +9,7 @@ mod domain_state_contracts;
 mod message_bus_contracts;
 mod ocr_workflow_contracts;
 mod persistence_theme_contracts;
+mod pr_review_workflow_contracts;
 mod tmux_harness_docs_contracts;
 mod visibility_filter_contracts;
 mod windows_support_contracts;

--- a/tests/core/pr_review_workflow_contracts.rs
+++ b/tests/core/pr_review_workflow_contracts.rs
@@ -69,9 +69,15 @@ fn step_body(content: &str, step_name: &str) -> String {
         })
         .unwrap_or_else(|| panic!("step '{step_name}' not found in workflow"));
 
-    let step_indent = lines
-        .get(start + 1)
-        .map_or(8, |l| l.len() - l.trim_start().len());
+    // Derive the step indentation from the first non-blank line after the
+    // `- name:` header. Skipping blank lines avoids a zero-indent if a blank
+    // line ever appears between the header and its first property, which
+    // would otherwise cause the parser to consume all subsequent steps.
+    let step_indent = lines[start + 1..]
+        .iter()
+        .map(|l| l.len() - l.trim_start().len())
+        .find(|&indent| indent > 0)
+        .unwrap_or(8);
 
     let mut body = String::new();
     body.push_str(lines[start]);

--- a/tests/core/pr_review_workflow_contracts.rs
+++ b/tests/core/pr_review_workflow_contracts.rs
@@ -1,0 +1,171 @@
+//! LLxprt PR Review workflow contract tests (issue #474).
+//!
+//! Regression guard for the stale-`base.sha` checkout defect. The
+//! `LLxprt PR Review` workflow (`.github/workflows/pr-review.yml`) runs
+//! `node scripts/ci-quota-check.mjs` and `node scripts/pr-review-walkthrough.mjs`
+//! against the working tree produced by its checkout step. Those scripts (and
+//! their helpers) were introduced by commit `8d0c45b` (PR #466). When the
+//! workflow checked out `github.event.pull_request.base.sha`, a PR whose
+//! recorded base SHA was a strict ancestor of `8d0c45b` got a tree lacking
+//! those scripts, causing `Cannot find module .../scripts/ci-quota-check.mjs`
+//! (exit 1) deterministically across reruns.
+//!
+//! All `git diff` operations in the workflow use explicit SHAs
+//! (`${MERGE_BASE}` and `${PR_HEAD_SHA}`), never the working tree, so the
+//! checked-out ref's only role is to supply the workflow-supporting scripts.
+//! The contract below asserts the checkout resolves scripts from the
+//! base-branch tip (which always contains them) while `base.sha` is preserved
+//! as the input to `git merge-base` for accurate diff scoping.
+//!
+//! These tests read the workflow as text (mirroring `ocr_workflow_contracts`)
+//! so CI fails mechanically if the regression returns.
+
+use std::path::{Path, PathBuf};
+
+const WORKFLOW_PATH: &str = ".github/workflows/pr-review.yml";
+
+/// Every script the workflow executes or the executed scripts import. The
+/// checkout tree must contain all of these; this is the exact failure
+/// surface from issue #474.
+const WORKFLOW_SUPPORTING_SCRIPTS: &[&str] = &[
+    "scripts/ci-quota-check.mjs",
+    "scripts/pr-review-walkthrough.mjs",
+    // Modules imported by pr-review-walkthrough.mjs (relative imports). If
+    // the checkout lacks these, the walkthrough step fails with a module
+    // resolution error after the quota step succeeds.
+    "scripts/pr-review-prompts.mjs",
+    "scripts/pr-review-llm-helpers.mjs",
+    "scripts/pr-review-artifacts.mjs",
+];
+
+fn repo_path(relative_path: impl AsRef<Path>) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path.as_ref())
+}
+
+fn read_workflow() -> String {
+    let path = repo_path(WORKFLOW_PATH);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()))
+}
+
+/// Extract the body of a single named workflow step, starting from the
+/// `- name: <step_name>` line until the next top-level `- name:` or
+/// step-level key at a lower indentation. Mirrors `ocr_workflow_contracts`
+/// so assertions bind to the named step and cannot be satisfied by comments
+/// or unrelated steps.
+fn step_body(content: &str, step_name: &str) -> String {
+    // pr-review.yml uses single-quoted step names (`- name: 'Step'`), so match
+    // both the quoted and unquoted forms of the `- name:` header.
+    let needles = [
+        format!("- name: {step_name}"),
+        format!("- name: '{step_name}'"),
+    ];
+    let lines: Vec<&str> = content.lines().collect();
+    let start = lines
+        .iter()
+        .position(|l| {
+            let trimmed = l.trim();
+            needles.iter().any(|needle| trimmed == *needle)
+        })
+        .unwrap_or_else(|| panic!("step '{step_name}' not found in workflow"));
+
+    let step_indent = lines
+        .get(start + 1)
+        .map_or(8, |l| l.len() - l.trim_start().len());
+
+    let mut body = String::new();
+    body.push_str(lines[start]);
+    body.push('\n');
+
+    for line in &lines[start + 1..] {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let indent = line.len() - line.trim_start().len();
+        if indent < step_indent && !trimmed.starts_with('#') {
+            break;
+        }
+        if indent == step_indent && trimmed.starts_with("- name:") {
+            break;
+        }
+        body.push_str(line);
+        body.push('\n');
+    }
+    body
+}
+
+// ---------------------------------------------------------------------------
+// Criterion A1 + A2: checkout resolves scripts from the base-branch tip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn checkout_does_not_use_stale_base_sha_as_ref() {
+    // The checkout step must NOT use github.event.pull_request.base.sha as
+    // its ref, because that SHA can be a strict ancestor of the commit that
+    // introduced the workflow-supporting scripts, yielding a tree that lacks
+    // them. The base-branch tip (base.ref) always contains the scripts.
+    let content = read_workflow();
+    let step = step_body(&content, "Checkout base revision");
+    assert!(
+        !step.contains("github.event.pull_request.base.sha"),
+        "checkout step must not use the possibly-stale github.event.pull_request.base.sha as its ref \
+         (issue #474: it can be older than the script-introducing commit and produce a tree lacking \
+         scripts/ci-quota-check.mjs)"
+    );
+}
+
+#[test]
+fn checkout_resolves_base_branch_tip() {
+    // The checkout ref must target the base branch so the working tree is
+    // guaranteed to contain the workflow-supporting scripts regardless of how
+    // stale the recorded base.sha is. base.ref is the base branch name and is
+    // the natural source of the branch tip.
+    let content = read_workflow();
+    let step = step_body(&content, "Checkout base revision");
+    assert!(
+        step.contains("github.event.pull_request.base.ref"),
+        "checkout step must resolve the base-branch tip via github.event.pull_request.base.ref so \
+         the tree always contains the workflow-supporting scripts (issue #474)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Criterion A2: every workflow-supporting script exists in the repository
+// ---------------------------------------------------------------------------
+
+#[test]
+fn workflow_supporting_scripts_exist_in_repository() {
+    // The scripts the workflow executes and imports must exist at the repo
+    // tip. This both documents the failure surface and guards against a
+    // future rename that would reintroduce a module-resolution failure.
+    for script in WORKFLOW_SUPPORTING_SCRIPTS {
+        let path = repo_path(script);
+        assert!(
+            path.is_file(),
+            "workflow-supporting script {script} must exist in the repository",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Criterion A3: base.sha is preserved as the git merge-base input
+// ---------------------------------------------------------------------------
+
+#[test]
+fn base_sha_still_feeds_merge_base_for_diff_scoping() {
+    // Diff scoping must remain anchored to the event's recorded base.sha via
+    // git merge-base, independent of the checked-out ref. This preserves the
+    // property that diffs contain only changes the PR actually introduced.
+    let content = read_workflow();
+    let step = step_body(&content, "Fetch pull request head");
+    assert!(
+        step.contains("github.event.pull_request.base.sha"),
+        "the event's base.sha must still be read into base_sha for git merge-base diff scoping \
+         (issue #474: the fix changes only the checkout ref, not the merge-base input)"
+    );
+    assert!(
+        step.contains("git merge-base"),
+        "base.sha must still feed git merge-base so diff scoping is unchanged"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the deterministic CI failure in the LLxprt PR Review workflow where a PR whose recorded pull_request.base.sha predates the commit that introduced the workflow and its supporting scripts (8d0c45b / PR #466) fails with "Cannot find module .../scripts/ci-quota-check.mjs".

## Root cause

The workflow checked out github.event.pull_request.base.sha and then ran node scripts/ci-quota-check.mjs (and later scripts/pr-review-walkthrough.mjs) against that working tree. Those scripts were introduced by 8d0c45b. For any PR whose base.sha is a strict ancestor of 8d0c45b, the checked-out tree lacks the scripts, producing a hard module-resolution failure that persists identically across reruns until base.sha advances.

Confirmed via git cat-file: scripts/ci-quota-check.mjs and all four pr-review-*.mjs helpers are absent at fccb22b (PR #444's recorded base.sha) and present at HEAD.

## Fix

Change the checkout ref from the possibly-stale base.sha to the base-branch tip (github.event.pull_request.base.ref). The base branch tip is guaranteed to contain every workflow-supporting script regardless of how stale the recorded base.sha is.

Diff scoping is unchanged: base.sha is still fetched (fetch-depth: 0) and still consumed by git merge-base in the "Fetch pull request head" step. Every git diff operation in the workflow uses explicit SHAs ($MERGE_BASE..$PR_HEAD_SHA), never the working tree, so the checked-out ref's only role was to supply the scripts.

## Acceptance matrix

| # | Criterion | Evidence |
|---|-----------|----------|
| A1 | Checkout no longer uses stale base.sha as its ref | tests/core/pr_review_workflow_contracts.rs::checkout_does_not_use_stale_base_sha_as_ref |
| A2 | Checkout resolves base-branch tip (always contains scripts) | tests/core/pr_review_workflow_contracts.rs::checkout_resolves_base_branch_tip + workflow_supporting_scripts_exist_in_repository |
| A3 | base.sha still feeds git merge-base (diff scoping unchanged) | tests/core/pr_review_workflow_contracts.rs::base_sha_still_feeds_merge_base_for_diff_scoping |
| A4 | Regression guard proves the fix structurally | New contract test (RED on main, GREEN on this branch) |

## Verification

- cargo fmt --all --check: pass
- cargo clippy --workspace --all-targets --all-features -- -D warnings: pass
- cargo build --workspace --all-features --locked: pass
- cargo test --test integration pr_review_workflow_contracts: 4/4 pass (was RED before fix)
- Full unit test suite (2574 + 804 tests): pass
- All standalone integration test binaries: pass

The harness_v1_fixtures failures and the guarded_dashboard_reorder_tui_scenario flake are pre-existing environmental TTY/tmux issues (proven to fail identically on clean origin/main via git stash); they are unrelated to this CI-workflow-only change.

## Non-goals

- Changes to product code, dependencies, or ci-quota-check.mjs script logic
- Changes to required product CI (ci.yml)
- Hardening of release.yml (tracked in #471)
- OCR reproducibility-manifest completeness (#464) or OCR config/secrets failures (#158)
- Changing pull_request_target semantics or fork-safety model (both preserved)

## Scope

4 files changed, 268 net insertions (well under the 25-file / 1,500-line target).