### PR TITLE
Preserve Windows agent working directories

### DIFF
--- a/dev-docs/tmux-scenarios/issue530/windows-agent-working-directory.json
+++ b/dev-docs/tmux-scenarios/issue530/windows-agent-working-directory.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "cols": 140,
+    "rows": 45,
+    "history_limit": 5000,
+    "initial_wait_ms": 0,
+    "wait_timeout_ms": 180000,
+    "assert_mode": "strict"
+  },
+  "steps": [
+    { "waitFor": "LLxprt Jefe" },
+    { "key": "M-5" },
+    { "waitFor": "branch-3" },
+    { "key": "l" },
+    { "waitFor": "F12 unfocus" },
+    { "waitFor": "branch-3" },
+    { "capture": "issue530-real-agent-working-directory" },
+    { "key": "C-c" },
+    { "key": "F12" },
+    { "key": "C-q" },
+    { "waitForExit": 5000 }
+  ]
+}

--- a/project-plans/issue530-plan.md
+++ b/project-plans/issue530-plan.md
@@ -1,0 +1,98 @@
+# Issue 530 Plan: Preserve the Requested Windows Agent Working Directory
+
+## Scope
+
+Fix the native Windows interactive launch boundary so the staged private session host starts the actual agent process in the immutable launch plan's requested working directory. Preserve psmux pane `-c` metadata, canonical executable identity, wrapper mediation, launch argv/environment, non-interactive behavior, and fail-closed launch semantics.
+
+## Diagnosis
+
+- `AgentLaunchPlan.cwd` contains the requested repository/work directory.
+- `src/runtime/commands.rs::local_launch_command` passes that value to `psmux new-session -c`.
+- On Windows, psmux starts a staged `jefe-session-host.exe --jefe-internal-agent-launch <plan.json>`.
+- `AgentLaunchPayload` serializes executable, wrapper, script launch, argv, and environment, but not cwd.
+- `run_launch_plan` builds the agent `Command` and calls `status()` without `Command::current_dir`, so the worker inherits the session-host process cwd. In the reported real path, LLxprt reports `C:\Windows` while psmux reports the requested repository directory.
+- The non-interactive boundary already applies `.current_dir(&plan.cwd)`, establishing the expected runtime contract.
+- The defect predates #526; recent Windows fixes restored launches and exposed it. Reverting #526/#528/#521 would not add cwd propagation and would reintroduce separate failures.
+
+## Acceptance Matrix
+
+| ID | Actor / path | Input and boundary | Observable success | Failure behavior / permitted side effects | Compatibility / proof |
+|---|---|---|---|---|---|
+| A1 | Windows private launch-plan writer | Requested absolute cwd containing spaces or non-ASCII characters | Payload serializes and consumes the exact `PathBuf` without lossy conversion | Missing cwd makes the payload malformed; no worker starts | Payload round-trip and command projection tests |
+| A2 | Staged Windows session host | Host process cwd differs from requested payload cwd | Actual child process starts with OS cwd equal to the requested directory | Missing/non-directory cwd returns a typed launcher failure before worker spawn | Native Windows child reporter test |
+| A3 | Real interactive LLxprt launch | Configured repository is outside `C:\Windows` | LLxprt reports the configured repository directory immediately after focus | Launch must not silently fall back to `C:\Windows`, home, or Jefe startup cwd | Issue #530 psmux TUI scenario RED then GREEN; user performs final real launch before push |
+| A4 | Local multiplexer command | Existing `AgentLaunchPlan.cwd` | `psmux new-session -c <cwd>` remains unchanged and the same cwd reaches the private payload | Existing multiplexer errors remain typed | Structural command/multiplexer tests |
+| A5 | Windows wrapper launch | Direct, `.cmd`, `.bat`, `.ps1`, and structured script launch | Existing #526 canonical fingerprint and launch-safe wrapper handling remain intact | Existing launch/probe failures remain fail-closed | Existing #525 tests plus focused launcher tests |
+| A6 | LLxprt launch options | Profile/mode/resume/sandbox configuration | Existing profile, `--yolo`, `--prompt-interactive`, and `--continue` argv remain unchanged | No field/default remapping | Existing #518/#525 tests and real-process argv evidence |
+| A7 | Non-interactive, Unix/tmux, and remote launches | Existing launch plans | Existing cwd behavior remains unchanged | No new fallback or shell interpolation | Cross-platform build/tests and existing scenarios |
+| A8 | Lifecycle ownership | Existing session host and Job containment | Cwd correction does not change process containment, recovery, or teardown | No #515 watchdog/reaper behavior is added | Diff review and existing lifecycle tests |
+
+## Non-goals
+
+- Do not change work-directory derivation, normalization, repository persistence, or agent selection.
+- Do not remove or rely solely on psmux `-c`; pane metadata and actual process cwd must agree.
+- Do not use an LLxprt-specific `--cd` argument instead of setting the OS process cwd.
+- Do not change canonical fingerprints, wrapper selection, candidate order, launch flags, remote quoting, or package selection.
+- Do not implement #515 lifecycle/watchdog work or #529 version-selector work.
+- Do not modify `.llxprt/`, workflows, dependencies, quality tooling, or unrelated tests.
+- Do not push or open a PR until the user launches a real local agent and confirms its actual directory.
+
+## Vertical Slice
+
+### Slice 1: Private payload owns actual child cwd (A1-A8)
+
+- Owner: runtime launch-plan transport and private session-host spawn boundary.
+- Allowed production paths: `src/runtime/agent_launcher.rs`, `src/runtime/multiplexer.rs`, `src/runtime/session_host.rs`, `src/runtime/commands.rs` only as required to thread the already-owned `AgentLaunchPlan.cwd`.
+- Allowed test/evidence paths: focused runtime tests, one issue #530 TUI scenario, and this plan.
+- RED: add the issue TUI scenario first and show current main focuses LLxprt with `C:\Windows`; add payload/child-process tests requiring the requested cwd.
+- GREEN: serialize cwd in `AgentLaunchPayload`, apply it with `Command::current_dir` before worker spawn, and reject a missing/non-directory cwd before containment/spawn.
+- REFACTOR: keep cwd application at one private-launch command boundary and preserve existing structured argv/environment construction.
+- Stop for approval if this requires a psmux patch, new process-management subsystem, public launch abstraction, persistence migration, dependency, workflow/tooling change, or any #515/#529 behavior.
+
+## Expected Paths
+
+- `project-plans/issue530-plan.md`
+- `dev-docs/tmux-scenarios/issue530/windows-agent-working-directory.json`
+- `src/runtime/agent_launcher.rs`
+- `src/runtime/multiplexer.rs`
+- `src/runtime/session_host.rs`
+- `src/runtime/commands.rs`
+- Existing focused tests in those modules, unless a small dedicated integration test is necessary for the child-reported cwd
+
+## Scope Ledger
+
+| Discovery | Disposition | Reason |
+|---|---|---|
+| `plan.cwd` and psmux `-c` are already correct | Accept as evidence | The defect is payload/spawn propagation, not work-dir derivation |
+| LLxprt reports `C:\Windows` while psmux reports the repository | Accept / in scope | Proves logical pane cwd and actual worker cwd diverge |
+| Private payload lacks cwd | Accept / in scope | This is the narrow transport gap |
+| Non-interactive launch already sets `current_dir` | Accept as reference | Establishes parity contract without a new abstraction |
+| #526 restored wrappers and exposed this gap | Accept as context | Revert would not fix cwd and would regress launchability |
+| #515 session-host owner watchdog | Defer / out of scope | Separate lifecycle subsystem |
+| #529 version-selector managed install | Defer / out of scope | Separate package-runtime failure |
+| Probe process cwd | Defer unless RED evidence requires it | Identity/help probes do not establish interactive agent cwd |
+
+## Review Counters
+
+- Pre-PR OCR runs: 0 / 2
+- Post-PR OCR runs: 0 / 2
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| Baseline | `issue530` from `origin/main` at `cae19a72` |
+| Issue/comments fetched | Complete via `gh issue view 530` |
+| TUI RED | Baseline scenario exited 1 while waiting for the focused agent to show `branch-3`; current-main LLxprt had reported `C:\\Windows` in the same native launch path |
+| Focused runtime RED/GREEN | Six payload/cwd tests pass; native psmux child reporter passes and records the requested directory |
+| Native fixed TUI evidence | Isolated exact-head LLxprt status line shows `~\\projects\\jefe\\branch-3`; proof-owned processes were removed with command-line ownership guards |
+| `cargo fmt --all --check` | Pass |
+| Strict Clippy | Pass: workspace, all targets/features, warnings denied |
+| Locked all-feature build | Pass using isolated target directory |
+| Locked all-feature tests | Pass using isolated target directory |
+| Isolated exact-head binary | `target/issue530/debug/jefe.exe` built successfully |
+| User real-launch cwd confirmation | Pass: user confirmed the isolated exact-head binary launches an actual agent in the actual configured directory |
+
+## Deferred Findings and Follow-ups
+
+- None yet.

--- a/src/runtime/agent_launcher.rs
+++ b/src/runtime/agent_launcher.rs
@@ -24,6 +24,10 @@ struct AgentLaunchPayload {
     script_launch: Option<ScriptLaunchPayload>,
     args: Vec<OsString>,
     environment: Vec<(OsString, OsString)>,
+    /// Canonical working directory the agent child must start in (issue #530).
+    /// Serializes losslessly so paths with spaces and non-ASCII survive the
+    /// private pane-host transport; a payload missing this field is malformed.
+    cwd: PathBuf,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -55,6 +59,7 @@ pub fn write_launch_plan(
     wrapper: AgentWrapperKind,
     args: &[OsString],
     environment: &[(OsString, OsString)],
+    cwd: &Path,
 ) -> Result<PathBuf, AgentLauncherError> {
     let payload = AgentLaunchPayload {
         path: executable.to_path_buf(),
@@ -62,6 +67,7 @@ pub fn write_launch_plan(
         script_launch: None,
         args: args.to_vec(),
         environment: environment.to_vec(),
+        cwd: cwd.to_path_buf(),
     };
     let bytes =
         serde_json::to_vec(&payload).map_err(|_| AgentLauncherError::PlanSerializationFailed)?;
@@ -101,6 +107,12 @@ pub fn run_launch_plan(path: &Path) -> Result<ExitStatus, AgentLauncherError> {
     std::fs::remove_file(path).map_err(|_| AgentLauncherError::CleanupFailed)?;
     let payload: AgentLaunchPayload =
         serde_json::from_slice(&bytes).map_err(|_| AgentLauncherError::InvalidPlanPayload)?;
+    // Issue #530: the requested cwd must exist and be a directory before the
+    // worker is spawned. A missing or non-directory cwd is a typed failure with
+    // no fallback so the agent never silently starts in the wrong directory.
+    if !payload.cwd.is_dir() {
+        return Err(AgentLauncherError::InvalidWorkingDirectory);
+    }
     let mut command = command_for_payload(&payload);
     for variable in ["TMUX", "TMUX_PANE", "TMUX_TMPDIR"] {
         command.env_remove(variable);
@@ -165,6 +177,14 @@ fn secure_launch_plan_file(path: &Path) -> std::io::Result<std::fs::File> {
 }
 
 fn command_for_payload(payload: &AgentLaunchPayload) -> Command {
+    let mut command = base_command_for_payload(payload);
+    // Issue #530: the actual agent child must start in the requested working
+    // directory, not the session-host process's inherited cwd.
+    command.current_dir(&payload.cwd);
+    command
+}
+
+fn base_command_for_payload(payload: &AgentLaunchPayload) -> Command {
     if let Some(script_launch) = &payload.script_launch {
         let mut command = Command::new(&script_launch.runtime);
         command.arg(&script_launch.entrypoint).args(&payload.args);
@@ -209,8 +229,11 @@ fn command_for_payload(payload: &AgentLaunchPayload) -> Command {
 #[cfg(all(test, windows))]
 mod tests {
     use std::ffi::OsString;
+    use std::path::PathBuf;
 
-    use super::{AgentLaunchPayload, AgentWrapperKindPayload, command_for_payload};
+    use super::{
+        AgentLaunchPayload, AgentLauncherError, AgentWrapperKindPayload, command_for_payload,
+    };
 
     #[test]
     fn canonical_command_script_payload_uses_launch_safe_path() {
@@ -227,6 +250,7 @@ mod tests {
             script_launch: None,
             args: vec![OsString::from("--version")],
             environment: Vec::new(),
+            cwd: dir.path().to_path_buf(),
         };
 
         let command = command_for_payload(&payload);
@@ -235,6 +259,140 @@ mod tests {
             args[3],
             super::super::agent_executable::strip_verbatim_prefix(&canonical),
             "the private pane launcher must not pass a verbatim wrapper path to cmd.exe"
+        );
+    }
+
+    // ── Issue #530: payload cwd projection and actual child cwd ──────────
+
+    #[test]
+    fn payload_cwd_round_trips_losslessly_through_serialization() {
+        let workdir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("could not create launcher fixture: {error}"));
+        let requested = workdir.path().join("repo with spaces Ω");
+        std::fs::create_dir_all(&requested)
+            .unwrap_or_else(|error| panic!("could not create requested cwd fixture: {error}"));
+        let payload = AgentLaunchPayload {
+            path: workdir.path().join("agent.exe"),
+            wrapper: AgentWrapperKindPayload::Direct,
+            script_launch: None,
+            args: vec![OsString::from("--version")],
+            environment: Vec::new(),
+            cwd: requested.clone(),
+        };
+        let bytes = serde_json::to_vec(&payload)
+            .unwrap_or_else(|error| panic!("payload should serialize: {error}"));
+        let decoded: AgentLaunchPayload = serde_json::from_slice(&bytes)
+            .unwrap_or_else(|error| panic!("payload should deserialize: {error}"));
+        assert_eq!(
+            decoded.cwd, requested,
+            "payload cwd must round-trip losslessly for paths with spaces and non-ASCII"
+        );
+    }
+
+    #[test]
+    fn command_for_payload_applies_requested_cwd_as_current_dir() {
+        let workdir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("could not create launcher fixture: {error}"));
+        let requested = workdir.path().join("requested cwd");
+        std::fs::create_dir_all(&requested)
+            .unwrap_or_else(|error| panic!("could not create requested cwd fixture: {error}"));
+        for wrapper in [
+            AgentWrapperKindPayload::Direct,
+            AgentWrapperKindPayload::CommandScript,
+            AgentWrapperKindPayload::PowerShellScript,
+        ] {
+            let payload = AgentLaunchPayload {
+                path: workdir.path().join("agent.bin"),
+                wrapper,
+                script_launch: None,
+                args: vec![OsString::from("--version")],
+                environment: Vec::new(),
+                cwd: requested.clone(),
+            };
+            let command = command_for_payload(&payload);
+            assert_eq!(
+                command.get_current_dir(),
+                Some(requested.as_path()),
+                "the staged session host must start the actual agent child in the requested cwd ({wrapper:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_cwd_in_payload_is_malformed() {
+        // A payload JSON without a `cwd` field must fail to deserialize so the
+        // missing-cwd contract cannot be silently bypassed.
+        let json = br#"{"path":"C:/agent.exe","wrapper":"Direct","script_launch":null,"args":[],"environment":[]}"#;
+        let result: Result<AgentLaunchPayload, _> = serde_json::from_slice(json);
+        assert!(
+            result.is_err(),
+            "a payload without cwd must be rejected as malformed"
+        );
+    }
+
+    #[test]
+    fn run_launch_plan_rejects_nonexistent_cwd_before_worker_spawn() {
+        let workdir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("could not create launcher fixture: {error}"));
+        let missing_cwd = workdir.path().join("does-not-exist");
+        let payload = AgentLaunchPayload {
+            path: PathBuf::from("C:/nonexistent-agent.exe"),
+            wrapper: AgentWrapperKindPayload::Direct,
+            script_launch: None,
+            args: Vec::new(),
+            environment: Vec::new(),
+            cwd: missing_cwd,
+        };
+        let bytes = serde_json::to_vec(&payload)
+            .unwrap_or_else(|error| panic!("payload should serialize: {error}"));
+        let plan_path = std::env::temp_dir().join(format!(
+            "jefe-agent-launch-{}-530-missing-cwd.json",
+            std::process::id()
+        ));
+        std::fs::write(&plan_path, &bytes)
+            .unwrap_or_else(|error| panic!("could not write plan fixture: {error}"));
+        let result = super::run_launch_plan(&plan_path);
+        assert!(
+            matches!(result, Err(AgentLauncherError::InvalidWorkingDirectory)),
+            "a nonexistent cwd must fail typed before worker spawn, got {result:?}"
+        );
+        assert!(
+            !plan_path.exists(),
+            "a rejected launch must still consume its private plan"
+        );
+    }
+
+    #[test]
+    fn run_launch_plan_rejects_non_directory_cwd_before_worker_spawn() {
+        let workdir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("could not create launcher fixture: {error}"));
+        let file_cwd = workdir.path().join("not-a-directory.txt");
+        std::fs::write(&file_cwd, b"file")
+            .unwrap_or_else(|error| panic!("could not write cwd fixture: {error}"));
+        let payload = AgentLaunchPayload {
+            path: PathBuf::from("C:/nonexistent-agent.exe"),
+            wrapper: AgentWrapperKindPayload::Direct,
+            script_launch: None,
+            args: Vec::new(),
+            environment: Vec::new(),
+            cwd: file_cwd,
+        };
+        let bytes = serde_json::to_vec(&payload)
+            .unwrap_or_else(|error| panic!("payload should serialize: {error}"));
+        let plan_path = std::env::temp_dir().join(format!(
+            "jefe-agent-launch-{}-530-file-cwd.json",
+            std::process::id()
+        ));
+        std::fs::write(&plan_path, &bytes)
+            .unwrap_or_else(|error| panic!("could not write plan fixture: {error}"));
+        let result = super::run_launch_plan(&plan_path);
+        assert!(
+            matches!(result, Err(AgentLauncherError::InvalidWorkingDirectory)),
+            "a non-directory cwd must fail typed before worker spawn, got {result:?}"
+        );
+        assert!(
+            !plan_path.exists(),
+            "a rejected launch must still consume its private plan"
         );
     }
 }
@@ -250,6 +408,10 @@ pub enum AgentLauncherError {
     InvalidPlanPayload,
     CleanupFailed,
     LaunchFailed,
+    /// The requested working directory does not exist or is not a directory
+    /// (issue #530). The worker is refused spawn so the agent never silently
+    /// starts in the wrong directory.
+    InvalidWorkingDirectory,
     /// Windows Job Object containment could not be established before spawning
     /// the worker (issue #467 Slice 3). Worker spawn is refused so a host can
     /// never start a descendant tree it cannot reliably contain.
@@ -278,6 +440,9 @@ impl std::fmt::Display for AgentLauncherError {
             }
             Self::CleanupFailed => formatter.write_str("internal agent launch plan cleanup failed"),
             Self::LaunchFailed => formatter.write_str("agent process could not be started"),
+            Self::InvalidWorkingDirectory => {
+                formatter.write_str("agent working directory does not exist or is not a directory")
+            }
             #[cfg(windows)]
             Self::ContainmentUnavailable => formatter.write_str(
                 "windows job object containment could not be established for agent worker",

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -399,11 +399,11 @@ fn local_launch_command(
         .collect();
     let pane_command = super::session_host::resolve_local_pane_command(
         &multiplexer,
-        &plan.executable,
-        plan.executable_wrapper,
+        (&plan.executable, plan.executable_wrapper),
         &pane_args,
         &environment,
         session_host_root.map(|root| (root, session_name)),
+        &plan.cwd,
     )?;
     for argument in pane_command {
         command.arg(argument);

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -211,37 +211,31 @@ impl MultiplexerPlan {
     /// Build a pane command from a resolved agent's explicit wrapper strategy.
     pub fn agent_pane_command_args(
         &self,
-        executable: &Path,
-        wrapper: AgentWrapperKind,
+        executable: (&Path, AgentWrapperKind),
         args: &[OsString],
         environment: &[(OsString, OsString)],
+        cwd: &Path,
     ) -> Result<Vec<OsString>, MultiplexerError> {
         if self.platform == LocalPlatform::Unix {
-            return self.pane_command_args(executable.as_os_str(), args, environment);
+            return self.pane_command_args(executable.0.as_os_str(), args, environment);
         }
 
         let launcher =
             std::env::current_exe().map_err(|_| MultiplexerError::CurrentExecutableUnavailable)?;
-        self.agent_pane_command_args_with_launcher(
-            executable,
-            wrapper,
-            args,
-            environment,
-            &launcher,
-        )
+        self.agent_pane_command_args_with_launcher(executable, args, environment, &launcher, cwd)
     }
 
     /// Build the Windows pane command with an explicit Jefe launcher path.
     #[doc(hidden)]
     pub fn agent_pane_command_args_with_launcher(
         &self,
-        executable: &Path,
-        wrapper: AgentWrapperKind,
+        executable: (&Path, AgentWrapperKind),
         args: &[OsString],
         environment: &[(OsString, OsString)],
         launcher: &Path,
+        cwd: &Path,
     ) -> Result<Vec<OsString>, MultiplexerError> {
-        let plan_path = write_launch_plan(executable, wrapper, args, environment)
+        let plan_path = write_launch_plan(executable.0, executable.1, args, environment, cwd)
             .map_err(MultiplexerError::AgentLaunchPlan)?;
         self.pane_command_args(
             launcher.as_os_str(),
@@ -263,24 +257,18 @@ impl MultiplexerPlan {
     /// command construction.
     pub fn agent_pane_command_args_with_staged_host(
         &self,
-        executable: &Path,
-        wrapper: AgentWrapperKind,
+        executable: (&Path, AgentWrapperKind),
         staged_host: &Path,
         args: &[OsString],
         environment: &[(OsString, OsString)],
+        cwd: &Path,
     ) -> Result<Vec<OsString>, MultiplexerError> {
         if self.platform != LocalPlatform::Windows {
             return Err(MultiplexerError::InvalidIsolation {
                 platform: self.platform,
             });
         }
-        self.agent_pane_command_args_with_launcher(
-            executable,
-            wrapper,
-            args,
-            environment,
-            staged_host,
-        )
+        self.agent_pane_command_args_with_launcher(executable, args, environment, staged_host, cwd)
     }
     #[must_use]
     pub const fn isolation(&self) -> &MultiplexerIsolation {

--- a/src/runtime/multiplexer_tests.rs
+++ b/src/runtime/multiplexer_tests.rs
@@ -340,11 +340,11 @@ fn windows_agent_pane_command_uses_staged_session_host_when_provided() {
         PathBuf::from("C:/State/session-hosts/jefe-agent-1/<digest>/jefe-session-host.exe");
     let pane = plan
         .agent_pane_command_args_with_staged_host(
-            executable.path(),
-            executable.wrapper_kind(),
+            (executable.path(), executable.wrapper_kind()),
             &staged_host,
             &[OsString::from("--profile"), OsString::from("default")],
             &[(OsString::from("LLXPRT_DEBUG"), OsString::from("api"))],
+            Path::new("C:/Repos/my-agent"),
         )
         .unwrap_or_else(|error| panic!("staged pane command should build: {error}"));
     assert_eq!(pane.len(), 1);
@@ -369,11 +369,11 @@ fn unix_agent_pane_command_has_no_staged_host_path() {
     let (_directory, executable) = resolved_fixture(AgentExecutablePlatform::Unix);
     let staged = PathBuf::from("/state/session-hosts/jefe-agent/host/jefe-session-host.exe");
     let result = plan.agent_pane_command_args_with_staged_host(
-        executable.path(),
-        executable.wrapper_kind(),
+        (executable.path(), executable.wrapper_kind()),
         &staged,
         &[OsString::from("--profile")],
         &[],
+        Path::new("/repos/my-agent"),
     );
     assert!(
         matches!(result, Err(MultiplexerError::InvalidIsolation { .. })),

--- a/src/runtime/session_host.rs
+++ b/src/runtime/session_host.rs
@@ -168,11 +168,11 @@ pub fn session_host_stage_request<'a>(
 /// unchanged (AC9).
 pub fn resolve_local_pane_command(
     multiplexer: &MultiplexerPlan,
-    executable: &Path,
-    wrapper: AgentWrapperKind,
+    executable: (&Path, AgentWrapperKind),
     pane_args: &[std::ffi::OsString],
     environment: &[(std::ffi::OsString, std::ffi::OsString)],
     session_host: Option<(&Path, &str)>,
+    cwd: &Path,
 ) -> Result<Vec<std::ffi::OsString>, RuntimeError> {
     match session_host.and_then(|(root, name)| session_host_stage_request(Some(root), Some(name))) {
         Some((root, name)) => {
@@ -186,15 +186,15 @@ pub fn resolve_local_pane_command(
             multiplexer
                 .agent_pane_command_args_with_staged_host(
                     executable,
-                    wrapper,
                     &staged,
                     pane_args,
                     environment,
+                    cwd,
                 )
                 .map_err(RuntimeError::Multiplexer)
         }
         None => multiplexer
-            .agent_pane_command_args(executable, wrapper, pane_args, environment)
+            .agent_pane_command_args(executable, pane_args, environment, cwd)
             .map_err(RuntimeError::Multiplexer),
     }
 }

--- a/tests/psmux_smoke.rs
+++ b/tests/psmux_smoke.rs
@@ -359,14 +359,17 @@ fn psmux_agent_launch_preserves_arguments_working_directory_and_environment_poli
     .unwrap_or_else(|error| panic!("construct psmux plan: {error}"));
     let pane = plan
         .agent_pane_command_args_with_launcher(
-            fixture.agent_executable.path(),
-            fixture.agent_executable.wrapper_kind(),
+            (
+                fixture.agent_executable.path(),
+                fixture.agent_executable.wrapper_kind(),
+            ),
             &fixture.launch_args,
             &[(
                 OsString::from("JEFE_FIXTURE_VALUE"),
                 OsString::from("environment & (Ω) %value%"),
             )],
             Path::new(JEFE),
+            fixture.work_dir.path(),
         )
         .unwrap_or_else(|error| panic!("build production pane command: {error}"));
     let mut command = vec![

--- a/tests/psmux_smoke/official_llxprt.rs
+++ b/tests/psmux_smoke/official_llxprt.rs
@@ -71,11 +71,14 @@ fn psmux_official_llxprt_launch_bypasses_cmd_and_delivers_full_prompt() {
     script_args.extend(launch_args);
     let pane = plan
         .agent_pane_command_args_with_launcher(
-            script.runtime(),
-            jefe::agent_candidate_path::AgentWrapperKind::Direct,
+            (
+                script.runtime(),
+                jefe::agent_candidate_path::AgentWrapperKind::Direct,
+            ),
             &script_args,
             &[],
             Path::new(JEFE),
+            fixture.work_dir.path(),
         )
         .unwrap_or_else(|error| panic!("build official pane command: {error}"));
     let mut command = vec![


### PR DESCRIPTION
## Summary

- carry the immutable local launch-plan cwd through the private Windows session-host payload
- apply that cwd to the actual agent child instead of inheriting the session-host cwd (`C:\Windows`)
- reject missing, nonexistent, or non-directory cwd values before worker spawn without an implicit fallback
- preserve psmux `-c`, canonical wrapper handling, argv/environment, Job containment, and Unix/remote behavior

Fixes #530

## Pre-push checklist

- [x] **Format** — `cargo fmt --all --check`; CI `Format (rustfmt)` passed
- [x] **Clippy allow policy** — CI passed
- [x] **Source file length** — CI passed
- [x] **Architecture boundary policy** — CI passed
- [x] **Lint** — `cargo clippy --workspace --all-targets --all-features -- -D warnings`; CI passed
- [x] **Complexity** — CI passed
- [x] **Coverage** — CI passed
- [x] **Build** — `cargo build --workspace --all-features --locked`; CI passed
- [x] **Tests** — `cargo test --workspace --all-features --locked`; CI passed
- [x] **Native Windows** — MSVC + psmux CI passed
- [x] **TUI/runtime smoke** — issue #530 scenario authored before implementation; native psmux child reporter and real LLxprt launch exercised

## Testing notes

- Added payload round-trip coverage for cwd values containing spaces and non-ASCII characters.
- Added Windows command projection coverage across direct, command-script, and PowerShell launch strategies.
- Added typed failure coverage for missing, nonexistent, and non-directory cwd values.
- Extended the native psmux child reporter test to assert the actual child cwd.
- Added `dev-docs/tmux-scenarios/issue530/windows-agent-working-directory.json` for the UI-visible regression.
- The user tested `target/issue530/debug/jefe.exe` with a real LLxprt agent and confirmed it launches in the configured repository directory.
- Exact-head CI passed, including coverage, build, test, native Windows, mergeability, OpenCodeReview, and LLxprt review.

## Reviewers / Assignees

Repository maintainers / CODEOWNERS.

## Scope

- 9 files, 317 insertions, 37 deletions
- no dependency, persistence-schema, workflow, `.llxprt`, lifecycle/watchdog (#515), or version-selector (#529) changes