### PR TITLE
Re-resolve stuck version[nightly] selectors after a TTL (Fixes #554)

### DIFF
--- a/project-plans/issue554-plan.md
+++ b/project-plans/issue554-plan.md
@@ -1,0 +1,84 @@
+# Issue #554 — `version[nightly]` cache never refreshes
+
+> when an agent has version[nightly] it is caching it under that name and never
+> updating to the latest nightly.
+
+## Root cause
+
+The active production install cache is `src/runtime/package_runtime.rs`, reached
+on every versioned launch via `launch_compose::prepare_launch → local_candidate
+→ finalize_local_invocation`. `cache_hit` treats an install as permanent once
+the `.jefe-installed` marker string matches the selector's **effective** dist-tag
+(e.g. `nightly` / `latest`) and the binary exists.
+
+Because the effective dist-tag is a constant, the marker **always** matches, so
+`npm install` never re-runs and the dist-tag is never re-resolved. Worse,
+`npm install` writes a `package-lock.json` that pins the resolved version, so
+even a forced re-install would reuse the stale resolution. Result: an agent on
+`version[nightly]` is frozen on the first nightly it ever downloaded.
+
+(`src/runtime/llxprt_install.rs` carries the identical latent bug, but its
+public entry points (`ensure_installed`, `local_managed_bin_dir`, …) have **no
+production callers** — the generalized `package_runtime.rs` superseded it. It is
+recorded as a deferred follow-up, not modified here.)
+
+## Fix
+
+A version selector is **volatile** when it resolves to a moving dist-tag
+(`Latest`, `LatestNightly`). For volatile selectors the cache must periodically
+re-resolve:
+
+1. The marker gains an install-time epoch line for volatile selectors
+   (`package\nbinary\neffective\n<epoch_secs>\n`). Pinned selectors keep the
+   unchanged 3-line marker (permanent hit — explicit versions are immutable).
+2. `cache_hit` accepts a `now: SystemTime`. For volatile selectors an absent or
+   TTL-expired timestamp line is a cache **miss** (re-resolve). Old 3-line
+   markers (no timestamp) auto-heal: they are treated as expired and reinstalled,
+   writing a fresh timestamped marker.
+3. On a volatile re-resolve, the stale `package-lock.json` is removed so
+   `npm install` re-resolves the dist-tag against the registry instead of
+   reusing the locked (old) version.
+4. `VOLATILE_SELECTOR_TTL = 12h` (nightlies publish daily; ~half the cadence
+   bounds staleness to ≤ 12h without hitting the registry on every launch).
+
+## Acceptance matrix
+
+| # | Actor / path | Input | Success behavior | Failure / diagnostic | Test |
+|---|---|---|---|---|---|
+| AC1 | `finalize_local_invocation` for a volatile (`latest nightly`) selection | cache marker timestamp older than TTL | cache treated as **miss** → `npm install` re-runs, fresh timestamp written | — | `volatile_cache_re_resolves_after_ttl` |
+| AC2 | same, marker timestamp within TTL | cache **hit** → `npm install` not invoked | — | `volatile_cache_stays_fresh_within_ttl` |
+| AC3 | volatile selection, old 3-line marker (no timestamp) | legacy/stuck cache | treated as **miss** → reinstalled, timestamped marker written (auto-heal) | — | `volatile_old_marker_without_timestamp_re_installs` |
+| AC4 | pinned (`Explicit`) selection, any age | permanent cache marker | cache **hit** regardless of age → `npm install` not invoked | — | `pinned_cache_remains_permanent_hit` |
+| AC5 | volatile re-resolve path | stale `package-lock.json` present | lockfile removed before `npm install` so dist-tag re-resolves | — | `volatile_re_resolve_removes_stale_lockfile` |
+| AC6 | `VersionSelector::is_volatile` | `Latest`/`LatestNightly` | `true`; `Direct`/`Explicit` → `false` | — | `agent_candidate_tests` |
+
+## Non-goals
+
+- Modifying the unused `llxprt_install.rs` (deferred follow-up: same latent bug,
+  no production callers).
+- Changing remote launches (remote uses `npm exec` structural argv, no jefe
+  managed cache on the remote host — unchanged).
+- Configurable / per-agent TTL (single named constant is sufficient).
+- Resolving/`npm view` lookups before install (rely on `npm install`'s own
+  dist-tag re-resolution once the lockfile is removed).
+- UI / "upgrade detection" changes (the symptom is the cache; fixing the cache
+  removes the stale-upgrade-offer loop).
+
+## Vertical slices
+
+1. **Domain**: `VersionSelector::is_volatile()` + unit tests.
+2. **Runtime cache freshness**: marker timestamp, `cache_hit(now)`, lockfile
+   removal, `finalize_local_invocation_at` testable seam. RED tests first.
+
+## Scope ledger
+
+| Item | Status |
+|---|---|
+| `src/agent_candidate.rs` (is_volatile + tests) | planned |
+| `src/runtime/package_runtime.rs` (TTL/marker/cache_hit/lockfile/seam) | planned |
+| `src/runtime/package_runtime_tests.rs` (RED→GREEN) | planned |
+| `src/agent_candidate_tests.rs` (is_volatile) | planned |
+| `project-plans/issue554-plan.md` (this doc) | added |
+| `llxprt_install.rs` same-class fix | **deferred** (dead code) |
+
+Review counters: OCR local pre-PR 0/2, OCR post-PR 0/2.

--- a/src/agent_candidate.rs
+++ b/src/agent_candidate.rs
@@ -89,6 +89,19 @@ impl VersionSelector {
         matches!(self, Self::Direct)
     }
 
+    /// Whether the selector resolves to a moving package-manager target whose
+    /// published version advances over time (a dist-tag or "latest" sentinel).
+    ///
+    /// `Latest` and `LatestNightly` are volatile: a fresh `npm install` may
+    /// resolve them to a newer build each time. `Direct` and `Explicit` are
+    /// not — an explicit version is an immutable pin. The managed install cache
+    /// uses this to re-resolve volatile selectors periodically (issue #554)
+    /// instead of caching the first resolution forever.
+    #[must_use]
+    pub const fn is_volatile(&self) -> bool {
+        matches!(self, Self::Latest | Self::LatestNightly)
+    }
+
     /// Normalized persisted value; `None` means direct.
     #[must_use]
     pub fn normalized(&self) -> Option<&str> {

--- a/src/agent_candidate_tests.rs
+++ b/src/agent_candidate_tests.rs
@@ -410,6 +410,21 @@ fn version_selector_blank_for_empty_string() {
 }
 
 #[test]
+fn version_selector_volatile_for_moving_sentinels_only() {
+    // Issue #554: only the moving dist-tag sentinels are volatile; an explicit
+    // version is an immutable pin even if its name contains "nightly".
+    assert!(VersionSelector::Latest.is_volatile());
+    assert!(VersionSelector::LatestNightly.is_volatile());
+    assert!(!VersionSelector::Direct.is_volatile());
+    assert!(
+        !VersionSelector::normalize("0.10.0-nightly.260720.abc")
+            .unwrap_or_else(|error| panic!("explicit selector: {error}"))
+            .is_volatile(),
+        "an explicit nightly version string is pinned, not volatile"
+    );
+}
+
+#[test]
 fn version_selector_rejects_nul_byte() {
     let Err(err) = VersionSelector::normalize("a\u{0}b") else {
         panic!("NUL rejected");

--- a/src/runtime/package_runtime.rs
+++ b/src/runtime/package_runtime.rs
@@ -396,9 +396,20 @@ fn prepare_managed_npm(
         write_package_json(&install_dir, selection)?;
         // Issue #554: a stale lockfile makes `npm install` reuse the previously
         // resolved dist-tag target. Drop it for volatile selectors so npm
-        // re-resolves `nightly`/`latest` against the registry.
+        // re-resolves `nightly`/`latest` against the registry. A real failure to
+        // remove an existing lockfile must surface — otherwise npm would silently
+        // reinstall the old target and the freshly stamped marker would freeze
+        // the stale build for another TTL window.
         if selection.selector().is_volatile() {
-            let _ = std::fs::remove_file(install_dir.join("package-lock.json"));
+            match std::fs::remove_file(install_dir.join("package-lock.json")) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(PackageRuntimeError::InstallDirectory(format!(
+                        "failed to remove stale lockfile for re-resolve: {error}"
+                    )));
+                }
+            }
         }
         run_npm_install(candidate, &install_dir)?;
     }

--- a/src/runtime/package_runtime.rs
+++ b/src/runtime/package_runtime.rs
@@ -8,7 +8,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Mutex;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use serde::Serialize;
 
@@ -24,6 +24,15 @@ use super::command_capture::run_command_capture_with_timeout;
 
 const INSTALL_TIMEOUT: Duration = Duration::from_secs(300);
 const INSTALL_MARKER: &str = ".jefe-installed";
+
+/// How long a volatile-selector install (a moving dist-tag such as `nightly`)
+/// is trusted before jefe re-resolves it against the registry (issue #554).
+///
+/// Nightlies publish roughly daily; trusting an install for ~half that cadence
+/// bounds staleness to about twelve hours without hitting the registry on every
+/// launch. Explicit (pinned) selectors are immutable and never expire.
+const VOLATILE_SELECTOR_TTL: Duration = Duration::from_secs(12 * 60 * 60);
+
 static INSTALL_LOCK: Mutex<()> = Mutex::new(());
 
 /// Local managed execution or remote structural execution.
@@ -197,6 +206,18 @@ pub fn finalize_local_invocation(
     candidate: &ResolvedCandidate,
     cache_root: &Path,
 ) -> Result<PackageInvocation, PackageRuntimeError> {
+    finalize_local_invocation_at(candidate, cache_root, SystemTime::now())
+}
+
+/// Time-injected core of [`finalize_local_invocation`] for deterministic tests.
+///
+/// `now` stamps the install marker and gates the volatile-selector freshness
+/// check (issue #554); production callers pass [`SystemTime::now`].
+pub fn finalize_local_invocation_at(
+    candidate: &ResolvedCandidate,
+    cache_root: &Path,
+    now: SystemTime,
+) -> Result<PackageInvocation, PackageRuntimeError> {
     let Some(selection) = candidate.package() else {
         return Ok(PackageInvocation {
             executable: candidate.executable().to_path_buf(),
@@ -206,7 +227,7 @@ pub fn finalize_local_invocation(
         });
     };
     if selection.runner() == PackageRunnerKind::Npm {
-        prepare_managed_npm(candidate, selection, cache_root)
+        prepare_managed_npm(candidate, selection, cache_root, now)
     } else {
         package_invocation(candidate, PackageExecutionTarget::Local, cache_root)?
             .ok_or(PackageRuntimeError::InvalidSelection)
@@ -276,22 +297,93 @@ fn managed_bin_dir(cache_root: &Path, selection: &PackageSelection) -> PathBuf {
         .join(".bin")
 }
 
-fn marker_contents(selection: &PackageSelection) -> String {
-    format!(
+fn marker_contents(selection: &PackageSelection, now: SystemTime) -> String {
+    let effective = selection
+        .selector()
+        .effective(selection.runner())
+        .unwrap_or_default();
+    let base = format!(
         "{}\n{}\n{}\n",
         selection.package(),
         selection.binary(),
-        selection
-            .selector()
-            .effective(selection.runner())
-            .unwrap_or_default()
+        effective
+    );
+    // Issue #554: volatile selectors carry an install-time epoch on a 4th line so
+    // the cache can expire and re-resolve the moving dist-tag. Pinned selectors
+    // keep the legacy 3-line marker (a permanent hit — explicit versions never
+    // change).
+    if !selection.selector().is_volatile() {
+        return base;
+    }
+    let secs = now
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs());
+    format!("{base}{secs}\n")
+}
+
+/// Whether the stored marker identifies this selection AND, for volatile
+/// selectors, was installed within [`VOLATILE_SELECTOR_TTL`] of `now`.
+fn cache_hit(
+    install_dir: &Path,
+    bin_dir: &Path,
+    selection: &PackageSelection,
+    now: SystemTime,
+) -> bool {
+    let Ok(stored) = std::fs::read_to_string(install_dir.join(INSTALL_MARKER)) else {
+        return false;
+    };
+    if !marker_identity_matches(&stored, selection) {
+        return false;
+    }
+    if selection.selector().is_volatile() && !marker_install_is_fresh(&stored, now) {
+        return false;
+    }
+    PathSnapshot::for_platform(
+        AgentExecutablePlatform::current(),
+        vec![bin_dir.to_path_buf()],
+        std::env::var_os("PATHEXT"),
     )
+    .resolve_binary(selection.binary())
+    .is_some()
+}
+
+/// Whether the stored marker's package/binary/effective lines match `selection`.
+fn marker_identity_matches(stored: &str, selection: &PackageSelection) -> bool {
+    let effective = selection
+        .selector()
+        .effective(selection.runner())
+        .unwrap_or_default();
+    let mut lines = stored.split('\n');
+    lines.next() == Some(selection.package())
+        && lines.next() == Some(selection.binary())
+        && lines.next() == Some(effective)
+}
+
+/// Whether a volatile selector's marker install-time line is still within TTL.
+///
+/// A missing or unparseable 4th line (a legacy/stuck 3-line marker) is treated
+/// as expired so the install is rebuilt and auto-healed (issue #554).
+fn marker_install_is_fresh(stored: &str, now: SystemTime) -> bool {
+    let Some(secs_str) = stored.split('\n').nth(3) else {
+        return false;
+    };
+    let Ok(secs) = secs_str.parse::<u64>() else {
+        return false;
+    };
+    let Some(installed) = SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(secs)) else {
+        return false;
+    };
+    // A future-dated marker (clock skew) is treated as expired: re-resolve
+    // rather than trust an untrusted timestamp.
+    now.duration_since(installed)
+        .is_ok_and(|age| age < VOLATILE_SELECTOR_TTL)
 }
 
 fn prepare_managed_npm(
     candidate: &ResolvedCandidate,
     selection: &PackageSelection,
     cache_root: &Path,
+    now: SystemTime,
 ) -> Result<PackageInvocation, PackageRuntimeError> {
     let _guard = match INSTALL_LOCK.lock() {
         Ok(guard) => guard,
@@ -299,9 +391,15 @@ fn prepare_managed_npm(
     };
     let install_dir = managed_install_dir(cache_root, selection);
     let bin_dir = managed_bin_dir(cache_root, selection);
-    let cache_hit = cache_hit(&install_dir, &bin_dir, selection);
+    let cache_hit = cache_hit(&install_dir, &bin_dir, selection, now);
     if !cache_hit {
         write_package_json(&install_dir, selection)?;
+        // Issue #554: a stale lockfile makes `npm install` reuse the previously
+        // resolved dist-tag target. Drop it for volatile selectors so npm
+        // re-resolves `nightly`/`latest` against the registry.
+        if selection.selector().is_volatile() {
+            let _ = std::fs::remove_file(install_dir.join("package-lock.json"));
+        }
         run_npm_install(candidate, &install_dir)?;
     }
     let snapshot = PathSnapshot::for_platform(
@@ -315,8 +413,11 @@ fn prepare_managed_npm(
         });
     };
     if !cache_hit {
-        std::fs::write(install_dir.join(INSTALL_MARKER), marker_contents(selection))
-            .map_err(|error| PackageRuntimeError::InstallDirectory(error.to_string()))?;
+        std::fs::write(
+            install_dir.join(INSTALL_MARKER),
+            marker_contents(selection, now),
+        )
+        .map_err(|error| PackageRuntimeError::InstallDirectory(error.to_string()))?;
     }
     let fingerprint = capture_candidate_fingerprint(&executable)
         .map_err(PackageRuntimeError::InstallDirectory)?;
@@ -326,18 +427,6 @@ fn prepare_managed_npm(
         prefix: Vec::new(),
         fingerprint: Some(fingerprint),
     })
-}
-
-fn cache_hit(install_dir: &Path, bin_dir: &Path, selection: &PackageSelection) -> bool {
-    std::fs::read_to_string(install_dir.join(INSTALL_MARKER))
-        .is_ok_and(|value| value == marker_contents(selection))
-        && PathSnapshot::for_platform(
-            AgentExecutablePlatform::current(),
-            vec![bin_dir.to_path_buf()],
-            std::env::var_os("PATHEXT"),
-        )
-        .resolve_binary(selection.binary())
-        .is_some()
 }
 
 #[derive(Serialize)]

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -356,6 +356,7 @@ fn counting_npm_stub(bin: &TempDir) {
         bin,
         "npm",
         "#!/bin/sh
+set -e
 if [ -f package-lock.json ]; then echo present >> .jefe-lock-witness; else echo absent >> .jefe-lock-witness; fi
 mkdir -p node_modules/.bin
 printf '#!/bin/sh\nexit 0\n' > node_modules/.bin/llxprt

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -3,7 +3,10 @@ use std::path::{Path, PathBuf};
 
 use tempfile::TempDir;
 
-use super::{PackageExecutionTarget, finalize_local_invocation, package_invocation};
+use super::{
+    PackageExecutionTarget, finalize_local_invocation, finalize_local_invocation_at,
+    package_invocation,
+};
 use crate::agent_candidate::{AgentCandidateResolver, CandidateResolution, VersionSelector};
 use crate::domain::RemoteRepositorySettings;
 use crate::domain::agent_definition::{Availability, Operation, Preflight, RemoteTarget};
@@ -334,4 +337,227 @@ fn shipped_unsupported_remote_cell_returns_exact_reason_without_package_effects(
         }
         other => panic!("unsupported remote cell: {other:?}"),
     }
+}
+
+// ── Issue #554: volatile-selector cache freshness ─────────────────────────
+//
+// `latest` / `latest nightly` resolve to moving dist-tags. The managed install
+// cache must re-resolve them periodically (TTL) instead of caching the first
+// resolution forever, and must drop a stale `package-lock.json` so npm actually
+// re-resolves the dist-tag.
+
+#[cfg(unix)]
+fn counting_npm_stub(bin: &TempDir) {
+    // Each invocation records one witness line: "present" if a package-lock.json
+    // already existed when the stub started, otherwise "absent". Counting lines
+    // therefore proves how many times `npm install` ran, and the content proves
+    // whether jefe removed a stale lockfile before re-installing.
+    executable(
+        bin,
+        "npm",
+        "#!/bin/sh
+if [ -f package-lock.json ]; then echo present >> .jefe-lock-witness; else echo absent >> .jefe-lock-witness; fi
+mkdir -p node_modules/.bin
+printf '#!/bin/sh\nexit 0\n' > node_modules/.bin/llxprt
+chmod 755 node_modules/.bin/llxprt
+",
+    );
+}
+
+/// Install directory owning a managed executable (`…/<hash>/node_modules/.bin/llxprt`).
+#[cfg(unix)]
+fn install_dir_of(executable: &Path) -> &Path {
+    executable
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .unwrap_or_else(|| panic!("managed executable lives under an install dir: {}", executable.display()))
+}
+
+#[cfg(unix)]
+fn witness_lines(install_dir: &Path) -> Vec<String> {
+    let path = install_dir.join(".jefe-lock-witness");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read install witness: {error}"))
+        .lines()
+        .map(std::string::ToString::to_string)
+        .collect()
+}
+
+#[cfg(unix)]
+fn volatile_npm_candidate(bin: &TempDir, selector: &str) -> ResolvedCandidate {
+    let definition = definition("LLxprt");
+    resolve_package(&definition, bin, selector)
+}
+
+/// A fixed base instant well after the Unix epoch so offsets stay representable.
+#[cfg(unix)]
+fn base_now() -> std::time::SystemTime {
+    std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000)
+}
+
+#[cfg(unix)]
+#[test]
+fn volatile_cache_stays_fresh_within_ttl() {
+    // AC2: a re-invocation inside the TTL is a cache hit — npm is not re-run.
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    counting_npm_stub(&bin);
+    let candidate = volatile_npm_candidate(&bin, "latest nightly");
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+
+    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("first install: {error}"));
+    let within_ttl =
+        base_now() + super::VOLATILE_SELECTOR_TTL - std::time::Duration::from_secs(1);
+    let second = finalize_local_invocation_at(&candidate, cache.path(), within_ttl)
+        .unwrap_or_else(|error| panic!("second invocation: {error}"));
+
+    assert_eq!(
+        witness_lines(install_dir_of(first.executable())).len(),
+        1,
+        "within-TTL re-invocation must be a cache hit (npm not re-run)"
+    );
+    assert_eq!(
+        first.executable(),
+        second.executable(),
+        "cache hit must reuse the same managed executable"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn volatile_cache_re_resolves_after_ttl() {
+    // AC1: once the install age exceeds the TTL, the cache is a miss and npm
+    // re-runs (re-resolving the moving dist-tag).
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    counting_npm_stub(&bin);
+    let candidate = volatile_npm_candidate(&bin, "latest nightly");
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+
+    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("first install: {error}"));
+    let expired = base_now() + super::VOLATILE_SELECTOR_TTL + std::time::Duration::from_secs(1);
+    finalize_local_invocation_at(&candidate, cache.path(), expired)
+        .unwrap_or_else(|error| panic!("expired re-resolve: {error}"));
+
+    assert_eq!(
+        witness_lines(install_dir_of(first.executable())).len(),
+        2,
+        "past-TTL re-invocation must re-run npm to re-resolve the dist-tag"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn volatile_old_marker_without_timestamp_re_installs() {
+    // AC3: a legacy/stuck marker (3 lines, no timestamp) for a volatile selector
+    // is treated as expired and re-installed, writing a fresh timestamped marker.
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    counting_npm_stub(&bin);
+    let candidate = volatile_npm_candidate(&bin, "latest nightly");
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+
+    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("first install: {error}"));
+    let install_dir = install_dir_of(first.executable()).to_path_buf();
+    // Simulate a stuck/legacy cache: overwrite the marker with the old 3-line
+    // form (no install-time line) while keeping the binary present.
+    let selection = candidate
+        .package()
+        .unwrap_or_else(|| panic!("volatile candidate carries a package selection"));
+    let effective = selection
+        .selector()
+        .effective(selection.runner())
+        .unwrap_or_default();
+    let legacy_marker =
+        format!("{}
+{}
+{}
+", selection.package(), selection.binary(), effective);
+    std::fs::write(install_dir.join(".jefe-installed"), legacy_marker)
+        .unwrap_or_else(|error| panic!("write legacy marker: {error}"));
+    assert_eq!(
+        witness_lines(&install_dir).len(),
+        1,
+        "setup: one install recorded so far"
+    );
+
+    // Any `now` should treat the timestamp-less marker as expired.
+    finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("legacy re-resolve: {error}"));
+    assert_eq!(
+        witness_lines(&install_dir).len(),
+        2,
+        "a timestamp-less volatile marker must trigger a re-install (auto-heal)"
+    );
+    let refreshed = std::fs::read_to_string(install_dir.join(".jefe-installed"))
+        .unwrap_or_else(|error| panic!("read refreshed marker: {error}"));
+    assert!(
+        refreshed.lines().count() >= 4,
+        "refreshed volatile marker must carry an install-time line: {refreshed:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn pinned_cache_remains_permanent_hit() {
+    // AC4: an explicit (pinned) version is immutable — the cache is a permanent
+    // hit regardless of how much time has passed.
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    counting_npm_stub(&bin);
+    let candidate = volatile_npm_candidate(&bin, "0.10.0-nightly.260720.abc");
+    assert!(
+        !candidate
+            .package()
+            .unwrap_or_else(|| panic!("pinned candidate"))
+            .selector()
+            .is_volatile(),
+        "fixture: explicit version is not volatile"
+    );
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+
+    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("first install: {error}"));
+    // Far beyond any TTL: a pinned version must still be a cache hit.
+    let far_future = base_now() + std::time::Duration::from_secs(365 * 24 * 60 * 60);
+    finalize_local_invocation_at(&candidate, cache.path(), far_future)
+        .unwrap_or_else(|error| panic!("pinned re-invocation: {error}"));
+    assert_eq!(
+        witness_lines(install_dir_of(first.executable())).len(),
+        1,
+        "a pinned version must be a permanent cache hit"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn volatile_re_resolve_removes_stale_lockfile() {
+    // AC5: when a volatile cache expires, jefe removes the stale package-lock.json
+    // before re-running npm so the dist-tag is re-resolved instead of reused.
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    counting_npm_stub(&bin);
+    let candidate = volatile_npm_candidate(&bin, "latest nightly");
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+
+    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("first install: {error}"));
+    let install_dir = install_dir_of(first.executable()).to_path_buf();
+    // Plant a stale lockfile exactly where npm would leave it.
+    std::fs::write(install_dir.join("package-lock.json"), "stale-lockfile")
+        .unwrap_or_else(|error| panic!("plant stale lockfile: {error}"));
+
+    let expired = base_now() + super::VOLATILE_SELECTOR_TTL + std::time::Duration::from_secs(1);
+    finalize_local_invocation_at(&candidate, cache.path(), expired)
+        .unwrap_or_else(|error| panic!("expired re-resolve: {error}"));
+
+    let lines = witness_lines(&install_dir);
+    assert_eq!(
+        lines.len(),
+        2,
+        "expired volatile cache must re-run npm"
+    );
+    assert_eq!(
+        lines[1], "absent",
+        "the stale package-lock.json must be removed before npm re-resolves (got {lines:?})",
+    );
 }

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -365,14 +365,28 @@ chmod 755 node_modules/.bin/llxprt
     );
 }
 
-/// Install directory owning a managed executable (`…/<hash>/node_modules/.bin/llxprt`).
+/// Install directory owning a managed executable.
+///
+/// Walks upward from the binary (`…/<hash>/node_modules/.bin/llxprt`) to the
+/// nearest ancestor that holds the `.jefe-installed` marker, rather than
+/// assuming a fixed directory depth, so a structural change cannot silently
+/// target the wrong directory.
 #[cfg(unix)]
 fn install_dir_of(executable: &Path) -> &Path {
-    executable
+    let mut dir = executable
         .parent()
-        .and_then(Path::parent)
-        .and_then(Path::parent)
-        .unwrap_or_else(|| panic!("managed executable lives under an install dir: {}", executable.display()))
+        .unwrap_or_else(|| panic!("managed executable has a parent dir: {}", executable.display()));
+    loop {
+        if dir.join(".jefe-installed").exists() {
+            return dir;
+        }
+        dir = dir.parent().unwrap_or_else(|| {
+            panic!(
+                "no ancestor of {} holds the .jefe-installed marker",
+                executable.display()
+            )
+        });
+    }
 }
 
 #[cfg(unix)]
@@ -493,9 +507,19 @@ fn volatile_old_marker_without_timestamp_re_installs() {
     );
     let refreshed = std::fs::read_to_string(install_dir.join(".jefe-installed"))
         .unwrap_or_else(|error| panic!("read refreshed marker: {error}"));
+    let lines: Vec<&str> = refreshed.lines().collect();
     assert!(
-        refreshed.lines().count() >= 4,
+        lines.len() >= 4,
         "refreshed volatile marker must carry an install-time line: {refreshed:?}"
+    );
+    // The identity lines must be preserved across the refresh (no corruption).
+    assert_eq!(lines[0], selection.package(), "package line preserved");
+    assert_eq!(lines[1], selection.binary(), "binary line preserved");
+    assert_eq!(lines[2], effective, "effective-selector line preserved");
+    assert!(
+        lines[3].parse::<u64>().is_ok(),
+        "the 4th line must be a valid install-time epoch, got {:?}",
+        lines[3]
     );
 }
 
@@ -560,5 +584,9 @@ fn volatile_re_resolve_removes_stale_lockfile() {
     assert_eq!(
         lines[1], "absent",
         "the stale package-lock.json must be removed before npm re-resolves (got {lines:?})",
+    );
+    assert!(
+        !install_dir.join("package-lock.json").exists(),
+        "the stale lockfile must remain absent after the re-resolve completes"
     );
 }


### PR DESCRIPTION
## Problem

When an agent is configured with `version[nightly]` (the `latest nightly` sentinel), jefe caches the installed build under a directory named `nightly/` and never refreshes it. The managed-install cache-hit check compared the marker file (which always contained the constant string `nightly`), so `npm install` was never re-run after the first download. The pinned nightly froze at the first resolution and never advanced to the current nightly — the agent was "stuck" on an old build.

The same defect affected the `latest` stable sentinel and the generic npm-backed package cache in `package_runtime.rs`.

## Root cause

A moving dist-tag selector (`nightly`, `latest`) has a constant effective install spec, so the cache marker was a permanent match. There was no freshness concept: once installed, the dist-tag was never re-resolved against the registry. Explicit (pinned) versions are immutable and correctly permanent — the bug was specific to the volatile dist-tag selectors.

## Fix

- **`VersionSelector::is_volatile()`** (domain) — distinguishes moving dist-tag sentinels (`Latest`, `LatestNightly`) from immutable explicit versions (`Direct`, `Explicit`), so the cache can treat only volatile selectors as expiring. An explicit `0.10.0-nightly.*` version string is pinned, not volatile.
- **TTL-bounded cache for volatile selectors** (`package_runtime.rs`) — volatile installs now stamp an epoch timestamp in the marker and are treated as a cache miss once older than `VOLATILE_SELECTOR_TTL` (12h, ~half the nightly publish cadence). On a miss, the stale `package-lock.json` is removed so npm re-resolves the dist-tag against the registry instead of reusing the previously pinned target.
- **Legacy compatibility + auto-heal** — pinned selectors keep the permanent, legacy 3-line marker (unchanged). A stuck legacy volatile marker with no timestamp is treated as expired, so existing "stuck" installs auto-heal on the next launch without manual cache clearing.

## Behavior matrix

| Selector | Marker | Cache behavior |
|---|---|---|
| `latest` / `latest nightly` | effective spec + epoch | Expires after 12h, re-resolves via npm |
| Explicit version (e.g. `0.9.0`) | effective spec only | Permanent hit (immutable pin) |
| Stuck legacy volatile marker | spec, no timestamp | Treated as expired → auto-heals |

## Tests (TDD)

Behavioral tests added in `package_runtime_tests.rs`:
- `volatile_cache_re_resolves_after_ttl` — install past TTL triggers re-resolve
- `volatile_cache_stays_fresh_within_ttl` — install within TTL is a permanent hit
- `pinned_cache_remains_permanent_hit` — explicit version never expires
- `volatile_old_marker_without_timestamp_re_installs` — stuck legacy marker auto-heals
- `volatile_re_resolve_removes_stale_lockfile` — package-lock.json removed before re-resolve

Plus `version_selector_volatile_for_moving_sentinels_only` in the domain unit tests.

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo build --workspace --all-features --locked` ✅
- `cargo test --workspace --all-features --locked` ✅ (one flaky harness timing test `harness_v1_fixtures::llxprt_continue_field_fixture_*` failed once under full parallel load; passes in isolation on both this branch and main — it uses a direct unversioned launch whose code path returns before the install-cache change)

## Scope

4 source files changed (~367 net lines), within the 25-file / 1,500-line budget. No new dependencies, no workflow/agent-memory/quality-tool changes. Open Code Review: 1 local run (within the 2+2 cap); both in-scope findings (lockfile error propagation, test stub `set -e`) were fixed.