### PR TITLE
Adds /assign self-assignment automation (Fixes #499)

### DIFF
--- a/.github/scripts/assign-constants.sh
+++ b/.github/scripts/assign-constants.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Shared constants for assignment automation scripts.
+#
+# Source-only — do NOT execute this file directly.
+# Sourced by assign-issue.sh and record-assignment-history.sh to eliminate
+# production drift for history-label policy values.
+#
+# Must remain shellcheck-clean (enable=all, severity=style).
+# shellcheck disable=SC2034
+
+HISTORY_PREFIX='asnhist--'
+HISTORY_COLOR='0E8A16'
+HISTORY_DESC='Issue assignment history index'
+
+# Validate a GitHub login per the real GitHub username rules:
+# 1-39 chars, alphanumeric segments separated by single hyphens; reject
+# leading/trailing/consecutive hyphens and non-alphanumeric characters.
+# Returns 0 on valid; nonzero on invalid.
+validate_github_login() {
+  local login="$1"
+  local len="${#login}"
+  [[ "${len}" -ge 1 && "${len}" -le 39 ]] || return 1
+  [[ "${login}" =~ ^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$ ]] || return 1
+}

--- a/.github/scripts/assign-issue.sh
+++ b/.github/scripts/assign-issue.sh
@@ -1,0 +1,1054 @@
+#!/usr/bin/env bash
+# Assign an issue to a commenter who posted an exact `/assign` command.
+# Invoked by .github/workflows/assign.yml.
+#
+# Uses targeted REST mutations (POST /labels, POST /assignees) instead of
+# whole-array PATCH to preserve concurrent human state and comma-bearing
+# label names. Adds label first, then assignee; rolls back only this run's
+# additions on partial failure.
+#
+# Durable history: after successful assignment/cap verification, this script
+# directly creates/validates the per-user history label (asnhist--LOGIN).
+# GitHub suppresses recursive issues:assigned workflows caused by
+# GITHUB_TOKEN, so the record-history job may not fire for automated
+# assignments. This script ensures durability regardless.
+set -euo pipefail
+
+MARKER='<!-- jefe-assign-feedback -->'
+AUTO_ASSIGNED_LABEL='auto-assigned'
+AUTO_ASSIGNED_COLOR='0E8A16'
+AUTO_ASSIGNED_DESC='Assigned via /assign automation'
+# Source shared history-label constants (policy values + login validation).
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/assign-constants.sh"
+MAX_ASSIGNMENTS=3
+BOT_LOGIN='github-actions[bot]'
+HISTORY_FILE="${ASSIGNMENT_HISTORY_FILE:-.github/assignment-history.txt}"
+
+: "${GITHUB_REPOSITORY:?Missing GITHUB_REPOSITORY}"
+: "${ISSUE_NUMBER:?Missing ISSUE_NUMBER}"
+: "${COMMENTER_LOGIN:?Missing COMMENTER_LOGIN}"
+
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  export GH_TOKEN
+elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  export GH_TOKEN="${GITHUB_TOKEN}"
+else
+  echo "‼ Missing \$GH_TOKEN / \$GITHUB_TOKEN" >&2
+  exit 1
+fi
+
+USER_LOGIN="${COMMENTER_LOGIN}"
+ISSUE="${ISSUE_NUMBER}"
+REPO="${GITHUB_REPOSITORY}"
+export ASSIGNEE_LOGIN="${USER_LOGIN}"
+
+ASSIGN_TEMP_DIR="$(mktemp -d)"
+MUTATION_STARTED=false
+LIFECYCLE_COMMITTED=false
+label_added_by_this_run=false
+
+# shellcheck disable=SC2329  # Invoked by EXIT/INT/TERM traps.
+cleanup_temp_files() {
+  if [[ -n "${ASSIGN_TEMP_DIR:-}" && -d "${ASSIGN_TEMP_DIR}" ]]; then
+    rm -rf -- "${ASSIGN_TEMP_DIR}"
+  fi
+}
+
+trap cleanup_temp_files EXIT
+export GITHUB_REPOSITORY="${REPO}"
+
+# ---------------------------------------------------------------------------
+# Read helpers: all return raw JSON arrays via jq for exact membership checks.
+# Tri-state: success (0, stdout=data), absence (1, no stdout), error (1+ via ||).
+# ---------------------------------------------------------------------------
+
+# Returns the raw .assignees JSON array from the issue object.
+get_issue_assignees_json() {
+  gh api "repos/${REPO}/issues/${ISSUE}" --jq '.assignees // []'
+}
+
+# Returns the raw .labels JSON array from the issue object.
+get_issue_labels_json() {
+  gh api "repos/${REPO}/issues/${ISSUE}" --jq '.labels // []'
+}
+
+# Returns the issue state string (e.g. "open", "closed").
+# Tri-state: success (0, stdout=state), error (nonzero, no stdout).
+get_issue_state() {
+  local raw
+  raw="$(gh api "repos/${REPO}/issues/${ISSUE}" --jq '.' )" || return 1
+  echo "${raw}" | jq -r '.state // empty'
+}
+
+# Validate an issue state string is exactly "open" or "closed".
+# Returns 0 if the state is recognized; nonzero otherwise.
+is_valid_state() {
+  local s="$1"
+  [[ "${s}" == "open" || "${s}" == "closed" ]]
+}
+
+# Count NON-PR issues assigned to a user using fully paginated REST.
+# Uses /repos/{repo}/issues?assignee=...&state=...&per_page=100, merges pages
+# externally, and explicitly excludes items where .pull_request != null.
+# Args: user, state_filter (must be "open", "closed", or "all" — omitted
+# state defaults to open on GitHub, so callers must be explicit).
+# Returns: numeric count on stdout; exit nonzero on any API error.
+rest_issue_count() {
+  local user="$1"
+  local state_filter="$2"
+  case "${state_filter}" in
+    open|closed|all) ;;
+    *)
+      echo "‼ rest_issue_count: invalid state_filter '${state_filter}'" >&2
+      return 1
+      ;;
+  esac
+  local url="repos/${REPO}/issues?assignee=${user}&state=${state_filter}&per_page=100"
+  local all_pages
+  all_pages="$(gh api "${url}" --paginate 2>/dev/null)" || return 1
+  # Merge paginated output (one JSON array per page) and count non-PR items.
+  local count
+  count="$(echo "${all_pages}" | jq -s \
+    'if all(.[]; type == "array") then add else error("non-array page") end
+     | [.[]? | select(.pull_request == null)] | length')" || return 1
+  if ! [[ "${count}" =~ ^[0-9]+$ ]]; then
+    echo "‼ Non-numeric REST issue count for @${user}" >&2
+    return 1
+  fi
+  echo "${count}"
+}
+
+# Returns the count of open NON-PR issues assigned to a user (numeric string).
+# Uses fully paginated REST /repos/{repo}/issues?assignee=...&state=open
+# instead of the Search API (avoids stale-index issues for cap enforcement).
+get_open_assigned_count() {
+  local user="$1"
+  rest_issue_count "${user}" "open"
+}
+
+get_merged_pr_count() {
+  local user="$1"
+  local _stderr_file raw
+  _stderr_file="$(mktemp "${ASSIGN_TEMP_DIR}/capture.XXXXXX")"
+  raw="$(gh api "search/issues?q=repo:${REPO}+author:${user}+type:pr+is:merged&per_page=1" --jq '.' 2>"${_stderr_file}")" || {
+    local _diag
+    _diag="$(cat "${_stderr_file}" 2>/dev/null || true)"
+    rm -f "${_stderr_file}"
+    echo "‼ Merged PR search failed for @${user}: ${_diag}" >&2
+    return 1
+  }
+  rm -f "${_stderr_file}"
+  # Parse full response: total_count numeric, incomplete_results exactly false.
+  local tc ir
+  tc="$(echo "${raw}" | jq -r '.total_count')" || return 1
+  ir="$(echo "${raw}" | jq -r '.incomplete_results')" || return 1
+  if ! [[ "${tc}" =~ ^[0-9]+$ ]]; then
+    echo "‼ Non-numeric or missing total_count for merged PR search for @${user}" >&2
+    return 1
+  fi
+  if [[ "${ir}" != "false" ]]; then
+    echo "‼ Search API returned incomplete_results (infra error) for @${user}" >&2
+    return 1
+  fi
+  echo "${tc}"
+}
+
+# Count current NON-PR issue assignments for a user via REST (avoids Search
+# API index lag). Returns numeric string.
+# Tri-state: 0 = query succeeded (stdout=count); nonzero = error.
+# Uses state=all so closed issues count as prior assignments (an omitted
+# state defaults to open on GitHub and would miss closed assignments).
+get_current_issue_count() {
+  local user="$1"
+  rest_issue_count "${user}" "all"
+}
+
+# Static backfill exact-line lookup (no API calls).
+has_backfill_assignment() {
+  local user="$1"
+  [[ -f "${HISTORY_FILE}" ]] || return 1
+  grep -Fxq -- "${user}" "${HISTORY_FILE}"
+}
+
+# O(1) GET for the per-login history label.
+# Tri-state: 0 = label exists with correct definition; 1 = absent or
+# collision (wrong definition); 2 = API error (non-404).
+has_history_label() {
+  local user="$1"
+  local label_name="${HISTORY_PREFIX}${user}"
+  local _stderr_file raw
+  _stderr_file="$(mktemp "${ASSIGN_TEMP_DIR}/capture.XXXXXX")"
+  raw="$(gh api "repos/${REPO}/labels/${label_name}" --jq '.' 2>"${_stderr_file}")" || {
+    local _diag
+    _diag="$(cat "${_stderr_file}" 2>/dev/null || true)"
+    rm -f "${_stderr_file}"
+    # Distinguish 404 (absence) from other failures (error).
+    # gh exits with code 1 for both, but stderr contains the HTTP status.
+    if echo "${_diag}" | grep -qE 'HTTP.?404|404.*not found'; then
+      return 1  # absence
+    fi
+    return 2  # error
+  }
+  rm -f "${_stderr_file}"
+  # Validate exact definition (collision detection).
+  local color desc
+  color="$(echo "${raw}" | jq -r '.color // ""')" || return 2
+  desc="$(echo "${raw}" | jq -r '.description // ""')" || return 2
+  if [[ "${color}" != "${HISTORY_COLOR}" ]] || [[ "${desc}" != "${HISTORY_DESC}" ]]; then
+    return 1  # collision with human label — treat as absent
+  fi
+  return 0
+}
+
+# Historical eligibility: current issue search, then backfill, then per-login label.
+# Any API error propagates as a failure (not eligibility).
+has_historical_assignment() {
+  local user="$1"
+  local current_count
+  current_count="$(get_current_issue_count "${user}")" || return 2
+  if [[ "${current_count}" -gt 0 ]]; then
+    return 0
+  fi
+  if has_backfill_assignment "${user}"; then
+    return 0
+  fi
+  has_history_label "${user}"
+  case $? in
+    0) return 0 ;;
+    1) return 1 ;;  # absent
+    *) return 2 ;;  # error
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Label definition validation helpers.
+# ---------------------------------------------------------------------------
+
+# Check if a label exists and validate its definition matches expected values.
+# Returns: 0 = exists with correct definition; 1 = absent; 2 = exists but
+# conflicting definition; 3 = API error.
+validate_label_definition() {
+  local label_name="$1"
+  local expected_color="$2"
+  local expected_desc="$3"
+  local _stderr_file raw
+  _stderr_file="$(mktemp "${ASSIGN_TEMP_DIR}/capture.XXXXXX")"
+  raw="$(gh api "repos/${REPO}/labels/${label_name}" --jq '.' 2>"${_stderr_file}")" || {
+    local _diag
+    _diag="$(cat "${_stderr_file}" 2>/dev/null || true)"
+    rm -f "${_stderr_file}"
+    if echo "${_diag}" | grep -qE 'HTTP.?404|404.*not found'; then
+      return 1  # absent
+    fi
+    return 3  # error
+  }
+  rm -f "${_stderr_file}"
+  local color desc
+  color="$(echo "${raw}" | jq -r '.color // ""')" || return 3
+  desc="$(echo "${raw}" | jq -r '.description // ""')" || return 3
+  if [[ "${color}" != "${expected_color}" ]] || [[ "${desc}" != "${expected_desc}" ]]; then
+    return 2  # conflicting definition
+  fi
+  return 0
+}
+
+ensure_label_exists() {
+  local label_name="$1"
+  local expected_color="$2"
+  local expected_desc="$3"
+  local rc
+  validate_label_definition "${label_name}" "${expected_color}" "${expected_desc}"
+  rc=$?
+  case ${rc} in
+    0) return 0 ;;  # exists, correct definition
+    1) ;;            # absent — proceed to create
+    2)
+      echo "‼ Label '${label_name}' exists with conflicting definition" >&2
+      return 1
+      ;;
+    3) return 1 ;;   # API error
+    *)
+      echo "‼ Unexpected label validation status: ${rc}" >&2
+      return 1
+      ;;
+  esac
+  # Create the label.
+  if ! gh api --method POST "repos/${REPO}/labels" \
+    -f name="${label_name}" \
+    -f color="${expected_color}" \
+    -f description="${expected_desc}" \
+    --silent >/dev/null 2>&1; then
+    # POST failed — re-check if it was created concurrently (race).
+    validate_label_definition "${label_name}" "${expected_color}" "${expected_desc}"
+    rc=$?
+    case ${rc} in
+      0) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Mutation helpers (targeted POST/DELETE).
+# ---------------------------------------------------------------------------
+
+# Add a single label via targeted POST (preserves existing labels, commas).
+add_label() {
+  local issue_num="$1"
+  local label_name="$2"
+  gh api --method POST "repos/${REPO}/issues/${issue_num}/labels" \
+    -f "labels[]=${label_name}" --silent >/dev/null 2>&1
+}
+
+# Add assignee via targeted POST (preserves existing assignees).
+add_assignee() {
+  local issue_num="$1"
+  local login="$2"
+  gh api --method POST "repos/${REPO}/issues/${issue_num}/assignees" \
+    -f "assignees[]=${login}" --silent >/dev/null 2>&1
+}
+
+# Remove assignee via targeted DELETE.
+remove_assignee() {
+  local issue_num="$1"
+  local login="$2"
+  gh api --method DELETE "repos/${REPO}/issues/${issue_num}/assignees" \
+    -f "assignees[]=${login}" --silent >/dev/null 2>&1
+}
+
+# Remove a single label via targeted DELETE. Uses jq @uri for URL encoding
+# to safely handle label names with special characters.
+remove_label() {
+  local issue_num="$1"
+  local label_name="$2"
+  local encoded
+  encoded="$(printf '%s' "${label_name}" | jq -sRr '@uri')"
+  gh api --method DELETE "repos/${REPO}/issues/${issue_num}/labels/${encoded}" \
+    --silent >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Verified rollback: removes only this run's assignee, re-reads exact
+# assignee JSON, then decides whether to also remove the label.
+#
+# If a competing winner remains assigned after removing this run's assignee,
+# the marker label is PRESERVED (the competing assignment owns it now).
+# If no other assignee remains and this run definitively owns the marker,
+# the label is also removed. Verified rollback must succeed; callers must
+# NOT treat a failed rollback as success.
+# ---------------------------------------------------------------------------
+
+rollback_ownership_from_snapshot() {
+  local assignees_json="$1"
+  local timeline_json="$2"
+  local login="$3"
+
+  echo "${timeline_json}" | jq -r \
+    --argjson current_assignees "${assignees_json}" \
+    --arg login="${login}" \
+    --arg bot="${BOT_LOGIN}" '
+      if type != "array" then error("timeline is not an array") else . end
+      | to_entries as $entries
+      | ($entries | map(select(
+          (.value.event == "assigned" or .value.event == "unassigned") and
+          (.value.assignee | type == "object") and
+          .value.assignee.login == $login
+        ))) as $transitions
+      | if ($current_assignees | map(.login) | index($login)) == null then
+          "ABSENT"
+        else
+          ($transitions | map(select(.value.assignee.login == $login)) | last // null) as $latest
+          | if $latest != null and
+               $latest.value.event == "assigned" and
+               ($latest.value.actor.login // "") == $bot then
+              "BOT \($latest.key) \($entries | length)"
+            else
+              "PRESERVE"
+            end
+        end
+    ' 2>/dev/null
+}
+
+marker_removal_is_safe() {
+  local assignees_json="$1"
+  local timeline_json="$2"
+
+  echo "${timeline_json}" | jq -e \
+    --argjson current_assignees "${assignees_json}" \
+    --arg bot="${BOT_LOGIN}" '
+      if type != "array" then error("timeline is not an array") else . end
+      | to_entries
+      | map(select(.value.event == "assigned" or .value.event == "unassigned")) as $transitions
+      | [$current_assignees[].login as $login
+          | ($transitions | map(select(
+              (.value.assignee | type == "object") and
+              .value.assignee.login == $login
+            )) | last // null) as $latest
+          | $latest != null and
+            $latest.value.event == "assigned" and
+            ($latest.value.actor.login // "") != "" and
+            $latest.value.actor.login != $bot
+        ] | all
+    ' >/dev/null 2>&1
+}
+
+human_takeover_before_rollback_unassign() {
+  local timeline_json="$1"
+  local login="$2"
+  local bot_assignment_pos="$3"
+  local snapshot_length="$4"
+
+  echo "${timeline_json}" | jq -e \
+    --arg login="${login}" \
+    --arg bot="${BOT_LOGIN}" \
+    --argjson bot_pos "${bot_assignment_pos}" \
+    --argjson snapshot_length "${snapshot_length}" '
+      to_entries as $entries
+      | ($entries | map(select(
+          .key >= $snapshot_length and
+          .value.event == "unassigned" and
+          .value.assignee.login == $login and
+          .value.actor.login == $bot
+        )) | first // null) as $cleanup_unassign
+      | $cleanup_unassign != null and
+        any($entries[];
+          .key > $bot_pos and
+          .key < $cleanup_unassign.key and
+          .value.event == "assigned" and
+          .value.assignee.login == $login and
+          (.value.actor.login // "") != $bot
+        )
+    ' >/dev/null 2>&1
+}
+
+rollback_this_run() {
+  local issue_num="$1"
+  local login="$2"
+  local label_name="$3"
+  local rolled_label="${4:-false}"
+  local assignees_json timeline_json ownership
+
+  if ! assignees_json="$(get_issue_assignees_json 2>/dev/null)" ||
+     ! timeline_json="$(fetch_timeline_json)" ||
+     ! ownership="$(rollback_ownership_from_snapshot "${assignees_json}" "${timeline_json}" "${login}")"; then
+    echo "‼ Rollback: failed to establish authoritative ownership for @${login} on #${issue_num}" >&2
+    return 1
+  fi
+
+  if [[ "${ownership}" == BOT\ * ]]; then
+    local bot_assignment_pos snapshot_length
+    read -r _ bot_assignment_pos snapshot_length <<<"${ownership}"
+    if ! remove_assignee "${issue_num}" "${login}"; then
+      echo "‼ Rollback: targeted DELETE failed for @${login} on #${issue_num}" >&2
+      return 1
+    fi
+
+    if ! assignees_json="$(get_issue_assignees_json 2>/dev/null)" ||
+       ! timeline_json="$(fetch_timeline_json)"; then
+      echo "‼ Rollback: failed to verify targeted DELETE for @${login} on #${issue_num}" >&2
+      return 1
+    fi
+
+    if human_takeover_before_rollback_unassign "${timeline_json}" "${login}" "${bot_assignment_pos}" "${snapshot_length}"; then
+      add_assignee "${issue_num}" "${login}" || true
+      if ! assignees_json="$(get_issue_assignees_json 2>/dev/null)" ||
+         ! echo "${assignees_json}" | jq -e --arg login="${login}" '[.[].login] | index($login) != null' >/dev/null 2>&1; then
+        echo "‼ Rollback compensation FAILED for human-owned @${login} on #${issue_num}" >&2
+      else
+        echo "‼ Rollback detected a concurrent human takeover of @${login}; restored assignee and retained marker" >&2
+      fi
+      return 1
+    fi
+
+    if echo "${assignees_json}" | jq -e --arg login="${login}" '[.[].login] | index($login) != null' >/dev/null 2>&1; then
+      echo "‼ Rollback verification FAILED: @${login} still assigned to #${issue_num}" >&2
+      return 1
+    fi
+  elif [[ "${ownership}" == "PRESERVE" ]]; then
+    echo "Rollback: preserving human/unknown-owned @${login} on #${issue_num}" >&2
+  elif [[ "${ownership}" != "ABSENT" ]]; then
+    echo "‼ Rollback: ambiguous ownership result for @${login} on #${issue_num}" >&2
+    return 1
+  fi
+
+  local preserve_marker_for_bot_contender=false
+  if echo "${assignees_json}" | jq -e --arg login="${login}" \
+    'any(.[]; .login != $login)' >/dev/null 2>&1; then
+    preserve_marker_for_bot_contender=true
+  fi
+
+  if [[ "${rolled_label}" == "true" ]]; then
+    if ! assignees_json="$(get_issue_assignees_json 2>/dev/null)" ||
+       ! timeline_json="$(fetch_timeline_json)"; then
+      echo "‼ Rollback: failed to verify marker ownership on #${issue_num}" >&2
+      return 1
+    fi
+    if [[ "${preserve_marker_for_bot_contender}" != "true" ]] &&
+       marker_removal_is_safe "${assignees_json}" "${timeline_json}"; then
+      remove_label "${issue_num}" "${label_name}" || true
+      local verify_labels
+      if ! verify_labels="$(get_issue_labels_json 2>/dev/null)"; then
+        echo "‼ Rollback: failed to verify label removal on #${issue_num}" >&2
+        return 1
+      fi
+      if echo "${verify_labels}" | jq -e --arg lbl "${label_name}" '[.[].name] | index($lbl) != null' >/dev/null 2>&1; then
+        echo "‼ Rollback verification FAILED: label '${label_name}' still on #${issue_num}" >&2
+        return 1
+      fi
+    fi
+  fi
+  return 0
+}
+
+# Verified rollback that exits nonzero if rollback itself fails.
+# Never treats a failed rollback as success. If rollback fails, the
+# state is left diagnosable (assignee/label may remain for next run).
+#
+# On SUCCESSFUL rollback, posts feedback only when post_feedback_on_success
+# is "true". Contention-loser callers pass "false" to avoid overwriting the
+# winner's sticky.
+#
+# Args: issue_num login label_name rolled_label feedback_msg exit_code [post_feedback_on_success]
+verified_rollback_and_fail() {
+  local issue_num="$1"
+  local login="$2"
+  local label_name="$3"
+  local rolled_label="$4"
+  local feedback_msg="$5"
+  local exit_code="${6:-1}"
+  local post_feedback_on_success="${7:-true}"
+
+  if ! rollback_this_run "${issue_num}" "${login}" "${label_name}" "${rolled_label}"; then
+    echo "‼ Rollback FAILED for @${login} on #${issue_num} — state left for diagnosis" >&2
+    post_sticky_feedback "${feedback_msg}" || true
+    exit "${exit_code}"
+  fi
+
+  if [[ "${post_feedback_on_success}" == "true" ]]; then
+    post_sticky_feedback "${feedback_msg}" || true
+  fi
+  exit "${exit_code}"
+}
+
+# shellcheck disable=SC2329  # Invoked by INT/TERM traps.
+handle_lifecycle_signal() {
+  local signal_name="$1"
+  local exit_code="$2"
+  trap - INT TERM
+  echo "‼ Received ${signal_name} during assignment lifecycle for @${USER_LOGIN} on #${ISSUE}" >&2
+  if [[ "${MUTATION_STARTED}" == "true" && "${LIFECYCLE_COMMITTED}" != "true" ]]; then
+    if rollback_this_run "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}"; then
+      echo "Rollback completed after ${signal_name}" >&2
+    else
+      echo "‼ Rollback after ${signal_name} could not be verified; recoverable marker state was retained" >&2
+    fi
+  fi
+  cleanup_temp_files
+  exit "${exit_code}"
+}
+
+# ---------------------------------------------------------------------------
+# Deterministic winner election via authoritative paginated timeline.
+#
+# Uses EVENT POSITION (flattened timeline array index) for total ordering —
+# NOT created_at timestamps (which collide at second resolution).
+#
+# Election algorithm:
+#   1. For each currently assigned login, find its latest assignment
+#      transition (assigned/unassigned) by EVENT POSITION.
+#   2. If ANY login's latest transition was made by a human (non-bot),
+#      the issue has human ownership — this run must rollback itself.
+#   3. Among bot-established current assignments, the earliest current-stint
+#      assigned event (by position) is the deterministic winner.
+#   4. At least one and at most one automated winner is guaranteed.
+#
+# Output: the winning login on stdout; empty if human ownership detected.
+# Returns: 0 = winner determined; 1 = error/ambiguous.
+# ---------------------------------------------------------------------------
+
+# Fetch and flatten the full paginated issue timeline.
+# Output: single JSON array on stdout.
+fetch_timeline_json() {
+  gh api "repos/${REPO}/issues/${ISSUE}/timeline?per_page=100" \
+    --paginate 2>/dev/null \
+    | jq -s 'if all(.[]; type == "array") then add else error("non-array page in timeline") end'
+}
+
+# Deterministic election: returns the winning login or empty.
+# Uses timeline event positions for total ordering.
+#
+# Args: assignees_json, timeline_json
+# Output: winning login (empty if human ownership), or "AMBIGUOUS".
+# Returns: 0 = success; 1 = error.
+elect_winner() {
+  local assignees_json="$1"
+  local timeline_json="$2"
+
+  local result
+  result="$(echo "${timeline_json}" | jq -r --argjson current_assignees "${assignees_json}" --arg bot "${BOT_LOGIN}" '
+    if type != "array" then error("timeline is not an array") else . end
+    | to_entries as $all_entries
+    | ($all_entries | map(select(.value.event == "assigned" or .value.event == "unassigned"))) as $assign_entries
+    | ($assign_entries | map(
+        select(
+          (.value.assignee | type == "object")
+          and (.value.assignee.login | type == "string")
+          and (.value.assignee.login | length > 0)
+        )
+      )) as $valid_assign_entries
+    | ($assign_entries | length) as $total_assign_entries
+    | ($valid_assign_entries | length) as $valid_count
+    | if $total_assign_entries > $valid_count then
+        error("malformed assignee data in timeline transition events")
+      else . end
+    | ($current_assignees | map(.login)) as $logins
+    | [
+        $logins[]
+        | . as $login
+        | ($valid_assign_entries | map(select(.value.assignee.login == $login))) as $login_transitions
+        | ($login_transitions | last // null) as $last_entry
+        | if $last_entry != null then
+            {
+              login: $login,
+              pos: $last_entry.key,
+              actor: ($last_entry.value.actor.login // "unknown"),
+              event: $last_entry.value.event
+            }
+          else
+            {
+              login: $login,
+              pos: -1,
+              actor: "unknown",
+              event: "unknown"
+            }
+          end
+      ] as $latest_per_login
+    | ($latest_per_login | map(select(.actor != $bot)) | length > 0) as $has_human
+    | if $has_human then
+        ""
+      else
+        ($latest_per_login
+          | map(select(.event == "assigned"))
+          | sort_by(.pos)
+          | .[0].login // "AMBIGUOUS")
+      end
+  ' 2>/dev/null)" || return 1
+
+  echo "${result}"
+}
+
+# Run the winner election: fetch fresh assignees + timeline, elect, and
+# determine if this run is the winner. Retries a bounded number of times
+# so contemporaneous contenders can appear in the timeline.
+#
+# Sets global: ELECTION_WINNER (the winning login or empty).
+# Returns: 0 = this run won or no winner needed; 1 = error/rollback needed.
+# Sets global: SHOULD_ROLLBACK (true/false).
+ELECTION_RETRIES="${ASSIGN_ELECTION_RETRIES:-5}"
+ELECTION_DELAY="${ASSIGN_ELECTION_DELAY:-1}"
+
+run_election() {
+  SHOULD_ROLLBACK="false"
+  local attempt
+  for attempt in $(seq 1 $((ELECTION_RETRIES + 1))); do
+    local assignees_json timeline_json
+    if ! assignees_json="$(get_issue_assignees_json)"; then
+      echo "‼ Election: failed to read assignees for #${ISSUE}" >&2
+      SHOULD_ROLLBACK="true"
+      return 1
+    fi
+    if ! timeline_json="$(fetch_timeline_json)"; then
+      echo "‼ Election: failed to fetch timeline for #${ISSUE}" >&2
+      SHOULD_ROLLBACK="true"
+      return 1
+    fi
+
+    local winner
+    if ! winner="$(elect_winner "${assignees_json}" "${timeline_json}")"; then
+      echo "‼ Election: error during election for #${ISSUE}" >&2
+      SHOULD_ROLLBACK="true"
+      return 1
+    fi
+
+    if [[ -z "${winner}" ]]; then
+      echo "WARNING: Human ownership detected on #${ISSUE}; rolling back @${USER_LOGIN}" >&2
+      SHOULD_ROLLBACK="true"
+      ELECTION_WINNER=""
+      return 0
+    fi
+
+    if [[ "${winner}" == "AMBIGUOUS" ]]; then
+      echo "‼ Election: ambiguous result for #${ISSUE}" >&2
+      SHOULD_ROLLBACK="true"
+      return 1
+    fi
+
+    if [[ "${winner}" == "${USER_LOGIN}" ]]; then
+      ELECTION_WINNER="${winner}"
+      SHOULD_ROLLBACK="false"
+      return 0
+    fi
+
+    if [[ "${attempt}" -le "${ELECTION_RETRIES}" ]]; then
+      sleep "${ELECTION_DELAY}"
+    fi
+  done
+
+  echo "WARNING: Election loser: @${USER_LOGIN} is not the winner (@${winner} won) on #${ISSUE}" >&2
+  ELECTION_WINNER="${winner}"
+  SHOULD_ROLLBACK="true"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Sticky feedback (fail-closed: lookup errors ≠ absence).
+# ---------------------------------------------------------------------------
+
+post_sticky_feedback() {
+  local message="$1"
+  local body
+  body="$(printf '%s\n%s\n' "${MARKER}" "${message}")"
+
+  local _comments_stderr_file
+  _comments_stderr_file="$(mktemp "${ASSIGN_TEMP_DIR}/capture.XXXXXX")"
+  local all_comments_raw
+  all_comments_raw="$(gh api "repos/${REPO}/issues/${ISSUE}/comments" --paginate 2>"${_comments_stderr_file}")" || {
+    echo "‼ Failed to fetch comments for feedback" >&2
+    cat "${_comments_stderr_file}" >&2 2>/dev/null || true
+    rm -f "${_comments_stderr_file}"
+    return 1
+  }
+  rm -f "${_comments_stderr_file}"
+
+  local all_comment_ids
+  all_comment_ids="$(echo "${all_comments_raw}" | jq -s 'add | [(.[]? | select(.user.login == $bot and ((.body // "") | startswith($marker))) | .id)] | sort' \
+    --arg bot "${BOT_LOGIN}" --arg marker "${MARKER}")" || {
+    echo "‼ Failed to parse comments for feedback" >&2
+    return 1
+  }
+
+  local count
+  count="$(echo "${all_comment_ids}" | jq 'length')"
+
+  if [[ "${count}" -eq 0 ]]; then
+    gh api --method POST "repos/${REPO}/issues/${ISSUE}/comments" \
+      -f body="${body}" --silent >/dev/null 2>&1 || return 1
+    return 0
+  fi
+
+  local keep_id
+  keep_id="$(echo "${all_comment_ids}" | jq -r '.[-1]')"
+
+  gh api --method PATCH "repos/${REPO}/issues/comments/${keep_id}" \
+    -f body="${body}" --silent >/dev/null 2>&1 || return 1
+
+  if [[ "${count}" -gt 1 ]]; then
+    echo "${all_comment_ids}" | jq -r '.[:-1][]' | while IFS= read -r dup_id; do
+      gh api --method DELETE "repos/${REPO}/issues/comments/${dup_id}" \
+        --silent >/dev/null 2>&1 || true
+    done
+  fi
+}
+
+abort_infra_error() {
+  local msg="$1"
+  echo "${msg}" >&2
+  post_sticky_feedback "[ERROR] Could not process /assign for @${USER_LOGIN}: unable to verify state due to an API error. Please try again or contact a maintainer." || true
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Main flow.
+# ---------------------------------------------------------------------------
+
+echo " Processing /assign for issue #${ISSUE} by @${USER_LOGIN}"
+
+# Step -1: Closed-issue guard — closed issues cannot be assigned.
+# Malformed/missing state is an infrastructure failure (exit 1).
+pre_state=""
+pre_state="$(get_issue_state)" || abort_infra_error "‼ Failed to read issue state for #${ISSUE}"
+if ! is_valid_state "${pre_state}"; then
+  abort_infra_error "‼ Issue #${ISSUE} has malformed state '${pre_state}'"
+fi
+if [[ "${pre_state}" != "open" ]]; then
+  echo "WARNING: Issue #${ISSUE} is ${pre_state}, not open"
+  post_sticky_feedback "[ERROR] Could not assign @${USER_LOGIN}: this issue is **${pre_state}**, not open. Only open issues can be assigned." || true
+  exit 0
+fi
+
+# Step 0: Read current assignees as JSON array (exact membership).
+pre_assignees_json=""
+pre_assignees_json="$(get_issue_assignees_json)" || abort_infra_error "‼ Failed to read assignees for #${ISSUE}"
+
+if echo "${pre_assignees_json}" | jq -e '. | length > 0' >/dev/null 2>&1; then
+  assignee_csv="$(echo "${pre_assignees_json}" | jq -r '[.[].login] | join(", ")')"
+  echo "WARNING: Issue #${ISSUE} is already assigned to: ${assignee_csv}"
+  post_sticky_feedback "[ERROR] Could not assign @${USER_LOGIN}: this issue is already assigned to **${assignee_csv}**." || true
+  exit 0
+fi
+
+# Step 0b: Check for pre-existing auto-assigned marker on an unassigned issue.
+# This is inconsistent provenance — fail closed, do not assign.
+pre_labels_json=""
+pre_labels_json="$(get_issue_labels_json)" || abort_infra_error "‼ Failed to read labels for #${ISSUE}"
+
+if echo "${pre_labels_json}" | jq -e --arg lbl "${AUTO_ASSIGNED_LABEL}" '[.[].name] | index($lbl) != null' >/dev/null 2>&1; then
+  echo "WARNING: Issue #${ISSUE} is unassigned but already carries '${AUTO_ASSIGNED_LABEL}' label — inconsistent provenance"
+  post_sticky_feedback "[ERROR] Could not assign @${USER_LOGIN}: this issue has an inconsistent state (auto-assigned label without an assignee). Please contact a maintainer." || true
+  exit 1
+fi
+
+# Step 1: Cap check (pre-mutation).
+open_count=""
+open_count="$(get_open_assigned_count "${USER_LOGIN}")" || abort_infra_error "‼ Failed to query open assigned count for @${USER_LOGIN}"
+
+if [[ "${open_count}" -ge "${MAX_ASSIGNMENTS}" ]]; then
+  echo "WARNING: @${USER_LOGIN} already has ${open_count} open assigned issues (max ${MAX_ASSIGNMENTS})"
+  post_sticky_feedback "[ERROR] Could not assign @${USER_LOGIN}: you already have **${open_count}** open assigned issues (maximum is **${MAX_ASSIGNMENTS}** per CONTRIBUTING.md). Please finish or unassign one first." || true
+  exit 0
+fi
+
+# Step 2: Eligibility.
+is_eligible=false
+eligibility_reason=""
+
+merged_count=""
+merged_count="$(get_merged_pr_count "${USER_LOGIN}")" || abort_infra_error "‼ Failed to query merged PRs for @${USER_LOGIN}"
+
+if [[ "${merged_count}" -gt 0 ]]; then
+  is_eligible=true
+  eligibility_reason="prior merged PR(s)"
+fi
+
+if [[ "${is_eligible}" != "true" ]]; then
+  hist_rc=0
+  has_historical_assignment "${USER_LOGIN}" || hist_rc=$?
+  case ${hist_rc} in
+    0)
+      is_eligible=true
+      eligibility_reason="prior issue assignment"
+      ;;
+    1) ;;  # absent — not eligible via history
+    2)
+      abort_infra_error "‼ Failed to query historical assignment for @${USER_LOGIN}"
+      ;;
+    *)
+      abort_infra_error "‼ Unexpected historical assignment status for @${USER_LOGIN}: ${hist_rc}"
+      ;;
+  esac
+fi
+
+if [[ "${is_eligible}" != "true" ]]; then
+  echo "WARNING: @${USER_LOGIN} is not eligible for self-assignment"
+  post_sticky_feedback "[ERROR] Could not assign @${USER_LOGIN}: eligibility requires at least one merged PR in this repository, or a prior issue assignment. Please open a PR first or ask a maintainer to assign you." || true
+  exit 0
+fi
+
+echo "[OK] Eligible via: ${eligibility_reason}"
+
+# Step 3: Validate/create the shared auto-assigned label (with exact definition).
+ensure_label_exists "${AUTO_ASSIGNED_LABEL}" "${AUTO_ASSIGNED_COLOR}" "${AUTO_ASSIGNED_DESC}" \
+  || abort_infra_error "‼ Failed to validate/create label '${AUTO_ASSIGNED_LABEL}'"
+
+# Step 4: Re-read assignees immediately before mutation (race protection).
+pre_assignees_json=""
+pre_assignees_json="$(get_issue_assignees_json)" || abort_infra_error "‼ Failed to re-read assignees for #${ISSUE}"
+
+if echo "${pre_assignees_json}" | jq -e '. | length > 0' >/dev/null 2>&1; then
+  assignee_csv="$(echo "${pre_assignees_json}" | jq -r '[.[].login] | join(", ")')"
+  echo "WARNING: Issue #${ISSUE} was assigned by a concurrent run: ${assignee_csv}"
+  post_sticky_feedback "[ERROR] Could not assign @${USER_LOGIN}: this issue was assigned to **${assignee_csv}** by a concurrent request." || true
+  exit 0
+fi
+
+# Step 4b: Re-validate issue state is still open immediately before mutation.
+pre_mutation_state=""
+pre_mutation_state="$(get_issue_state)" || abort_infra_error "‼ Failed to re-read issue state for #${ISSUE}"
+if ! is_valid_state "${pre_mutation_state}"; then
+  abort_infra_error "‼ Issue #${ISSUE} has malformed state '${pre_mutation_state}'"
+fi
+if [[ "${pre_mutation_state}" != "open" ]]; then
+  echo "WARNING: Issue #${ISSUE} became ${pre_mutation_state} before mutation"
+  post_sticky_feedback "[ERROR] Could not assign @${USER_LOGIN}: this issue is **${pre_mutation_state}**, not open. Only open issues can be assigned." || true
+  exit 0
+fi
+
+pre_open_count=""
+pre_open_count="$(get_open_assigned_count "${USER_LOGIN}")" || abort_infra_error "‼ Failed to re-query open assigned count for @${USER_LOGIN}"
+
+if [[ "${pre_open_count}" -ge "${MAX_ASSIGNMENTS}" ]]; then
+  echo "WARNING: @${USER_LOGIN} reached cap (${pre_open_count}) before assignment"
+  post_sticky_feedback "[ERROR] Could not assign @${USER_LOGIN}: you now have **${pre_open_count}** open assigned issues (maximum is **${MAX_ASSIGNMENTS}**). Another assignment may have completed concurrently." || true
+  exit 0
+fi
+
+# Step 5: Add auto-assigned label (targeted POST).
+MUTATION_STARTED=true
+trap 'handle_lifecycle_signal INT 130' INT
+trap 'handle_lifecycle_signal TERM 143' TERM
+
+if add_label "${ISSUE}" "${AUTO_ASSIGNED_LABEL}"; then
+  label_added_by_this_run=true
+else
+  # Label add failed — re-read to confirm current state.
+  verified_labels_json=""
+  if ! verified_labels_json="$(get_issue_labels_json)"; then
+    abort_infra_error "‼ Failed to verify labels after add failure for #${ISSUE}"
+  fi
+  if ! echo "${verified_labels_json}" | jq -e --arg lbl "${AUTO_ASSIGNED_LABEL}" '[.[].name] | index($lbl) != null' >/dev/null 2>&1; then
+    abort_infra_error "‼ Label add failed and label is not present for #${ISSUE}"
+  fi
+  # Label POST returned error but label IS confirmed present (applied_error
+  # or concurrent race). Track as confirmed-present so that ownership-aware
+  # rollback on every later failure and INT/TERM attempts marker removal.
+  # rollback_this_run / marker_removal_is_safe already preserve the marker
+  # when a competing assignment stint owns it.
+  label_added_by_this_run=true
+fi
+
+# Step 6: Add assignee (targeted POST).
+if ! add_assignee "${ISSUE}" "${USER_LOGIN}"; then
+  echo "‼ Assignee POST failed for #${ISSUE}" >&2
+  verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+    "[ERROR] Could not assign @${USER_LOGIN}: GitHub API error during assignment. Please try again or contact a maintainer." 1
+fi
+
+# Step 7: Deterministic winner election via authoritative paginated timeline.
+# Uses EVENT POSITION for total ordering. If any human owns the issue,
+# rollback. Among bot-established assignments, the earliest current-stint
+# assigned event wins. The winner waits/retries so contemporaneous
+# contenders can appear, then enforces exactly itself remains.
+ELECTION_WINNER=""
+SHOULD_ROLLBACK="false"
+
+if ! run_election; then
+  verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+    "[ERROR] Could not assign @${USER_LOGIN}: election verification failed. Please contact a maintainer." 1
+fi
+
+if [[ "${SHOULD_ROLLBACK}" == "true" ]]; then
+  if [[ -z "${ELECTION_WINNER}" ]]; then
+    verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+      "[ERROR] Could not assign @${USER_LOGIN}: a human has taken ownership of this issue." 1
+  else
+    verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+      "[ERROR] Could not assign @${USER_LOGIN}: another assignment was selected. Please try a different issue." 1 false
+  fi
+fi
+
+# Winner enforcement: wait/retry for losers to rollback, then verify
+# exactly this run's login remains assigned. Re-runs the election when
+# contention persists — only rolls back if this run is no longer the winner.
+enforcement_ok=false
+enforcement_retries=$((ELECTION_RETRIES * 3 + 5))
+for _e_attempt in $(seq 1 $((enforcement_retries + 1))); do
+  verified_assignees_json=""
+  if ! verified_assignees_json="$(get_issue_assignees_json)"; then
+    echo "‼ Failed to verify assignees for #${ISSUE}" >&2
+    verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+      "[ERROR] Could not assign @${USER_LOGIN}: unable to verify assignment state. Please contact a maintainer." 1
+  fi
+
+  assignee_count="$(echo "${verified_assignees_json}" | jq 'length')"
+  has_commenter="$(echo "${verified_assignees_json}" | jq -r --arg login "${USER_LOGIN}" '[.[].login] | index($login) != null')"
+
+  if [[ "${assignee_count}" == "1" ]] && [[ "${has_commenter}" == "true" ]]; then
+    enforcement_ok=true
+    break
+  fi
+
+  # Contention persists — re-run election to check if this run is still the winner.
+  # If no longer the winner, roll back. If still the winner, keep waiting.
+  if [[ "${has_commenter}" != "true" ]]; then
+    echo "WARNING: @${USER_LOGIN} no longer assigned to #${ISSUE} during enforcement" >&2
+    verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+      "[ERROR] Could not assign @${USER_LOGIN}: another assignment was selected. Please try a different issue." 1 false
+  fi
+
+  recheck_timeline=""
+  recheck_assignees=""
+  recheck_winner=""
+  if ! recheck_assignees="$(get_issue_assignees_json)" || \
+     ! recheck_timeline="$(fetch_timeline_json)"; then
+    echo "‼ Enforcement re-election: API error for #${ISSUE}" >&2
+    verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+      "[ERROR] Could not assign @${USER_LOGIN}: election verification failed. Please contact a maintainer." 1
+  fi
+
+  if ! recheck_winner="$(elect_winner "${recheck_assignees}" "${recheck_timeline}")"; then
+    echo "‼ Enforcement re-election: error for #${ISSUE}" >&2
+    verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+      "[ERROR] Could not assign @${USER_LOGIN}: election verification failed. Please contact a maintainer." 1
+  fi
+
+  if [[ -z "${recheck_winner}" ]]; then
+    echo "WARNING: Human ownership detected during enforcement on #${ISSUE}; rolling back @${USER_LOGIN}" >&2
+    verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+      "[ERROR] Could not assign @${USER_LOGIN}: a human has taken ownership of this issue." 1
+  fi
+
+  if [[ "${recheck_winner}" != "${USER_LOGIN}" ]]; then
+    echo "WARNING: @${USER_LOGIN} is no longer the winner (@${recheck_winner} won) on #${ISSUE}" >&2
+    verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+      "[ERROR] Could not assign @${USER_LOGIN}: another assignment was selected. Please try a different issue." 1 false
+  fi
+
+  if [[ "${_e_attempt}" -le "${enforcement_retries}" ]]; then
+    sleep "${ELECTION_DELAY}"
+  fi
+done
+
+if [[ "${enforcement_ok}" != "true" ]]; then
+  echo "WARNING: Post-election contention on #${ISSUE}: assignees = $(echo "${verified_assignees_json}" | jq -r '[.[].login] | join(", ")')" >&2
+  verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+    "[ERROR] Could not assign @${USER_LOGIN}: unable to enforce single-winner assignment. Please contact a maintainer." 1 false
+fi
+
+# Step 8: Verify label was added.
+verified_labels_json=""
+if ! verified_labels_json="$(get_issue_labels_json)"; then
+  verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+    "[ERROR] Could not assign @${USER_LOGIN}: unable to verify label state. Please contact a maintainer." 1
+fi
+
+if ! echo "${verified_labels_json}" | jq -e --arg lbl "${AUTO_ASSIGNED_LABEL}" '[.[].name] | index($lbl) != null' >/dev/null 2>&1; then
+  echo "‼ Label verification failed for #${ISSUE}" >&2
+  verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+    "[ERROR] Could not assign @${USER_LOGIN}: the label could not be verified. Please contact a maintainer." 1
+fi
+
+# Step 9: Post-mutation cap enforcement (fail-closed).
+post_open_count=""
+if ! post_open_count="$(get_open_assigned_count "${USER_LOGIN}")"; then
+  echo "‼ Post-mutation cap query failed for @${USER_LOGIN}" >&2
+  verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+    "[ERROR] Could not assign @${USER_LOGIN}: unable to verify the assignment cap due to an API error. Please try again or contact a maintainer." 1
+fi
+
+if [[ "${post_open_count}" -gt "${MAX_ASSIGNMENTS}" ]]; then
+  echo "WARNING: Post-mutation open count (${post_open_count}) exceeds cap; rolling back @${USER_LOGIN} on #${ISSUE}" >&2
+  # Verified rollback must succeed before exiting. If it fails, exit nonzero.
+  verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+    "[ERROR] Could not assign @${USER_LOGIN}: assignment would exceed the **${MAX_ASSIGNMENTS}**-issue cap. Another assignment may have completed concurrently." 1
+fi
+
+# Step 10: Create durable history label directly (GitHub suppresses recursive
+# issues:assigned workflows from GITHUB_TOKEN).
+# Delegates to the shared record-assignment-history.sh script for consistent
+# exact label definition validation and collision failure.
+if ! bash "$(dirname "${BASH_SOURCE[0]}")/record-assignment-history.sh"; then
+  echo "‼ Failed to create history label for @${USER_LOGIN}" >&2
+  verified_rollback_and_fail "${ISSUE}" "${USER_LOGIN}" "${AUTO_ASSIGNED_LABEL}" "${label_added_by_this_run}" \
+    "[ERROR] Could not assign @${USER_LOGIN}: failed to record assignment history. Please try again or contact a maintainer." 1
+fi
+
+LIFECYCLE_COMMITTED=true
+trap - INT TERM
+
+echo "[OK] Assigned @${USER_LOGIN} to issue #${ISSUE}"
+post_sticky_feedback "[OK] Assigned @${USER_LOGIN} to this issue via \`/assign\` (${eligibility_reason}).
+
+Please open a linked PR within **2 weeks**, or the automation may unassign stale auto-assignments (maintainer \`acoliver\` is exempt as an assignee)."
+exit 0

--- a/.github/scripts/record-assignment-history.sh
+++ b/.github/scripts/record-assignment-history.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Create or verify a per-user assignment history label.
+#
+# Used by both assign-issue.sh (direct durability) and the record-history
+# workflow job (issues:assigned events). Uses the same short-prefix exact
+# label definition validation (name, normalized color, description) and
+# collision failure as assign-issue.sh.
+set -euo pipefail
+
+# Source shared constants (history-label policy values + login validation).
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/assign-constants.sh"
+
+# Validate the sourced constants are non-empty and well-formed so that a
+# malformed source file cannot produce a degenerate label definition.
+if [[ -z "${HISTORY_PREFIX}" || -z "${HISTORY_COLOR}" || -z "${HISTORY_DESC}" ]]; then
+  printf '‼ Sourced history constants are empty (prefix/color/desc)
+' >&2
+  exit 1
+fi
+if ! [[ "${HISTORY_COLOR}" =~ ^[0-9A-Fa-f]{6}$ ]]; then
+  printf '‼ Sourced HISTORY_COLOR is not six hex chars: %q
+' "${HISTORY_COLOR}" >&2
+  exit 1
+fi
+
+# Check required tool availability with clear diagnostics before use.
+for _tool in gh jq; do
+  if ! command -v "${_tool}" >/dev/null 2>&1; then
+    printf '‼ Missing required tool: %s\n' "${_tool}" >&2
+    exit 1
+  fi
+done
+unset _tool
+
+: "${GITHUB_REPOSITORY:?Missing GITHUB_REPOSITORY}"
+: "${ASSIGNEE_LOGIN:?Missing ASSIGNEE_LOGIN}"
+
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  export GH_TOKEN
+elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  export GH_TOKEN="${GITHUB_TOKEN}"
+else
+  printf '‼ Missing %s / %s\n' "\$GH_TOKEN" "\$GITHUB_TOKEN" >&2
+  exit 1
+fi
+
+REPO="${GITHUB_REPOSITORY}"
+LOGIN="${ASSIGNEE_LOGIN}"
+
+# Validate login syntax before label construction.
+if ! validate_github_login "${LOGIN}"; then
+  printf '‼ Invalid GitHub login: %q\n' "${LOGIN}" >&2
+  exit 1
+fi
+
+LABEL_NAME="${HISTORY_PREFIX}${LOGIN}"
+
+# Guard against a malformed prefix/login combination exceeding the GitHub
+# 50-character label-name limit.
+if [[ "${#LABEL_NAME}" -gt 50 ]]; then
+  printf '‼ Constructed label name exceeds 50 chars: %q
+' "${LABEL_NAME}" >&2
+  exit 1
+fi
+
+# Track temp files for cleanup on signals/exit.
+_HISTORY_TMPFILES=()
+
+_history_cleanup() {
+  for _f in "${_HISTORY_TMPFILES[@]:-}"; do
+    [[ -n "${_f}" ]] && rm -f "${_f}" 2>/dev/null || true
+  done
+}
+trap _history_cleanup EXIT
+trap 'trap - EXIT; _history_cleanup; exit 130' INT TERM
+
+validate_history_label() {
+  local label_name="$1"
+  local _stderr_file raw
+  _stderr_file="$(mktemp)"
+  _HISTORY_TMPFILES+=("${_stderr_file}")
+  raw="$(gh api "repos/${REPO}/labels/${label_name}" --jq '.' 2>"${_stderr_file}")" || {
+    local _diag
+    _diag="$(cat "${_stderr_file}" 2>/dev/null || true)"
+    rm -f "${_stderr_file}"
+    # Distinguish 404 (absence) from other API failures (error).
+    # Case-insensitive so both "HTTP 404" and "status": "404" match.
+    if printf '%s' "${_diag}" | grep -qiE 'http.?404|404.*not found|status.{1,3}404'; then
+      return 1  # absent
+    fi
+    # Non-404 API error — log sanitized diagnostics and signal error.
+    printf '‼ validate_history_label: API error for %q: %s\n' "${label_name}" "$(printf '%s' "${_diag}" | head -1)" >&2
+    return 3
+  }
+  rm -f "${_stderr_file}"
+  local color desc
+  color="$(printf '%s' "${raw}" | jq -r '.color // ""')" || return 3
+  desc="$(printf '%s' "${raw}" | jq -r '.description // ""')" || return 3
+  if [[ "${color}" != "${HISTORY_COLOR}" ]] || [[ "${desc}" != "${HISTORY_DESC}" ]]; then
+    return 2  # collision — exists with conflicting definition
+  fi
+  return 0
+}
+
+# Initial presence check: 0=exists(correct), 1=absent, 2=collision, 3=API error.
+rc=0
+validate_history_label "${LABEL_NAME}" || rc=$?
+case ${rc} in
+  0)
+    printf 'Label %s already exists with correct definition\n' "${LABEL_NAME}"
+    exit 0
+    ;;
+  1) ;;  # absent — proceed to create
+  2)
+    printf '‼ Label %q exists with conflicting definition\n' "${LABEL_NAME}" >&2
+    exit 1
+    ;;
+  3)
+    printf '‼ Failed to check label %s (API error)\n' "${LABEL_NAME}" >&2
+    exit 1
+    ;;
+  *)
+    printf '‼ Unexpected label validation status: %s\n' "${rc}" >&2
+    exit 1
+    ;;
+esac
+
+# Capture POST stderr for diagnostics without relying on the global redirect.
+_post_stderr_file="$(mktemp)"
+_HISTORY_TMPFILES+=("${_post_stderr_file}")
+if ! gh api --method POST "repos/${REPO}/labels" \
+  -f name="${LABEL_NAME}" \
+  -f color="${HISTORY_COLOR}" \
+  -f description="${HISTORY_DESC}" \
+  --silent >/dev/null 2>"${_post_stderr_file}"; then
+  # POST failed — capture its sanitized first line for the final diagnostic.
+  _post_diag="$(head -1 "${_post_stderr_file}" 2>/dev/null | tr -d '\000-\037' || true)"
+  # Re-check whether it was created concurrently. Capture the return code
+  # directly (not via if/else, which loses $? of the condition).
+  rc=0
+  validate_history_label "${LABEL_NAME}" || rc=$?
+  case ${rc} in
+    0)
+      printf 'Label %s already exists (created concurrently)\n' "${LABEL_NAME}"
+      exit 0
+      ;;
+    1)
+      printf '‼ Failed to create label %s: label is absent after POST (POST stderr: %s)\n' \
+        "${LABEL_NAME}" "${_post_diag}" >&2
+      exit 1
+      ;;
+    2)
+      printf '‼ Label %q exists with conflicting definition (POST stderr: %s)\n' \
+        "${LABEL_NAME}" "${_post_diag}" >&2
+      exit 1
+      ;;
+    3)
+      printf '‼ Failed to recheck label %s after POST: API error (POST stderr: %s)\n' \
+        "${LABEL_NAME}" "${_post_diag}" >&2
+      exit 1
+      ;;
+    *)
+      printf '‼ Unexpected label validation status: %s (POST stderr: %s)\n' \
+        "${rc}" "${_post_diag}" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+printf 'Created label %s\n' "${LABEL_NAME}"

--- a/.github/scripts/unassign-stale-issues.sh
+++ b/.github/scripts/unassign-stale-issues.sh
@@ -1,0 +1,802 @@
+#!/usr/bin/env bash
+# Unassign stale auto-assigned issues with no qualifying linked PR activity
+# for 2 weeks. Invoked by .github/workflows/assign-stale-cleanup.yml.
+#
+# Uses targeted DELETE endpoints (never whole-array PATCH) to preserve
+# concurrent human state and comma-bearing label names. Only the exact
+# automation assignee and auto-assigned label are removed.
+#
+# acoliver is never unassigned. Timeline/API failures preserve state and
+# cause a nonzero exit (never destructive cleanup).
+set -euo pipefail
+
+AUTO_ASSIGNED_LABEL='auto-assigned'
+AUTO_ASSIGNED_COLOR='0E8A16'
+AUTO_ASSIGNED_DESC='Assigned via /assign automation'
+STALE_DAYS=14
+EXEMPT_LOGIN='acoliver'
+BOT_LOGIN='github-actions[bot]'
+ASSIGN_RETRY_DELAY="${ASSIGN_RETRY_DELAY:-5}"
+
+: "${GITHUB_REPOSITORY:?Missing GITHUB_REPOSITORY}"
+
+EXPECTED_REPO_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}"
+
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  export GH_TOKEN
+elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  export GH_TOKEN="${GITHUB_TOKEN}"
+else
+  echo "‼️ Missing \$GH_TOKEN / \$GITHUB_TOKEN" >&2
+  exit 1
+fi
+
+REPO="${GITHUB_REPOSITORY}"
+
+CLEANUP_TEMP_DIR="$(mktemp -d)"
+
+# shellcheck disable=SC2329  # Invoked by EXIT/INT/TERM traps.
+cleanup_temp_files() {
+  if [[ -n "${CLEANUP_TEMP_DIR:-}" && -d "${CLEANUP_TEMP_DIR}" ]]; then
+    rm -rf -- "${CLEANUP_TEMP_DIR}"
+  fi
+}
+
+trap cleanup_temp_files EXIT
+trap 'cleanup_temp_files; trap - EXIT; exit 130' INT
+trap 'cleanup_temp_files; trap - EXIT; exit 143' TERM
+
+retry_gh() {
+  local attempt
+  for attempt in 1 2 3 4; do
+    if "$@"; then
+      return 0
+    fi
+    if [[ "${attempt}" -lt 4 ]]; then
+      echo "Attempt ${attempt} failed, retrying: $*" >&2
+      sleep "${ASSIGN_RETRY_DELAY}"
+    fi
+  done
+  echo "All retries exhausted for: $*" >&2
+  return 1
+}
+
+threshold_iso() {
+  if [[ -n "${ASSIGN_NOW:-}" ]]; then
+    local now_epoch
+    now_epoch="$(iso_to_epoch "${ASSIGN_NOW}")" || return 1
+    local threshold_epoch
+    threshold_epoch=$((now_epoch - STALE_DAYS * 86400))
+    date -u -d "@${threshold_epoch}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+      date -u -r "${threshold_epoch}" +%Y-%m-%dT%H:%M:%SZ
+    return 0
+  fi
+  if date -u -d "${STALE_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null; then
+    return 0
+  fi
+  date -u -v-"${STALE_DAYS}"d +%Y-%m-%dT%H:%M:%SZ
+}
+
+iso_to_epoch() {
+  local iso="$1"
+  local normalized="${iso%Z}"
+  normalized="${normalized%%.*}"
+  if date -u -d "${normalized}Z" +%s 2>/dev/null; then
+    return 0
+  fi
+  date -u -j -f "%Y-%m-%dT%H:%M:%S" "${normalized}" +%s 2>/dev/null
+}
+
+# Run a command with bounded retry, capturing combined stdout.
+# Sets the global RETRY_CAPTURE_OUT on success. Returns 0 on success, 1 on
+# exhaustion. Stderr from the command is suppressed (goes to /dev/null).
+# Args: command...
+retry_gh_capture() {
+  local _capture_file
+  _capture_file="$(mktemp "${CLEANUP_TEMP_DIR}/capture.XXXXXX")"
+  local attempt
+  for attempt in 1 2 3 4; do
+    : >"${_capture_file}"
+    if "$@" >"${_capture_file}" 2>/dev/null; then
+      RETRY_CAPTURE_OUT="$(cat "${_capture_file}")"
+      rm -f "${_capture_file}"
+      return 0
+    fi
+    if [[ "${attempt}" -lt 4 ]]; then
+      echo "Attempt ${attempt} failed, retrying: $*" >&2
+      sleep "${ASSIGN_RETRY_DELAY}"
+    fi
+  done
+  rm -f "${_capture_file}"
+  echo "All retries exhausted for: $*" >&2
+  return 1
+}
+
+# gh api --paginate emits one JSON array per page; jq -s merges them.
+# Uses retry_gh_capture for bounded retry on transient failures. The gh call
+# and jq merge are run as a single bash -c with pipefail so that a gh failure
+# (nonzero exit, empty stdout) is detected even though jq succeeds on empty
+# input. Stdout is captured cleanly without stderr corruption.
+fetch_issue_timeline() {
+  local issue_number="$1"
+  local _raw_pages
+  if ! retry_gh_capture gh api "repos/${REPO}/issues/${issue_number}/timeline?per_page=100" --paginate; then
+    return 1
+  fi
+  _raw_pages="${RETRY_CAPTURE_OUT}"
+  printf '%s' "${_raw_pages}" | jq -s 'if all(.[]; type == "array") then add else error("non-array page in timeline") end'
+}
+
+# Read current assignees as a raw JSON array.
+get_issue_assignees_json() {
+  local issue_number="$1"
+  gh api "repos/${REPO}/issues/${issue_number}" \
+    --jq '.assignees // []' 2>/dev/null
+}
+
+
+# Provenance extraction from a pre-fetched timeline snapshot.
+# Args: assignees_json, timeline_json.
+# Output: "LOGIN TIMESTAMP POSITION" or empty. Returns nonzero on error/ambiguity.
+find_provenance_from_timeline() {
+  local assignees_json="$1"
+  local timeline_json="$2"
+
+  local result
+  result="$(echo "${timeline_json}" | jq -r \
+    --argjson current_assignees "${assignees_json}" \
+    --arg label="${AUTO_ASSIGNED_LABEL}" \
+    --arg bot="${BOT_LOGIN}" '
+    if type != "array" then error("timeline is not an array") else . end
+    | to_entries as $all_entries
+    | ($all_entries | map(select(.value.event == "assigned" or .value.event == "unassigned"))) as $assign_entries
+    | ($all_entries | map(select(.value.event == "labeled" or .value.event == "unlabeled"))) as $label_entries
+    | ($current_assignees | map(.login)) as $logins
+    | $logins[]
+    | . as $login
+    | ($assign_entries | map(select(.value.assignee.login == $login))) as $login_transitions
+    | ($login_transitions | last // null) as $last_entry
+    | ($login_transitions[-2] // null) as $boundary_entry
+    | if $last_entry != null and $last_entry.value.event == "assigned" and $last_entry.value.actor.login == $bot then
+        $last_entry.value.created_at as $assigned_at
+        | $last_entry.key as $assigned_pos
+        | ($boundary_entry.key // -1) as $boundary_pos
+        | ($label_entries | map(select(
+            .value.label.name == $label
+            and (.key > $boundary_pos)
+            and (.key <= $assigned_pos)
+            and .value.actor.login == $bot
+            and .value.event == "labeled"
+          )) | last // null) as $qualifying_entry
+        | if $qualifying_entry != null then
+            ($label_entries | map(select(
+              .value.label.name == $label
+              and (.key > $qualifying_entry.key)
+              and .value.event == "unlabeled"
+            )) | length > 0) as $has_invalidating_unlabel
+            | if $has_invalidating_unlabel then
+                empty
+              else
+                "\($login) \($assigned_at) \($assigned_pos)"
+              end
+          else
+            empty
+          end
+      else
+        empty
+      end
+  ' 2>/dev/null)" || return 1
+
+  local line_count
+  line_count="$(echo "${result}" | grep -c . || true)"
+  if [[ "${line_count}" -gt 1 ]]; then
+    echo "Multiple automated provenance records found" >&2
+    return 1
+  fi
+
+  echo "${result}"
+}
+
+# Qualifying linked PR requires the same repository and assignee author, with
+# linkage at or after assignment. Returns nonzero for malformed snapshots.
+has_qualifying_linked_pr_from_timeline() {
+  local assignee="$1"
+  local assigned_at="$2"
+  local timeline_json="$3"
+
+  local result
+  result="$(echo "${timeline_json}" | jq -r --arg assignee "${assignee}" --arg assigned_at "${assigned_at}" --arg repo_url "${EXPECTED_REPO_URL}" '
+    if type != "array" then error("timeline is not an array") else . end
+    | map(select(
+        (.event == "cross-referenced") and
+        (.source.issue.pull_request != null) and
+        (.source.issue.user.login == $assignee) and
+        (.created_at >= $assigned_at) and
+        (.source.issue.repository_url == $repo_url)
+      ))
+    | length > 0
+  ' 2>/dev/null)" || return 1
+
+  echo "${result}"
+}
+
+# Discover candidates: open issues with auto-assigned label.
+# GitHub /issues includes PRs; filter to issues only.
+# Captures gh stderr so a sanitized first line can be printed on failure
+# (pipefail already ensures no partial results leak through).
+discover_candidates() {
+  local _stderr_file _raw
+  _stderr_file="$(mktemp "${CLEANUP_TEMP_DIR}/discover.XXXXXX")"
+  _raw="$(gh api "repos/${REPO}/issues?state=open&labels=${AUTO_ASSIGNED_LABEL}&per_page=100" \
+    --paginate 2>"${_stderr_file}" \
+    | jq -sr 'if all(.[]; type == "array") then add else error("non-array page") end
+             | .[]? | select(.pull_request == null) | "\(.number)\t\(.assignees)"')"
+  local _rc=$?
+  if [[ "${_rc}" -ne 0 ]]; then
+    local _diag
+    _diag="$(head -1 "${_stderr_file}" 2>/dev/null | tr -d '\000-\037' || true)"
+    rm -f "${_stderr_file}"
+    printf '‼ Candidate discovery failed: %s\n' "${_diag}" >&2
+    return 1
+  fi
+  rm -f "${_stderr_file}"
+  printf '%s' "${_raw}"
+}
+
+# Remove only the auto-assigned label via targeted DELETE. Uses jq @uri.
+# On DELETE failure (including 404 from a race that already removed the
+# label), re-reads the issue to verify the label is actually absent. Only an
+# issue read confirming absence allows treating the failure as success.
+remove_label_targeted() {
+  local issue_number="$1"
+  local label_name="$2"
+  local encoded
+  encoded="$(printf '%s' "${label_name}" | jq -sRr '@uri')"
+  if retry_gh gh api --method DELETE "repos/${REPO}/issues/${issue_number}/labels/${encoded}" \
+    --silent >/dev/null 2>&1; then
+    return 0
+  fi
+  # DELETE failed — verify whether the label is actually absent via issue read.
+  local verify_labels
+  if ! verify_labels="$(gh api "repos/${REPO}/issues/${issue_number}" --jq '.labels // []' 2>/dev/null)"; then
+    echo "   Warning: Label-removal DELETE failed and verification read failed for #${issue_number}" >&2
+    return 1
+  fi
+  if echo "${verify_labels}" | jq -e --arg lbl "${label_name}" '[.[].name] | index($lbl) != null' >/dev/null 2>&1; then
+    echo "   Warning: Label-removal DELETE failed and label still present for #${issue_number}" >&2
+    return 1
+  fi
+  # Label is confirmed absent — desired state achieved despite DELETE failure.
+  return 0
+}
+
+# Remove only a specific assignee via targeted DELETE.
+remove_assignee_targeted() {
+  local issue_number="$1"
+  local login="$2"
+  if ! retry_gh gh api --method DELETE "repos/${REPO}/issues/${issue_number}/assignees" \
+    -f "assignees[]=${login}" --silent >/dev/null 2>&1; then
+    echo "   Warning: Assignee-removal DELETE failed for #${issue_number}" >&2
+    return 1
+  fi
+  return 0
+}
+
+# Remove auto-assigned label only (no assignees to clean).
+
+restore_assignee_targeted() {
+  local issue_number="$1"
+  local login="$2"
+  retry_gh gh api --method POST "repos/${REPO}/issues/${issue_number}/assignees" \
+    -f "assignees[]=${login}" --silent >/dev/null 2>&1 || true
+
+  local verify_assignees
+  if ! verify_assignees="$(get_issue_assignees_json "${issue_number}")"; then
+    return 1
+  fi
+  echo "${verify_assignees}" | jq -e --arg login="${login}" \
+    '[.[].login] | index($login) != null' >/dev/null 2>&1
+}
+
+# Restore the auto-assigned marker label via targeted POST. Verifies presence
+# after POST. Returns 0 if present, 1 otherwise.
+restore_label_targeted() {
+  local issue_number="$1"
+  retry_gh gh api --method POST "repos/${REPO}/issues/${issue_number}/labels" \
+    -f "labels[]=${AUTO_ASSIGNED_LABEL}" --silent >/dev/null 2>&1 || true
+
+  local verify_labels
+  if ! verify_labels="$(gh api "repos/${REPO}/issues/${issue_number}" --jq '.labels // []' 2>/dev/null)"; then
+    return 1
+  fi
+  echo "${verify_labels}" | jq -e --arg lbl "${AUTO_ASSIGNED_LABEL}" \
+    '[.[].name] | index($lbl) != null' >/dev/null 2>&1
+}
+
+human_takeover_before_cleanup_unassign() {
+  local timeline_json="$1"
+  local login="$2"
+  local bot_assignment_pos="$3"
+  local snapshot_length="$4"
+
+  echo "${timeline_json}" | jq -e \
+    --arg login="${login}" \
+    --arg bot="${BOT_LOGIN}" \
+    --argjson bot_pos "${bot_assignment_pos}" \
+    --argjson snapshot_length "${snapshot_length}" '
+      to_entries as $entries
+      | ($entries | map(select(
+          .key >= $snapshot_length and
+          .value.event == "unassigned" and
+          .value.assignee.login == $login and
+          .value.actor.login == $bot
+        )) | first // null) as $cleanup_unassign
+      | $cleanup_unassign != null and
+        any($entries[];
+          .key > $bot_pos and
+          .key < $cleanup_unassign.key and
+          .value.event == "assigned" and
+          .value.assignee.login == $login and
+          (.value.actor.login // "") != $bot
+        )
+    ' >/dev/null 2>&1
+}
+
+# Detect any fresh "assigned" transition at or after the pre-delete snapshot
+# position. A concurrent /assign (by bot OR human, any login) between our
+# pre-delete validation and the stale DELETE creates such an event.
+# Uses an ordered per-login transition model: returns true only if at least
+# one login's LATEST transition at or after the snapshot is "assigned".
+# A login that was assigned then independently unassigned does NOT count.
+# Returns 0 (true) if a live fresh assignment exists, 1 (false) otherwise.
+fresh_assignment_after_snapshot() {
+  local timeline_json="$1"
+  local snapshot_length="$2"
+
+  echo "${timeline_json}" | jq -e \
+    --argjson snapshot_length "${snapshot_length}" '
+      if type != "array" then error("timeline is not an array") else . end
+      | to_entries
+      | map(select(
+          .key >= $snapshot_length
+          and (.value.event == "assigned" or .value.event == "unassigned")
+        ))
+      | group_by(.value.assignee.login)
+      | map(select(length > 0))
+      | any((last | .value.event) == "assigned")
+    ' >/dev/null 2>&1
+}
+
+# Extract logins whose LATEST transition at or after the snapshot position
+# is "assigned". Uses an ordered per-login transition model: for each login,
+# examines all assigned/unassigned events at or after the snapshot, and only
+# includes the login if its last transition is "assigned". A login that was
+# assigned then independently unassigned after the snapshot is NOT restored.
+# Output: one login per line.
+fresh_assignment_logins_after_snapshot() {
+  local timeline_json="$1"
+  local snapshot_length="$2"
+
+  echo "${timeline_json}" | jq -r \
+    --argjson snapshot_length "${snapshot_length}" '
+      if type != "array" then error("timeline is not an array") else . end
+      | to_entries
+      | map(select(
+          .key >= $snapshot_length
+          and (.value.event == "assigned" or .value.event == "unassigned")
+        ))
+      | sort_by(.value.assignee.login)
+      | group_by(.value.assignee.login)
+      | map(select(length > 0))
+      | map(select((last | .value.event) == "assigned"))
+      | map(first | .value.assignee.login)
+      | .[]
+    ' 2>/dev/null
+}
+
+remove_label_only() {
+  local issue_number="$1"
+  remove_label_targeted "${issue_number}" "${AUTO_ASSIGNED_LABEL}"
+}
+
+# Validate the canonical auto-assigned label definition before any candidate
+# discovery or mutation (fail-closed, matching assign-issue.sh).
+# Returns: 0 = exists with correct definition; 1 = absent (clean no-op);
+# 2 = conflicting definition; 3 = API error.
+validate_marker_label() {
+  local _stderr_file raw
+  _stderr_file="$(mktemp "${CLEANUP_TEMP_DIR}/capture.XXXXXX")"
+  raw="$(gh api "repos/${REPO}/labels/${AUTO_ASSIGNED_LABEL}" --jq '.' 2>"${_stderr_file}")" || {
+    local _diag
+    _diag="$(cat "${_stderr_file}" 2>/dev/null || true)"
+    rm -f "${_stderr_file}"
+    if printf '%s' "${_diag}" | grep -qE 'HTTP.?404|404.*not found'; then
+      return 1
+    fi
+    return 3
+  }
+  rm -f "${_stderr_file}"
+  local color desc
+  color="$(echo "${raw}" | jq -r '.color // ""')" || return 3
+  desc="$(echo "${raw}" | jq -r '.description // ""')" || return 3
+  if [[ "${color}" != "${AUTO_ASSIGNED_COLOR}" ]] || [[ "${desc}" != "${AUTO_ASSIGNED_DESC}" ]]; then
+    return 2
+  fi
+  return 0
+}
+
+process_issue() {
+  local issue_number="$1"
+  local assignees_json="$2"
+  local threshold_epoch="$3"
+
+  local assignee_count
+  assignee_count="$(echo "${assignees_json}" | jq 'length' 2>/dev/null || echo '?')"
+
+  echo "🔄 Checking auto-assigned issue #${issue_number} (assignees: ${assignee_count})"
+
+  if [[ "${assignee_count}" == "0" ]]; then
+    echo "   No assignees; removing stale ${AUTO_ASSIGNED_LABEL} label"
+    remove_label_only "${issue_number}"
+    return $?
+  fi
+
+  local bot_assignment=""
+  local initial_timeline_json=""
+  # Fetch ONE initial timeline snapshot per issue and use it for BOTH
+  # initial provenance extraction and the initial linked-PR check. This
+  # avoids a duplicate timeline fetch (a separate fresh pre-delete snapshot
+  # is still mandatory before destructive DELETE for race safety).
+  initial_timeline_json="$(fetch_issue_timeline "${issue_number}")" || {
+    echo "   Warning: Initial timeline read failed for #${issue_number}; preserving state" >&2
+    return 1
+  }
+
+  bot_assignment="$(find_provenance_from_timeline "${assignees_json}" "${initial_timeline_json}")" || {
+    echo "   Warning: Provenance check failed for #${issue_number} (ambiguous or error); preserving state" >&2
+    return 1
+  }
+
+  if [[ -z "${bot_assignment}" ]]; then
+    echo "   No automated assignment provenance for #${issue_number}; removing label only"
+    remove_label_only "${issue_number}"
+    return $?
+  fi
+
+  local bot_login bot_assignment_rest bot_assigned_at bot_assigned_pos
+  bot_login="${bot_assignment%% *}"
+  bot_assignment_rest="${bot_assignment#* }"
+  bot_assigned_at="${bot_assignment_rest%% *}"
+  bot_assigned_pos="${bot_assignment_rest##* }"
+
+  echo "   Bot-assigned @${bot_login} at ${bot_assigned_at} (timeline position ${bot_assigned_pos})"
+
+  if [[ "${bot_login}" == "${EXEMPT_LOGIN}" ]]; then
+    echo "   Keeping @${EXEMPT_LOGIN} on #${issue_number} (exempt)"
+    return 0
+  fi
+
+  local bot_assigned_epoch
+  bot_assigned_epoch="$(iso_to_epoch "${bot_assigned_at}" || true)"
+  if [[ -z "${bot_assigned_epoch}" ]]; then
+    echo "   Warning: Could not parse assignment time '${bot_assigned_at}' for #${issue_number}; preserving state" >&2
+    return 1
+  fi
+
+  if [[ "${bot_assigned_epoch}" -gt "${threshold_epoch}" ]]; then
+    echo "   Assignment for #${issue_number} is newer than ${STALE_DAYS} days; keeping"
+    return 0
+  fi
+
+  # Use the same initial timeline snapshot for the initial linked-PR check
+  # (a separate fresh pre-delete snapshot is taken before DELETE).
+  local has_pr="false"
+  has_pr="$(has_qualifying_linked_pr_from_timeline "${bot_login}" "${bot_assigned_at}" "${initial_timeline_json}")" || {
+    echo "   Warning: Linked PR query failed for #${issue_number}; preserving state" >&2
+    return 1
+  }
+
+  if [[ "${has_pr}" == "true" ]]; then
+    echo "   @${bot_login} has qualifying linked PR activity for #${issue_number}; keeping"
+    return 0
+  fi
+
+  # Re-read current assignees and fetch ONE fresh timeline snapshot immediately
+  # before destructive DELETE. Both provenance revalidation and linked-PR
+  # revalidation run against this single snapshot, so a qualifying PR that
+  # appears between the initial check and the pre-delete revalidation is
+  # detected (race protection).
+  local pre_delete_assignees_json=""
+  pre_delete_assignees_json="$(get_issue_assignees_json "${issue_number}")" || {
+    echo "   Warning: Pre-delete assignee read failed for #${issue_number}; preserving state" >&2
+    return 1
+  }
+
+  local pre_delete_timeline_json=""
+  pre_delete_timeline_json="$(fetch_issue_timeline "${issue_number}")" || {
+    echo "   Warning: Pre-delete timeline read failed for #${issue_number}; preserving state" >&2
+    return 1
+  }
+
+  local pre_delete_assignment=""
+  pre_delete_assignment="$(find_provenance_from_timeline "${pre_delete_assignees_json}" "${pre_delete_timeline_json}")" || {
+    echo "   Warning: Pre-delete revalidation failed for #${issue_number}; preserving state" >&2
+    return 1
+  }
+
+  if [[ -z "${pre_delete_assignment}" ]]; then
+    echo "   Provenance changed before DELETE for #${issue_number}; human may have reassigned; removing label only"
+    remove_label_only "${issue_number}"
+    return $?
+  fi
+
+  local revalidated_login revalidated_rest revalidated_pos
+  revalidated_login="${pre_delete_assignment%% *}"
+  revalidated_rest="${pre_delete_assignment#* }"
+  revalidated_pos="${revalidated_rest##* }"
+  if [[ "${revalidated_login}" != "${bot_login}" ]]; then
+    echo "   Warning: Provenance login mismatch for #${issue_number}; preserving state" >&2
+    return 0
+  fi
+  if [[ "${revalidated_pos}" != "${bot_assigned_pos}" ]]; then
+    echo "   Warning: Provenance timeline position changed for #${issue_number}; preserving state" >&2
+    return 0
+  fi
+
+  # Re-run the linked-PR predicate against the same fresh pre-delete snapshot.
+  # A qualifying PR that appeared between the initial check and this pre-delete
+  # revalidation must block deletion (race protection).
+  local pre_delete_has_pr="false"
+  pre_delete_has_pr="$(has_qualifying_linked_pr_from_timeline "${bot_login}" "${bot_assigned_at}" "${pre_delete_timeline_json}")" || {
+    echo "   Warning: Pre-delete linked-PR revalidation failed for #${issue_number}; preserving state" >&2
+    return 1
+  }
+
+  if [[ "${pre_delete_has_pr}" == "true" ]]; then
+    echo "   @${bot_login} has qualifying linked PR activity (detected before DELETE) for #${issue_number}; keeping"
+    return 0
+  fi
+
+  # Verify bot_login is still assigned using exact jq index.
+  if ! echo "${pre_delete_assignees_json}" | jq -e --arg login="${bot_login}" '[.[].login] | index($login) != null' >/dev/null 2>&1; then
+    echo "   @${bot_login} no longer assigned before DELETE for #${issue_number}; nothing to do"
+    return 0
+  fi
+
+  echo "   Unassigning stale @${bot_login} from #${issue_number}"
+
+  local pre_delete_timeline_length
+  pre_delete_timeline_length="$(echo "${pre_delete_timeline_json}" | jq 'length')" || {
+    echo "   Warning: Could not capture pre-delete timeline position for #${issue_number}" >&2
+    return 1
+  }
+
+  # Remove assignee first via targeted DELETE.
+  if ! remove_assignee_targeted "${issue_number}" "${bot_login}"; then
+    return 1
+  fi
+
+  local post_assignee_delete_timeline=""
+  post_assignee_delete_timeline="$(fetch_issue_timeline "${issue_number}")" || {
+    echo "   Warning: Post-assignee-DELETE timeline read failed for #${issue_number}; retaining marker" >&2
+    return 1
+  }
+
+  if human_takeover_before_cleanup_unassign "${post_assignee_delete_timeline}" "${bot_login}" "${revalidated_pos}" "${pre_delete_timeline_length}"; then
+    if restore_assignee_targeted "${issue_number}" "${bot_login}"; then
+      echo "   Warning: Human same-login takeover detected during DELETE; restored @${bot_login} and retained marker for #${issue_number}" >&2
+    else
+      echo "   Warning: Human same-login takeover detected but compensation FAILED for @${bot_login} on #${issue_number}; marker retained" >&2
+    fi
+    return 1
+  fi
+
+  # Immediately re-read and verify login is absent BEFORE label DELETE.
+  # If still present (successful no-op or post-handler race), retain marker.
+  local mid_delete_assignees_json=""
+  if ! mid_delete_assignees_json="$(get_issue_assignees_json "${issue_number}")"; then
+    echo "   Warning: Post-assignee-DELETE verification read failed for #${issue_number}" >&2
+    return 1
+  fi
+
+  if echo "${mid_delete_assignees_json}" | jq -e --arg login="${bot_login}" '[.[].login] | index($login) != null' >/dev/null 2>&1; then
+    echo "   Warning: @${bot_login} still assigned after DELETE (no-op or race); retaining marker for #${issue_number}" >&2
+    return 1
+  fi
+
+  # Defensive reconciliation: check if any fresh assignment transition
+  # (by bot OR human, any login) appeared at or after the pre-delete
+  # snapshot position. A concurrent /assign between stale validation and
+  # the stale DELETE creates such an event. If detected, we must preserve
+  # the fresh assignment(s) and retain the auto-assigned marker.
+  #
+  # Same-login: the stale DELETE may have removed the fresh bot assignment.
+  # Restore it via targeted POST and verify.
+  # Different-login: the fresh assignee is untouched by the stale DELETE
+  # (targeted endpoint removes only bot_login). Just retain the marker.
+  if fresh_assignment_after_snapshot "${post_assignee_delete_timeline}" "${pre_delete_timeline_length}"; then
+    local _fresh_logins
+    _fresh_logins="$(fresh_assignment_logins_after_snapshot "${post_assignee_delete_timeline}" "${pre_delete_timeline_length}")" || true
+
+    local _restored_any=0
+    while IFS= read -r _fresh_login; do
+      [[ -z "${_fresh_login}" ]] && continue
+      # Check if this fresh login is currently assigned (it may have been
+      # deleted by the stale DELETE if it's the same login as bot_login).
+      if echo "${mid_delete_assignees_json}" | jq -e --arg login="${_fresh_login}" '[.[].login] | index($login) != null' >/dev/null 2>&1; then
+        # Already assigned — fresh assignment survives. Nothing to do.
+        :
+      else
+        # Same-login fresh assignment was deleted by the stale DELETE.
+        # Restore via targeted POST and verify.
+        if restore_assignee_targeted "${issue_number}" "${_fresh_login}"; then
+          echo "   Warning: Fresh assignment @${_fresh_login} was deleted by stale DELETE; restored and retaining marker for #${issue_number}" >&2
+          _restored_any=1
+        else
+          echo "   Warning: Fresh assignment @${_fresh_login} restoration FAILED for #${issue_number}; marker retained" >&2
+        fi
+      fi
+    done <<<"${_fresh_logins}"
+
+    echo "   Warning: Fresh assignment detected after stale DELETE; retaining marker for #${issue_number}" >&2
+    return 1
+  fi
+
+  # Pre-marker-delete reconciliation: re-read assignees + fresh timeline
+  # immediately before label DELETE to detect races that landed between the
+  # mid-assignee read and now. If a fresh assignment stint appeared, we must
+  # preserve/restore it and retain the marker — fail this issue safely.
+  local pre_label_assignees_json=""
+  pre_label_assignees_json="$(get_issue_assignees_json "${issue_number}")" || {
+    echo "   Warning: Pre-label-DELETE assignee read failed for #${issue_number}; retaining marker" >&2
+    return 1
+  }
+
+  local pre_label_timeline_json=""
+  pre_label_timeline_json="$(fetch_issue_timeline "${issue_number}")" || {
+    echo "   Warning: Pre-label-DELETE timeline read failed for #${issue_number}; retaining marker" >&2
+    return 1
+  }
+
+  local pre_label_timeline_length
+  pre_label_timeline_length="$(echo "${pre_label_timeline_json}" | jq 'length')" || {
+    echo "   Warning: Could not capture pre-label-DELETE timeline length for #${issue_number}" >&2
+    return 1
+  }
+
+  if fresh_assignment_after_snapshot "${pre_label_timeline_json}" "${pre_delete_timeline_length}"; then
+    local _pre_label_fresh_logins
+    _pre_label_fresh_logins="$(fresh_assignment_logins_after_snapshot "${pre_label_timeline_json}" "${pre_delete_timeline_length}")" || true
+    while IFS= read -r _fresh_login; do
+      [[ -z "${_fresh_login}" ]] && continue
+      if ! echo "${pre_label_assignees_json}" | jq -e --arg login="${_fresh_login}" '[.[].login] | index($login) != null' >/dev/null 2>&1; then
+        restore_assignee_targeted "${issue_number}" "${_fresh_login}" || true
+      fi
+    done <<<"${_pre_label_fresh_logins}"
+    echo "   Warning: Fresh assignment detected before label DELETE; retaining marker for #${issue_number}" >&2
+    return 1
+  fi
+
+  # Remove auto-assigned label via targeted DELETE.
+  if ! remove_label_targeted "${issue_number}" "${AUTO_ASSIGNED_LABEL}"; then
+    echo "   Assignment removed for #${issue_number}, but label remains for retry" >&2
+    return 1
+  fi
+
+  # Post-marker-delete compensation: re-read fresh timeline immediately
+  # after label DELETE. A fresh assignment that landed during or immediately
+  # after label DELETE must be compensated: restore the marker label so the
+  # fresh assignment is tracked.
+  local post_label_timeline_json=""
+  post_label_timeline_json="$(fetch_issue_timeline "${issue_number}")" || {
+    echo "   Warning: Post-label-DELETE timeline read failed for #${issue_number}; retaining marker" >&2
+    return 1
+  }
+
+  if fresh_assignment_after_snapshot "${post_label_timeline_json}" "${pre_label_timeline_length}"; then
+    # A fresh assignment appeared between pre-label-DELETE snapshot and now.
+    # Restore the marker so the fresh assignment is tracked.
+    if restore_label_targeted "${issue_number}"; then
+      echo "   Warning: Fresh assignment detected after label DELETE; restored marker for #${issue_number}" >&2
+    else
+      echo "   Warning: Fresh assignment detected after label DELETE but marker restore FAILED for #${issue_number}" >&2
+    fi
+    return 1
+  fi
+
+  # Re-read and verify final state using exact jq index.
+  local post_delete_assignees_json=""
+  post_delete_assignees_json="$(get_issue_assignees_json "${issue_number}")" || {
+    echo "   Warning: Post-delete verification read failed for #${issue_number}" >&2
+    return 1
+  }
+
+  if echo "${post_delete_assignees_json}" | jq -e --arg login="${bot_login}" '[.[].login] | index($login) != null' >/dev/null 2>&1; then
+    echo "   Warning: @${bot_login} still assigned after DELETE for #${issue_number}" >&2
+    return 1
+  fi
+
+  # Verify co-assignees were preserved using exact jq index.
+  local other_logins
+  other_logins="$(echo "${pre_delete_assignees_json}" | jq -r --arg bot "${bot_login}" '[.[].login] | map(select(. != $bot)) | .[]' 2>/dev/null || true)"
+  if [[ -n "${other_logins}" ]]; then
+    while IFS= read -r co_login; do
+      [[ -z "${co_login}" ]] && continue
+      if ! echo "${post_delete_assignees_json}" | jq -e --arg login="${co_login}" '[.[].login] | index($login) != null' >/dev/null 2>&1; then
+        echo "   Warning: Co-assignee @${co_login} was unexpectedly removed from #${issue_number}" >&2
+        return 1
+      fi
+    done <<<"${other_logins}"
+  fi
+
+  retry_gh gh api --method POST "repos/${REPO}/issues/${issue_number}/comments" \
+    -f body="⏱️ Automatically unassigned @${bot_login} from this issue.
+
+This issue was auto-assigned via \`/assign\` more than **${STALE_DAYS} days** ago with no qualifying linked PR activity. Comment \`/assign\` again if you still plan to work on it (subject to eligibility and the 3-issue cap)." \
+    --silent 2>/dev/null || true
+
+  return 0
+}
+
+echo " Scanning open issues with label:${AUTO_ASSIGNED_LABEL}"
+
+# Validate the canonical marker label definition before any discovery or
+# mutation. A missing marker label means no automation-provenance issues can
+# exist (discover_candidates would find none) — clean no-op. A conflicting
+# definition or API error must fail closed with no mutation.
+validate_marker_label || _marker_rc=$?
+case ${_marker_rc:-0} in
+  0) ;;  # correct definition — proceed
+  1)
+    echo "[OK] Marker label '${AUTO_ASSIGNED_LABEL}' is absent; nothing to clean"
+    exit 0
+    ;;
+  2)
+    echo "‼ Marker label '${AUTO_ASSIGNED_LABEL}' has a conflicting definition; aborting" >&2
+    exit 1
+    ;;
+  *)
+    echo "‼ Failed to validate marker label '${AUTO_ASSIGNED_LABEL}' (API error); aborting" >&2
+    exit 1
+    ;;
+esac
+
+THRESHOLD_ISO="$(threshold_iso)"
+THRESHOLD_EPOCH="$(iso_to_epoch "${THRESHOLD_ISO}")"
+echo "   Stale threshold: ${THRESHOLD_ISO} (epoch ${THRESHOLD_EPOCH})"
+
+GLOBAL_FAIL=0
+
+if ! CANDIDATES_RAW="$(discover_candidates)"; then
+  echo "‼️ Candidate discovery failed" >&2
+  exit 1
+fi
+
+if [[ -z "${CANDIDATES_RAW}" || "${CANDIDATES_RAW}" == $'\n' ]]; then
+  echo "✅ No auto-assigned open issues found"
+  exit 0
+fi
+
+CANDIDATES=()
+while IFS= read -r _line; do
+  [[ -n "${_line}" ]] && CANDIDATES+=("${_line}")
+done <<<"${CANDIDATES_RAW}"
+
+for row in "${CANDIDATES[@]}"; do
+  [[ -z "${row}" ]] && continue
+  issue_number="${row%%$'\t'*}"
+  assignees_json="${row#*$'\t'}"
+
+  if ! process_issue "${issue_number}" "${assignees_json}" "${THRESHOLD_EPOCH}"; then
+    echo "   Warning: Error processing #${issue_number}; continuing" >&2
+    GLOBAL_FAIL=1
+  fi
+done
+
+if [[ "${GLOBAL_FAIL}" -ne 0 ]]; then
+  echo "⚠️ Cleanup completed with errors (some issues preserved)" >&2
+  exit 1
+fi
+
+echo "✅ Stale auto-assignment cleanup finished"
+exit 0

--- a/.github/workflows/assign-stale-cleanup.yml
+++ b/.github/workflows/assign-stale-cleanup.yml
@@ -1,0 +1,57 @@
+name: Assign Stale Cleanup
+
+# Unassigns issues that were auto-assigned via /assign but have had no linked
+# PR activity for two weeks. Never unassigns acoliver.
+#
+# Uses targeted DELETE endpoints (never whole-array PATCH) to preserve
+# concurrent human state and comma-bearing label names.
+
+on:
+  schedule:
+    # Daily at 07:00 UTC
+    - cron: '0 7 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  cleanup:
+    name: Unassign stale auto-assignments
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Restrict scheduled runs to the canonical upstream repository.
+    if: ${{ github.repository == 'vybestack/llxprt-jefe' }}
+    # Coordinated concurrency so overlapping scheduled runs or manual
+    # dispatches serialize cleanly. cancel-in-progress is false so an
+    # in-flight cleanup completes its full reconciliation rather than
+    # being cancelled mid-mutation. The group is stable and repository-
+    # scoped (not run-specific).
+    concurrency:
+      group: stale-cleanup-${{ github.repository }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run unassign-stale-issues script
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          chmod +x ./.github/scripts/unassign-stale-issues.sh
+          ./.github/scripts/unassign-stale-issues.sh

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,120 @@
+name: Assign Issue
+
+# Implements the CONTRIBUTING.md `/assign` self-assignment convention.
+# Comment body must be exactly `/assign` (optional trailing LF/CRLF/tab only).
+#
+# Also records issue assignment events in a durable label index so that
+# /assign historical eligibility can use O(1) label lookups instead of
+# scanning repository events. The assign job itself creates the history
+# label directly (GitHub suppresses recursive issues:assigned workflows
+# triggered by GITHUB_TOKEN, so the record-history job may not fire for
+# automated assignments).
+
+on:
+  issue_comment:
+    types:
+      - created
+  issues:
+    types:
+      - assigned
+
+permissions:
+  contents: read
+  issues: write
+  # Required for merged-PR eligibility checks under an explicit permissions
+  # block (public repos are not exempt once permissions: is set).
+  pull-requests: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  assign:
+    name: Process /assign
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Exact `/assign` only (CONTRIBUTING.md). Support LF, CRLF, and trailing tab
+    # via toJSON equality (not startsWith) so `/assign foo` never matches.
+    # Ignore PR review comments and Bot accounts (spam hardening).
+    #
+    # Group concurrency by commenter user ID AND issue number so that
+    # /assign commands on distinct issues from the same actor run
+    # independently (GitHub retains only one pending job per group). The
+    # real-script post-mutation cap enforcement/election remains
+    # authoritative for bounding total assignments. In-flight attempts
+    # complete rather than being cancelled with partial mutations.
+    concurrency:
+      group: assign-${{ github.event.comment.user.id }}-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request == null &&
+      github.event.issue.state == 'open' &&
+      github.event.comment.user.type != 'Bot' &&
+      (github.event.comment.body == '/assign' ||
+       toJSON(github.event.comment.body) == '"/assign\n"' ||
+       toJSON(github.event.comment.body) == '"/assign\r\n"' ||
+       toJSON(github.event.comment.body) == '"/assign\t"')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run assign-issue script
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENTER_LOGIN: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          chmod +x ./.github/scripts/assign-issue.sh
+          ./.github/scripts/assign-issue.sh
+
+  record-history:
+    name: Record assignment history
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Indexes assignment events outside /assign (e.g. human/manual assignments).
+    # Does NOT filter bot senders: issue #2630 treats any prior assignment as
+    # history. GITHUB_TOKEN recursion is already suppressed by GitHub, so
+    # automated /assign assignments are also recorded directly in
+    # assign-issue.sh (this job may not fire for those).
+    #
+    # Serialize per assignee so rapid reassignments of the same user do not
+    # race on label creation. In-flight runs complete rather than being
+    # cancelled (avoid partial label state). The assign job preserves its own
+    # per-actor concurrency independently.
+    concurrency:
+      group: record-history-${{ github.event.assignee.id }}
+      cancel-in-progress: false
+    if: |
+      github.event_name == 'issues' &&
+      github.event.action == 'assigned'
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Record assignment-history label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
+        run: |
+          set -euo pipefail
+          chmod +x ./.github/scripts/record-assignment-history.sh
+          ./.github/scripts/record-assignment-history.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,18 @@ namespace-scoped cleanup. Failure diagnostics are written beneath
   merge.
 - Squash-merge or rebase-merge to `main`. Delete the feature branch after merge.
 
+## Self Assigning Issues
+
+To assign an issue to yourself, add a comment that contains **only** the text `/assign` (nothing else). A GitHub Action handles the request when:
+
+1. The issue is not already assigned.
+2. You are eligible: you have at least one **merged PR** in this repository, **or** you have a durable prior assignment (previously assigned to an issue here — current or past assignments in open or closed issues both qualify, recorded in a history index).
+3. You currently have fewer than **3** open issues assigned to you (hard cap to limit spam / hoarding).
+
+Bot accounts are ignored. On success the issue is labeled `auto-assigned` and a feedback comment is posted. Assignment may fail for several reasons (the issue was assigned by a concurrent request, the eligibility check could not be verified, GitHub API errors, or GitHub rejected or ignored the assignment because the account is unavailable or otherwise unassignable). The automation verifies each assignment and posts feedback reporting any failure.
+
+Auto-assignments older than **2 weeks** with no qualifying linked PR activity are unassigned automatically. Only the login assigned by the `/assign` automation is removed — manual co-assignees are preserved. The maintainer `acoliver` is exempt from cleanup. Comment `/assign` again if you still intend to work on the issue.
+
 ## Code review demand
 
 Keep active work in a draft PR (or use the documented WIP markers), run the

--- a/project-plans/issue499-plan.md
+++ b/project-plans/issue499-plan.md
@@ -1,0 +1,126 @@
+# Issue 499 delivery plan
+
+## Problem statement
+
+`vybestack/llxprt-code` has a GitHub Action for the `/assign` self-assignment
+convention (the `assign.yml` + `assign-stale-cleanup.yml` workflows backed by
+`assign-issue.sh`, `assign-assignment-history.sh`, `unassign-stale-issues.sh`,
+and the shared `assign-constants.sh`). `vybestack/llxprt-jefe` has no such
+automation. Issue #499 asks to port the `/assign` automation to this project so
+contributors can self-assign issues by commenting exactly `/assign`.
+
+The port is a CI/automation deliverable: no product (Rust) code, no
+dependencies, no agent-memory or quality-tool changes. The automation scripts
+are bash + `gh` + `jq`, already proven in llxprt-code. This plan ports them
+verbatim in semantics while adapting project-scoped identifiers (feedback
+marker, stale-cleanup repo guard) to the jefe convention.
+
+## Acceptance matrix
+
+| # | Actor / path | Input / boundary | Observable success | Observable failure / diagnostic | Behavioral test |
+|---|---|---|---|---|---|
+| A1 | `assign.yml` → `assign` job, `issue_comment` (created) on an **open issue** | Comment body is exactly `/assign` (LF/CRLF/trailing-tab only); commenter is not a bot | Commenter is assigned to the issue; `auto-assigned` label added; sticky feedback comment posted referencing jefe marker | Already assigned / cap exceeded / ineligible / closed → sticky feedback, no assignment | Structural: workflow `if:` matches exact `/assign` (+LF/CRLF/tab) on issue comments, excludes PR comments and bots |
+| A2 | `assign.yml` → `assign` job | Eligibility: >=1 merged PR **or** prior durable assignment history | Assignment proceeds | Ineligible → feedback explaining eligibility | Structural: `assign-issue.sh` present and referenced; eligibility helpers present |
+| A3 | `assign.yml` → `assign` job | Open-issue cap: <3 open assigned issues | Assignment proceeds; post-mutation cap enforced with rollback | Cap reached → feedback, no assignment | Structural: `MAX_ASSIGNMENTS=3` and cap-check logic present in script |
+| A4 | `assign.yml` → `assign` job | Concurrency contention | Deterministic winner election; losers roll back verified | Rollback failure → nonzero exit, state diagnosable | Structural: election/rollback helpers present |
+| A5 | `assign.yml` → `record-history` job, `issues` (assigned) | Any assignment event | Per-user history label `asnhist--LOGIN` created/verified (exact definition; collision fails) | API error → nonzero | Structural: job triggers on `issues: assigned`; calls `record-assignment-history.sh` |
+| A6 | `assign-stale-cleanup.yml` → `cleanup` job, schedule + `workflow_dispatch` | Open issues with `auto-assigned` label, assignment >14 days, no qualifying linked PR | Stale auto-assignee + label removed; co-assignees preserved; exempt login never removed | API/timeline failure → preserve state, nonzero exit | Structural: `if:` restricts to `vybestack/llxprt-jefe`; script referenced |
+| A7 | Shared marker convention | Feedback comments | Use `<!-- jefe-assign-feedback -->` (jefe convention, mirroring `<!-- jefe-ocr-review -->`) | (n/a) | Structural: marker in `assign-issue.sh` is jefe-prefixed |
+| A8 | CONTRIBUTING.md | Reader looking for how to self-assign | "Self Assigning Issues" section documents exact `/assign`, eligibility, cap, stale cleanup | (n/a) | Structural: CONTRIBUTING.md contains the section |
+
+## Non-goals
+
+- No changes to Rust product code, `Cargo.toml`, `Cargo.lock`, or dependencies.
+- No changes to required product CI (`ci.yml`), the mergeability gate, OCR, or
+  PR-review workflows.
+- No changes to agent-memory, quality-tool, or `.llxprt/` configuration.
+- No backfill file (`.github/assignment-history.txt`) shipped — eligibility via
+  the existing per-user label and merged-PR paths is sufficient for the port;
+  a backfill is an llxprt-code-specific historical artifact.
+- No porting of the llxprt-code JS-based assign harness tests (`assign-*.test.js`).
+  Those are JS/vitest artifacts tied to llxprt-code's Node test runner; jefe's
+  test layer is Rust. Behavioral coverage here is structural workflow-contract
+  tests in the established `tests/core/*_workflow_contracts.rs` pattern.
+- No fork-safety changes: `assign.yml` uses `issue_comment`/`issues` triggers
+  with `github.token` (the GITHUB_TOKEN), which is safe for self-assignment and
+  matches the upstream design. The automation runs from the base-branch
+  workflow definition (the code checked out is the default branch tree).
+
+## Planned vertical slices
+
+This is a single cohesive automation port; splitting it across multiple PRs
+would ship non-functional fragments (a workflow that calls a non-existent
+script). It is delivered as one vertical slice.
+
+### Slice 1 (only slice): port /assign automation + contract test
+
+- **Acceptance rows:** A1–A8
+- **Architecture owner:** CI/automation (`.github/workflows/`,
+  `.github/scripts/`, `CONTRIBUTING.md`, `tests/core/`).
+- **Allowed files:**
+  - `.github/scripts/assign-constants.sh` (new)
+  - `.github/scripts/assign-issue.sh` (new)
+  - `.github/scripts/record-assignment-history.sh` (new)
+  - `.github/scripts/unassign-stale-issues.sh` (new)
+  - `.github/workflows/assign.yml` (new)
+  - `.github/workflows/assign-stale-cleanup.yml` (new)
+  - `CONTRIBUTING.md` (new "Self Assigning Issues" section)
+  - `tests/core/assign_workflow_contracts.rs` (new)
+  - `tests/core/mod.rs` (one module declaration line)
+  - `project-plans/issue499-plan.md` (this file)
+- **RED:** new contract test fails on current main because the workflows,
+  scripts, and CONTRIBUTING section do not exist.
+- **GREEN completion criteria:** contract test passes; all six automation
+  files present and shellcheck-clean; CONTRIBUTING documents `/assign`;
+  `cargo xtask quick` green.
+- **Non-goals for this slice:** everything in the issue-level non-goals above.
+- **Verification commands:**
+  - `shellcheck .github/scripts/*.sh`
+  - `cargo test --test integration assign_workflow_contracts`
+  - `cargo xtask quick` (fmt, check, test)
+  - `make ci-check` (full gate)
+- **Stopping conditions:** any requirement to touch `ci.yml`, product Rust
+  code, dependencies, OCR/PR-review workflows, agent-memory, or quality-tool
+  configuration requires user approval.
+
+## Adaptations from llxprt-code to jefe (project-scoped identifiers)
+
+The automation scripts are ported **verbatim in logic**. Only project-scoped
+identifiers change:
+
+1. **Feedback marker** (`assign-issue.sh`): `<!-- llxprt-assign-feedback -->`
+   → `<!-- jefe-assign-feedback -->` (mirrors the existing
+   `<!-- jefe-ocr-review -->` marker convention in `ocr-review.yml`).
+2. **Stale-cleanup repo guard** (`assign-stale-cleanup.yml` `if:`): the
+   scheduled-run guard changes from `github.repository == 'vybestack/llxprt-code'`
+   to `github.repository == 'vybestack/llxprt-jefe'` so cleanup only runs on the
+   canonical upstream jefe repo (not forks).
+3. **Feedback stale-cleanup mention** (`unassign-stale-issues.sh` comment):
+   none — the exempt-login and threshold constants are identical. The
+   `EXEMPT_LOGIN='acoliver'` is the same maintainer for both repos.
+
+Everything else (label names `auto-assigned`, `asnhist--LOGIN`, colors,
+descriptions, cap `3`, stale threshold `14`, election algorithm, rollback
+logic, concurrency groups) is identical to the upstream proven implementation.
+
+## Scope ledger
+
+- `.github/scripts/assign-constants.sh` — new (A2, A5).
+- `.github/scripts/assign-issue.sh` — new (A1–A4, A7).
+- `.github/scripts/record-assignment-history.sh` — new (A5).
+- `.github/scripts/unassign-stale-issues.sh` — new (A6).
+- `.github/workflows/assign.yml` — new (A1–A5).
+- `.github/workflows/assign-stale-cleanup.yml` — new (A6).
+- `CONTRIBUTING.md` — new "Self Assigning Issues" section (A8).
+- `tests/core/assign_workflow_contracts.rs` — new structural test (A1–A8).
+- `tests/core/mod.rs` — one module declaration line (test wire-up).
+- `project-plans/issue499-plan.md` — this plan.
+
+No newly discovered out-of-scope work. No dependency, agent-memory, or
+quality-tool changes. Within the 25-file / 1,500-net-line target.
+
+## Review counters
+
+- Open Code Review (local, before PR): 0 / 2
+- Open Code Review (after PR): 0 / 2
+- CodeRabbit: pending PR

--- a/tests/core/assign_workflow_contracts.rs
+++ b/tests/core/assign_workflow_contracts.rs
@@ -1,0 +1,419 @@
+//! Assign Issue workflow contract tests (issue #499).
+//!
+//! These tests verify the `/assign` self-assignment automation ported from
+//! `vybestack/llxprt-code` (issue #499) is structurally wired into this
+//! repository. They read the workflows, scripts, and CONTRIBUTING.md as text
+//! (mirroring `ocr_workflow_contracts` and `pr_review_workflow_contracts`)
+//! and assert that each acceptance criterion from the issue plan is present.
+//!
+//! The automation is bash + `gh` + `jq` (no Rust product code), so behavioral
+//! coverage is structural: CI fails mechanically if a workflow trigger,
+//! script reference, jefe-scoped marker, repo guard, eligibility helper, cap
+//! constant, election/rollback logic, or documentation section regresses.
+
+use std::path::{Path, PathBuf};
+
+const ASSIGN_WORKFLOW_PATH: &str = ".github/workflows/assign.yml";
+const STALE_CLEANUP_WORKFLOW_PATH: &str = ".github/workflows/assign-stale-cleanup.yml";
+const ASSIGN_ISSUE_SCRIPT_PATH: &str = ".github/scripts/assign-issue.sh";
+const RECORD_HISTORY_SCRIPT_PATH: &str = ".github/scripts/record-assignment-history.sh";
+const UNASSIGN_STALE_SCRIPT_PATH: &str = ".github/scripts/unassign-stale-issues.sh";
+const ASSIGN_CONSTANTS_SCRIPT_PATH: &str = ".github/scripts/assign-constants.sh";
+const CONTRIBUTING_PATH: &str = "CONTRIBUTING.md";
+
+/// The jefe-scoped feedback marker, mirroring the `<!-- jefe-ocr-review -->`
+/// convention used in `ocr-review.yml`.
+const EXPECTED_MARKER: &str = "<!-- jefe-assign-feedback -->";
+
+fn repo_path(relative_path: impl AsRef<Path>) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path.as_ref())
+}
+
+fn read_file(path: impl AsRef<Path>) -> String {
+    let path = path.as_ref();
+    std::fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()))
+}
+
+fn read_workflow(workflow_path: &str) -> String {
+    read_file(repo_path(workflow_path))
+}
+
+fn read_script(script_path: &str) -> String {
+    read_file(repo_path(script_path))
+}
+
+/// Extract the body of a single named workflow job, starting from the
+/// `  <job_id>:` line until the next top-level job key. This isolates
+/// assertions so comments or content from unrelated jobs cannot satisfy a
+/// contract check. Job keys live at 2-space indentation under `jobs:`.
+fn job_body(content: &str, job_id: &str) -> String {
+    let needle = format!("  {job_id}:");
+    let lines: Vec<&str> = content.lines().collect();
+    let start = lines
+        .iter()
+        .position(|l| *l == needle)
+        .unwrap_or_else(|| panic!("job '{job_id}' not found in workflow"));
+
+    let mut body = String::new();
+    body.push_str(lines[start]);
+    body.push('\n');
+
+    for line in &lines[start + 1..] {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let indent = line.len() - line.trim_start().len();
+        // Stop at the next job header (2-space indented `key:` that is not
+        // the current job_id) or at a top-level key (0 indentation).
+        if indent <= 2 && trimmed.ends_with(':') && !trimmed.starts_with('#') {
+            break;
+        }
+        body.push_str(line);
+        body.push('\n');
+    }
+    body
+}
+
+// ---------------------------------------------------------------------------
+// A1: assign.yml triggers on exact /assign for open issues, excluding PRs/bots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assign_workflow_triggers_on_issue_comment_created() {
+    let content = read_workflow(ASSIGN_WORKFLOW_PATH);
+    assert!(
+        content.contains("issue_comment:") && content.contains("- created"),
+        "assign.yml must trigger on issue_comment created events"
+    );
+}
+
+#[test]
+fn assign_job_matches_exact_assign_command() {
+    let content = read_workflow(ASSIGN_WORKFLOW_PATH);
+    let job = job_body(&content, "assign");
+    // Exact /assign only — support LF, CRLF, and trailing tab via toJSON
+    // equality so /assign foo never matches.
+    assert!(
+        job.contains("github.event.comment.body == '/assign'"),
+        "assign job must match exact '/assign' (A1)"
+    );
+    assert!(
+        job.contains("toJSON(github.event.comment.body) == '\"/assign\\n\"'"),
+        "assign job must support trailing LF via toJSON (A1)"
+    );
+    assert!(
+        job.contains("toJSON(github.event.comment.body) == '\"/assign\\r\\n\"'"),
+        "assign job must support trailing CRLF via toJSON (A1)"
+    );
+    assert!(
+        job.contains("toJSON(github.event.comment.body) == '\"/assign\\t\"'"),
+        "assign job must support trailing tab via toJSON (A1)"
+    );
+}
+
+#[test]
+fn assign_job_excludes_pr_comments_and_bots() {
+    let content = read_workflow(ASSIGN_WORKFLOW_PATH);
+    let job = job_body(&content, "assign");
+    assert!(
+        job.contains("github.event.issue.pull_request == null"),
+        "assign job must ignore PR comments (A1)"
+    );
+    assert!(
+        job.contains("github.event.issue.state == 'open'"),
+        "assign job must only run on open issues (A1)"
+    );
+    assert!(
+        job.contains("github.event.comment.user.type != 'Bot'"),
+        "assign job must ignore bot accounts (A1)"
+    );
+}
+
+#[test]
+fn assign_job_calls_assign_issue_script() {
+    let content = read_workflow(ASSIGN_WORKFLOW_PATH);
+    let job = job_body(&content, "assign");
+    assert!(
+        job.contains(".github/scripts/assign-issue.sh"),
+        "assign job must invoke .github/scripts/assign-issue.sh (A1-A4)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A3: cap enforcement (MAX_ASSIGNMENTS=3)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assign_issue_script_enforces_three_issue_cap() {
+    let content = read_script(ASSIGN_ISSUE_SCRIPT_PATH);
+    assert!(
+        content.contains("MAX_ASSIGNMENTS=3"),
+        "assign-issue.sh must enforce the 3-issue cap (A3)"
+    );
+    assert!(
+        content.contains("get_open_assigned_count"),
+        "assign-issue.sh must have an open-assigned-count helper for cap checks (A3)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A2: eligibility helpers (merged PR or prior assignment)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assign_issue_script_has_merged_pr_eligibility() {
+    let content = read_script(ASSIGN_ISSUE_SCRIPT_PATH);
+    assert!(
+        content.contains("get_merged_pr_count"),
+        "assign-issue.sh must check merged PR count for eligibility (A2)"
+    );
+}
+
+#[test]
+fn assign_issue_script_has_historical_assignment_eligibility() {
+    let content = read_script(ASSIGN_ISSUE_SCRIPT_PATH);
+    assert!(
+        content.contains("has_historical_assignment"),
+        "assign-issue.sh must check prior assignment history for eligibility (A2)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A4: election + verified rollback logic
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assign_issue_script_has_winner_election() {
+    let content = read_script(ASSIGN_ISSUE_SCRIPT_PATH);
+    assert!(
+        content.contains("elect_winner"),
+        "assign-issue.sh must have a deterministic winner election (A4)"
+    );
+    assert!(
+        content.contains("run_election"),
+        "assign-issue.sh must run the election (A4)"
+    );
+}
+
+#[test]
+fn assign_issue_script_has_verified_rollback() {
+    let content = read_script(ASSIGN_ISSUE_SCRIPT_PATH);
+    assert!(
+        content.contains("verified_rollback_and_fail"),
+        "assign-issue.sh must have verified rollback on contention (A4)"
+    );
+    assert!(
+        content.contains("rollback_this_run"),
+        "assign-issue.sh must roll back this run's mutations (A4)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A7: jefe-scoped feedback marker
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assign_issue_script_uses_jefe_feedback_marker() {
+    let content = read_script(ASSIGN_ISSUE_SCRIPT_PATH);
+    assert!(
+        content.contains(EXPECTED_MARKER),
+        "assign-issue.sh must use the jefe-scoped feedback marker '{EXPECTED_MARKER}' (A7)"
+    );
+}
+
+#[test]
+fn assign_issue_script_does_not_use_llxprt_marker() {
+    let content = read_script(ASSIGN_ISSUE_SCRIPT_PATH);
+    assert!(
+        !content.contains("llxprt-assign-feedback"),
+        "assign-issue.sh must not carry the upstream llxprt-code marker (A7)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A5: record-history job + record-assignment-history.sh
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assign_workflow_triggers_on_issues_assigned() {
+    let content = read_workflow(ASSIGN_WORKFLOW_PATH);
+    assert!(
+        content.contains("issues:") && content.contains("- assigned"),
+        "assign.yml must trigger on issues assigned events (A5)"
+    );
+}
+
+#[test]
+fn record_history_job_calls_record_script() {
+    let content = read_workflow(ASSIGN_WORKFLOW_PATH);
+    let job = job_body(&content, "record-history");
+    assert!(
+        job.contains(".github/scripts/record-assignment-history.sh"),
+        "record-history job must invoke .github/scripts/record-assignment-history.sh (A5)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A6: stale cleanup workflow + repo guard + script
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stale_cleanup_workflow_exists_and_runs_script() {
+    let content = read_workflow(STALE_CLEANUP_WORKFLOW_PATH);
+    assert!(
+        content.contains(".github/scripts/unassign-stale-issues.sh"),
+        "assign-stale-cleanup.yml must invoke .github/scripts/unassign-stale-issues.sh (A6)"
+    );
+}
+
+#[test]
+fn stale_cleanup_workflow_guards_on_jefe_repo() {
+    let content = read_workflow(STALE_CLEANUP_WORKFLOW_PATH);
+    // The scheduled-run repo guard must restrict to the canonical jefe repo,
+    // not the upstream llxprt-code repo and not forks.
+    assert!(
+        content.contains("github.repository == 'vybestack/llxprt-jefe'"),
+        "assign-stale-cleanup.yml must guard scheduled runs to vybestack/llxprt-jefe (A6)"
+    );
+    assert!(
+        !content.contains("github.repository == 'vybestack/llxprt-code'"),
+        "assign-stale-cleanup.yml must not carry the upstream llxprt-code repo guard (A6)"
+    );
+}
+
+#[test]
+fn stale_cleanup_workflow_has_schedule_and_dispatch() {
+    let content = read_workflow(STALE_CLEANUP_WORKFLOW_PATH);
+    assert!(
+        content.contains("schedule:") && content.contains("cron:"),
+        "assign-stale-cleanup.yml must have a schedule trigger (A6)"
+    );
+    assert!(
+        content.contains("workflow_dispatch:"),
+        "assign-stale-cleanup.yml must have a workflow_dispatch trigger (A6)"
+    );
+}
+
+#[test]
+fn unassign_stale_script_preserves_exempt_and_coassignees() {
+    let content = read_script(UNASSIGN_STALE_SCRIPT_PATH);
+    assert!(
+        content.contains("EXEMPT_LOGIN='acoliver'"),
+        "unassign-stale-issues.sh must exempt acoliver from cleanup (A6)"
+    );
+    assert!(
+        content.contains("STALE_DAYS=14"),
+        "unassign-stale-issues.sh must use a 14-day stale threshold (A6)"
+    );
+    // Targeted DELETE preserves co-assignees; whole-array PATCH would not.
+    assert!(
+        content.contains("--method DELETE") && content.contains("assignees[]"),
+        "unassign-stale-issues.sh must use targeted DELETE for assignee removal (A6)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Shared constants + script existence
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assign_constants_script_has_history_label_constants() {
+    let content = read_script(ASSIGN_CONSTANTS_SCRIPT_PATH);
+    assert!(
+        content.contains("HISTORY_PREFIX='asnhist--'"),
+        "assign-constants.sh must define the asnhist-- history label prefix"
+    );
+    assert!(
+        content.contains("validate_github_login"),
+        "assign-constants.sh must define the login validator"
+    );
+}
+
+#[test]
+fn record_history_script_validates_label_definition() {
+    let content = read_script(RECORD_HISTORY_SCRIPT_PATH);
+    assert!(
+        content.contains("validate_history_label"),
+        "record-assignment-history.sh must validate the history label definition (A5)"
+    );
+    assert!(
+        content.contains("assign-constants.sh"),
+        "record-assignment-history.sh must source the shared constants"
+    );
+}
+
+#[test]
+fn all_automation_scripts_exist() {
+    for script in [
+        ASSIGN_ISSUE_SCRIPT_PATH,
+        RECORD_HISTORY_SCRIPT_PATH,
+        UNASSIGN_STALE_SCRIPT_PATH,
+        ASSIGN_CONSTANTS_SCRIPT_PATH,
+    ] {
+        let path = repo_path(script);
+        assert!(
+            path.is_file(),
+            "automation script {script} must exist in the repository",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A8: CONTRIBUTING.md documents the /assign convention
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contributing_documents_self_assigning_issues() {
+    let content = read_file(repo_path(CONTRIBUTING_PATH));
+    assert!(
+        content.contains("## Self Assigning Issues"),
+        "CONTRIBUTING.md must have a 'Self Assigning Issues' section (A8)"
+    );
+    assert!(
+        content.contains("/assign"),
+        "CONTRIBUTING.md must document the /assign command (A8)"
+    );
+    assert!(
+        content.contains("auto-assigned"),
+        "CONTRIBUTING.md must document the auto-assigned label (A8)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Permissions + concurrency guards (security/anti-spam hardening)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assign_workflow_has_safe_permissions() {
+    let content = read_workflow(ASSIGN_WORKFLOW_PATH);
+    // issues: write is required for assignment; pull-requests: read for the
+    // merged-PR eligibility check. contents: read for checkout.
+    assert!(
+        content.contains("issues: write"),
+        "assign.yml must have issues: write permission"
+    );
+    assert!(
+        content.contains("pull-requests: read"),
+        "assign.yml must have pull-requests: read permission"
+    );
+}
+
+#[test]
+fn assign_job_has_concurrency_group_per_commenter_and_issue() {
+    let content = read_workflow(ASSIGN_WORKFLOW_PATH);
+    let job = job_body(&content, "assign");
+    assert!(
+        job.contains("concurrency:"),
+        "assign job must have a concurrency group (anti-spam hardening)"
+    );
+    assert!(
+        job.contains("github.event.comment.user.id"),
+        "assign job concurrency must be grouped per commenter user id"
+    );
+    assert!(
+        job.contains("github.event.issue.number"),
+        "assign job concurrency must be grouped per issue number"
+    );
+}

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -3,6 +3,7 @@
 //! @plan PLAN-20260216-FIRSTVERSION-V1.P04
 //! @requirement REQ-TECH-002
 
+mod assign_workflow_contracts;
 mod clippy_allow_policy;
 mod dashboard_search_contracts;
 mod domain_state_contracts;


### PR DESCRIPTION
## Summary

Ports the `/assign` self-assignment GitHub Action automation from `vybestack/llxprt-code` to `vybestack/llxprt-jefe` so contributors can self-assign issues by commenting exactly `/assign`.

Closes #499.

## What this adds

**Workflows** (`.github/workflows/`):
- `assign.yml` — triggers on exact `/assign` issue comments (LF/CRLF/tab tolerant via `toJSON` equality, so `/assign foo` never matches) and on `issues:assigned` events. Ignores PR comments and bot accounts. Per-commenter+issue concurrency group and safe permissions (`issues: write`, `pull-requests: read`, `contents: read`).
- `assign-stale-cleanup.yml` — daily cron + `workflow_dispatch`. Unassigns stale auto-assignments older than 2 weeks with no qualifying linked PR. Restricted to `vybestack/llxprt-jefe` (the upstream llxprt-code repo guard was replaced).

**Scripts** (`.github/scripts/`):
- `assign-issue.sh` — eligibility (>=1 merged PR or prior durable assignment via history label), 3-open-issue cap, deterministic winner election via timeline event position, verified rollback on contention, sticky feedback. Feedback marker adapted to the jefe convention (jefe-assign-feedback marker).
- `record-assignment-history.sh` — creates/validates per-user `asnhist--LOGIN` history labels.
- `assign-constants.sh` — shared history-label constants + GitHub login validation (source-only).
- `unassign-stale-issues.sh` — targeted DELETE endpoints (preserves manual co-assignees and comma-bearing labels), exempts `acoliver`, race protection.

**Docs**: `CONTRIBUTING.md` gains a "Self Assigning Issues" section documenting the command, eligibility, cap, and 2-week stale cleanup.

**Tests**: `tests/core/assign_workflow_contracts.rs` adds 23 structural contract tests covering all acceptance criteria (A1-A8) — the automation is bash + `gh` + `jq` with no Rust product code, so coverage is structural over the workflows and scripts.

## Adaptations from upstream

- Feedback marker: upstream `llxprt-assign-feedback` adapted to the jefe marker convention (`jefe-assign-feedback`).
- Stale-cleanup repo guard: `vybestack/llxprt-code` to `vybestack/llxprt-jefe`.

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo build --workspace --all-features --locked` ✅
- `cargo test --workspace --all-features --locked` ✅
- `cargo xtask check architecture` / `source-size` / `clippy-allows` ✅
- `shellcheck` on all 4 scripts ✅ (clean)
- 23 new contract tests pass

## Notes

- All scripts are shellcheck-clean (exit 0, no warnings).
- `.llxprt/` was intentionally not modified or staged.
