### PR TITLE
Stop measuring machine load in gh_async delivery tests (Fixes #562)

### DIFF
--- a/src/app_input/gh_async.rs
+++ b/src/app_input/gh_async.rs
@@ -270,31 +270,29 @@ mod tests {
         let deliveries = GhDeliveryHandle::default();
         let (sender, receiver) = mpsc::channel();
 
-        smol::block_on(async move {
+        smol::block_on(async {
             let mut app = element!(PanicProbe(
                 deliveries: Some(deliveries),
                 notify: Some(sender),
             ));
-            let result = smol::future::or(
-                async move {
-                    let _: Vec<_> = app
-                        .mock_terminal_render_loop(MockTerminalConfig::default())
-                        .collect()
-                        .await;
-                    receiver.recv().ok()
-                },
-                async {
-                    smol::Timer::after(Duration::from_secs(10)).await;
-                    None
-                },
-            )
-            .await;
-            let message = result.unwrap_or_default();
-            assert!(
-                message.starts_with("panic handled: boom (at "),
-                "panic message and location must reach state: {message}"
-            );
+            let _: Vec<_> = app
+                .mock_terminal_render_loop(MockTerminalConfig::default())
+                .collect()
+                .await;
         });
+
+        // The probe sends before it exits the render loop, so the value is
+        // already queued once the loop above drains. `try_recv` keeps this a
+        // behavioural assertion rather than a wall-clock race, and the render
+        // loop itself is left unbounded so a genuine hang is caught by the test
+        // harness instead of by a deadline that only measures load (issue #562).
+        let message = receiver
+            .try_recv()
+            .unwrap_or_else(|_| panic!("the contained panic must reach state"));
+        assert!(
+            message.starts_with("panic handled: boom (at "),
+            "panic message and location must reach state: {message}"
+        );
     }
 
     #[derive(Default, Props)]
@@ -372,22 +370,17 @@ mod tests {
                 deliveries: Some(deliveries),
                 observed: Some(observed_tx),
             ));
-            let _: Vec<_> = smol::future::or(
-                async {
-                    app.mock_terminal_render_loop(MockTerminalConfig::default())
-                        .collect()
-                        .await
-                },
-                async {
-                    smol::Timer::after(Duration::from_secs(10)).await;
-                    Vec::new()
-                },
-            )
-            .await;
+            let _: Vec<_> = app
+                .mock_terminal_render_loop(MockTerminalConfig::default())
+                .collect()
+                .await;
         });
 
+        // The probe sends before it exits the render loop, so by the time the
+        // loop above has drained the value is already queued. `try_recv` keeps
+        // this a behavioural assertion instead of a wall-clock race (issue #562).
         let (render_thread, apply_thread) = observed_rx
-            .recv_timeout(Duration::from_secs(5))
+            .try_recv()
             .unwrap_or_else(|_| panic!("the background result must be applied"));
         assert_eq!(
             render_thread, apply_thread,
@@ -474,22 +467,16 @@ mod tests {
                 deliveries: Some(deliveries),
                 observed: Some(observed_tx),
             ));
-            let _: Vec<_> = smol::future::or(
-                async {
-                    app.mock_terminal_render_loop(MockTerminalConfig::default())
-                        .collect()
-                        .await
-                },
-                async {
-                    smol::Timer::after(Duration::from_secs(10)).await;
-                    Vec::new()
-                },
-            )
-            .await;
+            let _: Vec<_> = app
+                .mock_terminal_render_loop(MockTerminalConfig::default())
+                .collect()
+                .await;
         });
 
+        // Sent synchronously during the render that records the panic, so the
+        // value is queued once the loop above drains (issue #562).
         let (count, title, detail, screen_mode) = observed_rx
-            .recv_timeout(Duration::from_secs(5))
+            .try_recv()
             .unwrap_or_else(|_| panic!("a silent route panic must reach the errors screen"));
         assert_eq!(count, 1, "exactly one error entry must be retained");
         assert_eq!(title, "Background task panicked");
@@ -624,7 +611,22 @@ mod tests {
                 .await;
         });
 
-        assert!(worker_rx.recv_timeout(Duration::from_secs(2)).is_ok());
-        assert!(applied_rx.recv_timeout(Duration::from_millis(100)).is_err());
+        // The worker runs on a blocking thread and may still be scheduling when
+        // the render loop drains, so wait for it without a deadline: a genuine
+        // failure to deliver is a hang the harness catches, whereas a fixed
+        // budget only measures machine load (issue #562).
+        assert!(
+            worker_rx.recv().is_ok(),
+            "the worker must report that it produced a result"
+        );
+        // Deliberately a bounded *negative* assertion, not a `try_recv`. The
+        // worker signals `worker_notify` before `deliver()` runs, so the
+        // delivery may still be in flight here. A negative assertion can only
+        // ever catch more by waiting longer, so this window is not
+        // load-sensitive in the failing direction and must not be shortened.
+        assert!(
+            applied_rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            "a late worker result must not be applied after the component drops"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #562.

`late_request_result_is_not_applied_after_component_drop` asserted that a worker delivered
its result within a fixed 2 second budget:

```rust
assert!(worker_rx.recv_timeout(Duration::from_secs(2)).is_ok());
```

That budget was never contended while the `windows_native` job set `RUST_TEST_THREADS: "1"`.
#550 removed that serialization, so at default parallelism on a 2-core hosted runner —
alongside 799 sibling tests — the receive stopped being a behavioural assertion and became a
thread-scheduling measurement. It failed on run 30676845017 / job 91305793779, on a commit
that changed one line of whitespace in an unrelated file.

The test is right about the behaviour it guards and wrong about how it waits.

### The fix

Per the issue, the timeout is not raised, nothing is `#[ignore]`d, and the suite is not
re-serialized. The wait is restructured so it is no longer load-sensitive.

**1. The positive receive is now unbounded.**

```rust
assert!(
    worker_rx.recv().is_ok(),
    "the worker must report that it produced a result"
);
```

A worker that genuinely never delivers is a hang, and a hang fails the job through the
harness either way. A deadline can only ever add a second, wrong reason to fail. The sender
is owned by the detached worker task, so if the worker dies without sending, the channel
disconnects and `recv()` returns `Err` — this cannot wedge on a real regression.

**2. The 100ms window on `applied_rx` is deliberately kept.**

It is a *negative* assertion — nothing must arrive — and `worker_notify` fires before
`deliver()` runs, so the suppressed delivery may still be in flight at that point. A negative
assertion can only ever catch more by waiting longer, so this bound is not load-sensitive in
the failing direction. The comment in the source says so, and says it must not be shortened.

**3. The same defect in the three sibling tests in this module is fixed too.**

Each of them wrapped its mock render loop in a 10 second `smol::Timer` race and then waited a
further 5 seconds on a channel — the two largest fixed timeouts in the module, and both pure
load measurements. Every probe sends on its channel strictly before it calls `exit()`, and
`exit()` strictly precedes the render loop draining, so once `collect().await` returns the
value is already queued. The render loops are now awaited directly and the receives are
`try_recv()`, which turns "eventually, if the machine cooperates" into "already true".

This is called out explicitly because it is slightly wider than the single reported call
site. It is the same defect class in the same module, and the issue's acceptance requires
that no larger fixed timeout be introduced anywhere in the test; leaving a 10s deadline two
functions away would have been fixing the report rather than the defect.

Net effect on wall-clock constants in this module: three removed, one replaced with an
unbounded wait, none added or widened.

### Scope

One file, test-only, 50 insertions / 48 deletions. No production code path is touched.
Sub-issue of the Windows stabilization epic #539.

## Pre-push checklist

- [x] **Format** — `cargo fmt --all --check`, exit 0
- [x] **Clippy allow policy** — CI `Clippy allow policy` job green (no first-party allows added)
- [x] **Source file length** — CI `Source file length checks` green (`gh_async.rs` is 632 lines, net +2)
- [x] **Architecture boundary policy** — CI `Architecture boundary policy` green
- [x] **Lint** — `cargo clippy --workspace --all-targets --all-features -- -D warnings`, exit 0
- [x] **Complexity** — CI `Complexity checks` green
- [x] **Coverage** — CI `Coverage gate` and `Windows coverage floors` both green. Not run
      locally: this host's toolchain has no `profiler_builtins` component, so the
      instrumented link fails for environmental reasons unrelated to the change.
- [x] **Build** — `cargo build --workspace --all-features --locked`, exit 0
- [x] **Tests** — `cargo test --workspace --all-features --locked`, exit 0 (all 62 targets)

Optional TUI smoke: not applicable. This change touches no runtime or UI code.

## Testing notes

**RED demonstrated.** The suppression under test is iocraft's lifecycle binding: a delivery
queued on a dropped component's `use_async_handler` is never polled. Removing it — replacing
`DroppedDeliveryProbe`'s `use_async_handler` with a plain `Handler` that delivers
synchronously — makes the late result reach the dropped component:

```
test app_input::gh_async::tests::late_request_result_is_not_applied_after_component_drop ... FAILED
panicked at src\app_input\gh_async.rs:622:9:
a late worker result must not be applied after the component drops
test result: FAILED. 0 passed; 1 failed
```

The mutation was reverted; only the test-wait restructuring is in this PR.

**10 consecutive runs at default parallelism, on native Windows.** Whole 800-test binary, no
`--test-threads` override:

```
run 1..10: PASS
TOTAL_FAILURES=0
```

**Contended runs.** Because 10 sequential runs on an idle machine is exactly the measurement
that let this defect through in the first place, the same binary was also run as 6 concurrent
full-suite instances on one host, to force the contention a 2-core runner sees:

```
parallel 1..6: PASS
CONTENDED_FAILURES=0
```

**No larger fixed timeout introduced.** Confirmed by the diff. The only remaining wall-clock
values in the module are the pre-existing 10ms and 100ms `smol::Timer` sequencing delays
inside the probe components — which order the component swap and keep the app mounted while
the worker runs, and only ever fail in the direction of waiting longer — plus the retained
100ms negative-assertion window.

**Exact-head verification** at `f6075edf`, rebased on `origin/main` `e2c4dc2a`: fmt, clippy
`-D warnings`, locked all-feature build, and locked all-feature workspace test all exit 0.

## Reviewers / Assignees

@acoliver
