### PR TITLE
DO NOT MERGE: V6 demonstration for #545 (deliberate fmt error)

### DIFF
--- a/src/runtime/agent_probe_process.rs
+++ b/src/runtime/agent_probe_process.rs
@@ -232,7 +232,7 @@ mod tests {
     use super::{ProbeProcessError, run_probe_process};
 
     const NESTED_MARKER: &str = "JEFE_PROBE_STDIN_NESTED";
-    const STDIN_REPORTER_MARKER: &str = "JEFE_PROBE_STDIN_REPORTER";
+    const    STDIN_REPORTER_MARKER:&str="JEFE_PROBE_STDIN_REPORTER";
     const TEST_NAME: &str = "runtime::agent_probe_process::tests::probe_child_receives_null_stdin_under_inherited_parent_stdin";
 
     #[test]


### PR DESCRIPTION
Throwaway PR proving verification criterion V6 of #545.

A deliberate rustfmt violation is introduced in `src/runtime/agent_probe_process.rs`.

Expected: `Format (rustfmt)` fails, `Native Windows (MSVC + psmux)` fails at its own fmt step so its native steps report `skipped`, `Native Windows completion gate` therefore fails, and the ruleset blocks merge.

This PR will be closed and its branch deleted once the evidence is captured. Do not merge.