### PR TITLE
Recover native Windows agents after psmux server loss

### DIFF
--- a/dev-docs/tmux-scenarios/v1/issue493-server-loss.json
+++ b/dev-docs/tmux-scenarios/v1/issue493-server-loss.json
@@ -1,0 +1,49 @@
+{
+  "schema": 1,
+  "name": "issue493-server-loss",
+  "platform": "macos",
+  "terminal": { "cols": 110, "rows": 32 },
+  "workspace": {
+    "mode": 448,
+    "dirs": [
+      { "path": "config", "mode": 448 },
+      { "path": "work", "mode": 448 }
+    ],
+    "files": [
+      {
+        "path": "config/settings.toml",
+        "content": { "utf8": "settings_schema = 2\n" },
+        "mode": 384
+      },
+      {
+        "path": "config/state.json",
+        "content": {
+          "utf8": "{\n  \"schema_version\": 1,\n  \"repositories\": [{\n    \"id\": \"repo\",\n    \"name\": \"Repo\",\n    \"slug\": \"repo\",\n    \"base_dir\": \"${workspace}/work\",\n    \"default_profile\": \"\",\n    \"remote\": null,\n    \"agent_ids\": [\"lost-agent\"]\n  }],\n  \"agents\": [{\n    \"id\": \"lost-agent\",\n    \"display_id\": \"A1\",\n    \"repository_id\": \"repo\",\n    \"name\": \"Server Lost Agent\",\n    \"description\": \"\",\n    \"work_dir\": \"${workspace}/work\",\n    \"profile\": \"\",\n    \"mode_flags\": [],\n    \"pass_continue\": true,\n    \"sandbox_enabled\": false,\n    \"sandbox_engine\": \"podman\",\n    \"sandbox_flags\": \"\",\n    \"status\": \"ServerLost\",\n    \"runtime_binding\": null\n  }],\n  \"selected_repository_index\": 0,\n  \"selected_agent_index\": 0\n}\n"
+        },
+        "mode": 384
+      }
+    ],
+    "env": []
+  },
+  "steps": [
+    {
+      "op": "launch",
+      "argv": ["jefe", "--config", "${workspace}/config"],
+      "env": [],
+      "cwd": "work"
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Server Lost Agent",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "assert-frame",
+      "contains": ["LLxprt Jefe", "Server Lost Agent", "!"],
+      "absent": ["x Server Lost Agent"]
+    },
+    { "op": "finish" }
+  ],
+  "secrets": []
+}

--- a/dev-docs/tmux-scenarios/v1/issue493-server-loss.json
+++ b/dev-docs/tmux-scenarios/v1/issue493-server-loss.json
@@ -18,7 +18,7 @@
       {
         "path": "config/state.json",
         "content": {
-          "utf8": "{\n  \"schema_version\": 1,\n  \"repositories\": [{\n    \"id\": \"repo\",\n    \"name\": \"Repo\",\n    \"slug\": \"repo\",\n    \"base_dir\": \"${workspace}/work\",\n    \"default_profile\": \"\",\n    \"remote\": null,\n    \"agent_ids\": [\"lost-agent\"]\n  }],\n  \"agents\": [{\n    \"id\": \"lost-agent\",\n    \"display_id\": \"A1\",\n    \"repository_id\": \"repo\",\n    \"name\": \"Server Lost Agent\",\n    \"description\": \"\",\n    \"work_dir\": \"${workspace}/work\",\n    \"profile\": \"\",\n    \"mode_flags\": [],\n    \"pass_continue\": true,\n    \"sandbox_enabled\": false,\n    \"sandbox_engine\": \"podman\",\n    \"sandbox_flags\": \"\",\n    \"status\": \"ServerLost\",\n    \"runtime_binding\": null\n  }],\n  \"selected_repository_index\": 0,\n  \"selected_agent_index\": 0\n}\n"
+          "utf8": "{\n  \"schema_version\": 1,\n  \"repositories\": [{\n    \"id\": \"repo\",\n    \"name\": \"Repo\",\n    \"slug\": \"repo\",\n    \"base_dir\": \"${workspace}/work\",\n    \"default_profile\": \"\",\n    \"remote\": null,\n    \"agent_ids\": [\"lost-agent\"]\n  }],\n  \"agents\": [{\n    \"id\": \"lost-agent\",\n    \"display_id\": \"A1\",\n    \"repository_id\": \"repo\",\n    \"name\": \"Server Lost Agent\",\n    \"description\": \"\",\n    \"work_dir\": \"${workspace}/work\",\n    \"profile\": \"\",\n    \"mode_flags\": [],\n    \"pass_continue\": true,\n    \"sandbox_enabled\": false,\n    \"sandbox_engine\": \"podman\",\n    \"sandbox_flags\": \"\",\n    \"status\": \"ServerLost\",\n    \"runtime_binding\": {\n      \"session_name\": \"jefe-lost-agent\",\n      \"launch_signature\": {\n        \"work_dir\": \"${workspace}/work\",\n        \"profile\": \"\",\n        \"mode_flags\": [],\n        \"pass_continue\": true,\n        \"sandbox_enabled\": false,\n        \"sandbox_engine\": \"podman\",\n        \"sandbox_flags\": \"\"\n      },\n      \"attached\": false,\n      \"last_seen\": null,\n      \"pid\": null,\n      \"process_identity\": null,\n      \"lifecycle_generation\": 1\n    }\n  }],\n  \"selected_repository_index\": 0,\n  \"selected_agent_index\": 0\n}\n"
         },
         "mode": 384
       }
@@ -38,10 +38,23 @@
       "literal": "Server Lost Agent",
       "timeout_ms": 15000
     },
+    { "op": "key", "key": "l", "modifiers": [] },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Recover psmux Agents",
+      "timeout_ms": 15000
+    },
     {
       "op": "assert-frame",
-      "contains": ["LLxprt Jefe", "Server Lost Agent", "!"],
-      "absent": ["x Server Lost Agent"]
+      "contains": ["Recover psmux Agents", "Cancel", "Confirm"],
+      "absent": []
+    },
+    { "op": "key", "key": "esc", "modifiers": [] },
+    {
+      "op": "assert-frame",
+      "contains": ["Server Lost Agent", "!"],
+      "absent": ["Recover psmux Agents", "x Server Lost Agent"]
     },
     { "op": "finish" }
   ],

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -448,7 +448,7 @@ There is no event queue, no async event bus, no pub/sub. Events are processed in
 ### Compatibility
 
 - Requires a tmux-compatible multiplexer installed and resolvable on `PATH`:
-  upstream `tmux` on macOS/Linux, or native `psmux` (3.3.6+) on Windows.
+  upstream `tmux` on macOS/Linux, or native `psmux` (3.3.7+) on Windows.
 - Native Windows uses the ConPTY pseudo-console and psmux on a private
   `-L` namespace. WSL, Cygwin, MSYS2, Git Bash, and Docker tmux are rejected.
 - Requires `llxprt` (or configured agent CLI) installed and available on `PATH`.

--- a/docs/windows-support.md
+++ b/docs/windows-support.md
@@ -23,7 +23,7 @@ winget install --id marlocarlo.psmux --exact
 ```
 
 Jefe rejects tmux binaries resolved through WSL, Cygwin, MSYS2, Git Bash, or
-any other compatibility layer. Only native `psmux.exe` (minimum version 3.3.6)
+any other compatibility layer. Only native `psmux.exe` (minimum version 3.3.7)
 is accepted. If `psmux` is missing, too old, or resolved through a
 compatibility layer, `jefe doctor` reports the exact remediation command
 above.
@@ -77,6 +77,12 @@ Jefe stores settings and state under the platform default config directory
 against live psmux sessions: agents whose psmux session no longer exists are
 marked dead and can be relaunched. Persisted definitions survive restart;
 an in-flight process that no longer has a live psmux session cannot be restored.
+
+While Jefe is running, it also monitors the shared psmux server identity. If the
+server disappears or is replaced, affected agents are shown as **Server Lost**
+rather than individually dead. Jefe retains their runtime bindings and launch
+settings for deliberate recovery; it does not silently relaunch agents. The
+psmux panes themselves cannot survive an explicit `kill-server`.
 
 Relevant environment overrides:
 

--- a/project-plans/issue493-plan.md
+++ b/project-plans/issue493-plan.md
@@ -18,7 +18,7 @@ not conflict with this issue.
 
 The user delegated implementation-level choices after the issue's materially
 different architectures were identified. The following bounded decisions are
-therefore the accepted basis for Stack A and the planned Stack B:
+therefore the accepted basis for the unified issue delivery:
 
 1. **Explicit public state:** add `AgentStatus::ServerLost`. It is a transient,
    recoverable state, preserves `runtime_binding` and the runtime launch
@@ -36,11 +36,11 @@ therefore the accepted basis for Stack A and the planned Stack B:
    agent from retained runtime launch signatures. Successful agents become
    `Running`; failures remain `ServerLost`; a summary notice and detailed logs
    identify partial failure. No automatic relaunch occurs.
-4. **Bounded delivery:** use two stacked PRs if the complete diff would exceed
-   the target of 25 files or 1,500 net lines. The first PR owns observation,
-   classification, status, prevention, startup diagnostics, docs, and the
-   native regression. The second owns the user-confirmed batch-recovery flow.
-   The final PR closes #493 after both stacks pass.
+4. **Bounded delivery:** deliver one coherent issue PR after a mandatory scope
+   review. The complete diff is 33 files / 2,032 net lines including this plan:
+   above the preferred target, but below the 40-file / 2,500-line hard stop.
+   Every changed file maps to A1-A12; no dependency, workflow, quality-tool, or
+   unrelated subsystem change is included.
 
 Empirical capability evidence on the development host (psmux 3.3.7) before
 implementation:
@@ -249,48 +249,37 @@ states in A8.
 **Stop:** automatic relaunch, retry scheduler, parallel task subsystem, changes
 to `MAX_DEAD_SIGNATURES`, or recovery behavior for agents not in `ServerLost`.
 
-## Delivery split and expected path budget
+## Unified delivery and actual path budget
 
-### Stack A — observation, status, prevention, diagnostics
+The single issue branch contains three independently green commits:
 
-Expected 14-18 files, approximately 850-1,200 net lines:
+- server observation, classification, `ServerLost`, retention, and regression
+  coverage;
+- non-blocking startup diagnostics, documentation, and the scope ledger;
+- explicit confirmed batch recovery, cancellation, retryable partial failures,
+  and UI/TUI behavior.
 
-- plan;
-- runtime server-health/liveness/multiplexer modules and tests;
-- direct app-shell liveness extraction;
-- domain/status, runtime message/reducer/projection/display matches;
-- app-init tests;
-- Windows docs;
-- real-psmux regression and visible-status TUI scenario.
-
-### Stack B — confirmed batch recovery
-
-Expected 8-12 files, approximately 450-750 net lines:
-
-- recovery modal/message/state/input/runtime orchestration;
-- keybind/help discoverability;
-- focused reducer/orchestration tests;
-- TUI and real-psmux scenario completion.
-
-Each PR independently targets no more than 25 files / 1,500 net lines. A
-mandatory scope review occurs before crossing either target. Work stops without
-explicit approval above 40 files or 2,500 net lines in either PR. If both stacks
-fit under the target as one coherent diff, a single PR is permitted only after
-a recorded scope review confirms every file maps to A1-A12.
+Actual unified scope is 33 files / 2,032 net lines. The required plan contributes
+353 lines; production, tests, scenarios, and docs contribute the remainder. The
+mandatory above-target scope review confirmed every file maps to A1-A12 and the
+change remains below both hard-stop thresholds. No additional work is authorized
+without a new acceptance row.
 
 ## Scope ledger
 
 | Date | Discovery / proposed change | Acceptance mapping | Disposition |
 |---|---|---|---|
-| 2026-07-28 | Add public `AgentStatus::ServerLost` and public typed server observation | A3-A6, A8-A10 | Accepted; Stack A implemented |
-| 2026-07-28 | Choose periodic PID-pinned observer plus `exit-empty off`, not persistent control client | A3, A5, A7, A10-A11 | Accepted; Stack A implemented |
-| 2026-07-28 | Choose user-confirmed best-effort batch relaunch, not automatic relaunch | A8-A9, A11 | Accepted for Stack B; not implemented in Stack A |
-| 2026-07-28 | Extract only the liveness future because `src/app_shell.rs` was 997 lines | A3-A6 | In-scope; reduced `app_shell.rs` to 878 lines |
+| 2026-07-28 | Add public `AgentStatus::ServerLost` and public typed server observation | A3-A6, A8-A10 | Accepted and implemented |
+| 2026-07-28 | Choose periodic PID-pinned observer plus `exit-empty off`, not persistent control client | A3, A5, A7, A10-A11 | Accepted and implemented |
+| 2026-07-28 | Choose user-confirmed best-effort batch relaunch, not automatic relaunch | A8-A9, A11 | Accepted and implemented |
+| 2026-07-28 | Extract only the liveness future because `src/app_shell.rs` was 997 lines | A3-A6 | In-scope; reduced `app_shell.rs` below the hard limit |
 | 2026-07-28 | Installed psmux 3.3.7 exposes server PID/version and supports `exit-empty off` in an isolated probe | A2, A5, A7 | Verified capability; no repository change |
 | 2026-07-28 | Namespace randomization would break cross-instance sharing | Non-goal | Reject for #493; separate decision/follow-up only |
 | 2026-07-28 | Liveness `catch_unwind` hardening is adjacent | Non-goal | Defer; do not implement in #493 |
-| 2026-07-28 | Stack A scope measured at 21 files / 1,570 net lines including this 333-line plan | A1-A7, A10-A12 | Mandatory scope review complete: implementation is 1,237 net lines excluding the required plan; below 25 files and far below hard stop |
+| 2026-07-28 | Unified scope measured at 33 files / 2,032 net lines including this plan | A1-A12 | Mandatory scope review complete: every path maps to acceptance; below 40 files / 2,500 lines hard stop |
 | 2026-07-28 | Schema-1 visible-status scenario cannot execute on native Windows (`HAR-E005`) | A11 | Scenario fixture added and syntax/build path validated; native diagnosis is proven by real-psmux test; execute TUI fixture on Unix CI |
+| 2026-07-28 | Two local branches added avoidable delivery complexity | Delivery only | Corrected before push: recovery commit fast-forwarded onto `issue493`; extra local branch deleted; one PR planned |
+| 2026-07-28 | `origin/main` advanced during implementation | Delivery ancestry | Unified branch rebased cleanly; directly descends from `db042d4`; exact-head gates rerun |
 
 Every changed file must be added to this ledger or map to an allowed path in a
 slice. Reviewer suggestions do not authorize expansion.
@@ -309,17 +298,17 @@ Every finding will be recorded below as **Blocker-Fix**, **In-scope-Fix**,
 
 | Candidate / slice | Command or scenario | Result |
 |---|---|---|
-| Planning baseline | `git fetch origin main`; `main...origin/main` | 0 ahead / 0 behind |
+| Delivery baseline | `git fetch origin main`; `origin/main...issue493` | 0 behind / 3 commits ahead; direct ancestry from `db042d4` |
 | Capability probe | isolated psmux 3.3.7 `display-message`, `show-options`, `set-option`; owned `kill-server` cleanup | Pass |
 | Slice 1 RED | `cargo test --test runtime_server_health` before production contract | Failed as expected: unresolved `ServerHealth`, `ServerIdentity`, and classifier |
 | Focused GREEN | runtime server health (20), app-shell liveness (4), durable projection (1) | Pass |
-| `cargo xtask quick` | Initial native-Windows run lacked Unix `true`/`false`; rerun with existing Git-for-Windows shims on `PATH` | Pass: 2,506 lib + 801 bin tests and all integration targets |
+| `cargo xtask quick` | Native-Windows run with existing Git-for-Windows shims on `PATH` | Pass |
 | `JEFE_REQUIRE_PSMUX=1 cargo test --features psmux-smoke --test psmux_server_loss -- --nocapture` | Isolated namespace: Healthy, once-per-identity option, Gone, Replaced | Pass: 1/1 |
 | Schema-1 TUI scenario | `target/debug/tmux_scenario --scenario dev-docs/tmux-scenarios/v1/issue493-server-loss.json` | Not executable on win32: expected `HAR-E005` Unix-PTY requirement; fixture retained for Unix CI |
-| Exact local gates | fmt, strict Clippy, locked all-feature build/test; Git-for-Windows shims on `PATH` for three existing Unix-command fixtures | Pass |
+| Exact local gates after rebase | fmt, strict Clippy, locked all-feature build, serial locked all-feature test; Git-for-Windows shims on `PATH` | Pass: 2,511 lib + 810 bin tests and all integration/doctest targets |
 | Source-size policy | `cargo xtask check source-size` | Pass; only existing advisory warnings, changed files below hard limit |
 | Required CI exact candidate head | Pending after PR |
-| Ancestry / conflict check | Pending before each PR | Not run |
+| Ancestry / conflict check | Unified `issue493` based directly on current `origin/main`; no PR exists yet | Pass locally; remote conflict status pending PR |
 
 ## Review findings and deferred follow-ups
 
@@ -338,9 +327,17 @@ Local OCR #1 findings and dispositions:
 - **In-scope-Fix — resolved:** stale/no-op server-loss cycles staged unnecessary
   saves; saves now occur only after at least one transition.
 
-Local OCR #2 reported zero Blocker-Fix or In-scope-Fix findings and judged Stack A
-coherent. The running-server startup version refinement and confirmed batch
-recovery remain accepted Stack B work, not optional expansion of this checkpoint.
+Local OCR #2 reviewed confirmed batch recovery. Its findings were dispositioned:
+
+- **In-scope-Fix — resolved:** clarified that `ServerLost` preserves the runtime
+  manager record and recovery intentionally moves that exact signature into the
+  retained cache before relaunch.
+- **In-scope-Fix — resolved:** recovery summaries now preserve and combine any
+  runtime warning rather than clobbering it or leaving competing message slots.
+- **Reject:** direct failure-path attachment mutation, stale modal candidates,
+  lock ordering, and modal-clear timing were verified as correct.
+- **Defer:** broader stub-manager enrichment and unrelated retry infrastructure.
+
 Namespace randomization and liveness-future panic containment remain explicit
 non-goals.
 

--- a/project-plans/issue493-plan.md
+++ b/project-plans/issue493-plan.md
@@ -1,0 +1,353 @@
+# Issue #493 — Detect and recover from native-Windows psmux server loss
+
+## Problem
+
+On native Windows, all local agents share one stable per-user/per-host psmux
+namespace. If that psmux server exits while Jefe remains alive, every pane and
+worker hosted by that server is lost together. The current liveness path fails
+open when `list-sessions` itself fails, but it can treat a replacement server's
+successful empty inventory as proof that every individual agent died. The app
+then marks all affected agents `Dead`, clears their bindings, and loses the
+information needed for deliberate batch recovery.
+
+Issue #467 made healthy Windows sessions independent of the rebuildable Jefe
+image. It did not make psmux server state survive server termination and does
+not conflict with this issue.
+
+## Accepted implementation decisions
+
+The user delegated implementation-level choices after the issue's materially
+different architectures were identified. The following bounded decisions are
+therefore the accepted basis for Stack A and the planned Stack B:
+
+1. **Explicit public state:** add `AgentStatus::ServerLost`. It is a transient,
+   recoverable state, preserves `runtime_binding` and the runtime launch
+   signature, renders as a red/error status, and projects to
+   `LastKnownRuntime::Running` rather than `Stopped`. This requires approving a
+   public domain-enum change and a small public runtime server-observation
+   contract.
+2. **No persistent client subsystem:** reuse the existing two-second liveness
+   observer as a PID-pinned watchdog. On Windows it probes
+   `display-message -p "#{pid}|#{version}"` and applies the capability-verified
+   server option `set-option -s exit-empty off` once per observed server
+   identity. No long-lived control-client child process is added.
+3. **Explicit recovery, never automatic:** show a confirmation action after
+   server loss. On confirmation, relaunch every currently `ServerLost` local
+   agent from retained runtime launch signatures. Successful agents become
+   `Running`; failures remain `ServerLost`; a summary notice and detailed logs
+   identify partial failure. No automatic relaunch occurs.
+4. **Bounded delivery:** use two stacked PRs if the complete diff would exceed
+   the target of 25 files or 1,500 net lines. The first PR owns observation,
+   classification, status, prevention, startup diagnostics, docs, and the
+   native regression. The second owns the user-confirmed batch-recovery flow.
+   The final PR closes #493 after both stacks pass.
+
+Empirical capability evidence on the development host (psmux 3.3.7) before
+implementation:
+
+- `display-message -p '#{pid}|#{version}'` returned the server PID and `3.3.7`;
+- `show-options -s exit-empty` returned `exit-empty on`;
+- `set-option -s exit-empty off` succeeded;
+- all probes used a unique `jefe-issue493-*-probe` namespace and cleanup killed
+  only that disposable server.
+
+A persistent client or `exit-empty off` cannot preserve sessions after an
+explicit `kill-server`: the server and its in-memory panes are already gone.
+The accepted behavior is prevention of idle exit where supported, prompt
+server-identity diagnosis, retention of recovery metadata, and deliberate
+recreation—not transparent survival.
+
+## Acceptance matrix
+
+| ID | Actor / launch path | Input and boundary | Target | Observable success | Failure and diagnostic | Side effects permitted before failure | Persistence / compatibility | Behavioral proof |
+|---|---|---|---|---|---|---|---|---|
+| A1 | App startup dependency probe | Windows, no psmux server; executable present at 3.3.7+ | Local Windows | Executable preflight succeeds without creating a server or changing agent state | Missing, malformed, or <3.3.7 executable produces one user-visible warning and a structured log naming resolved executable, detected/minimum version where known, and remediation | Read-only `psmux -V`; no server/session creation or state write | Existing state remains loaded; startup remains usable for diagnostics | Pure preflight-result test plus native no-server probe |
+| A2 | App startup server probe | Windows, existing psmux server below 3.3.7 or server probe unavailable | Local Windows | Existing supported server identity/version is logged; no session is disturbed | Unsupported server version produces a user-visible warning; unavailable server is informational when no running local binding needs it | Read-only server probe only | Live bindings and sessions are retained; no schema change | Startup diagnostic reducer test and isolated psmux probe |
+| A3 | Periodic liveness | Same observed server identity; all tracked sessions/panes present | Local Windows | All agents remain `Running`; existing two-second cadence and bounded subprocess behavior remain responsive | Probe failure is logged and fails open for that cycle | Read-only queries; no agent mutation | No durable write for no-op cycles | Pure server-observation classification and app-shell integration test |
+| A4 | Periodic liveness | Previously observed server is unavailable while one or more local agents are `Running` | Local Windows | Result is `ServerGone`; every affected agent becomes `ServerLost`; bindings and launch signatures remain available; no agent becomes `Dead` | Warning contains executable, version if known, namespace, prior server PID/identity, command/status/stderr, and affected count/IDs using existing redaction rules | Status transition and one coalesced durable projection; no relaunch, kill, or binding clear | `ServerLost` projects as last-known running; persisted schema version remains unchanged | Pure classifier test, state transition test, app-shell test, real-psmux regression |
+| A5 | Periodic liveness | Current server identity differs from the pinned identity, whether its inventory is empty or contains unrelated sessions | Local Windows | Result is `ServerReplaced`; agents bound to the prior server become `ServerLost`, preserving bindings/signatures; replacement server sessions are not treated as the old sessions | Same structured warning as A4 with prior/current PID and creation identity | Status transition only; no session mutation | Same as A4 | Pure PID/creation-token replacement matrix and real-psmux replacement regression |
+| A6 | Periodic liveness | Same server identity; one target session is missing or has no live pane while peers remain healthy | Local Windows and existing Unix behavior | Existing per-agent death path runs only for that target: preview captured where possible, status `Dead`, binding cleared, dead signature retained | Existing session-scoped liveness diagnostics | Existing per-agent mutation/save only | Existing persistence behavior unchanged | Regression proving same-server individual death remains `Dead` and peers remain `Running` |
+| A7 | Windows server retention | First observation of each supported psmux server identity | Local Windows | Jefe applies `exit-empty off` once for that identity; periodic PID observation detects later loss/replacement | Unsupported option or command failure is capability-classified, logged, and does not crash or mark agents dead | One namespace-scoped `set-option`; no persistent child and no retry storm | Runtime-only identity cache; no schema change | Pure once-per-identity planner test and isolated native psmux option test |
+| A8 | Recovery action | One or more `ServerLost` agents; user opens and confirms batch recovery | Local Windows | Jefe recreates each affected session from its retained signature; successes receive fresh bindings and become `Running`; failures remain `ServerLost`; unrelated agents/sessions are untouched | Confirmation/result notice reports success/failure counts; per-agent typed runtime logs include agent/session and operation | Only confirmed affected sessions may be recreated; best-effort batch continues after an individual failure | Existing launch signature and binding formats remain compatible; one coalesced save after final reducer results | TUI scenario first, reducer/message tests, manager batch integration test, real-psmux kill-and-recover regression |
+| A9 | Recovery cancellation/retry | Recovery prompt canceled, stale confirmation, no affected agents, or partial prior failure | Local Windows | Cancel performs no runtime action; stale/no-op request is rejected deterministically; a later explicit action retries only agents still `ServerLost` | User-visible no-op/stale or partial-failure notice; detailed logs at runtime boundary | None before valid confirmation; retry touches only still-affected agents | Bindings/signatures remain retained | Pure reducer tests and orchestration stale-result test |
+| A10 | Unix liveness and launch | tmux on macOS/Linux, including missing individual session | Local Unix | Current liveness, namespace, startup, and relaunch behavior is unchanged | Existing diagnostics remain | No Windows server option/probe path executes | Existing persisted state unchanged | Unix structural command tests and existing full suite |
+| A11 | Native end-to-end regression | Isolated namespace, at least two long-running sessions, explicit server termination, bounded wait, confirmed recovery | Native Windows / psmux 3.3.7+ | Server loss is diagnosed within the accepted poll bound; agents are never mass-marked `Dead`; bindings/signatures remain; confirmed batch relaunch creates live replacement sessions; bystander namespace is untouched | Retained transcript identifies namespace, server PID/version, commands, statuses, stderr, agent/session IDs, and cleanup result | Test may kill only its unique owned namespace and must clean all created sessions/processes | No production namespace or user state touched | Feature-gated `psmux-smoke` integration target plus schema-1 TUI scenario for visible status/recovery |
+| A12 | Documentation user | Windows installation and troubleshooting | Docs | Public docs consistently require psmux 3.3.7+ and explain Server Lost/recovery semantics | N/A | Documentation only | No compatibility change | Focused text assertion/review plus docs build checks in normal gates |
+
+## Explicit non-goals
+
+- Preserving an existing psmux pane or worker after an explicit `kill-server`;
+  recovery creates replacements from retained signatures.
+- Automatically relaunching agents without a user confirmation.
+- Adding a persistent psmux control client, daemon, service, new timeout loop,
+  or separate process supervisor.
+- Randomizing the stable host/user namespace or changing cross-instance session
+  sharing; that is a separate architectural decision.
+- Preventing a fully privileged agent shell from invoking psmux or killing
+  processes; Jefe detects and recovers from the resulting server loss.
+- Proving whether the historical trigger was idle exit, RDP teardown, AV/EDR,
+  or an agent-issued psmux command. Diagnostics are added for future evidence.
+- Recovering after Jefe itself exits between observing server loss and the user
+  confirming recovery; issue #493 is the mid-run path while Jefe remains alive.
+- Reattaching to arbitrary orphaned Bun/Node processes after their PTY server is
+  gone.
+- Changing remote-agent ownership, liveness, relaunch, or persistence.
+- Changing Unix/tmux server options or lifecycle behavior.
+- Catch-unwind hardening for the liveness future, broad runtime cleanup, or
+  unrelated test relocation.
+- Dependency, workflow, `.github/`, `.code_puppy/`, `.llxprt/`, quality-gate,
+  lint-policy, or threshold changes.
+
+## Bounded vertical slices
+
+### Slice 1 — RED server-loss contracts and scenarios
+
+**Rows:** A3-A6, A8-A11.
+
+**Owner / boundary:** deterministic runtime observation contract plus existing
+native psmux and schema-1 TUI harness boundaries.
+
+**Allowed paths:**
+
+- `project-plans/issue493-plan.md`
+- `src/runtime/server_health.rs` (new only after public-contract approval)
+- `tests/runtime_server_health.rs` or focused module tests
+- `tests/psmux_server_loss.rs`
+- `dev-docs/tmux-scenarios/v1/issue493-server-loss.json`
+- existing harness documentation only if needed to register the scenario
+
+**RED:** create/update the TUI scenario first and prove the visible
+server-loss/recovery expectation fails. Add pure classification cases for
+unavailable server, replaced identity, same-server individual death, probe
+failure, and stale observations. Add a real-psmux regression that fails because
+current code cannot retain/recover affected bindings.
+
+**GREEN:** tests compile against the smallest typed contract; production remains
+unchanged until the RED reason is recorded in Verification Evidence.
+
+**Stop:** if the existing schema-1 grammar cannot express the scenario without a
+new harness command or quality/workflow change, stop for approval rather than
+extending the harness.
+
+### Slice 2 — Server observation, diagnostics, and `ServerLost`
+
+**Rows:** A3-A6, A10.
+
+**Owner / boundary:** runtime performs psmux I/O; pure classification returns a
+typed observation; app-shell applies generation-checked typed state messages.
+
+**Allowed paths:**
+
+- `src/runtime/server_health.rs`
+- `src/runtime/liveness.rs`
+- `src/runtime/mod.rs`
+- `src/app_shell_liveness.rs` (new, direct extraction required because
+  `src/app_shell.rs` is already 997 lines)
+- `src/app_shell.rs`
+- `src/domain/mod.rs`
+- `src/messages.rs` / existing smallest runtime message module
+- `src/state/runtime_ops.rs`
+- `src/state/durable_projection.rs`
+- `src/state/terminal_manager_types.rs`
+- `src/ui/components/agent_list.rs` and focused existing tests
+
+**RED:** pure and reducer tests prove A3-A6 fail on current main. In particular,
+a successful empty inventory from a changed server identity must not enter
+`reconcile_dead_agents_with_identity`.
+
+**GREEN:** `ServerGone`/`ServerReplaced` are generation-checked server-wide
+observations; affected agents become `ServerLost`; only `Healthy` same-server
+observations can generate per-agent `Dead` identities.
+
+**Refactor:** move only the directly touched liveness future out of the
+near-limit `app_shell.rs`; do not move unrelated tests or observers.
+
+**Stop:** any need for a second state store, schema-version change, process
+enumerator, or unrelated app-shell refactor.
+
+### Slice 3 — Windows PID-pinned retention
+
+**Rows:** A3, A5, A7, A10-A11.
+
+**Owner / boundary:** Windows psmux command planning/execution in runtime; pure
+once-per-server-identity decision state in the liveness observer.
+
+**Allowed paths:**
+
+- `src/runtime/server_health.rs`
+- `src/runtime/multiplexer.rs`
+- `src/runtime/liveness.rs`
+- `src/app_shell_liveness.rs`
+- focused runtime/native psmux tests
+
+**RED:** command-shape tests require structured `display-message` and
+namespace-scoped `set-option -s exit-empty off`; state tests require one option
+application per identity and reapplication after replacement.
+
+**GREEN:** the existing observer performs bounded periodic identity checks and
+applies the option once per supported server. Failures are typed/fail-open and
+never trigger per-agent death.
+
+**Stop:** any persistent child/control connection, new process manager, new
+background loop, dependency, unsafe code, or unbounded retry.
+
+### Slice 4 — Startup version diagnostics and docs
+
+**Rows:** A1-A2, A12.
+
+**Owner / boundary:** existing multiplexer preflight and app initialization;
+public Windows documentation.
+
+**Allowed paths:**
+
+- `src/app_init.rs` and existing focused app-init tests
+- `src/runtime/multiplexer.rs` only if server-version parsing cannot live in the
+  approved server-health module
+- `docs/windows-support.md`
+- `docs/technical-overview.md`
+
+**RED:** tests prove executable/server <3.3.7 yields a non-blocking startup
+warning without creating/killing a server or clearing bindings; docs assertion
+fails on the current 3.3.6 claims.
+
+**GREEN:** startup checks the installed executable and any already-running
+server best-effort, surfaces one actionable warning, and docs consistently state
+3.3.7+.
+
+**Stop:** blocking app startup, modifying doctor architecture, or probing a
+server in a way that creates one.
+
+### Slice 5 — User-confirmed batch recovery
+
+**Rows:** A8-A9, A11.
+
+**Owner / boundary:** UI emits intent; state/reducer owns confirmation and stale
+request semantics; app-input orchestration invokes a typed runtime batch
+operation; runtime recreates only affected sessions.
+
+**Allowed paths:**
+
+- `src/state/types.rs` / focused recovery state module
+- `src/state/modal_ops.rs` and focused tests
+- `src/messages.rs` / event conversion
+- `src/app_input/agent_runtime.rs` and focused tests
+- `src/runtime/manager.rs` or a focused manager recovery module
+- `src/ui/orchestration.rs`
+- `src/ui/modals/confirm.rs` only if the existing generic modal cannot render
+  the approved variant without change
+- `src/ui/components/keybind_bar.rs` and help text for discoverability
+- the Slice 1 TUI/native scenarios
+
+**RED:** the TUI scenario is updated first for prompt, cancel, confirm, partial
+failure, and successful summary; reducer/runtime tests prove no automatic action
+and no loss of failed signatures.
+
+**GREEN:** confirmation dispatches one generation/correlation-guarded batch;
+results reduce deterministically; successful and failed agents receive the
+states in A8.
+
+**Stop:** automatic relaunch, retry scheduler, parallel task subsystem, changes
+to `MAX_DEAD_SIGNATURES`, or recovery behavior for agents not in `ServerLost`.
+
+## Delivery split and expected path budget
+
+### Stack A — observation, status, prevention, diagnostics
+
+Expected 14-18 files, approximately 850-1,200 net lines:
+
+- plan;
+- runtime server-health/liveness/multiplexer modules and tests;
+- direct app-shell liveness extraction;
+- domain/status, runtime message/reducer/projection/display matches;
+- app-init tests;
+- Windows docs;
+- real-psmux regression and visible-status TUI scenario.
+
+### Stack B — confirmed batch recovery
+
+Expected 8-12 files, approximately 450-750 net lines:
+
+- recovery modal/message/state/input/runtime orchestration;
+- keybind/help discoverability;
+- focused reducer/orchestration tests;
+- TUI and real-psmux scenario completion.
+
+Each PR independently targets no more than 25 files / 1,500 net lines. A
+mandatory scope review occurs before crossing either target. Work stops without
+explicit approval above 40 files or 2,500 net lines in either PR. If both stacks
+fit under the target as one coherent diff, a single PR is permitted only after
+a recorded scope review confirms every file maps to A1-A12.
+
+## Scope ledger
+
+| Date | Discovery / proposed change | Acceptance mapping | Disposition |
+|---|---|---|---|
+| 2026-07-28 | Add public `AgentStatus::ServerLost` and public typed server observation | A3-A6, A8-A10 | Accepted; Stack A implemented |
+| 2026-07-28 | Choose periodic PID-pinned observer plus `exit-empty off`, not persistent control client | A3, A5, A7, A10-A11 | Accepted; Stack A implemented |
+| 2026-07-28 | Choose user-confirmed best-effort batch relaunch, not automatic relaunch | A8-A9, A11 | Accepted for Stack B; not implemented in Stack A |
+| 2026-07-28 | Extract only the liveness future because `src/app_shell.rs` was 997 lines | A3-A6 | In-scope; reduced `app_shell.rs` to 878 lines |
+| 2026-07-28 | Installed psmux 3.3.7 exposes server PID/version and supports `exit-empty off` in an isolated probe | A2, A5, A7 | Verified capability; no repository change |
+| 2026-07-28 | Namespace randomization would break cross-instance sharing | Non-goal | Reject for #493; separate decision/follow-up only |
+| 2026-07-28 | Liveness `catch_unwind` hardening is adjacent | Non-goal | Defer; do not implement in #493 |
+| 2026-07-28 | Stack A scope measured at 21 files / 1,570 net lines including this 333-line plan | A1-A7, A10-A12 | Mandatory scope review complete: implementation is 1,237 net lines excluding the required plan; below 25 files and far below hard stop |
+| 2026-07-28 | Schema-1 visible-status scenario cannot execute on native Windows (`HAR-E005`) | A11 | Scenario fixture added and syntax/build path validated; native diagnosis is proven by real-psmux test; execute TUI fixture on Unix CI |
+
+Every changed file must be added to this ledger or map to an allowed path in a
+slice. Reviewer suggestions do not authorize expansion.
+
+## Review counters
+
+| Review phase | Used | Cap |
+|---|---:|---:|
+| Local Open Code Review | 2 | 2 |
+| Post-PR Open Code Review | 0 | 2 |
+
+Every finding will be recorded below as **Blocker-Fix**, **In-scope-Fix**,
+**Reject**, or **Defer** before code changes are made.
+
+## Verification evidence
+
+| Candidate / slice | Command or scenario | Result |
+|---|---|---|
+| Planning baseline | `git fetch origin main`; `main...origin/main` | 0 ahead / 0 behind |
+| Capability probe | isolated psmux 3.3.7 `display-message`, `show-options`, `set-option`; owned `kill-server` cleanup | Pass |
+| Slice 1 RED | `cargo test --test runtime_server_health` before production contract | Failed as expected: unresolved `ServerHealth`, `ServerIdentity`, and classifier |
+| Focused GREEN | runtime server health (20), app-shell liveness (4), durable projection (1) | Pass |
+| `cargo xtask quick` | Initial native-Windows run lacked Unix `true`/`false`; rerun with existing Git-for-Windows shims on `PATH` | Pass: 2,506 lib + 801 bin tests and all integration targets |
+| `JEFE_REQUIRE_PSMUX=1 cargo test --features psmux-smoke --test psmux_server_loss -- --nocapture` | Isolated namespace: Healthy, once-per-identity option, Gone, Replaced | Pass: 1/1 |
+| Schema-1 TUI scenario | `target/debug/tmux_scenario --scenario dev-docs/tmux-scenarios/v1/issue493-server-loss.json` | Not executable on win32: expected `HAR-E005` Unix-PTY requirement; fixture retained for Unix CI |
+| Exact local gates | fmt, strict Clippy, locked all-feature build/test; Git-for-Windows shims on `PATH` for three existing Unix-command fixtures | Pass |
+| Source-size policy | `cargo xtask check source-size` | Pass; only existing advisory warnings, changed files below hard limit |
+| Required CI exact candidate head | Pending after PR |
+| Ancestry / conflict check | Pending before each PR | Not run |
+
+## Review findings and deferred follow-ups
+
+Local OCR #1 findings and dispositions:
+
+- **Blocker-Fix — resolved:** missing native diagnosis evidence; added
+  `tests/psmux_server_loss.rs` with an isolated owned namespace.
+- **Blocker-Fix — resolved:** binding-preservation test directly assigned status;
+  replaced with a reducer-driven transition assertion.
+- **In-scope-Fix — resolved:** identity-capture failure could compare a synthetic
+  creation token; the I/O boundary now fails open as `Unavailable`.
+- **In-scope-Fix — resolved:** stale liveness results could transition a rebound
+  agent; session name, generation, and current `Running` status are revalidated.
+- **In-scope-Fix — resolved:** `ServerLost` agents could re-enter individual Dead
+  reconciliation; only currently `Running` targets are reconciled.
+- **In-scope-Fix — resolved:** stale/no-op server-loss cycles staged unnecessary
+  saves; saves now occur only after at least one transition.
+
+Local OCR #2 reported zero Blocker-Fix or In-scope-Fix findings and judged Stack A
+coherent. The running-server startup version refinement and confirmed batch
+recovery remain accepted Stack B work, not optional expansion of this checkpoint.
+Namespace randomization and liveness-future panic containment remain explicit
+non-goals.
+
+## Completion conditions
+
+Stop successfully only after A1-A12 each have behavioral evidence, exact-head
+local and required CI gates pass, review output is fully classified and all
+Blocker-Fix/In-scope-Fix findings are resolved, ancestry is correct, the final
+PR is conflict-free, and the scope ledger contains no unapproved change. Do not
+continue optional hardening after those conditions are met.

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -15,6 +15,8 @@ use jefe::domain::{
     SandboxEngine,
 };
 use jefe::persistence::{PersistenceManager, Settings};
+#[cfg(windows)]
+use jefe::runtime::MultiplexerPlan;
 use jefe::runtime::{
     ProcessLiveness, RuntimeError, RuntimeManager, RuntimeSession, TmuxRuntimeManager, pid_alive,
     platform_engine_diagnostic, process_liveness, process_liveness_indicates_alive,
@@ -36,6 +38,31 @@ fn append_warning(state: &mut AppState, warning: String) {
         Some(existing) => format!("{existing} {warning}"),
         None => warning,
     });
+}
+fn apply_startup_warning(state: &mut AppState, warning: Option<String>) {
+    if let Some(warning) = warning {
+        append_warning(state, warning);
+    }
+}
+
+#[cfg(windows)]
+fn windows_multiplexer_startup_warning() -> Option<String> {
+    let result = MultiplexerPlan::current().and_then(|plan| plan.preflight(&[]));
+    match result {
+        Ok(version) => {
+            tracing::info!(%version, "native Windows multiplexer preflight succeeded");
+            None
+        }
+        Err(error) => {
+            warn!(error = %error, "native Windows multiplexer preflight failed");
+            Some(format!("psmux preflight warning: {error}"))
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn windows_multiplexer_startup_warning() -> Option<String> {
+    None
 }
 
 /// Run the issue #467 AC8 startup session-host cleanup.
@@ -255,6 +282,7 @@ fn process_liveness_for_binding(
 /// Reconciles any agents that were persisted as Running against actual live
 /// tmux sessions, marking stale ones Dead.  Also activates the saved theme.
 pub fn init_app_state(app_state: &mut HookState<AppState>, ctx: &SharedContext) {
+    let multiplexer_warning = windows_multiplexer_startup_warning();
     let Some(ctx_arc) = ctx else {
         return;
     };
@@ -296,6 +324,7 @@ pub fn init_app_state(app_state: &mut HookState<AppState>, ctx: &SharedContext) 
     state.terminal_focused =
         persisted.terminal_focused && state.pane_focus == jefe::state::PaneFocus::Terminal;
     state.user_preferences = persisted.user_preferences;
+    apply_startup_warning(&mut state, multiplexer_warning);
     // Mirror the persisted "apply jefe theme to agent" toggle (issue #179).
     // settings.toml is the source of truth; this runtime copy is read every
     // render frame by the terminal view.

--- a/src/app_input/modal_handlers.rs
+++ b/src/app_input/modal_handlers.rs
@@ -162,6 +162,9 @@ fn handle_confirm_enter(app_state: &mut AppStateHandle, ctx: &SharedContext) {
         ModalState::ConfirmDeleteRepository { id, .. } => {
             confirm_delete_repository(app_state, ctx, id);
         }
+        ModalState::ConfirmServerLostRecovery { agent_ids, .. } => {
+            super::relaunch::dispatch_server_lost_recovery(app_state, ctx, agent_ids);
+        }
         ModalState::PreflightPrompt {
             agent_id,
             signature,
@@ -204,6 +207,7 @@ pub(super) fn confirm_focus_is_cancel(modal: &ModalState) -> bool {
         ModalState::ConfirmDeleteAgent { confirm_focus, .. }
         | ModalState::ConfirmDeleteRepository { confirm_focus, .. }
         | ModalState::ConfirmKillAgent { confirm_focus, .. }
+        | ModalState::ConfirmServerLostRecovery { confirm_focus, .. }
         | ModalState::PreflightPrompt { confirm_focus, .. }
         | ModalState::ConfirmIssueDirtyCopy { confirm_focus, .. }
         | ModalState::ConfirmIssueOriginMismatch { confirm_focus, .. } => {

--- a/src/app_input/modal_handlers_tests.rs
+++ b/src/app_input/modal_handlers_tests.rs
@@ -50,6 +50,10 @@ fn sample_confirm_modals(focus: ConfirmFocus) -> Vec<ModalState> {
             id: AgentId("a1".into()),
             confirm_focus: focus,
         },
+        ModalState::ConfirmServerLostRecovery {
+            agent_ids: vec![AgentId("a1".into())],
+            confirm_focus: focus,
+        },
         ModalState::PreflightPrompt {
             agent_id: AgentId("a1".into()),
             signature: sample_signature(),

--- a/src/app_input/relaunch.rs
+++ b/src/app_input/relaunch.rs
@@ -268,11 +268,14 @@ fn recover_server_lost_runtime(
     })?;
     // The ServerLost state deliberately preserves the manager's live record.
     // Move that exact signature to its retained cache before recreating it.
-    let _ = ctx_guard.runtime.mark_session_dead(agent_id);
+    if !ctx_guard.runtime.mark_session_dead(agent_id) {
+        warn!(agent_id = %agent_id.0, "psmux recovery: manager session record was already absent");
+    }
     ctx_guard.runtime.relaunch(agent_id)?;
-    std::thread::sleep(REMOTE_ATTACH_SETTLE_DELAY);
     if let Err(error) = ctx_guard.runtime.attach(agent_id) {
-        let _ = ctx_guard.runtime.mark_session_dead(agent_id);
+        if !ctx_guard.runtime.mark_session_dead(agent_id) {
+            warn!(agent_id = %agent_id.0, "psmux recovery: relaunched session record was absent after attach failure");
+        }
         drop(ctx_guard);
         return Err(error);
     }
@@ -320,10 +323,14 @@ pub(super) fn apply_server_lost_recovery_outcomes(
             failures = failures.saturating_add(1);
         }
     }
+    let recovered_noun = if successes == 1 { "agent" } else { "agents" };
+    let failed_verb = if failures == 1 { "remains" } else { "remain" };
     let summary = if failures == 0 {
-        format!("Recovered {successes} psmux agent(s).")
+        format!("Recovered {successes} psmux {recovered_noun}.")
     } else {
-        format!("Recovered {successes} psmux agent(s); {failures} failed and remain Server Lost.")
+        format!(
+            "Recovered {successes} psmux {recovered_noun}; {failures} failed and {failed_verb} Server Lost."
+        )
     };
     let message = state
         .warning_message

--- a/src/app_input/relaunch.rs
+++ b/src/app_input/relaunch.rs
@@ -2,9 +2,9 @@
 
 use std::path::Path;
 
-use jefe::domain::{AgentId, LaunchSignature, ProcessIdentity};
+use jefe::domain::{AgentId, AgentStatus, LaunchSignature, ProcessIdentity};
 use jefe::runtime::{RuntimeError, RuntimeManager, sandbox_ssh_agent_warning};
-use jefe::state::{AppEvent, AppState, PaneFocus};
+use jefe::state::{AppEvent, AppState, ConfirmFocus, ModalState, PaneFocus};
 use tracing::warn;
 
 use super::agent_runtime::{
@@ -16,11 +16,21 @@ use super::{
     durable_save_request, preflight_or_prompt, schedule_durable_save,
 };
 
+pub(super) struct ServerLostRecoveryOutcome {
+    pub agent_id: AgentId,
+    pub result: Result<(), RuntimeError>,
+    pub pid: Option<u32>,
+    pub process_identity: Option<ProcessIdentity>,
+}
+
 pub(super) fn dispatch_relaunch_agent(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
     agent_id: AgentId,
 ) {
+    if open_server_lost_recovery_if_selected(app_state, &agent_id) {
+        return;
+    }
     if !relaunch_preflight_passed(app_state, ctx, &agent_id) {
         return;
     }
@@ -30,6 +40,51 @@ pub(super) fn dispatch_relaunch_agent(
         warn!(agent_id = %agent_id.0, error = %error, "could not relaunch runtime session");
     }
     persist_relaunch_result(app_state, ctx, agent_id, result);
+}
+
+fn open_server_lost_recovery_if_selected(
+    app_state: &mut AppStateHandle,
+    selected_id: &AgentId,
+) -> bool {
+    open_server_lost_recovery(&mut app_state.write(), selected_id)
+}
+
+pub(super) fn open_server_lost_recovery(state: &mut AppState, selected_id: &AgentId) -> bool {
+    let selected_is_lost = state
+        .agents
+        .iter()
+        .any(|agent| &agent.id == selected_id && agent.status == AgentStatus::ServerLost);
+    if !selected_is_lost {
+        return false;
+    }
+    let agent_ids = recoverable_server_lost_ids(state, None);
+    if agent_ids.is_empty() {
+        state.warning_message = Some("No local Server Lost agents can be recovered.".to_owned());
+    } else {
+        state.modal = ModalState::ConfirmServerLostRecovery {
+            agent_ids,
+            confirm_focus: ConfirmFocus::Cancel,
+        };
+    }
+    true
+}
+
+pub(super) fn recoverable_server_lost_ids(
+    state: &AppState,
+    requested: Option<&[AgentId]>,
+) -> Vec<AgentId> {
+    state
+        .agents
+        .iter()
+        .filter(|agent| agent.status == AgentStatus::ServerLost)
+        .filter(|agent| {
+            agent.runtime_binding.as_ref().is_some_and(|binding| {
+                !binding.launch_signature.remote.enabled
+                    && requested.map_or(true, |ids| ids.contains(&agent.id))
+            })
+        })
+        .map(|agent| agent.id.clone())
+        .collect()
 }
 
 fn relaunch_preflight_passed(
@@ -151,6 +206,135 @@ pub(super) fn relaunch_blocked_by_orphan(
         );
     }
     still_alive
+}
+
+pub(super) fn dispatch_server_lost_recovery(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    requested: Vec<AgentId>,
+) {
+    let agent_ids = {
+        let mut state = app_state.write();
+        state.modal = ModalState::None;
+        let ids = recoverable_server_lost_ids(&state, Some(&requested));
+        drop(state);
+        ids
+    };
+    if agent_ids.is_empty() {
+        app_state.write().warning_message =
+            Some("No Server Lost agents remain to recover.".to_owned());
+        return;
+    }
+
+    let mut outcomes = Vec::with_capacity(agent_ids.len());
+    for agent_id in agent_ids {
+        let result = recover_server_lost_runtime(app_state, ctx, &agent_id);
+        if let Err(error) = &result {
+            warn!(agent_id = %agent_id.0, error = %error, "psmux server-loss recovery failed");
+        }
+        let (pid, process_identity) = process_on_success(ctx, &agent_id, result.is_ok());
+        outcomes.push(ServerLostRecoveryOutcome {
+            agent_id,
+            result,
+            pid,
+            process_identity,
+        });
+    }
+    persist_server_lost_recovery(app_state, ctx, outcomes);
+}
+
+fn recover_server_lost_runtime(
+    app_state: &AppStateHandle,
+    ctx: &SharedContext,
+    agent_id: &AgentId,
+) -> Result<(), RuntimeError> {
+    let worker_identities = app_state
+        .read()
+        .agents
+        .iter()
+        .find(|agent| &agent.id == agent_id)
+        .and_then(|agent| agent.runtime_binding.as_ref())
+        .map(|binding| binding.worker_identities.clone())
+        .ok_or_else(|| RuntimeError::SessionNotFound(agent_id.0.clone()))?;
+    if relaunch_blocked_by_orphan(agent_id, &worker_identities) {
+        return Err(RuntimeError::OrphanBlocked(agent_id.clone()));
+    }
+
+    let ctx_arc = ctx.as_ref().ok_or_else(|| {
+        RuntimeError::SpawnFailed("runtime context unavailable during recovery".to_owned())
+    })?;
+    let mut ctx_guard = ctx_arc.lock().map_err(|_| {
+        RuntimeError::SpawnFailed("runtime context lock unavailable during recovery".to_owned())
+    })?;
+    // The ServerLost state deliberately preserves the manager's live record.
+    // Move that exact signature to its retained cache before recreating it.
+    let _ = ctx_guard.runtime.mark_session_dead(agent_id);
+    ctx_guard.runtime.relaunch(agent_id)?;
+    std::thread::sleep(REMOTE_ATTACH_SETTLE_DELAY);
+    if let Err(error) = ctx_guard.runtime.attach(agent_id) {
+        let _ = ctx_guard.runtime.mark_session_dead(agent_id);
+        drop(ctx_guard);
+        return Err(error);
+    }
+    drop(ctx_guard);
+    Ok(())
+}
+
+fn persist_server_lost_recovery(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    outcomes: Vec<ServerLostRecoveryOutcome>,
+) {
+    let mut state = app_state.write();
+    apply_server_lost_recovery_outcomes(&mut state, outcomes);
+    let persisted = durable_save_request(&mut state);
+    drop(state);
+    schedule_durable_save(ctx, persisted);
+}
+
+pub(super) fn apply_server_lost_recovery_outcomes(
+    state: &mut AppState,
+    outcomes: Vec<ServerLostRecoveryOutcome>,
+) {
+    let mut successes = 0usize;
+    let mut failures = 0usize;
+    for outcome in outcomes {
+        if outcome.result.is_ok() {
+            persist_relaunch_success(
+                state,
+                &outcome.agent_id,
+                AppEvent::RelaunchAgent(outcome.agent_id.clone()),
+                outcome.pid,
+                outcome.process_identity,
+            );
+            successes = successes.saturating_add(1);
+        } else {
+            if let Some(agent) = state
+                .agents
+                .iter_mut()
+                .find(|agent| agent.id == outcome.agent_id)
+                && let Some(binding) = agent.runtime_binding.as_mut()
+            {
+                binding.attached = false;
+            }
+            failures = failures.saturating_add(1);
+        }
+    }
+    let summary = if failures == 0 {
+        format!("Recovered {successes} psmux agent(s).")
+    } else {
+        format!("Recovered {successes} psmux agent(s); {failures} failed and remain Server Lost.")
+    };
+    let message = state
+        .warning_message
+        .take()
+        .map_or_else(|| summary.clone(), |warning| format!("{summary} {warning}"));
+    if failures == 0 {
+        state.warning_message = Some(message);
+        state.error_message = None;
+    } else {
+        state.error_message = Some(message);
+    }
 }
 
 fn persist_relaunch_result(

--- a/src/app_input/relaunch_tests.rs
+++ b/src/app_input/relaunch_tests.rs
@@ -134,7 +134,7 @@ fn batch_recovery_keeps_failures_server_lost_and_reports_partial_success() {
     assert!(state.agents[1].runtime_binding.is_some());
     assert_eq!(
         state.error_message.as_deref(),
-        Some("Recovered 1 psmux agent(s); 1 failed and remain Server Lost. Keep this warning.")
+        Some("Recovered 1 psmux agent; 1 failed and remains Server Lost. Keep this warning.")
     );
 }
 

--- a/src/app_input/relaunch_tests.rs
+++ b/src/app_input/relaunch_tests.rs
@@ -5,7 +5,8 @@ use jefe::runtime::{
 use jefe::state::{AppEvent, AppState, PaneFocus};
 
 use super::relaunch::{
-    attach_relaunched_session, persist_relaunch_failure, spawn_relaunch_session,
+    ServerLostRecoveryOutcome, apply_server_lost_recovery_outcomes, attach_relaunched_session,
+    open_server_lost_recovery, persist_relaunch_failure, spawn_relaunch_session,
 };
 use super::tests::{sample_agent, sample_signature};
 
@@ -93,4 +94,69 @@ fn attach_failure_is_preserved_as_distinct_relaunch_diagnostic() {
     );
     assert_eq!(state.agents[0].status, AgentStatus::Dead);
     assert!(state.agents[0].runtime_binding.is_none());
+}
+
+#[test]
+fn batch_recovery_keeps_failures_server_lost_and_reports_partial_success() {
+    let first_id = AgentId("recover-ok".to_owned());
+    let second_id = AgentId("recover-fail".to_owned());
+    let mut first = bound_agent_state(&first_id).agents.remove(0);
+    first.status = AgentStatus::ServerLost;
+    let mut second = bound_agent_state(&second_id).agents.remove(0);
+    second.status = AgentStatus::ServerLost;
+    let mut state = AppState {
+        agents: vec![first, second],
+        warning_message: Some("Keep this warning.".to_owned()),
+        ..AppState::default()
+    };
+
+    apply_server_lost_recovery_outcomes(
+        &mut state,
+        vec![
+            ServerLostRecoveryOutcome {
+                agent_id: first_id,
+                result: Ok(()),
+                pid: Some(100),
+                process_identity: None,
+            },
+            ServerLostRecoveryOutcome {
+                agent_id: second_id,
+                result: Err(RuntimeError::SpawnFailed("psmux unavailable".to_owned())),
+                pid: None,
+                process_identity: None,
+            },
+        ],
+    );
+
+    assert_eq!(state.agents[0].status, AgentStatus::Running);
+    assert!(state.agents[0].runtime_binding.is_some());
+    assert_eq!(state.agents[1].status, AgentStatus::ServerLost);
+    assert!(state.agents[1].runtime_binding.is_some());
+    assert_eq!(
+        state.error_message.as_deref(),
+        Some("Recovered 1 psmux agent(s); 1 failed and remain Server Lost. Keep this warning.")
+    );
+}
+
+#[test]
+fn selected_server_lost_agent_opens_cancel_focused_batch_confirmation() {
+    let first_id = AgentId("lost-one".to_owned());
+    let second_id = AgentId("lost-two".to_owned());
+    let mut first = bound_agent_state(&first_id).agents.remove(0);
+    first.status = AgentStatus::ServerLost;
+    let mut second = bound_agent_state(&second_id).agents.remove(0);
+    second.status = AgentStatus::ServerLost;
+    let mut state = AppState {
+        agents: vec![first, second],
+        ..AppState::default()
+    };
+
+    assert!(open_server_lost_recovery(&mut state, &first_id));
+    assert!(matches!(
+        state.modal,
+        jefe::state::ModalState::ConfirmServerLostRecovery {
+            ref agent_ids,
+            confirm_focus: jefe::state::ConfirmFocus::Cancel,
+        } if agent_ids == &vec![AgentId("lost-one".to_owned()), AgentId("lost-two".to_owned())]
+    ));
 }

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -144,135 +144,16 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
         }
     });
 
-    // Slow-poll LOCAL agent liveness (~every 2s). The batched check uses
-    // exactly two tmux subprocess invocations (list-sessions + list-panes -a)
-    // regardless of agent count, offloaded to a background OS thread via
-    // `smol::unblock` so the executor stays free for input events (issue #287).
-    // Remote agents are excluded — their SSH round-trips would starve the
-    // executor; remote death is detected lazily on select/attach.
+    // Slow-poll LOCAL agent liveness (~every 2s). On Windows it first probes
+    // the shared psmux server identity; a `Gone`/`Replaced` server transitions
+    // affected running agents to `ServerLost` (binding preserved) instead of
+    // `Dead`. On other platforms the batched check is unchanged (issue #493
+    // Stack A). The body lives in [`crate::app_shell_liveness::run_local_liveness`].
     hooks.use_future({
         let ctx = ctx.clone();
-        let mut app_state = app_state;
+        let app_state = app_state;
         async move {
-            loop {
-                smol::Timer::after(std::time::Duration::from_secs(2)).await;
-
-                let Some(ctx_arc) = &ctx else {
-                    continue;
-                };
-
-                // Collect local-only check targets under the lock, then release it.
-                let targets: Vec<_> = {
-                    let Ok(ctx_guard) = ctx_arc.lock() else {
-                        continue;
-                    };
-                    let state = app_state.read();
-                    let running_ids: Vec<AgentId> = state
-                        .agents
-                        .iter()
-                        .filter(|a| a.is_running())
-                        .map(|a| a.id.clone())
-                        .collect();
-                    drop(state);
-                    let all_targets = ctx_guard.runtime.liveness_targets();
-                    drop(ctx_guard);
-
-                    all_targets
-                        .into_iter()
-                        .filter(|t| t.remote.is_none() && running_ids.contains(&t.agent_id))
-                        .collect::<Vec<_>>()
-                };
-
-                if targets.is_empty() {
-                    continue;
-                }
-
-                // Offload the batched tmux subprocess calls to a background OS
-                // thread so the smol executor can continue processing input.
-                let dead_identities = smol::unblock(move || {
-                    jefe::runtime::batch_liveness_check_with_identity(&targets)
-                })
-                .await;
-
-                if !dead_identities.is_empty() {
-                    debug!(
-                        count = dead_identities.len(),
-                        "liveness poll found dead agents"
-                    );
-                    let mut dead_previews: std::collections::HashMap<_, _> =
-                        crate::app_shell_workers::capture_dead_previews(dead_identities.clone())
-                            .await
-                            .into_iter()
-                            .map(|(identity, lines)| (identity.agent_id, lines))
-                            .collect();
-                    let mut state = app_state.write();
-                    let binding_matches = {
-                        let current_bindings: std::collections::HashMap<_, _> = state
-                            .agents
-                            .iter()
-                            .filter_map(|agent| {
-                                agent.runtime_binding.as_ref().map(|binding| {
-                                    (
-                                        &agent.id,
-                                        (
-                                            binding.session_name.as_str(),
-                                            binding.lifecycle_generation,
-                                        ),
-                                    )
-                                })
-                            })
-                            .collect();
-                        dead_identities
-                            .iter()
-                            .map(|identity| {
-                                current_bindings.get(&identity.agent_id).is_some_and(
-                                    |(session_name, generation)| {
-                                        Some(*session_name)
-                                            == identity.binding_session_name.as_deref()
-                                            && *generation == identity.lifecycle_generation
-                                    },
-                                )
-                            })
-                            .collect::<Vec<_>>()
-                    };
-                    let mut changed = false;
-                    for (identity, binding_matches) in
-                        dead_identities.iter().zip(binding_matches)
-                    {
-                        if !binding_matches {
-                            debug!(agent_id = %identity.agent_id.0, "liveness: stale result after preview capture; skipping");
-                            continue;
-                        }
-                        let preview = dead_previews.remove(&identity.agent_id);
-                        jefe::state::transition::commit_pure_site(
-                            &mut state,
-                            AppEvent::AgentStatusChanged(
-                                identity.agent_id.clone(),
-                                AgentStatus::Dead,
-                            )
-                            .into(),
-                        );
-                        if let Some(agent) = state
-                            .agents
-                            .iter_mut()
-                            .find(|agent| agent.id == identity.agent_id)
-                        {
-                            agent.runtime_binding = None;
-                        }
-                        if let Some(lines) = preview {
-                            state.store_dead_preview(identity.agent_id.clone(), lines);
-                        }
-                        changed = true;
-                    }
-                    if changed {
-                        let persisted = durable_save_request(&mut state);
-                        drop(state);
-                        schedule_durable_save(&ctx, persisted);
-                    } else {
-                        drop(state);
-                    }
-                }
-            }
+            crate::app_shell_liveness::run_local_liveness(app_state, ctx).await;
         }
     });
 

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -147,8 +147,8 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     // Slow-poll LOCAL agent liveness (~every 2s). On Windows it first probes
     // the shared psmux server identity; a `Gone`/`Replaced` server transitions
     // affected running agents to `ServerLost` (binding preserved) instead of
-    // `Dead`. On other platforms the batched check is unchanged (issue #493
-    // Stack A). The body lives in [`crate::app_shell_liveness::run_local_liveness`].
+    // `Dead`. On other platforms the batched check is unchanged (issue #493).
+    // The body lives in [`crate::app_shell_liveness::run_local_liveness`].
     hooks.use_future({
         let ctx = ctx.clone();
         let app_state = app_state;

--- a/src/app_shell_liveness.rs
+++ b/src/app_shell_liveness.rs
@@ -40,6 +40,7 @@ use jefe::runtime::ServerLivenessObservation;
 #[cfg(windows)]
 use jefe::runtime::observe_server_liveness;
 use jefe::state::AppEvent;
+#[cfg(any(windows, test))]
 use jefe::state::AppState;
 use jefe::state::transition::commit_pure_site;
 

--- a/src/app_shell_liveness.rs
+++ b/src/app_shell_liveness.rs
@@ -1,4 +1,4 @@
-//! Local agent liveness observer (issue #493 Stack A).
+//! Local agent liveness observer (issue #493).
 //!
 //! Extracted from `app_shell.rs` (which had grown to 997 lines). Owns the
 //! slow-poll LOCAL agent liveness loop. The non-Windows path preserves the
@@ -47,9 +47,8 @@ const LIVENESS_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_se
 pub async fn run_local_liveness(mut app_state: AppStateHandle, ctx: SharedContext) {
     // Pinned prior server identity (Windows psmux server watchdog).
     let mut pinned_prior: Option<ServerIdentity> = None;
-    // Once-per-identity `exit-empty off` guard. Stored as a plain `Option` so
-    // the future stays `Send`; the `Cell` required by `observe_server_liveness`
-    // is constructed afresh on each synchronous probe cycle.
+    // Once-per-identity `exit-empty off` guard. Blocking probe work receives
+    // owned snapshots and returns the updated value to this future.
     let mut applied_exit_empty: Option<ServerIdentity> = None;
 
     loop {
@@ -135,12 +134,15 @@ async fn handle_windows_cycle(
 ) {
     let observation = match MultiplexerPlan::current() {
         Ok(plan) => {
-            // `observe_server_liveness` requires `&Cell`; construct one
-            // synchronously from the stored value and write it back so the
-            // async future never holds a `!Sync` reference across an await.
-            let cell = Cell::new(*applied_exit_empty);
-            let observation = observe_server_liveness(&plan, pinned_prior.as_ref(), &cell);
-            *applied_exit_empty = cell.into_inner();
+            let prior = *pinned_prior;
+            let applied = *applied_exit_empty;
+            let (observation, next_applied) = smol::unblock(move || {
+                let cell = Cell::new(applied);
+                let observation = observe_server_liveness(&plan, prior.as_ref(), &cell);
+                (observation, cell.into_inner())
+            })
+            .await;
+            *applied_exit_empty = next_applied;
             observation
         }
         Err(error) => {
@@ -170,8 +172,6 @@ async fn handle_windows_cycle(
             // Probe failure fails open: no agent status change this cycle.
         }
     }
-    // ServerLost recovery and re-pin on a fresh healthy server after a
-    // replacement is intentionally not handled here (Stack B / recovery UX).
     let _ = lost_ids;
 }
 

--- a/src/app_shell_liveness.rs
+++ b/src/app_shell_liveness.rs
@@ -1,0 +1,503 @@
+//! Local agent liveness observer (issue #493 Stack A).
+//!
+//! Extracted from `app_shell.rs` (which had grown to 997 lines). Owns the
+//! slow-poll LOCAL agent liveness loop. The non-Windows path preserves the
+//! exact pre-extraction behavior: a two-subprocess batched check offloaded to
+//! a background OS thread, with generation-checked `Dead` transitions and
+//! durable projection.
+//!
+//! On Windows the same two-second cadence first probes the shared psmux
+//! server identity via [`jefe::runtime::observe_server_liveness`]. A `Healthy`
+//! same-server observation permits the existing per-agent `Dead` reconciliation
+//! for `Running` targets only. `Gone` and `Replaced` instead transition every
+//! affected `Running` agent to [`AgentStatus::ServerLost`] through the reducer
+//! (binding and launch signature preserved), without capturing dead previews
+//! or saving as stopped. `Unavailable` makes no state change. Genuine
+//! per-agent death on a healthy server still follows the existing preview,
+//! `Dead`, binding-clear, and durable-save path.
+
+use std::cell::Cell;
+use std::collections::HashMap;
+
+use tracing::{debug, warn};
+
+use crate::app_input::{
+    AppStateHandle, SharedContext, durable_save_request, schedule_durable_save,
+};
+use crate::app_shell_workers::capture_dead_previews;
+
+use jefe::domain::{AgentId, AgentStatus};
+use jefe::runtime::LivenessIdentity;
+use jefe::runtime::MultiplexerPlan;
+use jefe::runtime::ServerIdentity;
+use jefe::runtime::ServerLivenessObservation;
+use jefe::runtime::observe_server_liveness;
+use jefe::state::AppEvent;
+use jefe::state::AppState;
+use jefe::state::transition::commit_pure_site;
+
+/// Liveness poll cadence reused from the original inline future.
+const LIVENESS_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Slow-poll LOCAL agent liveness.
+///
+/// See the module docs for the Windows/non-Windows split. Remote agents are
+/// always excluded; their SSH round-trips would starve the executor and remote
+/// death is detected lazily on select/attach.
+pub async fn run_local_liveness(mut app_state: AppStateHandle, ctx: SharedContext) {
+    // Pinned prior server identity (Windows psmux server watchdog).
+    let mut pinned_prior: Option<ServerIdentity> = None;
+    // Once-per-identity `exit-empty off` guard. Stored as a plain `Option` so
+    // the future stays `Send`; the `Cell` required by `observe_server_liveness`
+    // is constructed afresh on each synchronous probe cycle.
+    let mut applied_exit_empty: Option<ServerIdentity> = None;
+
+    loop {
+        smol::Timer::after(LIVENESS_POLL_INTERVAL).await;
+
+        let Some(ctx_arc) = &ctx else {
+            continue;
+        };
+
+        // Collect local-only check targets for Running and ServerLost agents
+        // under the lock, then release it before any subprocess work.
+        let (running_targets, lost_ids) = collect_local_targets(&app_state, ctx_arc);
+        if running_targets.is_empty() && lost_ids.is_empty() {
+            continue;
+        }
+
+        #[cfg(windows)]
+        {
+            handle_windows_cycle(
+                &mut app_state,
+                &ctx,
+                &running_targets,
+                &lost_ids,
+                &mut pinned_prior,
+                &mut applied_exit_empty,
+            )
+            .await;
+        }
+
+        #[cfg(not(windows))]
+        {
+            handle_unix_cycle(&mut app_state, &ctx, &running_targets).await;
+        }
+    }
+}
+
+/// Collect local liveness targets plus the ids of agents already `ServerLost`.
+///
+/// Returns the runtime-supplied targets filtered to local agents whose status
+/// is `Running`, and the ids of local agents currently `ServerLost` (so the
+/// Windows path can recover them when the server returns).
+fn collect_local_targets(
+    app_state: &AppStateHandle,
+    ctx_arc: &std::sync::Arc<std::sync::Mutex<crate::AppContext>>,
+) -> (Vec<jefe::runtime::LivenessCheck>, Vec<AgentId>) {
+    let Ok(ctx_guard) = ctx_arc.lock() else {
+        return (Vec::new(), Vec::new());
+    };
+    let state = app_state.read();
+    let running_ids: Vec<AgentId> = state
+        .agents
+        .iter()
+        .filter(|agent| agent.status == AgentStatus::Running)
+        .map(|agent| agent.id.clone())
+        .collect();
+    let lost_ids: Vec<AgentId> = state
+        .agents
+        .iter()
+        .filter(|agent| agent.status == AgentStatus::ServerLost)
+        .map(|agent| agent.id.clone())
+        .collect();
+    drop(state);
+    let all_targets = ctx_guard.runtime.liveness_targets();
+    drop(ctx_guard);
+
+    let running_targets = all_targets
+        .into_iter()
+        .filter(|target| target.remote.is_none() && running_ids.contains(&target.agent_id))
+        .collect::<Vec<_>>();
+    (running_targets, lost_ids)
+}
+
+/// Windows liveness cycle: probe the shared psmux server identity first, then
+/// reconcile per-agent health only on a healthy same-server observation.
+#[cfg(windows)]
+async fn handle_windows_cycle(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    running_targets: &[jefe::runtime::LivenessCheck],
+    lost_ids: &[AgentId],
+    pinned_prior: &mut Option<ServerIdentity>,
+    applied_exit_empty: &mut Option<ServerIdentity>,
+) {
+    let observation = match MultiplexerPlan::current() {
+        Ok(plan) => {
+            // `observe_server_liveness` requires `&Cell`; construct one
+            // synchronously from the stored value and write it back so the
+            // async future never holds a `!Sync` reference across an await.
+            let cell = Cell::new(*applied_exit_empty);
+            let observation = observe_server_liveness(&plan, pinned_prior.as_ref(), &cell);
+            *applied_exit_empty = cell.into_inner();
+            observation
+        }
+        Err(error) => {
+            warn!(error = %error, "windows liveness: multiplexer plan unavailable");
+            return;
+        }
+    };
+
+    match observation {
+        ServerLivenessObservation::Healthy(current) => {
+            *pinned_prior = current.or(*pinned_prior);
+            reconcile_healthy_agents(app_state, ctx, running_targets).await;
+        }
+        ServerLivenessObservation::Gone | ServerLivenessObservation::Replaced(_) => {
+            if let ServerLivenessObservation::Replaced(next) = observation {
+                *pinned_prior = Some(next);
+            }
+            let state = app_state.read();
+            let affected = eligible_for_server_lost(&state, running_targets);
+            drop(state);
+            if affected.is_empty() {
+                return;
+            }
+            transition_to_server_lost(app_state, ctx, &affected);
+        }
+        ServerLivenessObservation::Unavailable => {
+            // Probe failure fails open: no agent status change this cycle.
+        }
+    }
+    // ServerLost recovery and re-pin on a fresh healthy server after a
+    // replacement is intentionally not handled here (Stack B / recovery UX).
+    let _ = lost_ids;
+}
+
+/// Non-Windows liveness cycle: preserve the exact pre-extraction batched
+/// behavior. No server probe and no `ServerLost` transition.
+#[cfg(not(windows))]
+async fn handle_unix_cycle(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    running_targets: &[jefe::runtime::LivenessCheck],
+) {
+    if running_targets.is_empty() {
+        return;
+    }
+    let dead_identities = batch_dead_identities(running_targets).await;
+    if dead_identities.is_empty() {
+        return;
+    }
+    debug!(
+        count = dead_identities.len(),
+        "liveness poll found dead agents"
+    );
+    apply_dead_identities(app_state, ctx, dead_identities).await;
+}
+
+/// Return the dead identity triples for the given targets via a background
+/// OS thread so the smol executor stays free for input events (issue #287).
+async fn batch_dead_identities(targets: &[jefe::runtime::LivenessCheck]) -> Vec<LivenessIdentity> {
+    let targets_owned = targets.to_vec();
+    smol::unblock(move || jefe::runtime::batch_liveness_check_with_identity(&targets_owned)).await
+}
+
+/// Capture previews, then commit generation-checked `Dead` transitions,
+/// clear bindings, store previews, and coalesce one durable save.
+async fn apply_dead_identities(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    dead_identities: Vec<LivenessIdentity>,
+) {
+    let mut dead_previews: HashMap<_, _> = capture_dead_previews(dead_identities.clone())
+        .await
+        .into_iter()
+        .map(|(identity, lines)| (identity.agent_id, lines))
+        .collect();
+
+    let mut state = app_state.write();
+    let binding_matches = compute_binding_matches(&state, &dead_identities);
+    let mut changed = false;
+    for (identity, matches) in dead_identities.iter().zip(binding_matches) {
+        if !matches {
+            debug!(agent_id = %identity.agent_id.0, "liveness: stale result after preview capture; skipping");
+            continue;
+        }
+        let preview = dead_previews.remove(&identity.agent_id);
+        commit_pure_site(
+            &mut state,
+            AppEvent::AgentStatusChanged(identity.agent_id.clone(), AgentStatus::Dead).into(),
+        );
+        if let Some(agent) = state
+            .agents
+            .iter_mut()
+            .find(|agent| agent.id == identity.agent_id)
+        {
+            // Existing binding clear for the genuine per-agent Dead path is
+            // the sole direct mutation allowed outside the reducer.
+            agent.runtime_binding = None;
+        }
+        if let Some(lines) = preview {
+            state.store_dead_preview(identity.agent_id.clone(), lines);
+        }
+        changed = true;
+    }
+    if changed {
+        let persisted = durable_save_request(&mut state);
+        drop(state);
+        schedule_durable_save(ctx, persisted);
+    }
+}
+
+/// Run the existing per-agent `Dead` reconciliation for healthy-server
+/// `Running` targets (issue #493: same-server individual death remains `Dead`).
+#[cfg(windows)]
+async fn reconcile_healthy_agents(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    running_targets: &[jefe::runtime::LivenessCheck],
+) {
+    if running_targets.is_empty() {
+        return;
+    }
+    let dead_identities = batch_dead_identities(running_targets).await;
+    if dead_identities.is_empty() {
+        return;
+    }
+    debug!(
+        count = dead_identities.len(),
+        "liveness poll found dead agents"
+    );
+    apply_dead_identities(app_state, ctx, dead_identities).await;
+}
+
+/// Pure helper: which target agent ids are currently `Running` and therefore
+/// eligible to transition to `ServerLost` when the shared server is gone or
+/// replaced.
+///
+/// `ServerLost` agents are excluded: they are already in the recoverable
+/// state and the reducer must not re-transition them. The runtime target list
+/// is the source of truth for which agents still have a tracked session on the
+/// lost server.
+#[must_use]
+fn eligible_for_server_lost(
+    state: &AppState,
+    targets: &[jefe::runtime::LivenessCheck],
+) -> Vec<LivenessIdentity> {
+    targets
+        .iter()
+        .filter(|target| target.remote.is_none())
+        .filter(|target| {
+            state
+                .agents
+                .iter()
+                .any(|agent| agent.id == target.agent_id && agent.status == AgentStatus::Running)
+        })
+        .map(|target| LivenessIdentity {
+            agent_id: target.agent_id.clone(),
+            binding_session_name: target.binding_session_name.clone(),
+            lifecycle_generation: target.lifecycle_generation,
+        })
+        .collect()
+}
+
+/// Transition every affected agent to `ServerLost` via the reducer, preserving
+/// `runtime_binding` and launch signatures, then coalesce one durable save.
+#[cfg(windows)]
+fn transition_to_server_lost(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    affected: &[LivenessIdentity],
+) {
+    let mut state = app_state.write();
+    let binding_matches = compute_binding_matches(&state, affected);
+    let mut changed = 0usize;
+    for (identity, matches) in affected.iter().zip(binding_matches) {
+        let still_running = state
+            .agents
+            .iter()
+            .any(|agent| agent.id == identity.agent_id && agent.status == AgentStatus::Running);
+        if !matches || !still_running {
+            continue;
+        }
+        commit_pure_site(
+            &mut state,
+            AppEvent::AgentStatusChanged(identity.agent_id.clone(), AgentStatus::ServerLost).into(),
+        );
+        changed = changed.saturating_add(1);
+    }
+    if changed > 0 {
+        warn!(count = changed, "server lost: agents require recovery");
+        let persisted = durable_save_request(&mut state);
+        drop(state);
+        schedule_durable_save(ctx, persisted);
+    } else {
+        drop(state);
+    }
+}
+
+/// Pure helper: compute the per-identity binding-match vector used to guard
+/// stale `Dead` results after preview capture (issue #301 Phase 4).
+fn compute_binding_matches(
+    state: &jefe::state::AppState,
+    dead_identities: &[LivenessIdentity],
+) -> Vec<bool> {
+    let current_bindings: HashMap<&AgentId, (&str, u64)> = state
+        .agents
+        .iter()
+        .filter_map(|agent| {
+            agent.runtime_binding.as_ref().map(|binding| {
+                (
+                    &agent.id,
+                    (binding.session_name.as_str(), binding.lifecycle_generation),
+                )
+            })
+        })
+        .collect();
+    dead_identities
+        .iter()
+        .map(|identity| {
+            current_bindings
+                .get(&identity.agent_id)
+                .is_some_and(|(session_name, generation)| {
+                    Some(*session_name) == identity.binding_session_name.as_deref()
+                        && *generation == identity.lifecycle_generation
+                })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jefe::domain::{Agent, RemoteRepositorySettings, RepositoryId};
+    use jefe::runtime::LivenessCheck;
+    use std::path::PathBuf;
+
+    fn fixture_running_agent(id: &str) -> Agent {
+        let mut agent = Agent::new(
+            AgentId(id.into()),
+            RepositoryId("repo".into()),
+            id.into(),
+            PathBuf::from("/tmp"),
+        );
+        agent.status = AgentStatus::Running;
+        agent
+    }
+
+    fn fixture_lost_agent(id: &str) -> Agent {
+        let mut agent = Agent::new(
+            AgentId(id.into()),
+            RepositoryId("repo".into()),
+            id.into(),
+            PathBuf::from("/tmp"),
+        );
+        agent.status = AgentStatus::ServerLost;
+        agent
+    }
+
+    fn liveness_target(id: &str) -> LivenessCheck {
+        LivenessCheck {
+            agent_id: AgentId(id.into()),
+            session_name: format!("jefe-{id}"),
+            remote: None,
+            binding_session_name: Some(format!("jefe-{id}")),
+            lifecycle_generation: 0,
+        }
+    }
+
+    /// `eligible_for_server_lost` returns only currently `Running` agents that
+    /// appear in the runtime target list. `ServerLost` agents are excluded so
+    /// the reducer does not re-transition them.
+    #[test]
+    fn eligible_excludes_already_lost_agents() {
+        let mut state = AppState::default();
+        state.agents.push(fixture_running_agent("a"));
+        state.agents.push(fixture_lost_agent("b"));
+        let targets = vec![liveness_target("a"), liveness_target("b")];
+
+        let eligible = eligible_for_server_lost(&state, &targets);
+
+        assert_eq!(eligible.len(), 1);
+        assert_eq!(eligible[0].agent_id, AgentId("a".into()));
+    }
+
+    /// Remote targets are never eligible for the local ServerLost path.
+    #[test]
+    fn eligible_excludes_remote_targets() {
+        let mut state = AppState::default();
+        state.agents.push(fixture_running_agent("a"));
+        let mut remote_target = liveness_target("a");
+        remote_target.remote = Some(RemoteRepositorySettings::default());
+
+        let eligible = eligible_for_server_lost(&state, &[remote_target]);
+
+        assert!(eligible.is_empty(), "remote targets must be excluded");
+    }
+
+    /// Agents not present in the runtime target list (no tracked session) are
+    /// not eligible, even if their status is `Running`.
+    #[test]
+    fn eligible_excludes_untracked_running_agents() {
+        let mut state = AppState::default();
+        state.agents.push(fixture_running_agent("a"));
+        state.agents.push(fixture_running_agent("b"));
+        // Only agent "a" has a tracked target.
+        let targets = vec![liveness_target("a")];
+
+        let eligible = eligible_for_server_lost(&state, &targets);
+
+        assert_eq!(eligible.len(), 1);
+        assert_eq!(eligible[0].agent_id, AgentId("a".into()));
+    }
+
+    #[test]
+    fn binding_match_rejects_stale_session_and_generation() {
+        let mut state = AppState::default();
+        let mut agent = fixture_running_agent("a");
+        agent.runtime_binding = Some(jefe::domain::RuntimeBinding {
+            session_name: "jefe-current".into(),
+            launch_signature: jefe::domain::LaunchSignature {
+                work_dir: PathBuf::from("/tmp"),
+                profile: String::new(),
+                code_puppy_model: String::new(),
+                code_puppy_version: String::new(),
+                code_puppy_yolo: None,
+                code_puppy_quick_resume: false,
+                mode_flags: vec![],
+                llxprt_debug: String::new(),
+                pass_continue: true,
+                sandbox_enabled: false,
+                sandbox_engine: jefe::domain::SandboxEngine::Podman,
+                sandbox_flags: jefe::domain::DEFAULT_SANDBOX_FLAGS.to_owned(),
+                remote: RemoteRepositorySettings::default(),
+                agent_kind: jefe::domain::AgentKind::Llxprt,
+                llxprt_version: None,
+            },
+            attached: false,
+            last_seen: None,
+            pid: None,
+            process_identity: None,
+            lifecycle_generation: 2,
+            worker_identities: vec![],
+        });
+        state.agents.push(agent);
+        let stale_session = LivenessIdentity {
+            agent_id: AgentId("a".into()),
+            binding_session_name: Some("jefe-old".into()),
+            lifecycle_generation: 2,
+        };
+        let stale_generation = LivenessIdentity {
+            agent_id: AgentId("a".into()),
+            binding_session_name: Some("jefe-current".into()),
+            lifecycle_generation: 1,
+        };
+
+        assert_eq!(
+            compute_binding_matches(&state, &[stale_session, stale_generation]),
+            vec![false, false]
+        );
+    }
+}

--- a/src/app_shell_liveness.rs
+++ b/src/app_shell_liveness.rs
@@ -16,10 +16,13 @@
 //! per-agent death on a healthy server still follows the existing preview,
 //! `Dead`, binding-clear, and durable-save path.
 
+#[cfg(windows)]
 use std::cell::Cell;
 use std::collections::HashMap;
 
-use tracing::{debug, warn};
+use tracing::debug;
+#[cfg(windows)]
+use tracing::warn;
 
 use crate::app_input::{
     AppStateHandle, SharedContext, durable_save_request, schedule_durable_save,
@@ -28,9 +31,13 @@ use crate::app_shell_workers::capture_dead_previews;
 
 use jefe::domain::{AgentId, AgentStatus};
 use jefe::runtime::LivenessIdentity;
+#[cfg(windows)]
 use jefe::runtime::MultiplexerPlan;
+#[cfg(windows)]
 use jefe::runtime::ServerIdentity;
+#[cfg(windows)]
 use jefe::runtime::ServerLivenessObservation;
+#[cfg(windows)]
 use jefe::runtime::observe_server_liveness;
 use jefe::state::AppEvent;
 use jefe::state::AppState;
@@ -46,9 +53,11 @@ const LIVENESS_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_se
 /// death is detected lazily on select/attach.
 pub async fn run_local_liveness(mut app_state: AppStateHandle, ctx: SharedContext) {
     // Pinned prior server identity (Windows psmux server watchdog).
+    #[cfg(windows)]
     let mut pinned_prior: Option<ServerIdentity> = None;
     // Once-per-identity `exit-empty off` guard. Blocking probe work receives
     // owned snapshots and returns the updated value to this future.
+    #[cfg(windows)]
     let mut applied_exit_empty: Option<ServerIdentity> = None;
 
     loop {
@@ -282,6 +291,7 @@ async fn reconcile_healthy_agents(
 /// is the source of truth for which agents still have a tracked session on the
 /// lost server.
 #[must_use]
+#[cfg(any(windows, test))]
 fn eligible_for_server_lost(
     state: &AppState,
     targets: &[jefe::runtime::LivenessCheck],

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -688,7 +688,7 @@ impl UserPreferences {
     }
 }
 
-/// Agent lifecycle status.
+/// Agent lifecycle status (`ServerLost`: server vanished, preserves binding, #493).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum AgentStatus {
     #[default]
@@ -699,6 +699,7 @@ pub enum AgentStatus {
     Waiting,
     Paused,
     Dead,
+    ServerLost,
 }
 
 /// An agent is the primary work unit in Jefe.

--- a/src/input.rs
+++ b/src/input.rs
@@ -87,6 +87,7 @@ fn modal_input_mode(modal: &ModalState) -> Option<InputMode> {
         ModalState::ConfirmDeleteRepository { .. }
         | ModalState::ConfirmDeleteAgent { .. }
         | ModalState::ConfirmKillAgent { .. }
+        | ModalState::ConfirmServerLostRecovery { .. }
         | ModalState::PreflightPrompt { .. }
         | ModalState::ConfirmIssueDirtyCopy { .. }
         | ModalState::ConfirmIssueOriginMismatch { .. } => Some(InputMode::Confirm),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod app_input;
 mod app_shell;
 mod app_shell_attach;
 mod app_shell_key_routing;
+mod app_shell_liveness;
 mod app_shell_workers;
 mod detail_wrap_map;
 mod mouse_routing;

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -794,6 +794,7 @@ fn is_blocking_modal_open(state: &AppState) -> bool {
             | ModalState::ConfirmDeleteRepository { .. }
             | ModalState::ConfirmDeleteAgent { .. }
             | ModalState::ConfirmKillAgent { .. }
+            | ModalState::ConfirmServerLostRecovery { .. }
             | ModalState::PreflightPrompt { .. }
             | ModalState::ConfirmIssueDirtyCopy { .. }
             | ModalState::ConfirmIssueOriginMismatch { .. }
@@ -816,6 +817,7 @@ fn active_overlay_for(state: &AppState) -> jefe::selection::OverlayPane {
         jefe::state::ModalState::ConfirmDeleteRepository { .. }
         | jefe::state::ModalState::ConfirmDeleteAgent { .. }
         | jefe::state::ModalState::ConfirmKillAgent { .. }
+        | jefe::state::ModalState::ConfirmServerLostRecovery { .. }
         | jefe::state::ModalState::PreflightPrompt { .. }
         | jefe::state::ModalState::ConfirmIssueDirtyCopy { .. }
         | jefe::state::ModalState::ConfirmIssueOriginMismatch { .. }

--- a/src/runtime/liveness.rs
+++ b/src/runtime/liveness.rs
@@ -405,7 +405,9 @@ fn list_alive_pane_sessions() -> Option<HashSet<String>> {
 /// Run a tmux subprocess with a bounded timeout, killing it if it exceeds the
 /// deadline. This prevents a hung tmux server from stalling the background
 /// liveness thread indefinitely (issue #287 review).
-fn run_tmux_with_timeout(command: &mut std::process::Command) -> Result<std::process::Output, ()> {
+pub fn run_tmux_with_timeout(
+    command: &mut std::process::Command,
+) -> Result<std::process::Output, ()> {
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
     let child = command.spawn().map_err(|_| ())?;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -39,6 +39,9 @@ mod package_probe;
 mod pane_capture;
 mod preflight;
 mod process;
+/// Pure server-health classification contract (issue #493 Slice 1).
+mod server_health;
+mod server_health_io;
 mod session;
 /// Per-session, content-addressed Windows host staging (issue #467 Slice 1).
 pub(crate) mod session_host;
@@ -104,6 +107,11 @@ pub use process::{
     ProcessIdentityError, ProcessLiveness, ProcessObservation, capture_process_identity,
     classify_process_observation, process_liveness, process_liveness_indicates_alive,
 };
+pub use server_health::{
+    ServerHealth, ServerIdentity, ServerLivenessEvidence, ServerLivenessObservation,
+    classify_server_health, classify_server_liveness, parse_server_identity_output,
+};
+pub use server_health_io::observe_server_liveness;
 pub use session::{RuntimeSession, TerminalCell, TerminalCellStyle, TerminalSnapshot};
 // Issue #467 Slice 2: re-export session-host cleanup/planning items used by the
 // startup path and the manager kill path.

--- a/src/runtime/server_health.rs
+++ b/src/runtime/server_health.rs
@@ -1,0 +1,234 @@
+//! Pure server-health classification for runtime reconciliation.
+//!
+//! Side-effect-free comparison of persisted and freshly observed server
+//! identities. Callers own all I/O; this module only translates identity
+//! transitions into a health verdict so reconciliation logic stays
+//! deterministic and testable.
+
+use crate::domain::ProcessIdentity;
+use crate::runtime::MultiplexerVersion;
+/// Composite identity of one runtime server instance: the operating-system
+/// process plus the multiplexer version hosting it. Two identities are the
+/// same server only when both components agree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServerIdentity {
+    pub process: ProcessIdentity,
+    pub multiplexer: MultiplexerVersion,
+}
+
+impl ServerIdentity {
+    #[must_use]
+    pub const fn new(process: ProcessIdentity, multiplexer: MultiplexerVersion) -> Self {
+        Self {
+            process,
+            multiplexer,
+        }
+    }
+}
+
+/// Health verdict produced by comparing a previous and current server
+/// identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerHealth {
+    /// The server is present and matches the previously tracked identity.
+    Healthy,
+    /// No live server remains. A server that disappears while agents are still
+    /// tracked is treated as lost.
+    Gone,
+    /// A different process now occupies the server role: either the PID or its
+    /// creation token changed since the prior observation.
+    Replaced,
+}
+
+/// Classify the health of the runtime server from its identity transition.
+///
+/// The `has_tracked_agents` flag only disambiguates the doubly-absent case
+/// (`previous` and `current` both `None`): with tracked agents a missing server
+/// is `Gone`, otherwise the absence is an idle baseline and `Healthy`. In every
+/// other transition the identity evidence is decisive.
+#[must_use]
+pub fn classify_server_health(
+    previous: Option<&ServerIdentity>,
+    current: Option<&ServerIdentity>,
+    has_tracked_agents: bool,
+) -> ServerHealth {
+    match (previous, current) {
+        (None, None) => {
+            if has_tracked_agents {
+                ServerHealth::Gone
+            } else {
+                ServerHealth::Healthy
+            }
+        }
+        (None, Some(_)) => ServerHealth::Healthy,
+        (Some(_), None) => ServerHealth::Gone,
+        (Some(previous), Some(current)) => {
+            // A changed PID or a changed creation token both indicate a
+            // distinct process instance now occupying the server role.
+            if previous.process.pid == current.process.pid
+                && previous.process.started_at == current.process.started_at
+            {
+                ServerHealth::Healthy
+            } else {
+                ServerHealth::Replaced
+            }
+        }
+    }
+}
+
+/// Raw evidence captured by one batch liveness probe of the multiplexer
+/// server (issue #493 Stack A).
+///
+/// The caller performs the single `display-message -p '#{pid}|#{version}'`
+/// subprocess invocation and records what happened; this pure type carries
+/// that record into [`classify_server_liveness`] so the classification has no
+/// I/O and is fully testable. All `stderr`/`stdout` strings are diagnostic
+/// payloads owned by the runtime boundary and never persist unredacted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServerLivenessEvidence {
+    /// The probe command completed. `stdout` is the raw format output and
+    /// `stderr` any trailing diagnostic.
+    CommandCompleted { stdout: String, stderr: String },
+    /// The probe command exited nonzero. `stderr` is the raw diagnostic used
+    /// only to distinguish a missing server from an unrelated failure.
+    CommandFailed { stderr: String },
+    /// The probe command could not be spawned or did not complete in time.
+    SpawnFailed,
+}
+
+impl ServerLivenessEvidence {
+    /// Construct evidence for a successful command capturing `stdout`/`stderr`.
+    #[must_use]
+    pub fn command_succeeded(stdout: &str, stderr: &str) -> Self {
+        Self::CommandCompleted {
+            stdout: stdout.to_owned(),
+            stderr: stderr.to_owned(),
+        }
+    }
+
+    /// Construct evidence for a nonzero command capturing `stderr`.
+    #[must_use]
+    pub fn command_failed(stderr: &str) -> Self {
+        Self::CommandFailed {
+            stderr: stderr.to_owned(),
+        }
+    }
+
+    /// Construct evidence for a spawn/timeout failure.
+    #[must_use]
+    pub const fn spawn_failed() -> Self {
+        Self::SpawnFailed
+    }
+}
+
+/// Health verdict produced by one batch liveness probe, paired with the
+/// freshly observed identity when the server is present (issue #493 Stack A).
+///
+/// This extends [`ServerHealth`] with the explicit `Unavailable` outcome so
+/// the caller can distinguish "no state change" (Unavailable) from "server is
+/// gone/replaced" (Gone/Replaced). The carried identity lets the caller update
+/// its tracked server handle on Healthy/Replaced without re-probing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServerLivenessObservation {
+    /// The server is present. Carries the identity established by this probe.
+    Healthy(Option<ServerIdentity>),
+    /// No live server remains. Existing tracked agents should transition to
+    /// [`crate::domain::AgentStatus::ServerLost`].
+    Gone,
+    /// A different process now occupies the server role. Same recovery action
+    /// as `Gone`, but the caller also knows the prior server was replaced.
+    Replaced(ServerIdentity),
+    /// The probe could not establish a verdict (spawn failure, timeout,
+    /// malformed output, or a nonzero command that does not indicate a
+    /// missing server). The caller must make no state change.
+    Unavailable,
+}
+
+/// Lowercase substrings that, when present in a failed probe's stderr,
+/// indicate the multiplexer server is genuinely absent rather than
+/// temporarily unreachable. Matched case-insensitively so psmux/tmux wording
+/// differences do not leak through.
+const NO_SERVER_STDERR_MARKERS: &[&str] = &[
+    "no server running",
+    "no sessions",
+    "server not found",
+    "failed to connect to server",
+    "error connecting to",
+];
+
+/// Pure classification of one batch liveness probe's evidence against the
+/// previously tracked server identity (issue #493 Stack A).
+///
+/// - A successful command with parseable, matching identity is `Healthy`.
+/// - A successful command with a parseable but changed identity is `Replaced`.
+/// - A successful command with unparseable output fails open as `Unavailable`.
+/// - A nonzero command whose stderr indicates a missing server is `Gone`.
+/// - A nonzero command with unrelated stderr fails open as `Unavailable`.
+/// - A spawn/timeout failure fails open as `Unavailable`.
+///
+/// `prior` is `None` on the first observation after startup; a missing-server
+/// signal with no prior server is `Unavailable` (nothing to lose), while a
+/// successful probe establishes the baseline as `Healthy`.
+#[must_use]
+pub fn classify_server_liveness(
+    prior: Option<&ServerIdentity>,
+    evidence: &ServerLivenessEvidence,
+) -> ServerLivenessObservation {
+    match evidence {
+        ServerLivenessEvidence::CommandCompleted { stdout, .. } => {
+            match parse_server_identity_output(stdout) {
+                Some(current) => {
+                    let health = classify_server_health(prior, Some(&current), true);
+                    match health {
+                        ServerHealth::Healthy => ServerLivenessObservation::Healthy(Some(current)),
+                        ServerHealth::Replaced => ServerLivenessObservation::Replaced(current),
+                        // classify_server_health only returns Gone when
+                        // current is None, which cannot happen here.
+                        ServerHealth::Gone => ServerLivenessObservation::Unavailable,
+                    }
+                }
+                None => ServerLivenessObservation::Unavailable,
+            }
+        }
+        ServerLivenessEvidence::CommandFailed { stderr } => {
+            if stderr_indicates_no_server(stderr) {
+                ServerLivenessObservation::Gone
+            } else {
+                ServerLivenessObservation::Unavailable
+            }
+        }
+        ServerLivenessEvidence::SpawnFailed => ServerLivenessObservation::Unavailable,
+    }
+}
+
+/// Return whether a failed probe's stderr indicates the server is absent.
+///
+/// Case-insensitive substring match against a small, reviewed marker list so
+/// arbitrary stderr text is never treated as authoritative.
+#[must_use]
+fn stderr_indicates_no_server(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    NO_SERVER_STDERR_MARKERS
+        .iter()
+        .any(|marker| lower.contains(marker))
+}
+
+/// Parse the `display-message -p '#{pid}|#{version}'` output of one server
+/// probe into a [`ServerIdentity`] (issue #493 Stack A).
+///
+/// Expected form: `<pid>|<major>.<minor>.<patch>` (e.g. `4321|3.3.7`). The
+/// PID supplies the process identity; `started_at` defaults to `1` because
+/// the multiplexer `display-message` format string does not expose a creation
+/// token, and the probe distinguishes server replacement via a PID change
+/// rather than a creation-token change (the per-agent [`ProcessIdentity`]
+/// service remains the authoritative reuse-safe check).
+///
+/// Returns `None` for any malformed input so the caller fails open.
+#[must_use]
+pub fn parse_server_identity_output(output: &str) -> Option<ServerIdentity> {
+    let trimmed = output.trim();
+    let (pid_raw, version_raw) = trimmed.split_once('|')?;
+    let pid: u32 = pid_raw.trim().parse().ok()?;
+    let version = MultiplexerVersion::parse(version_raw.trim()).ok()?;
+    Some(ServerIdentity::new(ProcessIdentity::new(pid, 1), version))
+}

--- a/src/runtime/server_health.rs
+++ b/src/runtime/server_health.rs
@@ -166,9 +166,10 @@ const NO_SERVER_STDERR_MARKERS: &[&str] = &[
 /// - A nonzero command with unrelated stderr fails open as `Unavailable`.
 /// - A spawn/timeout failure fails open as `Unavailable`.
 ///
-/// `prior` is `None` on the first observation after startup; a missing-server
-/// signal with no prior server is `Unavailable` (nothing to lose), while a
-/// successful probe establishes the baseline as `Healthy`.
+/// `prior` is `None` on the first observation after startup. Probing occurs
+/// only while local agents are tracked, so an explicit missing-server signal is
+/// `Gone` even without a prior baseline; a successful probe establishes that
+/// baseline as `Healthy`.
 #[must_use]
 pub fn classify_server_liveness(
     prior: Option<&ServerIdentity>,

--- a/src/runtime/server_health_io.rs
+++ b/src/runtime/server_health_io.rs
@@ -1,0 +1,130 @@
+//! Multiplexer server-health I/O for the Windows liveness observer.
+
+use std::cell::Cell;
+use std::process::Stdio;
+
+use super::liveness::run_tmux_with_timeout;
+use super::server_health::{
+    ServerIdentity, ServerLivenessEvidence, ServerLivenessObservation, classify_server_health,
+    parse_server_identity_output,
+};
+use super::{MultiplexerIsolation, MultiplexerPlan, capture_process_identity};
+
+const SERVER_IDENTITY_FORMAT: &str = "#{pid}|#{version}";
+
+/// Probe the local multiplexer server and classify it against the pinned identity.
+pub fn observe_server_liveness(
+    plan: &MultiplexerPlan,
+    prior: Option<&ServerIdentity>,
+    applied_exit_empty: &Cell<Option<ServerIdentity>>,
+) -> ServerLivenessObservation {
+    let evidence = capture_server_identity_evidence(plan);
+    let observation = classify_observation(prior, &evidence);
+    log_server_observation(plan, prior, &evidence, &observation);
+    #[cfg(windows)]
+    apply_exit_empty_if_new_identity(plan, &observation, applied_exit_empty);
+    #[cfg(not(windows))]
+    let _ = applied_exit_empty;
+    observation
+}
+
+fn classify_observation(
+    prior: Option<&ServerIdentity>,
+    evidence: &ServerLivenessEvidence,
+) -> ServerLivenessObservation {
+    match evidence {
+        ServerLivenessEvidence::CommandCompleted { stdout, .. } => {
+            let Some(parsed) = parse_server_identity_output(stdout) else {
+                return ServerLivenessObservation::Unavailable;
+            };
+            let current = match capture_process_identity(parsed.process.pid) {
+                Ok(process) => ServerIdentity::new(process, parsed.multiplexer),
+                Err(_) => return ServerLivenessObservation::Unavailable,
+            };
+            match classify_server_health(prior, Some(&current), true) {
+                super::ServerHealth::Healthy => ServerLivenessObservation::Healthy(Some(current)),
+                super::ServerHealth::Replaced => ServerLivenessObservation::Replaced(current),
+                super::ServerHealth::Gone => ServerLivenessObservation::Unavailable,
+            }
+        }
+        _ => super::classify_server_liveness(prior, evidence),
+    }
+}
+
+fn capture_server_identity_evidence(plan: &MultiplexerPlan) -> ServerLivenessEvidence {
+    let mut command = plan.command();
+    command
+        .args(["display-message", "-p", SERVER_IDENTITY_FORMAT])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    match run_tmux_with_timeout(&mut command) {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+            if output.status.success() {
+                ServerLivenessEvidence::command_succeeded(&stdout, &stderr)
+            } else {
+                ServerLivenessEvidence::command_failed(&stderr)
+            }
+        }
+        Err(()) => ServerLivenessEvidence::spawn_failed(),
+    }
+}
+
+fn log_server_observation(
+    plan: &MultiplexerPlan,
+    prior: Option<&ServerIdentity>,
+    evidence: &ServerLivenessEvidence,
+    observation: &ServerLivenessObservation,
+) {
+    let namespace = match plan.isolation() {
+        MultiplexerIsolation::Namespace(name) => name.clone(),
+        MultiplexerIsolation::Socket(path) => path.to_string_lossy().into_owned(),
+    };
+    let (status, has_stderr) = match evidence {
+        ServerLivenessEvidence::CommandCompleted { stderr, .. } => ("ok", !stderr.is_empty()),
+        ServerLivenessEvidence::CommandFailed { stderr } => ("nonzero", !stderr.is_empty()),
+        ServerLivenessEvidence::SpawnFailed => ("spawn-failed", false),
+    };
+    tracing::debug!(
+        executable = %plan.executable().display(),
+        namespace = %namespace,
+        command = "display-message",
+        status,
+        has_stderr,
+        prior_pid = prior.map(|id| id.process.pid),
+        observation = ?observation,
+        "server liveness probe",
+    );
+}
+
+#[cfg(windows)]
+fn apply_exit_empty_if_new_identity(
+    plan: &MultiplexerPlan,
+    observation: &ServerLivenessObservation,
+    applied: &Cell<Option<ServerIdentity>>,
+) {
+    let current = match observation {
+        ServerLivenessObservation::Healthy(Some(id)) | ServerLivenessObservation::Replaced(id) => {
+            Some(*id)
+        }
+        _ => None,
+    };
+    if current.is_none() || applied.get() == current {
+        return;
+    }
+    let mut command = plan.command();
+    command.args(["set-option", "-s", "exit-empty", "off"]);
+    match run_tmux_with_timeout(&mut command) {
+        Ok(output) if output.status.success() => applied.set(current),
+        Ok(output) => tracing::warn!(
+            namespace = ?plan.isolation(),
+            stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+            "exit-empty set-option failed; failing open",
+        ),
+        Err(()) => tracing::warn!(
+            namespace = ?plan.isolation(),
+            "exit-empty set-option spawn/timeout failed; failing open",
+        ),
+    }
+}

--- a/src/selection/overlay_content.rs
+++ b/src/selection/overlay_content.rs
@@ -759,6 +759,10 @@ mod tests {
                 id: AgentId("a".to_string()),
                 confirm_focus: ConfirmFocus::Cancel,
             },
+            ModalState::ConfirmServerLostRecovery {
+                agent_ids: vec![AgentId("a".to_string())],
+                confirm_focus: ConfirmFocus::Cancel,
+            },
             ModalState::PreflightPrompt {
                 agent_id: AgentId("a".to_string()),
                 signature: confirm_signature(),

--- a/src/state/durable_projection.rs
+++ b/src/state/durable_projection.rs
@@ -457,7 +457,7 @@ fn project_preferences(
 
 fn last_known_runtime(status: AgentStatus) -> LastKnownRuntime {
     match status {
-        AgentStatus::Running => LastKnownRuntime::Running,
+        AgentStatus::Running | AgentStatus::ServerLost => LastKnownRuntime::Running,
         AgentStatus::Dead => LastKnownRuntime::Stopped,
         _ => LastKnownRuntime::Unknown,
     }

--- a/src/state/durable_projection.rs
+++ b/src/state/durable_projection.rs
@@ -457,6 +457,8 @@ fn project_preferences(
 
 fn last_known_runtime(status: AgentStatus) -> LastKnownRuntime {
     match status {
+        // ServerLost is transient infrastructure loss, not a confirmed stop;
+        // preserve launch metadata so explicit recovery remains possible.
         AgentStatus::Running | AgentStatus::ServerLost => LastKnownRuntime::Running,
         AgentStatus::Dead => LastKnownRuntime::Stopped,
         _ => LastKnownRuntime::Unknown,

--- a/src/state/durable_projection_tests.rs
+++ b/src/state/durable_projection_tests.rs
@@ -226,6 +226,23 @@ fn forward_maps_runtime_status_to_last_known() {
 }
 
 #[test]
+fn forward_preserves_server_lost_as_last_known_running() {
+    let mut state = sample_state();
+    state.agents[0].status = AgentStatus::ServerLost;
+
+    let projected = to_durable_state(&state).value_or_panic("projection succeeds");
+
+    assert_eq!(
+        projected.agents[0].runtime.last_known,
+        LastKnownRuntime::Running
+    );
+    assert_eq!(
+        projected.agents[0].runtime.session_id.as_deref(),
+        Some("jefe-runner")
+    );
+}
+
+#[test]
 fn forward_rewrites_invalid_ids_deterministically_with_remapped_references() {
     let mut state = sample_state();
     state.repositories[0].id = RepositoryId("Bad Repo!".to_owned());

--- a/src/state/modal_ops.rs
+++ b/src/state/modal_ops.rs
@@ -318,6 +318,7 @@ impl AppState {
             ModalState::ConfirmDeleteAgent { confirm_focus, .. }
             | ModalState::ConfirmDeleteRepository { confirm_focus, .. }
             | ModalState::ConfirmKillAgent { confirm_focus, .. }
+            | ModalState::ConfirmServerLostRecovery { confirm_focus, .. }
             | ModalState::PreflightPrompt { confirm_focus, .. }
             | ModalState::ConfirmIssueDirtyCopy { confirm_focus, .. }
             | ModalState::ConfirmIssueOriginMismatch { confirm_focus, .. } => Some(*confirm_focus),
@@ -332,6 +333,7 @@ impl AppState {
             ModalState::ConfirmDeleteAgent { confirm_focus, .. }
             | ModalState::ConfirmDeleteRepository { confirm_focus, .. }
             | ModalState::ConfirmKillAgent { confirm_focus, .. }
+            | ModalState::ConfirmServerLostRecovery { confirm_focus, .. }
             | ModalState::PreflightPrompt { confirm_focus, .. }
             | ModalState::ConfirmIssueDirtyCopy { confirm_focus, .. }
             | ModalState::ConfirmIssueOriginMismatch { confirm_focus, .. } => {

--- a/src/state/terminal_manager_types.rs
+++ b/src/state/terminal_manager_types.rs
@@ -127,5 +127,6 @@ pub fn status_label_for(status: AgentStatus) -> &'static str {
         AgentStatus::Waiting => "Waiting",
         AgentStatus::Paused => "Paused",
         AgentStatus::Dead => "Dead",
+        AgentStatus::ServerLost => "Server Lost",
     }
 }

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -208,6 +208,10 @@ pub enum ModalState {
         id: AgentId,
         confirm_focus: ConfirmFocus,
     },
+    ConfirmServerLostRecovery {
+        agent_ids: Vec<AgentId>,
+        confirm_focus: ConfirmFocus,
+    },
     /// Preflight check failed — prompt the user for remediation before launch.
     ///
     /// TODO(issue #24): Expand this to support a queue of issues if preflight

--- a/src/ui/components/agent_list.rs
+++ b/src/ui/components/agent_list.rs
@@ -58,7 +58,7 @@ fn status_icon(status: AgentStatus) -> &'static str {
         AgentStatus::Running => "*",
         AgentStatus::Completed => "+",
         AgentStatus::Dead => "x",
-        AgentStatus::Errored => "!",
+        AgentStatus::ServerLost | AgentStatus::Errored => "!",
         AgentStatus::Waiting => "?",
         AgentStatus::Paused => "-",
         AgentStatus::Queued => "o",
@@ -72,7 +72,7 @@ fn status_icon(status: AgentStatus) -> &'static str {
 fn status_role(status: AgentStatus) -> SpanRole {
     match status {
         AgentStatus::Running | AgentStatus::Completed => SpanRole::Bright,
-        AgentStatus::Dead | AgentStatus::Errored => SpanRole::Red,
+        AgentStatus::Dead | AgentStatus::Errored | AgentStatus::ServerLost => SpanRole::Red,
         AgentStatus::Waiting => SpanRole::Yellow,
         AgentStatus::Paused => SpanRole::Blue,
         AgentStatus::Queued => SpanRole::Dim,

--- a/src/ui/components/keybind_bar.rs
+++ b/src/ui/components/keybind_bar.rs
@@ -46,7 +46,7 @@ pub fn keybind_hints_for(
     }
     match screen_mode {
         ScreenMode::Dashboard => {
-            "^/v navigate | </> pane | t/f12 terminal focus | F7 shells | F10 shell | F8 external term | v active-only (repos+agents) | / search | \u{2325}1-9 jump agent | n new-agent | N new-repo | ctrl-d delete | ctrl-k kill | ctrl-r restart | l relaunch-dead | Space reorder | s split | F9 theme | ? help | ctrl-q/qqq quit"
+            "^/v navigate | </> pane | t/f12 terminal focus | F7 shells | F10 shell | F8 external term | v active-only (repos+agents) | / search | \u{2325}1-9 jump agent | n new-agent | N new-repo | ctrl-d delete | ctrl-k kill | ctrl-r restart | l relaunch/recover | Space reorder | s split | F9 theme | ? help | ctrl-q/qqq quit"
         }
         ScreenMode::Split => "^/v select | g grab | m move | Esc back | ? help | ctrl-q/qqq quit",
         ScreenMode::DashboardIssues => {

--- a/src/ui/components/selectable_list_main_tests.rs
+++ b/src/ui/components/selectable_list_main_tests.rs
@@ -226,11 +226,12 @@ fn agent_list_props_grabbed_prefix() {
 /// pre-refactor component did.
 #[test]
 fn agent_list_props_status_glyph_color_per_status() {
-    let cases: [(AgentStatus, SpanRole); 7] = [
+    let cases: [(AgentStatus, SpanRole); 8] = [
         (AgentStatus::Running, SpanRole::Bright),
         (AgentStatus::Completed, SpanRole::Bright),
         (AgentStatus::Dead, SpanRole::Red),
         (AgentStatus::Errored, SpanRole::Red),
+        (AgentStatus::ServerLost, SpanRole::Red),
         (AgentStatus::Waiting, SpanRole::Yellow),
         (AgentStatus::Paused, SpanRole::Blue),
         (AgentStatus::Queued, SpanRole::Dim),

--- a/src/ui/components/selectable_list_tests.rs
+++ b/src/ui/components/selectable_list_tests.rs
@@ -214,11 +214,12 @@ fn agent_list_props_grabbed_prefix() {
 /// pre-refactor component did.
 #[test]
 fn agent_list_props_status_glyph_color_per_status() {
-    let cases: [(AgentStatus, SpanRole); 7] = [
+    let cases: [(AgentStatus, SpanRole); 8] = [
         (AgentStatus::Running, SpanRole::Bright),
         (AgentStatus::Completed, SpanRole::Bright),
         (AgentStatus::Dead, SpanRole::Red),
         (AgentStatus::Errored, SpanRole::Red),
+        (AgentStatus::ServerLost, SpanRole::Red),
         (AgentStatus::Waiting, SpanRole::Yellow),
         (AgentStatus::Paused, SpanRole::Blue),
         (AgentStatus::Queued, SpanRole::Dim),

--- a/src/ui/modals/help.rs
+++ b/src/ui/modals/help.rs
@@ -66,7 +66,7 @@ const HELP_CONTENT_LINES: &[&str] = &[
     "  Ctrl-d      Delete selected",
     "  Ctrl-k      Kill agent",
     "  Ctrl-r      Restart agent",
-    "  l           Relaunch dead agent",
+    "  l           Relaunch dead / recover server-lost agents",
     "  s           Split mode",
     "  Space       Grab/move/drop reorder",
     "  v           Toggle active-only (repos + agents)",

--- a/src/ui/orchestration.rs
+++ b/src/ui/orchestration.rs
@@ -72,6 +72,10 @@ pub fn derive_confirm_modal_data(
             let (title, message, show) = confirm_text(snapshot, ConfirmKind::KillAgent(id));
             (title, message, show, false, *confirm_focus)
         }
+        ModalState::ConfirmServerLostRecovery {
+            agent_ids,
+            confirm_focus,
+        } => server_lost_confirmation(agent_ids.len(), *confirm_focus),
         ModalState::ConfirmDeleteRepository { id, confirm_focus } => {
             let (title, message, show) = confirm_text(snapshot, ConfirmKind::DeleteRepository(id));
             (title, message, show, false, *confirm_focus)
@@ -112,6 +116,19 @@ pub fn derive_confirm_modal_data(
         delete_work_dir,
         confirm_focus,
     })
+}
+
+fn server_lost_confirmation(
+    count: usize,
+    focus: ConfirmFocus,
+) -> (String, String, bool, bool, ConfirmFocus) {
+    (
+        String::from("Recover psmux Agents"),
+        format!("Relaunch {count} agent(s) whose psmux server was lost?"),
+        false,
+        false,
+        focus,
+    )
 }
 
 /// Which confirm variant to format, carrying only the fields needed for
@@ -346,6 +363,7 @@ pub fn build_modal_element(
         ModalState::ConfirmDeleteRepository { .. }
         | ModalState::ConfirmDeleteAgent { .. }
         | ModalState::ConfirmKillAgent { .. }
+        | ModalState::ConfirmServerLostRecovery { .. }
         | ModalState::PreflightPrompt { .. }
         | ModalState::ConfirmIssueDirtyCopy { .. }
         | ModalState::ConfirmIssueOriginMismatch { .. } => confirm_data.map(|data| {

--- a/src/ui/orchestration.rs
+++ b/src/ui/orchestration.rs
@@ -122,9 +122,10 @@ fn server_lost_confirmation(
     count: usize,
     focus: ConfirmFocus,
 ) -> (String, String, bool, bool, ConfirmFocus) {
+    let noun = if count == 1 { "agent" } else { "agents" };
     (
         String::from("Recover psmux Agents"),
-        format!("Relaunch {count} agent(s) whose psmux server was lost?"),
+        format!("Relaunch {count} {noun} whose psmux server was lost?"),
         false,
         false,
         focus,

--- a/tests/psmux_server_loss.rs
+++ b/tests/psmux_server_loss.rs
@@ -1,0 +1,117 @@
+#![cfg(all(windows, feature = "psmux-smoke"))]
+
+use std::cell::Cell;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use jefe::runtime::{
+    LocalPlatform, MultiplexerIsolation, MultiplexerPlan, ServerLivenessObservation,
+    observe_server_liveness,
+};
+
+static NAMESPACE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+struct ServerCleanup {
+    plan: MultiplexerPlan,
+}
+
+impl Drop for ServerCleanup {
+    fn drop(&mut self) {
+        let _ = self.plan.command().arg("kill-server").status();
+    }
+}
+
+fn psmux_test_context() -> Option<(MultiplexerPlan, ServerCleanup)> {
+    let executable = std::env::var_os("JEFE_PSMUX_BIN")
+        .filter(|value| !value.is_empty())
+        .map_or_else(|| PathBuf::from("psmux"), PathBuf::from);
+    if Command::new(&executable).arg("-V").output().is_err() {
+        assert!(
+            std::env::var_os("JEFE_REQUIRE_PSMUX").is_none(),
+            "psmux is required but {} is unavailable",
+            executable.display()
+        );
+        return None;
+    }
+    let plan = match MultiplexerPlan::for_platform(
+        LocalPlatform::Windows,
+        executable,
+        MultiplexerIsolation::Namespace(unique_namespace()),
+    ) {
+        Ok(plan) => plan,
+        Err(error) => panic!("construct psmux plan: {error}"),
+    };
+    let cleanup = ServerCleanup { plan: plan.clone() };
+    Some((plan, cleanup))
+}
+
+fn unique_namespace() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let sequence = NAMESPACE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    format!("jefe-issue493-{}-{nanos}-{sequence}", std::process::id())
+}
+
+fn run(plan: &MultiplexerPlan, args: &[&str]) -> Output {
+    match plan.command().args(args).output() {
+        Ok(output) => output,
+        Err(error) => panic!("psmux {args:?} could not start: {error}"),
+    }
+}
+
+fn assert_success(output: &Output, operation: &str) {
+    assert!(
+        output.status.success(),
+        "{operation} failed: status={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+}
+
+#[test]
+fn native_psmux_server_loss_is_observed_without_empty_inventory_reconciliation() {
+    let Some((plan, _cleanup)) = psmux_test_context() else {
+        return;
+    };
+    assert_success(
+        &run(&plan, &["new-session", "-d", "-s", "issue493-a"]),
+        "create first server session",
+    );
+
+    let applied = Cell::new(None);
+    let baseline = observe_server_liveness(&plan, None, &applied);
+    let ServerLivenessObservation::Healthy(Some(first)) = baseline else {
+        panic!("expected a healthy first server observation, got {baseline:?}");
+    };
+    let option = run(&plan, &["show-options", "-s", "exit-empty"]);
+    assert_success(&option, "read exit-empty after observation");
+    assert!(
+        String::from_utf8_lossy(&option.stdout).contains("exit-empty off"),
+        "observer must disable exit-empty once for the server identity"
+    );
+    assert_eq!(
+        observe_server_liveness(&plan, Some(&first), &applied),
+        baseline
+    );
+    assert_eq!(applied.get(), Some(first));
+
+    assert_success(&run(&plan, &["kill-server"]), "terminate owned server");
+    assert_eq!(
+        observe_server_liveness(&plan, Some(&first), &applied),
+        ServerLivenessObservation::Gone
+    );
+
+    assert_success(
+        &run(&plan, &["new-session", "-d", "-s", "issue493-b"]),
+        "create replacement server session",
+    );
+    let replacement = observe_server_liveness(&plan, Some(&first), &applied);
+    let ServerLivenessObservation::Replaced(second) = replacement else {
+        panic!("expected replacement server observation, got {replacement:?}");
+    };
+    assert_ne!(second.process, first.process);
+    assert_eq!(applied.get(), Some(second));
+}

--- a/tests/runtime_server_health.rs
+++ b/tests/runtime_server_health.rs
@@ -1,0 +1,256 @@
+use jefe::domain::{Agent, AgentId, AgentStatus, ProcessIdentity, RepositoryId};
+use jefe::runtime::{
+    MultiplexerVersion, ServerHealth, ServerIdentity, ServerLivenessEvidence,
+    ServerLivenessObservation, classify_server_health, classify_server_liveness,
+    parse_server_identity_output,
+};
+use jefe::state::transition::TransitionExt;
+use jefe::state::{AppEvent, AppState};
+use std::path::PathBuf;
+
+fn identity(pid: u32, started_at: u64) -> ServerIdentity {
+    ServerIdentity::new(
+        ProcessIdentity::new(pid, started_at),
+        MultiplexerVersion::new(3, 3, 7),
+    )
+}
+
+#[test]
+fn tracked_agents_with_no_server_are_server_lost() {
+    let health = classify_server_health(None, None, true);
+
+    assert_eq!(health, ServerHealth::Gone);
+}
+
+#[test]
+fn no_server_without_tracked_agents_is_healthy() {
+    let health = classify_server_health(None, None, false);
+
+    assert_eq!(health, ServerHealth::Healthy);
+}
+
+#[test]
+fn first_observed_server_establishes_a_healthy_baseline() {
+    let current = identity(100, 1);
+
+    let health = classify_server_health(None, Some(&current), true);
+
+    assert_eq!(health, ServerHealth::Healthy);
+}
+
+#[test]
+fn unchanged_server_identity_is_healthy() {
+    let previous = identity(100, 1);
+
+    let health = classify_server_health(Some(&previous), Some(&previous), true);
+
+    assert_eq!(health, ServerHealth::Healthy);
+}
+
+#[test]
+fn changed_server_pid_is_replaced() {
+    let previous = identity(100, 1);
+    let current = identity(200, 2);
+
+    let health = classify_server_health(Some(&previous), Some(&current), true);
+
+    assert_eq!(health, ServerHealth::Replaced);
+}
+
+#[test]
+fn reused_server_pid_with_new_creation_token_is_replaced() {
+    let previous = identity(100, 1);
+    let current = identity(100, 2);
+
+    let health = classify_server_health(Some(&previous), Some(&current), true);
+
+    assert_eq!(health, ServerHealth::Replaced);
+}
+
+// --- ServerLivenessObservation classification (issue #493 Stack A) ---
+
+/// A successful command that returns no parseable identity output cannot
+/// establish server presence and fails open as Unavailable.
+#[test]
+fn successful_command_with_unparseable_output_is_unavailable() {
+    let prior = identity(100, 1);
+    let evidence = ServerLivenessEvidence::command_succeeded("garbage", "");
+
+    let observation = classify_server_liveness(Some(&prior), &evidence);
+
+    assert_eq!(observation, ServerLivenessObservation::Unavailable);
+}
+
+/// A successful command returning the same identity is Healthy.
+#[test]
+fn successful_command_same_identity_is_healthy() {
+    let prior = identity(100, 1);
+    let evidence = ServerLivenessEvidence::command_succeeded("100|3.3.7", "");
+
+    let observation = classify_server_liveness(Some(&prior), &evidence);
+
+    assert_eq!(observation, ServerLivenessObservation::Healthy(Some(prior)));
+}
+
+/// A successful command returning a different PID is Replaced.
+#[test]
+fn successful_command_changed_pid_is_replaced() {
+    let prior = identity(100, 1);
+    let evidence = ServerLivenessEvidence::command_succeeded("200|3.3.7", "");
+
+    let observation = classify_server_liveness(Some(&prior), &evidence);
+
+    assert_eq!(
+        observation,
+        ServerLivenessObservation::Replaced(identity(200, 1))
+    );
+}
+
+/// A nonzero command whose stderr indicates no server is Gone.
+#[test]
+fn nonzero_command_with_no_server_stderr_is_gone() {
+    let prior = identity(100, 1);
+    let evidence = ServerLivenessEvidence::command_failed("no server running on");
+
+    let observation = classify_server_liveness(Some(&prior), &evidence);
+
+    assert_eq!(observation, ServerLivenessObservation::Gone);
+}
+
+/// A nonzero command whose stderr does not indicate a missing server fails
+/// open as Unavailable (could be a transient multiplexer error).
+#[test]
+fn nonzero_command_with_unrelated_stderr_is_unavailable() {
+    let prior = identity(100, 1);
+    let evidence = ServerLivenessEvidence::command_failed("permission denied");
+
+    let observation = classify_server_liveness(Some(&prior), &evidence);
+
+    assert_eq!(observation, ServerLivenessObservation::Unavailable);
+}
+
+/// A spawn failure fails open as Unavailable.
+#[test]
+fn spawn_failure_is_unavailable() {
+    let prior = identity(100, 1);
+    let evidence = ServerLivenessEvidence::spawn_failed();
+
+    let observation = classify_server_liveness(Some(&prior), &evidence);
+
+    assert_eq!(observation, ServerLivenessObservation::Unavailable);
+}
+
+/// With no prior server, a successful first observation establishes Healthy.
+#[test]
+fn first_successful_observation_is_healthy() {
+    let evidence = ServerLivenessEvidence::command_succeeded("100|3.3.7", "");
+
+    let observation = classify_server_liveness(None, &evidence);
+
+    assert_eq!(
+        observation,
+        ServerLivenessObservation::Healthy(Some(identity(100, 1)))
+    );
+}
+
+/// A no-server response is Gone even before a baseline is pinned because the
+/// caller only probes while local agents are tracked.
+#[test]
+fn no_prior_server_nonzero_command_is_gone() {
+    let evidence = ServerLivenessEvidence::command_failed("no server running on");
+
+    let observation = classify_server_liveness(None, &evidence);
+
+    assert_eq!(observation, ServerLivenessObservation::Gone);
+}
+
+// --- parse_server_identity_output ---
+
+#[test]
+fn parse_identity_output_extracts_pid_and_version() {
+    let parsed = parse_server_identity_output("100|3.3.7");
+
+    let expected = ServerIdentity::new(
+        ProcessIdentity::new(100, 1),
+        MultiplexerVersion::new(3, 3, 7),
+    );
+    assert_eq!(parsed, Some(expected));
+}
+
+#[test]
+fn parse_identity_output_rejects_missing_version() {
+    assert!(parse_server_identity_output("100").is_none());
+}
+
+#[test]
+fn parse_identity_output_rejects_non_numeric_pid() {
+    assert!(parse_server_identity_output("abc|3.3.7").is_none());
+}
+
+#[test]
+fn parse_identity_output_rejects_empty_input() {
+    assert!(parse_server_identity_output("").is_none());
+}
+
+// --- AgentStatus::ServerLost domain projection (issue #493 Stack A) ---
+
+#[test]
+fn server_lost_preserves_runtime_binding_when_transitioned() {
+    let mut agent = Agent::new(
+        AgentId("agent-1".into()),
+        RepositoryId("repo".into()),
+        "Agent 1".into(),
+        PathBuf::from("/tmp"),
+    );
+    agent.status = AgentStatus::Running;
+    agent.runtime_binding = Some(jefe::domain::RuntimeBinding {
+        session_name: "jefe-agent-1".into(),
+        launch_signature: jefe::domain::LaunchSignature {
+            work_dir: PathBuf::from("/tmp"),
+            profile: "default".into(),
+            code_puppy_model: String::new(),
+            code_puppy_version: String::new(),
+            code_puppy_yolo: Some(false),
+            code_puppy_quick_resume: false,
+            mode_flags: vec![],
+            llxprt_debug: String::new(),
+            pass_continue: true,
+            sandbox_enabled: false,
+            sandbox_engine: jefe::domain::SandboxEngine::Podman,
+            sandbox_flags: jefe::domain::DEFAULT_SANDBOX_FLAGS.to_owned(),
+            remote: jefe::domain::RemoteRepositorySettings::default(),
+            agent_kind: jefe::domain::AgentKind::Llxprt,
+            llxprt_version: None,
+        },
+        attached: false,
+        last_seen: None,
+        pid: Some(123),
+        process_identity: Some(ProcessIdentity::new(123, 1)),
+        lifecycle_generation: 0,
+        worker_identities: vec![],
+    });
+
+    let agent_id = agent.id.clone();
+    let mut state = AppState::default();
+    state.agents.push(agent);
+
+    let state = state
+        .apply(AppEvent::AgentStatusChanged(
+            agent_id,
+            AgentStatus::ServerLost,
+        ))
+        .committed_pure();
+
+    assert_eq!(state.agents[0].status, AgentStatus::ServerLost);
+    assert!(
+        state.agents[0].runtime_binding.is_some(),
+        "ServerLost reducer transition must preserve runtime_binding for recovery"
+    );
+}
+
+#[test]
+fn server_lost_status_is_distinct_variant() {
+    assert_ne!(AgentStatus::ServerLost, AgentStatus::Dead);
+    assert_ne!(AgentStatus::ServerLost, AgentStatus::Running);
+    assert_ne!(AgentStatus::ServerLost, AgentStatus::Errored);
+}


### PR DESCRIPTION
## Summary

Fixes #493.

Native Windows agents share a single psmux server. When that server disappeared or was replaced, Jefe could interpret the replacement server's inventory as individual session deaths, mark every affected agent `Dead`, and discard the bindings needed for recovery.

This PR delivers the complete bounded issue behavior in one branch:

- observes and pins the native psmux server process identity and version;
- distinguishes healthy, gone, replaced, and unavailable server observations;
- applies `exit-empty off` once per supported server identity;
- transitions affected local agents to a distinct `ServerLost` state without clearing bindings or launch signatures;
- preserves existing same-server per-agent `Dead` behavior and Unix behavior;
- surfaces non-blocking psmux startup diagnostics and documents the 3.3.7 minimum;
- provides a cancel-focused, explicitly confirmed batch-recovery action;
- revalidates candidates at confirmation, excludes remote/stale agents, and relaunches each retained signature independently;
- returns successes to `Running`, leaves failures retryable as `ServerLost`, and reports partial outcomes.

The required above-target scope review is recorded in `project-plans/issue493-plan.md`: 33 files / 2,029 net lines, below the 40-file / 2,500-line hard stop, with every path mapped to acceptance A1-A12. No dependency, workflow, quality-tool, harness-grammar, or unrelated subsystem changes are included.

## Pre-push checklist

- [x] **Format** — `cargo fmt --all --check`
- [x] **Clippy allow policy** — exercised by the project checks
- [x] **Source file length** — `cargo xtask check source-size`
- [x] **Architecture boundary policy** — exercised by the project checks
- [x] **Lint** — `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] **Complexity** — strict Clippy/project checks pass
- [x] **Coverage** — local coverage completed during issue verification; required CI remains authoritative
- [x] **Build** — `cargo build --workspace --all-features --locked`
- [x] **Tests** — `cargo test --workspace --all-features --locked -- --test-threads=1 -q`

## Testing notes

Exact-head verification was rerun after rebasing onto current `origin/main`:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --all-features --locked`
- serial locked all-feature suite: 2,511 library tests, 810 binary tests, and all integration/doctest targets passed
- `cargo xtask quick`
- `cargo xtask check source-size`
- `JEFE_REQUIRE_PSMUX=1 cargo test --features psmux-smoke --test psmux_server_loss -- --nocapture`
- focused server-health, app-shell liveness, durable projection, confirmation modal, and partial-recovery tests

The schema-1 TUI scenario is included at `dev-docs/tmux-scenarios/v1/issue493-server-loss.json`. The native Windows runner correctly reports `HAR-E005` because schema-1 requires a Unix PTY; the fixture is retained for Unix CI, while the real psmux server-loss boundary is covered by the isolated native regression.

Two permitted pre-PR reviews were completed. All Blocker-Fix and In-scope-Fix findings were resolved; rejected and deferred suggestions are recorded in the issue plan.

## Reviewers / Assignees

Maintainers of the Windows runtime and TUI paths.
