### PR TITLE
Preserve ownership through TextBox row projection (Fixes #436)

### DIFF
--- a/project-plans/issue436-plan.md
+++ b/project-plans/issue436-plan.md
@@ -131,8 +131,14 @@ No unapproved scope discoveries are open.
 ## Review counters
 
 - Pre-PR Open Code Review: 1 / 2 (local run completed: 0 comments, "Looks good to me")
-- Post-PR Open Code Review: 0 / 2
+- Post-PR Open Code Review: 1 / 2 (CI OpenCodeReview job completed: 1 inline comment, triaged below)
 - Independent Rust/DeepThinker review cycles: 0 / 2
+
+## Review triage
+
+| Finding | Classification | Resolution |
+| --- | --- | --- |
+| CI OCR: `project_line_segments` signature changed from `&[WrapSegment]` to `Vec<WrapSegment>`, future callers passing a reference will fail to compile | Reject | This is the intended design of the fix, not a defect. (1) `project_line_segments` is a private function with no public API surface, no submodules, and no external callers — the OCR search itself confirmed only one call site. (2) The by-value signature IS what issue #436 requires: consuming the segment vector is what enables each segment String to be moved into TextBoxRow instead of cloned. (3) The Rust compiler enforcing ownership at compile time is a safety feature. Comment replied to and resolved. |
 
 ## Verification evidence
 

--- a/project-plans/issue436-plan.md
+++ b/project-plans/issue436-plan.md
@@ -1,0 +1,152 @@
+# Issue 436 delivery plan
+
+## Issue and baseline
+
+- GitHub: https://github.com/vybestack/llxprt-jefe/issues/436
+- Branch: `issue436`
+- Branch-start base: `main` at `4faf76ab`
+- Reported behavior: PR #427 (issue #422) introduced two avoidable copies and
+  one redundant scalar traversal while extracting TextBox wrapped-row
+  projection helpers:
+  1. `project_line_segments` borrows a local `Vec<WrapSegment>` and clones
+     every segment `String` into `TextBoxRow` even though the segment vector
+     is immediately discarded.
+  2. `project_line_segments` already computes `rendered_chars`, but
+     `caret_col_for_segment` recounts the same segment
+     (`seg.text.chars().count()`) when clamping the caret.
+  3. The later visible-row step clones `display_rows[disp_idx].clone()` into
+     the padded viewport even though `display_rows` could be consumed in place.
+- Origin: deferred OpenCodeReview findings from PR #427 / issue #422. The two
+  OCR comments about the scalar recount are duplicate reports of the same
+  expression and are handled as one root cause.
+- Constraint: these are performance and ownership-quality improvements, NOT
+  correctness defects. No behavior change is permitted.
+
+## Chosen contract
+
+`project_line_segments` consumes `Vec<WrapSegment>` by value (moving each
+segment `text` into the produced `TextBoxRow`) instead of borrowing and
+cloning. The already-computed `rendered_chars` scalar is threaded into the
+caret-clamp path so `caret_col_for_segment` no longer recomputes
+`seg.text.chars().count()`. The flat `display_rows` buffer is consumed
+in place (drain/truncate/pad) when building the fixed-size viewport so the
+final visible rows are moved rather than cloned.
+
+All public APIs (`build_text_box_view`, `TextBoxView`, `TextBoxRow`,
+`TextCaret`, `WrapRow`, `wrap_text`), text/caret/viewport/wrap-boundary/gutter
+behavior, dependencies, lint/complexity/safety/coverage, and CI remain
+unchanged. No new public abstraction, dependency, unsafe code, or behavior
+change.
+
+## Acceptance matrix
+
+| ID | Actor / launch path | Inputs and boundary cases | Target | Observable success | Observable failure / diagnostics | Permitted side effects | Persistence / compatibility | Proof |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| A1 | `build_text_box_view` pure projection (all existing callers) | Empty text; short line; long line that wraps; CJK/wide glyphs; combining marks; exact-cell-width trailing caret; one-row and multi-row viewports; trailing newline; zero width; zero viewport | All platforms; pure projection | Identical `TextBoxView` output (rows, caret columns, `first_visible_row`, `total_lines`, `total_display_rows`) to the pre-change baseline for every input | Any difference in row text, caret column, viewport anchor, or row count | None | Public API, types, and behavior unchanged | All pre-existing `text_box_view` unit tests pass unchanged; regression snapshot of representative fixtures |
+| A2 | TextBox iocraft renderer (`ui::components::text_box`) and its callers | Wide body before gutter; wrap-boundary caret; wide prefix; scroll indicators | Local TUI; iocraft renderer | Rendered output identical to baseline (gutter visible, caret reversed, no overflow) | Any rendered difference | Render only | Existing `TextBoxProps` and reducer behavior unchanged | Pre-existing TextBox renderer tests pass unchanged |
+| A3 | Integration `text_box_layout` suite | Multi-line scrolling, wrapped rows, zero viewport | Library integration | Viewport anchoring and total counts unchanged | Any count/anchor difference | None | Integration contract unchanged | `tests/text_box_layout.rs` passes unchanged |
+| A4 | Ownership quality | `project_line_segments` input segment vector | Pure projection | `WrapSegment` values are consumed (moved) into `TextBoxRow`; no `.clone()` of segment `String` in the projection | A remaining `.clone()` on segment text in `project_line_segments` | None | N/A | Source inspection: no `seg.text.clone()` remains in `project_line_segments` |
+| A5 | Scalar reuse | `caret_col_for_segment` clamp | Pure projection | The clamp uses the already-computed `rendered_chars` instead of recomputing `seg.text.chars().count()` | A remaining `seg.text.chars().count()` in `caret_col_for_segment` | None | N/A | Source inspection: no `chars().count()` recount in `caret_col_for_segment` |
+| A6 | Visible-row ownership | `display_rows` -> fixed viewport | Pure projection | The visible rows are moved (drain/truncate/pad) rather than `.clone()`d | A remaining `display_rows[disp_idx].clone()` | None | N/A | Source inspection: no `display_rows[…].clone()` remains |
+
+## Explicit non-goals
+
+- No behavior change of any kind: identical projection output for every input.
+- No public API, type, dependency, manifest, lockfile, workflow,
+  agent-memory, `.llxprt/`, `.code_puppy/`, quality-gate, or harness change.
+- No new public abstraction, module, or trait.
+- No unsafe code (the crate forbids it; `[lints.rust] unsafe_code = "forbid"`).
+- No lint suppression or complexity/size threshold change.
+- No grapheme/cell coordinate model change; source/caret offsets remain scalar.
+- No unrelated refactor or test relocation. The deferred
+  `src/text_box_view.rs` > 750-line warning split (issue #422 scope ledger)
+  remains out of scope.
+- No change to `text_wrap::wrap_text` or `WrapRow`.
+- No horizontal scrolling, gutter redesign, or wrap-mode change.
+
+## Bounded vertical slices
+
+This issue is a single cohesive ownership refactor of one pure projection
+module. It does not cross more than three architectural ownership layers (it
+touches only `src/text_box_view.rs`). Per ISSUE-DELIVERY §3 it is delivered as
+one slice because the three changes are inseparable within the same ownership
+flow (consuming the segment vector is what enables the in-place viewport
+build).
+
+### Slice S1 (only slice): preserve ownership through TextBox projection
+
+- **Acceptance rows:** A1, A2, A3, A4, A5, A6
+- **Architecture owner:** iocraft-free `text_box_view` pure projection.
+  Integration boundary: the private `project_line_segments`,
+  `caret_col_for_segment`, and `build_text_box_view` viewport-build steps.
+- **Allowed production paths:** `src/text_box_view.rs` only.
+- **Allowed evidence paths:** existing unit tests in `src/text_box_view.rs`,
+  `src/ui/components/text_box.rs`, `tests/text_box_layout.rs`, and this plan.
+- **RED:** The refactor preserves behavior, so the existing comprehensive
+  suite IS the regression net. Before refactoring, capture a golden snapshot
+  of `build_text_box_view` output for representative inputs (empty, short,
+  wrapped, CJK, combining, exact-width trailing caret, multi-line scroll,
+  trailing newline, zero width, zero viewport). After refactoring, assert the
+  output is byte-identical. If any fixture diverges, that is RED.
+- **GREEN:** (1) Change `project_line_segments` to take `Vec<WrapSegment>` by
+  value and move each `seg.text` into the `TextBoxRow`. (2) Thread
+  `rendered_chars` into `caret_col_for_segment` and remove the
+  `seg.text.chars().count()` recount. (3) Replace the
+  `display_rows[disp_idx].clone()` viewport build with an in-place
+  drain/truncate/pad that moves rows. All existing tests pass unchanged.
+- **REFACTOR:** Keep each function under project complexity/size limits; no
+  signature expansion beyond threading the already-computed scalar.
+- **Verification:** focused `text_box_view`, TextBox renderer, and
+  `text_box_layout` suites; `cargo fmt --all --check`;
+  `cargo clippy --workspace --all-targets --all-features -- -D warnings`;
+  `cargo build --workspace --all-features --locked`;
+  `cargo test --workspace --all-features --locked`.
+- **Stop conditions:** any behavior difference; a new public
+  abstraction/module; a dependency/workflow/agent-memory/quality-tool change;
+  a path outside `src/text_box_view.rs`; unsafe code; lint suppression.
+
+## Expected paths by layer
+
+| Layer | Expected paths | Acceptance mapping |
+| --- | --- | --- |
+| TextBox pure projection | `src/text_box_view.rs` | A1, A4, A5, A6 |
+| TextBox thin renderer (evidence only) | `src/ui/components/text_box.rs` | A2 |
+| Integration contract (evidence only) | `tests/text_box_layout.rs` | A3 |
+| Delivery record | `project-plans/issue436-plan.md` | all rows |
+
+Expected scope: 1 changed production file (`src/text_box_view.rs`) plus this
+plan. Well under the 25-file / 1,500-line targets.
+
+## Scope ledger
+
+| Discovery | Disposition | Rationale / follow-up |
+| --- | --- | --- |
+| `src/text_box_view.rs` is above the 750-line warning threshold but below the 1000-line hard gate (deferred from issue #422) | Preserve / Defer | Splitting the module is unrelated to this ownership refactor and remains a separate bounded follow-up. |
+| The two OCR comments about the scalar recount are duplicates of the same expression | Reject (duplicate) | Handled as one root cause per the issue origin note. |
+| `caret_at_full_width_end` and `caret_in_hidden_suffix` already receive `rendered_chars`/`rendered_width` and do not recount | Preserve | Only `caret_col_for_segment` has the redundant recount. |
+| The visible-row clone requires consuming `display_rows` in place | In-scope fix | Drain the visible window, truncate/pad to `viewport_rows`. |
+
+No unapproved scope discoveries are open.
+
+## Review counters
+
+- Pre-PR Open Code Review: 1 / 2 (local run completed: 0 comments, "Looks good to me")
+- Post-PR Open Code Review: 0 / 2
+- Independent Rust/DeepThinker review cycles: 0 / 2
+
+## Verification evidence
+
+| Candidate head | Command / evidence | Result |
+| --- | --- | --- |
+| `4faf76ab` (main) | baseline `text_box_view` (31), TextBox renderer (4), `text_box_layout` (5) | PASS: all 40 baseline tests green before any change. |
+| issue436 working tree | focused `text_box_view` (31), TextBox renderer (4), `text_box_layout` (5) | PASS: identical counts after refactor. |
+| issue436 working tree | source inspection: no `seg.text.clone()`, no `chars().count()` recount, no `display_rows[…].clone()` | PASS: all three clones removed. |
+| issue436 working tree | `cargo fmt --all --check` | PASS. |
+| issue436 working tree | `cargo clippy --workspace --all-targets --all-features -- -D warnings` | PASS. |
+| issue436 working tree | `cargo build --workspace --all-features --locked` | PASS. |
+| issue436 working tree | `cargo test --workspace --all-features --locked` | PASS: 2574 lib tests + all integration suites; one flaky `settings_edit_fixture` fails only under full-workspace parallel load and passes in isolation on both main and this branch (pre-existing fixture-parallelism flake, unrelated to the pure-projection change). |
+
+## Deferred findings and follow-ups
+
+- `src/text_box_view.rs` > 750-line warning split: deferred from issue #422,
+  still out of scope here.

--- a/src/text_box_view.rs
+++ b/src/text_box_view.rs
@@ -196,7 +196,7 @@ pub fn build_text_box_view(
     let total_lines = lines.len();
     let caret = byte_cursor_to_caret(text, byte_cursor);
 
-    let (display_rows, caret_row_idx) =
+    let (mut display_rows, caret_row_idx) =
         build_wrapped_display_rows(&lines, caret, content_width, viewport_rows);
     let total_display = display_rows.len();
 
@@ -214,19 +214,15 @@ pub fn build_text_box_view(
     let caret_row = caret_row_idx.unwrap_or(0);
     let first = vertical_first_visible(caret_row, viewport_rows, total_display);
 
-    let mut rows: Vec<TextBoxRow> = Vec::with_capacity(viewport_rows);
-    for vp_idx in 0..viewport_rows {
-        let disp_idx = first + vp_idx;
-        if disp_idx < total_display {
-            rows.push(display_rows[disp_idx].clone());
-        } else {
-            // Pad blank rows so the component occupies a fixed height.
-            rows.push(TextBoxRow {
-                text: String::new(),
-                caret_col: None,
-            });
-        }
-    }
+    // Move the visible window out of display_rows instead of cloning each
+    // row. display_rows is owned by this function and unused after this point.
+    let visible_end = (first + viewport_rows).min(total_display);
+    let mut rows: Vec<TextBoxRow> = display_rows.drain(first..visible_end).collect();
+    // Pad blank rows so the component occupies a fixed height.
+    rows.resize_with(viewport_rows, || TextBoxRow {
+        text: String::new(),
+        caret_col: None,
+    });
 
     TextBoxView {
         rows,
@@ -270,7 +266,7 @@ fn build_wrapped_display_rows(
             content_width,
             viewport_rows,
         };
-        let (mut line_rows, line_caret_row) = project_line_segments(&segments, line_context);
+        let (mut line_rows, line_caret_row) = project_line_segments(segments, line_context);
         if let Some(line_caret_row) = line_caret_row {
             caret_row_idx = Some(display_rows.len().saturating_add(line_caret_row));
         }
@@ -289,23 +285,24 @@ struct LineWrapContext {
 }
 
 fn project_line_segments(
-    segments: &[WrapSegment],
+    segments: Vec<WrapSegment>,
     context: LineWrapContext,
 ) -> (Vec<TextBoxRow>, Option<usize>) {
     let mut rows = Vec::with_capacity(segments.len().saturating_add(1));
     let mut caret_row = None;
     let mut boundary_caret_pending = false;
-    for (segment_index, seg) in segments.iter().enumerate() {
+    let segment_count = segments.len();
+    for (segment_index, seg) in segments.into_iter().enumerate() {
         let rendered_chars = seg.text.chars().count();
         let rendered_width = UnicodeWidthStr::width(seg.text.as_str());
-        let hidden_suffix = caret_in_hidden_suffix(seg, rendered_chars, rendered_width, context);
-        let full_width_end = caret_at_full_width_end(seg, rendered_width, context);
-        let is_last_segment = segment_index + 1 == segments.len();
+        let hidden_suffix = caret_in_hidden_suffix(&seg, rendered_chars, rendered_width, context);
+        let full_width_end = caret_at_full_width_end(&seg, rendered_width, context);
+        let is_last_segment = segment_index + 1 == segment_count;
         let needs_trailing_row = full_width_end || (hidden_suffix && is_last_segment);
         let trailing_row = needs_trailing_row && context.viewport_rows >= 2;
         if trailing_row {
             rows.push(TextBoxRow {
-                text: seg.text.clone(),
+                text: seg.text,
                 caret_col: None,
             });
             caret_row = Some(rows.len());
@@ -320,15 +317,15 @@ fn project_line_segments(
             rendered_width,
             hidden_suffix,
             full_width_end,
-            has_next: segment_index + 1 < segments.len(),
+            has_next: segment_index + 1 < segment_count,
         };
         let segment_caret =
-            segment_caret_col(seg, context, segment_context, &mut boundary_caret_pending);
+            segment_caret_col(&seg, context, segment_context, &mut boundary_caret_pending);
         if segment_caret.is_some() {
             caret_row = Some(rows.len());
         }
         rows.push(TextBoxRow {
-            text: seg.text.clone(),
+            text: seg.text,
             caret_col: segment_caret,
         });
     }
@@ -363,6 +360,7 @@ fn segment_caret_col(
     }
     caret_col_for_segment(
         seg,
+        segment.rendered_chars,
         segment.rendered_width,
         line.caret,
         line.line_idx,
@@ -404,10 +402,14 @@ fn caret_in_hidden_suffix(
 /// - the segment is empty (`start == end`) and the caret sits at that
 ///   position (a blank line / trailing-newline row).
 ///
+/// `rendered_chars` is the already-computed scalar length of `seg.text` and
+/// is reused here instead of recomputing `seg.text.chars().count()`.
+///
 /// @requirement REQ-PR-009
 /// @requirement REQ-TEXTBOX-WRAP
 fn caret_col_for_segment(
     seg: &WrapSegment,
+    rendered_chars: usize,
     seg_width: usize,
     caret: TextCaret,
     line_idx: usize,
@@ -425,12 +427,7 @@ fn caret_col_for_segment(
     let trailing_at_end = caret_at_seg_end && seg_has_room;
     let on_blank_row = seg_is_empty && caret_at_seg_end;
     if in_range || trailing_at_end || on_blank_row {
-        Some(
-            caret
-                .col
-                .saturating_sub(seg.start)
-                .min(seg.text.chars().count()),
-        )
+        Some(caret.col.saturating_sub(seg.start).min(rendered_chars))
     } else {
         None
     }


### PR DESCRIPTION
## Summary

Fixes #436 — reduces avoidable copying and one redundant scalar traversal in the TextBox wrapped-row projection (`src/text_box_view.rs`), deferred from PR #427 / issue #422.

## Changes

Three ownership-quality improvements with **no behavior change**:

1. **Consume `WrapSegment` values instead of cloning** — `project_line_segments` now takes `Vec<WrapSegment>` by value and moves each segment `String` into `TextBoxRow` instead of cloning it. The segment vector is immediately discarded after projection, so the clones were always avoidable.

2. **Reuse `rendered_chars` for caret clamping** — `caret_col_for_segment` now receives the already-computed `rendered_chars` scalar instead of recomputing `seg.text.chars().count()`. The two OCR comments about this recount were duplicate reports of the same expression and are handled as one root cause.

3. **Move visible rows instead of cloning** — the viewport build step now drains the owned `display_rows` buffer in place (`drain(first..visible_end)` + `resize_with` padding) instead of cloning each visible row via `display_rows[disp_idx].clone()`.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo build --workspace --all-features --locked` — passed
- `cargo test --workspace --all-features --locked` — 2574 lib tests + all integration suites pass (one flaky `settings_edit_fixture` fails only under full-workspace parallel load; passes in isolation on both main and this branch — pre-existing fixture-parallelism flake)
- Focused suites unchanged: `text_box_view` (31), TextBox renderer (4), `text_box_layout` (5)
- Pre-PR OCR review: 0 comments ("Looks good to me")

## Scope

1 production file (`src/text_box_view.rs`, +27/-30) + delivery plan. No new dependency, public API, abstraction, unsafe code, lint suppression, or behavior change.
