### PR TITLE
Keep panic diagnostics out of the terminal (Fixes #496)

### DIFF
--- a/dev-docs/tmux-scenarios/v1/panic-capture-errors.json
+++ b/dev-docs/tmux-scenarios/v1/panic-capture-errors.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "name": "panic-capture-errors",
+  "platform": "macos",
+  "terminal": { "cols": 100, "rows": 30 },
+  "workspace": {
+    "mode": 448,
+    "dirs": [{ "path": "work", "mode": 448 }],
+    "files": [],
+    "env": []
+  },
+  "steps": [
+    {
+      "op": "launch",
+      "argv": ["jefe-harness-probe"],
+      "env": [],
+      "cwd": "work"
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "PROBE READY",
+      "timeout_ms": 15000
+    },
+    { "op": "text", "text": "panic-errors\n" },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "PANIC ERRORS READY",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "assert-frame",
+      "contains": [
+        "STATUS ERROR TITLE <none>",
+        "Source: Panic",
+        "issue-496-ui-panic",
+        "PANIC ERRORS READY"
+      ],
+      "absent": ["thread '", "panicked at", "ERR: issue-496-ui-panic"]
+    },
+    { "op": "finish" }
+  ],
+  "secrets": []
+}

--- a/project-plans/issue496-plan.md
+++ b/project-plans/issue496-plan.md
@@ -1,0 +1,256 @@
+# Issue #496 — Global panic capture and executor-owned app state
+
+## Status
+
+**Accepted for implementation.** The user delegated the bounded architecture and
+test-boundary decisions to the implementer and requested completion without
+additional approval prompts. The decisions below are therefore authoritative;
+the normal hard scope and quality stop conditions still apply.
+
+Planning base: `30344e2bec5c72b30bcbe422ef03bc2811e8e3ae` (current
+`origin/main` when the issue branch was created).
+
+## Problem and validated root cause
+
+Jefe installs a file-backed tracing subscriber when configured, but it does not
+replace Rust's default process panic hook before entering the TUI. The default
+hook writes panic diagnostics to stderr, which corrupts the alternate-screen UI.
+
+The concrete `blocking-N` trigger is
+`app_input::terminal_manager::complete_pending_shell_focus`: it copies
+`AppStateHandle` into `smol::unblock`, then calls `state.try_read()` from the
+blocking worker through `select_pending_runtime_shell` and
+`pending_focus_matches`. The complete audit found this is the only non-GitHub
+`smol::unblock` closure that accesses `AppStateHandle`/`State<AppState>`.
+
+A panic hook controls diagnostics but does not catch an unwind. Therefore it can
+permanently prevent the default hook from printing raw panic text, but it cannot
+promise that an arbitrary uncontained panic continues execution long enough for
+the render loop to show the queued report. Awaiting a panicked `smol::unblock`
+can resume the unwind on the executor.
+
+## Accepted implementation decisions
+
+1. **Capture, not broad recovery.** Install a global hook that never delegates to
+   the default hook, logs and queues every panic, and lets normal Rust unwind
+   semantics continue. Panics contained by an existing safe boundary can be
+   drained into Errors; an uncontained fatal panic is still captured/logged and
+   emits no raw terminal text, but is not promised to render in-app. Remove the
+   known off-thread state trigger rather than adding broad `catch_unwind` around
+   runtime work with potentially partial external side effects.
+2. **Configured logging contract.** "Recorded in the log file" means recorded
+   when Jefe's existing file tracing sink is configured and initialized. Do not
+   create a new default log location or change logging privacy/storage policy.
+3. **Private ownership.** Keep `panic_capture` private to the binary; do not add
+   a public library API. Install it after `logging::init()` and before terminal
+   initialization / `smol::block_on`.
+4. **Silent semantics.** A silent panic entry is retained in the full Errors
+   ring and never becomes the status banner or changes screen/focus/error-list
+   selection/scroll. It does not erase an older unrelated visible error banner.
+5. **Bounded queue.** Cap undrained panic reports at the existing 50-entry error
+   capacity and retain the newest reports. Do not add a panic-recovery or
+   redaction subsystem.
+6. **No debugger delegation.** Debugger-specific delegation is a non-goal because
+   the previous/default hook may write to the terminal.
+7. **TUI evidence boundary.** The real app has no deterministic legal input that
+   intentionally panics. A required real-TTY test cannot be added without a new
+   test boundary. Approve a narrowly scoped, non-shipping integration fixture
+   that exercises the same panic-capture-to-Errors projection in the schema-1
+   TUI harness, with child-process tests separately proving real startup hook
+   ordering, blocking-pool capture, configured logging, and empty stderr. The
+   fixture design must be reviewed before implementation and must not add a
+   production panic trigger, public API, dependency, or quality-rule exception.
+
+If every arbitrary panic must recover and render in-app, or every run must create
+a log file, stop this bounded plan and approve a separate recovery/logging
+architecture first.
+
+## Decision-complete acceptance matrix (conditional on the decisions above)
+
+| ID | Actor / launch path | Input and boundaries | Target | Observable success | Observable failure / diagnostics | Side effects before failure | Persistence / compatibility | Behavioral evidence |
+|---|---|---|---|---|---|---|---|---|
+| A1 | Normal Jefe TUI startup after logging initialization | Any panic whose hook runs after installation; string and non-string payloads; optional source location; named or unnamed thread | Local/remote terminal; macOS, Linux, Windows | Global hook emits no stdout/stderr, extracts payload/location/thread metadata, traces the report, and queues it | Uncontained unwind retains Rust fail-fast semantics; report is available to configured tracing and queue before unwind continues | Queue append and configured trace event only | No durable-state schema change; CLI paths completed before hook installation remain unchanged | Fresh child process installs the real hook, triggers a caught panic, and proves stdout/stderr do not contain the payload and one report drains |
+| A2 | Blocking-pool worker with survivable containment | Panic inside `smol::unblock`, caught at the test boundary after the hook runs | macOS/Linux/Windows | Report includes worker identity and payload, configured log contains it, queue drains exactly once | Logging is absent only when the existing sink is unconfigured/failed; queue remains the in-process diagnostic | Same as A1 | Existing logging opt-in behavior is preserved | Cross-platform child-process test with unique configured log file; no exact `blocking-N` suffix assertion |
+| A3 | App-shell poll loop | Zero, one, or multiple queued reports; queue overflow retains newest 50 | TUI executor thread | Drain converts reports into silent `ErrorSource::Panic` entries | Poisoned queue ownership is recovered inside the hook boundary without terminal output; no app-state access occurs in the hook | Errors ring mutation on executor only | Errors remain runtime-only | State/integration test proves ordered exactly-once drain and capacity behavior |
+| A4 | Status bar and Errors screen | Silent panic after no visible error and after an older visible error | All TUI platforms | Panic is listed and selectable/copyable on Errors; it never becomes `ERR:` and does not change screen, focus, selection, or scroll | Older visible error remains the visible banner until existing behavior clears/replaces it | Append to Errors ring only | `silent` deserializes as false when absent for compatibility | State tests plus projection tests for `Source: Panic`; approved schema-1 fixture scenario verifies frame behavior |
+| A5 | Pending shell-focus completion | Pending owner/generation stable, stale before select, stale after select, runtime success/failure | tmux and psmux paths | Worker receives only plain snapshot/context runtime inputs; multiplexer select is off-thread; executor revalidates and commits/compensates | Typed runtime error follows existing reducer behavior; stale result is not committed and existing compensation runs | Multiplexer select may occur before executor detects staleness, matching current contract | No persistence format change | Focused orchestration regression plus existing generation/reducer tests; no source-text-only proof |
+| A6 | Existing GitHub worker containment | Contained and uncontained caught worker panics after global hook installation | All platforms | `worker_panic::contain` still attributes contained panic site and suppresses delegation; uncontained panic delegates to global capture | Existing GitHub worker failure behavior remains unchanged | Existing Errors behavior for contained GitHub failures | No route migration | Child-process composition test installs global hook first, then exercises contained and uncontained-caught cases |
+| A7 | Exact candidate head | All accepted paths and boundaries | Local gates plus native Windows CI | Format, policy, architecture, strict/complexity Clippy, coverage, locked build, tests, scenario, CI, ancestry, and conflict checks pass | Any interrupted/skipped/stale-SHA gate is incomplete | None beyond test fixtures | No compatibility regression | `cargo xtask ci`, approved TUI fixture gate, PR CI and review evidence on exact SHA |
+
+## Explicit non-goals
+
+- No migration of the 31 `gh_async::spawn_gh_work` routes; their centralized
+  `worker_panic::contain` path remains unchanged.
+- No broad panic recovery or generic task-supervision subsystem.
+- No claim that `set_hook` catches unwind, handles abort/signals/faults, or can
+  render after a fatal executor unwind.
+- No default log-file policy, logging documentation expansion, or payload
+  redaction subsystem.
+- No iocraft/generational-box/vendor changes.
+- No project-wide `unwrap`/`expect` cleanup.
+- No debugger-specific previous-hook delegation.
+- No production panic trigger, hidden production test command, public panic API,
+  dependency change, quality-gate change, lint suppression, threshold increase,
+  unrelated refactor, or unrelated test move.
+- No change that clears an older visible error banner when a silent panic arrives.
+- No defensive `catch_unwind` around runtime operations that already return
+  typed errors.
+
+## Bounded vertical slices
+
+### Slice 1 — Silent Panic domain/state/UI semantics (A3, A4)
+
+- **Owners:** domain model, deterministic state, pure projection, thin UI label.
+- **Allowed paths:** `src/domain/errors.rs`, `src/state/errors_types.rs`,
+  `src/state/selectors.rs`, `src/state/errors_tests.rs`,
+  `src/selection/errors_content.rs`, `src/selection/content_tests.rs`,
+  `src/ui/screens/errors.rs`.
+- **RED:** silent insertion/visible-selector/focus-selection-scroll/serde tests
+  and Panic source projection test fail for missing behavior.
+- **GREEN:** silent entries remain in the ring while status projection skips them.
+- **Stop:** any durable schema migration, new public abstraction, or unrelated UI
+  redesign becomes necessary.
+- **Focused verification:** relevant lib tests and `cargo xtask quick`.
+
+### Slice 2 — Global capture, logging, queue drain, and hook composition (A1-A4, A6)
+
+- **Owners:** binary startup and app-shell orchestration boundary.
+- **Allowed paths:** new private `src/panic_capture.rs`, `src/main.rs`,
+  `src/app_shell.rs`, and test-only changes in `src/app_input/worker_panic.rs`.
+- **RED:** child-process blocking-worker test proves current default-hook stderr;
+  hook-composition test proves global capture is absent before implementation.
+- **GREEN:** private hook installs after logging, queues bounded reports, traces to
+  configured sink, drains on executor, and composes with existing containment.
+- **Stop:** app-shell exceeds 1,000 lines, hook needs a public library module,
+  logging policy must change, or broad recovery is required.
+- **Focused verification:** child tests, app-shell/state tests, source-size and
+  architecture checks, then `cargo xtask quick`.
+
+### Slice 3 — Executor-owned pending focus state (A5)
+
+- **Owner:** terminal-manager orchestration boundary.
+- **Allowed paths:** `src/app_input/terminal_manager.rs` and an existing adjacent
+  test module if required.
+- **RED:** behavioral orchestration test proves stale pending focus is not
+  confirmed and compensation remains correct while select work is off-thread.
+- **GREEN:** no `AppStateHandle` enters the worker; pre/post validation and typed
+  runtime handling pass.
+- **Stop:** a new public runtime trait, process subsystem, vendor change, or
+  unrelated terminal-manager refactor is required.
+- **Focused verification:** terminal-manager/reducer tests and `cargo xtask quick`.
+
+### Slice 4 — TUI evidence and exact-head delivery (A4, A7)
+
+- **Owner:** schema-1 non-shipping test fixture only.
+- **Allowed paths:** to be finalized after approval and design inspection;
+  expected under `dev-docs/tmux-scenarios/v1/` plus the smallest existing fixture
+  registration/test boundary.
+- **RED:** scenario shows missing Panic entry or status suppression before the
+  behavior exists.
+- **GREEN:** real-TTY frame excludes payload/`ERR:` while Errors projection shows
+  Panic; child test remains the strict stderr-channel proof.
+- **Stop:** production panic orchestration, dependency/manifest change, public
+  abstraction, or more than the approved fixture files is required.
+- **Verification:** scenario target and full `cargo xtask ci` on exact head.
+
+## Expected files by architectural layer
+
+| Layer | Expected path | Acceptance |
+|---|---|---|
+| Plan | `project-plans/issue496-plan.md` | workflow evidence |
+| Binary boundary | `src/panic_capture.rs` (new) | A1-A3 |
+| Startup | `src/main.rs` | A1, A6 |
+| App orchestration | `src/app_shell.rs` | A3 |
+| Runtime orchestration | `src/app_input/terminal_manager.rs` | A5 |
+| Worker composition test | `src/app_input/worker_panic.rs` | A6 |
+| Domain | `src/domain/errors.rs` | A3, A4 |
+| State | `src/state/errors_types.rs`, `src/state/selectors.rs` | A3, A4 |
+| State tests | `src/state/errors_tests.rs` | A3, A4 |
+| Projection | `src/selection/errors_content.rs` | A4 |
+| Projection tests | `src/selection/content_tests.rs` | A4 |
+| UI | `src/ui/screens/errors.rs` | A4 |
+| TUI evidence | `dev-docs/tmux-scenarios/v1/panic-capture-errors.json`, `src/bin/jefe-harness-probe.rs`, `tests/harness_v1_fixtures.rs` | A4, A7 |
+| Typed capture route | `src/messages/errors.rs`, `src/messages/errors_conversion.rs`, `src/messages/event_conversion.rs`, `src/state/events.rs`, `src/state/errors_ops.rs` | A3, A4 |
+| Executor drain boundary | `src/app_shell_panic.rs` | A3 |
+
+Final scope is 22 files and 881 net added lines after rebasing onto current main,
+below the 25-file / 1,500-line target. The mainline liveness extraction reduced
+`src/app_shell.rs` below its former 1,000-line limit; the issue integration does
+not add a second orchestration path.
+
+## Off-thread audit ledger
+
+| Site | App state in worker? | Disposition |
+|---|---:|---|
+| `src/app_shell_workers.rs` liveness closure | No | Leave unchanged |
+| `src/app_shell_workers.rs` persistence closure | No | Leave existing typed/caught callback boundary unchanged |
+| `src/app_shell_workers.rs` history closure | No | Leave unchanged |
+| `src/app_input/terminal_manager.rs` preview closure | No | Leave unchanged |
+| `src/app_input/terminal_manager.rs` pending-focus closure | **Yes** | Fix in Slice 3 |
+| `src/app_input/shell_overlay.rs` existence closure | No | Leave unchanged |
+| `src/app_input/shell_overlay.rs` inventory closure | No | Leave unchanged |
+| `src/app_shell.rs` liveness closure | No | Leave unchanged |
+| `src/app_shell.rs` attach closure | No | Leave unchanged |
+| `src/app_shell.rs` persistence scheduling closure | No | Leave unchanged |
+| `src/app_input/gh_async.rs` centralized worker closure | No direct state; contained | Explicitly excluded with all 31 routes |
+
+No other non-GitHub `smol::unblock` state capture was found. Reviewer suggestions
+to add broad containment are outside the accepted architecture unless concrete
+source evidence changes this ledger.
+
+## Scope ledger
+
+| Status | File / discovery | Mapping / disposition |
+|---|---|---|
+| Complete | `project-plans/issue496-plan.md` | mandatory bounded workflow record |
+| Complete | production/domain/state/projection paths listed above | A1-A6 |
+| Complete | adjacent state/projection/worker tests | behavioral evidence for A1-A6 |
+| Complete | schema-1 scenario, probe command, and fixture registration | non-shipping real-PTY evidence for A4/A7 |
+| Complete | typed Errors message/event/reducer route | preserves unidirectional state ownership for A3/A4 |
+| Reject | all other audited `smol::unblock` closures | no app state access; no defect to fix |
+| Defer | unconditional default log file | separate logging/privacy policy |
+| Defer | generic panic recovery/task supervision | separate architecture with consistency semantics |
+
+Every changed file must be entered here and map to an acceptance row before edit.
+Stop for approval above 25 files or 1,500 net changed lines; stop unconditionally
+without explicit approval above 40 files or 2,500 net changed lines.
+
+## Review counters and finding dispositions
+
+- DeepThinker planning analysis: complete.
+- Local Rust/DeepThinker review cycles: 1 / 2, all findings triaged.
+- Local CodeRabbit review: complete, 2 / 2 findings **In-scope-Fix** and resolved.
+- OCR before PR: 1 / 2, 3 / 3 findings **In-scope-Fix** and resolved.
+- OCR after PR: 0 / 2.
+- CodeRabbit PR findings: pending PR.
+
+Review dispositions: preserve selected error identity; revalidate stale
+same-owner generations; drain unconditionally on the executor; route capture
+through typed reducer messages; add real-PTY evidence; assert blocking-worker
+stdout/stderr, log, capacity, non-string payload, and exact-once behavior; retain
+the newest silent report at full capacity; use `VecDeque` for bounded queue
+eviction; and isolate fixture capture from stale reports. The proposed
+hook-reentrancy wrapper was **Reject** because hook code cannot safely recover a
+subscriber panic, and the accepted fail-fast contract avoids layered panic
+recovery.
+
+## Verification evidence
+
+| Candidate SHA | Command / evidence | Result |
+|---|---|---|
+| `4a976a22` | Slice RED compile/tests | failed for missing Panic/silent/hook contracts as intended |
+| `4a976a22` | strict Clippy, format, clippy-allow, source-size, architecture, locked workspace build | pass after rebase |
+| `4a976a22` | blocking hook, worker composition, silent state/selection/capacity, stale focus regressions | pass |
+| `4a976a22` | `panic_capture_fixture_projects_silent_error_without_raw_terminal_output` | pass in schema-1 real PTY |
+| pre-rebase reviewed head | `cargo xtask ci` through format/policy/architecture/strict+complexity Clippy/coverage | pass; locked all-test phase exposed only the existing editor-fixture timeout |
+| pre-rebase reviewed head | locked all-feature Jefe suite with editor fixture isolated serially | pass |
+| current `origin/main` | strict Clippy/all-test gate | blocked by `actions_tests_sort.rs` using the obsolete four-argument `Repository::new`; same source exists on origin/main and is outside issue scope |
+| `4a976a22` | DeepThinker/Rust review, local CodeRabbit, OCR 1/2 | complete and triaged |
+| `4a976a22` | ancestry | rebased: one issue commit ahead, zero behind `origin/main` |
+| pending PR head | native Windows / PR CI / PR CodeRabbit / conflict check | pending |
+
+## Deferred findings / follow-ups
+
+No follow-up issue has been created. If approval requires unconditional panic
+recovery or default logging, create separate decision-complete issues rather
+than expanding issue #496 automatically.

--- a/project-plans/issue496-plan.md
+++ b/project-plans/issue496-plan.md
@@ -172,8 +172,9 @@ architecture first.
 | TUI evidence | `dev-docs/tmux-scenarios/v1/panic-capture-errors.json`, `src/bin/jefe-harness-probe.rs`, `tests/harness_v1_fixtures.rs` | A4, A7 |
 | Typed capture route | `src/messages/errors.rs`, `src/messages/errors_conversion.rs`, `src/messages/event_conversion.rs`, `src/state/events.rs`, `src/state/errors_ops.rs` | A3, A4 |
 | Executor drain boundary | `src/app_shell_panic.rs` | A3 |
+| Exact-head CI compatibility | `src/state/actions_tests_sort.rs`, `src/state/prs_test_fixtures.rs` | A7 |
 
-Final scope is 22 files and 881 net added lines after rebasing onto current main,
+Final scope is 24 files and 968 net added lines after the PR review remediation,
 below the 25-file / 1,500-line target. The mainline liveness extraction reduced
 `src/app_shell.rs` below its former 1,000-line limit; the issue integration does
 not add a second orchestration path.
@@ -207,6 +208,9 @@ source evidence changes this ledger.
 | Complete | adjacent state/projection/worker tests | behavioral evidence for A1-A6 |
 | Complete | schema-1 scenario, probe command, and fixture registration | non-shipping real-PTY evidence for A4/A7 |
 | Complete | typed Errors message/event/reducer route | preserves unidirectional state ownership for A3/A4 |
+| Complete | `src/state/actions_tests_sort.rs` constructor fixture | minimal A7 compatibility repair for the inherited current-main compile failure seen in all failed PR CI jobs |
+| Complete | `src/state/prs_test_fixtures.rs` fixture initialization | minimal A7 repair for the inherited 61/60-line strict-Clippy failure exposed after the compile blocker was fixed; removes an assignment that redundantly restated the default |
+| Complete | selected silent-entry eviction fallback regression | PR OCR finding; A4 selection continuity now chooses the adjacent older entry |
 | Reject | all other audited `smol::unblock` closures | no app state access; no defect to fix |
 | Defer | unconditional default log file | separate logging/privacy policy |
 | Defer | generic panic recovery/task supervision | separate architecture with consistency semantics |
@@ -221,17 +225,24 @@ without explicit approval above 40 files or 2,500 net changed lines.
 - Local Rust/DeepThinker review cycles: 1 / 2, all findings triaged.
 - Local CodeRabbit review: complete, 2 / 2 findings **In-scope-Fix** and resolved.
 - OCR before PR: 1 / 2, 3 / 3 findings **In-scope-Fix** and resolved.
-- OCR after PR: 0 / 2.
-- CodeRabbit PR findings: pending PR.
+- OCR after PR: 1 / 2; one finding **In-scope-Fix**, two findings **Reject**.
+- CodeRabbit PR findings: no findings; the service reported its review-volume limit.
 
 Review dispositions: preserve selected error identity; revalidate stale
 same-owner generations; drain unconditionally on the executor; route capture
 through typed reducer messages; add real-PTY evidence; assert blocking-worker
 stdout/stderr, log, capacity, non-string payload, and exact-once behavior; retain
 the newest silent report at full capacity; use `VecDeque` for bounded queue
-eviction; and isolate fixture capture from stale reports. The proposed
-hook-reentrancy wrapper was **Reject** because hook code cannot safely recover a
-subscriber panic, and the accepted fail-fast contract avoids layered panic
+eviction; and isolate fixture capture from stale reports. The post-PR selection
+finding was fixed with a RED/GREEN regression that falls back to the adjacent
+older entry when the selected silent entry is evicted. The zero-capacity finding
+was **Reject** because `ERROR_STORE_CAPACITY` is the nonzero constant 50 and one
+entry is evicted per overflow. The visible-eviction finding was **Reject** because
+when a full visible-only store accepts the required newest panic report, evicting
+the oldest visible entry leaves `last_visible_error()` and the status projection
+unchanged; discarding the new panic would violate A3/A4. The proposed
+hook-reentrancy wrapper was also **Reject** because hook code cannot safely recover
+a subscriber panic, and the accepted fail-fast contract avoids layered panic
 recovery.
 
 ## Verification evidence
@@ -244,10 +255,14 @@ recovery.
 | `4a976a22` | `panic_capture_fixture_projects_silent_error_without_raw_terminal_output` | pass in schema-1 real PTY |
 | pre-rebase reviewed head | `cargo xtask ci` through format/policy/architecture/strict+complexity Clippy/coverage | pass; locked all-test phase exposed only the existing editor-fixture timeout |
 | pre-rebase reviewed head | locked all-feature Jefe suite with editor fixture isolated serially | pass |
-| current `origin/main` | strict Clippy/all-test gate | blocked by `actions_tests_sort.rs` using the obsolete four-argument `Repository::new`; same source exists on origin/main and is outside issue scope |
+| current `origin/main` | strict Clippy/all-test gate | blocked by `actions_tests_sort.rs` using the obsolete four-argument `Repository::new`; the same source exists on `origin/main` |
+| PR head `d11f9c97` | PR CI | format/policy/source-size/architecture passed; strict Clippy, complexity, coverage, and native Windows all failed on that inherited constructor mismatch |
+| working remediation | focused Actions sorting suite | 9 passed after supplying the established shipped type/default map fixture |
+| working remediation | local strict Clippy | constructor compile blocker cleared; exposed inherited 61/60-line `prs_state_with_detail` fixture, reduced by removing a redundant assignment of the default inline state |
+| working remediation | selected silent-entry eviction regression | RED selected the oldest entry; GREEN selects the adjacent older entry while visible-banner capacity behavior still passes |
 | `4a976a22` | DeepThinker/Rust review, local CodeRabbit, OCR 1/2 | complete and triaged |
-| `4a976a22` | ancestry | rebased: one issue commit ahead, zero behind `origin/main` |
-| pending PR head | native Windows / PR CI / PR CodeRabbit / conflict check | pending |
+| `d11f9c97` | ancestry / PR mergeability | one issue commit ahead, zero behind `origin/main`; PR conflict-free |
+| pending candidate head | full local gates / native Windows / PR CI / conflict check | pending |
 
 ## Deferred findings / follow-ups
 

--- a/src/app_input/terminal_manager.rs
+++ b/src/app_input/terminal_manager.rs
@@ -242,24 +242,17 @@ fn expected_focus_screen(origin: ShellFocusOrigin) -> ScreenMode {
     }
 }
 
-fn pending_focus_matches(state: &AppStateHandle, owner: &AgentId, generation: u64) -> bool {
-    state.try_read().is_some_and(|state| {
-        matches!(
-            state.terminal_manager.pending_focus.as_ref(),
-            Some(value) if value.agent_id == *owner && value.generation == generation
-        )
-    })
+fn pending_focus_matches(state: &AppState, owner: &AgentId, generation: u64) -> bool {
+    matches!(
+        state.terminal_manager.pending_focus.as_ref(),
+        Some(value) if value.agent_id == *owner && value.generation == generation
+    )
 }
 
 fn select_pending_runtime_shell(
-    state: &AppStateHandle,
     ctx: &std::sync::Arc<std::sync::Mutex<crate::AppContext>>,
     owner: &AgentId,
-    generation: u64,
 ) -> Result<SelectOutcome, jefe::runtime::RuntimeError> {
-    if !pending_focus_matches(state, owner, generation) {
-        return Ok(SelectOutcome::PendingGone);
-    }
     let inputs = {
         let guard = ctx.lock().map_err(|_| {
             jefe::runtime::RuntimeError::CapabilityProbeFailed(
@@ -296,8 +289,6 @@ fn select_pending_runtime_shell(
 
 /// Outcome of an off-lock select-existing shell operation (issue #374 S5).
 enum SelectOutcome {
-    /// Pending focus no longer matches — nothing to confirm.
-    PendingGone,
     /// Select succeeded and the owner is still attached. Carries the
     /// snapshotted session for compensation if confirmation later goes stale.
     Selected(String),
@@ -333,24 +324,24 @@ pub async fn complete_pending_shell_focus(
     let Some(ctx_arc) = ctx.as_ref() else {
         return;
     };
+    if !pending_focus_matches(&app_state.read(), &attached_agent_id, pending.generation) {
+        return;
+    }
     let ctx_clone = std::sync::Arc::clone(ctx_arc);
     let owner = attached_agent_id.clone();
-    let state_for_guard = app_state;
-    let pending_generation = pending.generation;
-    let result = smol::unblock(move || {
-        select_pending_runtime_shell(&state_for_guard, &ctx_clone, &owner, pending_generation)
-    })
-    .await;
+    let result = smol::unblock(move || select_pending_runtime_shell(&ctx_clone, &owner)).await;
     let outcome = match result {
         Ok(outcome) => outcome,
         Err(error) => {
+            if !pending_focus_matches(&app_state.read(), &attached_agent_id, pending.generation) {
+                return;
+            }
             warn!(agent_id = %attached_agent_id.0, error = %error, "manager: focus shell failed");
             on_shell_attach_failed(&mut app_state, &attached_agent_id);
             return;
         }
     };
     let selected_session_name = match outcome {
-        SelectOutcome::PendingGone => return,
         SelectOutcome::Stale(session_name) => {
             warn!(
                 agent_id = %attached_agent_id.0,
@@ -423,4 +414,36 @@ pub fn on_shell_attach_failed(app_state: &mut AppStateHandle, failed_agent_id: &
         "Failed to focus shell for agent {}.",
         failed_agent_id.0
     ));
+}
+
+#[cfg(test)]
+mod pending_focus_tests {
+    use super::*;
+    use jefe::state::PendingShellFocus;
+
+    #[test]
+    fn pending_focus_match_is_evaluated_from_executor_snapshot() {
+        let agent_id = AgentId("agent-496".to_owned());
+        let mut state = AppState::default();
+        state.terminal_manager.pending_focus = Some(PendingShellFocus {
+            agent_id: agent_id.clone(),
+            generation: 7,
+            origin: ShellFocusOrigin::ManagerEnter,
+        });
+
+        assert!(pending_focus_matches(&state, &agent_id, 7));
+        assert!(!pending_focus_matches(
+            &state,
+            &AgentId("other-agent".to_owned()),
+            7
+        ));
+        state.terminal_manager.pending_focus = Some(PendingShellFocus {
+            agent_id: agent_id.clone(),
+            generation: 8,
+            origin: ShellFocusOrigin::ManagerEnter,
+        });
+        assert!(!pending_focus_matches(&state, &agent_id, 7));
+        state.terminal_manager.pending_focus = None;
+        assert!(!pending_focus_matches(&state, &agent_id, 7));
+    }
 }

--- a/src/app_input/worker_panic.rs
+++ b/src/app_input/worker_panic.rs
@@ -6,10 +6,9 @@
 //! drawing on, so the report is torn across the interface and lost on the next
 //! render.
 //!
-//! [`contain`] runs a closure with the payload captured instead of printed, so
+//! [`contain`] runs a closure with the payload captured instead of delegated, so
 //! the caller can route it to the errors screen. Containment is scoped to the
-//! calling thread for the duration of that closure: panics anywhere else keep
-//! the previously installed hook and stay loud.
+//! calling thread; other panics delegate to the process hook installed earlier.
 
 use std::cell::{Cell, RefCell};
 use std::sync::Once;
@@ -23,9 +22,8 @@ thread_local! {
 
 /// Install the containment-aware panic hook exactly once per process.
 ///
-/// The hook delegates to the previously installed hook for every panic that is
-/// not inside a [`contain`] boundary, so uncontained panics keep their normal
-/// diagnostics.
+/// The hook delegates every uncontained panic to the previously installed
+/// process hook, which is Jefe's silent global capture hook during normal startup.
 fn install_hook() {
     static INSTALL: Once = Once::new();
     INSTALL.call_once(|| {
@@ -202,6 +200,56 @@ stderr:
         );
     }
 
+    const GLOBAL_HOOK_CHILD_VAR: &str = "JEFE_WORKER_GLOBAL_PANIC_HOOK_CHILD";
+
+    #[test]
+    fn containment_composes_with_global_panic_capture() {
+        if std::env::var_os(GLOBAL_HOOK_CHILD_VAR).is_some() {
+            run_global_hook_child();
+            return;
+        }
+
+        let executable = std::env::current_exe()
+            .unwrap_or_else(|error| panic!("the test executable path must resolve: {error}"));
+        let output = std::process::Command::new(executable)
+            .args([
+                "--exact",
+                "app_input::worker_panic::tests::containment_composes_with_global_panic_capture",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env(GLOBAL_HOOK_CHILD_VAR, "1")
+            .output()
+            .unwrap_or_else(|error| panic!("the child test process must start: {error}"));
+        assert!(
+            output.status.success(),
+            "child hook assertions failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !String::from_utf8_lossy(&output.stderr).contains("global-uncontained"),
+            "the global hook must not write the delegated panic to stderr"
+        );
+    }
+
+    fn run_global_hook_child() {
+        crate::panic_capture::install_panic_hook();
+        let contained = contain(|| panic!("worker-contained"));
+        assert!(contained.is_err(), "worker containment must remain active");
+        assert!(
+            crate::panic_capture::drain_panic_reports().is_empty(),
+            "contained worker panic must not reach the global queue"
+        );
+
+        let uncontained = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            panic!("global-uncontained")
+        }));
+        assert!(uncontained.is_err(), "uncontained panic must still unwind");
+        let reports = crate::panic_capture::drain_panic_reports();
+        assert_eq!(reports.len(), 1, "global capture must receive delegation");
+        assert_eq!(reports[0].message, "global-uncontained");
+    }
     /// Each worker thread records its own location, so simultaneous panics
     /// cannot be attributed to each other's source site.
     #[test]

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -88,7 +88,7 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
 
     hooks.use_future({
         let ctx = ctx.clone();
-        let app_state = app_state;
+        let mut app_state = app_state;
         let mut render_tick = render_tick;
         async move {
             const POLL_MS: u64 = 16;
@@ -115,7 +115,7 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
                     || (terminal_focused && dirty)
                     || (running_preview && elapsed_ms >= PREVIEW_THROTTLE_MS && dirty);
 
-                if should_render {
+                if crate::app_shell_panic::drain_into_errors(&mut app_state) || should_render {
                     elapsed_ms = 0;
                     let tick = render_tick.get();
                     render_tick.set(tick.wrapping_add(1));

--- a/src/app_shell_panic.rs
+++ b/src/app_shell_panic.rs
@@ -1,0 +1,19 @@
+//! Executor-owned delivery of process-global panic reports.
+
+use crate::app_input::AppStateHandle;
+
+pub fn drain_into_errors(app_state: &mut AppStateHandle) -> bool {
+    let reports = crate::panic_capture::drain_panic_reports();
+    if reports.is_empty() {
+        return false;
+    }
+    let mut state = app_state.write();
+    for report in reports {
+        jefe::state::transition::commit_pure_site(
+            &mut state,
+            jefe::messages::AppMessage::Errors(report.into_errors_message()),
+        );
+    }
+    drop(state);
+    true
+}

--- a/src/bin/jefe-harness-probe.rs
+++ b/src/bin/jefe-harness-probe.rs
@@ -17,6 +17,14 @@
 use std::io::{BufRead, Write};
 use std::process::ExitCode;
 
+#[path = "../panic_capture.rs"]
+mod panic_capture;
+
+fn init_diagnostics() {
+    jefe::logging::init();
+    panic_capture::install_panic_hook();
+}
+
 fn main() -> ExitCode {
     match run() {
         Ok(()) => ExitCode::SUCCESS,
@@ -95,9 +103,47 @@ fn handle_line(line: &str, run_sequence: &mut u64) -> Result<bool, String> {
             let value = std::env::var(name).unwrap_or_else(|_| "<unset>".to_string());
             print_line(&format!("ENV {name}={value}"))?;
         }
+        Some("panic-errors") => render_panic_errors()?,
         Some(_) | None => print_line(&format!("INPUT: {line}"))?,
     }
     Ok(false)
+}
+fn render_panic_errors() -> Result<(), String> {
+    const PANIC_MARKER: &str = "issue-496-ui-panic";
+    init_diagnostics();
+    let _ = panic_capture::drain_panic_reports();
+    let unwind = std::panic::catch_unwind(|| std::panic::panic_any(PANIC_MARKER.to_owned()));
+    if unwind.is_ok() {
+        return Err("panic fixture did not unwind".to_owned());
+    }
+    let mut state = jefe::state::AppState::default();
+    let reports = panic_capture::drain_panic_reports();
+    if reports.is_empty() {
+        return Err("panic fixture did not capture a report".to_owned());
+    }
+    for report in reports {
+        jefe::state::transition::commit_pure_site(
+            &mut state,
+            jefe::messages::AppMessage::Errors(report.into_errors_message()),
+        );
+    }
+    print_line(&format!(
+        "STATUS ERROR TITLE {}",
+        state.last_error_title().as_deref().unwrap_or("<none>")
+    ))?;
+    state.errors_state.selected_index = Some(0);
+    let content = jefe::selection::pane_content_lines(
+        jefe::selection::SelectablePane::ErrorDetail,
+        &state,
+        None,
+        &[],
+        100,
+        30,
+    );
+    for line in content.lines {
+        print_line(&line)?;
+    }
+    print_line("PANIC ERRORS READY")
 }
 
 fn run_command(sequence: u64, args: &[String]) -> Result<(), String> {

--- a/src/domain/errors.rs
+++ b/src/domain/errors.rs
@@ -19,6 +19,7 @@ pub enum ErrorSource {
     Persistence,
     Agent,
     Startup,
+    Panic,
     #[default]
     Other,
 }
@@ -33,6 +34,7 @@ impl ErrorSource {
             Self::Persistence => "persistence",
             Self::Agent => "agent",
             Self::Startup => "startup",
+            Self::Panic => "panic",
             Self::Other => "other",
         }
     }
@@ -56,4 +58,7 @@ pub struct ErrorEntry {
     pub source: ErrorSource,
     /// Unix epoch seconds (UTC) of when the error was captured.
     pub timestamp: String,
+    /// Whether status projections should omit this entry.
+    #[serde(default)]
+    pub silent: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,11 @@ mod app_shell;
 mod app_shell_attach;
 mod app_shell_key_routing;
 mod app_shell_liveness;
+mod app_shell_panic;
 mod app_shell_workers;
 mod detail_wrap_map;
 mod mouse_routing;
+mod panic_capture;
 mod pty_encoding;
 mod terminal_init;
 
@@ -200,6 +202,10 @@ fn runtime_manager(rows: u16, cols: u16, state_path: &std::path::Path) -> TmuxRu
         },
     )
 }
+fn init_diagnostics() {
+    jefe::logging::init();
+    panic_capture::install_panic_hook();
+}
 
 fn run_app(context: Arc<std::sync::Mutex<AppContext>>) {
     smol::block_on(async {
@@ -243,8 +249,8 @@ fn main() {
     let published_settings = startup.settings;
     let persistence = startup.manager;
 
-    // Initialize structured logging only after persistence has validated.
-    jefe::logging::init();
+    // Initialize diagnostics only after persistence has validated.
+    init_diagnostics();
     tracing::info!(version = jefe::VERSION, "jefe starting");
     tracing::debug!(
         log_file = ?jefe::logging::log_file_path(),

--- a/src/messages/errors.rs
+++ b/src/messages/errors.rs
@@ -4,6 +4,7 @@
 //! mutation correlation. Messages cover only mode lifecycle, list navigation,
 //! detail scrolling, and clearing the log.
 
+use crate::domain::ErrorSource;
 use crate::messages::{NavDir, ScrollDir};
 
 /// Errors mode messages.
@@ -17,6 +18,12 @@ pub enum ErrorsMessage {
     CycleFocus,
     CycleFocusReverse,
     ScrollDetail(ScrollDir),
+    CaptureSilent {
+        title: String,
+        detail: String,
+        source: ErrorSource,
+        timestamp: String,
+    },
     ClearAll,
 }
 
@@ -32,6 +39,7 @@ impl ErrorsMessage {
             Self::CycleFocus => "ErrorsCycleFocus",
             Self::CycleFocusReverse => "ErrorsCycleFocusReverse",
             Self::ScrollDetail(_) => "ErrorsScrollDetail",
+            Self::CaptureSilent { .. } => "ErrorsCaptureSilent",
             Self::ClearAll => "ErrorsClearAll",
         }
     }

--- a/src/messages/errors_conversion.rs
+++ b/src/messages/errors_conversion.rs
@@ -32,6 +32,12 @@ impl ErrorsMessage {
             AppEvent::ErrorsScrollDetailDown => Self::ScrollDetail(ScrollDir::Down),
             AppEvent::ErrorsScrollDetailPageUp => Self::ScrollDetail(ScrollDir::PageUp),
             AppEvent::ErrorsScrollDetailPageDown => Self::ScrollDetail(ScrollDir::PageDown),
+            AppEvent::CaptureSilentError(title, detail, source, timestamp) => Self::CaptureSilent {
+                title,
+                detail,
+                source,
+                timestamp,
+            },
             AppEvent::ErrorsClearAll => Self::ClearAll,
             _ => unreachable!("unhandled event for ErrorsMessage: {:?}", event),
         }
@@ -48,6 +54,12 @@ impl ErrorsMessage {
             Self::CycleFocus => AppEvent::ErrorsCycleFocus,
             Self::CycleFocusReverse => AppEvent::ErrorsCycleFocusReverse,
             Self::ScrollDetail(dir) => Self::map_scroll(dir),
+            Self::CaptureSilent {
+                title,
+                detail,
+                source,
+                timestamp,
+            } => AppEvent::CaptureSilentError(title, detail, source, timestamp),
             Self::ClearAll => AppEvent::ErrorsClearAll,
         }
     }

--- a/src/messages/event_conversion.rs
+++ b/src/messages/event_conversion.rs
@@ -312,6 +312,7 @@ impl AppMessage {
                 | AppEvent::ErrorsScrollDetailDown
                 | AppEvent::ErrorsScrollDetailPageUp
                 | AppEvent::ErrorsScrollDetailPageDown
+                | AppEvent::CaptureSilentError(..)
                 | AppEvent::ErrorsClearAll
         )
     }

--- a/src/panic_capture.rs
+++ b/src/panic_capture.rs
@@ -1,0 +1,219 @@
+//! Process-wide panic diagnostics for the terminal application.
+//!
+//! The hook never touches terminal streams or application state. It records a
+//! bounded diagnostic for the executor-owned render loop to drain.
+
+use std::collections::VecDeque;
+use std::sync::{Mutex, MutexGuard, Once};
+
+use jefe::domain::{ERROR_STORE_CAPACITY, ErrorSource};
+use jefe::messages::ErrorsMessage;
+
+static INSTALL: Once = Once::new();
+static REPORTS: Mutex<VecDeque<PanicReport>> = Mutex::new(VecDeque::new());
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PanicReport {
+    pub message: String,
+    pub location: Option<String>,
+    pub thread: String,
+    timestamp: String,
+}
+
+pub fn install_panic_hook() {
+    INSTALL.call_once(|| {
+        std::panic::set_hook(Box::new(|info| {
+            let message = info
+                .payload()
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| {
+                    info.payload()
+                        .downcast_ref::<&'static str>()
+                        .map(ToString::to_string)
+                })
+                .unwrap_or_else(|| "unknown panic".to_owned());
+            capture_panic(message, info.location().map(ToString::to_string));
+        }));
+    });
+}
+
+fn capture_panic(message: String, location: Option<String>) {
+    let thread = thread_label();
+    let timestamp = timestamp();
+    tracing::error!(
+        target: "jefe::panic",
+        panic_message = %message,
+        panic_location = ?location,
+        panic_thread = %thread,
+        "thread panicked"
+    );
+    let mut reports = reports_guard();
+    if reports.len() == ERROR_STORE_CAPACITY {
+        reports.pop_front();
+    }
+    reports.push_back(PanicReport {
+        message,
+        location,
+        thread,
+        timestamp,
+    });
+}
+
+fn thread_label() -> String {
+    let thread = std::thread::current();
+    let name = thread.name().unwrap_or("unnamed");
+    format!("{name} ({:?})", thread.id())
+}
+
+fn timestamp() -> String {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or_else(
+            |_| "0".to_owned(),
+            |duration| duration.as_secs().to_string(),
+        )
+}
+
+fn reports_guard() -> MutexGuard<'static, VecDeque<PanicReport>> {
+    match REPORTS.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+pub fn drain_panic_reports() -> Vec<PanicReport> {
+    std::mem::take(&mut *reports_guard()).into()
+}
+
+impl PanicReport {
+    pub fn into_errors_message(self) -> ErrorsMessage {
+        let detail = report_detail(&self);
+        ErrorsMessage::CaptureSilent {
+            title: format!("Panic on {}", self.thread),
+            detail,
+            source: ErrorSource::Panic,
+            timestamp: self.timestamp,
+        }
+    }
+}
+
+fn report_detail(report: &PanicReport) -> String {
+    report.location.as_ref().map_or_else(
+        || format!("{}\nThread: {}", report.message, report.thread),
+        |location| {
+            format!(
+                "{}\nThread: {}\nLocation: {location}",
+                report.message, report.thread
+            )
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CHILD_ENV: &str = "JEFE_PANIC_CAPTURE_CHILD";
+    const PANIC_MARKER: &str = "issue-496-blocking-panic";
+
+    #[test]
+    fn blocking_pool_panic_is_logged_and_captured_without_stderr() {
+        if std::env::var_os(CHILD_ENV).is_some() {
+            run_blocking_pool_child();
+            return;
+        }
+
+        let executable = std::env::current_exe()
+            .unwrap_or_else(|error| panic!("test executable path must resolve: {error}"));
+        let log_path = std::env::temp_dir().join(format!(
+            "jefe-panic-capture-{}-{}.log",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let output = std::process::Command::new(executable)
+            .args([
+                "--exact",
+                "panic_capture::tests::blocking_pool_panic_is_logged_and_captured_without_stderr",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env(CHILD_ENV, "1")
+            .env("JEFE_LOG_FILE", &log_path)
+            .env("JEFE_LOG", "error")
+            .output()
+            .unwrap_or_else(|error| panic!("panic-capture child must start: {error}"));
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "child assertions failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            !stdout.contains(PANIC_MARKER),
+            "global hook must not print panic payload to stdout: {stdout}"
+        );
+        assert!(
+            !stderr.contains(PANIC_MARKER),
+            "global hook must not print panic payload to stderr: {stderr}"
+        );
+        let log = std::fs::read_to_string(&log_path)
+            .unwrap_or_else(|error| panic!("configured panic log must be readable: {error}"));
+        assert!(
+            log.contains(PANIC_MARKER),
+            "configured log must contain the panic record: {log}"
+        );
+        let _ = std::fs::remove_file(log_path);
+    }
+
+    fn run_blocking_pool_child() {
+        crate::init_diagnostics();
+        let unwind = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            smol::block_on(smol::unblock(|| panic!("{PANIC_MARKER}")))
+        }));
+        assert!(unwind.is_err(), "the blocking worker must still unwind");
+
+        let reports = drain_panic_reports();
+        assert_eq!(reports.len(), 1, "the hook must enqueue exactly one report");
+        let report = &reports[0];
+        assert_eq!(report.message, PANIC_MARKER);
+        assert!(
+            !report.thread.is_empty(),
+            "worker identity must be recorded"
+        );
+        assert!(report.location.is_some(), "panic location must be recorded");
+
+        for index in 0..ERROR_STORE_CAPACITY + 5 {
+            capture_panic(format!("queue-{index}"), None);
+        }
+        let reports = drain_panic_reports();
+        assert_eq!(reports.len(), ERROR_STORE_CAPACITY);
+        assert_eq!(
+            reports.first().map(|report| report.message.as_str()),
+            Some("queue-5")
+        );
+        assert_eq!(
+            reports.last().map(|report| report.message.as_str()),
+            Some("queue-54")
+        );
+        assert!(
+            drain_panic_reports().is_empty(),
+            "reports must drain exactly once"
+        );
+
+        let unknown = std::panic::catch_unwind(|| std::panic::panic_any(42_u8));
+        assert!(unknown.is_err(), "non-string payload must still unwind");
+        let reports = drain_panic_reports();
+        assert_eq!(
+            reports.first().map(|report| report.message.as_str()),
+            Some("unknown panic")
+        );
+    }
+
+    fn unique_suffix() -> u128 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_nanos())
+    }
+}

--- a/src/selection/content_tests.rs
+++ b/src/selection/content_tests.rs
@@ -647,3 +647,28 @@ fn confirm_modal_lines_include_title_and_message() {
         "confirm modal must include the message with the agent name"
     );
 }
+
+#[test]
+fn panic_error_detail_remains_selectable_and_identifies_its_source() {
+    let mut state = AppState::default();
+    crate::state::transition::commit_pure_site(
+        &mut state,
+        crate::messages::AppMessage::Errors(crate::messages::ErrorsMessage::CaptureSilent {
+            title: "blocking worker panic".into(),
+            detail: "worker exploded".into(),
+            source: crate::domain::ErrorSource::Panic,
+            timestamp: "panic-ts".into(),
+        }),
+    );
+    state.errors_state.selected_index = Some(0);
+
+    let content = pane_content_lines(SelectablePane::ErrorDetail, &state, None, &[], 120, 40);
+
+    assert!(
+        content
+            .lines
+            .iter()
+            .any(|line| line.contains("Source: Panic"))
+    );
+    assert!(content.lines.iter().any(|line| line == "worker exploded"));
+}

--- a/src/selection/errors_content.rs
+++ b/src/selection/errors_content.rs
@@ -54,6 +54,7 @@ pub fn error_detail_lines(state: &AppState) -> PaneContent {
         crate::domain::ErrorSource::Persistence => "Persistence",
         crate::domain::ErrorSource::Agent => "Agent",
         crate::domain::ErrorSource::Startup => "Startup",
+        crate::domain::ErrorSource::Panic => "Panic",
         crate::domain::ErrorSource::Other => "Other",
     };
     let mut lines = vec![

--- a/src/state/actions_tests_sort.rs
+++ b/src/state/actions_tests_sort.rs
@@ -13,6 +13,8 @@ mod tests {
         let mut state = AppState::default();
         let repo = Repository::new(
             RepositoryId("test_repo".to_string()),
+            crate::domain::shipped_agent_type(3),
+            crate::domain::TypedMap::new(),
             "test_repo".to_string(),
             "test_repo".to_string(),
             std::path::PathBuf::from("/tmp"),

--- a/src/state/errors_ops.rs
+++ b/src/state/errors_ops.rs
@@ -153,6 +153,16 @@ impl AppState {
             ErrorsMessage::CycleFocus => self.cycle_error_focus(),
             ErrorsMessage::CycleFocusReverse => self.cycle_error_focus_reverse(),
             ErrorsMessage::ScrollDetail(dir) => self.handle_error_scroll(dir),
+            ErrorsMessage::CaptureSilent {
+                title,
+                detail,
+                source,
+                timestamp,
+            } => {
+                self.errors_state
+                    .push_silent(title, detail, source, timestamp);
+                true
+            }
             ErrorsMessage::ClearAll => self.clear_all_errors(),
         }
     }

--- a/src/state/errors_tests.rs
+++ b/src/state/errors_tests.rs
@@ -556,6 +556,60 @@ fn silent_capacity_preserves_the_visible_banner_entry() {
 }
 
 #[test]
+fn evicting_selected_silent_error_selects_the_adjacent_older_entry() {
+    let mut state = AppState::default();
+    state.errors_state.push(
+        "oldest visible".into(),
+        "oldest detail".into(),
+        ErrorSource::Other,
+        "oldest-ts".into(),
+        false,
+    );
+    state.errors_state.push(
+        "adjacent older visible".into(),
+        "adjacent detail".into(),
+        ErrorSource::Other,
+        "adjacent-ts".into(),
+        false,
+    );
+    state.errors_state.push_silent(
+        "selected panic".into(),
+        "selected detail".into(),
+        ErrorSource::Panic,
+        "selected-ts".into(),
+    );
+    for index in 0..crate::domain::ERROR_STORE_CAPACITY - 3 {
+        state.errors_state.push(
+            format!("newer visible {index}"),
+            format!("newer detail {index}"),
+            ErrorSource::Other,
+            "newer-ts".into(),
+            false,
+        );
+    }
+    state.errors_state.selected_index = state
+        .errors_state
+        .errors
+        .iter()
+        .position(|entry| entry.title == "selected panic");
+
+    state.errors_state.push_silent(
+        "new panic".into(),
+        "new detail".into(),
+        ErrorSource::Panic,
+        "new-ts".into(),
+    );
+
+    assert_eq!(
+        state
+            .errors_state
+            .selected_error()
+            .map(|entry| entry.title.as_str()),
+        Some("adjacent older visible")
+    );
+}
+
+#[test]
 fn legacy_error_entry_deserializes_as_visible() {
     let json = r#"{
         "seq": 7,

--- a/src/state/errors_tests.rs
+++ b/src/state/errors_tests.rs
@@ -408,8 +408,15 @@ fn push_preserves_selection_when_active() {
     );
     assert_eq!(
         state.errors_state.selected_index,
-        Some(1),
-        "selection should be preserved when not snapping"
+        Some(2),
+        "selection should follow the same entry when not snapping"
+    );
+    assert_eq!(
+        state
+            .errors_state
+            .selected_error()
+            .map(|entry| entry.title.as_str()),
+        Some("first")
     );
     assert_eq!(
         state.errors_state.detail_scroll_offset, 3,
@@ -454,4 +461,112 @@ fn nav_while_repo_focused_does_not_move_error_selection() {
     assert_eq!(state.errors_state.selected_index, before);
     state.apply_errors_message(ErrorsMessage::Navigate(NavDir::End));
     assert_eq!(state.errors_state.selected_index, before);
+}
+
+#[test]
+fn silent_panic_is_stored_without_changing_visible_error_or_navigation() {
+    let mut state = AppState::default();
+    state.screen_mode = ScreenMode::DashboardErrors;
+    state.pane_focus = crate::state::PaneFocus::Repositories;
+    state.errors_state.active = true;
+    state.errors_state.focus = ErrorsFocus::ErrorDetail;
+    state.errors_state.push(
+        "visible failure".into(),
+        "visible detail".into(),
+        ErrorSource::Other,
+        "visible-ts".into(),
+        false,
+    );
+    state.errors_state.selected_index = Some(0);
+    state.errors_state.detail_scroll_offset = 4;
+
+    state.apply_errors_message(ErrorsMessage::CaptureSilent {
+        title: "blocking worker panic".into(),
+        detail: "panic detail".into(),
+        source: ErrorSource::Panic,
+        timestamp: "panic-ts".into(),
+    });
+
+    assert_eq!(state.errors_state.count(), 2);
+    let newest = state.errors_state.last_error();
+    assert!(
+        matches!(newest, Some(entry) if entry.source == ErrorSource::Panic && entry.silent),
+        "the panic must remain in the full error ring: {newest:?}"
+    );
+    assert_eq!(
+        state
+            .errors_state
+            .last_visible_error()
+            .map(|entry| entry.title.as_str()),
+        Some("visible failure")
+    );
+    assert_eq!(state.last_error_title().as_deref(), Some("visible failure"));
+    assert_eq!(state.screen_mode, ScreenMode::DashboardErrors);
+    assert_eq!(state.pane_focus, crate::state::PaneFocus::Repositories);
+    assert_eq!(state.errors_state.focus, ErrorsFocus::ErrorDetail);
+    assert_eq!(state.errors_state.selected_index, Some(1));
+    assert_eq!(
+        state
+            .errors_state
+            .selected_error()
+            .map(|entry| entry.title.as_str()),
+        Some("visible failure")
+    );
+    assert_eq!(state.errors_state.detail_scroll_offset, 4);
+}
+
+#[test]
+fn silent_capacity_preserves_the_visible_banner_entry() {
+    let mut state = AppState::default();
+    state.errors_state.push(
+        "visible failure".into(),
+        "visible detail".into(),
+        ErrorSource::Other,
+        "visible-ts".into(),
+        false,
+    );
+    for index in 0..crate::domain::ERROR_STORE_CAPACITY {
+        state.errors_state.push_silent(
+            format!("panic {index}"),
+            format!("detail {index}"),
+            ErrorSource::Panic,
+            "panic-ts".into(),
+        );
+    }
+
+    assert_eq!(
+        state.errors_state.count(),
+        crate::domain::ERROR_STORE_CAPACITY
+    );
+    assert_eq!(
+        state
+            .errors_state
+            .last_error()
+            .map(|entry| entry.title.as_str()),
+        Some("panic 49")
+    );
+    assert_eq!(state.last_error_title().as_deref(), Some("visible failure"));
+    assert!(
+        state
+            .errors_state
+            .errors
+            .iter()
+            .any(|entry| entry.title == "visible failure")
+    );
+}
+
+#[test]
+fn legacy_error_entry_deserializes_as_visible() {
+    let json = r#"{
+        "seq": 7,
+        "title": "legacy failure",
+        "detail": "legacy detail",
+        "source": "Other",
+        "timestamp": "legacy-ts"
+    }"#;
+
+    let entry: crate::domain::ErrorEntry = serde_json::from_str(json)
+        .unwrap_or_else(|error| panic!("legacy error entry must deserialize: {error}"));
+
+    assert!(!entry.silent, "legacy entries must remain status-visible");
 }

--- a/src/state/errors_types.rs
+++ b/src/state/errors_types.rs
@@ -156,7 +156,7 @@ impl ErrorsState {
         let selected_seq = self.selected_error().map(|selected| selected.seq);
         self.next_seq = self.next_seq.saturating_add(1);
         self.errors.insert(0, entry);
-        if self.errors.len() > ERROR_STORE_CAPACITY {
+        let evicted_index = if self.errors.len() > ERROR_STORE_CAPACITY {
             let oldest = self.errors.len() - 1;
             let evict = if preserve_visible {
                 self.errors
@@ -170,7 +170,10 @@ impl ErrorsState {
                 oldest
             };
             self.errors.remove(evict);
-        }
+            Some(evict)
+        } else {
+            None
+        };
         if snap_to_newest {
             self.selected_index = Some(0);
             self.detail_scroll_offset = 0;
@@ -179,7 +182,7 @@ impl ErrorsState {
                 .errors
                 .iter()
                 .position(|entry| entry.seq == selected_seq)
-                .or_else(|| self.errors.len().checked_sub(1));
+                .or_else(|| evicted_index.map(|index| index.min(self.errors.len() - 1)));
         }
     }
 

--- a/src/state/errors_types.rs
+++ b/src/state/errors_types.rs
@@ -127,15 +127,59 @@ impl ErrorsState {
             detail,
             source,
             timestamp,
+            silent: false,
         };
+        self.store(entry, snap_to_newest, false);
+    }
+
+    /// Push an entry that remains available in Errors without changing the
+    /// current selection or status-bar error projection.
+    pub fn push_silent(
+        &mut self,
+        title: String,
+        detail: String,
+        source: ErrorSource,
+        timestamp: String,
+    ) {
+        let entry = ErrorEntry {
+            seq: self.next_seq,
+            title,
+            detail,
+            source,
+            timestamp,
+            silent: true,
+        };
+        self.store(entry, false, true);
+    }
+
+    fn store(&mut self, entry: ErrorEntry, snap_to_newest: bool, preserve_visible: bool) {
+        let selected_seq = self.selected_error().map(|selected| selected.seq);
         self.next_seq = self.next_seq.saturating_add(1);
         self.errors.insert(0, entry);
         if self.errors.len() > ERROR_STORE_CAPACITY {
-            self.errors.truncate(ERROR_STORE_CAPACITY);
+            let oldest = self.errors.len() - 1;
+            let evict = if preserve_visible {
+                self.errors
+                    .iter()
+                    .enumerate()
+                    .skip(1)
+                    .rev()
+                    .find_map(|(index, entry)| entry.silent.then_some(index))
+                    .unwrap_or(oldest)
+            } else {
+                oldest
+            };
+            self.errors.remove(evict);
         }
         if snap_to_newest {
             self.selected_index = Some(0);
             self.detail_scroll_offset = 0;
+        } else if let Some(selected_seq) = selected_seq {
+            self.selected_index = self
+                .errors
+                .iter()
+                .position(|entry| entry.seq == selected_seq)
+                .or_else(|| self.errors.len().checked_sub(1));
         }
     }
 
@@ -143,6 +187,12 @@ impl ErrorsState {
     #[must_use]
     pub fn last_error(&self) -> Option<&ErrorEntry> {
         self.errors.first()
+    }
+
+    /// The most recent entry eligible for status-bar display, if any.
+    #[must_use]
+    pub fn last_visible_error(&self) -> Option<&ErrorEntry> {
+        self.errors.iter().find(|entry| !entry.silent)
     }
 
     /// Whether the error log is empty.

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -969,11 +969,11 @@ pub enum AppEvent {
     ErrorsScrollDetailDown,
     ErrorsScrollDetailPageUp,
     ErrorsScrollDetailPageDown,
+    CaptureSilentError(String, String, crate::domain::ErrorSource, String),
     ErrorsClearAll,
 
-    /// F7 from Dashboard opens the Terminal Manager screen.
+    /// F7 opens Terminal Manager; Esc/F12 returns to Dashboard.
     EnterTerminalManagerMode,
-    /// Esc/F12 leaves the Terminal Manager and returns to Dashboard.
     ExitTerminalManagerMode,
     TerminalManagerNavigateUp,
     TerminalManagerNavigateDown,
@@ -989,14 +989,12 @@ pub enum AppEvent {
     ConfirmShellFocus(crate::domain::AgentId),
     /// Fail a pending focus (attach failed or owner no longer Running).
     FailShellFocus,
-    /// A preview capture result for the selected shell. Correlated by owner
-    /// and generation so stale captures are discarded.
+    /// Selected-shell preview, correlated so stale captures are discarded.
     ShellPreviewResult {
         agent_id: crate::domain::AgentId,
         generation: u64,
         ok: bool,
         lines: Vec<String>,
     },
-    /// A shell was closed (runtime already removed the inventory entry).
     ShellClosed(crate::domain::AgentId),
 }

--- a/src/state/prs_test_fixtures.rs
+++ b/src/state/prs_test_fixtures.rs
@@ -13,7 +13,7 @@ use crate::domain::{
     PullRequestDetail, Repository, RepositoryId,
 };
 use crate::state::AppState;
-use crate::state::types::{InlineState, PrFocus, PrListIdentity, ScreenMode};
+use crate::state::types::{PrFocus, PrListIdentity, ScreenMode};
 
 /// Build an empty comment list bound to the detail's repo and number (test helper).
 fn empty_comments(
@@ -95,7 +95,6 @@ pub fn prs_state_with_detail(repo_id: &str, pr_number: u64) -> AppState {
         mergeable: None,
         merge_state_status: None,
     });
-    state.prs_state.inline_state = InlineState::None;
     state
 }
 

--- a/src/state/selectors.rs
+++ b/src/state/selectors.rs
@@ -175,8 +175,8 @@ impl AppState {
     #[must_use]
     pub fn last_error_title(&self) -> Option<String> {
         self.errors_state
-            .last_error()
-            .map(|error| error.title.clone())
+            .last_visible_error()
+            .map(|entry| entry.title.clone())
     }
 }
 

--- a/src/ui/screens/errors.rs
+++ b/src/ui/screens/errors.rs
@@ -113,6 +113,7 @@ pub fn ErrorsScreen(props: &ErrorsScreenProps) -> impl Into<AnyElement<'static>>
                 crate::domain::ErrorSource::Persistence => "Persistence",
                 crate::domain::ErrorSource::Agent => "Agent",
                 crate::domain::ErrorSource::Startup => "Startup",
+                crate::domain::ErrorSource::Panic => "Panic",
                 crate::domain::ErrorSource::Other => "Other",
             };
             let meta = format!("{source_label} · {}", entry.timestamp);

--- a/tests/harness_v1_fixtures.rs
+++ b/tests/harness_v1_fixtures.rs
@@ -129,6 +129,13 @@ fn config_path_fixture_runs_the_real_provider_free_binary() {
 }
 
 #[test]
+fn panic_capture_fixture_projects_silent_error_without_raw_terminal_output() {
+    let outcome = run_fixture("panic-capture-errors.json");
+    assert_passed("panic-capture-errors", &outcome);
+    cleanup(&outcome);
+}
+
+#[test]
 fn config_provider_free_fixture_starts_no_captured_provider() {
     let outcome = run_fixture("config-provider-free.json");
     assert_passed("config-provider-free", &outcome);


### PR DESCRIPTION
## Summary
- install one process-global panic hook after logging so panic diagnostics never write over the TUI
- drain bounded panic reports on the executor into silent Errors entries without changing the visible banner or navigation
- remove the pending-shell-focus AppState handle from blocking workers and revalidate state on the executor
- add child-process, reducer/projection, hook-composition, and schema-1 real-PTY regression coverage
- preserve adjacent error selection when a selected silent entry is evicted

## Pre-push checklist

- [x] **Format** — `cargo xtask fmt`
- [x] **Clippy allow policy** — `cargo xtask check clippy-allows`
- [x] **Source file length** — `cargo xtask check source-size`
- [x] **Architecture boundary policy** — `cargo xtask check architecture`
- [x] **Lint** — strict all-target/all-feature Clippy
- [x] **Complexity** — strict complexity Clippy
- [x] **Coverage** — 70.23% line coverage
- [x] **Build** — locked all-feature workspace build
- [x] **Tests** — locked all-feature workspace tests
- [x] **TUI smoke** — schema-1 real-PTY panic capture scenario

## Testing notes

- The locked all-feature workspace suite passed serially; serial execution avoids a local target helper-binary race on the external workspace volume.
- The schema-1 real-PTY panic capture fixture passed under coverage and the full suite.
- The focused Actions sorting fixture passed all 9 tests.
- The selected silent-entry eviction regression was proven RED against the oldest-entry jump and GREEN with adjacent selection.
- Exact-head GitHub CI is green for format, policy, architecture, strict and complexity Clippy, coverage, build, tests, and native Windows.

## Review

- Rust/DeepThinker review complete and triaged.
- Local CodeRabbit reviews complete; the PR service reported its temporary review-volume limit and posted no findings.
- Pre-PR OCR findings resolved.
- Post-PR OCR: one finding fixed, two findings rejected with source-based replies; all three threads resolved.

## Scope

- 24 files, 968 net changed lines; within the 25-file / 1,500-line target.
- Includes two minimal current-main CI compatibility repairs exposed by the PR: update an Actions test constructor fixture and remove a redundant default assignment that exceeded strict Clippy's function-line limit.

## Reviewers / Assignees

- Assignee: @acoliver
- Automated Rust, CodeRabbit, OCR, and LLxprt review evidence is recorded above and in the issue plan.

Fixes #496
