### PR TITLE
Make Send Issue delivery contract repo-neutral and scope-focused (Fixes #532)

### DIFF
--- a/project-plans/issue532-plan.md
+++ b/project-plans/issue532-plan.md
@@ -1,0 +1,84 @@
+# Issue 532 — Fresh Send Issue delivery contract: repo-neutral & scope-focused
+
+## Links
+
+- Issue: https://github.com/vybestack/llxprt-jefe/issues/532
+
+## Problem
+
+`ISSUE_DELIVERY_WORKFLOW` in `src/app_input/fresh_prompt.rs` is appended to
+every fresh Send Issue prompt Jefe sends to an agent. Two defects:
+
+1. It opens with "Follow the canonical bounded issue-delivery policy in
+   dev-docs/workflow/ISSUE-DELIVERY.md". That path exists only inside the jefe
+   repo; target repos (e.g. llxprt-code) do not contain it, so agents are told
+   to follow a file that is absent.
+2. It hard-codes numeric budgets — "25 files or 1,500 net changed lines",
+   "40 files or 2,500 net changed lines", "mandatory scope review above either
+   threshold", "hard scope budget" — which makes agents optimize for file/line
+   counts rather than actual issue scope.
+
+## Decision-complete acceptance matrix
+
+| ID | Actor / path | Inputs & boundary | Observable success | Observable failure / diagnostic | Side effects before failure | Persistence / compat | Behavioral test |
+|----|--------------|-------------------|--------------------|---------------------------------|----------------------------|----------------------|-----------------|
+| A1 | Fresh Send Issue → `fresh_prompt_instruction(Issue, ..)` | Any issue body, any repo | Instruction ends with a delivery contract that is self-contained (no jefe-only doc path) and scope-focused | Contract still referencing `dev-docs/workflow/ISSUE-DELIVERY.md` → focused unit test fails | None | Runtime-neutral; no behavior change to PR prompts | `fresh_prompt::issue_delivery_workflow_*` |
+| A2 | Same | — | Contract contains NO numeric file/line budgets and NO "hard scope budget" | Presence of "net changed lines"/"hard scope budget" → negative assertion fails | None | — | negative assertions in scope-guardrail test |
+| A3 | Same | — | Contract still requires acceptance shaping + stop-for-approval guardrails (unplanned subsystem, public abstraction, workflow/agent-memory/quality-tool/dependency change, unrelated refactor/test move, out-of-scope behavior) | Missing guardrail → assertion fails | None | — | `issue_delivery_workflow_stops_unplanned_scope_expansion` |
+| A4 | Same | — | Contract still defines four-way review triage + OCR cap + standards-preservation closer | Missing clause → assertion fails | None | — | `issue_delivery_workflow_bounds_and_triages_review`, completion test |
+| A5 | Issue send modal → `prepare_issue_launch_signature` | Fixture issue agent | Produced instruction asserts the new (repo-neutral, count-free) contract | Old-string assertions fail | None | — | `issue_send_modal_tests` |
+
+## Non-goals
+
+- Do NOT change the jefe-internal `dev-docs/workflow/ISSUE-DELIVERY.md` doc — it
+  is not injected and remains jefe's own process reference.
+- Do NOT change PR-prompt behavior (`FreshPromptKind::PullRequest` path).
+- Do NOT remove the OCR review cap, review triage, or the standards-preservation
+  closer (harmful to drop; out of scope).
+- Do NOT change compaction/truncation thresholds or the tmux sizing logic beyond
+  updating the now-stale "~1.5 KB" comment if the appendix shrinks.
+
+## Vertical slice
+
+Single slice: rewrite `ISSUE_DELIVERY_WORKFLOW` + its assertions.
+
+1. RED: replace the four `fresh_prompt` contract tests and the one
+   `issue_send_modal_tests` assertion with the new contract (scope-focus +
+   negative assertions that the doc path and counts are gone). Run focused
+   tests → fail.
+2. GREEN: rewrite `ISSUE_DELIVERY_WORKFLOW` to the repo-neutral, count-free,
+   scope-focused contract. Run focused tests → pass.
+3. Update the stale "~1.5 KB appendix" doc comments to reflect the new size.
+4. Full verification: `make ci-check`.
+
+## Expected files
+
+- `src/app_input/fresh_prompt.rs` (constant + tests + sizing comments)
+- `src/app_input/issue_send_modal_tests.rs` (one assertion block)
+- `project-plans/issue532-plan.md` (this plan)
+
+## Scope ledger
+
+- Decision: drop "scope ledger is clean" from the *injected* contract because a
+  scope ledger is a jefe-plan artifact absent in target repos (same class as
+  the removed doc reference); it created an unsatisfiable completion gate.
+  Keep the OCR cap because it is a harmless *limit* (trivially satisfied when
+  OCR is unused), not an unsatisfiable gate.
+- No other behavior changes.
+
+## Review counters
+
+- OCR: 0 local / 0 PR so far (cap 2/2).
+
+## Verification evidence
+
+- RED: `cargo test --bin jefe issue_delivery_workflow` — 2 failed (missing
+  `acceptance criteria`, `outside the issue's scope`) against the old constant.
+- GREEN: `cargo test --bin jefe issue_delivery_workflow` — 4 passed; modal
+  test `issue_send_projects_fresh_operation_and_prompt` passed.
+- Appendix size: 1320 bytes (~1.3 KB), down from ~1.5 KB; sizing comments updated.
+- `cargo fmt --all --check`: clean.
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
+- `cargo build --workspace --all-features --locked`: clean.
+- `cargo test --workspace --all-features --locked -- --test-threads=1`: all bins
+  green, 0 failed.

--- a/src/app_input/fresh_prompt.rs
+++ b/src/app_input/fresh_prompt.rs
@@ -18,27 +18,31 @@ impl FreshPromptKind {
     }
 }
 
-/// Runtime-neutral delivery contract appended to every fresh Send Issue
-/// instruction. Issue-specific content remains in the prompt file; this text
-/// defines how an agent must carry that issue through review and CI.
+/// Runtime-neutral, repo-neutral delivery contract appended to every fresh
+/// Send Issue instruction. Issue-specific content remains in the prompt file;
+/// this text defines how an agent must carry that issue through review and CI.
+///
+/// It is deliberately self-contained: it references no project-specific file
+/// (the canonical process lives in jefe's own `dev-docs/workflow/`, which does
+/// not exist in target repositories) and uses scope adherence rather than
+/// hard-coded file/line counts as the scope guardrail.
 pub(super) const ISSUE_DELIVERY_WORKFLOW: &str = concat!(
-    "Follow the canonical bounded issue-delivery policy in ",
-    "dev-docs/workflow/ISSUE-DELIVERY.md. Before implementation, shape a decision-complete ",
-    "acceptance matrix and record explicit non-goals, bounded vertical slices, expected paths, and a ",
-    "scope ledger. Agents must stop for approval before adding an unplanned subsystem or public ",
-    "abstraction, ",
-    "making a workflow, agent-memory, quality-tool, or dependency change, moving an unrelated ",
-    "refactor or test move into scope, implementing behavior outside the acceptance matrix, or ",
-    "exceeding the hard scope budget. Target no more than 25 files or 1,500 net changed lines, perform ",
-    "a mandatory scope review above either threshold, and stop without approval above 40 files or ",
-    "2,500 net changed lines. Classify every review finding as Blocker-Fix, In-scope-Fix, Reject, or ",
-    "Defer; reviewer suggestions do not authorize scope expansion. Limit Open Code Review to two ",
-    "local and two PR OCR reviews per issue/PR effort. Declare exact-head completion only when every ",
-    "accepted behavior has behavioral evidence, local verification and CI pass on the candidate head, ",
-    "reviews are complete and triaged, all Blocker-Fix and In-scope-Fix findings are resolved, correct ",
-    "ancestry is confirmed, the PR is conflict-free, and the scope ",
-    "ledger is clean. Stop successfully when accepted behavior and all required gates are complete. ",
-    "Do not continue optional hardening or cleanup, and do not weaken architecture, TDD, lint, ",
+    "Before implementing, shape the issue into clear acceptance criteria: the ",
+    "behavior to deliver, the relevant inputs and boundary cases, and the tests ",
+    "that will prove it. Implement only the accepted behavior and keep every change ",
+    "strictly within the issue's scope; do not expand scope to add adjacent cleanup ",
+    "or speculative hardening, and stop for approval before adding an unplanned ",
+    "subsystem or public abstraction, making a workflow, agent-memory, quality-tool, ",
+    "or dependency change, moving an unrelated refactor or test into scope, or ",
+    "implementing behavior outside the issue's scope. Classify every review finding ",
+    "as Blocker-Fix, In-scope-Fix, Reject, or Defer; reviewer suggestions do not ",
+    "authorize scope expansion. Limit Open Code Review to two local and two PR OCR ",
+    "reviews per issue/PR effort. Declare completion only when every accepted behavior ",
+    "has behavioral evidence, local verification and CI pass on the candidate head, ",
+    "reviews are complete and triaged, all Blocker-Fix and In-scope-Fix findings are ",
+    "resolved, and the PR is conflict-free with correct ancestry. Stop successfully ",
+    "when accepted behavior is complete and all required gates pass. Do not continue ",
+    "optional hardening or cleanup, and do not weaken architecture, TDD, lint, ",
     "complexity, source-size, safety, coverage, cross-platform, or CI requirements."
 );
 
@@ -59,7 +63,7 @@ pub(super) fn fresh_prompt_instruction(
 ///
 /// Cross-platform safe bound that stays well under the smallest OS
 /// command-line length limit (Windows CreateProcess: ~32 KB). The
-/// `ISSUE_DELIVERY_WORKFLOW` appendix adds ~1.5 KB for issues.
+/// `ISSUE_DELIVERY_WORKFLOW` appendix adds ~1.3 KB for issues.
 ///
 /// Note: the binding constraint on Unix is **tmux's pane-command limit**
 /// (~16,340 bytes on tmux 3.x), not the OS `ARG_MAX`. Prompt content that
@@ -73,7 +77,7 @@ pub(super) const MAX_PROMPT_CONTENT_BYTES: usize = 24_000;
 /// being inlined verbatim.
 ///
 /// Sized so that the compacted prompt — including metadata, base prompt, the
-/// `ISSUE_DELIVERY_WORKFLOW` appendix (~1.5 KB for issues), and the
+/// `ISSUE_DELIVERY_WORKFLOW` appendix (~1.3 KB for issues), and the
 /// instruction framing — stays comfortably under tmux's pane-command limit
 /// ([`TMUX_PANE_COMMAND_LIMIT_BYTES`]).
 ///
@@ -227,18 +231,27 @@ mod tests {
     }
 
     #[test]
-    fn issue_delivery_workflow_references_policy_and_shapes_accepted_scope() {
+    fn issue_delivery_workflow_is_repo_neutral_and_scope_focused() {
+        // Scope-first: the agent must shape acceptance criteria and stay in scope.
         for required in [
-            "dev-docs/workflow/ISSUE-DELIVERY.md",
-            "decision-complete acceptance matrix",
-            "explicit non-goals",
-            "bounded vertical slices",
-            "expected paths",
-            "scope ledger",
+            "acceptance criteria",
+            "Implement only the accepted behavior",
+            "within the issue's scope",
         ] {
             assert!(
                 ISSUE_DELIVERY_WORKFLOW.contains(required),
                 "issue delivery workflow must require {required}"
+            );
+        }
+        // Repo-neutral: no jefe-only doc path and no hard-coded file/line budgets.
+        for forbidden in [
+            "dev-docs/workflow/ISSUE-DELIVERY.md",
+            "net changed lines",
+            "hard scope budget",
+        ] {
+            assert!(
+                !ISSUE_DELIVERY_WORKFLOW.contains(forbidden),
+                "issue delivery workflow must not include jefe-only artifact: {forbidden}"
             );
         }
         assert!(!ISSUE_DELIVERY_WORKFLOW.contains("CodeRabbit"));
@@ -251,10 +264,8 @@ mod tests {
             "unplanned subsystem",
             "public abstraction",
             "workflow, agent-memory, quality-tool, or dependency change",
-            "unrelated refactor or test move",
-            "behavior outside the acceptance matrix",
-            "25 files or 1,500 net changed lines",
-            "40 files or 2,500 net changed lines",
+            "unrelated refactor or test",
+            "outside the issue's scope",
         ] {
             assert!(
                 ISSUE_DELIVERY_WORKFLOW.contains(required),
@@ -281,17 +292,16 @@ mod tests {
     }
 
     #[test]
-    fn issue_delivery_workflow_defines_exact_head_success() {
+    fn issue_delivery_workflow_defines_completion_readiness() {
         for required in [
-            "exact-head",
             "behavioral evidence",
             "local verification",
             "CI",
+            "candidate head",
             "reviews are complete and triaged",
             "Blocker-Fix and In-scope-Fix findings are resolved",
             "correct ancestry",
             "conflict-free",
-            "scope ledger is clean",
             "Stop successfully",
             "Do not continue optional hardening",
         ] {

--- a/src/app_input/issue_send_modal_tests.rs
+++ b/src/app_input/issue_send_modal_tests.rs
@@ -127,11 +127,11 @@ fn issue_send_projects_fresh_operation_and_prompt() {
             other => panic!("expected typed prompt, got {other:?}"),
         };
     assert!(instruction.contains(issue_prompt));
-    assert!(instruction.contains("dev-docs/workflow/ISSUE-DELIVERY.md"));
-    assert!(instruction.contains("decision-complete acceptance matrix"));
+    assert!(!instruction.contains("dev-docs/workflow/ISSUE-DELIVERY.md"));
+    assert!(instruction.contains("acceptance criteria"));
     assert!(instruction.contains("stop for approval"));
     assert!(instruction.contains("Blocker-Fix"));
-    assert!(instruction.contains("scope ledger is clean"));
+    assert!(!instruction.contains("net changed lines"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The `ISSUE_DELIVERY_WORKFLOW` text appended to every fresh Send Issue prompt that Jefe sends to an agent had two problems (issue #532):

1. It opened with "Follow the canonical bounded issue-delivery policy in dev-docs/workflow/ISSUE-DELIVERY.md". That path exists only inside the jefe repo; when Jefe drives work in another repository (e.g. llxprt-code), the agent is told to follow a file that is absent — misleading and unactionable.
2. It hard-coded numeric budgets ("25 files or 1,500 net changed lines", "40 files or 2,500 net changed lines", "hard scope budget"), which makes agents optimize for file/line counts rather than actual issue scope.

## Change

Rewrote the injected delivery contract to be self-contained and scope-first:

- Removed the jefe-only `dev-docs/workflow/ISSUE-DELIVERY.md` reference so the contract is valid in any repository.
- Removed the hard-coded file/line-count budgets and the "hard scope budget" framing; replaced them with a directive to implement only the accepted behavior and stay strictly within the issue's scope.
- Kept the valuable guardrails: shape acceptance criteria first, stop-for-approval conditions (unplanned subsystem / public abstraction / workflow-agent-memory-quality-tool-dependency change / unrelated refactor or test / out-of-scope behavior), four-way review triage (Blocker-Fix, In-scope-Fix, Reject, Defer), OCR cap, completion readiness, and the standards-preservation closer.
- Dropped the jefe-plan-only "scope ledger is clean" completion gate (a scope ledger does not exist in target repos), while keeping the OCR cap since it is a harmless limit rather than an unsatisfiable gate.

The jefe-internal `dev-docs/workflow/ISSUE-DELIVERY.md` process doc is intentionally left unchanged — it is not injected and remains jefe's own process reference.

## Tests

- Updated the four `fresh_prompt` contract tests to assert the new repo-neutral, count-free contract, including negative assertions that the doc path and counts are gone (RED -> GREEN).
- Updated the `issue_send_modal_tests` assertion to verify the produced instruction no longer carries the jefe-only path or counts while still carrying the scope/review guardrails.

## Verification

- cargo fmt --all --check: clean
- cargo clippy --workspace --all-targets --all-features -- -D warnings: clean
- cargo build --workspace --all-features --locked: clean
- cargo test --workspace --all-features --locked -- --test-threads=1: all green, 0 failed
- Open Code Review: 0 comments

Closes #532