### PR TITLE
Deny rustc warnings in [lints.rust] so every cargo invocation fails on them (Fixes #564)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,11 @@ path = "src/bin/jefe-jsp-compliance.rs"
 iocraft = { path = "vendor/iocraft" }
 
 [lints.rust]
+# Issue #564: deny all rustc warnings on every cargo invocation (build, check,
+# test, clippy) — not only the clippy CI jobs that pass -D warnings. Scoped to
+# the rust namespace, so [lints.clippy] allow entries are unaffected.
 unsafe_code = "forbid"
+warnings = "deny"
 
 [lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/project-plans/issue564-plan.md
+++ b/project-plans/issue564-plan.md
@@ -1,0 +1,61 @@
+# Issue #564 — Rustc warnings only enforced by the single clippy CI job
+
+> `unused_imports`, `dead_code`, `unused_variables`, `unused_mut` (rustc lints)
+> are only denied by the clippy jobs that pass `-D warnings`. Every other path
+> (`cargo build`, `cargo test`, `cargo check`) tolerates them, so a real unused
+> import is green everywhere except one gate. Fix: deny rustc warnings at the
+> lowest level via `[lints.rust] warnings = "deny"`.
+
+## Acceptance matrix
+
+| # | Launch path | Input | Success behavior | Failure behavior | Evidence |
+|---|-------------|-------|------------------|------------------|----------|
+| A1 | `cargo build` (local + CI `build`) | clean tree | green | n/a | full suite |
+| A2 | `cargo build` (local + CI `build`) | source with unused import | **fails** with rustc `unused_imports` denied | exit != 0 | procedural verification |
+| A3 | `cargo check` (local) | source with unused import | **fails** | exit != 0 | procedural verification |
+| A4 | `cargo test` (local + CI `test`) | source with unused import | **fails** to compile | exit != 0 | procedural verification |
+| A5 | `cargo clippy -- -D warnings` (CI `lint`/`windows_clippy`) | clean tree | green (no regression) | n/a | full suite |
+| A6 | `[lints.clippy]` allow-list | clean tree | still suppresses intended clippy lints | n/a | clippy green + `lint_config_policy` guard |
+| A7 | `[lints.rust]` config | Cargo.toml | `warnings = "deny"` + `unsafe_code = "forbid"` present | regression test fails if removed | `tests/lint_config_policy.rs` |
+
+## Non-goals
+
+- Changing clippy lint levels or complexity / source-size / architecture policies.
+- Adding new clippy lints or changing `pedantic` / `nursery` levels.
+- Adding a Makefile / justfile local runner (optional item 3 — out of scope).
+- Enumerating individual rustc lints instead of blanket `warnings = "deny"`
+  (optional item 2 — the primary recommendation is the blanket deny).
+- Adding `-D warnings` to CI `build` / `test` jobs explicitly (optional item 4 —
+  redundant once `[lints]` denies warnings).
+
+## Vertical slice
+
+1. **RED** — `tests/lint_config_policy.rs`: repository-text contract test
+   (mirrors `tests/coderabbit_policy.rs` / `tests/ocr_review_policy.rs`) that
+   parses `Cargo.toml`, asserts `[lints.rust]` contains `warnings = "deny"` and
+   `unsafe_code = "forbid"`, and that the `[lints.clippy]` allow entries
+   (`needless_pass_by_value`, `redundant_clone`) remain `allow`. Fails on the
+   current tree (no `warnings` key).
+2. **GREEN** — add `warnings = "deny"` to `[lints.rust]` in `Cargo.toml`. The
+   tree is already clippy `-D warnings` clean, so this is a no-op on current
+   code and only tightens the gate going forward. Test passes.
+
+## Expected files
+
+- `Cargo.toml` — `[lints.rust]` gains `warnings = "deny"` (1 line).
+- `tests/lint_config_policy.rs` — new regression guard.
+
+## Behavioral verification (procedural, not committed)
+
+- Temporarily introduce an unused import in a source file; confirm
+  `cargo build`, `cargo check`, and `cargo test` all fail; restore clean tree.
+- Run full suite green on the clean tree.
+
+## Scope ledger
+
+- (none — within budget: 2 files, ~1 net source line + test)
+
+## Review counters
+
+- Local OCR: 0 / 2
+- PR OCR: 0 / 2

--- a/project-plans/issue564-plan.md
+++ b/project-plans/issue564-plan.md
@@ -57,5 +57,5 @@
 
 ## Review counters
 
-- Local OCR: 0 / 2
+- Local OCR: 1 / 2 (run 1: 2 files, 0 comments — clean)
 - PR OCR: 0 / 2

--- a/tests/lint_config_policy.rs
+++ b/tests/lint_config_policy.rs
@@ -1,0 +1,78 @@
+//! Repository-level contract test for the workspace lint configuration.
+//!
+//! Issue #564: rustc warnings (`unused_imports`, `dead_code`,
+//! `unused_variables`, `unused_mut`) were only denied by the clippy CI jobs
+//! that pass `-D warnings`. Every other cargo invocation (`build`, `check`,
+//! `test`) tolerated them. Denying warnings inside `[lints.rust]` makes every
+//! cargo invocation fail on a rustc warning, not just clippy.
+//!
+//! These tests assert over `Cargo.toml` text (mirroring
+//! `tests/coderabbit_policy.rs` / `tests/ocr_review_policy.rs`) so CI fails
+//! mechanically if the deny-warnings baseline or the clippy allow-list
+//! regresses.
+
+use std::{fs, io, path::Path};
+
+fn repository_text(relative_path: &str) -> io::Result<String> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path);
+    fs::read_to_string(&path).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("could not read {}: {error}", path.display()),
+        )
+    })
+}
+
+/// Collect the body of a TOML `[table]` header: the lines after `header` until
+/// the next line beginning with `[` at the top level.
+fn toml_section<'a>(text: &'a str, header: &str) -> Vec<&'a str> {
+    let needle = format!("[{header}]");
+    text.lines()
+        .skip_while(|line| line.trim() != needle)
+        .skip(1)
+        .take_while(|line| !line.trim_start().starts_with('['))
+        .collect()
+}
+
+fn section_has_setting(section: &[&str], setting: &str) -> bool {
+    section
+        .iter()
+        .any(|line| line.trim() == setting || line.trim().starts_with(&format!("{setting} ")))
+}
+
+#[test]
+fn lints_rust_denies_all_warnings_and_forbids_unsafe() -> io::Result<()> {
+    let manifest = repository_text("Cargo.toml")?;
+    let lints_rust = toml_section(&manifest, "lints.rust");
+
+    assert!(
+        section_has_setting(&lints_rust, "warnings = \"deny\""),
+        "[lints.rust] must set warnings = \"deny\" so every cargo invocation \
+         (build/check/test) fails on a rustc warning, not just clippy"
+    );
+    assert!(
+        section_has_setting(&lints_rust, "unsafe_code = \"forbid\""),
+        "[lints.rust] must keep unsafe_code = \"forbid\""
+    );
+
+    Ok(())
+}
+
+#[test]
+fn lints_clippy_allow_list_still_suppresses_intended_lints() -> io::Result<()> {
+    let manifest = repository_text("Cargo.toml")?;
+    let lints_clippy = toml_section(&manifest, "lints.clippy");
+
+    // The [lints.rust] warnings=deny change must not touch the clippy
+    // namespace; the deliberately-allowed clippy lints must remain allowed so
+    // the existing clippy runs do not regress.
+    for allowed in ["needless_pass_by_value", "redundant_clone"] {
+        assert!(
+            section_has_setting(&lints_clippy, &format!("{allowed} = \"allow\"")),
+            "[lints.clippy] must still allow {allowed}; the rust deny-warnings \
+             change is scoped to the rust namespace"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes #564.

Rustc warnings (`unused_imports`, `dead_code`, `unused_variables`, `unused_mut`) were only enforced by the single clippy CI job that passes `-D warnings`. Every other path — `cargo build`, `cargo check`, `cargo test`, locally and in CI — tolerated them, so a real unused import compiled and tested green everywhere except that one gate. This is a fragile single line of defense and a poor local feedback loop that contradicts the project's fail-fast stance.

## Change

Add `warnings = "deny"` to `[lints.rust]` in `Cargo.toml`:

```toml
[lints.rust]
unsafe_code = "forbid"
warnings = "deny"
```

This is the idiomatic, Cargo-native way to deny all rustc warnings on **every** invocation (build, check, test, clippy). It is scoped to the `rust` lint namespace, so the existing `[lints.clippy]` allow entries (`needless_pass_by_value`, `redundant_clone`, …) are unaffected — those are clippy lints and still apply only during clippy. The tree is already clippy `-D warnings` clean, so this is a no-op on current code and only tightens the gate going forward.

Adds `tests/lint_config_policy.rs` — a repository-text contract guard mirroring `tests/coderabbit_policy.rs` / `tests/ocr_review_policy.rs` — so the deny-warnings baseline and the clippy allow-list cannot silently regress.

## Acceptance evidence

| Criterion | Evidence |
|-----------|----------|
| Unused import fails `cargo build` / `check` / `test` locally | Injected `use std::sync::Barrier;` into `src/lib.rs`; all three failed with exit 101, `-D unused-imports implied by -D warnings` |
| Unused import fails every CI job that compiles code | `[lints.rust]` lives in `Cargo.toml`, so the CI `build` (`cargo build … --locked`) and `test` (`cargo test … --locked`) jobs, plus `windows_clippy` / `windows_native`, all inherit the deny |
| No clean clippy run regresses | `cargo clippy --workspace --all-targets --all-features -- -D warnings` green on clean tree |
| `[lints.clippy]` allow-list still suppresses intended lints | `lint_config_policy` guard asserts the allow entries remain; clippy green confirms |

## Local verification (clean tree)

- `cargo fmt --all --check` — green
- `cargo build --workspace --all-features --locked` — green (now denies warnings)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — green
- `cargo test --workspace --all-features --locked` — green (0 failures)
- Local OCR run 1/2 — 2 files reviewed, 0 comments

## Non-goals

- Changing clippy lint levels or complexity / source-size / architecture policies.
- Adding new clippy lints or changing `pedantic` / `nursery` levels.
- Adding a Makefile / justfile local runner, enumerating individual rustc lints, or adding `-D warnings` to CI build/test jobs explicitly (all optional hardening items explicitly marked out of scope by the issue).
