### PR TITLE
Restore valid LLxprt fresh-send arguments (Fixes #520)

### DIFF
--- a/dev-docs/tmux-scenarios/v1/llxprt-continue-field.json
+++ b/dev-docs/tmux-scenarios/v1/llxprt-continue-field.json
@@ -1,0 +1,96 @@
+{
+  "schema": 1,
+  "name": "llxprt-continue-field",
+  "platform": "macos",
+  "terminal": { "cols": 140, "rows": 40 },
+  "workspace": {
+    "mode": 448,
+    "dirs": [
+      { "path": "config", "mode": 448 },
+      { "path": "repo", "mode": 493 },
+      { "path": "repo/.git", "mode": 448 },
+      { "path": "repo/.git/refs", "mode": 448 },
+      { "path": "repo/.git/refs/heads", "mode": 448 },
+      { "path": "repo/.git/refs/remotes", "mode": 448 },
+      { "path": "repo/.git/refs/remotes/origin", "mode": 448 },
+      { "path": "repo/.git/objects", "mode": 448 },
+      { "path": "repo/.git/objects/info", "mode": 448 },
+      { "path": "repo/.git/objects/pack", "mode": 448 }
+    ],
+    "files": [
+      {
+        "path": "bin/llxprt",
+        "content": {
+          "utf8": "#!/bin/sh\ncase \"${1:-}\" in\n  --version) printf '0.10.0\\n' ;;\n  --help) printf '%s\\n' '--prompt-interactive --profile-load --sandbox --sandbox-engine --yolo --approval-mode --continue' ;;\n  *) exec llxprt-agent \"$@\" ;;\nesac\n"
+        },
+        "mode": 493
+      },
+      {
+        "path": "repo/.git/HEAD",
+        "content": { "utf8": "ref: refs/heads/main\n" },
+        "mode": 384
+      },
+      {
+        "path": "repo/.git/config",
+        "content": {
+          "utf8": "[core]\n\trepositoryformatversion = 0\n\tbare = false\n[remote \"origin\"]\n\turl = https://github.com/owner/repo-230.git\n"
+        },
+        "mode": 384
+      },
+      {
+        "path": "repo/.git/refs/remotes/origin/HEAD",
+        "content": { "utf8": "ref: refs/remotes/origin/main\n" },
+        "mode": 384
+      },
+      {
+        "path": "config/settings.toml",
+        "content": { "utf8": "settings_schema = 2\n" },
+        "mode": 384
+      },
+      {
+        "path": "config/state.json",
+        "content": {
+          "utf8": "{\n  \"schema_version\": 1,\n  \"repositories\": [{\n    \"id\": \"repo-520\",\n    \"name\": \"Issue 520\",\n    \"slug\": \"issue-520\",\n    \"base_dir\": \".\",\n    \"default_profile\": \"glm\",\n    \"default_code_puppy_model\": \"\",\n    \"github_repo\": \"owner/repo-230\",\n    \"github_issue_pr_repo\": \"\",\n    \"remote\": {\"enabled\": false, \"login_user\": \"\", \"host\": \"\", \"port\": null},\n    \"issue_base_prompt\": \"\",\n    \"default_agent_kind\": \"llxprt\",\n    \"agent_ids\": [\"agent-520\"]\n  }],\n  \"agents\": [{\n    \"id\": \"agent-520\",\n    \"display_id\": \"agent-520\",\n    \"repository_id\": \"repo-520\",\n    \"shortcut_slot\": null,\n    \"name\": \"branch-520\",\n    \"description\": \"\",\n    \"work_dir\": \".\",\n    \"profile\": \"glm\",\n    \"code_puppy_model\": \"\",\n    \"code_puppy_yolo\": null,\n    \"code_puppy_quick_resume\": false,\n    \"mode_flags\": [\"--yolo\"],\n    \"llxprt_debug\": \"\",\n    \"pass_continue\": true,\n    \"sandbox_enabled\": false,\n    \"sandbox_engine\": \"podman\",\n    \"sandbox_flags\": \"\",\n    \"agent_kind\": \"llxprt\",\n    \"status\": \"Queued\",\n    \"runtime_binding\": null\n  }],\n  \"selected_repository_index\": 0,\n  \"selected_agent_index\": null,\n  \"hide_idle_repositories\": false,\n  \"last_selected_agent_by_repo\": [],\n  \"pane_focus\": \"\",\n  \"terminal_focused\": false,\n  \"user_preferences\": {}\n}\n"
+        },
+        "mode": 384
+      }
+    ],
+    "env": [
+      { "name": "PATH", "value": "${workspace}/bin:/usr/bin:/bin" }
+    ]
+  },
+  "steps": [
+    {
+      "op": "capture",
+      "name": "llxprt-agent",
+      "path": "bin/llxprt-agent",
+      "behavior": {
+        "stdout": "",
+        "stderr": "",
+        "exit_code": 0,
+        "stdin_limit": 0,
+        "hang": false,
+        "spawn_child_hang": false
+      }
+    },
+    {
+      "op": "launch",
+      "argv": ["jefe", "--config", "${workspace}/config"],
+      "env": [],
+      "cwd": "repo"
+    },
+    { "op": "wait", "source": "frame", "literal": "LLxprt Jefe", "timeout_ms": 15000 },
+    { "op": "key", "key": "i", "modifiers": [] },
+    { "op": "wait", "source": "frame", "literal": "Issues", "timeout_ms": 15000 },
+    { "op": "wait", "source": "frame", "literal": "#230", "timeout_ms": 15000 },
+    { "op": "key", "key": "enter", "modifiers": [] },
+    { "op": "wait", "source": "frame", "literal": "Issue #230 detail body", "timeout_ms": 15000 },
+    { "op": "key", "key": "S", "modifiers": [] },
+    { "op": "wait", "source": "frame", "literal": "Send to Agent", "timeout_ms": 15000 },
+    { "op": "wait", "source": "frame", "literal": "branch-520", "timeout_ms": 15000 },
+    { "op": "key", "key": "enter", "modifiers": [] },
+    { "op": "wait", "source": "frame", "literal": "Issues", "timeout_ms": 30000 },
+    { "op": "finish" }
+  ],
+  "secrets": []
+}

--- a/project-plans/issue520-plan.md
+++ b/project-plans/issue520-plan.md
@@ -1,0 +1,138 @@
+# Issue #520 — Fix malformed LLxprt fresh-send prompt arguments
+
+## Status
+
+Accepted for implementation. The user requested that issue #520 be filed and driven through a complete fix and pull request without additional approval for bounded work.
+
+Planning base: `88005aba` (current `origin/main` when branch `issue520` was created).
+
+Upstream symptom: https://github.com/vybestack/llxprt-code/issues/2851
+Regressing Jefe change: PR #501 / commit `7b12edcd`
+
+## Validated root cause
+
+The shipped LLxprt definition declares `prompt_interactive` as a Boolean field with a flag emitter. The legacy form's **Pass --continue** checkbox writes that field. A fresh Issue or Pull Request plan therefore emits a bare `--prompt-interactive` before the fresh-send boundary appends the real `-i <prompt>` pair.
+
+The resulting structural argv is:
+
+    --profile-load glm --yolo --prompt-interactive -i <prompt>
+
+LLxprt defines `--prompt-interactive` and `-i` as aliases of one string-valued option. Its parser combines the malformed duplicate into an array, which later fails at `initialPrompt.trim()`. Before PR #501, Jefe emitted exactly one prompt-valued option. The Jefe correction belongs in the definition and deterministic operation projection, not in the process executor.
+
+## Decision-complete acceptance matrix
+
+| ID | Actor / launch path | Inputs and boundaries | Observable success | Failure / side effects | Persistence / compatibility | Behavioral evidence |
+|---|---|---|---|---|---|---|
+| A1 | Local LLxprt Fresh Issue | profile `glm`; YOLO true; continuation true; exact multi-line issue prompt | Exact final argv is `--profile-load`, `glm`, `--yolo`, `-i`, prompt; empty plan env; exact cwd | No bare/duplicate prompt alias or continuation reaches runtime | Post-501 obsolete `prompt-interactive` value cannot affect the plan | Full shipped-definition `prepare_launch` regression and TUI form scenario |
+| A2 | Local LLxprt Fresh Pull Request | Same matrix with exact PR prompt | Same fresh-session contract with PR bytes | Same zero-malformed-argv rule | Same | Full shipped-definition regression |
+| A3 | Remote LLxprt Fresh Issue / Fresh Pull Request | Same typed values and remote target | Structural agent argv has the A1/A2 semantics and audited remote serialization | Unsupported/invalid plan performs no SSH/process effect | Same | Remote full-plan/transcript tests |
+| A4 | LLxprt Normal and Resume | continuation true and false | True emits fixture-proven `--continue`; false emits no continuation | No normal/resume plan emits bare `--prompt-interactive` | New form saves typed `continue` | Local/remote plan goldens and form tests |
+| A5 | Existing schema-2 values created by PR #501 | obsolete `prompt-interactive` present, `continue` absent | Launch projection copies only declared fields, so obsolete data cannot emit malformed argv; editing replaces it with current generated values | Runtime does not filter product arguments or coerce prompt values | No state schema bump; unknown durable bytes remain lossless until the form is explicitly saved | Launch/form tests |
+| A6 | Issues screen Send confirmation through the real TUI | schema-1 LLxprt agent with profile `glm`, YOLO true, and `pass_continue=true`; issue #230 | One captured launch has `--profile-load glm --yolo -i <full issue prompt>` and the Issues UI remains usable | No duplicate prompt alias or continuation reaches the process | Schema-1 migration supplies canonical `continue`, then FreshIssue projection omits it | Real-PTY harness scenario with deterministic GitHub, Git, tmux, and process captures |
+
+## Accepted implementation decisions
+
+1. Replace the LLxprt Boolean `prompt_interactive` field/emitter with Boolean `continue`, whose flag token is resolved from the existing fixture-proven `continue -> --continue` capability.
+2. Make launch-value projection accept the operation rather than a prompt-only Boolean. Fresh Issue and Fresh Pull Request omit both `prompt` and `continue`; fresh-send assembly remains the sole prompt owner.
+3. Update legacy form visibility/build/edit projection to read/write `continue` while retaining the user-facing **Pass --continue** label and existing default.
+4. Do not add a runtime argv filter, LLxprt-specific executor branch, prompt coercion, dependency, schema bump, or broad migration subsystem.
+5. Existing post-501 `prompt-interactive` keys are not declared after the correction. `launch_values` already projects only declared fields before strict plan validation, so they are retained durably but cannot affect execution. Explicitly editing an agent rewrites the current generated values.
+
+## Non-goals
+
+- Fixing LLxprt's independent scalar-option validation bug in this repository.
+- Changing prompt text, Issue/PR selection, preflight order, environment inheritance, tmux behavior, or remote escaping.
+- Adding compatibility fallbacks, process-boundary argument scanning, or defensive prompt normalization.
+- Redesigning generated forms or the agent-definition schema.
+- Dependency, quality-gate, workflow, `.llxprt/`, `.code_puppy/`, or unrelated documentation changes.
+- Moving unrelated tests or cleaning up adjacent issue #382 architecture.
+
+## Bounded vertical slices
+
+### Slice 1 — UI contract and semantic definition (A4, A6)
+
+- **Owners:** shipped definition, deterministic form projection, thin existing UI.
+- **Allowed paths:** `dev-docs/tmux-scenarios/v1/llxprt-continue-field.json`, `tests/harness_v1_fixtures.rs`, `src/domain/agent_definition/shipped/llxprt.rs`, `src/state/form_projection.rs`, `src/state/form_build.rs`, `src/state/modal_ops.rs`, and focused existing form tests.
+- **RED:** real-PTY scenario and form tests require the declared `continue` field behind **Pass --continue**; current definition exposes `prompt_interactive` instead.
+- **GREEN:** field visibility/default/save/edit behavior uses `continue`; normal/remote goldens emit `--continue`.
+- **Stop:** a state schema migration, public abstraction, new fixture subsystem, or UI redesign becomes necessary.
+- **Verification:** focused form/definition/plan tests and `cargo xtask quick`.
+
+### Slice 2 — Fresh operation contract (A1-A3, A5)
+
+- **Owners:** deterministic launch composition and existing fresh-send boundary.
+- **Allowed paths:** `src/runtime/launch_compose.rs`, adjacent runtime tests, `tests/agent_local_plan.rs`, `tests/issue382_behavior.rs`, and `tests/issue382/fresh_send.rs`.
+- **RED:** full shipped-definition tests require exact complete local/remote argv with continuation true and prove obsolete `prompt-interactive` cannot emit.
+- **GREEN:** fresh projection omits prompt and continuation; fresh-send adds one exact prompt-valued option.
+- **Stop:** a new runtime layer, process filter, remote serializer change, persistence schema bump, or unrelated route is required.
+- **Verification:** focused runtime/integration tests, updated scenario, and `cargo xtask quick`.
+
+### Slice 3 — Exact-head delivery (A1-A6)
+
+- **Owner:** verification/review/PR workflow only.
+- **Allowed paths:** no new production paths; only in-scope review fixes mapped in the ledger.
+- **GREEN:** tmux scenario, `make ci-check`, Rust/DeepThinker review, Open Code Review, PR CI, CodeRabbit triage, ancestry and conflict checks pass on exact head.
+- **Stop:** hard scope budget, unrelated mainline conflict, or required-gate blocker needs an unplanned subsystem.
+
+## Expected files by architectural layer
+
+| Layer | Expected path | Acceptance |
+|---|---|---|
+| Plan | `project-plans/issue520-plan.md` | workflow evidence |
+| TUI evidence | `dev-docs/tmux-scenarios/v1/llxprt-continue-field.json`, `tests/harness_v1_fixtures.rs` | A6 |
+| Shipped policy | `src/domain/agent_definition/shipped/llxprt.rs` | A1-A4 |
+| Form projection/build/edit | `src/state/form_projection.rs`, `src/state/form_build.rs`, `src/state/modal_ops.rs` | A4-A6 |
+| Form tests | existing focused generated/form test modules as required | A4-A6 |
+| Launch composition | `src/runtime/launch_compose.rs` and adjacent tests | A1-A5 |
+| Local/remote goldens | `src/runtime/agent_plan_tests.rs`, `src/runtime/agent_remote_plan_tests.rs`, `tests/agent_local_plan.rs`, `tests/issue382_behavior.rs` | A1-A4 |
+| Fresh-send acceptance | `src/runtime/agent_fresh_send_tests.rs`, `tests/issue382/fresh_send.rs` if required | A1-A3 |
+
+Target: no more than 15 changed files and 800 net lines for the green implementation; repository hard workflow thresholds remain 25 files / 1,500 net lines before mandatory review and 40 files / 2,500 net lines before an approval stop.
+
+## Scope ledger
+
+| Status | File / discovery | Mapping / disposition |
+|---|---|---|
+| Complete | GitHub issue #520, branch, and this plan | requested workflow |
+| Complete | shipped definition and form projection/build/edit paths | A4-A6 |
+| Complete | operation-aware composition and extracted focused tests | A1-A5; extraction keeps generic production source within architecture policy |
+| Complete | schema-1 migration and fixed-vector updates | A5-A6; `pass_continue` maps one way to canonical `continue` |
+| Complete | local/remote plan goldens and normal/resume matrix | A1-A4 |
+| Complete | real-PTY Issues Send scenario, capture assertion, and deterministic GH/Git/tmux shims | A6; captures the actual structural LLxprt invocation after repository preparation |
+| Complete | stale Issue Send comments/test name correction | review maintainability finding; documents operation-owned continuation omission |
+| Reject | OCR claim that stale `prompt-interactive` test data is dead | the seeded obsolete value is required evidence that undeclared schema-2 data cannot execute |
+| Reject | runtime argument filtering | hides invalid definition and violates ownership |
+| Defer | LLxprt CLI scalar validation | upstream llxprt-code issue #2851 |
+
+Final bounded scope is 22 paths, below the repository target of 25 files and 1,500 net lines. It exceeds the issue's initial 15-file implementation target because review-required migration, explicit-edit, architecture extraction, and real process-capture evidence were added. A mandatory scope review found every path maps directly to A1-A6; no new public abstraction, production subsystem, dependency, quality rule, or unrelated behavior was added.
+
+## Review counters
+
+- DeepThinker root-cause investigation: complete (read-only).
+- Local Rust/DeepThinker review cycles: 1 / 2, findings triaged and remediated.
+- OCR before PR: 1 / 2; two comments evaluated, with stale-data premise rejected and architecture extraction/remediation completed.
+- OCR after PR: 0 / 2.
+- CodeRabbit PR findings: pending.
+
+Finding dispositions: **Blocker-Fix** architecture token violation fixed by extracting tests; **In-scope-Fix** schema-1 canonical continuation, explicit-edit stale-value removal, full operation matrix, captured Issues Send flow, and stale comments/test name; **Reject** removal of the stale schema-2 test value because it is A5 evidence.
+
+## Verification evidence
+
+| Candidate | Command / evidence | Result |
+|---|---|---|
+| `88005aba` | root-cause source/history investigation | malformed duplicate prompt option confirmed |
+| RED working tree | operation-aware compile, migration, and explicit-edit tests | failed for the intended missing contracts |
+| GREEN working tree | `runtime::launch_compose::tests` | 3 passed: fresh Issue/PR exact argv plus local/remote normal/resume true/false |
+| GREEN working tree | schema-1 fixed vectors and explicit-edit regression | passed after canonical mapping and declared-value projection |
+| GREEN working tree | `llxprt_continue_field_fixture_sends_one_exact_issue_prompt` | passed; one captured LLxprt invocation, one `-i`, full prompt, no continuation |
+| GREEN working tree | architecture and source-size gates | passed; `launch_compose.rs` is 625 lines |
+| exact working head | format, strict Clippy, locked all-feature build | passed |
+| exact working head | locked all-feature library tests | 2,794 passed, 1 ignored |
+| exact working head | locked all-feature integration tests | all test binaries passed, including all 22 harness scenarios |
+| exact working head | architecture, source-size, shell syntax, JSON parse, diff check | passed; only existing source-size warnings |
+| exact working head | `make ci-check` | unavailable because this checkout has no Make target; exact component gates above were run instead |
+| pending PR head | CI, CodeRabbit, ancestry, conflict check | pending |
+
+## Deferred findings / follow-ups
+
+LLxprt should independently reject a yargs array for repeated scalar prompt aliases before React startup. That remains tracked by https://github.com/vybestack/llxprt-code/issues/2851 and is not implemented in this Jefe issue.

--- a/scripts/issue520-gh-shim.sh
+++ b/scripts/issue520-gh-shim.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -eu
+
+if [ -d .git ] && ! git rev-parse --verify HEAD >/dev/null 2>&1; then
+  git config user.name fixture
+  git config user.email fixture@example.com
+  git commit --allow-empty --quiet -m fixture
+  git update-ref refs/remotes/origin/main HEAD
+fi
+
+case "${1:-} ${2:-}" in
+  "auth status")
+    printf '%s\n' 'github.com' '  Logged in to github.com account testuser'
+    ;;
+  "issue view")
+    printf '%s\n' '{"number":230,"title":"Agent chooser identity and worktree status","state":"OPEN","author":{"login":"testuser"},"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z","labels":{"nodes":[]},"assignees":{"nodes":[]},"milestone":null,"body":"Issue #230 detail body","url":"https://github.com/owner/repo-230/issues/230","id":"I_kwADOAAAABc230","comments":[]}'
+    ;;
+  "api graphql")
+    case "$*" in
+      *"search(type: ISSUE"*)
+        printf '%s\n' '{"data":{"search":{"nodes":[{"id":"I_kwADOAAAABc230","number":230,"title":"Agent chooser identity and worktree status","state":"OPEN","author":{"login":"testuser"},"updatedAt":"2024-01-01T00:00:00Z","assignees":{"nodes":[]},"labels":{"nodes":[]},"issueType":null,"milestone":null,"comments":{"totalCount":0}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}'
+        ;;
+      *"issue(number:"*)
+        printf '%s\n' '{"data":{"repository":{"issue":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}'
+        ;;
+      *)
+        printf 'issue520 gh shim: rejected GraphQL request\n' >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    printf 'issue520 gh shim: rejected command\n' >&2
+    exit 1
+    ;;
+esac

--- a/scripts/issue520-git-shim.sh
+++ b/scripts/issue520-git-shim.sh
@@ -7,9 +7,8 @@ case "${1:-}" in
     exit 0
     ;;
   checkout)
-    shift
-    if [ "${1:-}" = "-B" ]; then
-      "$real_git" reset --hard --quiet "${3:?missing revision}"
+    if [ "${2:-}" = "-B" ]; then
+      "$real_git" reset --hard --quiet "${4:-HEAD}"
       exit 0
     fi
     ;;

--- a/scripts/issue520-git-shim.sh
+++ b/scripts/issue520-git-shim.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+real_git=/usr/bin/git
+case "${1:-}" in
+  fetch)
+    exit 0
+    ;;
+  checkout)
+    shift
+    if [ "${1:-}" = "-B" ]; then
+      "$real_git" reset --hard --quiet "${3:?missing revision}"
+      exit 0
+    fi
+    ;;
+esac
+exec "$real_git" "$@"

--- a/scripts/issue520-tmux-shim.sh
+++ b/scripts/issue520-tmux-shim.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+case " $* " in
+  *" -V "*)
+    printf 'tmux 3.4
+'
+    exit 0
+    ;;
+esac
+if [ "${1:-}" = "display-message" ] && [ "${2:-}" = "-p" ]; then
+  printf '12345|tmux 3.4
+'
+  exit 0
+fi
+
+case " $* " in
+  *" new-session "*)
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "-c" ]; then
+        shift
+        cd "${1:?missing cwd}"
+      elif [ "$1" = "env" ]; then
+        shift
+        while [ "${1:-}" = "-u" ]; do
+          shift 2
+        done
+        exec "$@"
+      fi
+      shift
+    done
+    ;;
+esac
+exit 0

--- a/scripts/issue520-tmux-shim.sh
+++ b/scripts/issue520-tmux-shim.sh
@@ -31,4 +31,4 @@ case " $* " in
     done
     ;;
 esac
-exit 0
+exit 64

--- a/src/app_input/issue_send_modal_tests.rs
+++ b/src/app_input/issue_send_modal_tests.rs
@@ -96,15 +96,11 @@ fn state_for_issue_agent_chooser_send(
     state
 }
 
-/// The issue-driven launch path must force `pass_continue = false` on the
-/// constructed launch signature, even though the agent's configured
-/// `pass_continue` defaults to `true`. This test resolves the send info
-/// (which copies the agent's `pass_continue`) and then applies the SAME
-/// override `dispatch_agent_chooser_confirm` applies, asserting `--continue`
-/// would never reach the agent. The git prep + spawn require a runtime/git
-/// repo and are guarded out in unit tests (SharedContext is None).
+/// The issue-driven path changes the operation to FreshIssue and carries the
+/// exact bounded-delivery prompt as a typed value. Launch composition owns the
+/// later continuation omission and prompt argument shape.
 #[test]
-fn issue_send_forces_pass_continue_false_on_launch_signature() {
+fn issue_send_projects_fresh_operation_and_prompt() {
     let agent_id = AgentId(String::from("issue-agent-1"));
     // This test only exercises pure struct transforms — the work_dir is
     // never materialized on disk — so a static path suffices.

--- a/src/app_input/issues_send.rs
+++ b/src/app_input/issues_send.rs
@@ -148,18 +148,17 @@ fn handle_initial_prep_outcome(
     }
 }
 
-/// Build the launch signature for an issue-driven launch from the agent's
-/// base signature. Issue-driven launches are always fresh instructions, so
-/// `pass_continue` is forced to `false` regardless of the agent's configured
-/// value, and the issue prompt instruction is appended with the correct
-/// per-kind arg shape.
+/// Build the launch request for an issue-driven launch from the agent's base
+/// request. Issue-driven launches always select the fresh operation and carry
+/// the exact issue prompt as a typed value. Operation-aware launch composition
+/// then omits continuation before fresh-send emits the prompt argument.
 ///
-/// Delegates to [`prepare_fresh_prompt_signature`] so the issue and PR send
-/// paths share the same kind-specific arg construction. CodePuppy and LLxprt
-/// share identical prep; only the launch signature/runtime args differ.
+/// Delegates to [`prepare_fresh_prompt_signature`] so Issue and Pull Request
+/// send paths share the same prompt construction while the definition owns the
+/// final argument shape.
 ///
-/// Extracted as a pure function so the `pass_continue = false` override is
-/// unit-testable without a runtime/git context.
+/// Extracted as a pure function so operation and prompt projection are
+/// unit-testable without a runtime or Git context.
 pub(super) fn prepare_issue_launch_signature(
     sig: AgentLaunchRequest,
     prompt_content: &str,

--- a/src/domain/agent_definition/shipped/llxprt.rs
+++ b/src/domain/agent_definition/shipped/llxprt.rs
@@ -31,9 +31,6 @@ fn emitters() -> Vec<Emitter> {
             field: "yolo".to_string(),
         },
         Emitter::Flag {
-            field: "prompt_interactive".to_string(),
-        },
-        Emitter::Flag {
             field: "continue".to_string(),
         },
     ]
@@ -90,7 +87,6 @@ pub fn build() -> AgentDefinition {
         agent_fields: vec![
             sig_string_field("version_selector"),
             sig_string_field("prompt"),
-            bool_field("prompt_interactive"),
             bool_field("continue"),
         ],
         emitters: emitters(),

--- a/src/persistence/migration.rs
+++ b/src/persistence/migration.rs
@@ -576,6 +576,13 @@ fn agent_values(
             json!(agent_version_selector(source, definition)),
         )?;
     }
+    if declares_agent_field(definition, "continue") {
+        crate::domain::canonical_values::insert_json(
+            &mut values,
+            "continue",
+            json!(source.pass_continue),
+        )?;
+    }
     Ok(values)
 }
 

--- a/src/persistence/migration_tests.rs
+++ b/src/persistence/migration_tests.rs
@@ -95,6 +95,14 @@ fn assert_agent_migration(state: &crate::domain::StateV2) {
         None,
         "PID and process evidence must not enter typed product values"
     );
+    assert_eq!(
+        state.agents[0].values.get(&id("continue")),
+        Some(&TypedValue::Bool(true))
+    );
+    assert_eq!(
+        state.agents[2].values.get(&id("continue")),
+        Some(&TypedValue::Bool(true))
+    );
 }
 
 fn assert_selection_and_preferences(state: &crate::domain::StateV2) {
@@ -263,6 +271,36 @@ fn colliding_agent_legacy_identities_receive_source_order_ordinals() {
     assert_eq!(first.state().agents[1].id, second.state().agents[1].id);
 }
 
+fn assert_remote_fixed_vectors(
+    repository: &crate::domain::RepositoryRecord,
+    agent: &crate::domain::AgentRecord,
+) {
+    assert_eq!(
+        repository.id.as_str(),
+        "repo.90c36b6f6cad7eb526f60ebdc4fbaac14ecf08aabfc9656626f09ff4bf8b5d30"
+    );
+    assert_eq!(
+        agent.id.as_str(),
+        "agent.dd89951a73af6fea961078bbe54ee58ded798508e64f2e5a4980d724b8239d70"
+    );
+    assert_eq!(
+        agent.launch_signature.definition_hash.as_str(),
+        "cb10a1d073096703ffe8b3bd86f662a1b1dc92250341b3f3f06818eccd56755b"
+    );
+    assert_eq!(
+        agent.launch_signature.typed_value_hash.as_str(),
+        "b859c48f763a1b58092842a89715aa8ab78f3ace690421b71e6b0aa31ce6a047"
+    );
+    assert_eq!(
+        crate::domain::canonical_values::typed_field(&agent.values, "continue"),
+        Some(&TypedValue::Bool(true))
+    );
+    assert_eq!(
+        agent.launch_signature.target_fingerprint.as_str(),
+        "bce3a6722845694a877fcfffdee9528be975ed9deef7c00bc3047a11e289844b"
+    );
+}
+
 #[test]
 fn remote_schema1_ids_and_hashes_match_fixed_vectors() {
     let source = serde_json::to_vec(&json!({
@@ -307,26 +345,7 @@ fn remote_schema1_ids_and_hashes_match_fixed_vectors() {
     let repository = &migrated.state().repositories[0];
     let agent = &migrated.state().agents[0];
 
-    assert_eq!(
-        repository.id.as_str(),
-        "repo.90c36b6f6cad7eb526f60ebdc4fbaac14ecf08aabfc9656626f09ff4bf8b5d30"
-    );
-    assert_eq!(
-        agent.id.as_str(),
-        "agent.dd89951a73af6fea961078bbe54ee58ded798508e64f2e5a4980d724b8239d70"
-    );
-    assert_eq!(
-        agent.launch_signature.definition_hash.as_str(),
-        "7572f5e82ecab05268886416c27e70b6c76b37a51ca5d7053a9c2d865de4d8a8"
-    );
-    assert_eq!(
-        agent.launch_signature.typed_value_hash.as_str(),
-        "14e6bc5b61c3f4bc64e1f6c436e37ab779d98e9e5eed98141ad90339c637307c"
-    );
-    assert_eq!(
-        agent.launch_signature.target_fingerprint.as_str(),
-        "bce3a6722845694a877fcfffdee9528be975ed9deef7c00bc3047a11e289844b"
-    );
+    assert_remote_fixed_vectors(repository, agent);
 }
 
 #[test]

--- a/src/runtime/agent_plan_tests.rs
+++ b/src/runtime/agent_plan_tests.rs
@@ -97,7 +97,7 @@ fn default_field_values_are_used_when_not_provided() {
 fn flag_resolves_token_from_capability_probe() {
     let definition = llxprt();
     let mut values = LaunchFieldValues::new();
-    values.set_agent("prompt_interactive", FieldValue::Boolean(true));
+    values.set_agent("continue", FieldValue::Boolean(true));
     let request = PlanRequest {
         definition: &definition,
         operation: Operation::Normal,
@@ -130,10 +130,7 @@ fn flag_resolves_token_from_capability_probe() {
         .iter()
         .map(|a| a.to_string_lossy().into_owned())
         .collect();
-    assert_eq!(
-        argv,
-        vec!["--yolo".to_string(), "--prompt-interactive".to_string()]
-    );
+    assert_eq!(argv, vec!["--yolo".to_string(), "--continue".to_string()]);
 }
 
 #[test]

--- a/src/runtime/agent_remote_plan_tests.rs
+++ b/src/runtime/agent_remote_plan_tests.rs
@@ -210,7 +210,7 @@ fn llxprt_remote_normal_produces_golden_transcript() {
     let definition = llxprt();
     let mut values = LaunchFieldValues::new();
     values.set_repository("profile", FieldValue::String("dev".to_string()));
-    values.set_agent("prompt_interactive", FieldValue::Boolean(true));
+    values.set_agent("continue", FieldValue::Boolean(true));
     let settings = remote_settings();
     let request = make_request(&definition, &values, &settings, Operation::Normal);
     let transcript = match plan_remote_launch(&request) {
@@ -219,7 +219,7 @@ fn llxprt_remote_normal_produces_golden_transcript() {
     };
     assert_eq!(
         transcript.remote_command(),
-        "cd '/srv/project' && exec '/opt/bin/llxprt' '--profile-load' 'dev' '--yolo' '--prompt-interactive'"
+        "cd '/srv/project' && exec '/opt/bin/llxprt' '--profile-load' 'dev' '--yolo' '--continue'"
     );
     let argv: Vec<String> = transcript
         .agent_argv()
@@ -232,7 +232,7 @@ fn llxprt_remote_normal_produces_golden_transcript() {
             "--profile-load".to_string(),
             "dev".to_string(),
             "--yolo".to_string(),
-            "--prompt-interactive".to_string(),
+            "--continue".to_string(),
         ]
     );
 }

--- a/src/runtime/launch_compose.rs
+++ b/src/runtime/launch_compose.rs
@@ -125,11 +125,7 @@ pub fn prepare_launch(
     validate_support_before_effects(&definition, configuration)?;
     let selector = version_selector(&configuration.values)?;
     let target = launch_target(configuration)?;
-    let values = launch_values(
-        &definition,
-        &configuration.values,
-        configuration.operation.is_fresh(),
-    )?;
+    let values = launch_values(&definition, &configuration.values, configuration.operation)?;
     let candidate = if configuration.remote.enabled {
         remote_candidate(
             &definition,
@@ -564,16 +560,16 @@ fn resolved_candidate(
 fn launch_values(
     definition: &AgentDefinition,
     values: &TypedMap,
-    omit_prompt: bool,
+    operation: crate::domain::agent_definition::Operation,
 ) -> Result<LaunchFieldValues, RuntimeError> {
     let mut launch = LaunchFieldValues::new();
     for field in &definition.repository_fields {
-        if let Some(value) = launch_field(values, field, omit_prompt)? {
+        if let Some(value) = launch_field(values, field, operation)? {
             launch.set_repository(field.id.clone(), value);
         }
     }
     for field in &definition.agent_fields {
-        if let Some(value) = launch_field(values, field, omit_prompt)? {
+        if let Some(value) = launch_field(values, field, operation)? {
             launch.set_agent(field.id.clone(), value);
         }
     }
@@ -583,9 +579,9 @@ fn launch_values(
 fn launch_field(
     values: &TypedMap,
     field: &crate::domain::agent_definition::Field,
-    omit_prompt: bool,
+    operation: crate::domain::agent_definition::Operation,
 ) -> Result<Option<FieldValue>, RuntimeError> {
-    if omit_prompt && field.id == "prompt" {
+    if operation.is_fresh() && matches!(field.id.as_str(), "prompt" | "continue") {
         return Ok(None);
     }
     typed_field(values, &field.id)
@@ -623,3 +619,7 @@ fn to_field_value(kind: FieldKind, value: &TypedValue) -> Result<FieldValue, Run
     };
     Ok(converted)
 }
+
+#[cfg(test)]
+#[path = "launch_compose_tests.rs"]
+mod tests;

--- a/src/runtime/launch_compose_tests.rs
+++ b/src/runtime/launch_compose_tests.rs
@@ -1,0 +1,251 @@
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+
+use super::*;
+use crate::domain::Id;
+use crate::domain::RemoteRepositorySettings;
+use crate::domain::agent_definition::{
+    AgentLaunchPlan, Availability, FieldValue, Operation, Preflight, RemoteTarget, Target,
+};
+use crate::runtime::agent_plan::{LaunchFieldValues, PlanOutcome, PlanRequest, plan_local_launch};
+use crate::runtime::agent_remote_plan::{RemotePlanOutcome, RemotePlanRequest, plan_remote_launch};
+use crate::runtime::{
+    AuthorizationResult, ExecutionEvidence, PreparationOutcome, ProcessSandboxInspector,
+    authorize_execution, prepare_execution, prepare_fresh_send,
+};
+
+const PROMPT: &str = "exact prompt bytes\nwith a second line";
+
+fn llxprt() -> AgentDefinition {
+    AgentDefinition::shipped()
+        .into_iter()
+        .find(|definition| definition.id.as_str() == "core.llxprt")
+        .unwrap_or_else(|| panic!("LLxprt definition must be shipped"))
+}
+
+fn typed_values(continuation: bool) -> TypedMap {
+    let mut values = TypedMap::new();
+    for (field, value) in [
+        ("profile", TypedValue::String("glm".to_owned())),
+        ("yolo", TypedValue::Bool(true)),
+        ("continue", TypedValue::Bool(continuation)),
+        ("prompt-interactive", TypedValue::Bool(true)),
+    ] {
+        let key = Id::parse(field)
+            .unwrap_or_else(|error| panic!("{field} must be a valid typed key: {error}"));
+        values.insert(key, value);
+    }
+    values
+}
+
+fn local_target() -> Target {
+    Target::Local {
+        canonical_cwd: PathBuf::from("/srv/project"),
+    }
+}
+
+fn local_plan(
+    definition: &AgentDefinition,
+    values: &LaunchFieldValues,
+    operation: Operation,
+) -> AgentLaunchPlan {
+    let request = PlanRequest {
+        definition,
+        operation,
+        target: local_target(),
+        executable: PathBuf::from("/opt/bin/llxprt"),
+        executable_fingerprint: crate::agent_candidate_fingerprint::CandidateFingerprint::new(
+            PathBuf::from("/opt/bin/llxprt"),
+            None,
+            None,
+            0,
+            0,
+        ),
+        executable_wrapper: crate::agent_candidate_path::AgentWrapperKind::Direct,
+        argv_prefix: Vec::new(),
+        probe: Availability::InstalledCompatible {
+            identity: "0.10.0".to_owned(),
+            capabilities: vec![
+                "prompt-interactive".to_owned(),
+                "profile".to_owned(),
+                "yolo".to_owned(),
+                "continue".to_owned(),
+            ],
+            generation: 1,
+        },
+        probe_generation: 1,
+        target_generation: 1,
+        values,
+        activation_generation: 1,
+        preflight: Preflight::default(),
+    };
+    match plan_local_launch(&request) {
+        PlanOutcome::Supported(plan) => *plan,
+        other => panic!("LLxprt operation must plan: {other:?}"),
+    }
+}
+
+fn prepare_fresh_plan(operation: Operation) -> AgentLaunchPlan {
+    let definition = llxprt();
+    let projected = launch_values(&definition, &typed_values(true), operation)
+        .unwrap_or_else(|error| panic!("fresh values must project: {error}"));
+    let plan = local_plan(&definition, &projected, operation);
+    let evidence = ExecutionEvidence::new(
+        plan.definition_sha256,
+        plan.executable_fingerprint.clone(),
+        1,
+        1,
+        1,
+    );
+    let authorized = match authorize_execution(&plan, &evidence) {
+        AuthorizationResult::Authorized(authorized) => authorized,
+        AuthorizationResult::Rejected(rejection) => panic!("plan must authorize: {rejection}"),
+    };
+    let cleared = match prepare_execution(authorized, None, &ProcessSandboxInspector::new()) {
+        PreparationOutcome::Cleared(cleared) => cleared,
+        PreparationOutcome::Unavailable(reason) => panic!("plan must clear: {reason}"),
+    };
+    prepare_fresh_send(&definition, cleared, PROMPT)
+        .unwrap_or_else(|error| panic!("fresh send must prepare: {error}"))
+        .plan()
+        .clone()
+}
+
+#[test]
+fn fresh_llxprt_plan_emits_one_prompt_without_continuation() {
+    for operation in [Operation::FreshIssue, Operation::FreshPullRequest] {
+        let plan = prepare_fresh_plan(operation);
+        assert_eq!(
+            plan.argv,
+            ["--profile-load", "glm", "--yolo", "-i", PROMPT].map(OsString::from)
+        );
+        assert!(plan.env.is_empty());
+        assert_eq!(plan.cwd, PathBuf::from("/srv/project"));
+        assert_eq!(
+            plan.argv
+                .iter()
+                .filter(|argument| {
+                    matches!(
+                        argument.as_os_str().to_str(),
+                        Some("-i" | "--prompt-interactive")
+                    )
+                })
+                .count(),
+            1
+        );
+        assert!(
+            !plan
+                .argv
+                .iter()
+                .any(|argument| argument == OsStr::new("--continue"))
+        );
+    }
+}
+
+#[test]
+fn normal_and_resume_emit_only_selected_continuation() {
+    let definition = llxprt();
+    for operation in [Operation::Normal, Operation::Resume] {
+        for continuation in [false, true] {
+            let projected = launch_values(&definition, &typed_values(continuation), operation)
+                .unwrap_or_else(|error| panic!("values must project: {error}"));
+            assert_eq!(
+                projected.agent("continue"),
+                Some(&FieldValue::Boolean(continuation))
+            );
+            let expected = if continuation {
+                vec!["--profile-load", "glm", "--yolo", "--continue"]
+            } else {
+                vec!["--profile-load", "glm", "--yolo"]
+            };
+            assert_eq!(
+                local_plan(&definition, &projected, operation).argv,
+                expected.into_iter().map(OsString::from).collect::<Vec<_>>()
+            );
+        }
+    }
+}
+
+fn remote_target() -> Target {
+    Target::Remote(RemoteTarget {
+        user: "dev".to_owned(),
+        host: "example.com".to_owned(),
+        port: Some(22),
+        run_as_user: String::new(),
+        canonical_cwd: PathBuf::from("/srv/project"),
+    })
+}
+
+fn remote_settings() -> RemoteRepositorySettings {
+    RemoteRepositorySettings {
+        enabled: true,
+        login_user: "dev".to_owned(),
+        host: "example.com".to_owned(),
+        port: Some(22),
+        ..RemoteRepositorySettings::default()
+    }
+}
+
+fn remote_plan(
+    definition: &AgentDefinition,
+    values: &LaunchFieldValues,
+    operation: Operation,
+) -> AgentLaunchPlan {
+    let settings = remote_settings();
+    let request = RemotePlanRequest {
+        definition,
+        operation,
+        target: remote_target(),
+        executable: PathBuf::from("/opt/bin/llxprt"),
+        executable_fingerprint: crate::agent_candidate_fingerprint::CandidateFingerprint::new(
+            PathBuf::from("/opt/bin/llxprt"),
+            None,
+            None,
+            0,
+            0,
+        ),
+        executable_wrapper: crate::agent_candidate_path::AgentWrapperKind::Direct,
+        argv_prefix: Vec::new(),
+        probe: Availability::InstalledCompatible {
+            identity: "0.10.0".to_owned(),
+            capabilities: vec![
+                "prompt-interactive".to_owned(),
+                "profile".to_owned(),
+                "yolo".to_owned(),
+                "continue".to_owned(),
+            ],
+            generation: 1,
+        },
+        probe_generation: 1,
+        target_generation: 1,
+        activation_generation: 1,
+        values,
+        preflight: Preflight::default(),
+        ssh_settings: &settings,
+    };
+    match plan_remote_launch(&request) {
+        RemotePlanOutcome::Transcript(transcript) => transcript.plan().clone(),
+        other => panic!("remote LLxprt operation must plan: {other:?}"),
+    }
+}
+
+#[test]
+fn remote_normal_and_resume_emit_only_selected_continuation() {
+    let definition = llxprt();
+    for operation in [Operation::Normal, Operation::Resume] {
+        for continuation in [false, true] {
+            let projected = launch_values(&definition, &typed_values(continuation), operation)
+                .unwrap_or_else(|error| panic!("values must project: {error}"));
+            let plan = remote_plan(&definition, &projected, operation);
+            assert_eq!(
+                plan.argv
+                    .iter()
+                    .any(|argument| argument == OsStr::new("--continue")),
+                continuation
+            );
+            assert!(!plan.argv.iter().any(|argument| {
+                argument == OsStr::new("-i") || argument == OsStr::new("--prompt-interactive")
+            }));
+        }
+    }
+}

--- a/src/state/form_build.rs
+++ b/src/state/form_build.rs
@@ -256,7 +256,7 @@ impl AppState {
             agent.work_dir = std::path::PathBuf::from(new_dir);
         }
         let mut values = if agent.type_id == type_id {
-            agent.values.clone()
+            declared_values(&definition, &agent.values)
         } else if repository.default_type_id == type_id {
             repository.default_values.clone()
         } else {
@@ -274,6 +274,18 @@ fn active_type_id(value: &str) -> Option<AgentTypeId> {
 
 fn definition_for_type(type_id: &AgentTypeId) -> Option<AgentDefinition> {
     super::form_projection::definition_for_type(type_id)
+}
+
+fn declared_values(definition: &AgentDefinition, values: &TypedMap) -> TypedMap {
+    definition
+        .repository_fields
+        .iter()
+        .chain(definition.agent_fields.iter())
+        .filter_map(|field| {
+            let key = typed_key(&field.id)?;
+            values.get(&key).cloned().map(|value| (key, value))
+        })
+        .collect()
 }
 
 fn default_values(definition: &AgentDefinition) -> TypedMap {

--- a/src/state/form_build.rs
+++ b/src/state/form_build.rs
@@ -256,7 +256,9 @@ impl AppState {
             agent.work_dir = std::path::PathBuf::from(new_dir);
         }
         let mut values = if agent.type_id == type_id {
-            declared_values(&definition, &agent.values)
+            let mut values = agent.values.clone();
+            remove_replaced_agent_values(&definition, &mut values);
+            values
         } else if repository.default_type_id == type_id {
             repository.default_values.clone()
         } else {
@@ -276,16 +278,21 @@ fn definition_for_type(type_id: &AgentTypeId) -> Option<AgentDefinition> {
     super::form_projection::definition_for_type(type_id)
 }
 
-fn declared_values(definition: &AgentDefinition, values: &TypedMap) -> TypedMap {
-    definition
-        .repository_fields
+fn remove_replaced_agent_values(definition: &AgentDefinition, values: &mut TypedMap) {
+    let declares_continue = definition
+        .agent_fields
         .iter()
-        .chain(definition.agent_fields.iter())
-        .filter_map(|field| {
-            let key = typed_key(&field.id)?;
-            values.get(&key).cloned().map(|value| (key, value))
-        })
-        .collect()
+        .any(|field| field.id == "continue");
+    let declares_prompt_boolean = definition
+        .agent_fields
+        .iter()
+        .any(|field| field.id == "prompt_interactive");
+    if declares_continue
+        && !declares_prompt_boolean
+        && let Some(key) = typed_key("prompt_interactive")
+    {
+        values.remove(&key);
+    }
 }
 
 fn default_values(definition: &AgentDefinition) -> TypedMap {

--- a/src/state/form_ops_tests.rs
+++ b/src/state/form_ops_tests.rs
@@ -341,6 +341,12 @@ fn update_llxprt_agent_replaces_obsolete_prompt_interactive_value() {
         serde_json::Value::Bool(true),
     )
     .unwrap_or_else(|error| panic!("valid obsolete prompt fixture: {error}"));
+    crate::domain::canonical_values::insert_json(
+        &mut values,
+        "future_metadata",
+        serde_json::Value::String("preserve me".to_owned()),
+    )
+    .unwrap_or_else(|error| panic!("valid undeclared metadata fixture: {error}"));
     let mut agent = Agent::new(
         crate::domain::AgentId("agent-obsolete-prompt".to_owned()),
         repository.id.clone(),
@@ -365,6 +371,10 @@ fn update_llxprt_agent_replaces_obsolete_prompt_interactive_value() {
     );
     assert!(
         crate::domain::canonical_values::typed_field(&agent.values, "prompt_interactive").is_none()
+    );
+    assert_eq!(
+        crate::domain::canonical_values::typed_field(&agent.values, "future_metadata"),
+        Some(&crate::domain::TypedValue::String("preserve me".to_owned()))
     );
 }
 #[test]

--- a/src/state/form_ops_tests.rs
+++ b/src/state/form_ops_tests.rs
@@ -332,6 +332,42 @@ fn update_agent_empty_mode_disables_declared_yolo_value() {
 }
 
 #[test]
+fn update_llxprt_agent_replaces_obsolete_prompt_interactive_value() {
+    let repository = seed_repository();
+    let mut values = crate::domain::TypedMap::new();
+    crate::domain::canonical_values::insert_json(
+        &mut values,
+        "prompt_interactive",
+        serde_json::Value::Bool(true),
+    )
+    .unwrap_or_else(|error| panic!("valid obsolete prompt fixture: {error}"));
+    let mut agent = Agent::new(
+        crate::domain::AgentId("agent-obsolete-prompt".to_owned()),
+        repository.id.clone(),
+        crate::domain::shipped_agent_type(3),
+        values,
+        "Agent".to_owned(),
+        std::path::PathBuf::from("/tmp/agent"),
+    );
+    let fields = AgentFormFields {
+        name: "Agent".to_owned(),
+        work_dir: "/tmp/agent".to_owned(),
+        agent_type_id: "core.llxprt".to_owned(),
+        pass_continue: false,
+        ..AgentFormFields::default()
+    };
+
+    AppState::update_agent_from_fields(&mut agent, &repository, &fields);
+
+    assert_eq!(
+        crate::domain::canonical_values::typed_field(&agent.values, "continue"),
+        Some(&crate::domain::TypedValue::Bool(false))
+    );
+    assert!(
+        crate::domain::canonical_values::typed_field(&agent.values, "prompt_interactive").is_none()
+    );
+}
+#[test]
 fn repository_checkbox_toggle_updates_remote_fields() {
     let mut state = AppState {
         repositories: vec![seed_repository()],

--- a/src/state/form_projection.rs
+++ b/src/state/form_projection.rs
@@ -65,7 +65,7 @@ pub enum AgentFormField {
     VersionSelector,
     Yolo,
     Interactive,
-    PromptInteractive,
+    Continue,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -88,7 +88,7 @@ impl AgentFormFieldVisibility {
 
     #[must_use]
     pub fn shows_llxprt_fields(&self) -> bool {
-        self.shows_profile_fields() && self.contains(AgentFormField::PromptInteractive)
+        self.shows_profile_fields() && self.contains(AgentFormField::Continue)
     }
 }
 
@@ -115,7 +115,7 @@ pub fn agent_form_visibility(type_id: Option<&AgentTypeId>) -> AgentFormFieldVis
             has_agent("version_selector").then_some(AgentFormField::VersionSelector),
             has_repository("yolo").then_some(AgentFormField::Yolo),
             has_agent("interactive").then_some(AgentFormField::Interactive),
-            has_agent("prompt_interactive").then_some(AgentFormField::PromptInteractive),
+            has_agent("continue").then_some(AgentFormField::Continue),
         ]
         .into_iter()
         .flatten()
@@ -146,7 +146,7 @@ pub fn is_field_visible(
         }
         F::CodePuppyQuickResume => visibility.contains(AgentFormField::Interactive),
         F::Mode => visibility.shows_profile_fields() && visibility.contains(AgentFormField::Yolo),
-        F::PassContinue => visibility.contains(AgentFormField::PromptInteractive),
+        F::PassContinue => visibility.contains(AgentFormField::Continue),
         F::Shortcut | F::Name | F::Description | F::WorkDir | F::AgentType => true,
     }
 }

--- a/src/state/generated_form_submit_tests.rs
+++ b/src/state/generated_form_submit_tests.rs
@@ -21,10 +21,10 @@ fn llxprt_definition() -> AgentDefinition {
         .unwrap_or_else(|| panic!("LLxprt definition must be shipped"))
 }
 
-fn compatible_with_prompt_interactive() -> Availability {
+fn compatible_llxprt() -> Availability {
     Availability::InstalledCompatible {
         identity: "0.10.0".to_string(),
-        capabilities: vec!["prompt-interactive".to_string()],
+        capabilities: vec!["prompt-interactive".to_string(), "continue".to_string()],
         generation: 1,
     }
 }
@@ -42,7 +42,7 @@ fn test_repository() -> Repository {
 
 fn build_form_for_llxprt() -> GeneratedAgentForm {
     let definition = llxprt_definition();
-    let availability = compatible_with_prompt_interactive();
+    let availability = compatible_llxprt();
     GeneratedAgentForm::from_definition(&definition, &availability)
         .unwrap_or_else(|error| panic!("LLxprt definition must produce a form: {error}"))
 }
@@ -69,7 +69,7 @@ fn form_result_with_values(values: Vec<FieldValue>) -> GeneratedAgentFormResult 
                 value: values[3].clone(),
             },
             FormFieldValue {
-                id: crate::state::generated_form::FormFieldId::agent("prompt_interactive"),
+                id: crate::state::generated_form::FormFieldId::agent("continue"),
                 value: values[4].clone(),
             },
         ],
@@ -113,9 +113,9 @@ fn values_from_form_result_normalizes_underscores_to_hyphens() {
         Some(&TypedValue::String("do the thing".to_string()))
     );
 
-    let prompt_interactive = Id::parse("prompt-interactive")
-        .unwrap_or_else(|error| panic!("prompt-interactive is a valid Id: {error}"));
-    assert_eq!(map.get(&prompt_interactive), Some(&TypedValue::Bool(true)));
+    let continuation =
+        Id::parse("continue").unwrap_or_else(|error| panic!("continue is a valid Id: {error}"));
+    assert_eq!(map.get(&continuation), Some(&TypedValue::Bool(true)));
 }
 
 #[test]
@@ -266,7 +266,7 @@ fn agent_type_id_is_preserved_in_modal_state() {
     // Verifies the type_id field on ModalState::GeneratedAgent — the selected
     // definition/type ID is the sole authority for the canonical path.
     let type_id = llxprt_definition().id;
-    let availability = compatible_with_prompt_interactive();
+    let availability = compatible_llxprt();
     let observation = AgentAvailabilityObservation::new(&llxprt_definition(), true, availability);
     let mut state = crate::state::AppState {
         agent_type_availability: vec![observation],

--- a/tests/agent_local_plan.rs
+++ b/tests/agent_local_plan.rs
@@ -98,13 +98,11 @@ fn llxprt_normal_golden_plan() {
     let mut values = LaunchFieldValues::new();
     values.set_repository("profile", FieldValue::String("my-profile".to_string()));
     values.set_repository("yolo", FieldValue::Boolean(true));
-    values.set_agent("prompt_interactive", FieldValue::Boolean(true));
     values.set_agent("continue", FieldValue::Boolean(true));
     let plan = assert_supported(llxprt_plan_request(&definition, &values), "llxprt normal");
     // Argv emitted element-by-element in declaration order:
     //   Option{--profile-load, profile} -> --profile-load, my-profile
     //   Flag{yolo}                       -> --yolo
-    //   Flag{prompt_interactive}         -> --prompt-interactive
     //   Flag{continue}                   -> --continue
     assert_eq!(
         plan.argv,
@@ -112,7 +110,6 @@ fn llxprt_normal_golden_plan() {
             os("--profile-load"),
             os("my-profile"),
             os("--yolo"),
-            os("--prompt-interactive"),
             os("--continue"),
         ],
     );
@@ -852,7 +849,6 @@ fn llxprt_false_boolean_fields_omit_flags_independently() {
     let definition = shipped("LLxprt");
     let mut values = LaunchFieldValues::new();
     values.set_repository("yolo", FieldValue::Boolean(false));
-    values.set_agent("prompt_interactive", FieldValue::Boolean(true));
     values.set_agent("continue", FieldValue::Boolean(false));
 
     let plan = assert_supported(
@@ -860,7 +856,7 @@ fn llxprt_false_boolean_fields_omit_flags_independently() {
         "llxprt false flags",
     );
     let argv = argv_strings(&plan);
-    assert!(argv.contains(&"--prompt-interactive".to_string()));
+    assert!(!argv.contains(&"--prompt-interactive".to_string()));
     assert!(!argv.contains(&"--yolo".to_string()));
     assert!(!argv.contains(&"--continue".to_string()));
 }

--- a/tests/generated_form_model.rs
+++ b/tests/generated_form_model.rs
@@ -417,10 +417,10 @@ fn llxprt_generated_form_defaults_yolo_to_true() {
     assert_eq!(yolo.value(), &FieldValue::Boolean(true));
 }
 
-/// LLxprt must declare an independent agent-scope `continue` boolean field
-/// distinct from `prompt_interactive`.
+/// LLxprt must declare an agent-scope `continue` boolean without exposing the
+/// prompt-valued interactive option as a Boolean form field.
 #[test]
-fn llxprt_generated_form_exposes_independent_continue_field() {
+fn llxprt_generated_form_exposes_only_the_continue_boolean() {
     let definition = llxprt_shipped();
     assert!(
         definition
@@ -438,10 +438,10 @@ fn llxprt_generated_form_exposes_independent_continue_field() {
         panic!("LLxprt form must expose an agent continue field");
     };
     assert_eq!(continue_field.value(), &FieldValue::Boolean(false));
-    // prompt_interactive remains independent and present.
     assert!(
         draft
             .field(&FormFieldId::agent("prompt_interactive"))
-            .is_some()
+            .is_none(),
+        "prompt-interactive is a prompt-valued operation capability, not a Boolean field"
     );
 }

--- a/tests/harness_v1_fixtures.rs
+++ b/tests/harness_v1_fixtures.rs
@@ -54,6 +54,14 @@ fn run_fixture(name: &str) -> RunOutcome {
     if name == "pr-delta-review.json" {
         installs.push(("gh".to_string(), repo_path("scripts/issue376-gh-shim.sh")));
     }
+    if name == "llxprt-continue-field.json" {
+        installs.push(("gh".to_string(), repo_path("scripts/issue520-gh-shim.sh")));
+        installs.push(("git".to_string(), repo_path("scripts/issue520-git-shim.sh")));
+        installs.push((
+            "tmux".to_string(),
+            repo_path("scripts/issue520-tmux-shim.sh"),
+        ));
+    }
     let config = RunnerConfig {
         shim_binary: bin_path("jefe-capture-shim"),
         installs,
@@ -132,6 +140,50 @@ fn config_path_fixture_runs_the_real_provider_free_binary() {
 fn panic_capture_fixture_projects_silent_error_without_raw_terminal_output() {
     let outcome = run_fixture("panic-capture-errors.json");
     assert_passed("panic-capture-errors", &outcome);
+    cleanup(&outcome);
+}
+
+#[test]
+fn llxprt_continue_field_fixture_sends_one_exact_issue_prompt() {
+    let outcome = run_fixture("llxprt-continue-field.json");
+    assert_passed("llxprt-continue-field", &outcome);
+    let capture = outcome
+        .report
+        .captures
+        .iter()
+        .find(|capture| capture.name == "llxprt-agent")
+        .unwrap_or_else(|| panic!("LLxprt launch capture must be reported"));
+    let invocation = capture
+        .invocations
+        .first()
+        .unwrap_or_else(|| panic!("Issues Send must launch LLxprt once"));
+    assert_eq!(capture.invocations.len(), 1);
+    assert_eq!(
+        invocation.argv[..5],
+        ["llxprt-agent", "--profile-load", "glm", "--yolo", "-i"]
+    );
+    assert_eq!(
+        invocation
+            .argv
+            .iter()
+            .filter(|argument| matches!(argument.as_str(), "-i" | "--prompt-interactive"))
+            .count(),
+        1
+    );
+    assert!(
+        !invocation
+            .argv
+            .iter()
+            .any(|argument| argument == "--continue")
+    );
+    let prompt = invocation
+        .argv
+        .get(5)
+        .unwrap_or_else(|| panic!("fresh issue prompt must follow -i"));
+    assert!(prompt.starts_with("Read and work on the following GitHub issue.\n\n"));
+    assert!(prompt.contains("# GitHub Issue #230: Agent chooser identity and worktree status\n"));
+    assert!(prompt.contains("**Repository:** owner/repo-230"));
+    assert!(prompt.contains("## Body\n\nIssue #230 detail body"));
     cleanup(&outcome);
 }
 

--- a/tests/issue382_behavior.rs
+++ b/tests/issue382_behavior.rs
@@ -477,7 +477,7 @@ fn assert_llxprt_golden(llxprt: &AgentDefinition) {
     use jefe::runtime::agent_plan::LaunchFieldValues;
     let mut values = LaunchFieldValues::new();
     values.set_repository("profile", FieldValue::String("dev".to_string()));
-    values.set_agent("prompt_interactive", FieldValue::Boolean(true));
+    values.set_agent("continue", FieldValue::Boolean(true));
     let plan = assert_golden_local_plan(llxprt, Operation::Normal, "/opt/bin/llxprt", &values);
     assert_eq!(plan.type_id, llxprt.id);
     assert_eq!(plan.definition_sha256, llxprt.sha256());
@@ -487,7 +487,7 @@ fn assert_llxprt_golden(llxprt: &AgentDefinition) {
     assert!(plan.signature_excludes_secrets());
     let argv = argv_of(&plan);
     assert!(argv.contains(&"--profile-load".to_string()));
-    assert!(argv.contains(&"--prompt-interactive".to_string()));
+    assert!(argv.contains(&"--continue".to_string()));
     assert!(argv.contains(&"dev".to_string()));
     assert!(plan.env.is_empty(), "no ambient env vars in plan");
 }
@@ -728,7 +728,7 @@ fn assert_llxprt_remote_golden() {
         jefe::domain::agent_definition::FieldValue::String("dev".to_string()),
     );
     values.set_agent(
-        "prompt_interactive",
+        "continue",
         jefe::domain::agent_definition::FieldValue::Boolean(true),
     );
     let request = remote_request(
@@ -744,7 +744,7 @@ fn assert_llxprt_remote_golden() {
     };
     assert_eq!(
         transcript.remote_command(),
-        "cd '/srv/project' && exec '/opt/bin/llxprt' '--profile-load' 'dev' '--yolo' '--prompt-interactive'"
+        "cd '/srv/project' && exec '/opt/bin/llxprt' '--profile-load' 'dev' '--yolo' '--continue'"
     );
     let agent_argv: Vec<String> = transcript
         .agent_argv()
@@ -757,7 +757,7 @@ fn assert_llxprt_remote_golden() {
             "--profile-load".to_string(),
             "dev".to_string(),
             "--yolo".to_string(),
-            "--prompt-interactive".to_string(),
+            "--continue".to_string(),
         ]
     );
     assert_golden_ssh_arguments(&transcript);


### PR DESCRIPTION
## Summary

- Model LLxprt continuation as the fixture-proven --continue capability instead of a bare prompt option.
- Omit continuation and stored prompt fields from fresh Issue and Pull Request plans so fresh-send owns the single -i prompt pair.
- Migrate schema-1 pass_continue values, normalize obsolete schema-2 prompt-interactive values on edit, and update local/remote plan contracts.
- Add a real PTY Issues Send scenario that captures the complete LLxprt invocation after Git preparation.

Fixes #520

Upstream symptom: https://github.com/vybestack/llxprt-code/issues/2851

## Pre-push checklist

This checkout has no make ci-check target, so the exact component gates were run directly.

- [x] Format — cargo fmt --all --check
- [x] Clippy allow policy — passed in PR CI
- [x] Source file length — cargo xtask check source-size
- [x] Architecture boundary policy — cargo xtask check architecture
- [x] Lint — cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] Complexity — passed in PR CI
- [x] Coverage — passed in PR CI
- [x] Build — cargo build --workspace --all-features --locked
- [x] Tests — locked all-feature library and integration test suites
- [x] TUI smoke — real issue-send schema-1 PTY fixture with captured process argv

## Testing notes

The real PTY scenario starts with schema-1 pass_continue enabled, loads issue 230 through deterministic GitHub and Git boundaries, sends it to an existing LLxprt agent, and records exactly one process invocation:

    llxprt-agent --profile-load glm --yolo -i <full issue prompt>

It asserts no --continue and no extra --prompt-interactive. Focused tests also cover FreshIssue and FreshPullRequest plus local and remote Normal/Resume continuation true/false.

Local evidence:

- locked all-feature library suite: 2,794 passed, 1 ignored
- locked all-feature integration test binaries: passed, including all 22 harness scenarios
- shell syntax, scenario JSON, architecture, source-size, and diff checks passed
- Rust/DeepThinker review and one pre-PR Open Code Review run completed with findings triaged

Scope is 22 changed paths and 772 net added lines, below repository target thresholds. No dependency, schema version, executor filter, public abstraction, quality-rule change, or project-memory change.

## Reviewers / Assignees

Automated Rust/DeepThinker, Open Code Review, LLxprt PR Review, and CodeRabbit workflows.
