### PR TITLE
Detect current terminal emulator for F8 launch (Fixes #549)

### DIFF
--- a/src/runtime/external_terminal.rs
+++ b/src/runtime/external_terminal.rs
@@ -195,7 +195,7 @@ fn macos_app_for_emulator(detected: &str) -> Option<&'static str> {
     match detected {
         "iTerm.app" | "com.googlecode.iterm2" => Some("iTerm"),
         "Apple_Terminal" | "com.apple.Terminal" => Some("Terminal"),
-        "WezTerm" => Some("WezTerm"),
+        "WezTerm" | "com.github.wez.wezterm" => Some("WezTerm"),
         _ => None,
     }
 }

--- a/src/runtime/external_terminal.rs
+++ b/src/runtime/external_terminal.rs
@@ -119,8 +119,9 @@ fn jefe_terminal_override() -> Option<String> {
 ///
 /// Resolution order:
 /// 1. `JEFE_TERMINAL` environment variable (user override).
-/// 2. Platform-specific discovered emulator.
-/// 3. `NoTerminalFound` error.
+/// 2. Auto-detect the emulator jefe is running inside (`TERM_PROGRAM` etc.).
+/// 3. Platform-specific discovered/default emulator.
+/// 4. `NoTerminalFound` error.
 ///
 /// The work directory is validated to exist before the plan is built so callers
 /// can surface an actionable warning without spawning.
@@ -138,10 +139,64 @@ pub fn build_external_terminal_plan(
         return Ok(plan_from_override(&override_prog, work_dir, platform));
     }
 
+    // Auto-detect the terminal jefe is running inside, so a user in iTerm2 or
+    // WezTerm gets that emulator rather than the platform default (#549).
+    if let Some(detected) = detect_emulator_from_env() {
+        if let Some(plan) = plan_from_detected(&detected, work_dir, platform) {
+            return Ok(plan);
+        }
+    }
+
     match platform {
         DesktopPlatform::Macos => Ok(plan_macos(work_dir)),
         DesktopPlatform::Linux => plan_linux(work_dir),
         DesktopPlatform::Windows => Ok(plan_windows(work_dir)),
+    }
+}
+
+/// Detect the terminal emulator jefe is running inside, from its own process
+/// environment. Reads `TERM_PROGRAM` (set by iTerm2, Apple Terminal, WezTerm,
+/// VS Code, …) and falls back to macOS' `__CFBundleIdentifier` bundle id.
+fn detect_emulator_from_env() -> Option<String> {
+    std::env::var("TERM_PROGRAM")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            std::env::var("__CFBundleIdentifier")
+                .ok()
+                .filter(|s| !s.is_empty())
+        })
+}
+
+/// Resolve a detected emulator identifier into a structural launch plan.
+///
+/// Returns `None` for unrecognized identifiers so the caller falls back to the
+/// platform default rather than guessing. Pure: no env reads, no I/O.
+fn plan_from_detected(
+    detected: &str,
+    work_dir: &Path,
+    platform: DesktopPlatform,
+) -> Option<ExternalTerminalPlan> {
+    match platform {
+        DesktopPlatform::Macos => {
+            macos_app_for_emulator(detected).map(|app| plan_macos_open(work_dir, app))
+        }
+        DesktopPlatform::Linux => linux_plan_for_emulator(detected, work_dir),
+        // Windows Terminal is already the `plan_windows` default, so a detected
+        // identifier never overrides it.
+        DesktopPlatform::Windows => None,
+    }
+}
+
+/// Map a detected macOS terminal identifier (`TERM_PROGRAM` value or
+/// `__CFBundleIdentifier` bundle id) to the app name `open -a` expects.
+#[must_use]
+fn macos_app_for_emulator(detected: &str) -> Option<&'static str> {
+    match detected {
+        "iTerm.app" | "com.googlecode.iterm2" => Some("iTerm"),
+        "Apple_Terminal" | "com.apple.Terminal" => Some("Terminal"),
+        "WezTerm" => Some("WezTerm"),
+        _ => None,
     }
 }
 
@@ -167,11 +222,17 @@ fn plan_from_override(
 
 /// macOS default: Terminal.app via `open`.
 fn plan_macos(work_dir: &Path) -> ExternalTerminalPlan {
+    plan_macos_open(work_dir, "Terminal")
+}
+
+/// macOS: open a named app (`open -a <app> <workdir>`) in the work directory.
+/// Used both for the default and for a detected/override app name (#549).
+fn plan_macos_open(work_dir: &Path, app: &str) -> ExternalTerminalPlan {
     ExternalTerminalPlan {
         program: "open".to_owned(),
         args: vec![
             "-a".to_owned(),
-            "Terminal".to_owned(),
+            app.to_owned(),
             work_dir.to_string_lossy().into_owned(),
         ],
         work_dir: work_dir.to_path_buf(),
@@ -200,6 +261,25 @@ fn plan_linux(work_dir: &Path) -> Result<ExternalTerminalPlan, ExternalTerminalE
     }
 
     Err(ExternalTerminalError::NoTerminalFound)
+}
+
+/// Build a structural plan for a known Linux emulator detected from the
+/// environment (`TERM_PROGRAM`). Returns `None` for unrecognized emulators so
+/// the caller falls back to PATH discovery. Pure: no env reads, no I/O.
+fn linux_plan_for_emulator(detected: &str, work_dir: &Path) -> Option<ExternalTerminalPlan> {
+    let program = match detected {
+        "WezTerm" => "wezterm",
+        _ => return None,
+    };
+    Some(ExternalTerminalPlan {
+        program: program.to_owned(),
+        args: vec![
+            "start".to_owned(),
+            "--cwd".to_owned(),
+            work_dir.to_string_lossy().into_owned(),
+        ],
+        work_dir: work_dir.to_path_buf(),
+    })
 }
 
 fn linux_gnome_args(work_dir: &Path) -> Vec<String> {

--- a/src/runtime/external_terminal_tests.rs
+++ b/src/runtime/external_terminal_tests.rs
@@ -145,6 +145,15 @@ fn macos_maps_wezterm_to_wezterm_app() {
 }
 
 #[test]
+fn macos_maps_wezterm_bundle_id_to_wezterm_app() {
+    // __CFBundleIdentifier fallback when TERM_PROGRAM is unset (#549 review).
+    assert_eq!(
+        super::macos_app_for_emulator("com.github.wez.wezterm"),
+        Some("WezTerm")
+    );
+}
+
+#[test]
 fn macos_unknown_emulator_maps_to_none() {
     assert_eq!(super::macos_app_for_emulator("MysteryTerm"), None);
     assert_eq!(super::macos_app_for_emulator(""), None);
@@ -194,8 +203,14 @@ fn linux_maps_wezterm_emulator_to_wezterm_plan() {
         panic!("WezTerm must resolve to a plan");
     };
     assert_eq!(plan.program, "wezterm");
-    assert!(plan.args.iter().any(|arg| arg == "--cwd"));
-    assert!(plan.args.iter().any(|arg| arg == "start"));
+    assert_eq!(
+        plan.args,
+        vec![
+            "start".to_owned(),
+            "--cwd".to_owned(),
+            dir.to_string_lossy().to_string()
+        ]
+    );
     assert_eq!(plan.work_dir, dir);
 }
 

--- a/src/runtime/external_terminal_tests.rs
+++ b/src/runtime/external_terminal_tests.rs
@@ -41,10 +41,13 @@ fn plan_accepts_valid_work_dir() {
 // ── A9: macOS structural plan ─────────────────────────────────────────────
 
 #[test]
-fn macos_plan_uses_open_terminal_app() {
+fn macos_default_plan_uses_open_terminal_app() {
+    // Test the pure default plan directly. The full `build_external_terminal_plan`
+    // resolver now honors a detected emulator from the environment (#549), so
+    // exercising the default path here keeps the assertion deterministic
+    // regardless of which terminal runs `cargo test`.
     let dir = tmp_work_dir();
-    let plan = build_external_terminal_plan(&dir, DesktopPlatform::Macos)
-        .unwrap_or_else(|e| panic!("macos plan: {e}"));
+    let plan = super::plan_macos(&dir);
     assert_eq!(plan.program, "open");
     assert!(plan.args.contains(&"-a".to_owned()));
     assert!(plan.args.contains(&"Terminal".to_owned()));
@@ -107,6 +110,107 @@ fn windows_wt_plan_uses_separate_argv() {
         let has_d_flag = plan.args.iter().any(|arg| arg == "-d");
         assert!(has_d_flag, "wt.exe plan must have -d as separate arg");
     }
+}
+
+// ── Terminal detection mappings (issue #549) ──────────────────────────────
+
+#[test]
+fn macos_maps_iterm_term_program_to_iterm_app() {
+    assert_eq!(super::macos_app_for_emulator("iTerm.app"), Some("iTerm"));
+}
+
+#[test]
+fn macos_maps_iterm_bundle_id_to_iterm_app() {
+    assert_eq!(
+        super::macos_app_for_emulator("com.googlecode.iterm2"),
+        Some("iTerm")
+    );
+}
+
+#[test]
+fn macos_maps_apple_terminal_to_terminal_app() {
+    assert_eq!(
+        super::macos_app_for_emulator("Apple_Terminal"),
+        Some("Terminal")
+    );
+    assert_eq!(
+        super::macos_app_for_emulator("com.apple.Terminal"),
+        Some("Terminal")
+    );
+}
+
+#[test]
+fn macos_maps_wezterm_to_wezterm_app() {
+    assert_eq!(super::macos_app_for_emulator("WezTerm"), Some("WezTerm"));
+}
+
+#[test]
+fn macos_unknown_emulator_maps_to_none() {
+    assert_eq!(super::macos_app_for_emulator("MysteryTerm"), None);
+    assert_eq!(super::macos_app_for_emulator(""), None);
+}
+
+#[test]
+fn plan_macos_open_is_structural_argv_for_named_app() {
+    let dir = tmp_work_dir();
+    let plan = super::plan_macos_open(&dir, "iTerm");
+    assert_eq!(plan.program, "open");
+    assert_eq!(
+        plan.args,
+        vec![
+            "-a".to_owned(),
+            "iTerm".to_owned(),
+            dir.to_string_lossy().to_string()
+        ]
+    );
+    for arg in &plan.args {
+        assert!(!arg.contains("&&"), "dangerous shell operator in: {arg}");
+        assert!(!arg.contains(';'), "dangerous separator in: {arg}");
+        assert!(!arg.starts_with("cd "), "shell cd command in: {arg}");
+    }
+}
+
+#[test]
+fn plan_from_detected_macos_iterm_produces_open_a_iterm() {
+    let dir = tmp_work_dir();
+    let Some(plan) = super::plan_from_detected("iTerm.app", &dir, DesktopPlatform::Macos) else {
+        panic!("iTerm.app must resolve to a plan");
+    };
+    assert_eq!(plan.program, "open");
+    assert!(plan.args.contains(&"iTerm".to_owned()));
+    assert_eq!(plan.work_dir, dir);
+}
+
+#[test]
+fn plan_from_detected_macos_unknown_falls_back_to_none() {
+    let dir = tmp_work_dir();
+    assert!(super::plan_from_detected("MysteryTerm", &dir, DesktopPlatform::Macos).is_none());
+}
+
+#[test]
+fn linux_maps_wezterm_emulator_to_wezterm_plan() {
+    let dir = tmp_work_dir();
+    let Some(plan) = super::linux_plan_for_emulator("WezTerm", &dir) else {
+        panic!("WezTerm must resolve to a plan");
+    };
+    assert_eq!(plan.program, "wezterm");
+    assert!(plan.args.iter().any(|arg| arg == "--cwd"));
+    assert!(plan.args.iter().any(|arg| arg == "start"));
+    assert_eq!(plan.work_dir, dir);
+}
+
+#[test]
+fn linux_unknown_emulator_maps_to_none() {
+    let dir = tmp_work_dir();
+    assert!(super::linux_plan_for_emulator("MysteryTerm", &dir).is_none());
+}
+
+#[test]
+fn plan_from_detected_windows_is_none_so_default_wins() {
+    let dir = tmp_work_dir();
+    assert!(
+        super::plan_from_detected("Windows Terminal", &dir, DesktopPlatform::Windows).is_none()
+    );
 }
 
 // ── JEFE_TERMINAL override (structural) ───────────────────────────────────

--- a/tests/issue382/agent_probe_runtime.rs
+++ b/tests/issue382/agent_probe_runtime.rs
@@ -217,18 +217,13 @@ fn assert_one_fixture(definitions: &[AgentDefinition], fixture: &Path, generatio
         result.executable_fingerprint(),
         Some(install.resolved().fingerprint())
     );
-    // A trusted capability probe (issue #534) takes its capabilities from the
-    // shipped declaration, so it must not spend a second `--help` invocation.
-    let trusted = install
-        .definition
-        .probe
-        .capabilities
-        .as_ref()
-        .is_some_and(|probe| probe.trusted);
-    let expected_invocations: &[&str] = if trusted {
-        &["--version"]
-    } else {
-        &["--version", "--help"]
+    // Trusted capability probes skip the `--help` subprocess (#534) and run only
+    // the `--version` identity probe; a missing capability probe also skips
+    // `--help`; an untrusted probe still verifies `--help`.
+    let expected_invocations: &[&str] = match install.definition.probe.capabilities.as_ref() {
+        None => &["--version"],
+        Some(probe) if probe.trusted => &["--version"],
+        Some(_) => &["--version", "--help"],
     };
     assert_eq!(install.invocations(), expected_invocations);
 }


### PR DESCRIPTION
## Summary

Closes #549. F8 (open external terminal) previously hardcoded macOS Terminal.app via `open -a Terminal`, regardless of which terminal the user launched jefe from. This PR adds **auto-detection** of the terminal jefe is running inside, so a user in iTerm2 (or WezTerm) gets that emulator instead of always falling back to Terminal.app.

The settings.toml `[terminal] external` override (the explicit escape hatch) is split into follow-up #551, since it requires extending the schema-2 owned-document settings system — a separate, larger change.

This PR also repairs **four CI gates that were red on `main`** (regressions from #534/#535), per the no-known-failures policy.

## How detection works

Resolution order in `build_external_terminal_plan` (`src/runtime/external_terminal.rs`):

1. `JEFE_TERMINAL` env override (unchanged).
2. **Auto-detect** from jefe's own process env (new): `TERM_PROGRAM` → `__CFBundleIdentifier` fallback. Maps known identifiers to a structural `open -a <app>` (macOS) or `wezterm start --cwd` (Linux) plan.
3. Platform default (Terminal.app / gnome-terminal+ / wt.exe) — unchanged.

Detection reads jefe's process env, i.e. whatever terminal the user typed `jefe` into. Unknown identifiers fall through to the platform default rather than guessing. Windows detection returns `None` (wt.exe is already the `plan_windows` default).

All plans remain **structural-argv only** — no shell strings (the existing invariant in `external_terminal_tests.rs` is preserved).

## Changes

**Detection (issue #549):**
- `src/runtime/external_terminal.rs`: `detect_emulator_from_env`, `macos_app_for_emulator` (iTerm/Terminal/WezTerm mapping incl. bundle ids), `linux_plan_for_emulator` (WezTerm), `plan_from_detected`, parameterized `plan_macos_open`. Wired as resolution step 2.
- `src/runtime/external_terminal_tests.rs`: 9 new tests covering identifier mappings, bundle-id fallback, structural-argv safety, and per-platform plan composition.

**Main CI gate repairs (regressions from #534/#535):**
- `src/runtime/agent_probe.rs`: pre-existing `cargo fmt` deviation that failed the Format gate (and the Native Windows gate, which runs the same fmt check).
- `tests/issue382/agent_probe_runtime.rs`: `probe_parser_four_agents` asserted `--version --help` for all fixtures, but trusted agents (LLxprt) now correctly skip `--help` (#534 design). The panic also aborted the coverage run (hence the Coverage gate failure). Fixed with a `match` that distinguishes trusted / missing / untrusted probes.
- `tests/issue382_behavior.rs` → `tests/issue534_trusted_probe.rs`: the two #534 shipped-definition tests were appended to `issue382_behavior.rs`, pushing it to 1028 lines over the 1000-line source-size hard limit. Moved into a new self-contained platform-agnostic file.

## Verification

- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓ (incl. complexity clippy)
- `cargo xtask check source-size` ✓ (issue382_behavior.rs now 992 lines)
- `cargo xtask check architecture` ✓
- `cargo test --workspace --all-features` ✓ (zero failures)
- `cargo xtask coverage` ✓ — 71.19% (gate ≥30%)
- Open Code Review: 3 findings, all addressed in commit `838990f1` (WezTerm bundle-id gap, test arg-ordering assertion, probe-test None handling).

## Non-goals / out of scope

- settings.toml `[terminal] external` override → #551.
- Parent-process-tree detection (documented tmux caveat; the env override covers it).
