### PR TITLE
Add true pre-run OCR reproducibility manifest and reconcile docs (Fixes #464)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -713,6 +713,157 @@ jobs:
             });
             core.setOutput('reserved', 'true');
 
+      - name: Write pre-run OCR reproducibility manifest
+        # True launch-time snapshot (issue #464): write manifest.pre.json BEFORE
+        # the OCR run so created_at, phase, and trusted-base/worktree state are
+        # recorded as they were at launch, not after the result is posted. This
+        # mirrors the llxprt-code ocr-review-local pre-run manifest and makes the
+        # manifest a provable pre-run snapshot rather than a post-run summary.
+        if: always()
+        shell: bash
+        env:
+          BASE_SHA: ${{ env.BASE_SHA }}
+          HEAD_SHA: ${{ env.HEAD_SHA }}
+          BASE_REF: ${{ steps.pr-context.outputs.base_ref }}
+          OCR_LLM_URL: ${{ vars.OCR_LLM_URL }}
+          OCR_LLM_MODEL: ${{ vars.OCR_LLM_MODEL }}
+          OCR_USE_ANTHROPIC: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
+          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const crypto = require('crypto');
+          const { execSync } = require('child_process');
+
+          const escapeWorkflowCommand = (value) => String(value)
+            .replaceAll('%', '%25')
+            .replaceAll(String.fromCharCode(13), '%0D')
+            .replaceAll(String.fromCharCode(10), '%0A');
+          const warning = (message) => {
+            process.stdout.write('::warning::' + escapeWorkflowCommand(message) + String.fromCharCode(10));
+          };
+
+          const sha256 = (value) => crypto.createHash('sha256').update(value).digest('hex');
+          const readTrim = (name, fallback = '') => {
+            try { return fs.readFileSync(name, 'utf8').trim(); } catch (_) { return fallback; }
+          };
+          const fileHash = (name) => {
+            try { return sha256(fs.readFileSync(name)); } catch (_) { return null; }
+          };
+          // Run a git command in the trusted checkout, returning a trimmed
+          // string. Failures (e.g. empty diff) yield the fallback so a missing
+          // piece of evidence does not abort the whole manifest write.
+          const gitText = (args, fallback = '') => {
+            try {
+              return execSync(`git ${args}`, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+            } catch (_) {
+              return fallback;
+            }
+          };
+
+          // Trusted base: the actual checked-out HEAD (the trusted base branch
+          // tip), distinct from the merge-base used as scope.base.
+          const trustedHead = gitText('rev-parse HEAD', null);
+          const baseRef = process.env.BASE_REF || null;
+
+          // Worktree state at launch time. The trusted checkout is expected to
+          // be clean, but recording the clean flag + diff hashes makes the
+          // snapshot auditable and detects any unexpected drift before the run.
+          const porcelain = gitText('status --porcelain', '');
+          const clean = porcelain === '';
+          const diffHash = (spec) => {
+            const diff = gitText(spec, '');
+            return diff === '' ? null : sha256(diff);
+          };
+          const worktree = {
+            clean,
+            staged_diff_sha256: diffHash('diff --cached'),
+            unstaged_diff_sha256: diffHash('diff'),
+            untracked_files_sha256: (() => {
+              const untracked = gitText('ls-files --others --exclude-standard', '');
+              return untracked === '' ? null : sha256(untracked);
+            })(),
+          };
+
+          // Rule hash: fingerprint the exact OCR rule.json CI will use.
+          const rulePath = `${process.env.HOME}/.opencodereview/rule.json`;
+          const ruleSha256 = fileHash(rulePath);
+
+          // Preview hash: capture the selected-file-set fingerprint when the
+          // conditional preview step ran and wrote ocr-preview.txt.
+          const previewSha256 = fileHash('ocr-preview.txt');
+
+          // Provider config by shape only (never the raw key).
+          const urlRaw = process.env.OCR_LLM_URL || '';
+          let urlShape = null;
+          try {
+            if (urlRaw) {
+              const u = new URL(urlRaw);
+              const firstSegment = u.pathname.split('/').filter(Boolean)[0] || '';
+              urlShape = `${u.protocol}//${u.host}${firstSegment ? '/' + firstSegment : ''}`;
+            }
+          } catch (_) {
+            urlShape = 'unparseable';
+          }
+          const providerName = process.env.OCR_USE_ANTHROPIC === 'true' ? 'anthropic-compatible' : 'openai-compatible';
+          const providerConfig = {
+            provider: providerName,
+            custom_providers: {
+              [providerName]: {
+                url_shape: urlShape,
+                protocol: process.env.OCR_USE_ANTHROPIC === 'true' ? 'anthropic' : 'openai',
+                model: process.env.OCR_LLM_MODEL || null,
+                credential_present: Boolean(process.env.OCR_LLM_TOKEN),
+              },
+            },
+          };
+
+          // Fixed control vector and exact scope vector — the two argument
+          // sets that must match for two runs to be comparable.
+          const controlArgs = ['--audience', 'agent', '--format', 'json', '--concurrency', '2', '--timeout', '30'];
+          const scopeArgs = ['--from', process.env.BASE_SHA || null, '--to', process.env.HEAD_SHA || null];
+
+          const pre = {
+            schema: 'ocr-review-manifest-v1',
+            phase: 'pre-run',
+            created_at: new Date().toISOString(),
+            repository: process.env.GITHUB_REPOSITORY || null,
+            run_id: process.env.GITHUB_RUN_ID || null,
+            run_attempt: process.env.GITHUB_RUN_ATTEMPT || null,
+            event_name: process.env.GITHUB_EVENT_NAME || null,
+            trusted_base: {
+              head: trustedHead,
+              branch: baseRef,
+            },
+            scope: {
+              mode: 'cumulative',
+              base: process.env.BASE_SHA || null,
+              head: process.env.HEAD_SHA || null,
+            },
+            worktree,
+            control_args: controlArgs,
+            scope_args: scopeArgs,
+            rule_sha256: ruleSha256,
+            preview_sha256: previewSha256,
+            ocr: {
+              version: readTrim('ocr-version.txt', 'unknown') || 'unknown',
+              phase: readTrim('ocr-phase.txt', 'unknown') || 'unknown',
+              provider: providerConfig,
+              redacted_config_sha256: sha256(JSON.stringify(providerConfig)),
+            },
+            // Comparison eligibility is machine-supported: the recorded
+            // trusted-base, worktree, arg, rule, and provider evidence lets a
+            // reviewer decide comparability from the manifest alone.
+            comparison_eligible: true,
+            coverage_hint: 'See manifest.post.json for the final coverage classification.',
+          };
+          try {
+            fs.writeFileSync('manifest.pre.json', JSON.stringify(pre, null, 2) + String.fromCharCode(10));
+          } catch (writeErr) {
+            warning(`Could not write manifest.pre.json: ${writeErr.message || writeErr}`);
+          }
+          NODE
+
       - name: Run OpenCodeReview
         id: ocr-review
         if: ${{ steps.ocr-budget.outputs.should_run == 'true' && (github.event_name != 'pull_request_target' || steps.ocr-reservation.outputs.reserved == 'true') }}
@@ -1348,21 +1499,17 @@ jobs:
 
 
       - name: Build OCR reproducibility manifests
-        # Re-sync rigor from llxprt-code: emit manifest.pre.json (scope, refs,
-        # OCR version, redacted provider config + its sha256, worktree state),
-        # manifest.post.json (exit code, reported statuses, coverage, artifact
-        # hashes), and sha256.txt over uploaded artifacts. Provider fields are
-        # captured by shape only (never the key) and the redaction step below
+        # Post-run manifest: emit manifest.post.json (exit code, run id,
+        # reported statuses, coverage, parse_error, artifact hashes including
+        # the pre-run snapshot) and sha256.txt over uploaded artifacts. The
+        # pre-run snapshot (manifest.pre.json) is written by the dedicated
+        # pre-run step and is NOT rewritten here. The redaction step below
         # runs after this so any accidental secret in a manifest is destroyed.
         if: ${{ always() && steps.ocr-budget.outputs.should_run == 'true' }}
         shell: bash
         env:
           BASE_SHA: ${{ env.BASE_SHA }}
           HEAD_SHA: ${{ env.HEAD_SHA }}
-          OCR_LLM_URL: ${{ vars.OCR_LLM_URL }}
-          OCR_LLM_MODEL: ${{ vars.OCR_LLM_MODEL }}
-          OCR_USE_ANTHROPIC: ${{ vars.OCR_LLM_USE_ANTHROPIC }}
-          OCR_LLM_TOKEN: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
         run: |
           node <<'NODE'
           const fs = require('fs');
@@ -1384,35 +1531,6 @@ jobs:
             try { return sha256(fs.readFileSync(name)); } catch (_) { return null; }
           };
 
-          // Provider config by shape only: scheme/host/path, protocol, model,
-          // and a boolean credential presence. The raw key is never written.
-          const urlRaw = process.env.OCR_LLM_URL || '';
-          let urlShape = null;
-          try {
-            if (urlRaw) {
-              const u = new URL(urlRaw);
-              // Capture only the shape, never the full pathname: a provider
-              // fingerprint needs scheme + host + the first path segment only.
-              // Truncating prevents any secret embedded deeper in the path
-              // from being written to the manifest.
-              const firstSegment = u.pathname.split('/').filter(Boolean)[0] || '';
-              urlShape = `${u.protocol}//${u.host}${firstSegment ? '/' + firstSegment : ''}`;
-            }
-          } catch (_) {
-            urlShape = 'unparseable';
-          }
-          const providerName = process.env.OCR_USE_ANTHROPIC === 'true' ? 'anthropic-compatible' : 'openai-compatible';
-          const providerConfig = {
-            provider: providerName,
-            custom_providers: {
-              [providerName]: {
-                url_shape: urlShape,
-                protocol: process.env.OCR_USE_ANTHROPIC === 'true' ? 'anthropic' : 'openai',
-                model: process.env.OCR_LLM_MODEL || null,
-                credential_present: Boolean(process.env.OCR_LLM_TOKEN),
-              },
-            },
-          };
           // Best-effort reported-status extraction for the manifest. The
           // coverage classification itself is read from ocr-coverage.txt,
           // which the posting step writes as the single source of truth, so
@@ -1447,10 +1565,18 @@ jobs:
             return 'unknown';
           }
           let coverageParsed = null;
+          let parseError = null;
           try {
             const raw = readTrim('ocr-result.json', '');
-            if (raw) coverageParsed = JSON.parse(raw);
-          } catch (_) { coverageParsed = null; }
+            if (raw) {
+              coverageParsed = JSON.parse(raw);
+            } else {
+              parseError = 'ocr-result.json was empty or missing';
+            }
+          } catch (parseErr) {
+            coverageParsed = null;
+            parseError = parseErr.message || String(parseErr);
+          }
           const persistedCoverage = readTrim('ocr-coverage.txt', '').trim();
           const knownCoverage = new Set(['complete_best_effort', 'partial', 'failed', 'unknown']);
           const coverage = knownCoverage.has(persistedCoverage)
@@ -1459,50 +1585,44 @@ jobs:
           let reportedStatuses = [];
           try { reportedStatuses = extractStatuses(coverageParsed); } catch (_) {}
 
-          const pre = {
-            schema: 'ocr-review-manifest-v1',
-            created_at: new Date().toISOString(),
-            repository: process.env.GITHUB_REPOSITORY || null,
-            run_id: process.env.GITHUB_RUN_ID || null,
-            run_attempt: process.env.GITHUB_RUN_ATTEMPT || null,
-            event_name: process.env.GITHUB_EVENT_NAME || null,
-            scope: {
-              mode: 'cumulative',
-              base: process.env.BASE_SHA || null,
-              head: process.env.HEAD_SHA || null,
-            },
-            ocr: {
-              version: readTrim('ocr-version.txt', 'unknown') || 'unknown',
-              phase: readTrim('ocr-phase.txt', 'unknown') || 'unknown',
-              provider: providerConfig,
-              redacted_config_sha256: sha256(JSON.stringify(providerConfig)),
-            },
-            coverage_hint: 'See manifest.post.json for the final coverage classification.',
-          };
-          fs.writeFileSync('manifest.pre.json', `${JSON.stringify(pre, null, 2)}\n`);
+          // manifest.pre.json is now written by the dedicated pre-run step.
+          // This post step must NOT overwrite it: the pre snapshot records the
+          // launch-time state (trusted base, worktree, args, rule hash) and is
+          // immutable after the run.
 
           const artifactNames = [
             'ocr-result.json', 'ocr-stdout.raw', 'ocr-stderr.log', 'ocr-version.txt',
             'ocr-preview.txt', 'ocr-preview-stderr.log', 'ocr-exit-code.txt',
             'ocr-phase.txt', 'ocr-infrastructure-failure.txt', 'ocr-policy-failure.txt',
+            // The pre-run snapshot is itself an audited artifact whose hash
+            // belongs in the post manifest's artifact map.
+            'manifest.pre.json',
           ];
           const hashes = {};
           for (const name of artifactNames) hashes[name] = fileHash(name);
           const post = {
             schema: 'ocr-review-manifest-v1',
             completed_at: new Date().toISOString(),
+            run_id: process.env.GITHUB_RUN_ID || null,
+            run_attempt: process.env.GITHUB_RUN_ATTEMPT || null,
             exit_code: exitCode,
             reported_statuses: reportedStatuses,
             coverage,
+            parse_error: parseError,
             artifacts: hashes,
             note: 'Coverage is best-effort pending upstream manifest support.',
           };
           fs.writeFileSync('manifest.post.json', `${JSON.stringify(post, null, 2)}\n`);
 
           // sha256.txt over every manifested artifact, including the manifests.
-          const allForHash = [...artifactNames, 'manifest.pre.json', 'manifest.post.json'];
+          // artifactNames already includes manifest.pre.json; add the post
+          // manifest so its hash is covered without duplicating the pre entry.
+          const allForHash = [...artifactNames, 'manifest.post.json'];
           const lines = [];
+          const seen = new Set();
           for (const name of allForHash) {
+            if (seen.has(name)) continue;
+            seen.add(name);
             const digest = fileHash(name);
             if (digest) lines.push(`${digest}  ${name}`);
           }

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -719,7 +719,13 @@ jobs:
         # recorded as they were at launch, not after the result is posted. This
         # mirrors the llxprt-code ocr-review-local pre-run manifest and makes the
         # manifest a provable pre-run snapshot rather than a post-run summary.
-        if: always()
+        #
+        # continue-on-error: the manifest is a reproducibility aid, not a
+        # functional requirement. A transient script failure must not prevent
+        # the OCR review from running. The step emits workflow-command warnings
+        # on any failure so the loss of the snapshot is visible.
+        if: ${{ always() && steps.ocr-budget.outputs.should_run == 'true' }}
+        continue-on-error: true
         shell: bash
         env:
           BASE_SHA: ${{ env.BASE_SHA }}
@@ -823,6 +829,18 @@ jobs:
           const controlArgs = ['--audience', 'agent', '--format', 'json', '--concurrency', '2', '--timeout', '30'];
           const scopeArgs = ['--from', process.env.BASE_SHA || null, '--to', process.env.HEAD_SHA || null];
 
+          // Comparison eligibility is only meaningful when the core evidence
+          // was captured. A missing trusted-base HEAD, rule hash, or scope
+          // range means the run cannot be proven comparable to another.
+          const comparisonEligible =
+            trustedHead !== null &&
+            ruleSha256 !== null &&
+            Boolean(process.env.BASE_SHA) &&
+            Boolean(process.env.HEAD_SHA);
+          if (!comparisonEligible) {
+            warning('Pre-run manifest recorded incomplete comparison-eligibility evidence (trusted-base HEAD, rule hash, or scope range missing).');
+          }
+
           const pre = {
             schema: 'ocr-review-manifest-v1',
             phase: 'pre-run',
@@ -847,14 +865,14 @@ jobs:
             preview_sha256: previewSha256,
             ocr: {
               version: readTrim('ocr-version.txt', 'unknown') || 'unknown',
-              phase: readTrim('ocr-phase.txt', 'unknown') || 'unknown',
+              // At pre-run time the review has not started, so ocr-phase.txt
+              // reflects the setup phase, not the review. The manifest-level
+              // phase: 'pre-run' above is the authoritative pre-run label.
+              phase: readTrim('ocr-phase.txt', 'pre-run') || 'pre-run',
               provider: providerConfig,
               redacted_config_sha256: sha256(JSON.stringify(providerConfig)),
             },
-            // Comparison eligibility is machine-supported: the recorded
-            // trusted-base, worktree, arg, rule, and provider evidence lets a
-            // reviewer decide comparability from the manifest alone.
-            comparison_eligible: true,
+            comparison_eligible: comparisonEligible,
             coverage_hint: 'See manifest.post.json for the final coverage classification.',
           };
           try {
@@ -1600,6 +1618,9 @@ jobs:
           ];
           const hashes = {};
           for (const name of artifactNames) hashes[name] = fileHash(name);
+          if (hashes['manifest.pre.json'] === null) {
+            warning('manifest.pre.json is missing or empty; the pre-run snapshot was not captured, so the reproducibility chain is incomplete.');
+          }
           const post = {
             schema: 'ocr-review-manifest-v1',
             completed_at: new Date().toISOString(),

--- a/dev-docs/code-review-process.md
+++ b/dev-docs/code-review-process.md
@@ -90,9 +90,17 @@ same thing unless all of the following match:
 - Provider, model, protocol, and account generation.
 - Concurrency, rules, and redacted configuration (compare via the
   `redacted_config_sha256` in `manifest.pre.json`).
-- Worktree state (the manifest records HEAD, branch, and diff hashes).
+- Worktree state (clean flag and diff hashes) and trusted-base HEAD/branch.
 
-When any of these differ, treat the runs as independent observations, not as
+The CI workflow records this evidence in `manifest.pre.json` as a true
+pre-run snapshot: the checked-out trusted base (`trusted_base.head` /
+`trusted_base.branch`), the worktree state (clean flag plus staged, unstaged,
+and untracked diff hashes), the fixed control arg vector
+(`control_args`), the scope arg vector (`scope_args`), the rule hash
+(`rule_sha256`), the preview hash (`preview_sha256`), and the redacted
+provider configuration shape. Each field is hashed into `sha256.txt` so
+tampering with any input after the run is detectable. When any of these
+differ between two runs, treat the runs as independent observations, not as
 a before/after measurement. The reproducibility manifests
 (`manifest.pre.json`, `manifest.post.json`, `sha256.txt`) exist so this
 eligibility can be checked after the fact.
@@ -100,7 +108,12 @@ eligibility can be checked after the fact.
 ## Provider and remediation discipline
 
 - Do not switch providers, edit OCR configuration, or run routine
-  connectivity tests as part of an ordinary review.
+  connectivity tests as part of an ordinary local review. The CI workflow is
+  an explicit exception: it runs a single bounded `ocr llm test` connectivity
+  preflight (with an explicit timeout) before the expensive review scope so a
+  provider outage or credential error is surfaced early rather than wasting a
+  full review run. This preflight is infrastructure, not a review action, and
+  does not switch providers or modify configuration.
 - Do not retry a review automatically or resume a range/commit review with a
   different provider lineage; a manual provider transition is a new run with
   recorded lineage.

--- a/project-plans/issue464-plan.md
+++ b/project-plans/issue464-plan.md
@@ -1,74 +1,128 @@
-# Issue #464 — Restore OCR reproducibility manifest execution
+# Issue #464 — OCR reproducibility manifest integrity and completeness
 
-## Scope
+Follow-up to #449. PR #453 shipped the manifest triple and coverage
+classification; this issue closes the A1 reproducibility-integrity gaps that a
+functional-completeness audit (DeepThinker) identified against llxprt-code's
+`ocr-review-local` wrapper.
 
-Issue #464 already owns OCR reproducibility-manifest integrity. PR #475 proved that
-`Build OCR reproducibility manifests` always fails because a plain `node` heredoc
-imports undeclared package `@actions/core`.
+## Status of prior work on this issue
+
+- PR #482 (`bf0ff3d9`) fixed the demonstrated runtime blocker from the issue
+  comment: the plain-shell manifest builder imported undeclared `@actions/core`.
+  That is **done** and guarded by
+  `ocr_manifest_builder_uses_dependency_free_workflow_commands`.
+- Commit `bcb1045f` (for #449) reconciled the coverage doc: a zero-exit
+  unparsable result is documented as `unknown`, not `failed`. That is **done**.
+
+This plan covers the remaining open findings from the issue body.
 
 ## Acceptance matrix
 
-| # | Boundary | Success | Failure | Proof |
-|---|---|---|---|---|
-| AC1 | `Build OCR reproducibility manifests` plain-shell Node process | Runs using only Node built-ins and repository-declared inputs | Missing runtime package cannot abort manifest generation | Scoped repository contract test |
-| AC2 | GitHub Actions diagnostics | Manifest chmod failures remain visible as Actions warnings | Diagnostic emission does not require an npm package | Contract test for dependency-free workflow command encoding |
-| AC3 | Existing manifest/redaction/upload contract | Manifest triple, redaction, checksums, and upload paths are unchanged | No provider secret or unredacted artifact is uploaded | Existing OCR policy tests |
-| AC4 | Exact-head OCR workflow | Manifest-build step passes after OCR result posting | Infrastructure failure remains classified by existing downstream steps | PR workflow evidence |
+| ID  | Slice | Boundary | Observable success | Observable failure / diagnostic | Side effects | Persistence | Proof |
+|-----|-------|----------|--------------------|---------------------------------|--------------|-------------|-------|
+| AC1 | S1 | Pre-run manifest step ordering | A workflow step named to write `manifest.pre.json` runs **before** `Run OpenCodeReview` and before the post/parse steps | The step must not be absent or placed after the run | Writes `manifest.pre.json` only | File lives until upload/redaction | Contract test asserts the pre-run step precedes the run step |
+| AC2 | S1 | Pre-run manifest evidence: trusted base | `manifest.pre.json` records the checked-out trusted-base HEAD and base branch (distinct from the merge-base scope.base) | Field absent → contract fails | None (read-only git) | Captured at launch time | Contract test asserts `trusted_base` block with `head`/`branch` keys |
+| AC3 | S1 | Pre-run manifest evidence: worktree state | `manifest.pre.json` records worktree clean flag and staged/unstaged/untracked diff hashes | Missing → contract fails | Reads git status/diff only | Snapshot at launch | Contract test asserts `worktree` block with `clean` + diff-hash keys |
+| AC4 | S1 | Pre-run manifest evidence: fixed + scope arg vectors | `manifest.pre.json` records the fixed OCR control vector and the exact scope arg vector | Missing → contract fails | None | Recorded at launch | Contract test asserts `control_args` + `scope_args` fields |
+| AC5 | S1 | Pre-run manifest evidence: rule hash | `manifest.pre.json` records the sha256 of the OCR rule.json used by CI | Missing → contract fails | Reads rule.json | Fingerprint at launch | Contract test asserts `rule_sha256` field |
+| AC6 | S1 | Pre-run manifest evidence: comparison eligibility | `manifest.pre.json` records an explicit `comparison_eligible` boolean | Missing → contract fails | None | Machine-supported signal | Contract test asserts `comparison_eligible` field |
+| AC7 | S2 | Post-manifest does not overwrite the pre-run snapshot | The post step writes `manifest.post.json` only; it does NOT rewrite `manifest.pre.json` | If it rewrites pre → contract fails | None | Pre snapshot preserved | Contract test asserts the post step body has no `writeFileSync('manifest.pre.json'` |
+| AC8 | S2 | Post-manifest completeness | `manifest.post.json` records `run_id`, `parse_error`, and includes `manifest.pre.json` in its `artifacts` map | Missing → contract fails | None | Completeness | Contract test asserts fields and artifact key |
+| AC9 | S3 | Doc: connectivity preflight carve-out | `dev-docs/code-review-process.md` reconciles the "no routine connectivity tests" rule with the CI bounded preflight by carving out an explicit CI exception | Doc still contradicts workflow → contract fails | None | Versioned contract | Contract test asserts the doc mentions the CI connectivity exception |
+| AC10 | S3 | Doc: comparison eligibility is machine-supported | The doc's comparison-eligibility section reflects that the evidence is now recorded in `manifest.pre.json` | Claim is still unsupportable → contract fails | None | Versioned contract | Contract test asserts the doc references the recorded evidence fields |
 
 ## Non-goals
 
-- No OCR coverage-classification, model/provider, review-scope, or finding-posting changes.
-- No new npm or Rust dependency.
-- No redesign of the broader manifest schema tracked by issue #464.
-- No workflow-gating change.
+- Do **not** change A2 coverage classification (matches the wrapper exactly).
+- Do **not** port local-only wrapper ergonomics (interactive polling, detached
+  execution, workspace mode for uncommitted changes).
+- Do **not** change OCR provider/model, finding-posting, or required-gate
+  behavior.
+- Do **not** add the optional "reporting checklist + impact grouping from the
+  llxprt-code skill to the versioned rubric" (explicitly optional in the issue;
+  deferred to avoid scope expansion).
+- Do **not** re-litigate Finding 4 (coverage doc: zero-exit unparsable = unknown)
+  — already reconciled in `bcb1045f`.
+- Do **not** re-litigate the `@actions/core` runtime blocker — already fixed in
+  PR #482.
+- Do **not** run an unconditional `ocr review --preview` on every run (that
+  would add provider cost); the rule hash + conditional preview hash capture the
+  selected-file-set fingerprint.
+- Do **not** modify `.llxprt/`.
 
-## Vertical slice
+## Vertical slices
 
-1. Add a contract test scoped to the manifest-build step proving it does not
-   import `@actions/core` and emits dependency-free Actions warning commands.
-2. Prove RED against current main.
-3. Replace the single `core.warning` use with safe workflow-command emission.
-4. Run focused OCR policy tests and full required verification.
-5. Open an issue-linked PR and verify the exact-head OCR manifest step.
+### Slice S1 — True pre-run manifest step (AC1–AC6)
 
-## Expected paths
+1. **Owner / boundary:** `.github/workflows/ocr-review.yml` step ordering; new
+   step placed after `Configure OCR review rules` (so rule.json exists) and
+   after the trusted checkout + merge-base resolution, but **before** `Run
+   OpenCodeReview`. Contract test: `tests/core/ocr_workflow_contracts.rs`.
+2. **RED:** add contract tests asserting the pre-run step exists before the run
+   step and captures every required evidence field.
+3. **GREEN:** add a `Write pre-run OCR reproducibility manifest` step (plain
+   `node` heredoc, dependency-free, workflow-command warnings) that records:
+   trusted base (HEAD = `git rev-parse HEAD` on the trusted checkout; branch =
+   `pr-context` base_ref), scope (mode, base = merge-base, head = PR head),
+   worktree state (clean flag + sha256 of staged/unstaged/untracked diffs),
+   control_args (`--audience agent --format json --concurrency 2 --timeout 30`),
+   scope_args (`--from BASE --to HEAD`), rule sha256, comparison_eligible, OCR
+   version + redacted provider shape + redacted_config_sha256, run_id/attempt.
+4. **Non-goals for S1:** no post-manifest rewrite; no doc changes.
 
-- `.github/workflows/ocr-review.yml`
-- `tests/core/ocr_workflow_contracts.rs`
-- `project-plans/issue464-plan.md`
+### Slice S2 — Post-manifest completeness and pre-snapshot preservation (AC7–AC8)
+
+1. **Owner / boundary:** the existing `Build OCR reproducibility manifests`
+   step. Contract test: `tests/core/ocr_workflow_contracts.rs`.
+2. **RED:** contract test asserting the post step does NOT write
+   `manifest.pre.json` and that the post manifest carries `run_id`,
+   `parse_error`, and `manifest.pre.json` in `artifacts`.
+3. **GREEN:** remove the pre-manifest write from the post step; add
+   `run_id`/`run_attempt`/`parse_error` to the post manifest; add
+   `manifest.pre.json` to the post artifact-hash map (computed from the
+   pre-run file on disk).
+
+### Slice S3 — Doc reconciliation (AC9–AC10)
+
+1. **Owner / boundary:** `dev-docs/code-review-process.md`. Contract test:
+   `tests/ocr_review_policy.rs`.
+2. **RED:** contract test asserting the doc carves out the CI connectivity
+   preflight and reflects machine-supported comparison eligibility.
+3. **GREEN:** update the "Provider and remediation discipline" and "Run
+   comparison eligibility" sections.
+
+## Expected files
+
+- `.github/workflows/ocr-review.yml` (S1, S2)
+- `tests/core/ocr_workflow_contracts.rs` (S1, S2 contract tests)
+- `tests/ocr_review_policy.rs` (S3 contract tests)
+- `dev-docs/code-review-process.md` (S3)
+- `project-plans/issue464-plan.md` (this file)
+
+## Scope budget
+
+Target ≤ 25 files / ≤ 1,500 net changed lines. Mandatory scope review above
+either; hard stop without approval above 40 files / 2,500 net lines.
 
 ## Scope ledger
 
-| Date | Item | Disposition |
-|---|---|---|
-| 2026-07-27 | Existing issue #464 confirmed as owner | Accepted |
-| 2026-07-27 | Exact PR #475 failure added to issue #464 | Accepted |
-| 2026-07-27 | Dedicated branch `issue464` created from merged main `eaba9f2` | Accepted |
+| Date       | Item                                                          | Disposition |
+|------------|---------------------------------------------------------------|-------------|
+| 2026-07-27 | PR #482 fixed the `@actions/core` runtime blocker             | Done        |
+| 2026-07-27 | Commit `bcb1045f` reconciled coverage doc (zero-exit unparsable = unknown) | Done |
+| 2026-07-28 | Branch `issue464` created from main                           | Accepted    |
+| 2026-07-28 | S1–S3 acceptance matrix shaped                                | Accepted    |
 
 ## Review counters
 
-- OCR pre-PR: 0/2 (one bounded GLM review completed; no OCR run requested)
+- OCR pre-PR: 0/2
 - OCR post-PR: 0/2
 
-## Review triage
+## Verification
 
-- **Blocker—Fix:** none.
-- **In-scope—Fix:** none. The dependency-free warning command escapes `%`, CR,
-  and LF before writing to the GitHub Actions command channel.
-- **Reject:** broader YAML/dependency restructuring is unnecessary for the
-  two-line runtime defect and would expand issue scope.
-- **Defer:** broader manifest-schema completeness remains tracked by issue #464.
-
-## Verification evidence
-
-- RED: focused integration contract failed because the manifest step imported
-  unavailable `@actions/core`.
-- GREEN: focused contract passed after replacement with built-in Node output.
-- All 19 scoped OCR workflow contracts passed.
-- All 7 repository OCR policy tests passed.
-- `cargo fmt --all --check`, policy checks, strict Clippy, and complexity checks
-  passed in the full `cargo xtask ci` attempt.
-- Full local coverage/test completion is blocked by the pre-existing native
-  `tests/psmux_attach.rs` terminal-input assertion; this workflow-only diff does
-  not touch that route. Required exact-head Linux and Windows CI will provide
-  authoritative full-suite evidence.
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo build --workspace --all-features --locked`
+- `cargo test --workspace --all-features --locked` (or `make ci-check`)
+- Focused: `cargo test -p jefe --test integration core::ocr_workflow_contracts`
+  and `cargo test -p jefe --test ocr_review_policy`

--- a/tests/core/ocr_workflow_contracts.rs
+++ b/tests/core/ocr_workflow_contracts.rs
@@ -400,6 +400,150 @@ fn ocr_manifest_builder_uses_dependency_free_workflow_commands() {
     );
 }
 
+/// Return the 1-based line index of the `- name: <step_name>` header line, or
+/// `None` when the step is absent. Used to assert workflow step ordering.
+fn step_line(content: &str, step_name: &str) -> Option<usize> {
+    let needle = format!("- name: {step_name}");
+    content.lines().position(|l| l.trim() == needle)
+}
+
+// ---------------------------------------------------------------------------
+// Issue #464: true pre-run reproducibility manifest (structural ordering)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pre_run_manifest_step_exists_before_run_step() {
+    let content = read_workflow();
+    let pre_line = step_line(&content, "Write pre-run OCR reproducibility manifest");
+    let run_line = step_line(&content, "Run OpenCodeReview");
+    let pre = pre_line.unwrap_or_else(|| {
+        panic!("Workflow must define a 'Write pre-run OCR reproducibility manifest' step")
+    });
+    let run = run_line.unwrap_or_else(|| panic!("'Run OpenCodeReview' step not found"));
+    assert!(
+        pre < run,
+        "The pre-run manifest step must run BEFORE 'Run OpenCodeReview' so manifest.pre.json is a true launch-time snapshot (pre line {pre} must precede run line {run})"
+    );
+}
+
+#[test]
+fn pre_run_manifest_step_captures_trusted_base() {
+    let content = read_workflow();
+    let step = step_body(&content, "Write pre-run OCR reproducibility manifest");
+    // The trusted base is the checked-out base (HEAD after trusted checkout),
+    // distinct from the merge-base scope. Both the HEAD and the base branch
+    // name must be recorded.
+    assert!(
+        step.contains("trusted_base"),
+        "Pre-run manifest must record the trusted_base block (checked-out HEAD + branch, distinct from the reviewed merge-base)"
+    );
+    assert!(
+        step.contains("rev-parse HEAD") || step.contains("git rev-parse HEAD"),
+        "Pre-run manifest must capture the trusted checkout HEAD via git rev-parse"
+    );
+    assert!(
+        step.contains("base_ref") || step.contains("BASE_REF"),
+        "Pre-run manifest must record the trusted base branch name"
+    );
+}
+
+#[test]
+fn pre_run_manifest_step_captures_worktree_state() {
+    let content = read_workflow();
+    let step = step_body(&content, "Write pre-run OCR reproducibility manifest");
+    // Worktree state: clean flag + diff hashes for staged/unstaged/untracked.
+    assert!(
+        step.contains("worktree"),
+        "Pre-run manifest must record worktree state"
+    );
+    assert!(
+        step.contains("clean"),
+        "Pre-run manifest must record the worktree clean flag"
+    );
+}
+
+#[test]
+fn pre_run_manifest_step_captures_control_and_scope_args() {
+    let content = read_workflow();
+    let step = step_body(&content, "Write pre-run OCR reproducibility manifest");
+    assert!(
+        step.contains("control_args") || step.contains("controlArgs"),
+        "Pre-run manifest must record the fixed OCR control argument vector"
+    );
+    assert!(
+        step.contains("--audience") && step.contains("--concurrency") && step.contains("--timeout"),
+        "Pre-run manifest must record the fixed control args (--audience, --concurrency, --timeout)"
+    );
+    assert!(
+        step.contains("scope_args") || step.contains("scopeArgs"),
+        "Pre-run manifest must record the exact scope argument vector"
+    );
+}
+
+#[test]
+fn pre_run_manifest_step_captures_rule_hash() {
+    let content = read_workflow();
+    let step = step_body(&content, "Write pre-run OCR reproducibility manifest");
+    assert!(
+        step.contains("rule") && step.contains("sha256"),
+        "Pre-run manifest must record the sha256 of the OCR rule.json used by CI"
+    );
+}
+
+#[test]
+fn pre_run_manifest_step_records_comparison_eligibility() {
+    let content = read_workflow();
+    let step = step_body(&content, "Write pre-run OCR reproducibility manifest");
+    assert!(
+        step.contains("comparison_eligible") || step.contains("comparisonEligible"),
+        "Pre-run manifest must record an explicit comparison_eligible field so eligibility is machine-supported"
+    );
+}
+
+#[test]
+fn pre_run_manifest_step_is_dependency_free() {
+    let content = read_workflow();
+    let step = step_body(&content, "Write pre-run OCR reproducibility manifest");
+    assert!(
+        !step.contains("require('@actions/core')") && !step.contains("require(\"@actions/core\")"),
+        "Pre-run manifest Node must not import @actions/core (mirrors the post-step contract)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #464: post-manifest completeness and pre-snapshot preservation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn post_manifest_step_does_not_overwrite_pre_snapshot() {
+    let content = read_workflow();
+    let step = step_body(&content, "Build OCR reproducibility manifests");
+    // The post step must write manifest.post.json only. It must NOT rewrite
+    // manifest.pre.json, which is now a true pre-run snapshot written earlier.
+    assert!(
+        !step.contains("writeFileSync('manifest.pre.json'")
+            && !step.contains("writeFileSync(\"manifest.pre.json\""),
+        "Post manifest step must not overwrite the pre-run manifest.pre.json snapshot"
+    );
+}
+
+#[test]
+fn post_manifest_step_carries_run_id_and_parse_error_and_pre_artifact() {
+    let content = read_workflow();
+    let step = step_body(&content, "Build OCR reproducibility manifests");
+    // The post manifest must record run_id, parse_error, and include
+    // manifest.pre.json in its artifacts map.
+    assert!(step.contains("run_id"), "Post manifest must record run_id");
+    assert!(
+        step.contains("parse_error"),
+        "Post manifest must record a parse_error field"
+    );
+    assert!(
+        step.contains("'manifest.pre.json'") || step.contains("\"manifest.pre.json\""),
+        "Post manifest artifacts map must include the manifest.pre.json hash"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Criterion 10: preserve existing protections
 // ---------------------------------------------------------------------------

--- a/tests/core/ocr_workflow_contracts.rs
+++ b/tests/core/ocr_workflow_contracts.rs
@@ -400,7 +400,7 @@ fn ocr_manifest_builder_uses_dependency_free_workflow_commands() {
     );
 }
 
-/// Return the 1-based line index of the `- name: <step_name>` header line, or
+/// Return the 0-based line index of the `- name: <step_name>` header line, or
 /// `None` when the step is absent. Used to assert workflow step ordering.
 fn step_line(content: &str, step_name: &str) -> Option<usize> {
     let needle = format!("- name: {step_name}");
@@ -457,8 +457,8 @@ fn pre_run_manifest_step_captures_worktree_state() {
         "Pre-run manifest must record worktree state"
     );
     assert!(
-        step.contains("clean"),
-        "Pre-run manifest must record the worktree clean flag"
+        step.contains("staged_diff_sha256"),
+        "Pre-run manifest must record the worktree clean flag and diff hashes"
     );
 }
 

--- a/tests/ocr_review_policy.rs
+++ b/tests/ocr_review_policy.rs
@@ -216,3 +216,50 @@ fn contributor_guide_links_the_review_process_rubric() -> io::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn doc_reconciles_ci_connectivity_preflight_with_no_routine_tests_rule() -> io::Result<()> {
+    // Issue #464 Finding 5: the CI workflow runs a bounded `ocr llm test`
+    // connectivity preflight on every run, while the doc says "do not run
+    // routine connectivity tests." The doc must carve out an explicit CI
+    // exception so the prose no longer contradicts the workflow.
+    let rubric = repository_text("dev-docs/code-review-process.md")?;
+    let provider_section = markdown_section(&rubric, "Provider and remediation discipline");
+
+    assert!(
+        provider_section.contains("connectivity"),
+        "provider/remediation section must address connectivity preflight to reconcile with the CI workflow"
+    );
+    // The carve-out must distinguish the bounded CI preflight from ordinary
+    // interactive/local connectivity tests.
+    assert!(
+        provider_section.to_lowercase().contains("ci") || provider_section.contains("CI"),
+        "provider/remediation section must explicitly carve out the CI bounded connectivity preflight"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn doc_comparison_eligibility_records_machine_supported_evidence() -> io::Result<()> {
+    // Issue #464 Finding 3: the doc claims the manifest triple lets eligibility
+    // be checked after the fact. With the pre-run manifest now recording
+    // trusted-base, worktree, arg, rule, and provider evidence, the doc must
+    // reflect that the comparison-eligibility check is machine-supported, not
+    // merely documented.
+    let rubric = repository_text("dev-docs/code-review-process.md")?;
+    let comparison = markdown_section(&rubric, "Run comparison eligibility");
+
+    // The comparison section must reference the manifest evidence that makes
+    // eligibility machine-checkable.
+    assert!(
+        comparison.contains("worktree"),
+        "comparison-eligibility section must reference worktree state evidence recorded in the manifest"
+    );
+    assert!(
+        comparison.contains("manifest"),
+        "comparison-eligibility section must reference the reproducibility manifest"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes #464 — OCR reproducibility manifest integrity and completeness (follow-up to #449).

The manifest triple shipped in #449 was structurally incomplete. This PR closes the remaining open findings from the DeepThinker audit (the `@actions/core` runtime blocker and the coverage-doc contradiction were already fixed in PR #482 and commit `bcb1045f` respectively).

## Changes

### Finding 1 — manifest.pre.json was generated after the OCR run, not before

- Added a new `Write pre-run OCR reproducibility manifest` workflow step that runs **before** `Run OpenCodeReview`, so `created_at`, `phase`, trusted-base, and worktree state are a true launch-time snapshot.

### Finding 2 — missing reproducibility evidence

The pre-run manifest now captures:

- `trusted_base.head` / `trusted_base.branch` — the actual checked-out base (distinct from the reviewed merge-base).
- `worktree` — clean flag plus sha256 of staged, unstaged, and untracked diffs.
- `control_args` — the fixed OCR argument vector.
- `scope_args` — the exact scope argument vector.
- `rule_sha256` — hash of the CI OCR rule.json.
- `preview_sha256` — fingerprint of the selected-file-set.
- `comparison_eligible` — explicit machine-supported boolean.
- Provider config by shape only (never the raw key), with `redacted_config_sha256`.

The post manifest (`manifest.post.json`) no longer overwrites `manifest.pre.json`, now records `run_id`, `run_attempt`, and `parse_error`, and includes `manifest.pre.json` in its `artifacts` hash map.

### Finding 3 — comparison eligibility documented but not machine-supported

`manifest.pre.json` now records every evidence field the comparison-eligibility check needs. The doc (`dev-docs/code-review-process.md`) is updated to reflect that eligibility is machine-supported and lists the recorded fields.

### Finding 5 — connectivity preflight contradicts the "no routine connectivity tests" rule

The doc now carves out an explicit CI exception for the bounded `ocr llm test` preflight, distinguishing it from ordinary local connectivity tests.

## Test plan

Contract tests (RED → GREEN), matching the existing `ocr_workflow_contracts.rs` and `ocr_review_policy.rs` pattern:

- `pre_run_manifest_step_exists_before_run_step` — ordering (AC1)
- `pre_run_manifest_step_captures_trusted_base` (AC2)
- `pre_run_manifest_step_captures_worktree_state` (AC3)
- `pre_run_manifest_step_captures_control_and_scope_args` (AC4)
- `pre_run_manifest_step_captures_rule_hash` (AC5)
- `pre_run_manifest_step_records_comparison_eligibility` (AC6)
- `pre_run_manifest_step_is_dependency_free` (AC7)
- `post_manifest_step_does_not_overwrite_pre_snapshot` (AC8)
- `post_manifest_step_carries_run_id_and_parse_error_and_pre_artifact` (AC9)
- `doc_reconciles_ci_connectivity_preflight_with_no_routine_tests_rule` (AC10)
- `doc_comparison_eligibility_records_machine_supported_evidence` (AC10)

## Verification

Passed locally on the candidate head:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --all-features --locked`
- `cargo test --workspace --all-features --locked` — all pass, 0 failures

## Scope

5 files changed, +502 / -124 (~378 net lines). Well within the 25-file / 1,500-line target.

## Non-goals

- No A2 coverage-classification changes (matches the wrapper exactly).
- No local-only wrapper ergonomics (interactive polling, detached execution, workspace mode).
- No OCR provider/model, finding-posting, or required-gate behavior changes.
- No `.llxprt/` modifications.
