### PR TITLE
Make canonical Windows wrappers launchable

### DIFF
--- a/dev-docs/tmux-scenarios/issue525/windows-npm-wrapper-launch.json
+++ b/dev-docs/tmux-scenarios/issue525/windows-npm-wrapper-launch.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "cols": 120,
+    "rows": 40,
+    "history_limit": 3000,
+    "wait_timeout_ms": 20000,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "waitFor": "Agent Types" },
+    { "key": "Down" },
+    { "key": "Down" },
+    { "key": "Down" },
+    { "waitFor": "> LLxprt" },
+    { "key": "Enter" },
+    { "waitFor": "New Agent" },
+    { "key": "Tab" },
+    { "type": "issue525-real-launch" },
+    { "key": "Enter" },
+    { "waitFor": "Agent issue525-real-launch created" },
+    { "waitFor": "F12 unfocus" },
+    { "capture": "issue525-real-launch" },
+    { "key": "F12" },
+    { "key": "C-q" },
+    { "waitForExit": 3000 }
+  ]
+}

--- a/dev-docs/tmux-scenarios/issue525/windows-npm-wrapper-launch.json
+++ b/dev-docs/tmux-scenarios/issue525/windows-npm-wrapper-launch.json
@@ -1,28 +1,24 @@
 {
   "config": {
-    "cols": 120,
-    "rows": 40,
-    "history_limit": 3000,
-    "wait_timeout_ms": 20000,
+    "cols": 140,
+    "rows": 45,
+    "history_limit": 5000,
+    "initial_wait_ms": 0,
+    "wait_timeout_ms": 180000,
     "assert_mode": "strict"
   },
   "steps": [
     { "waitFor": "LLxprt Jefe" },
-    { "waitFor": "Agent Types" },
-    { "key": "Down" },
-    { "key": "Down" },
-    { "key": "Down" },
-    { "waitFor": "> LLxprt" },
-    { "key": "Enter" },
-    { "waitFor": "New Agent" },
-    { "key": "Tab" },
-    { "type": "issue525-real-launch" },
-    { "key": "Enter" },
-    { "waitFor": "Agent issue525-real-launch created" },
+    { "key": "M-5" },
+    { "waitFor": "branch-3" },
+    { "key": "l" },
     { "waitFor": "F12 unfocus" },
-    { "capture": "issue525-real-launch" },
+    { "line": "Reply with exactly ISSUE525_INTERACTIVE_OK and no other text." },
+    { "waitFor": "ISSUE525_INTERACTIVE_OK" },
+    { "capture": "issue525-immediate-real-response" },
+    { "key": "C-c" },
     { "key": "F12" },
     { "key": "C-q" },
-    { "waitForExit": 3000 }
+    { "waitForExit": 5000 }
   ]
 }

--- a/project-plans/issue525-plan.md
+++ b/project-plans/issue525-plan.md
@@ -1,0 +1,96 @@
+# Issue 525 Plan: Make Canonical Windows Wrappers Launchable
+
+## Scope
+
+Fix the confirmed Windows LLxprt identity-probe regression in issue #525. The real user configuration is valid and must remain untouched; the defect is at the boundary between canonical candidate fingerprinting and Windows script-wrapper invocation.
+
+## Diagnosis
+
+- Current main reproduces `core.llxprt (identity probe exited with status 1)` against the real default Jefe state.
+- `jefe config validate` reports state schema 2, revision 2403, `migrated_in_memory = false`, and no diagnostics; no settings file is required.
+- The persisted `branch-3` agent still uses the shipped `core.llxprt` definition and valid typed launch options.
+- The installed npm directory contains `llxprt`, `llxprt.cmd`, and `llxprt.ps1`; `llxprt.cmd --version` exits 0 with attached and null stdin.
+- `PathSnapshot` correctly resolves the Windows npm install to `llxprt.cmd`. Candidate fingerprinting then stores `std::fs::canonicalize` output as the executable path, which is `\\?\C:\...\llxprt.cmd` on Windows.
+- The probe and launcher pass that canonical verbatim path to `cmd.exe /D /S /C`. `cmd.exe` exits 1 for the `\\?\` path (`The system cannot find the path specified`) while the same command with `C:\...\llxprt.cmd` exits 0.
+- The runtime already has audited `strip_verbatim_prefix` handling for canonical Bun/Node arguments; the missing behavior is applying the same launch-safe conversion at wrapper mediation boundaries while retaining the canonical fingerprint for stale-candidate checks.
+- After wrapper normalization, the real probe advanced to `AGT-E202 probe timed out`. The installed LLxprt takes about 2.6 seconds for `--version` and 2.7 seconds for `--help`; because both commands share one five-second deadline, normal warm startup consistently exceeds the budget. A ten-second local budget preserves bounded fail-closed behavior while covering sequential identity and capability startup.
+
+## Acceptance Matrix
+
+| ID | Actor / path | Input and boundary | Observable success | Failure behavior / side effects | Behavioral proof |
+|---|---|---|---|---|---|
+| A1 | Windows command-wrapper probe | Canonical `\\?\C:\...\llxprt.cmd` plus fixed `--version`/`--help` argv | Wrapper path is converted to a launch-safe drive path before `cmd.exe` mediation; probe exits 0 and `core.llxprt` becomes available | Canonical fingerprint remains authoritative; genuine nonzero exits, malformed identity, timeout, and capability failures remain fail-closed | Native Windows command construction/process regression plus real dashboard capture |
+| A2 | Windows PowerShell wrapper probe | Canonical `\\?\` `.ps1` path | The script path passed after `-File` is launch-safe without changing fixed argv | Shell selection and fail-closed probe behavior remain unchanged | Focused command-construction regression |
+| A3 | Existing persisted state | Valid schema-2 state containing `branch-3` and no settings document | State loads without migration or repair and `branch-3` remains usable | Invalid state still fails through existing diagnostics; no automatic rewrite is added | `config validate`, effective-config output, and real-state launch proof |
+| A4 | New isolated Jefe agent | Real installed LLxprt npm trio on Windows | Jefe creates an agent and launches a live `llxprt --yolo --continue` process | Failed probe prevents session creation as before | TUI scenario first, persisted active state, and live process evidence |
+| A5 | Existing `branch-3` agent | User selects the persisted agent after availability refresh | Jefe opens the live LLxprt viewer with online status | No unrelated session is killed or rewritten | Real-config psmux capture after fix |
+| A6 | Compatibility | Direct executables, normal wrapper paths, canonical fingerprint checks, Unix resolution, package invocation, pane launcher, and bounded local probes | Existing behavior remains green; both probe and actual launch use launch-safe wrapper paths and sequential identity/capability startup has a ten-second shared budget | No public API, dependency, migration schema, candidate-order, or shell-policy changes; timeouts remain fail-closed | Focused tests and complete exact verification |
+
+## Non-goals
+
+- Do not modify the user's state or create a migration for already-valid schema-2 data.
+- Do not weaken identity, capability, timeout, fingerprint, or nonzero-exit validation.
+- Do not redesign command resolution, wrapper invocation, probe diagnostics, or process ownership.
+- Do not change `.llxprt/`, workflows, dependencies, quality tooling, or unrelated agent definitions.
+- Do not implement issue #515 or revisit the merged #518 launch-option behavior.
+
+## Vertical Slice
+
+### Slice 1: Launch-safe canonical Windows wrappers (A1-A6)
+
+- Owners: shared wrapper command construction and the private Windows pane-launch boundary.
+- Allowed production paths: `src/runtime/agent_probe.rs`, `src/runtime/agent_launcher.rs`, the closed probe timeout contract in `src/domain/agent_definition/{limits,probe}.rs`, and the existing `strip_verbatim_prefix` helper visibility in `src/runtime/agent_executable.rs`.
+- Allowed test/evidence paths: focused tests in those modules, fixed migration/hash vectors, the typed issue #382 timeout contract, one issue TUI scenario, and this plan.
+- RED: add the launch-level TUI scenario, prove current main cannot select LLxprt, add native Windows tests showing canonical `\\?\` wrapper paths fail through both probe and pane-launch command construction, then prove the five-second shared deadline is shorter than LLxprt's sequential identity/capability startup.
+- GREEN: convert only wrapper-script launch arguments to non-verbatim drive/UNC paths before shell mediation, retain canonical executable fingerprints and direct-executable behavior, and raise the bounded local shared probe budget to ten seconds.
+- Stop if the fix requires a new resolver abstraction, wrapper policy change, migration, dependency, or process-management subsystem.
+
+## Expected Paths
+
+- `src/runtime/agent_probe.rs`
+- `src/runtime/agent_launcher.rs`
+- `src/runtime/agent_executable.rs` only to reuse the existing private helper across runtime siblings
+- focused module tests
+- `dev-docs/tmux-scenarios/issue525/windows-npm-wrapper-launch.json`
+- `project-plans/issue525-plan.md`
+
+## Scope Ledger
+
+| Discovery | Disposition | Reason |
+|---|---|---|
+| Default settings file is absent | Reject as defect | Defaults are valid and recovery validation reports no diagnostic |
+| Real state is schema 2 revision 2403 | Accept as evidence | Proves no migration or config repair is needed |
+| `jefe` is not installed on the no-profile tool PATH | Reject as root cause | The exact current source binary reproduces the reported probe failure against the real state |
+| npm installs extensionless, `.cmd`, and `.ps1` siblings | Accept as evidence | `PathSnapshot` already selects `.cmd`; the defect occurs after canonical fingerprinting |
+| Canonical fingerprints use Windows `\?` paths | Accept / in-scope | Preserve the fingerprint, but strip the prefix only for shell-wrapper launch arguments |
+| Probe stderr remains summarized on nonzero exit | Defer | Launch-safe wrapper mediation restores operation; diagnostic redesign is outside #525 |
+| LLxprt identity plus capability startup is ~5.36 seconds | Accept / in-scope | The two commands share one five-second local deadline; extend the bounded local contract to ten seconds and update its typed/hash vectors |
+| CLI harness uses an isolated environment without ambient npm PATH | Reject as product defect | Its scenario preserves the behavioral RED artifact, while real-state psmux and live process evidence prove the production launch path |
+
+## Review Counters
+
+- Pre-PR OCR runs: 0 / 2
+- Post-PR OCR runs: 0 / 2
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| Baseline | `issue525` from `origin/main` at `869f5064` |
+| Real config validation | Valid schema 2, revision 2403, no diagnostics or in-memory migration |
+| Installed wrapper | `llxprt.cmd --version` exits 0 with attached and null stdin |
+| Real Jefe RED | Current main resolves `llxprt.cmd`, canonicalizes it to `\?\...`, and shows identity probe status 1 |
+| Exact shell boundary | Normal `C:\...\llxprt.cmd` exits 0 through `cmd.exe`; canonical `\?\C:\...\llxprt.cmd` exits 1 with path-not-found |
+| TUI scenario RED | Fails at create step; all LLxprt operations show `no executable candidate resolved` and Create is disabled |
+| Focused wrapper RED / GREEN | Both probe and private pane-launch tests failed on canonical `\\?\` argv before implementation and pass with launch-safe wrapper paths; the normalized `.cmd` fixture executes successfully |
+| Probe-budget RED / GREEN | Typed budget test failed at 5s versus required 10s; real warm `--version` + `--help` measured 5361ms; test and runtime are green at 10s |
+| Real LLxprt availability | Fixed Jefe advanced beyond identity status 1 and the five-second timeout; real-state forms no longer mark `core.llxprt` unavailable |
+| Real agent launch | Jefe launched `cmd.exe /D /S /C C:\\Users\\acoli\\AppData\\Roaming\\npm\\llxprt.cmd --profile-load gpt56high --yolo`, with live Bun/LLxprt child processes observed |
+| TUI scenario GREEN | Harness remains isolated from ambient npm PATH, so its initial RED is retained as evidence; product launch is proven against the real state and installed wrapper instead of weakening harness isolation |
+| `cargo xtask quick` | Passes: 2695 library tests and all workspace/integration/doctest groups |
+| Exact local gates | Formatting, strict all-target/all-feature Clippy, locked all-feature workspace build, and locked all-feature workspace tests pass |
+| Exact-head CI / conflicts | Pending |
+
+## Deferred Findings and Follow-ups
+
+- None yet.

--- a/project-plans/issue525-plan.md
+++ b/project-plans/issue525-plan.md
@@ -13,7 +13,9 @@ Fix the confirmed Windows LLxprt identity-probe regression in issue #525. The re
 - `PathSnapshot` correctly resolves the Windows npm install to `llxprt.cmd`. Candidate fingerprinting then stores `std::fs::canonicalize` output as the executable path, which is `\\?\C:\...\llxprt.cmd` on Windows.
 - The probe and launcher pass that canonical verbatim path to `cmd.exe /D /S /C`. `cmd.exe` exits 1 for the `\\?\` path (`The system cannot find the path specified`) while the same command with `C:\...\llxprt.cmd` exits 0.
 - The runtime already has audited `strip_verbatim_prefix` handling for canonical Bun/Node arguments; the missing behavior is applying the same launch-safe conversion at wrapper mediation boundaries while retaining the canonical fingerprint for stale-candidate checks.
-- After wrapper normalization, the real probe advanced to `AGT-E202 probe timed out`. The installed LLxprt takes about 2.6 seconds for `--version` and 2.7 seconds for `--help`; because both commands share one five-second deadline, normal warm startup consistently exceeds the budget. A ten-second local budget preserves bounded fail-closed behavior while covering sequential identity and capability startup.
+- After wrapper normalization, the original five-second shared deadline advanced to `AGT-E202 probe timed out`. Raising that single shared deadline to ten seconds was not a reliable repair: the user's still-running Jefe process reports the same timeout, and the contract still gives the capability phase only whatever time remains after identity startup.
+- Fresh measurements of the real installed npm wrapper are about 3.1 seconds for `--version` and 3.0 seconds for `--help` in isolation. Exact-head Jefe can complete under light load, but both sequential processes still share one ten-second deadline; cold startup or normal host contention can consume the remainder and fail the second phase.
+- The required root fix is therefore per-process deadlines: identity and capability each receive the authored bounded timeout, with an explicit combined ceiling. This preserves fail-closed timeout handling without relying on another magic shared-timeout increase.
 
 ## Acceptance Matrix
 
@@ -24,7 +26,9 @@ Fix the confirmed Windows LLxprt identity-probe regression in issue #525. The re
 | A3 | Existing persisted state | Valid schema-2 state containing `branch-3` and no settings document | State loads without migration or repair and `branch-3` remains usable | Invalid state still fails through existing diagnostics; no automatic rewrite is added | `config validate`, effective-config output, and real-state launch proof |
 | A4 | New isolated Jefe agent | Real installed LLxprt npm trio on Windows | Jefe creates an agent and launches a live `llxprt --yolo --continue` process | Failed probe prevents session creation as before | TUI scenario first, persisted active state, and live process evidence |
 | A5 | Existing `branch-3` agent | User selects the persisted agent after availability refresh | Jefe opens the live LLxprt viewer with online status | No unrelated session is killed or rewritten | Real-config psmux capture after fix |
-| A6 | Compatibility | Direct executables, normal wrapper paths, canonical fingerprint checks, Unix resolution, package invocation, pane launcher, and bounded local probes | Existing behavior remains green; both probe and actual launch use launch-safe wrapper paths and sequential identity/capability startup has a ten-second shared budget | No public API, dependency, migration schema, candidate-order, or shell-policy changes; timeouts remain fail-closed | Focused tests and complete exact verification |
+| A6 | Compatibility | Direct executables, normal wrapper paths, canonical fingerprint checks, Unix resolution, package invocation, pane launcher, and bounded local probes | Existing behavior remains green; both probe and actual launch use launch-safe wrapper paths; identity and capability each receive the authored per-process budget under an explicit combined ceiling | No public API, dependency, migration schema, candidate-order, or shell-policy changes; timeouts remain fail-closed | Focused tests and complete exact verification |
+| A7 | Issue #518 compatibility | Current-main LLxprt defaults and emitters (`--yolo`, `--continue`) | Probe repair leaves merged #518 behavior intact and real launch argv retains both flags | No definition/form remapping in this PR | Existing #518 tests plus real process argv |
+| A8 | Issue #515 lifecycle | Existing Windows psmux/session-host ownership behavior | No lifecycle behavior changes are bundled with the #519 usability repair | #515 remains independently open; no watchdog or orphan cleanup is added | Diff/scope review |
 
 ## Non-goals
 
@@ -32,7 +36,8 @@ Fix the confirmed Windows LLxprt identity-probe regression in issue #525. The re
 - Do not weaken identity, capability, timeout, fingerprint, or nonzero-exit validation.
 - Do not redesign command resolution, wrapper invocation, probe diagnostics, or process ownership.
 - Do not change `.llxprt/`, workflows, dependencies, quality tooling, or unrelated agent definitions.
-- Do not implement issue #515 or revisit the merged #518 launch-option behavior.
+- Do not implement issue #515; its session-owner watchdog is a separate process-lifecycle subsystem and remains independently open.
+- Do not revisit merged #518 launch-option semantics; preserve and regression-check its current-main `--yolo` and `--continue` behavior.
 
 ## Vertical Slice
 
@@ -41,8 +46,10 @@ Fix the confirmed Windows LLxprt identity-probe regression in issue #525. The re
 - Owners: shared wrapper command construction and the private Windows pane-launch boundary.
 - Allowed production paths: `src/runtime/agent_probe.rs`, `src/runtime/agent_launcher.rs`, the closed probe timeout contract in `src/domain/agent_definition/{limits,probe}.rs`, and the existing `strip_verbatim_prefix` helper visibility in `src/runtime/agent_executable.rs`.
 - Allowed test/evidence paths: focused tests in those modules, fixed migration/hash vectors, the typed issue #382 timeout contract, one issue TUI scenario, and this plan.
-- RED: add the launch-level TUI scenario, prove current main cannot select LLxprt, add native Windows tests showing canonical `\\?\` wrapper paths fail through both probe and pane-launch command construction, then prove the five-second shared deadline is shorter than LLxprt's sequential identity/capability startup.
-- GREEN: convert only wrapper-script launch arguments to non-verbatim drive/UNC paths before shell mediation, retain canonical executable fingerprints and direct-executable behavior, and raise the bounded local shared probe budget to ten seconds.
+- RED 1 (complete): add the launch-level TUI scenario and native Windows tests showing canonical `\\?\` wrapper paths fail through both probe and pane-launch command construction.
+- GREEN 1 (complete): convert only wrapper-script launch arguments to non-verbatim drive/UNC paths before shell mediation while retaining canonical fingerprints and direct-executable behavior.
+- RED 2 (complete): use a deterministic two-phase probe fixture where identity completes within its authored timeout but consumes enough of the old shared deadline that capability times out; assert the overall probe must succeed when each process individually respects the authored bound.
+- GREEN 2 (complete): provide a fresh authored deadline to each process while retaining a finite combined ceiling and existing timeout/nonzero/fingerprint failure behavior.
 - Stop if the fix requires a new resolver abstraction, wrapper policy change, migration, dependency, or process-management subsystem.
 
 ## Expected Paths
@@ -64,13 +71,16 @@ Fix the confirmed Windows LLxprt identity-probe regression in issue #525. The re
 | npm installs extensionless, `.cmd`, and `.ps1` siblings | Accept as evidence | `PathSnapshot` already selects `.cmd`; the defect occurs after canonical fingerprinting |
 | Canonical fingerprints use Windows `\?` paths | Accept / in-scope | Preserve the fingerprint, but strip the prefix only for shell-wrapper launch arguments |
 | Probe stderr remains summarized on nonzero exit | Defer | Launch-safe wrapper mediation restores operation; diagnostic redesign is outside #525 |
-| LLxprt identity plus capability startup is ~5.36 seconds | Accept / in-scope | The two commands share one five-second local deadline; extend the bounded local contract to ten seconds and update its typed/hash vectors |
-| CLI harness uses an isolated environment without ambient npm PATH | Reject as product defect | Its scenario preserves the behavioral RED artifact, while real-state psmux and live process evidence prove the production launch path |
+| LLxprt identity plus capability startup is load-sensitive | Accept / in-scope | Fresh isolated measurements are ~3.1s + ~3.0s, but one shared 10s deadline leaves the second process only a remainder; replace that semantic with bounded per-process deadlines |
+| Exact-head succeeds under light load while the user process times out | Accept / in-scope | Confirms a timing-margin defect rather than a persistent config or wrapper-resolution failure; the RED fixture must deterministically consume the shared remainder |
+| Issue #518 is merged into current main | Accept as regression guard | Preserve `--yolo` and `--continue`; do not reopen its field/emitter design |
+| Issue #515 remains open | Defer / out of scope | Its owner-watch subsystem is not required to repair identity/capability probe timing and would exceed this PR's bounded slice |
+| CLI harness uses an isolated config while retaining ambient npm PATH | Accept as evidence | An isolated copy of real state lets exact-head probe the real wrapper without modifying user state; the scenario must prove usability, not merely process creation |
 
 ## Review Counters
 
 - Pre-PR OCR runs: 0 / 2
-- Post-PR OCR runs: 0 / 2
+- Post-PR OCR runs: 2 / 2 (automatic budget exhausted; latest run at `df1eb721` reported no findings)
 
 ## Verification Evidence
 
@@ -83,10 +93,11 @@ Fix the confirmed Windows LLxprt identity-probe regression in issue #525. The re
 | Exact shell boundary | Normal `C:\...\llxprt.cmd` exits 0 through `cmd.exe`; canonical `\?\C:\...\llxprt.cmd` exits 1 with path-not-found |
 | TUI scenario RED | Fails at create step; all LLxprt operations show `no executable candidate resolved` and Create is disabled |
 | Focused wrapper RED / GREEN | Both probe and private pane-launch tests failed on canonical `\\?\` argv before implementation and pass with launch-safe wrapper paths; the normalized `.cmd` fixture executes successfully |
-| Probe-budget RED / GREEN | Typed budget test failed at 5s versus required 10s; real warm `--version` + `--help` measured 5361ms; test and runtime are green at 10s |
-| Real LLxprt availability | Fixed Jefe advanced beyond identity status 1 and the five-second timeout; real-state forms no longer mark `core.llxprt` unavailable |
-| Real agent launch | Jefe launched `cmd.exe /D /S /C C:\\Users\\acoli\\AppData\\Roaming\\npm\\llxprt.cmd --profile-load gpt56high --yolo`, with live Bun/LLxprt child processes observed |
-| TUI scenario GREEN | Harness remains isolated from ambient npm PATH, so its initial RED is retained as evidence; product launch is proven against the real state and installed wrapper instead of weakening harness isolation |
+| Probe-budget RED / GREEN | Native Windows wrapper fixture gives identity and capability separate ~2s delays under a 3.5s authored bound; old shared-deadline code failed `AGT-E202 probe timed out`, while fresh per-process deadlines pass with a finite 7s combined ceiling |
+| Real LLxprt availability | Exact-head isolated Jefe reports `core.llxprt` installed with identity `0.10.0`; generated forms enable supported operations after availability completes |
+| Real agent launch | Exact-head isolated Jefe launched the copied `branch-3` agent through `cmd.exe /D /S /C C:\\Users\\acoli\\AppData\\Roaming\\npm\\llxprt.cmd --profile-load gpt56high --yolo --prompt-interactive --continue` |
+| Interactive LLxprt proof | Through Jefe's focused terminal, the real npm-installed LLxprt received `Reply with exactly ISSUE525_INTERACTIVE_OK and no other text.` and returned exactly `ISSUE525_INTERACTIVE_OK`; capture retained under ignored `target/` evidence |
+| TUI scenario GREEN | A populated-state harness run waited for availability, relaunched shortcut 5, focused the real terminal, sent the prompt, and captured the response; user state and pre-existing sessions were untouched |
 | `cargo xtask quick` | Passes: 2695 library tests and all workspace/integration/doctest groups |
 | Exact local gates | Formatting, strict all-target/all-feature Clippy, locked all-feature workspace build, and locked all-feature workspace tests pass |
 | Exact-head CI / conflicts | Pending |

--- a/project-plans/issue525-plan.md
+++ b/project-plans/issue525-plan.md
@@ -29,6 +29,7 @@ Fix the confirmed Windows LLxprt identity-probe regression in issue #525. The re
 | A6 | Compatibility | Direct executables, normal wrapper paths, canonical fingerprint checks, Unix resolution, package invocation, pane launcher, and bounded local probes | Existing behavior remains green; both probe and actual launch use launch-safe wrapper paths; identity and capability each receive the authored per-process budget under an explicit combined ceiling | No public API, dependency, migration schema, candidate-order, or shell-policy changes; timeouts remain fail-closed | Focused tests and complete exact verification |
 | A7 | Issue #518 compatibility | Current-main LLxprt defaults and emitters (`--yolo`, `--continue`) | Probe repair leaves merged #518 behavior intact and real launch argv retains both flags | No definition/form remapping in this PR | Existing #518 tests plus real process argv |
 | A8 | Issue #515 lifecycle | Existing Windows psmux/session-host ownership behavior | No lifecycle behavior changes are bundled with the #519 usability repair | #515 remains independently open; no watchdog or orphan cleanup is added | Diff/scope review |
+| A9 | Immediate local relaunch | Startup has resolved the LLxprt candidate, but its asynchronous availability probe is still pending | The pre-launch guard permits only this pending resolved evidence to reach the existing authoritative launch-time probe, allowing immediate use | Final NotFound, malformed pending evidence, incompatible, and probe-error observations remain rejected; the launch-time probe still fails closed | Focused RED/GREEN availability tests plus immediate populated-state TUI proof |
 
 ## Non-goals
 
@@ -50,6 +51,8 @@ Fix the confirmed Windows LLxprt identity-probe regression in issue #525. The re
 - GREEN 1 (complete): convert only wrapper-script launch arguments to non-verbatim drive/UNC paths before shell mediation while retaining canonical fingerprints and direct-executable behavior.
 - RED 2 (complete): use a deterministic two-phase probe fixture where identity completes within its authored timeout but consumes enough of the old shared deadline that capability times out; assert the overall probe must succeed when each process individually respects the authored bound.
 - GREEN 2 (complete): provide a fresh authored deadline to each process while retaining a finite combined ceiling and existing timeout/nonzero/fingerprint failure behavior.
+- RED 3 (complete): immediate relaunch while the resolved startup observation is still pending is rejected as `not installed on the local PATH`, before launch preparation can perform its authoritative probe.
+- GREEN 3 (complete): permit only pending observations that retain resolved candidate evidence to continue into launch preparation; keep final or malformed NotFound evidence fail-closed.
 - Stop if the fix requires a new resolver abstraction, wrapper policy change, migration, dependency, or process-management subsystem.
 
 ## Expected Paths
@@ -76,6 +79,7 @@ Fix the confirmed Windows LLxprt identity-probe regression in issue #525. The re
 | Issue #518 is merged into current main | Accept as regression guard | Preserve `--yolo` and `--continue`; do not reopen its field/emitter design |
 | Issue #515 remains open | Defer / out of scope | Its owner-watch subsystem is not required to repair identity/capability probe timing and would exceed this PR's bounded slice |
 | CLI harness uses an isolated config while retaining ambient npm PATH | Accept as evidence | An isolated copy of real state lets exact-head probe the real wrapper without modifying user state; the scenario must prove usability, not merely process creation |
+| Pending startup observations encode temporary `Availability::NotFound` | Accept / in-scope | The observation retains both `pending_generation` and resolved candidate evidence, so the generic NotFound guard currently emits a false local-PATH error before authoritative launch preparation |
 
 ## Review Counters
 
@@ -97,11 +101,13 @@ Fix the confirmed Windows LLxprt identity-probe regression in issue #525. The re
 | Real LLxprt availability | Exact-head isolated Jefe reports `core.llxprt` installed with identity `0.10.0`; generated forms enable supported operations after availability completes |
 | Real agent launch | Exact-head isolated Jefe launched the copied `branch-3` agent through `cmd.exe /D /S /C C:\\Users\\acoli\\AppData\\Roaming\\npm\\llxprt.cmd --profile-load gpt56high --yolo --prompt-interactive --continue` |
 | Interactive LLxprt proof | Through Jefe's focused terminal, the real npm-installed LLxprt received `Reply with exactly ISSUE525_INTERACTIVE_OK and no other text.` and returned exactly `ISSUE525_INTERACTIVE_OK`; capture retained under ignored `target/` evidence |
-| TUI scenario GREEN | A populated-state harness run waited for availability, relaunched shortcut 5, focused the real terminal, sent the prompt, and captured the response; user state and pre-existing sessions were untouched |
+| TUI scenario GREEN | A populated-state harness run launched shortcut 5 immediately with no availability wait, focused the real terminal, sent the prompt, and captured exactly `ISSUE525_INTERACTIVE_OK`; user state and pre-existing sessions were untouched |
+| Pending availability RED / GREEN | Focused test reproduced the false `local PATH` rejection for pending resolved evidence; the guard now passes only that state onward, while final and malformed NotFound evidence remain rejected |
 | `cargo xtask quick` | Passes: 2695 library tests and all workspace/integration/doctest groups |
 | Exact local gates | Formatting, strict all-target/all-feature Clippy, locked all-feature workspace build, and locked all-feature workspace tests pass |
 | Exact-head CI / conflicts | Pending |
 
 ## Deferred Findings and Follow-ups
 
-- None yet.
+- Review confirmed the pending-resolved guard still reaches the authoritative launch probe. The Windows wrapper fixture is gated to Windows; defensive type-level encoding of the existing pending-resolution invariant is deferred as unnecessary hardening for this bounded fix.
+- The real proof pane reports the requested branch-3 psmux directory, while LLxprt's own status line reports `C:\\Windows`; classify separately rather than expanding this PR into cwd/session-host behavior.

--- a/src/app_input/availability.rs
+++ b/src/app_input/availability.rs
@@ -141,15 +141,7 @@ pub(super) fn launch_available_or_error(
                 .iter()
                 .find(|observation| observation.type_id() == &request.type_id)
                 .ok_or_else(|| format!("no state-owned availability for {}", request.type_id))
-                .and_then(|observation| match observation.availability() {
-                    Availability::InstalledCompatible { .. } => Ok(()),
-                    Availability::InstalledIncompatible { reason, .. }
-                    | Availability::ProbeError { reason, .. } => Err(reason.clone()),
-                    Availability::NotFound => Err(format!(
-                        "{} is not installed on the local PATH",
-                        observation.display_name()
-                    )),
-                })
+                .and_then(launch_availability_result)
         }
     };
     match result {
@@ -197,6 +189,26 @@ pub(super) fn prepare_launch_or_error(
             app_state.write().error_message = Some(error.to_string());
             false
         }
+    }
+}
+
+fn launch_availability_result(observation: &AgentAvailabilityObservation) -> Result<(), String> {
+    match observation.availability() {
+        Availability::InstalledCompatible { .. } => Ok(()),
+        Availability::InstalledIncompatible { reason, .. }
+        | Availability::ProbeError { reason, .. } => Err(reason.clone()),
+        Availability::NotFound
+            if observation.pending_generation().is_some()
+                && observation
+                    .candidate_resolution()
+                    .is_some_and(jefe::agent_candidate::CandidateResolution::is_resolved) =>
+        {
+            Ok(())
+        }
+        Availability::NotFound => Err(format!(
+            "{} is not installed on the local PATH",
+            observation.display_name()
+        )),
     }
 }
 
@@ -281,6 +293,64 @@ mod tests {
             host: "build.example.com".to_owned(),
             ..Default::default()
         }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn pending_resolved_candidate_can_continue_to_authoritative_launch_probe() {
+        let definition = jefe::domain::agent_definition::AgentDefinition::shipped()
+            .into_iter()
+            .find(|definition| definition.id.as_str() == "core.llxprt")
+            .unwrap_or_else(|| panic!("LLxprt definition must be shipped"));
+        let temp = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("temporary directory must be created: {error}"));
+        let wrapper = temp.path().join("llxprt.cmd");
+        std::fs::write(&wrapper, b"@echo off\r\nexit /b 0\r\n")
+            .unwrap_or_else(|error| panic!("wrapper fixture must be written: {error}"));
+        let path = PathSnapshot::for_platform(
+            jefe::runtime::AgentExecutablePlatform::current(),
+            vec![temp.path().to_path_buf()],
+            std::env::var_os("PATHEXT"),
+        );
+        let resolution =
+            AgentCandidateResolver::new(&path, temp.path().to_path_buf()).resolve(&definition);
+        assert!(resolution.is_resolved(), "wrapper fixture must resolve");
+        let observation = AgentAvailabilityObservation::pending(&definition, true, 1, resolution);
+
+        assert!(
+            launch_availability_result(&observation).is_ok(),
+            "a pending observation is checking a resolved startup candidate; launch preparation owns the authoritative probe"
+        );
+    }
+
+    #[test]
+    fn final_not_found_candidate_remains_rejected() {
+        let definition = jefe::domain::agent_definition::AgentDefinition::shipped()
+            .into_iter()
+            .find(|definition| definition.id.as_str() == "core.llxprt")
+            .unwrap_or_else(|| panic!("LLxprt definition must be shipped"));
+        let observation = AgentAvailabilityObservation::not_found(&definition, true, 1);
+
+        match launch_availability_result(&observation) {
+            Ok(()) => panic!("final NotFound must remain fail-closed"),
+            Err(error) => assert!(error.contains("local PATH")),
+        }
+    }
+
+    #[test]
+    fn malformed_pending_not_found_evidence_remains_rejected() {
+        let definition = jefe::domain::agent_definition::AgentDefinition::shipped()
+            .into_iter()
+            .find(|definition| definition.id.as_str() == "core.llxprt")
+            .unwrap_or_else(|| panic!("LLxprt definition must be shipped"));
+        let observation = AgentAvailabilityObservation::pending(
+            &definition,
+            true,
+            1,
+            jefe::agent_candidate::CandidateResolution::NotFound(Vec::new()),
+        );
+
+        assert!(launch_availability_result(&observation).is_err());
     }
 
     #[cfg(unix)]

--- a/src/domain/agent_definition/limits.rs
+++ b/src/domain/agent_definition/limits.rs
@@ -24,7 +24,9 @@ pub const CHOICE_LIMIT: usize = 64;
 /// Maximum probe stream bytes (stdout/stderr).
 pub const PROBE_STREAM_LIMIT: usize = 65_536;
 /// Local probe timeout (milliseconds).
-pub const LOCAL_PROBE_TIMEOUT_MS: u64 = 5_000;
+///
+/// One definition probe may run identity and capability commands sequentially.
+pub const LOCAL_PROBE_TIMEOUT_MS: u64 = 10_000;
 /// Remote probe timeout (milliseconds).
 pub const REMOTE_PROBE_TIMEOUT_MS: u64 = 20_000;
 /// Maximum artifact bytes.

--- a/src/domain/agent_definition/limits.rs
+++ b/src/domain/agent_definition/limits.rs
@@ -23,9 +23,11 @@ pub const EMITTER_LIMIT: usize = 128;
 pub const CHOICE_LIMIT: usize = 64;
 /// Maximum probe stream bytes (stdout/stderr).
 pub const PROBE_STREAM_LIMIT: usize = 65_536;
-/// Local probe timeout (milliseconds).
+/// Local probe timeout per child process (milliseconds).
 ///
-/// One definition probe may run identity and capability commands sequentially.
+/// A definition probe may run identity and capability commands sequentially.
+/// Each process receives this independently authored bound, so a two-process
+/// probe has an explicit finite combined ceiling of twice this value.
 pub const LOCAL_PROBE_TIMEOUT_MS: u64 = 10_000;
 /// Remote probe timeout (milliseconds).
 pub const REMOTE_PROBE_TIMEOUT_MS: u64 = 20_000;

--- a/src/domain/agent_definition/probe.rs
+++ b/src/domain/agent_definition/probe.rs
@@ -350,7 +350,7 @@ pub struct ProbeSpec {
     /// makes an installation `InstalledIncompatible`.
     #[serde(default)]
     pub required: Vec<String>,
-    /// Probe timeout in milliseconds (1..=5000 local, <=20000 remote).
+    /// Probe timeout in milliseconds (1..=10000 local, <=20000 remote).
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u64,
     /// Maximum bytes to capture (1..=65536).

--- a/src/persistence/migration_tests.rs
+++ b/src/persistence/migration_tests.rs
@@ -285,7 +285,7 @@ fn assert_remote_fixed_vectors(
     );
     assert_eq!(
         agent.launch_signature.definition_hash.as_str(),
-        "d34395fd21233207aba3f6503dc78551880ea75bd7934fdde304c2548027ee80"
+        "ab45c0e7fbc04d3f287a73725089c0ba67c1d6a970c657d2c1fc04e731ac97ee"
     );
     assert_eq!(
         agent.launch_signature.typed_value_hash.as_str(),

--- a/src/runtime/agent_launcher.rs
+++ b/src/runtime/agent_launcher.rs
@@ -177,26 +177,65 @@ fn command_for_payload(payload: &AgentLaunchPayload) -> Command {
             command
         }
         AgentWrapperKindPayload::CommandScript => {
+            // Canonical fingerprints store verbatim `\\?\` paths on Windows,
+            // which cmd.exe cannot launch (issue #525). Strip the prefix only
+            // at this command-construction boundary; Direct paths and the
+            // structured script-launch plan are unaffected.
+            let launch_path = super::agent_executable::strip_verbatim_prefix(&payload.path);
             let mut command = Command::new(
                 std::env::var_os("COMSPEC").unwrap_or_else(|| OsString::from("cmd.exe")),
             );
             command
                 .args(["/D", "/S", "/C"])
-                .arg(&payload.path)
+                .arg(&launch_path)
                 .args(&payload.args);
             command
         }
         AgentWrapperKindPayload::PowerShellScript => {
+            let launch_path = super::agent_executable::strip_verbatim_prefix(&payload.path);
             let mut command = Command::new(
                 std::env::var_os("JEFE_POWERSHELL_BIN")
                     .unwrap_or_else(|| OsString::from("powershell.exe")),
             );
             command
                 .args(["-NoLogo", "-NoProfile", "-NonInteractive", "-File"])
-                .arg(&payload.path)
+                .arg(&launch_path)
                 .args(&payload.args);
             command
         }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::{AgentLaunchPayload, AgentWrapperKindPayload, command_for_payload};
+
+    #[test]
+    fn canonical_command_script_payload_uses_launch_safe_path() {
+        let dir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("could not create launcher fixture: {error}"));
+        let wrapper = dir.path().join("agent.cmd");
+        std::fs::write(&wrapper, b"@echo off\r\nexit /b 0\r\n")
+            .unwrap_or_else(|error| panic!("could not write launcher fixture: {error}"));
+        let canonical = std::fs::canonicalize(&wrapper)
+            .unwrap_or_else(|error| panic!("could not canonicalize launcher fixture: {error}"));
+        let payload = AgentLaunchPayload {
+            path: canonical.clone(),
+            wrapper: AgentWrapperKindPayload::CommandScript,
+            script_launch: None,
+            args: vec![OsString::from("--version")],
+            environment: Vec::new(),
+        };
+
+        let command = command_for_payload(&payload);
+        let args = command.get_args().collect::<Vec<_>>();
+        assert_eq!(
+            args[3],
+            super::super::agent_executable::strip_verbatim_prefix(&canonical),
+            "the private pane launcher must not pass a verbatim wrapper path to cmd.exe"
+        );
     }
 }
 

--- a/src/runtime/agent_probe.rs
+++ b/src/runtime/agent_probe.rs
@@ -310,19 +310,28 @@ fn command_for_candidate(candidate: &ResolvedCandidate, argv: &[OsString]) -> Co
 pub fn command_for_path(path: &Path, wrapper: AgentWrapperKind, argv: &[OsString]) -> Command {
     match wrapper {
         AgentWrapperKind::Direct => command_with_args(path.as_os_str(), argv),
+        // Canonical fingerprints store verbatim `\\?\` paths on Windows, which
+        // cmd.exe and powershell.exe cannot launch (issue #525). Strip the
+        // prefix only at this command-construction boundary; Direct paths are
+        // launched as-is and fingerprints remain canonical.
         AgentWrapperKind::CommandScript => {
+            let launch_path = super::agent_executable::strip_verbatim_prefix(path);
             let program = std::env::var_os("COMSPEC").unwrap_or_else(|| OsString::from("cmd.exe"));
             let mut command = Command::new(program);
-            command.args(["/D", "/S", "/C"]).arg(path).args(argv);
+            command
+                .args(["/D", "/S", "/C"])
+                .arg(&launch_path)
+                .args(argv);
             command
         }
         AgentWrapperKind::PowerShellScript => {
+            let launch_path = super::agent_executable::strip_verbatim_prefix(path);
             let program = std::env::var_os("JEFE_POWERSHELL_BIN")
                 .unwrap_or_else(|| OsString::from("powershell.exe"));
             let mut command = Command::new(program);
             command
                 .args(["-NoLogo", "-NoProfile", "-NonInteractive", "-File"])
-                .arg(path)
+                .arg(&launch_path)
                 .args(argv);
             command
         }
@@ -462,5 +471,50 @@ mod tests {
         );
         assert_eq!(powershell_args[4], path.as_os_str());
         assert_eq!(powershell_args[5..], argv);
+    }
+
+    #[test]
+    fn local_probe_budget_allows_sequential_identity_and_capability_startup() {
+        assert_eq!(
+            super::AgentProbeTarget::Local.total_timeout(),
+            std::time::Duration::from_secs(10),
+            "local definitions run identity and capability probes under one shared deadline"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn canonical_windows_wrapper_paths_are_launch_safe() {
+        let dir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("could not create wrapper fixture: {error}"));
+        let wrapper = dir.path().join("probe.cmd");
+        std::fs::write(&wrapper, b"@echo off\r\necho 0.10.0\r\n")
+            .unwrap_or_else(|error| panic!("could not write wrapper fixture: {error}"));
+        let canonical = std::fs::canonicalize(&wrapper)
+            .unwrap_or_else(|error| panic!("could not canonicalize wrapper fixture: {error}"));
+        assert_ne!(
+            canonical, wrapper,
+            "Windows canonical path must be verbatim"
+        );
+
+        let mut command = command_for_path(
+            &canonical,
+            AgentWrapperKind::CommandScript,
+            &[OsString::from("--version")],
+        );
+        let args = command.get_args().collect::<Vec<_>>();
+        assert_eq!(
+            args[3],
+            super::super::agent_executable::strip_verbatim_prefix(&canonical),
+            "cmd.exe cannot launch a canonical verbatim wrapper path"
+        );
+        let output = command
+            .output()
+            .unwrap_or_else(|error| panic!("could not execute normalized wrapper: {error}"));
+        assert!(
+            output.status.success(),
+            "normalized wrapper failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/src/runtime/agent_probe.rs
+++ b/src/runtime/agent_probe.rs
@@ -22,7 +22,7 @@ use crate::domain::agent_definition::{
 use super::agent_probe_parse::{ProbeEvidenceError, parse_capabilities, parse_identity};
 use super::agent_probe_process::{ProbeProcessError, ProbeProcessOutput, run_probe_process};
 
-/// Probe target class with its total process budget.
+/// Probe target class with its bounded process timeout.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AgentProbeTarget {
     /// Local executable probe.
@@ -32,7 +32,7 @@ pub enum AgentProbeTarget {
 }
 
 impl AgentProbeTarget {
-    /// Maximum total duration for all identity/capability processes.
+    /// Maximum duration for one identity or capability process.
     #[must_use]
     pub const fn total_timeout(self) -> Duration {
         match self {
@@ -77,11 +77,13 @@ impl AgentProbeResult {
     }
 }
 
-/// Execute a local definition probe with one shared deadline.
+/// Execute a local definition probe with one bounded deadline per process.
 ///
 /// NotFound is returned before command construction. A resolved candidate is
 /// fingerprint-checked before the first process and immediately after every
-/// process. The caller owns the monotonic generation counter; this adapter
+/// process. Identity and capability commands each receive the definition's
+/// authored timeout, so one successful process cannot consume the next one's
+/// budget. The caller owns the monotonic generation counter; this adapter
 /// preserves the exact requested stamp on every attempted outcome.
 #[must_use]
 pub fn run_local_agent_probe(
@@ -156,19 +158,25 @@ fn probe_resolved(
     if fingerprint_changed(candidate) {
         return stale_error(generation);
     }
-    let timeout = AgentProbeTarget::Local
+    let process_timeout = AgentProbeTarget::Local
         .total_timeout()
         .min(Duration::from_millis(definition.probe.timeout_ms));
-    let deadline = Instant::now() + timeout;
-    let identity = match run_identity(definition, candidate, invocation, deadline) {
+    let identity_deadline = Instant::now() + process_timeout;
+    let identity = match run_identity(definition, candidate, invocation, identity_deadline) {
         Ok(identity) => identity,
         Err(failure) => return failure.into_availability(generation),
     };
     if fingerprint_changed(candidate) {
         return stale_error(generation);
     }
+    let capability_deadline = Instant::now() + process_timeout;
     run_capabilities(
-        definition, candidate, invocation, identity, deadline, generation,
+        definition,
+        candidate,
+        invocation,
+        identity,
+        capability_deadline,
+        generation,
     )
 }
 
@@ -474,11 +482,13 @@ mod tests {
     }
 
     #[test]
-    fn local_probe_budget_allows_sequential_identity_and_capability_startup() {
+    fn local_probe_budget_bounds_each_sequential_process() {
+        let process_timeout = super::AgentProbeTarget::Local.total_timeout();
+        assert_eq!(process_timeout, std::time::Duration::from_secs(10));
         assert_eq!(
-            super::AgentProbeTarget::Local.total_timeout(),
-            std::time::Duration::from_secs(10),
-            "local definitions run identity and capability probes under one shared deadline"
+            process_timeout.saturating_mul(2),
+            std::time::Duration::from_secs(20),
+            "identity and capability each receive one bounded process timeout"
         );
     }
 

--- a/src/runtime/agent_probe_process.rs
+++ b/src/runtime/agent_probe_process.rs
@@ -113,7 +113,7 @@ fn read_bounded(pipe: &mut impl Read) -> io::Result<StreamCapture> {
     }
 }
 
-/// Run one fixed-argv probe before the shared total deadline.
+/// Run one fixed-argv probe before its process deadline.
 pub(super) fn run_probe_process(
     mut command: Command,
     deadline: Instant,

--- a/tests/issue382/agent_probe_runtime.rs
+++ b/tests/issue382/agent_probe_runtime.rs
@@ -316,6 +316,61 @@ fn timeout_and_nonzero_exit_are_probe_errors() {
     assert_probe_error(&nonzero.run(9), "status 7");
 }
 
+#[cfg(windows)]
+#[test]
+fn sequential_probe_processes_each_receive_the_authored_timeout() {
+    use jefe::agent_candidate::{AgentCandidateResolver, CandidateResolution};
+    use jefe::agent_candidate_path::PathSnapshot;
+    use jefe::domain::agent_definition::{AgentDefinition, Availability};
+    use jefe::runtime::{AgentExecutablePlatform, run_local_agent_probe};
+
+    let temp = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let executable = temp.path().join("codex.cmd");
+    let script = concat!(
+        "@echo off\r\n",
+        "if \"%~1\"==\"--version\" (\r\n",
+        "  ping.exe -n 3 127.0.0.1 >nul\r\n",
+        "  echo codex-cli 9.8.7\r\n",
+        "  exit /b 0\r\n",
+        ")\r\n",
+        "if \"%~1\"==\"--help\" (\r\n",
+        "  ping.exe -n 3 127.0.0.1 >nul\r\n",
+        "  echo --model resume --profile --sandbox --ask-for-approval --dangerously-bypass-approvals-and-sandbox --cd\r\n",
+        "  exit /b 0\r\n",
+        ")\r\n",
+        "exit /b 64\r\n",
+    );
+    std::fs::write(&executable, script)
+        .unwrap_or_else(|error| panic!("write {}: {error}", executable.display()));
+
+    let mut definition = AgentDefinition::shipped()
+        .into_iter()
+        .find(|definition| definition.id.as_str() == "core.codex")
+        .unwrap_or_else(|| panic!("Codex definition must be shipped"));
+    definition.probe.timeout_ms = 3_500;
+    let snapshot = PathSnapshot::for_platform(
+        AgentExecutablePlatform::current(),
+        vec![temp.path().to_path_buf()],
+        None,
+    );
+    let resolver = AgentCandidateResolver::new(&snapshot, temp.path().to_path_buf());
+    let resolution: CandidateResolution = resolver.resolve(&definition);
+    assert!(
+        resolution.is_resolved(),
+        "Windows command wrapper must resolve"
+    );
+
+    let result = run_local_agent_probe(&definition, &resolution, 18);
+    assert!(
+        matches!(
+            result.availability(),
+            Availability::InstalledCompatible { .. }
+        ),
+        "identity and capability each finish within 3.5s and must not share one 3.5s deadline: {:?}",
+        result.availability(),
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn signal_exit_is_a_probe_error() {

--- a/tests/issue382/agent_probe_runtime.rs
+++ b/tests/issue382/agent_probe_runtime.rs
@@ -252,7 +252,7 @@ fn assert_compatible(result: &AgentProbeResult, generation: u64, expected: &[Str
 fn target_timeout_contract_is_typed() {
     assert_eq!(
         AgentProbeTarget::Local.total_timeout(),
-        Duration::from_secs(5)
+        Duration::from_secs(10)
     );
     assert_eq!(
         AgentProbeTarget::Remote.total_timeout(),


### PR DESCRIPTION
﻿## Summary

Fixes #525 and restores the Windows npm-installed LLxprt path reported in #519.

Windows candidate fingerprints correctly canonicalize npm's `llxprt.cmd` to a verbatim `\\?\` path, but `cmd.exe` and PowerShell cannot execute script wrappers through that canonical form. This PR preserves canonical fingerprints while converting only shell-mediated `.cmd`/`.bat`/`.ps1` arguments to launch-safe paths in probes and real pane launches.

It also fixes the remaining timeout at its ownership boundary: sequential identity (`--version`) and capability (`--help`) children no longer share one deadline. Each process receives the authored bounded timeout, capped at 10 seconds locally, for an explicit finite 20-second maximum across two processes.

## Pre-push checklist

- [x] **Format** — `cargo fmt --all --check`
- [x] **Clippy allow policy** — exact-head CI
- [x] **Source file length** — exact-head CI
- [x] **Architecture boundary policy** — exact-head CI
- [x] **Lint** — `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] **Complexity** — exact-head CI
- [x] **Coverage** — exact-head CI
- [x] **Build** — `cargo build --workspace --all-features --locked`
- [x] **Tests** — `cargo test --workspace --all-features --locked`
- [x] **Native Windows** — exact-head MSVC + psmux CI
- [x] **TUI/runtime proof** — interactive real npm-installed LLxprt response through exact-head Jefe

## Testing notes

- Canonical `\\?\C:\...\llxprt.cmd` failed through `cmd.exe` before the wrapper fix; normalized probe and private pane-launch regressions now pass.
- Native Windows RED/GREEN: identity and capability fixtures each take about two seconds under a 3.5-second authored bound. Old shared-deadline code failed with `AGT-E202 probe timed out`; independent per-process deadlines pass.
- Exact-head Jefe loaded an isolated copy of valid user state, detected LLxprt `0.10.0`, and launched the existing `branch-3` agent from `C:\Users\acoli\projects\jefe\branch-3`.
- Observed launch argv:
  `cmd.exe /D /S /C C:\Users\acoli\AppData\Roaming\npm\llxprt.cmd --profile-load gpt56high --yolo --prompt-interactive --continue`
- Through Jefe's focused terminal, LLxprt received `Reply with exactly ISSUE525_INTERACTIVE_OK and no other text.` and replied exactly `ISSUE525_INTERACTIVE_OK`.
- Process/session lifecycle work from #515 remains explicitly out of scope.
- Exact-head CI, coverage, native Windows + psmux, OCR budget gate, mergeability gate, and LLxprt review all pass.

## Reviewers / Assignees

Repository maintainers / owners of Windows runtime probing and launch composition.

## Scope

9 files, 315 insertions, 18 deletions across two green commits. No user config migration, dependency, public abstraction, workflow, `.llxprt`, candidate-order, shell-policy, or process-lifecycle changes.

## Immediate-launch follow-up

- Fixed a startup race where a resolved LLxprt candidate was temporarily represented as pending `NotFound`, causing an immediate relaunch to report that LLxprt was not on local PATH.
- Only pending observations with retained resolved candidate evidence can pass the preliminary guard; final/malformed `NotFound`, incompatible, and probe-error states remain rejected.
- The existing launch-time probe remains authoritative and fail-closed.
- Exact real Windows proof launched persisted `branch-3` immediately with no availability wait and LLxprt returned exactly `ISSUE525_INTERACTIVE_OK` with `--profile-load gpt56high --yolo --prompt-interactive --continue`.
