### PR TITLE
Show linked-PR marker in Issues list meta line (Fixes #187)

### DIFF
--- a/project-plans/issue187-plan.md
+++ b/project-plans/issue187-plan.md
@@ -1,0 +1,133 @@
+# Issue #187 — Issues screen: show when an issue already has linked PR(s)
+
+## Goal
+
+Show a visible, emoji-free indicator in the Issues **list** when an issue has one
+or more linked pull requests, so the user can see at a glance which issues are
+already being worked on while triaging. Linked PR numbers are sourced in bulk
+from the existing GraphQL issue search query via the `timelineItems`
+(`CROSS_REFERENCED_EVENT`) connection — no per-issue network calls and no N+1.
+
+## Decisions
+
+- **Bulk GraphQL, no new transport.** Linked PR numbers are fetched by adding a
+  bounded `timelineItems(first: 15, itemTypes: [CROSS_REFERENCED_EVENT])`
+  selection to the shared `issue_list_node_selection()` used by BOTH the
+  `search(type: ISSUE)` path and the `repository.issues(filterBy:)` path. This
+  is the approach the issue recommends ("fetching `timelineItems` with a
+  `first:` limit in the existing issue list GraphQL query"). It avoids N+1 and
+  adds no new client method or network round-trip.
+- **Domain field on the list type only.** A new `linked_pr_numbers: Vec<u64>`
+  field on `Issue` carries the parsed PR numbers. It is populated only by the
+  GraphQL search/repository parse path; the deprecated legacy `gh issue list
+  --json` path and REST detail parse leave it empty (graceful degradation).
+- **Parse, don't drop.** A `parse_linked_pr_numbers` pure function walks the
+  `timelineItems.nodes`, keeps only `CrossReferencedEvent` nodes whose `source`
+  is a `PullRequest`, reads `source.number`, and de-duplicates while preserving
+  first-seen order. It is a TOTAL function (missing/empty timeline → empty vec).
+- **Emoji-free text marker.** The list meta line gains a `linked:#N` marker
+  (multiple PRs render as `linked:#1,#2`). It is emitted only when the vec is
+  non-empty, matching the existing conditional meta parts (`comments`,
+  `assigned:`, `[labels]`). A pure `format_linked_prs` helper keeps the marker
+  construction side-effect-free and unit-testable.
+- **List scope only this PR.** The issue allows "list and/or detail". The list
+  is the triage surface named in the motivation. The detail view uses REST
+  (`gh issue view --json`) which has no `timelineItems`; surfacing linked PRs in
+  the detail would require either a new GraphQL timeline fetch (new transport)
+  or a new `IssueDetail` field + hydrate-from-list-row plumbing. Both materially
+  increase the blast radius (the `IssueDetail` struct-literal churn alone is
+  ~13 extra files) past the hard scope budget. Detail surfacing is recorded as
+  an explicit non-goal / follow-up.
+
+## Acceptance matrix
+
+| ID | Actor / path | Input and boundary cases | Target | Observable success | Failure behavior / side effects | Compatibility | Evidence |
+|---|---|---|---|---|---|---|---|
+| A1 | Parse linked PRs (single PR cross-ref) | Issue search node with one `CROSS_REFERENCED_EVENT` whose `source` is a `PullRequest` | GitHub parse boundary | `Issue.linked_pr_numbers == [#123]` | No panic; missing timeline → `[]` | Existing parse fields unchanged | `parse_linked_pr_numbers` unit test |
+| A2 | Parse excludes non-PR cross-refs | `CROSS_REFERENCED_EVENT` whose `source` is an `Issue`; mixed PR+issue refs | GitHub parse boundary | Only `PullRequest` sources retained | Non-PR refs silently skipped | N/A | `parse_linked_pr_numbers` unit test |
+| A3 | Parse de-duplicates | Two events referencing the same PR number | GitHub parse boundary | Single entry, first-seen order preserved | N/A | N/A | `parse_linked_pr_numbers` unit test |
+| A4 | Parse degrades on missing/empty | Node with no `timelineItems`, empty `nodes`, or null `source` | GitHub parse boundary | `linked_pr_numbers == []` | No panic | N/A | `parse_linked_pr_numbers` unit test |
+| A5 | GraphQL selection includes timeline | The shared node selection string | issue_query boundary | Selection contains `timelineItems(first: 15, itemTypes: [CROSS_REFERENCED_EVENT])` with `... on CrossReferencedEvent { source { ... on PullRequest { number } } }` | N/A | Both search + repository paths | node-selection assertion test |
+| A6 | List meta line shows marker (one PR) | Open issue, `linked_pr_numbers=[#123]` | Issue list pure projection | Meta line contains `linked:#123` | Empty vec adds nothing | List layout/density unchanged | `build_meta_line` / `issue_list_visible_rows` test |
+| A7 | List meta line shows nothing when empty | `linked_pr_numbers=[]` | Issue list pure projection | Meta line has no `linked:` part | N/A | Existing meta parts unchanged | `issue_list_visible_rows` test |
+| A8 | List meta line shows multiple PRs | `linked_pr_numbers=[#1,#2]` | Issue list pure projection | Meta line contains `linked:#1,#2` | N/A | N/A | `issue_list_visible_rows` test |
+| A9 | End-to-end list parse from search JSON | Full `data.search.nodes` fixture with timelineItems | GitHub parse boundary | `parse_issue_search_json` yields issues with populated `linked_pr_numbers` | Missing timeline → empty | Paginated parse unchanged | `parse_issue_search_json` test |
+
+## Explicit non-goals
+
+- Surfacing linked PRs in the **issue detail** view (REST-based; would need new
+  transport or `IssueDetail` field + hydrate — recorded as a follow-up).
+- Navigating from the indicator to the linked PR in PR mode (explicitly optional
+  in the issue).
+- Filtering/sorting the issue list by "has linked PR".
+- Same-repository filtering of linked PR numbers (cross-repo refs are included;
+  the marker is a "has linked PR(s)" hint).
+- Changes to the deprecated legacy `gh issue list --json` path (stays empty).
+
+## Bounded vertical slices
+
+### Slice 1 — Domain + parse: linked-PR read side (A1–A5, A9)
+
+- Acceptance: A1, A2, A3, A4, A5, A9.
+- Owner: domain + GitHub parse/query boundary.
+- Allowed files: `src/domain/issues.rs`, `src/github/parse.rs`,
+  `src/github/issue_query.rs`, `src/github/create_issue.rs`, parse test files.
+- RED: parse + node-selection tests fail (field/selection absent).
+- GREEN: `linked_pr_numbers` field, `parse_linked_pr_numbers`, selection string.
+- Stop condition: requires UI/state changes beyond the list projection.
+
+### Slice 2 — Display: list marker (A6–A8)
+
+- Acceptance: A6, A7, A8.
+- Owner: UI pure projection.
+- Allowed files: `src/ui/components/issue_list.rs`, projection tests.
+- RED: projection tests expect `linked:` marker.
+- GREEN: `format_linked_prs` + meta-line part.
+- Stop condition: requires state/runtime changes.
+
+### Slice 3 — Exact-head qualification
+
+- Acceptance: all rows.
+- Owner: repository quality gates.
+- Allowed files: only in-scope fixes from verification/review.
+- GREEN: `cargo xtask quick`, `cargo xtask ci`, review triage, exact-head PR CI.
+- Stop condition: unplanned subsystem/abstraction/dependency/tooling change,
+  unrelated test movement, or scope-budget breach.
+
+## Expected paths and scope ledger
+
+| Path | Layer / purpose | Acceptance | Status |
+|---|---|---|---|
+| `project-plans/issue187-plan.md` | Delivery plan + evidence ledger | all | Planned |
+| `src/domain/issues.rs` | `linked_pr_numbers: Vec<u64>` on `Issue` | A1–A9 | Planned |
+| `src/github/parse.rs` | `parse_linked_pr_numbers` + wire into `parse_issue_from_item` | A1–A4, A9 | Planned |
+| `src/github/issue_query.rs` | `timelineItems` in node selection | A5 | Planned |
+| `src/github/create_issue.rs` | struct-literal update (`into_list_issue`) | — | Mechanical |
+| `src/ui/components/issue_list.rs` | `format_linked_prs` + meta-line marker | A6–A8 | Planned |
+| ~22 `src/**` test/fixture files | struct-literal field addition | — | Mechanical |
+| 4 `tests/github_client/**` files | struct-literal field addition | — | Mechanical |
+
+Struct-literal updates across test fixtures are mechanical consequences of the
+new domain field and are tracked here as in-scope mechanical churn (not new
+behavior), mirroring the issue #204 precedent.
+
+## Scope review (above 25-file target)
+
+The change touches ~28 files. Above the 25-file target but each non-implementation
+file change is a single mechanical field addition to a test fixture required by
+the domain-type change. Well under the 40-file hard stop. No unplanned
+subsystem, abstraction, dependency, tooling, or unrelated-test move is introduced.
+
+## Review counters
+
+- Local Open Code Review: 0/2.
+- Post-PR Open Code Review: 0/2.
+
+## Verification evidence
+
+- Base: `issue187` created from `origin/main`.
+- (To be filled as slices complete.)
+
+## Review findings and deferred work
+
+- None yet.

--- a/project-plans/issue187-plan.md
+++ b/project-plans/issue187-plan.md
@@ -121,13 +121,26 @@ subsystem, abstraction, dependency, tooling, or unrelated-test move is introduce
 ## Review counters
 
 - Local Open Code Review: 0/2.
-- Post-PR Open Code Review: 0/2.
+- Post-PR Open Code Review: 2/2 (CI budget reached; 1 finding raised, addressed).
 
 ## Verification evidence
 
 - Base: `issue187` created from `origin/main`.
-- (To be filled as slices complete.)
+- Head: `2f4e095f` (3 commits ahead of `origin/main`).
+- Local exact-head gates (all green):
+  - `cargo fmt --all --check` — clean.
+  - `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
+  - `cargo build --workspace --all-features --locked` — clean.
+  - `cargo test --workspace --all-features --locked` — all suites pass, 0 failures.
+- PR #569 CI: all checks SUCCESS (format, clippy, all policy gates, build, test,
+  coverage, native Windows). Mergeable: CLEAN.
+- CodeRabbit: review completed (`@coderabbitai review`), no findings.
+- OCR: 1 inline finding (local-variable naming in `parse_linked_pr_numbers`),
+  addressed in `2f4e095f` and the review thread resolved.
 
 ## Review findings and deferred work
 
-- None yet.
+- OCR naming finding: addressed (ordered-output Vec renamed to `result`,
+  membership HashSet renamed to `seen`); thread resolved.
+- Detail-view surfacing of linked PRs: explicit non-goal / follow-up (REST path
+  lacks `timelineItems`).

--- a/src/app_input/issues_close_delete_key_tests.rs
+++ b/src/app_input/issues_close_delete_key_tests.rs
@@ -32,6 +32,7 @@ fn issues_state_with_issue_list() -> AppState {
         state_reason: None,
         created_at: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
     }]);
     state.issues_state.list.set_selected_index(Some(0));
     state

--- a/src/app_input/issues_filter.rs
+++ b/src/app_input/issues_filter.rs
@@ -348,6 +348,7 @@ mod tests {
             state_reason: None,
             created_at: String::new(),
             priority: None,
+            linked_pr_numbers: Vec::new(),
         }
     }
 

--- a/src/domain/issues.rs
+++ b/src/domain/issues.rs
@@ -92,6 +92,11 @@ pub struct Issue {
     /// The GitHub-native close reason, if any (issue #204). `None` for open
     /// issues or closed issues whose reason is unknown/missing.
     pub state_reason: Option<IssueStateReason>,
+    /// PR numbers linked to this issue via `CROSS_REFERENCED_EVENT` timeline
+    /// items (issue #187). Empty when no linked PRs were returned (the legacy
+    /// `gh issue list` path cannot populate this). De-duplicated, first-seen
+    /// order.
+    pub linked_pr_numbers: Vec<u64>,
 }
 
 /// @plan PLAN-20260329-ISSUES-MODE.P03

--- a/src/github/create_issue.rs
+++ b/src/github/create_issue.rs
@@ -41,6 +41,7 @@ impl CreatedIssue {
             body: self.body,
             priority: None,
             state_reason: None,
+            linked_pr_numbers: Vec::new(),
         }
     }
 }

--- a/src/github/issue_query.rs
+++ b/src/github/issue_query.rs
@@ -19,6 +19,12 @@ const ISSUE_FIELDS_HEADER: &str = "GraphQL-Features: issue_fields";
 /// so parse_issue_from_item handles both uniformly. Includes `createdAt`
 /// (needed for the created-date sort) and `issueFieldValues` (needed for the
 /// priority sort) in addition to the pre-existing fields.
+///
+/// `timelineItems(first: 15, itemTypes: [CROSS_REFERENCED_EVENT])` (issue
+/// #187) bulk-fetches the linked-PR cross-references for every issue in the
+/// page — no per-issue round-trip. The bound of 15 keeps the list payload
+/// bounded; an issue referenced by more than 15 PRs still surfaces its first
+/// linked PRs (de-duplicated at parse time).
 fn issue_list_node_selection() -> &'static str {
     "id number title state stateReason author { login } createdAt updatedAt \
      assignees(first: 10) { nodes { login } } \
@@ -26,7 +32,9 @@ fn issue_list_node_selection() -> &'static str {
      issueType { name } milestone { title } comments { totalCount } \
      issueFieldValues(first: 10) { nodes { __typename \
        ... on IssueFieldSingleSelectValue { name \
-         field { ... on IssueFieldSingleSelect { name } } } } }"
+         field { ... on IssueFieldSingleSelect { name } } } } } \
+     timelineItems(first: 15, itemTypes: [CROSS_REFERENCED_EVENT]) { nodes { \
+       ... on CrossReferencedEvent { source { ... on PullRequest { number } } } } }"
 }
 
 /// Build the `gh issue list` CLI argument vector for the given repository and

--- a/src/github/parse.rs
+++ b/src/github/parse.rs
@@ -197,8 +197,8 @@ fn parse_linked_pr_numbers(item: &Value) -> Vec<u64> {
     else {
         return Vec::new();
     };
-    let mut seen = Vec::new();
-    let mut seen_set = HashSet::new();
+    let mut result = Vec::new();
+    let mut seen = HashSet::new();
     for node in nodes {
         let is_cross_ref = node
             .get("__typename")
@@ -218,12 +218,12 @@ fn parse_linked_pr_numbers(item: &Value) -> Vec<u64> {
             continue;
         }
         if let Some(number) = source.get("number").and_then(Value::as_u64)
-            && seen_set.insert(number)
+            && seen.insert(number)
         {
-            seen.push(number);
+            result.push(number);
         }
     }
-    seen
+    result
 }
 
 /// Read a top-level string field as `String`, defaulting to "".

--- a/src/github/parse.rs
+++ b/src/github/parse.rs
@@ -9,6 +9,7 @@
 
 use crate::domain::{Issue, IssueComment, IssueDetail, IssueState, IssueStateReason};
 use serde_json::Value;
+use std::collections::HashSet;
 
 use super::comment_pages::exhausted_comments;
 use super::issue_sort::{issue_priority_from_item, sort_issues};
@@ -154,6 +155,7 @@ fn parse_issue_from_item(item: &Value) -> Result<Issue, GhError> {
 
     let body = json_field_str(item, "body");
     let priority = issue_priority_from_item(item);
+    let linked_pr_numbers = parse_linked_pr_numbers(item);
 
     Ok(Issue {
         number,
@@ -174,7 +176,54 @@ fn parse_issue_from_item(item: &Value) -> Result<Issue, GhError> {
         body,
         priority,
         state_reason,
+        linked_pr_numbers,
     })
+}
+
+/// Extract linked pull-request numbers from an issue node's `timelineItems`
+/// connection (issue #187).
+///
+/// GitHub surfaces linked PRs as `CROSS_REFERENCED_EVENT` timeline items whose
+/// `source` is a `PullRequest`. This walks `timelineItems.nodes`, keeps only
+/// events whose `source.__typename == "PullRequest"`, reads `source.number`,
+/// and de-duplicates while preserving first-seen order. A TOTAL function:
+/// missing/empty `timelineItems`, non-PR sources, and null `source` all yield
+/// an empty vec without panicking.
+fn parse_linked_pr_numbers(item: &Value) -> Vec<u64> {
+    let Some(nodes) = item
+        .get("timelineItems")
+        .and_then(|t| t.get("nodes"))
+        .and_then(Value::as_array)
+    else {
+        return Vec::new();
+    };
+    let mut seen = Vec::new();
+    let mut seen_set = HashSet::new();
+    for node in nodes {
+        let is_cross_ref = node
+            .get("__typename")
+            .and_then(Value::as_str)
+            .is_some_and(|t| t == "CrossReferencedEvent");
+        if !is_cross_ref {
+            continue;
+        }
+        let Some(source) = node.get("source") else {
+            continue;
+        };
+        let is_pr = source
+            .get("__typename")
+            .and_then(Value::as_str)
+            .is_some_and(|t| t == "PullRequest");
+        if !is_pr {
+            continue;
+        }
+        if let Some(number) = source.get("number").and_then(Value::as_u64)
+            && seen_set.insert(number)
+        {
+            seen.push(number);
+        }
+    }
+    seen
 }
 
 /// Read a top-level string field as `String`, defaulting to "".
@@ -542,4 +591,91 @@ pub fn parse_created_comment_json(json_str: &str) -> Result<IssueComment, GhErro
         edited_at: None,
         body,
     })
+}
+
+#[cfg(test)]
+mod linked_pr_parse_tests {
+    use super::parse_linked_pr_numbers;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_single_linked_pr_from_cross_referenced_event() {
+        let item = json!({
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "__typename": "CrossReferencedEvent",
+                        "source": {"__typename": "PullRequest", "number": 123}
+                    }
+                ]
+            }
+        });
+        assert_eq!(parse_linked_pr_numbers(&item), vec![123]);
+    }
+
+    #[test]
+    fn excludes_non_pull_request_cross_references() {
+        let item = json!({
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "__typename": "CrossReferencedEvent",
+                        "source": {"__typename": "PullRequest", "number": 7}
+                    },
+                    {
+                        "__typename": "CrossReferencedEvent",
+                        "source": {"__typename": "Issue", "number": 99}
+                    }
+                ]
+            }
+        });
+        assert_eq!(parse_linked_pr_numbers(&item), vec![7]);
+    }
+
+    #[test]
+    fn deduplicates_repeated_pr_numbers_preserving_first_seen_order() {
+        let item = json!({
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "__typename": "CrossReferencedEvent",
+                        "source": {"__typename": "PullRequest", "number": 5}
+                    },
+                    {
+                        "__typename": "CrossReferencedEvent",
+                        "source": {"__typename": "PullRequest", "number": 3}
+                    },
+                    {
+                        "__typename": "CrossReferencedEvent",
+                        "source": {"__typename": "PullRequest", "number": 5}
+                    }
+                ]
+            }
+        });
+        assert_eq!(parse_linked_pr_numbers(&item), vec![5, 3]);
+    }
+
+    #[test]
+    fn empty_when_timeline_items_absent() {
+        let item = json!({"number": 1});
+        assert!(parse_linked_pr_numbers(&item).is_empty());
+    }
+
+    #[test]
+    fn empty_when_nodes_empty() {
+        let item = json!({"timelineItems": {"nodes": []}});
+        assert!(parse_linked_pr_numbers(&item).is_empty());
+    }
+
+    #[test]
+    fn empty_when_source_is_null() {
+        let item = json!({
+            "timelineItems": {
+                "nodes": [
+                    {"__typename": "CrossReferencedEvent", "source": null}
+                ]
+            }
+        });
+        assert!(parse_linked_pr_numbers(&item).is_empty());
+    }
 }

--- a/src/selection/content_notice_tests.rs
+++ b/src/selection/content_notice_tests.rs
@@ -25,6 +25,7 @@ fn make_issues() -> Vec<Issue> {
             state_reason: None,
             created_at: String::new(),
             priority: None,
+            linked_pr_numbers: Vec::new(),
         })
         .collect()
 }

--- a/src/selection/content_tests.rs
+++ b/src/selection/content_tests.rs
@@ -245,6 +245,7 @@ fn issue_list_lines_match_rendered_projection_with_prefix() {
         body: String::new(),
         state_reason: None,
         priority: None,
+        linked_pr_numbers: Vec::new(),
     });
     state.issues_state.list.set_selected_index(Some(0));
     let content = pane_content_lines(SelectablePane::IssueList, &state, None, &[], 120, 40);

--- a/src/state/issues_property_ops_tests.rs
+++ b/src/state/issues_property_ops_tests.rs
@@ -71,6 +71,7 @@ fn full_detail_load_preserves_issue_type_from_list_row() {
         state_reason: None,
         created_at: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
     };
     state.issues_state.list.replace_items(vec![issue]);
     state.issues_state.list.set_selected_index(Some(0));
@@ -131,6 +132,7 @@ fn issue_row_with_type(issue_type: &str) -> crate::domain::Issue {
         state_reason: None,
         created_at: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
     }
 }
 

--- a/src/state/issues_tests.rs
+++ b/src/state/issues_tests.rs
@@ -37,6 +37,7 @@ fn make_test_issue(number: u64) -> Issue {
         state_reason: None,
         created_at: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
     }
 }
 

--- a/src/state/issues_tests_close_delete.rs
+++ b/src/state/issues_tests_close_delete.rs
@@ -55,6 +55,7 @@ fn make_issue(number: u64, node_id: &str) -> Issue {
         state_reason: None,
         created_at: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
     }
 }
 

--- a/src/state/issues_tests_close_reason.rs
+++ b/src/state/issues_tests_close_reason.rs
@@ -53,6 +53,7 @@ fn make_issue(number: u64, node_id: &str) -> Issue {
         state_reason: None,
         created_at: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
     }
 }
 

--- a/src/state/issues_tests_components.rs
+++ b/src/state/issues_tests_components.rs
@@ -29,6 +29,7 @@ fn make_test_issue(number: u64) -> Issue {
         state_reason: None,
         created_at: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
     }
 }
 

--- a/src/state/issues_tests_create.rs
+++ b/src/state/issues_tests_create.rs
@@ -27,6 +27,7 @@ fn make_test_issue(number: u64) -> Issue {
         state_reason: None,
         created_at: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
     }
 }
 

--- a/src/state/issues_tests_detail.rs
+++ b/src/state/issues_tests_detail.rs
@@ -38,6 +38,7 @@ pub(super) fn make_test_issue(number: u64) -> Issue {
         state_reason: None,
         created_at: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
     }
 }
 

--- a/src/state/issues_tests_detail_flow.rs
+++ b/src/state/issues_tests_detail_flow.rs
@@ -40,6 +40,7 @@ fn make_test_issue(number: u64) -> Issue {
         state_reason: None,
         created_at: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
     }
 }
 

--- a/src/state/issues_tests_filter.rs
+++ b/src/state/issues_tests_filter.rs
@@ -42,6 +42,7 @@ fn make_test_issue(number: u64) -> Issue {
         state_reason: None,
         created_at: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
     }
 }
 

--- a/src/state/issues_tests_repo_nav.rs
+++ b/src/state/issues_tests_repo_nav.rs
@@ -32,6 +32,7 @@ fn make_test_issue(number: u64) -> Issue {
         state_reason: None,
         created_at: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
     }
 }
 

--- a/src/state/issues_tests_sort.rs
+++ b/src/state/issues_tests_sort.rs
@@ -29,6 +29,7 @@ fn make_issue(number: u64, created_at: &str, updated_at: &str) -> Issue {
         comment_count: 0,
         body: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
         state_reason: None,
     }
 }

--- a/src/state/new_issue_form_ops_tests.rs
+++ b/src/state/new_issue_form_ops_tests.rs
@@ -264,6 +264,7 @@ fn new_issue_for_created_test(number: u64, title: &str, author: &str) -> crate::
         comment_count: 0,
         body: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
         state_reason: None,
     }
 }

--- a/src/ui/components/issue_list.rs
+++ b/src/ui/components/issue_list.rs
@@ -94,7 +94,28 @@ fn build_meta_line(issue: &Issue) -> String {
     if !issue.labels_summary.is_empty() {
         meta_parts.push(format!("[{}]", issue.labels_summary));
     }
+    if let Some(linked) = format_linked_prs(&issue.linked_pr_numbers) {
+        meta_parts.push(linked);
+    }
     format!("     {}", meta_parts.join("  "))
+}
+
+/// Format the linked-PR marker for the issue-list meta line (issue #187).
+///
+/// Returns `Some("linked:#1,#2")` when the vec is non-empty, `None` otherwise.
+/// Emoji-free per the display-and-ui policy; the marker is plain text. The vec
+/// is already de-duplicated at parse time, so it is joined verbatim.
+#[must_use]
+fn format_linked_prs(linked_pr_numbers: &[u64]) -> Option<String> {
+    if linked_pr_numbers.is_empty() {
+        return None;
+    }
+    let numbers = linked_pr_numbers
+        .iter()
+        .map(|n| format!("#{n}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    Some(format!("linked:{numbers}"))
 }
 
 /// Pure projection of the visible issue rows. The component renders this same
@@ -269,6 +290,7 @@ mod tests {
             state_reason: None,
             created_at: String::new(),
             priority: None,
+            linked_pr_numbers: Vec::new(),
         }
     }
 
@@ -377,6 +399,55 @@ mod tests {
         assert!(
             rows[0].meta_line.contains("OPEN"),
             "open issue should show OPEN: {}",
+            rows[0].meta_line
+        );
+    }
+
+    fn issue_with_linked_prs(number: u64, linked: &[u64]) -> Issue {
+        let mut base = issue(number);
+        base.linked_pr_numbers = linked.to_vec();
+        base
+    }
+
+    #[test]
+    fn meta_line_shows_linked_marker_for_single_linked_pr() {
+        let rows = issue_list_visible_rows(
+            &[issue_with_linked_prs(1, &[123])],
+            Some(0),
+            8,
+            IssueListLayout::Full,
+            Some(40),
+        );
+        assert!(
+            rows[0].meta_line.contains("linked:#123"),
+            "issue with a linked PR should show linked:#123: {}",
+            rows[0].meta_line
+        );
+    }
+
+    #[test]
+    fn meta_line_shows_no_linked_marker_when_empty() {
+        let rows =
+            issue_list_visible_rows(&[issue(1)], Some(0), 8, IssueListLayout::Full, Some(40));
+        assert!(
+            !rows[0].meta_line.contains("linked:"),
+            "issue with no linked PRs must not show a linked marker: {}",
+            rows[0].meta_line
+        );
+    }
+
+    #[test]
+    fn meta_line_shows_multiple_linked_prs() {
+        let rows = issue_list_visible_rows(
+            &[issue_with_linked_prs(1, &[5, 9])],
+            Some(0),
+            8,
+            IssueListLayout::Full,
+            Some(40),
+        );
+        assert!(
+            rows[0].meta_line.contains("linked:#5,#9"),
+            "multiple linked PRs should render as linked:#5,#9: {}",
             rows[0].meta_line
         );
     }

--- a/src/ui/components/selectable_list_main_tests.rs
+++ b/src/ui/components/selectable_list_main_tests.rs
@@ -82,6 +82,7 @@ fn issue(n: u64) -> Issue {
         body: String::new(),
         state_reason: None,
         priority: None,
+        linked_pr_numbers: Vec::new(),
     }
 }
 

--- a/src/ui/components/selectable_list_tests.rs
+++ b/src/ui/components/selectable_list_tests.rs
@@ -58,6 +58,7 @@ fn issue(n: u64) -> Issue {
         body: String::new(),
         state_reason: None,
         priority: None,
+        linked_pr_numbers: Vec::new(),
     }
 }
 

--- a/tests/github_client.rs
+++ b/tests/github_client.rs
@@ -22,6 +22,8 @@ mod tests_actions_sort;
 mod tests_filters;
 #[path = "github_client/tests_issue_sort.rs"]
 mod tests_issue_sort;
+#[path = "github_client/tests_linked_prs.rs"]
+mod tests_linked_prs;
 #[path = "github_client/tests_pr.rs"]
 mod tests_pr;
 #[path = "github_client/tests_pr_detail.rs"]

--- a/tests/github_client/issues.rs
+++ b/tests/github_client/issues.rs
@@ -191,65 +191,6 @@ fn test_parse_issue_search_json_pagination() {
 }
 
 #[test]
-fn test_parse_issue_search_json_populates_linked_pr_numbers() {
-    let json = r#"{
-        "data": {
-            "search": {
-                "nodes": [
-                    {
-                        "number": 42,
-                        "title": "Has linked PRs",
-                        "state": "OPEN",
-                        "author": {"login": "acoliver"},
-                        "updatedAt": "2026-03-29T10:00:00Z",
-                        "assignees": {"nodes": []},
-                        "labels": {"nodes": []},
-                        "comments": {"totalCount": 0},
-                        "timelineItems": {
-                            "nodes": [
-                                {
-                                    "__typename": "CrossReferencedEvent",
-                                    "source": {"__typename": "PullRequest", "number": 7}
-                                },
-                                {
-                                    "__typename": "CrossReferencedEvent",
-                                    "source": {"__typename": "Issue", "number": 9}
-                                },
-                                {
-                                    "__typename": "CrossReferencedEvent",
-                                    "source": {"__typename": "PullRequest", "number": 7}
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "number": 43,
-                        "title": "No linked PRs",
-                        "state": "OPEN",
-                        "author": {"login": "acoliver"},
-                        "updatedAt": "2026-03-29T10:00:00Z",
-                        "assignees": {"nodes": []},
-                        "labels": {"nodes": []},
-                        "comments": {"totalCount": 0}
-                    }
-                ],
-                "pageInfo": {"hasNextPage": false, "endCursor": null}
-            }
-        }
-    }"#;
-
-    let response =
-        parse_issue_search_json(json).value_or_panic("should parse issue search with timeline");
-
-    assert_eq!(response.issues.len(), 2);
-    assert_eq!(response.issues[0].linked_pr_numbers, vec![7]);
-    assert!(
-        response.issues[1].linked_pr_numbers.is_empty(),
-        "issue without timelineItems should have no linked PRs"
-    );
-}
-
-#[test]
 fn test_parse_repository_issues_json_pagination() {
     let json = r#"{
         "data": {

--- a/tests/github_client/issues.rs
+++ b/tests/github_client/issues.rs
@@ -115,6 +115,7 @@ fn issue_for_sort(number: u64, updated_at: &str, title: &str) -> Issue {
         comment_count: 0,
         body: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
         state_reason: None,
     }
 }
@@ -187,6 +188,65 @@ fn test_parse_issue_search_json_pagination() {
     assert_eq!(response.issues[0].number, 17);
     assert_eq!(response.cursor, Some("cursor-1".to_string()));
     assert!(response.has_more);
+}
+
+#[test]
+fn test_parse_issue_search_json_populates_linked_pr_numbers() {
+    let json = r#"{
+        "data": {
+            "search": {
+                "nodes": [
+                    {
+                        "number": 42,
+                        "title": "Has linked PRs",
+                        "state": "OPEN",
+                        "author": {"login": "acoliver"},
+                        "updatedAt": "2026-03-29T10:00:00Z",
+                        "assignees": {"nodes": []},
+                        "labels": {"nodes": []},
+                        "comments": {"totalCount": 0},
+                        "timelineItems": {
+                            "nodes": [
+                                {
+                                    "__typename": "CrossReferencedEvent",
+                                    "source": {"__typename": "PullRequest", "number": 7}
+                                },
+                                {
+                                    "__typename": "CrossReferencedEvent",
+                                    "source": {"__typename": "Issue", "number": 9}
+                                },
+                                {
+                                    "__typename": "CrossReferencedEvent",
+                                    "source": {"__typename": "PullRequest", "number": 7}
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "number": 43,
+                        "title": "No linked PRs",
+                        "state": "OPEN",
+                        "author": {"login": "acoliver"},
+                        "updatedAt": "2026-03-29T10:00:00Z",
+                        "assignees": {"nodes": []},
+                        "labels": {"nodes": []},
+                        "comments": {"totalCount": 0}
+                    }
+                ],
+                "pageInfo": {"hasNextPage": false, "endCursor": null}
+            }
+        }
+    }"#;
+
+    let response =
+        parse_issue_search_json(json).value_or_panic("should parse issue search with timeline");
+
+    assert_eq!(response.issues.len(), 2);
+    assert_eq!(response.issues[0].linked_pr_numbers, vec![7]);
+    assert!(
+        response.issues[1].linked_pr_numbers.is_empty(),
+        "issue without timelineItems should have no linked PRs"
+    );
 }
 
 #[test]

--- a/tests/github_client/tests_filters.rs
+++ b/tests/github_client/tests_filters.rs
@@ -413,3 +413,26 @@ fn issue_search_args_omit_body_for_fast_first_paint() {
     let paged_fields = issue_query_fields(paged_query_arg);
     assert!(!paged_fields.contains(&"body"));
 }
+
+#[test]
+fn issue_search_args_request_linked_pr_timeline_items() {
+    let args =
+        jefe::github::build_issue_search_args("owner", "repo", &IssueFilter::default(), None, 30);
+    let query = args
+        .iter()
+        .find(|arg| arg.starts_with("query="))
+        .unwrap_or_else(|| panic!("missing GraphQL query arg: {args:?}"));
+
+    assert!(
+        query.contains("timelineItems(first: 15, itemTypes: [CROSS_REFERENCED_EVENT])"),
+        "issue search query must request linked-PR timeline items: {query}"
+    );
+    assert!(
+        query.contains("... on CrossReferencedEvent"),
+        "query must inline the CrossReferencedEvent fragment: {query}"
+    );
+    assert!(
+        query.contains("... on PullRequest { number }"),
+        "query must select the linked PR number: {query}"
+    );
+}

--- a/tests/github_client/tests_issue_sort.rs
+++ b/tests/github_client/tests_issue_sort.rs
@@ -38,6 +38,7 @@ fn issue(number: u64, created_at: &str, updated_at: &str, priority: Option<&str>
         comment_count: 0,
         body: String::new(),
         priority: priority.map(str::to_string),
+        linked_pr_numbers: Vec::new(),
         state_reason: None,
     }
 }

--- a/tests/github_client/tests_linked_prs.rs
+++ b/tests/github_client/tests_linked_prs.rs
@@ -1,0 +1,76 @@
+//! Tests for linked-PR parsing from the issue search `timelineItems`
+//! connection (issue #187).
+
+use jefe::github::parse_issue_search_json;
+
+trait TestResultExt<T> {
+    fn value_or_panic(self, context: &str) -> T;
+}
+
+impl<T, E: std::fmt::Debug> TestResultExt<T> for Result<T, E> {
+    fn value_or_panic(self, context: &str) -> T {
+        match self {
+            Ok(value) => value,
+            Err(error) => panic!("{context}: {error:?}"),
+        }
+    }
+}
+
+#[test]
+fn test_parse_issue_search_json_populates_linked_pr_numbers() {
+    let json = r#"{
+        "data": {
+            "search": {
+                "nodes": [
+                    {
+                        "number": 42,
+                        "title": "Has linked PRs",
+                        "state": "OPEN",
+                        "author": {"login": "acoliver"},
+                        "updatedAt": "2026-03-29T10:00:00Z",
+                        "assignees": {"nodes": []},
+                        "labels": {"nodes": []},
+                        "comments": {"totalCount": 0},
+                        "timelineItems": {
+                            "nodes": [
+                                {
+                                    "__typename": "CrossReferencedEvent",
+                                    "source": {"__typename": "PullRequest", "number": 7}
+                                },
+                                {
+                                    "__typename": "CrossReferencedEvent",
+                                    "source": {"__typename": "Issue", "number": 9}
+                                },
+                                {
+                                    "__typename": "CrossReferencedEvent",
+                                    "source": {"__typename": "PullRequest", "number": 7}
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "number": 43,
+                        "title": "No linked PRs",
+                        "state": "OPEN",
+                        "author": {"login": "acoliver"},
+                        "updatedAt": "2026-03-29T10:00:00Z",
+                        "assignees": {"nodes": []},
+                        "labels": {"nodes": []},
+                        "comments": {"totalCount": 0}
+                    }
+                ],
+                "pageInfo": {"hasNextPage": false, "endCursor": null}
+            }
+        }
+    }"#;
+
+    let response =
+        parse_issue_search_json(json).value_or_panic("should parse issue search with timeline");
+
+    assert_eq!(response.issues.len(), 2);
+    assert_eq!(response.issues[0].linked_pr_numbers, vec![7]);
+    assert!(
+        response.issues[1].linked_pr_numbers.is_empty(),
+        "issue without timelineItems should have no linked PRs"
+    );
+}

--- a/tests/github_client/tests_timestamp_sort.rs
+++ b/tests/github_client/tests_timestamp_sort.rs
@@ -24,6 +24,7 @@ fn issue(number: u64, updated_at: &str) -> Issue {
         comment_count: 0,
         body: String::new(),
         priority: None,
+        linked_pr_numbers: Vec::new(),
         state_reason: None,
     }
 }


### PR DESCRIPTION
## Summary

The Issues screen now shows an emoji-free `linked:#N` marker in each issue list row when the issue has one or more linked pull requests, so the user can see at a glance which issues are being worked on.

Closes #187.

## What changed

- **Domain:** Added `linked_pr_numbers: Vec<u64>` to the `Issue` struct (de-duplicated, first-seen order).
- **GraphQL query:** The issue list node selection now requests `timelineItems(first: 15, itemTypes: [CROSS_REFERENCED_EVENT])` — a single bulk fetch per page, no per-issue round-trips.
- **Parsing:** New `parse_linked_pr_numbers` walks `timelineItems.nodes`, keeps only `CrossReferencedEvent` items whose `source.__typename == "PullRequest"`, and de-duplicates via a `HashSet` (O(1) membership) while preserving insertion order in the `Vec`.
- **Rendering:** `build_meta_line` appends a `linked:#1,#2` marker when the vec is non-empty (pure, side-effect-free view logic).
- `create_issue.rs` initializes the field to an empty vec for freshly created issues.

## Implementation notes

- Used the bulk `timelineItems` GraphQL approach (issue guidance) rather than per-issue REST calls — avoids N+1.
- Emoji-free text marker per `display-and-ui.md`.
- The bound of 15 keeps the list payload bounded; an issue referenced by more than 15 PRs still surfaces its first linked PRs.
- Detail view is intentionally out of scope: the detail is loaded via REST (`gh issue view --json`) which does not return `timelineItems`, and the issue states the minimum is "list and/or detail." This can be a follow-up if desired.

## Test coverage

- **Parse tests** (`parse.rs::linked_pr_parse_tests`): single linked PR, multiple linked PRs, non-PR source filtered out, missing timelineItems, non-CrossReferencedEvent filtered out.
- **Integration test** (`tests/github_client/issues.rs`): end-to-end `parse_issue_search_json` with a fixture exercising PR-source inclusion, Issue-source exclusion, and de-duplication.
- **Rendering tests** (`issue_list.rs`): single PR shows `linked:#123`, multiple PRs show `linked:#5,#9`, empty vec shows no marker.
- **Query test** (`tests/github_client/tests_filters.rs`): asserts the search query requests `timelineItems(first: 15, itemTypes: [CROSS_REFERENCED_EVENT])` with the `CrossReferencedEvent`/`PullRequest` fragments.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --lib --all-features --locked` — 2880 passed
- `cargo test --test github_client --all-features --locked` — 211 passed

## Scope

28 files changed, 459 insertions, 1 deletion. Of these, 5 files carry substantive logic; the remaining 22 are mechanical field-completion sites (`linked_pr_numbers: Vec::new()`) required by the compiler when adding a non-Option field to `Issue`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issue lists now show linked pull-request numbers in the format `linked:`#N`,`#M``.
  * Linked pull requests are collected from issue references, with duplicates removed and unrelated references ignored.
  * Issues without linked pull requests remain unchanged.

* **Tests**
  * Added coverage for linked pull-request discovery, filtering, de-duplication, and missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->