### PR TITLE
Restore LLxprt launches after definition cutover

### DIFF
--- a/dev-docs/tmux-scenarios/issue519/llxprt-launch-options.json
+++ b/dev-docs/tmux-scenarios/issue519/llxprt-launch-options.json
@@ -1,0 +1,26 @@
+{
+  "config": {
+    "cols": 120,
+    "rows": 40,
+    "history_limit": 2000,
+    "initial_wait_ms": 1500,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "waitFor": "Agent Types" },
+    { "key": "Down" },
+    { "key": "Down" },
+    { "key": "Down" },
+    { "waitFor": "> LLxprt" },
+    { "key": "Enter" },
+    { "waitFor": "New Agent" },
+    { "waitFor": "Yolo: [x]" },
+    { "waitFor": "Continue: [ ]" },
+    { "expect": "Prompt Interactive: [ ]" },
+    { "capture": "llxprt-launch-options" },
+    { "key": "Escape" },
+    { "key": "C-q" },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/project-plans/issue519-plan.md
+++ b/project-plans/issue519-plan.md
@@ -1,0 +1,105 @@
+# Issue 519 Plan: Restore LLxprt Availability and Launch Defaults
+
+## Scope
+
+Deliver one bounded regression PR for issues #519 and #518. Both regressions were introduced by the definition-driven launch change in PR #501 and prevent a normal LLxprt workflow. Issue #515 is explicitly deferred because it requires a separate Windows process-ownership subsystem and native lifecycle suite.
+
+## Diagnosis
+
+- The installed LLxprt resolves on this Windows machine and both `llxprt --version` and `llxprt --help` exit successfully from PowerShell and `cmd.exe`.
+- `cargo run --locked --bin jefe -- doctor` detects LLxprt, but doctor only proves candidate resolution; the dashboard availability worker executes the definition probe.
+- `run_probe_process` pipes stdout/stderr but leaves stdin inherited. Under a detached psmux/session-host context, a Windows npm wrapper can receive an unusable inherited console handle and exit non-zero. Sibling non-interactive process boundaries explicitly use `Stdio::null()`.
+- The probe failure is converted to `identity probe exited with status 1`, marks `core.llxprt` unavailable, and blocks every local launch.
+- The LLxprt definition independently lost the default `yolo = true`, declares no `continue` field/emitter, and maps legacy `pass_continue` to the unrelated `prompt_interactive` field.
+
+## Acceptance Matrix
+
+| ID | Actor / path | Input and boundary | Observable success | Failure behavior / side effects | Behavioral proof |
+|---|---|---|---|---|---|
+| A1 | Local definition probe | Probe is launched from a parent with readable/inherited stdin, including detached Windows wrappers | Probe child receives EOF on stdin, captures bounded stdout/stderr, and valid LLxprt evidence becomes `InstalledCompatible` | Existing timeout, truncation, non-zero exit, fingerprint, and identity failures remain fail-closed; no launch occurs | Deterministic process-boundary regression plus existing probe suite |
+| A2 | Windows LLxprt wrapper | Direct selector resolves the npm `.cmd`/`.ps1` wrapper | `--version` and `--help` probes complete without console-input dependence | A genuine non-zero exit still returns `AGT-E202`; identity checks are not weakened | Focused Windows wrapper/probe test and local source-tree evidence |
+| A3 | Generated LLxprt form | New agent with no manual YOLO edit | `Yolo` is visible and defaults to checked; committed typed value is `true` | Other definitions and explicit false remain unchanged | TUI scenario first, generated-form model/submit test |
+| A4 | LLxprt launch plan | Committed `yolo = true` or `false` | True emits `--yolo`; false omits it | No product branching in planner | Golden local-plan test |
+| A5 | Generated and legacy LLxprt forms | Continue enabled/disabled independently from prompt-interactive | Definition exposes a `continue` boolean and true emits `--continue`; false omits it | Missing capability disables only the corresponding field; unsupported launch remains fail-closed | Generated-form projection and golden local-plan tests |
+| A6 | Legacy edit/submit bridge | Existing `pass_continue` checkbox is submitted | Value maps to typed `continue`, not `prompt_interactive` | No Code Puppy or migration behavior changes | Focused state/form regression test |
+| A7 | Compatibility | Existing Code Puppy, Codex, Claude, remote, package-selector, and persisted explicit values | Existing behavior remains green | No new dependencies, schema, emitter kind, or public subsystem | Focused regressions plus complete CI suite |
+
+## Non-goals
+
+- Do not accept non-zero probe exits, weaken identity recognition, retry arbitrary CLI failures, or bypass capability requirements.
+- Do not change the global generated-form empty value; LLxprt owns its own YOLO default.
+- Do not change Code Puppy YOLO or continuation semantics.
+- Do not migrate already-persisted explicit `yolo = false` values.
+- Do not remove or redesign `prompt_interactive`; make continuation independent.
+- Do not add diagnostics unless the stdin fix fails to restore the detached probe and captured stderr is needed for further diagnosis.
+- Do not implement issue #515 in this PR. It introduces ancestor identity discovery, an owner watchdog, launcher wiring, and native psmux lifecycle tests across unrelated ownership layers.
+
+## Vertical Slices
+
+### Slice 1: Non-interactive probe stdin (A1-A2)
+
+- Owner: runtime process boundary.
+- Allowed paths: `src/runtime/agent_probe_process.rs` and its focused tests.
+- RED: a nested probe test supplies parent stdin and asserts the probe child observes EOF.
+- GREEN: explicitly configure probe stdin as `Stdio::null()`.
+- Stop if deterministic proof requires a new detached-process or multiplexer subsystem, or if the one-line fix does not restore the reported context.
+
+### Slice 2: LLxprt defaults and continuation (A3-A7)
+
+- Owner: shipped definition data and the legacy form-to-typed-value bridge.
+- Allowed paths: LLxprt shipped definition, focused form/plan tests, and one issue TUI scenario.
+- RED: add the TUI scenario first, then tests proving default checked YOLO, independent Continue, and emitted argv.
+- GREEN: set LLxprt's field default, declare the continuation field, add the existing flag emitter, and correct the legacy bridge.
+- Stop if this requires a global generated-form change, a new emitter type, persistence migration, or product-specific planner branch.
+
+## Expected Paths
+
+- `src/runtime/agent_probe_process.rs`
+- `src/domain/agent_definition/shipped/llxprt.rs`
+- `src/state/form_build.rs`
+- `src/state/modal_ops.rs` only if loading the corrected legacy `continue` value cannot be handled without it
+- `tests/issue382/agent_probe_runtime.rs` or a focused sibling test
+- `tests/agent_local_plan.rs`
+- `tests/generated_form_model.rs`
+- `tests/generated_form_submit.rs`
+- focused state form tests
+- `dev-docs/tmux-scenarios/issue519/llxprt-launch-options.json`
+
+## Scope Ledger
+
+| Discovery | Disposition | Reason |
+|---|---|---|
+| Probe drops stderr when formatting non-zero status | Defer | A1 is green; diagnostic expansion is not required to restore operation |
+| Existing explicit false YOLO values remain false | Accept / non-goal | Preserve user-authored durable values |
+| Definition and typed-value fixed vectors changed | Accept / in-scope | The LLxprt schema default/field and corrected `pass_continue -> continue` bridge intentionally change both canonical hashes |
+| Local Windows coverage instrumentation exits while compiling `jefe` without a diagnostic | Defer to exact-head CI | The exact fmt, Clippy, locked build, and locked test gates pass locally; do not change quality tooling in this issue |
+| Existing Windows tests require Git `true`/`false` on `PATH` | Reject as issue scope | The same test-only environment requirement exists on `main`; quick/exact tests pass when Git's Unix tools are on `PATH` |
+| Issue #515 Windows owner watchdog | Defer to its own PR | New subsystem and unrelated lifecycle acceptance matrix |
+
+## Review Counters
+
+- Pre-PR OCR runs: 0 / 2
+- Post-PR OCR runs: 0 / 2
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| Baseline branch | `issue519` from `origin/main` at `07cb9342` |
+| Installed `llxprt --version` / `--help` | Both exit 0 in attached PowerShell/cmd context |
+| Current source `jefe doctor` | Passes and reports LLxprt detected |
+| TUI scenario RED | Failed at `Yolo: [x]` before implementation; the form showed unchecked YOLO and no Continue row |
+| Probe process RED | Exact nested Windows test failed because the probe consumed the inherited stdin line when `Stdio::null()` was temporarily absent |
+| Focused GREEN tests | Probe stdin exact test; 18 local-plan tests; 7 generated-form model tests; 9 generated-form submit tests; 5 issue #317 tests; 25 issue #382 tests |
+| TUI scenario GREEN | `llxprt-launch-options.json`: `ok: 15 steps` against the final built binary |
+| `cargo xtask quick` | Passes with Git's `usr/bin` on `PATH` for existing Windows tests that invoke `true`/`false` |
+| Exact required local gates | `cargo fmt --all --check`, strict workspace Clippy, locked all-feature workspace build, and locked all-feature workspace tests all pass |
+| `cargo xtask ci` | Format, policy, source-size, architecture, lint, and complexity pass; local Windows coverage instrumentation exits while compiling `jefe` without a rustc diagnostic, including after canonical cache cleanup and serial compilation |
+| Scope | 14 issue files, 464 insertions / 34 deletions including this plan and the scenario; below project limits |
+| Exact-head CI / conflicts | Pending PR CI and mergeability check |
+
+## Deferred Findings and Follow-ups
+
+- Issue #515 remains open for a dedicated Windows session-owner watchdog PR.
+- Exact-head CI owns the coverage proof because local Windows `cargo-llvm-cov` exits during instrumented `jefe` compilation without a compiler diagnostic; no quality-gate or dependency changes are authorized in this PR.
+- If exact-head native Windows evidence shows the stdin fix does not restore issue #519, expose bounded probe stderr before selecting any further behavior change.

--- a/project-plans/issue519-plan.md
+++ b/project-plans/issue519-plan.md
@@ -85,7 +85,7 @@ Deliver one bounded regression PR for issues #519 and #518. Both regressions wer
 
 | Check | Result |
 |---|---|
-| Baseline branch | `issue519` from `origin/main` at `07cb9342` |
+| Baseline branch | `issue519`, rebased onto `origin/main` at `88005aba` |
 | Installed `llxprt --version` / `--help` | Both exit 0 in attached PowerShell/cmd context |
 | Current source `jefe doctor` | Passes and reports LLxprt detected |
 | TUI scenario RED | Failed at `Yolo: [x]` before implementation; the form showed unchecked YOLO and no Continue row |

--- a/src/domain/agent_definition/shipped/llxprt.rs
+++ b/src/domain/agent_definition/shipped/llxprt.rs
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 
 use super::super::definition::AgentDefinition;
-use super::super::fields::Emitter;
+use super::super::fields::{Emitter, Field, FieldValue};
 use super::super::normalize::Normalize;
 use super::super::type_id::{CandidateKind, ExecutableCandidate};
 use super::super::types::{
@@ -33,7 +33,17 @@ fn emitters() -> Vec<Emitter> {
         Emitter::Flag {
             field: "prompt_interactive".to_string(),
         },
+        Emitter::Flag {
+            field: "continue".to_string(),
+        },
     ]
+}
+
+/// Repository YOLO field defaulting to true for the LLxprt product.
+fn llxprt_yolo_field() -> Field {
+    let mut field = bool_field("yolo");
+    field.default = Some(FieldValue::Boolean(true));
+    field
 }
 
 /// Build the core.llxprt shipped definition.
@@ -76,11 +86,12 @@ pub fn build() -> AgentDefinition {
                 supported: Support::supported(),
             },
         },
-        repository_fields: vec![sig_string_field("profile"), bool_field("yolo")],
+        repository_fields: vec![sig_string_field("profile"), llxprt_yolo_field()],
         agent_fields: vec![
             sig_string_field("version_selector"),
             sig_string_field("prompt"),
             bool_field("prompt_interactive"),
+            bool_field("continue"),
         ],
         emitters: emitters(),
     })

--- a/src/persistence/migration_tests.rs
+++ b/src/persistence/migration_tests.rs
@@ -317,11 +317,11 @@ fn remote_schema1_ids_and_hashes_match_fixed_vectors() {
     );
     assert_eq!(
         agent.launch_signature.definition_hash.as_str(),
-        "331745dd745096662a038abef912d8ce1679ef3295a37c9bcb6c2332b369c00a"
+        "7572f5e82ecab05268886416c27e70b6c76b37a51ca5d7053a9c2d865de4d8a8"
     );
     assert_eq!(
         agent.launch_signature.typed_value_hash.as_str(),
-        "317635609f3f1ee811c753d07008568a43d250759865199d43b1188f84c0f277"
+        "14e6bc5b61c3f4bc64e1f6c436e37ab779d98e9e5eed98141ad90339c637307c"
     );
     assert_eq!(
         agent.launch_signature.target_fingerprint.as_str(),

--- a/src/runtime/agent_plan_tests.rs
+++ b/src/runtime/agent_plan_tests.rs
@@ -89,9 +89,8 @@ fn default_field_values_are_used_when_not_provided() {
         PlanOutcome::Supported(plan) => *plan,
         other => panic!("expected supported, got {other:?}"),
     };
-    // LLxprt's profile field has no default, so the Option emitter skips.
-    // yolo and prompt_interactive default to false, so Flags skip.
-    assert!(plan.argv.is_empty(), "no emitters fire with all defaults");
+    // LLxprt's profile has no default, while yolo defaults on.
+    assert_eq!(plan.argv, ["--yolo"]);
 }
 
 #[test]
@@ -131,7 +130,10 @@ fn flag_resolves_token_from_capability_probe() {
         .iter()
         .map(|a| a.to_string_lossy().into_owned())
         .collect();
-    assert_eq!(argv, vec!["--prompt-interactive".to_string()]);
+    assert_eq!(
+        argv,
+        vec!["--yolo".to_string(), "--prompt-interactive".to_string()]
+    );
 }
 
 #[test]
@@ -166,8 +168,8 @@ fn empty_string_value_skips_option_emitter() {
         PlanOutcome::Supported(plan) => *plan,
         other => panic!("expected supported, got {other:?}"),
     };
-    // Whitespace-only profile string skips the Option emitter.
-    assert!(plan.argv.is_empty(), "whitespace-only value skipped");
+    // Whitespace-only profile skips its Option emitter; default yolo remains.
+    assert_eq!(plan.argv, ["--yolo"]);
 }
 
 #[test]

--- a/src/runtime/agent_probe_process.rs
+++ b/src/runtime/agent_probe_process.rs
@@ -118,7 +118,10 @@ pub(super) fn run_probe_process(
     mut command: Command,
     deadline: Instant,
 ) -> Result<ProbeProcessOutput, ProbeProcessError> {
-    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
     configure_process_tree(&mut command);
     let mut child = command
         .spawn()
@@ -218,4 +221,73 @@ fn terminate_process_tree(child: &mut Child) {
 fn terminate_process_tree(child: &mut Child) {
     let _ = child.kill();
     let _ = child.wait();
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    use super::{ProbeProcessError, run_probe_process};
+
+    const NESTED_MARKER: &str = "JEFE_PROBE_STDIN_NESTED";
+    const TEST_NAME: &str = "runtime::agent_probe_process::tests::probe_child_receives_null_stdin_under_inherited_parent_stdin";
+
+    #[test]
+    fn probe_child_receives_null_stdin_under_inherited_parent_stdin() {
+        if std::env::var_os(NESTED_MARKER).is_some() {
+            run_nested_probe_child();
+            return;
+        }
+
+        let exe = std::env::current_exe()
+            .unwrap_or_else(|error| panic!("could not resolve test binary: {error}"));
+        let mut child = Command::new(exe)
+            .env(NESTED_MARKER, "1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(["--exact", TEST_NAME, "--nocapture"])
+            .spawn()
+            .unwrap_or_else(|error| panic!("could not spawn nested test: {error}"));
+        let mut stdin = child
+            .stdin
+            .take()
+            .unwrap_or_else(|| panic!("nested test must expose piped stdin"));
+        stdin
+            .write_all(b"this line must never reach the probe child\n")
+            .unwrap_or_else(|error| panic!("could not write parent stdin: {error}"));
+        drop(stdin);
+
+        let output = child
+            .wait_with_output()
+            .unwrap_or_else(|error| panic!("could not wait for nested test: {error}"));
+        assert!(
+            output.status.success(),
+            "nested probe test failed: status {:?}, stderr: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    fn run_nested_probe_child() {
+        let script = concat!(
+            "$line = [Console]::In.ReadLine(); ",
+            "if ($null -ne $line) { exit 1 } else { exit 0 }"
+        );
+        let mut command = Command::new("powershell.exe");
+        command.args(["-NoProfile", "-NonInteractive", "-Command", script]);
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let output = run_probe_process(command, deadline).unwrap_or_else(|error| match error {
+            ProbeProcessError::Timeout => panic!("probe process timed out"),
+            ProbeProcessError::Failed(detail) => panic!("probe process failed: {detail}"),
+        });
+        assert!(
+            output.status.success(),
+            "probe child must exit 0 on null stdin, got {:?}; stderr: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr.bytes),
+        );
+    }
 }

--- a/src/runtime/agent_remote_plan_tests.rs
+++ b/src/runtime/agent_remote_plan_tests.rs
@@ -219,7 +219,7 @@ fn llxprt_remote_normal_produces_golden_transcript() {
     };
     assert_eq!(
         transcript.remote_command(),
-        "cd '/srv/project' && exec '/opt/bin/llxprt' '--profile-load' 'dev' '--prompt-interactive'"
+        "cd '/srv/project' && exec '/opt/bin/llxprt' '--profile-load' 'dev' '--yolo' '--prompt-interactive'"
     );
     let argv: Vec<String> = transcript
         .agent_argv()
@@ -231,6 +231,7 @@ fn llxprt_remote_normal_produces_golden_transcript() {
         &[
             "--profile-load".to_string(),
             "dev".to_string(),
+            "--yolo".to_string(),
             "--prompt-interactive".to_string(),
         ]
     );

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -127,7 +127,7 @@ fn local_npm_uses_general_managed_exact_install_after_precheck() {
     let candidate = resolve_package(&definition, &bin, "2.0.0");
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
     let plan = local_base_plan(&definition, &candidate, 8, cache.path());
-    assert!(plan.argv.is_empty(), "managed binary receives only emitted argv");
+    assert_eq!(plan.argv, [OsString::from("--yolo")]);
     assert!(plan.executable.starts_with(cache.path()));
     assert!(
         plan.executable
@@ -214,6 +214,7 @@ fn remote_npm_prefix_flows_through_the_audited_serializer() {
             "--package=@vybestack/llxprt-code@nightly",
             "--",
             "llxprt",
+            "--yolo",
         ]
         .map(OsString::from)
     );

--- a/src/state/form_build.rs
+++ b/src/state/form_build.rs
@@ -378,7 +378,7 @@ fn merge_agent_values(
             "interactive" => Some(FieldValue::Boolean(
                 fields.code_puppy_quick_resume.enabled(),
             )),
-            "prompt_interactive" => Some(FieldValue::Boolean(fields.pass_continue)),
+            "continue" => Some(FieldValue::Boolean(fields.pass_continue)),
             _ => None,
         };
         if let Some(value) = value {

--- a/src/state/form_ops_tests.rs
+++ b/src/state/form_ops_tests.rs
@@ -107,9 +107,9 @@ fn open_new_agent_falls_back_to_first_installed_when_repo_default_not_installed(
     let ModalState::NewAgent { fields, .. } = state.modal else {
         panic!("expected new-agent modal, got {:?}", state.modal);
     };
-    // Repo default is CodePuppy but it's not installed → fall back to Llxprt.
+    // Repo default is CodePuppy but it is not installed, so LLxprt is selected.
     assert_eq!(fields.agent_type_id, "core.llxprt");
-    assert_eq!(fields.mode, "");
+    assert_eq!(fields.mode, "--yolo");
 }
 
 #[test]

--- a/src/state/modal_ops.rs
+++ b/src/state/modal_ops.rs
@@ -399,7 +399,7 @@ impl AppState {
                         String::new()
                     },
                     llxprt_debug: String::new(),
-                    pass_continue: typed_bool(&a.values, "prompt_interactive").unwrap_or(true),
+                    pass_continue: typed_bool(&a.values, "continue").unwrap_or(true),
                     sandbox_enabled: false,
                     sandbox_engine: SandboxEngine::default().label().to_owned(),
                     sandbox_flags: DEFAULT_SANDBOX_FLAGS.to_owned(),

--- a/tests/agent_local_plan.rs
+++ b/tests/agent_local_plan.rs
@@ -51,19 +51,12 @@ fn local_target() -> Target {
     }
 }
 
-// ---------------------------------------------------------------------------
-// LLxprt Normal — fixture-golden argv/env/cwd plan
-// ---------------------------------------------------------------------------
-
-#[test]
-fn llxprt_normal_golden_plan() {
-    let definition = shipped("LLxprt");
-    let mut values = LaunchFieldValues::new();
-    values.set_repository("profile", FieldValue::String("my-profile".to_string()));
-    values.set_repository("yolo", FieldValue::Boolean(true));
-    values.set_agent("prompt_interactive", FieldValue::Boolean(true));
-    let request = PlanRequest {
-        definition: &definition,
+fn llxprt_plan_request<'a>(
+    definition: &'a AgentDefinition,
+    values: &'a LaunchFieldValues,
+) -> PlanRequest<'a> {
+    PlanRequest {
+        definition,
         operation: Operation::Normal,
         target: local_target(),
         executable: PathBuf::from("/opt/llxprt/bin/llxprt"),
@@ -89,15 +82,30 @@ fn llxprt_normal_golden_plan() {
         ),
         probe_generation: 3,
         target_generation: 1,
-        values: &values,
+        values,
         activation_generation: 1,
         preflight: Preflight::default(),
-    };
-    let plan = assert_supported(request, "llxprt normal");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LLxprt Normal — fixture-golden argv/env/cwd plan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn llxprt_normal_golden_plan() {
+    let definition = shipped("LLxprt");
+    let mut values = LaunchFieldValues::new();
+    values.set_repository("profile", FieldValue::String("my-profile".to_string()));
+    values.set_repository("yolo", FieldValue::Boolean(true));
+    values.set_agent("prompt_interactive", FieldValue::Boolean(true));
+    values.set_agent("continue", FieldValue::Boolean(true));
+    let plan = assert_supported(llxprt_plan_request(&definition, &values), "llxprt normal");
     // Argv emitted element-by-element in declaration order:
     //   Option{--profile-load, profile} -> --profile-load, my-profile
     //   Flag{yolo}                       -> --yolo
     //   Flag{prompt_interactive}         -> --prompt-interactive
+    //   Flag{continue}                   -> --continue
     assert_eq!(
         plan.argv,
         vec![
@@ -105,6 +113,7 @@ fn llxprt_normal_golden_plan() {
             os("my-profile"),
             os("--yolo"),
             os("--prompt-interactive"),
+            os("--continue"),
         ],
     );
     assert_eq!(plan.executable, PathBuf::from("/opt/llxprt/bin/llxprt"));
@@ -836,4 +845,22 @@ fn assert_repeated_option_ordering(as_strings: &[String]) {
         prompt_pos < first_include_pos,
         "positional precedes the pushed repeated option in declaration order"
     );
+}
+
+#[test]
+fn llxprt_false_boolean_fields_omit_flags_independently() {
+    let definition = shipped("LLxprt");
+    let mut values = LaunchFieldValues::new();
+    values.set_repository("yolo", FieldValue::Boolean(false));
+    values.set_agent("prompt_interactive", FieldValue::Boolean(true));
+    values.set_agent("continue", FieldValue::Boolean(false));
+
+    let plan = assert_supported(
+        llxprt_plan_request(&definition, &values),
+        "llxprt false flags",
+    );
+    let argv = argv_strings(&plan);
+    assert!(argv.contains(&"--prompt-interactive".to_string()));
+    assert!(!argv.contains(&"--yolo".to_string()));
+    assert!(!argv.contains(&"--continue".to_string()));
 }

--- a/tests/generated_form_model.rs
+++ b/tests/generated_form_model.rs
@@ -376,3 +376,72 @@ fn reducer_edits_remaining_typed_kinds_and_reports_lower_bound() {
         Some(2)
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #519: LLxprt default YOLO and independent Continue field
+// ---------------------------------------------------------------------------
+
+fn llxprt_shipped() -> AgentDefinition {
+    AgentDefinition::shipped()
+        .into_iter()
+        .find(|definition| definition.id.as_str() == "core.llxprt")
+        .unwrap_or_else(|| panic!("LLxprt definition must be shipped"))
+}
+
+fn llxprt_compatible() -> Availability {
+    Availability::InstalledCompatible {
+        identity: "0.10.0".to_string(),
+        capabilities: vec![
+            "prompt-interactive".to_string(),
+            "profile".to_string(),
+            "yolo".to_string(),
+            "continue".to_string(),
+        ],
+        generation: 1,
+    }
+}
+
+/// A newly generated LLxprt form must default repository `yolo` to true so the
+/// product-specific launch default is restored without touching other agents.
+#[test]
+fn llxprt_generated_form_defaults_yolo_to_true() {
+    let definition = llxprt_shipped();
+    let draft = GeneratedFormDraft::from_definition(&definition, &llxprt_compatible());
+    let Ok(draft) = draft else {
+        panic!("LLxprt definition should generate a form: {draft:?}");
+    };
+    let yolo = draft.field(&FormFieldId::repository("yolo"));
+    let Some(yolo) = yolo else {
+        panic!("LLxprt form must expose a repository yolo field");
+    };
+    assert_eq!(yolo.value(), &FieldValue::Boolean(true));
+}
+
+/// LLxprt must declare an independent agent-scope `continue` boolean field
+/// distinct from `prompt_interactive`.
+#[test]
+fn llxprt_generated_form_exposes_independent_continue_field() {
+    let definition = llxprt_shipped();
+    assert!(
+        definition
+            .agent_fields
+            .iter()
+            .any(|field| field.id == "continue" && field.kind == FieldKind::Boolean),
+        "LLxprt must declare an agent-scope continue boolean field"
+    );
+    let draft = GeneratedFormDraft::from_definition(&definition, &llxprt_compatible());
+    let Ok(draft) = draft else {
+        panic!("LLxprt definition should generate a form: {draft:?}");
+    };
+    let continue_field = draft.field(&FormFieldId::agent("continue"));
+    let Some(continue_field) = continue_field else {
+        panic!("LLxprt form must expose an agent continue field");
+    };
+    assert_eq!(continue_field.value(), &FieldValue::Boolean(false));
+    // prompt_interactive remains independent and present.
+    assert!(
+        draft
+            .field(&FormFieldId::agent("prompt_interactive"))
+            .is_some()
+    );
+}

--- a/tests/generated_form_submit.rs
+++ b/tests/generated_form_submit.rs
@@ -7,7 +7,8 @@
 
 use jefe::agent_status_view::AgentAvailabilityObservation;
 use jefe::domain::agent_definition::{AgentDefinition, AgentTypeId, Availability, Operation};
-use jefe::domain::{Id, Repository, RepositoryId, TypedMap};
+use jefe::domain::canonical_values::typed_field;
+use jefe::domain::{Id, Repository, RepositoryId, TypedMap, TypedValue};
 use jefe::state::generated_agent_form::{
     GeneratedAgentFormFocus, GeneratedAgentFormIntent, GeneratedTarget,
 };
@@ -310,5 +311,120 @@ fn submit_without_repository_has_zero_effects() {
         submitted.agents.len(),
         before_agents,
         "no repository means zero agents created"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #519: legacy pass_continue maps to typed continue, not prompt_interactive
+// ---------------------------------------------------------------------------
+
+/// The legacy NewAgent form's `pass_continue` checkbox must populate the typed
+/// `continue` field for an LLxprt agent, leaving `prompt_interactive`
+/// independent.
+#[test]
+fn legacy_pass_continue_maps_to_typed_continue_for_llxprt() {
+    let type_id = AgentTypeId::parse("core.llxprt")
+        .unwrap_or_else(|error| panic!("valid LLxprt type id: {error}"));
+    let repository = test_repository(type_id.clone());
+    let mut state = AppState {
+        repositories: vec![repository],
+        selected_repository_index: Some(0),
+        available_agent_type_ids: vec![type_id.clone()],
+        pane_focus: PaneFocus::Agents,
+        ..AppState::default()
+    }
+    .apply(AppEvent::OpenNewAgent(RepositoryId(
+        "test-repo".to_string(),
+    )))
+    .committed_pure();
+
+    let ModalState::NewAgent { fields, .. } = &mut state.modal else {
+        panic!("new agent modal should be open");
+    };
+    fields.name = "Continue Bridge".to_string();
+    fields.agent_type_id = "core.llxprt".to_string();
+    fields.pass_continue = false;
+
+    let submitted = state.apply(AppEvent::SubmitForm).committed_pure();
+    assert_eq!(submitted.modal, ModalState::None, "modal must close");
+    assert_eq!(submitted.agents.len(), 1, "one agent created");
+    let agent = &submitted.agents[0];
+    let continue_value = typed_field(&agent.values, "continue");
+    assert_eq!(
+        continue_value,
+        Some(&TypedValue::Bool(false)),
+        "pass_continue=false must map to typed continue=false"
+    );
+    // prompt_interactive remains absent rather than being driven by
+    // pass_continue.
+    assert!(
+        typed_field(&agent.values, "prompt_interactive").is_none(),
+        "prompt_interactive must stay independent of pass_continue"
+    );
+}
+
+/// The legacy EditAgent modal must load `pass_continue` from the typed
+/// `continue` value, not `prompt_interactive`.
+#[test]
+fn edit_modal_loads_pass_continue_from_typed_continue() {
+    let type_id = AgentTypeId::parse("core.llxprt")
+        .unwrap_or_else(|error| panic!("valid LLxprt type id: {error}"));
+    let mut repository = test_repository(type_id.clone());
+    // Seed a repository default with continue=false so the new-agent form
+    // inherits it, then verify the edit modal reflects typed continue.
+    let continue_id =
+        Id::parse("continue").unwrap_or_else(|error| panic!("valid continue id: {error}"));
+    repository
+        .default_values
+        .insert(continue_id, TypedValue::Bool(false));
+    let prompt_id = Id::parse("prompt-interactive")
+        .unwrap_or_else(|error| panic!("valid prompt-interactive id: {error}"));
+    repository
+        .default_values
+        .insert(prompt_id, TypedValue::Bool(true));
+
+    let mut state = AppState {
+        repositories: vec![repository],
+        selected_repository_index: Some(0),
+        available_agent_type_ids: vec![type_id.clone()],
+        pane_focus: PaneFocus::Agents,
+        ..AppState::default()
+    }
+    .apply(AppEvent::OpenNewAgent(RepositoryId(
+        "test-repo".to_string(),
+    )))
+    .committed_pure();
+
+    let ModalState::NewAgent { fields, .. } = &mut state.modal else {
+        panic!("new agent modal should be open");
+    };
+    fields.name = "Edit Source".to_string();
+    fields.agent_type_id = "core.llxprt".to_string();
+    fields.pass_continue = false;
+
+    let mut submitted = state.apply(AppEvent::SubmitForm).committed_pure();
+    let agent_id = submitted.agents[0].id.clone();
+    assert_eq!(
+        typed_field(&submitted.agents[0].values, "continue"),
+        Some(&TypedValue::Bool(false)),
+        "created agent must retain typed continue=false"
+    );
+    assert_eq!(
+        typed_field(&submitted.agents[0].values, "prompt_interactive"),
+        Some(&TypedValue::Bool(true)),
+        "fixture must retain typed prompt_interactive=true"
+    );
+
+    submitted = submitted
+        .apply(AppEvent::OpenEditAgent(agent_id))
+        .committed_pure();
+    let ModalState::EditAgent { fields, .. } = &submitted.modal else {
+        panic!("edit agent modal should be open");
+    };
+    // continue=false -> pass_continue must be false; prompt_interactive=true
+    // must NOT leak into pass_continue.
+    assert!(
+        !fields.pass_continue,
+        "edit modal must load pass_continue from typed continue (false), got true"
     );
 }

--- a/tests/issue382_behavior.rs
+++ b/tests/issue382_behavior.rs
@@ -744,7 +744,7 @@ fn assert_llxprt_remote_golden() {
     };
     assert_eq!(
         transcript.remote_command(),
-        "cd '/srv/project' && exec '/opt/bin/llxprt' '--profile-load' 'dev' '--prompt-interactive'"
+        "cd '/srv/project' && exec '/opt/bin/llxprt' '--profile-load' 'dev' '--yolo' '--prompt-interactive'"
     );
     let agent_argv: Vec<String> = transcript
         .agent_argv()
@@ -756,6 +756,7 @@ fn assert_llxprt_remote_golden() {
         &[
             "--profile-load".to_string(),
             "dev".to_string(),
+            "--yolo".to_string(),
             "--prompt-interactive".to_string(),
         ]
     );


### PR DESCRIPTION
## Summary

- make definition probes explicitly non-interactive so detached Windows/npm LLxprt probes cannot consume or depend on inherited console stdin
- restore LLxprt's definition-owned `--yolo` default
- add an independent `continue` field/emitter and correct the legacy `pass_continue` bridge without changing `prompt_interactive`

Fixes #519
Fixes #518

## Diagnosis

PR #501 moved availability and launch behavior into agent definitions. The probe process captured stdout/stderr but inherited stdin; in detached Windows psmux/session-host contexts that can give npm wrappers an unusable console handle and produce `identity probe exited with status 1`, making `core.llxprt` unavailable. The same cutover also declared LLxprt YOLO with no true default and mapped legacy continuation state to `prompt_interactive` without a `continue` emitter.

The probe remains fail-closed for timeouts, truncation, nonzero exits, fingerprint changes, identity mismatches, and missing required capabilities.

## Behavioral evidence

- Windows probe RED/GREEN: nested test failed when the probe inherited readable stdin, then passed with `Stdio::null()`
- TUI RED/GREEN: the pre-fix generated form lacked checked YOLO/Continue; final `llxprt-launch-options.json` passes all 15 steps and displays:
  - `Yolo: [x]`
  - `Continue: [ ]`
  - `Prompt Interactive: [ ]`
- local and remote launch goldens prove true emits `--yolo`/`--continue`, while explicit false omits each independently
- legacy submit/edit regressions prove `pass_continue` maps to typed `continue`, not `prompt_interactive`

## Verification

Passed locally on the candidate code:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --all-features --locked`
- `cargo test --workspace --all-features --locked`
- `cargo xtask quick` (with Git `usr/bin` on native Windows `PATH` for existing tests invoking `true`/`false`)
- native Windows TUI harness scenario: `ok: 15 steps`

`cargo xtask ci` passes format, policy, source-size, architecture, strict lint, and complexity locally. Its local Windows coverage instrumentation exits while compiling the `jefe` library without a rustc diagnostic, including after canonical cache cleanup and serial compilation; required exact-head CI owns the coverage proof.

## Scope

- 14 files
- 464 insertions / 34 deletions
- no dependency, schema, quality-tool, or `.llxprt` changes

## Deferred

Issue #515 is intentionally not included. It requires a separate Windows psmux-owner watchdog, ancestor identity observation, launcher wiring, and native lifecycle suite across unrelated ownership layers.
