### PR TITLE
Serialize managed package installs across processes and publish them atomically (Fixes #556)

### DIFF
--- a/.github/clippy/clippy.toml
+++ b/.github/clippy/clippy.toml
@@ -1,4 +1,5 @@
-msrv = "1.75"
+# Kept in lockstep with the root clippy.toml; see the rationale there.
+msrv = "1.89"
 
 # Mirror root clippy.toml thresholds so CLIPPY_CONF_DIR does not
 # silently fall back to clippy defaults in CI.

--- a/clippy.toml
+++ b/clippy.toml
@@ -5,7 +5,14 @@
 # local clippy runs (without CLIPPY_CONF_DIR) apply the same MSRV-aware lint
 # decisions as CI (e.g. from_mins is const-stable since 1.91, so the
 # duration_suboptimal_units suggestion is suppressed under this MSRV).
-msrv = "1.75"
+#
+# 1.89 is the floor at which `std::fs::File::try_lock`/`unlock` are stable.
+# The managed package-install cache is guarded by that kernel advisory lock
+# (issue #556), which is the only correct way to serialize installs across
+# processes without an added dependency or `unsafe`. The previous value of
+# 1.75 predated `edition = "2024"` (Rust 1.85) and could not have built this
+# crate; CI has always used the stable toolchain.
+msrv = "1.89"
 
 # Maximum cognitive complexity per function
 cognitive-complexity-threshold = 15

--- a/project-plans/issue555-plan.md
+++ b/project-plans/issue555-plan.md
@@ -1,0 +1,274 @@
+# Issue #555 / #556 — managed package-cache installs are unsafe across jefe processes and are not atomic
+
+Parent: **#555**. Delivered slice: **#556** (cross-process lock + atomic install,
+implemented and verified on Unix). The Windows slice is **#557** and is
+explicitly *not* delivered here — it must be developed and verified on native
+Windows. This PR keeps the tree working on all platforms.
+
+## Root cause
+
+`src/runtime/package_runtime.rs::prepare_managed_npm` is the sole production
+install path for managed npm agents (`launch_compose::prepare_launch →
+local_candidate → finalize_local_invocation`, and `agent_probe →
+prepare_local_probe`). It has three defects:
+
+1. **No cross-process mutual exclusion.** The install directory
+   `<cache_root>/<selector-digest>/` is *per machine*, but the only guard is a
+   `static INSTALL_LOCK: Mutex<()>`, which is *per process*. Two jefe processes
+   that both miss the same digest run `npm install` concurrently into the same
+   directory. This is #425 Problem B (`ENOTEMPTY … rename …/node_modules/…`)
+   reproduced one level up, inside jefe's own directory. The `Mutex` was never
+   intended as directory-level exclusion — it is an intra-process invariant
+   guard for the runtime/capture-worker split, and it stays for that purpose.
+2. **Installation is not atomic.** `write_package_json` → `run_npm_install` →
+   (only on success) `.jefe-installed` marker, all mutating the *final* path.
+   An interrupted install leaves `package.json` with no `node_modules` and no
+   marker; a concurrent reader can observe a half-built `node_modules` tree.
+3. **The cache-hit check is an unprotected two-part read** (marker contents plus
+   binary resolution) with nothing preventing a concurrent writer from rewriting
+   `node_modules` between the two parts.
+
+#554 (landed as `509661a`) converts this from dormant to live: volatile
+selectors now reinstall on TTL expiry, so installs are routine rather than
+once-ever.
+
+## Fix
+
+### Cross-process advisory lock
+
+A new private runtime module `src/runtime/package_install_lock.rs` owns the
+protocol. The lock file is `<cache_root>/<digest>.lock` — a **sibling** of the
+install directory, not inside it, because the install directory is now replaced
+wholesale by `rename`.
+
+The lock is a **kernel advisory lock**: `std::fs::File::try_lock` /
+`File::unlock`, which are `flock` on Unix and `LockFileEx` on Windows — exactly
+what the issue's proposed direction asked for. They are stable std since Rust
+1.89, so this needs no new dependency and no `unsafe`.
+
+Because the lock lives in the kernel and is attached to the open file
+description, the operating system releases it when the holder exits for any
+reason, including `SIGKILL`. That removes the entire class of problems a
+userspace lock would have to solve:
+
+- a legitimate install is **never** declared stale however long it runs, which
+  is precisely the mistake npm's five-second stale threshold made;
+- a crashed holder needs no recovery, so there is no window in which two
+  processes could each decide to recover the same lock;
+- there is no on-disk ownership record, so no pid identity, no liveness
+  probing, no file mtime and no wall-clock reasoning enters the protocol;
+- the lock file is never unlinked, so no process can remove a lock another
+  process holds.
+
+Waiting polls `try_lock` and is bounded by `INSTALL_TIMEOUT + LOCK_WAIT_GRACE`.
+Exceeding the ceiling is a typed, fail-closed error — never a forced steal. The
+lock file is a zero-byte sentinel, created if absent and never truncated,
+because another process may already hold it.
+
+Lock scope: acquired **before** the cache-hit check and held through the marker
+write, binary resolution, and fingerprint capture, closing defect 3.
+
+Ordering: a **per-digest** intra-process guard is taken first, then the file
+lock. The `static INSTALL_LOCK` from #382 becomes a keyed
+`BTreeMap<digest, Arc<Mutex<()>>>` because preparation now waits on another
+process: a process-global guard would let one contended digest block every
+unrelated one.
+
+This serializes processes on one machine against one local cache directory,
+which is what `dirs::cache_dir()` provides. Advisory locking over a network
+filesystem is emulated at best; jefe does not support a shared network package
+cache, and the module says so.
+
+### Atomic install
+
+`npm install` never touches the final path again:
+
+1. `<cache_root>/.staging-<digest>/` — any leftover is removed first, so staging
+   always starts empty.
+2. `package.json` written into staging; `npm install` runs with staging as cwd.
+3. The binary is resolved **in staging** and must exist, else
+   `InstalledBinaryMissing` — a broken tree is never promoted.
+4. The `.jefe-installed` marker is written **into staging**, so the promoted
+   directory is complete the instant it appears. There is no window in which
+   `node_modules` exists without its marker.
+5. Promotion: if the install directory exists, `rename` it to
+   `<cache_root>/.retired-<digest>/`; `rename` staging into place; then remove
+   the retired tree. Neither `rename` ever targets an existing directory, so
+   both are valid on Unix and Windows. If publication fails after the previous
+   entry was retired, that entry is restored, and a restore that itself fails
+   is reported rather than hidden.
+
+A reader that goes through preparation observes either the complete previous
+tree or the complete new tree — never a partial one — because it holds the same
+lock. An interrupted install leaves only staging; the final path is untouched
+and the next attempt starts from a clean staging dir.
+
+Publication is two renames, so a process killed between them leaves the
+published path absent with a complete tree at the retired path.
+`restore_interrupted_promotion` reconciles that under the lock **before** the
+cache is consulted: a retired tree with no published entry is republished, and
+a retired tree alongside a published entry is discarded. A crash therefore never
+strands a valid cache entry or forces a network install to recover.
+
+Because staging always starts empty, a re-install can never see a previous
+`package-lock.json`, which **subsumes** #554's explicit volatile lockfile
+removal. That now-unreachable removal is deleted and #554's behavioral guarantee
+("an expired volatile re-resolve must not let npm see a prior lockfile") is
+retained as an assertion in the existing #554 test.
+
+### Typed, bounded, redacted diagnostics
+
+Two new `PackageRuntimeError` variants: `InstallLockUnavailable` and
+`InstallPromotionFailed`. Every detail string is truncated to
+`MAX_DETAIL_CHARS` (256) and carries the selector digest plus the
+`io::ErrorKind` — never an absolute cache path (which embeds the user's home
+directory and therefore the account name).
+
+The issue's proposed direction also asked for a distinct stale-lock-recovery
+variant. Under a kernel advisory lock there is no stale-lock recovery step to
+fail, so that variant would be unreachable and is deliberately not added.
+
+## Acceptance matrix
+
+| # | Actor / launch path | Input / boundary | Success behavior | Failure behavior + diagnostic location | Side effects permitted before failure | Persistence / compatibility | Behavioral proof |
+|---|---|---|---|---|---|---|---|
+| A1 | Two concurrent OS processes calling `finalize_local_invocation_at` (production preparation boundary) for the same digest | same cache root, same selector, cold cache; npm stub sleeps to widen the window | both succeed; `npm install` runs **exactly once**; both resolve the identical executable path | n/a | second process waits on the lock | on-disk cache layout unchanged for readers | `concurrent_processes_install_once_and_agree` (re-execs the test binary twice) |
+| A2 | `finalize_local_invocation_at`, cache miss | npm stub asserts, from inside the install, that the *final* install directory holds no `node_modules` | install is built in `.staging-<digest>` and renamed into place; final path never holds a partial tree | n/a | staging directory created | final directory only ever complete | `install_is_staged_and_promoted_atomically` |
+| A3 | `finalize_local_invocation_at`, cache miss, npm fails mid-install | stub creates a partial `node_modules` then exits non-zero | typed `InstallFailed`; final install directory has **no marker** and no promoted tree; a subsequent run with a healthy stub installs successfully | `PackageRuntimeError::InstallFailed` | staging left behind, reclaimed by the next run | no cache hit is ever produced from an interrupted install | `interrupted_install_leaves_no_cache_hit_and_retries_cleanly` |
+| A3b | Preparation after a process was killed between the two publication renames | published path absent, complete tree at the retired path | the previous entry is republished under the lock; no npm install is required | `InstallPromotionFailed` if the reconciling rename fails | none | a crash never strands a valid cache entry | `a_promotion_interrupted_after_retiring_restores_the_previous_install`, `a_completed_promotion_discards_a_leftover_retired_tree` |
+| A4a | A second OS process takes the lock and is **killed** without releasing it | holder dies with the lock held | the kernel releases the lock; the next acquisition succeeds with no recovery step and no timeout | n/a | none | — | `a_lock_whose_holder_was_killed_is_available_without_recovery` |
+| A4b | A second OS process holds the lock for the whole (shortened, injected) ceiling | holder alive throughout | never taken over; once the holder releases, the waiter acquires | `PackageRuntimeError::InstallLockUnavailable` | none | — | `a_lock_held_by_a_live_process_is_never_taken_over` |
+| A4c | `prepare_managed_npm_with_lock_policy` while the digest is held | held for longer than the injected ceiling | fails closed | `InstallLockUnavailable`; no install directory is created | none — no install, no staging | — | `a_live_installer_blocks_preparation_with_a_typed_redacted_error` |
+| A5 | Both new failure variants | unopenable lock, expired wait, failed publication | — | each variant is distinct, `Display` is bounded, carries the selector digest, and contains no path separator, cache path, or home directory | none | — | `a_lock_that_cannot_be_opened_is_typed_bounded_and_redacted`, `a_wait_timeout_is_typed_bounded_and_redacted`, `a_failed_promotion_is_typed_bounded_and_redacted` |
+| A6 | Existing single-process npm behavior | existing package-runtime, #554 TTL, probe, and launch-compose tests | unchanged and green; no timing-dependent assertions added | — | — | marker format unchanged | existing `package_runtime_tests.rs`, `tests/issue382/package_selector.rs` |
+| A7 | uvx preparation | uvx candidate | unchanged: no lock, no staging, structural `--from` prefix | — | — | — | `local_uvx_is_a_closed_structural_prefix`, `structural_uvx_probe_executes_the_selected_agent_invocation` |
+
+## Non-goals
+
+- Selector normalization, digest derivation, cache-key semantics (#554).
+- Probe budgets / probe phase semantics (#553).
+- Any new dependency (`libc`, `rustix`, `fs2`, `fd-lock`, …). `unsafe` stays
+  forbidden.
+- Background installer, daemon, or install queue.
+- Windows-specific locking work and native-Windows verification (#557).
+- Garbage-collecting the package cache, cache size limits, or eviction.
+- `src/runtime/llxprt_install.rs` (superseded, no production callers — already
+  a recorded #554 follow-up).
+
+## Vertical slices
+
+1. **Lock protocol** — `src/runtime/package_install_lock.rs`: identity-based
+   staleness, `create_new` acquisition, verified rename takeover, bounded wait,
+   RAII release. RED: A4a/A4b/A4c/A5.
+2. **Atomic install + lock integration** — `src/runtime/package_runtime.rs`:
+   staging/promotion, marker-in-staging, lock held across cache-hit check
+   through fingerprint capture, new typed variants. RED: A1/A2/A3/A5.
+
+Both slices live in one architectural layer (`src/runtime`) and one orchestration
+route (managed npm preparation), so no stacked split is required.
+
+## Expected paths
+
+| Layer | Path | Change |
+|---|---|---|
+| runtime | `src/runtime/package_install_lock.rs` | new (private module) |
+| runtime | `src/runtime/package_runtime.rs` | modified |
+| runtime | `src/runtime/mod.rs` | register private module |
+| tests | `src/runtime/package_runtime_lock_tests.rs` | new |
+| tests | `src/runtime/package_runtime_tests.rs` | witness helper adapted to an absolute path (staging makes an in-directory witness unobservable across installs); #554 assertions preserved |
+| tests | `src/runtime/package_install_lock_tests.rs` | new |
+| quality tooling | `clippy.toml`, `.github/clippy/clippy.toml` | `msrv` corrected (approved, S6) |
+| collateral | 11 files under `src/` and `tests/` | mechanical `collapsible_if` / `unnecessary_map_or` rewrites newly required by the corrected `msrv` (S7) |
+| docs | `project-plans/issue555-plan.md` | this plan |
+
+Budget: 24 files, +1,684 net lines. Inside the 25-file target; above the
+1,500-line target, so the mandatory scope review below applies. Far below the
+40-file / 2,500-line hard stop.
+
+## Mandatory scope review (net lines above target)
+
+Every changed file maps to an acceptance row or to an approved scope-ledger
+entry, and nothing was added that is not required by them:
+
+| Group | Files | Net | Justification |
+|---|---|---|---|
+| Production behavior | `package_install_lock.rs`, `package_runtime.rs`, `mod.rs` | ~+340 | Acceptance rows A1–A5 and scope-ledger S1, S8, S9. |
+| Behavioral tests | `package_install_lock_tests.rs`, `package_runtime_lock_tests.rs`, `package_runtime_tests.rs` | ~+830 | One test per acceptance row plus the two-process harness A1 requires. Test coverage is the largest group and is explicitly not treated as scope expansion. |
+| Plan and triage record | `project-plans/issue555-plan.md` | ~+310 | Required by the workflow (acceptance matrix, non-goals, ledger, review counters, triage). Documentation only. |
+| Approved MSRV correction and its collateral | `clippy.toml`, `.github/clippy/clippy.toml`, 11 mechanical source files | ~+40 | Scope-ledger S6 (user-approved) and S7 (unavoidable, machine-applied, semantically identical). |
+
+No new subsystem, public abstraction, dependency, or behavior outside the
+acceptance matrix was introduced. The overage is documentation and behavioral
+tests, not production surface, so the work is not split.
+
+## Scope ledger
+
+| # | Discovered work | Disposition |
+|---|---|---|
+| S1 | New private module `package_install_lock.rs` instead of growing `package_runtime.rs` | **In scope.** `package_runtime.rs` is already 503 lines against a 750-line warn / 1000-line hard gate. Same layer, same route, `pub(super)` only — an internal split, not a new public abstraction. |
+| S2 | #554's explicit `package-lock.json` removal becomes unreachable under fresh staging | **In scope.** Removing unreachable code is required by the accepted behavior; #554's behavioral assertion is preserved in its existing test. |
+| S3 | #554 witness helper moves from `<install_dir>/.jefe-lock-witness` to an absolute path supplied by env | **In scope.** Forced by A2 (staging starts empty), not an unrelated test move. Assertions unchanged. |
+| S4 | Re-exec of the unit-test binary to obtain a genuine second OS process for A1 | **In scope.** Uses `std::env::current_exe`, an established pattern in this repo (`process_tests.rs`, `harness_v1.rs`). No new `[[bin]]`, no manifest change. |
+| S5 | Lock-wait ceiling injected via a private `LockPolicy` seam so A4b/A4c do not sleep for the production 5-minute ceiling | **In scope.** Test seam only; the public preparation boundary keeps its signature and production defaults. |
+| S6 | `clippy.toml` / `.github/clippy/clippy.toml` `msrv` raised from `1.75` to `1.89` | **Approved by the user.** Required to use `std::fs::File::try_lock`, which is the only correct lock available without a new dependency or `unsafe`. The old value was already impossible: `edition = "2024"` needs Rust ≥ 1.85, `Cargo.toml` declares no `rust-version`, and every CI job uses the stable toolchain. Not a loosening — no threshold was raised and no lint was downgraded or suppressed. |
+| S7 | 16 pre-existing `collapsible_if` / `unnecessary_map_or` sites across 11 files became lint errors once the `msrv` was corrected (let-chains and `is_none_or` are ≥ 1.88) | **In scope as unavoidable collateral of S6.** Every edit is clippy's own machine-applicable rewrite and semantically identical. The alternative — suppression attributes — is forbidden by the lint-guardrail policy. |
+| S8 | `INSTALL_LOCK` changed from one process-global mutex to a per-digest map | **In scope (review finding).** Preparation now waits on another process while holding the intra-process guard, so a global guard would newly let one contended digest block every unrelated one. Preserves the #382 invariant at the correct granularity. |
+| S9 | `restore_interrupted_promotion` added | **In scope (review finding).** Publication is two renames; without reconciliation a crash between them strands a valid cache entry and forces a network install to recover. |
+
+## Review counters
+
+- Local OCR runs (cap 2): 1 — commit-scoped, `complete_best_effort`, artifacts under
+  `~/Library/Logs/llxprt-code/opencodereview/runs/20260801T055530Z-ce3f71ee/`
+  (plus corroborating runs launched inside the two review subagents).
+- PR OCR runs (cap 2): 2 — both automatic, on PR #572. The bot reports
+  "Automatic OCR review budget: 2 of 2 used". No further review runs are
+  requested; remaining work is remediation only.
+
+## Review triage
+
+Cycle 1: `rustreviewer` and `deepthinker` (independent, full-scope) plus OCR.
+
+| Finding | Disposition |
+|---|---|
+| Stale takeover (`rename` + read-back) is not compare-and-swap; two recoverers can both own the lock, and an earlier guard can unlink a successor's lock | **Blocker — Fixed.** Replaced the entire userspace protocol with `std::fs::File::try_lock` (kernel `flock`/`LockFileEx`). No takeover, no unlink, no ownership record. |
+| Create-then-write window plus wall-clock `content_grace` allows stealing a live lock; read errors read as an empty body; clock jumps break both directions | **Blocker — Fixed.** No lock body, no mtime and no wall clock remain in the protocol. |
+| Crash between the two publication renames strands the previous good tree; rollback failure is swallowed; retired tree deleted while the published path is absent | **Blocker — Fixed.** `restore_interrupted_promotion` reconciles under the lock before the cache is consulted; a failed restore is reported as its own diagnostic. |
+| `remove_tree` treats every metadata error as absence, so staging may not actually be reset | **In-scope — Fixed.** Only `NotFound` counts as absent; `Path::exists` replaced by a fallible `exists`. |
+| Degraded pid-only self identity defeats pid-reuse detection and is cached for the process lifetime | **Fixed by design.** No identity is recorded at all. |
+| One process-global install mutex held across a cross-process wait blocks unrelated digests | **In-scope — Fixed.** Per-digest guards (S8). |
+| Promotion diagnostics do not carry the selector digest the plan claims | **In-scope — Fixed.** Promotion shares the lock module's bounded/redacted formatter and asserts the digest. |
+| Timeout diagnostic asserts the holder is live when liveness was only not disproven | **Fixed by design.** The kernel answer is definitive; the message now states the lock is still held. |
+| Orphaned `.claim-*` files accumulate after a crash | **Fixed by design.** No claim files exist. |
+| The two-process test has no start barrier, so a loaded machine could serialize the children and pass against an unserialized implementation; children are not reaped and stderr is discarded | **In-scope — Fixed.** Children publish readiness and park until the parent releases a start marker; stderr goes to per-child files; an RAII guard always kills and reaps. |
+| Lock tests only exercise one in-process recoverer | **In-scope — Fixed.** Contended and killed-holder cases now use a real second OS process. |
+| Publication briefly leaves the path absent, so a consumer that already resolved an executable but has not spawned it — or a running agent loading files by path — is not protected. Fix requires generation-addressed install directories, a pointer swap, retention of referenced generations, and re-fingerprinting before spawn | **Defer.** Real, but it is a property of the fixed-path cache design that predates this change (in-place `npm install` was strictly worse), and the remedy changes cache-key/path semantics — an explicit non-goal here. Follow-up issue filed. |
+| Cache hits now require a writable cache root, so a read-only or full cache fails a launch that previously succeeded | **Reject (accepted trade-off).** The issue's stated direction requires the lock to be taken before the cache-hit check. Removing it safely needs the deferred generation-addressed design. |
+| Add `fs2`/`fd-lock`, or an audited OS-lock implementation | **Reject.** Unnecessary: std provides the same primitive. Adding a dependency is an explicit non-goal. |
+| No `fsync`, so power-loss durability is not guaranteed | **Reject.** Power-loss durability is not claimed; the documentation says process crash. |
+| Shared network/NFS or cross-PID-namespace caches are unsound | **Reject (documented).** jefe's cache is the local per-user `dirs::cache_dir()`; the module states that a shared network cache is unsupported. |
+| Volatile marker stamps `now` from before the wait, slightly shortening the next TTL | **Reject.** `now` is injected for determinism; the shift is bounded by the install duration and immaterial against a 12 h TTL. |
+
+Cycle 2: Open Code Review on PR #572 (2 automatic runs, 17 inline findings).
+
+| Finding | Disposition |
+|---|---|
+| Reconciliation discards the retired tree whenever the published path merely *exists*, so a corrupt published entry destroys the last complete copy | **Blocker — Fixed.** The retired tree is discarded only once the published entry is structurally complete (marker present, selected binary resolvable); otherwise the unusable published directory is removed and the retired one republished. The check is structural rather than `cache_hit`, because a merely TTL-expired entry is still a better offline fallback than none. New test `an_unusable_published_install_is_replaced_by_the_retired_tree`. |
+| `INSTALL_LOCKS` grows without bound (reported twice) | **In-scope — Fixed.** `install_guard_for` drops guards the map alone references before inserting. Safe because a preparer keeps its `Arc` alive across the whole critical section, so two preparers of one digest can never receive different mutexes. |
+| `HolderProcess::release` calls `wait` with no timeout, turning a hung holder into a stalled CI run | **In-scope — Fixed.** `wait_bounded` polls `try_wait` against a 30 s deadline and kills the child on overrun. No `wait-timeout` dependency added. |
+| `HolderProcess` borrows the `TempDir` instead of owning it | **In-scope — Fixed.** It now owns the `TempDir`, so the compiler enforces the lifetime. |
+| Test file inherits `Duration`/`Instant` from the parent module's glob | **In-scope — Fixed.** Explicit imports added. |
+| Generated shell stubs splice paths into single quotes and could break on an embedded quote (reported three times, across both test files and the `settle` argument) | **In-scope — Fixed.** Every interpolated value goes through the repository's existing `runtime::commands::shell_escape_single`, and the scripts bind them to shell variables. |
+| Diagnostic length assertion used `MAX_DETAIL_CHARS * 2`, which is slack rather than a derived bound | **In-scope — Fixed.** A named `MAX_DIAGNOSTIC_CHARS = MAX_DETAIL_CHARS + 64` (the fixed `Display` prefix) is used by every diagnostic assertion. |
+| The two-process test protocol has no summary documentation | **In-scope — Fixed.** Module-level doc block describing the re-execution contract, the environment channel, the barrier file naming, the report format, and child ownership. |
+| `observed_candidate` resolves the candidate twice | **Reject (documented).** Not redundant: the first resolution is the only way to derive the published install directory the stub must be told about, and the second must follow the real stub so the candidate fingerprints the npm that actually runs. Comment added. |
+| Guards are held across `npm install`; drop and reacquire, or stage per process and lock only for promotion | **Reject.** Spanning the install is the point of the lock, and per-process staging would let N processes each run a full install of the same package — the duplicated work A1 forbids. The claim that unrelated digests are blocked is incorrect: both guards are keyed by digest. Tradeoff now stated in the code. |
+| Add a runtime assertion or wrapper enforcing lock-acquisition order to prevent a future ABBA deadlock | **Reject.** Both acquisitions are adjacent lines of one private function and `package_install_lock::acquire` has no other production caller. Thread-local lock-order tracking would be a new subsystem guarding a hypothetical future edit. |
+| The barrier plus the 1 s stub delay makes the two-process test timing-sensitive on loaded CI | **Reject.** The barrier is what removes the timing sensitivity: both children are proved to be inside preparation before either is released, so overlap does not depend on spawn order or scheduling. The 60 s deadline is a hang guard that fails the test, not a synchronization assumption. |
+| `is_none_or` equivalence confirmation | **No action.** Informational. |
+
+## Deferred findings
+
+- Generation-addressed managed installs so a consumer that has already resolved
+  an executable, or a running agent that loads files by path, is insulated from
+  a replacement — plus the read-only-cache fast path that becomes possible once
+  published generations are immutable. Filed as **#571**.

--- a/src/app_input/relaunch.rs
+++ b/src/app_input/relaunch.rs
@@ -83,7 +83,7 @@ pub(super) fn recoverable_server_lost_ids(
                 .iter()
                 .find(|repository| repository.id == agent.repository_id)
                 .is_some_and(|repository| !repository.remote.enabled)
-                && requested.map_or(true, |ids| ids.contains(&agent.id))
+                && requested.is_none_or(|ids| ids.contains(&agent.id))
         })
         .map(|agent| agent.id.clone())
         .collect()

--- a/src/border_capability/mod.rs
+++ b/src/border_capability/mod.rs
@@ -264,8 +264,8 @@ mod windows_adapter {
             // terminal_init sibling module: log on failure so a stray glyph is
             // observable in diagnostics without failing the probe). This must
             // run regardless of whether the read-back succeeded.
-            if let Some(cell) = original.first() {
-                if let Err(error) = console.write_output(
+            if let Some(cell) = original.first()
+                && let Err(error) = console.write_output(
                     &[CharInfo {
                         char_value: cell.char_value,
                         attributes: cell.attributes,
@@ -273,13 +273,13 @@ mod windows_adapter {
                     Self::SINGLE_CELL,
                     Self::ORIGIN,
                     Self::scratch_region(scratch_x, scratch_y),
-                ) {
-                    tracing::warn!(
-                        error = %error,
-                        "rounded-corner probe: failed to restore scratch cell; \
-                         a stray glyph may be visible briefly"
-                    );
-                }
+                )
+            {
+                tracing::warn!(
+                    error = %error,
+                    "rounded-corner probe: failed to restore scratch cell; \
+                     a stray glyph may be visible briefly"
+                );
             }
 
             // Now surface the read-back error (fail-safe to RoundSupported at

--- a/src/jsp/v1/compliance/reference_adapter.rs
+++ b/src/jsp/v1/compliance/reference_adapter.rs
@@ -485,11 +485,11 @@ fn bind_server_interaction(interaction: &mut serde_json::Value, credential: &Cre
     {
         bind_server_identity(&mut request["body"], &credential.identity);
     }
-    if interaction.get("stream").is_some() {
-        if let Some(items) = interaction["stream"].as_array_mut() {
-            for item in items {
-                bind_server_identity(&mut item["document"], &credential.identity);
-            }
+    if interaction.get("stream").is_some()
+        && let Some(items) = interaction["stream"].as_array_mut()
+    {
+        for item in items {
+            bind_server_identity(&mut item["document"], &credential.identity);
         }
     }
     if interaction

--- a/src/jsp/v1/compliance/schema_utf8.rs
+++ b/src/jsp/v1/compliance/schema_utf8.rs
@@ -6,7 +6,7 @@ pub(super) fn custom_utf8_valid(root: &Value, schema: &Value, instance: &Value) 
     let reference_valid = schema
         .get("$ref")
         .and_then(Value::as_str)
-        .map_or(true, |reference| {
+        .is_none_or(|reference| {
             reference
                 .strip_prefix('#')
                 .and_then(|pointer| root.pointer(pointer))
@@ -29,7 +29,7 @@ pub(super) fn custom_utf8_valid(root: &Value, schema: &Value, instance: &Value) 
         (Some(properties), Some(object)) => object.iter().all(|(key, value)| {
             properties
                 .get(key)
-                .map_or(true, |child| custom_utf8_valid(root, child, value))
+                .is_none_or(|child| custom_utf8_valid(root, child, value))
         }),
         _ => true,
     };
@@ -42,7 +42,7 @@ pub(super) fn custom_utf8_valid(root: &Value, schema: &Value, instance: &Value) 
     let branches_valid = schema
         .get("oneOf")
         .and_then(Value::as_array)
-        .map_or(true, |branches| {
+        .is_none_or(|branches| {
             branches
                 .iter()
                 .filter(|branch| branch_matches_discriminator(branch, instance))
@@ -56,9 +56,9 @@ fn branch_matches_discriminator(branch: &Value, instance: &Value) -> bool {
         return true;
     };
     properties.iter().all(|(key, property)| {
-        property.get("const").map_or(true, |expected| {
-            instance.get(key).is_some_and(|actual| actual == expected)
-        })
+        property
+            .get("const")
+            .is_none_or(|expected| instance.get(key).is_some_and(|actual| actual == expected))
     })
 }
 

--- a/src/jsp/v1/parse.rs
+++ b/src/jsp/v1/parse.rs
@@ -66,19 +66,19 @@ pub(super) fn expect_kind(input: &[u8], expected: &str) -> Result<(), JspError> 
         // deserialization below with a precise location.
         return Ok(());
     };
-    if let Some(schema) = probe.schema {
-        if schema != ACCEPTED_SCHEMA {
-            return Err(JspError::unsupported_version(format!(
-                "document.schema: unsupported schema version (accepted: {ACCEPTED_SCHEMA})"
-            )));
-        }
+    if let Some(schema) = probe.schema
+        && schema != ACCEPTED_SCHEMA
+    {
+        return Err(JspError::unsupported_version(format!(
+            "document.schema: unsupported schema version (accepted: {ACCEPTED_SCHEMA})"
+        )));
     }
-    if let Some(kind) = probe.kind {
-        if kind != expected {
-            return Err(JspError::unsupported_version(format!(
-                "document.kind: unsupported kind (accepted: {expected})"
-            )));
-        }
+    if let Some(kind) = probe.kind
+        && kind != expected
+    {
+        return Err(JspError::unsupported_version(format!(
+            "document.kind: unsupported kind (accepted: {expected})"
+        )));
     }
     Ok(())
 }

--- a/src/recovery_editor.rs
+++ b/src/recovery_editor.rs
@@ -153,7 +153,7 @@ fn parse_windows_word(chars: &[char], mut index: usize) -> (String, usize) {
         }
         if chars.get(index) == Some(&'"') {
             push_backslashes(&mut word, backslashes / 2);
-            if backslashes % 2 == 0 {
+            if backslashes.is_multiple_of(2) {
                 quoted = !quoted;
             } else {
                 word.push('"');

--- a/src/runtime/agent_execution_guard_tests.rs
+++ b/src/runtime/agent_execution_guard_tests.rs
@@ -152,7 +152,7 @@ fn exact_match_authorizes_and_borrows_plan() {
     let evidence = base_evidence();
     match authorize_execution(&plan, &evidence) {
         AuthorizationResult::Authorized(authorized) => {
-            assert!(std::ptr::eq(authorized.plan(), &plan));
+            assert!(std::ptr::eq(authorized.plan(), &raw const plan));
             assert_eq!(authorized.plan().definition_sha256, plan.definition_sha256);
             assert_eq!(authorized.plan().executable, plan.executable);
             assert_eq!(authorized.plan().probe_generation, plan.probe_generation);

--- a/src/runtime/agent_preflight.rs
+++ b/src/runtime/agent_preflight.rs
@@ -435,14 +435,14 @@ pub fn prepare_execution<'a>(
 
     // 4. Detect engine fingerprint change.
     let observed = engine_outcome.fingerprint();
-    if let Some(expected) = expected_engine_fingerprint {
-        if observed != expected {
-            return PreparationOutcome::Unavailable(UnavailableReason::EngineFingerprintChanged {
-                engine: engine.clone(),
-                expected: expected.to_owned(),
-                actual: observed.to_owned(),
-            });
-        }
+    if let Some(expected) = expected_engine_fingerprint
+        && observed != expected
+    {
+        return PreparationOutcome::Unavailable(UnavailableReason::EngineFingerprintChanged {
+            engine: engine.clone(),
+            expected: expected.to_owned(),
+            actual: observed.to_owned(),
+        });
     }
 
     // 5. Inspect image with fixed structural argv (never pull/build).

--- a/src/runtime/external_terminal.rs
+++ b/src/runtime/external_terminal.rs
@@ -141,10 +141,10 @@ pub fn build_external_terminal_plan(
 
     // Auto-detect the terminal jefe is running inside, so a user in iTerm2 or
     // WezTerm gets that emulator rather than the platform default (#549).
-    if let Some(detected) = detect_emulator_from_env() {
-        if let Some(plan) = plan_from_detected(&detected, work_dir, platform) {
-            return Ok(plan);
-        }
+    if let Some(detected) = detect_emulator_from_env()
+        && let Some(plan) = plan_from_detected(&detected, work_dir, platform)
+    {
+        return Ok(plan);
     }
 
     match platform {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -52,6 +52,9 @@ mod multiplexer;
 /// Non-interactive (single-prompt, capture-stdout) agent execution (issue #214).
 mod non_interactive;
 mod orphan;
+/// Cross-process advisory lock over the managed package install cache
+/// (issue #556).
+mod package_install_lock;
 mod package_probe;
 /// Generic package-backed invocation and preparation boundary (issue #382 S12).
 pub mod package_runtime;

--- a/src/runtime/package_install_lock.rs
+++ b/src/runtime/package_install_lock.rs
@@ -1,0 +1,176 @@
+//! Cross-process advisory lock for the managed package install cache.
+//!
+//! The managed install directory `<cache_root>/<selector-digest>/` is a
+//! **per-machine** resource, so the per-digest mutex in
+//! [`super::package_runtime`] cannot serialize it. Without this lock, two jefe
+//! processes that miss the same digest run `npm install` concurrently into one
+//! directory — issue #425 Problem B reproduced inside jefe's own cache.
+//!
+//! # Protocol
+//!
+//! The lock is a kernel advisory lock (`flock` on Unix, `LockFileEx` on
+//! Windows) taken through [`std::fs::File::try_lock`] on
+//! `<cache_root>/<digest>.lock`, a **sibling** of the install directory rather
+//! than a file inside it: the install directory is replaced wholesale by
+//! `rename`, which would carry away a lock held inside it.
+//!
+//! Because the lock lives in the kernel and is attached to the open file
+//! description, the operating system releases it when the holder exits for any
+//! reason, including `SIGKILL` and a power loss. There is consequently no
+//! stale-lock state to detect and no lock ownership recorded on disk:
+//!
+//! - a legitimate install is never declared stale no matter how long it runs,
+//!   which is precisely the mistake npm's five-second stale threshold made;
+//! - a crashed holder needs no recovery, so there is no window in which two
+//!   processes could each decide to recover the same lock;
+//! - the lock file is never unlinked, so no process can remove a lock that
+//!   another process is holding.
+//!
+//! Waiting is bounded by the install timeout plus a grace margin, after which
+//! acquisition fails closed with a typed error rather than proceeding
+//! unlocked. The lock file itself is a zero-byte sentinel; it is created if
+//! absent and never truncated, because another process may already hold it.
+//!
+//! # Scope
+//!
+//! This serializes processes on one machine against one local cache directory,
+//! which is what `dirs::cache_dir()` provides. Advisory locking over a network
+//! filesystem is emulated at best; jefe does not support a shared network
+//! package cache.
+
+use std::fs::{File, OpenOptions, TryLockError};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use crate::domain::agent_definition::limits::PACKAGE_MATERIALIZATION_TIMEOUT_MS;
+
+use super::package_runtime::PackageRuntimeError;
+
+/// Margin added to the install timeout to derive the wait ceiling.
+const LOCK_WAIT_GRACE: Duration = Duration::from_secs(30);
+
+/// Upper bound on any diagnostic detail carried by a lock failure.
+pub(super) const MAX_DETAIL_CHARS: usize = 256;
+
+/// Leading digest characters included in diagnostics for correlation.
+const DIGEST_DIAGNOSTIC_CHARS: usize = 12;
+
+/// Timing envelope for one lock acquisition.
+///
+/// [`Self::production`] is the only configuration used by jefe; the fields
+/// exist so tests can exercise the waiting path without sleeping for the
+/// production ceiling.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct LockPolicy {
+    /// Longest total time spent waiting before failing closed.
+    pub(super) ceiling: Duration,
+    /// Delay between acquisition attempts.
+    pub(super) poll_interval: Duration,
+}
+
+impl LockPolicy {
+    /// Production timings, with the ceiling derived from the install timeout.
+    pub(super) const fn production() -> Self {
+        Self {
+            ceiling: Duration::from_millis(PACKAGE_MATERIALIZATION_TIMEOUT_MS)
+                .saturating_add(LOCK_WAIT_GRACE),
+            poll_interval: Duration::from_millis(50),
+        }
+    }
+}
+
+/// Held managed-install lock.
+///
+/// The kernel releases the lock when the file is closed, which happens when
+/// this guard is dropped and equally when the process dies.
+#[derive(Debug)]
+pub(super) struct InstallLockGuard {
+    file: File,
+}
+
+impl Drop for InstallLockGuard {
+    fn drop(&mut self) {
+        if let Err(error) = self.file.unlock() {
+            // Closing the file releases the lock regardless, so this is
+            // reported rather than escalated.
+            tracing::warn!(
+                kind = ?error.kind(),
+                "could not release the managed package install lock"
+            );
+        }
+    }
+}
+
+/// Acquire the cross-process managed-install lock for one selector digest.
+///
+/// Blocks while another process holds the lock and fails closed once
+/// `policy.ceiling` elapses.
+///
+/// # Errors
+/// [`PackageRuntimeError::InstallLockUnavailable`] when the lock file cannot
+/// be opened, when the platform reports a locking error, or when the lock is
+/// still held at the ceiling.
+pub(super) fn acquire(
+    lock_path: &Path,
+    digest: &str,
+    policy: LockPolicy,
+) -> Result<InstallLockGuard, PackageRuntimeError> {
+    // Never truncate: another process may be holding this exact file.
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(lock_path)
+        .map_err(|error| {
+            unavailable(
+                digest,
+                &format!("cannot open lock file ({:?})", error.kind()),
+            )
+        })?;
+    let started = Instant::now();
+    loop {
+        match file.try_lock() {
+            Ok(()) => return Ok(InstallLockGuard { file }),
+            Err(TryLockError::WouldBlock) => {}
+            Err(TryLockError::Error(error)) => {
+                return Err(unavailable(
+                    digest,
+                    &format!("platform lock failed ({:?})", error.kind()),
+                ));
+            }
+        }
+        if started.elapsed() >= policy.ceiling {
+            return Err(unavailable(
+                digest,
+                &format!(
+                    "still held by another process after {}s",
+                    policy.ceiling.as_secs()
+                ),
+            ));
+        }
+        std::thread::sleep(policy.poll_interval);
+    }
+}
+
+fn unavailable(digest: &str, message: &str) -> PackageRuntimeError {
+    PackageRuntimeError::InstallLockUnavailable(bounded_detail(digest, message))
+}
+
+/// Bounded, redacted diagnostic detail.
+///
+/// Carries the leading digest characters for correlation and never an absolute
+/// cache path, which would embed the user's home directory and account name.
+pub(super) fn bounded_detail(digest: &str, message: &str) -> String {
+    let short: String = digest.chars().take(DIGEST_DIAGNOSTIC_CHARS).collect();
+    format!("digest={short}: {message}")
+        .chars()
+        .take(MAX_DETAIL_CHARS)
+        .collect()
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    include!("package_install_lock_tests.rs");
+}

--- a/src/runtime/package_install_lock_tests.rs
+++ b/src/runtime/package_install_lock_tests.rs
@@ -1,0 +1,283 @@
+// Issue #556: cross-process managed-install lock.
+//
+// Included into `package_install_lock::tests`.
+//
+// A lock that is only exercised from one process proves nothing, so the
+// contended cases run a second real OS process. Re-executing the test binary
+// through `std::env::current_exe` is the repository's established way to obtain
+// one (`process_tests.rs`, `tests/harness_v1.rs`) and needs no extra `[[bin]]`.
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+const DIGEST: &str = "0123456789abcdef0123456789abcdef";
+
+/// Directory the holder child operates in. Absent for every ordinary run.
+const HOLDER_DIR_ENV: &str = "JEFE_TEST_INSTALL_LOCK_HOLDER_DIR";
+const HOLDER_TEST_PATH: &str = "runtime::package_install_lock::tests::install_lock_holder_process";
+
+const HELD_MARKER: &str = "held";
+const RELEASE_MARKER: &str = "release";
+
+/// Longest a test will wait for a child to reach a state or exit.
+const CHILD_DEADLINE: Duration = Duration::from_secs(30);
+
+fn fast_policy(ceiling: Duration) -> LockPolicy {
+    LockPolicy {
+        ceiling,
+        poll_interval: Duration::from_millis(10),
+    }
+}
+
+fn lock_dir() -> TempDir {
+    tempfile::tempdir().unwrap_or_else(|error| panic!("lock dir: {error}"))
+}
+
+fn lock_path(dir: &Path) -> PathBuf {
+    dir.join("digest.lock")
+}
+
+/// Wait for `path` to appear, failing the test rather than hanging forever.
+fn await_path(path: &Path, what: &str) {
+    let deadline = Instant::now() + CHILD_DEADLINE;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    panic!("timed out waiting for {what}: {}", path.display());
+}
+
+/// A second OS process that takes the lock and holds it until told to stop.
+///
+/// Inert unless the parent test supplies the channel directory, so an ordinary
+/// `cargo test` run executes it as a no-op.
+#[test]
+fn install_lock_holder_process() {
+    let Some(dir) = std::env::var_os(HOLDER_DIR_ENV) else {
+        return;
+    };
+    let dir = PathBuf::from(dir);
+    let held = acquire(&lock_path(&dir), DIGEST, LockPolicy::production())
+        .unwrap_or_else(|error| panic!("holder could not acquire the lock: {error}"));
+    std::fs::write(dir.join(HELD_MARKER), "held")
+        .unwrap_or_else(|error| panic!("publish held marker: {error}"));
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while Instant::now() < deadline && !dir.join(RELEASE_MARKER).exists() {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    drop(held);
+}
+
+/// A running holder child, always reaped even if the test panics.
+///
+/// The holder owns its channel directory so the compiler, rather than a
+/// convention, guarantees the directory outlives the child process.
+struct HolderProcess {
+    child: std::process::Child,
+    directory: TempDir,
+}
+
+impl HolderProcess {
+    /// Spawn the holder and return once it has actually taken the lock.
+    fn start() -> Self {
+        let directory = lock_dir();
+        let binary = std::env::current_exe().unwrap_or_else(|error| panic!("current_exe: {error}"));
+        let child = std::process::Command::new(binary)
+            .args(["--exact", HOLDER_TEST_PATH, "--nocapture", "--test-threads=1"])
+            .env(HOLDER_DIR_ENV, directory.path())
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap_or_else(|error| panic!("spawn lock holder: {error}"));
+        let held = directory.path().join(HELD_MARKER);
+        let holder = Self { child, directory };
+        await_path(&held, "the holder to take the lock");
+        holder
+    }
+
+    /// Channel directory, which is also the directory holding the lock file.
+    fn directory(&self) -> &Path {
+        self.directory.path()
+    }
+
+    /// The contended lock.
+    fn lock_path(&self) -> PathBuf {
+        lock_path(self.directory())
+    }
+
+    /// Ask the holder to release the lock and exit normally.
+    fn release(&mut self) {
+        std::fs::write(self.directory().join(RELEASE_MARKER), "release")
+            .unwrap_or_else(|error| panic!("publish release marker: {error}"));
+        let status = self.wait_bounded("release");
+        assert!(status.success(), "lock holder failed: {status:?}");
+    }
+
+    /// Kill the holder without giving it any chance to clean up.
+    fn kill(&mut self) {
+        self.child
+            .kill()
+            .unwrap_or_else(|error| panic!("kill lock holder: {error}"));
+        self.wait_bounded("kill");
+    }
+
+    /// Reap the child within [`CHILD_DEADLINE`].
+    ///
+    /// A plain `wait` would turn a hung holder into a stalled CI run instead of
+    /// a failing test, so the wait is bounded and the child is killed if it
+    /// overruns.
+    fn wait_bounded(&mut self, what: &str) -> std::process::ExitStatus {
+        let deadline = Instant::now() + CHILD_DEADLINE;
+        while Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(status)) => return status,
+                Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+                Err(error) => panic!("wait for lock holder ({what}): {error}"),
+            }
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        panic!("lock holder did not exit within the deadline after {what}");
+    }
+}
+
+impl Drop for HolderProcess {
+    fn drop(&mut self) {
+        // A panicking test must not leave a process holding the lock.
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn an_uncontended_lock_is_acquired_and_released() {
+    let dir = lock_dir();
+    let path = lock_path(dir.path());
+    {
+        let _guard = acquire(&path, DIGEST, LockPolicy::production())
+            .unwrap_or_else(|error| panic!("acquire: {error}"));
+        assert!(path.exists(), "an acquired lock must exist on disk");
+    }
+    let reacquired = acquire(&path, DIGEST, fast_policy(Duration::from_millis(200)));
+    assert!(
+        reacquired.is_ok(),
+        "a released lock must be immediately reacquirable: {reacquired:?}"
+    );
+}
+
+#[test]
+fn a_lock_held_by_a_live_process_is_never_taken_over() {
+    // A4b: a live holder is respected for the whole ceiling, however long its
+    // install runs. Declaring a live holder stale is the mistake npm's fixed
+    // five-second threshold made (issue #425 Problem B).
+    let mut holder = HolderProcess::start();
+
+    let outcome = acquire(
+        &holder.lock_path(),
+        DIGEST,
+        fast_policy(Duration::from_millis(200)),
+    );
+
+    let error = outcome
+        .err()
+        .unwrap_or_else(|| panic!("a live holder's lock must never be taken over"));
+    assert!(
+        matches!(error, PackageRuntimeError::InstallLockUnavailable(_)),
+        "waiting out a live holder must fail closed with a lock error, got {error:?}"
+    );
+
+    // A1 (lock level): once the holder is finished, the waiter proceeds.
+    holder.release();
+    let after_release = acquire(
+        &holder.lock_path(),
+        DIGEST,
+        fast_policy(Duration::from_secs(30)),
+    );
+    assert!(
+        after_release.is_ok(),
+        "the lock must become available once the holder releases it: {after_release:?}"
+    );
+}
+
+#[test]
+fn a_lock_whose_holder_was_killed_is_available_without_recovery() {
+    // A4a: the holder dies without releasing anything. The kernel owns the
+    // lock, so there is no stale state to detect and no timeout to wait out.
+    let mut holder = HolderProcess::start();
+    holder.kill();
+
+    let outcome = acquire(
+        &holder.lock_path(),
+        DIGEST,
+        fast_policy(Duration::from_secs(30)),
+    );
+
+    assert!(
+        outcome.is_ok(),
+        "a killed holder's lock must be available again with no recovery step: {outcome:?}"
+    );
+}
+
+#[test]
+fn a_lock_that_cannot_be_opened_is_typed_bounded_and_redacted() {
+    // A5: acquisition failure is typed and carries no absolute path.
+    let dir = lock_dir();
+    let missing = dir.path().join("absent-directory").join("digest.lock");
+
+    let error = acquire(&missing, DIGEST, fast_policy(Duration::from_millis(50)))
+        .err()
+        .unwrap_or_else(|| panic!("a lock under a missing directory cannot be opened"));
+
+    assert!(
+        matches!(error, PackageRuntimeError::InstallLockUnavailable(_)),
+        "lock acquisition failure must be its own variant, got {error:?}"
+    );
+    assert_diagnostic_is_bounded_and_redacted(&error.to_string(), dir.path());
+}
+
+#[test]
+fn a_wait_timeout_is_typed_bounded_and_redacted() {
+    // A5: the ceiling failure carries the same bounded, redacted shape.
+    let mut holder = HolderProcess::start();
+
+    let error = acquire(
+        &holder.lock_path(),
+        DIGEST,
+        fast_policy(Duration::from_millis(100)),
+    )
+    .err()
+    .unwrap_or_else(|| panic!("waiting out a live holder must fail"));
+
+    assert_diagnostic_is_bounded_and_redacted(&error.to_string(), holder.directory());
+    holder.release();
+}
+
+/// Longest a rendered diagnostic may be: the bounded detail plus the fixed
+/// `Display` prefix each variant prepends.
+const MAX_DIAGNOSTIC_CHARS: usize = MAX_DETAIL_CHARS + 64;
+
+/// A managed-install diagnostic must stay short and must not leak the cache
+/// location, which contains the user's home directory and account name.
+fn assert_diagnostic_is_bounded_and_redacted(diagnostic: &str, cache_root: &Path) {
+    assert!(
+        diagnostic.chars().count() <= MAX_DIAGNOSTIC_CHARS,
+        "diagnostic must be bounded: {diagnostic:?}"
+    );
+    assert!(
+        !diagnostic.contains(&cache_root.display().to_string()),
+        "diagnostic must not embed the cache location: {diagnostic:?}"
+    );
+    assert!(
+        !diagnostic.contains(std::path::MAIN_SEPARATOR),
+        "diagnostic must not embed any path: {diagnostic:?}"
+    );
+    assert!(
+        diagnostic.contains("digest=0123456789ab"),
+        "diagnostic must correlate to the selector digest: {diagnostic:?}"
+    );
+}

--- a/src/runtime/package_runtime.rs
+++ b/src/runtime/package_runtime.rs
@@ -4,10 +4,11 @@
 //! structural prefix without product-specific branches.
 
 use std::collections::BTreeMap;
+
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
 use serde::Serialize;
@@ -21,11 +22,18 @@ use crate::domain::agent_definition::DefinitionSha256;
 
 use super::agent_probe::command_for_path;
 use super::command_capture::run_command_capture_with_timeout;
+use super::package_install_lock::{self, LockPolicy};
 
 const INSTALL_TIMEOUT: Duration = Duration::from_millis(
     crate::domain::agent_definition::limits::PACKAGE_MATERIALIZATION_TIMEOUT_MS,
 );
 const INSTALL_MARKER: &str = ".jefe-installed";
+
+/// Directory-name prefixes for the two transient siblings of an install
+/// directory. Both begin with `.`, which no selector digest (lowercase hex) can
+/// produce, so neither can collide with a published cache entry.
+const STAGING_PREFIX: &str = ".staging-";
+const RETIRED_PREFIX: &str = ".retired-";
 
 /// How long a volatile-selector install (a moving dist-tag such as `nightly`)
 /// is trusted before jefe re-resolves it against the registry (issue #554).
@@ -35,7 +43,30 @@ const INSTALL_MARKER: &str = ".jefe-installed";
 /// launch. Explicit (pinned) selectors are immutable and never expire.
 const VOLATILE_SELECTOR_TTL: Duration = Duration::from_secs(12 * 60 * 60);
 
-static INSTALL_LOCK: Mutex<()> = Mutex::new(());
+/// Per-digest intra-process install guards (issue #382, narrowed by #556).
+///
+/// The runtime, the non-interactive rewrite path, and the capture worker share
+/// this process, so the single-preparer-per-digest invariant is guarded
+/// explicitly rather than assumed. The guard is keyed by digest because
+/// preparation now waits on another process's install: a process-global guard
+/// would make one contended digest block every unrelated one.
+static INSTALL_LOCKS: Mutex<BTreeMap<String, Arc<Mutex<()>>>> = Mutex::new(BTreeMap::new());
+
+/// The intra-process guard for one selector digest, created on first use.
+///
+/// Unreferenced guards are dropped first so a long-lived process that sees many
+/// distinct selectors does not accumulate them. A guard is only unreferenced
+/// once no preparer holds it: a preparer keeps its `Arc` alive for the whole
+/// critical section, so two preparers of one digest can never be handed
+/// different mutexes.
+fn install_guard_for(digest: &str) -> Arc<Mutex<()>> {
+    let mut guards = match INSTALL_LOCKS.lock() {
+        Ok(guards) => guards,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    guards.retain(|_, guard| Arc::strong_count(guard) > 1);
+    Arc::clone(guards.entry(digest.to_owned()).or_default())
+}
 
 /// Local managed execution or remote structural execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,6 +128,11 @@ pub enum PackageRuntimeError {
     InstallFailed(String),
     /// The selected installed package binary is absent.
     InstalledBinaryMissing { binary: String },
+    /// Another jefe process holds the managed-install lock for this digest and
+    /// still held it at the wait ceiling (issue #556).
+    InstallLockUnavailable(String),
+    /// A complete staged install could not be published into the cache.
+    InstallPromotionFailed(String),
 }
 
 impl std::fmt::Display for PackageRuntimeError {
@@ -126,6 +162,14 @@ impl std::fmt::Display for PackageRuntimeError {
             Self::InstalledBinaryMissing { binary } => write!(
                 formatter,
                 "managed package binary `{binary}` is missing after install"
+            ),
+            Self::InstallLockUnavailable(detail) => write!(
+                formatter,
+                "could not acquire the managed package install lock: {detail}"
+            ),
+            Self::InstallPromotionFailed(detail) => write!(
+                formatter,
+                "could not publish the staged managed package install: {detail}"
             ),
         }
     }
@@ -294,9 +338,12 @@ fn append_digest_part(bytes: &mut Vec<u8>, part: &[u8]) {
 }
 
 fn managed_bin_dir(cache_root: &Path, selection: &PackageSelection) -> PathBuf {
-    managed_install_dir(cache_root, selection)
-        .join("node_modules")
-        .join(".bin")
+    bin_dir_of(&managed_install_dir(cache_root, selection))
+}
+
+/// Executable directory inside a managed install tree, published or staged.
+fn bin_dir_of(install_dir: &Path) -> PathBuf {
+    install_dir.join("node_modules").join(".bin")
 }
 
 fn marker_contents(selection: &PackageSelection, now: SystemTime) -> String {
@@ -387,34 +434,58 @@ fn prepare_managed_npm(
     cache_root: &Path,
     now: SystemTime,
 ) -> Result<PackageInvocation, PackageRuntimeError> {
-    let _guard = match INSTALL_LOCK.lock() {
+    prepare_managed_npm_with_lock_policy(
+        candidate,
+        selection,
+        cache_root,
+        now,
+        LockPolicy::production(),
+    )
+}
+
+/// Lock-policy-injected core of [`prepare_managed_npm`].
+///
+/// `policy` is [`LockPolicy::production`] on every production path; the
+/// parameter exists so tests can exercise waiting and stale-lock recovery
+/// without sleeping for the production ceiling.
+fn prepare_managed_npm_with_lock_policy(
+    candidate: &ResolvedCandidate,
+    selection: &PackageSelection,
+    cache_root: &Path,
+    now: SystemTime,
+    policy: LockPolicy,
+) -> Result<PackageInvocation, PackageRuntimeError> {
+    let digest = selection_digest(selection).to_hex();
+    // Ordering is always the intra-process digest guard, then the cross-process
+    // lock. `digest_guard` outlives `_guard`, and `_guard` outlives `_lock`,
+    // so both are released in the reverse order.
+    let digest_guard = install_guard_for(&digest);
+    let _guard = match digest_guard.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
+    std::fs::create_dir_all(cache_root)
+        .map_err(|error| PackageRuntimeError::InstallDirectory(error.to_string()))?;
     let install_dir = managed_install_dir(cache_root, selection);
     let bin_dir = managed_bin_dir(cache_root, selection);
-    let cache_hit = cache_hit(&install_dir, &bin_dir, selection, now);
-    if !cache_hit {
-        write_package_json(&install_dir, selection)?;
-        // Issue #554: a stale lockfile makes `npm install` reuse the previously
-        // resolved dist-tag target. Drop it for volatile selectors so npm
-        // re-resolves `nightly`/`latest` against the registry. A real failure to
-        // remove an existing lockfile must surface — otherwise npm would silently
-        // reinstall the old target and the freshly stamped marker would freeze
-        // the stale build for another TTL window.
-        if selection.selector().is_volatile() {
-            match std::fs::remove_file(install_dir.join("package-lock.json")) {
-                Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => {
-                    return Err(PackageRuntimeError::InstallDirectory(format!(
-                        "failed to remove stale lockfile for re-resolve: {error}"
-                    )));
-                }
-            }
-        }
-        run_npm_install(candidate, &install_dir)?;
+    let retired = cache_root.join(format!("{RETIRED_PREFIX}{digest}"));
+    // Held from before the cache-hit check through the fingerprint capture, so
+    // no other process can rewrite the tree under a reader that has already
+    // decided the cache is a hit. Spanning `npm install` is the point of the
+    // lock, not an oversight: this boundary is synchronous by contract (it is
+    // called from launch composition and from the probe adapter, never from an
+    // async executor), and both guards are keyed by digest, so a slow install
+    // blocks only other preparers of the same selector.
+    let _lock =
+        package_install_lock::acquire(&install_lock_path(cache_root, &digest), &digest, policy)?;
+    reconcile_interrupted_promotion(&install_dir, &retired, selection, &digest)?;
+
+    if !cache_hit(&install_dir, &bin_dir, selection, now) {
+        let staging = cache_root.join(format!("{STAGING_PREFIX}{digest}"));
+        build_staged_install(candidate, selection, &staging, now)?;
+        promote_staged_install(&staging, &install_dir, &retired, &digest)?;
     }
+
     let snapshot = PathSnapshot::for_platform(
         AgentExecutablePlatform::current(),
         vec![bin_dir],
@@ -425,13 +496,6 @@ fn prepare_managed_npm(
             binary: selection.binary().to_owned(),
         });
     };
-    if !cache_hit {
-        std::fs::write(
-            install_dir.join(INSTALL_MARKER),
-            marker_contents(selection, now),
-        )
-        .map_err(|error| PackageRuntimeError::InstallDirectory(error.to_string()))?;
-    }
     let fingerprint = capture_candidate_fingerprint(&executable)
         .map_err(PackageRuntimeError::InstallDirectory)?;
     Ok(PackageInvocation {
@@ -440,6 +504,180 @@ fn prepare_managed_npm(
         prefix: Vec::new(),
         fingerprint: Some(fingerprint),
     })
+}
+
+/// Cross-process lock file for one selector digest.
+///
+/// A sibling of the install directory rather than a file inside it: the install
+/// directory is replaced wholesale by `rename`, which would carry away a lock
+/// held inside it.
+fn install_lock_path(cache_root: &Path, digest: &str) -> PathBuf {
+    cache_root.join(format!("{digest}.lock"))
+}
+
+/// Build a complete, marked install in a staging directory.
+///
+/// Staging always starts empty, so nothing from a previous entry — including a
+/// `package-lock.json` that would pin an already-resolved dist-tag (issue #554)
+/// — can leak into a re-resolve. The marker is written last but still *inside*
+/// staging, so the directory published by [`promote_staged_install`] is
+/// complete the instant it appears: there is no window in which `node_modules`
+/// exists without its marker.
+fn build_staged_install(
+    candidate: &ResolvedCandidate,
+    selection: &PackageSelection,
+    staging: &Path,
+    now: SystemTime,
+) -> Result<(), PackageRuntimeError> {
+    remove_tree(staging).map_err(|error| {
+        PackageRuntimeError::InstallDirectory(format!("failed to reset staging: {error}"))
+    })?;
+    write_package_json(staging, selection)?;
+    run_npm_install(candidate, staging)?;
+    let snapshot = PathSnapshot::for_platform(
+        AgentExecutablePlatform::current(),
+        vec![bin_dir_of(staging)],
+        std::env::var_os("PATHEXT"),
+    );
+    if snapshot.resolve_binary(selection.binary()).is_none() {
+        // Fail before publication: a tree without its selected binary is never
+        // promoted into the cache.
+        return Err(PackageRuntimeError::InstalledBinaryMissing {
+            binary: selection.binary().to_owned(),
+        });
+    }
+    std::fs::write(
+        staging.join(INSTALL_MARKER),
+        marker_contents(selection, now),
+    )
+    .map_err(|error| PackageRuntimeError::InstallDirectory(error.to_string()))
+}
+
+/// Reconcile a cache entry left retired by a promotion that never completed.
+///
+/// Publication retires the previous entry before publishing the new one, so a
+/// process that dies between those two renames leaves the install path absent
+/// while a complete previous tree sits at the retired path. Without this, the
+/// next preparation would have to reach the registry to become usable again;
+/// with it, the previous entry is simply published again.
+///
+/// The retired tree is only discarded once the published entry is known to be
+/// structurally complete. Discarding it against an unusable published entry
+/// would throw away the one tree that could still run offline.
+fn reconcile_interrupted_promotion(
+    install_dir: &Path,
+    retired: &Path,
+    selection: &PackageSelection,
+    digest: &str,
+) -> Result<(), PackageRuntimeError> {
+    if !exists(retired)
+        .map_err(|error| promotion_failure(digest, "inspect retired install", &error))?
+    {
+        return Ok(());
+    }
+    if install_is_complete(install_dir, selection) {
+        // Publication completed; the retired tree is only leftover cleanup.
+        return remove_tree(retired)
+            .map_err(|error| promotion_failure(digest, "discard retired install", &error));
+    }
+    remove_tree(install_dir)
+        .map_err(|error| promotion_failure(digest, "discard unusable install", &error))?;
+    std::fs::rename(retired, install_dir)
+        .map_err(|error| promotion_failure(digest, "restore retired install", &error))
+}
+
+/// Whether a published directory holds both its marker and its selected binary.
+///
+/// Structural only: freshness is [`cache_hit`]'s concern, because an entry that
+/// is merely past its TTL is still a better fallback than no entry at all.
+fn install_is_complete(install_dir: &Path, selection: &PackageSelection) -> bool {
+    if !install_dir.join(INSTALL_MARKER).exists() {
+        return false;
+    }
+    PathSnapshot::for_platform(
+        AgentExecutablePlatform::current(),
+        vec![bin_dir_of(install_dir)],
+        std::env::var_os("PATHEXT"),
+    )
+    .resolve_binary(selection.binary())
+    .is_some()
+}
+
+/// Publish a completed staging directory at the install path by rename.
+///
+/// Neither rename ever targets an existing directory, which keeps the sequence
+/// valid on Unix and Windows alike. A reader that goes through preparation
+/// therefore observes either the complete previous tree or the complete new
+/// one, because it holds the same lock; the published path is briefly absent
+/// between the two renames, which is why [`restore_interrupted_promotion`]
+/// reconciles that state under the lock before the cache is consulted.
+///
+/// If publication fails after the previous entry was retired, that entry is
+/// restored, and a restore that itself fails is reported rather than hidden.
+fn promote_staged_install(
+    staging: &Path,
+    install_dir: &Path,
+    retired: &Path,
+    digest: &str,
+) -> Result<(), PackageRuntimeError> {
+    let retired_existing = exists(install_dir)
+        .map_err(|error| promotion_failure(digest, "inspect published install", &error))?;
+    if retired_existing {
+        std::fs::rename(install_dir, retired)
+            .map_err(|error| promotion_failure(digest, "retire published install", &error))?;
+    }
+    if let Err(error) = std::fs::rename(staging, install_dir) {
+        if retired_existing && std::fs::rename(retired, install_dir).is_err() {
+            return Err(promotion_failure(
+                digest,
+                "publish staged install and restore the previous install",
+                &error,
+            ));
+        }
+        return Err(promotion_failure(digest, "publish staged install", &error));
+    }
+    if let Err(error) = remove_tree(retired) {
+        // The published entry is complete and usable; the leftover tree is
+        // reclaimed by the next preparation.
+        tracing::warn!(kind = ?error.kind(), "could not discard the retired managed install");
+    }
+    Ok(())
+}
+
+/// Bounded, redacted promotion diagnostic. Absolute cache paths are omitted:
+/// they embed the user's home directory and therefore the account name.
+fn promotion_failure(digest: &str, stage: &str, error: &std::io::Error) -> PackageRuntimeError {
+    PackageRuntimeError::InstallPromotionFailed(package_install_lock::bounded_detail(
+        digest,
+        &format!("{stage} failed ({:?})", error.kind()),
+    ))
+}
+
+/// Whether a path exists, distinguishing absence from an unreadable path.
+fn exists(path: &Path) -> std::io::Result<bool> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+/// Remove a path whether it is a directory or a file.
+///
+/// Only a genuinely absent path counts as already removed: an unreadable path
+/// must not be mistaken for a clean slate, or a staging directory that was
+/// never actually reset would be reused.
+fn remove_tree(path: &Path) -> std::io::Result<()> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if metadata.is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    }
 }
 
 #[derive(Serialize)]
@@ -500,4 +738,5 @@ mod tests {
     use crate::domain::agent_definition::{AgentDefinition, AgentLaunchPlan, Target};
 
     include!("package_runtime_tests.rs");
+    include!("package_runtime_lock_tests.rs");
 }

--- a/src/runtime/package_runtime_lock_tests.rs
+++ b/src/runtime/package_runtime_lock_tests.rs
@@ -1,0 +1,717 @@
+// Issue #556: cross-process serialization and atomic promotion of the managed
+// package install cache.
+//
+// Included into `package_runtime::tests`; the helpers (`executable`,
+// `definition`, `resolve_package`, `base_now`, …) come from
+// `package_runtime_tests.rs`.
+//
+// # Two-process protocol
+//
+// Serialization cannot be proved from one process, so the contended test
+// re-executes the test binary — the repository's established way to obtain a
+// real second OS process (`process_tests.rs`, `tests/harness_v1.rs`) — with a
+// `--exact` filter naming `managed_install_child_process`. That test is inert
+// unless the four `CHILD_*` environment variables are present, so an ordinary
+// run executes it as a no-op.
+//
+// Each child is given a cache root, a directory holding the npm stub, a report
+// path, and a barrier directory. It publishes `ready-<report file name>` into
+// the barrier directory, blocks until the parent publishes `start`, runs the
+// production preparation boundary, and writes a single tab-separated report
+// line: `ok	<resolved executable>` or `err	<diagnostic>`.
+//
+// The barrier is what makes the test deterministic: both children are proved to
+// be inside preparation before either is released, so the result does not
+// depend on spawn timing or machine load. `InstallerProcesses` owns the
+// children and kills and reaps them on drop, so a panicking test cannot leave
+// an installer running.
+
+/// Environment channel used to run one test-binary process as a second, real
+/// jefe installer. `std::env::current_exe` re-execution is the repository's
+/// established way to obtain a genuine second OS process from a test
+/// (`process_tests.rs`, `tests/harness_v1.rs`); it needs no extra `[[bin]]`.
+#[cfg(unix)]
+const CHILD_CACHE_ENV: &str = "JEFE_TEST_INSTALL_CHILD_CACHE";
+#[cfg(unix)]
+const CHILD_BIN_ENV: &str = "JEFE_TEST_INSTALL_CHILD_BIN";
+#[cfg(unix)]
+const CHILD_OUT_ENV: &str = "JEFE_TEST_INSTALL_CHILD_OUT";
+/// Directory holding the start barrier that makes the two installers overlap.
+#[cfg(unix)]
+const CHILD_BARRIER_ENV: &str = "JEFE_TEST_INSTALL_CHILD_BARRIER";
+#[cfg(unix)]
+const CHILD_TEST_PATH: &str = "runtime::package_runtime::tests::managed_install_child_process";
+
+use crate::runtime::commands::shell_escape_single;
+
+/// Published install directory for a resolved managed candidate.
+#[cfg(unix)]
+fn final_install_dir(candidate: &ResolvedCandidate, cache_root: &Path) -> PathBuf {
+    let selection = candidate
+        .package()
+        .unwrap_or_else(|| panic!("candidate carries a package selection"));
+    super::managed_install_dir(cache_root, selection)
+}
+
+/// Shell-safe single-quoted form of a path, so a stub script cannot be broken
+/// by a quote or a space anywhere in the temporary directory.
+#[cfg(unix)]
+fn shell_quote(path: &Path) -> String {
+    shell_escape_single(&path.to_string_lossy())
+}
+
+/// npm stub that builds a complete tree and then, *while still installing*,
+/// records its own working directory and what a concurrent reader would see at
+/// the published install directory.
+///
+/// Observing after the tree exists is what makes the observation meaningful:
+/// an install that mutates the published directory in place is caught as
+/// `final-partial` (tree present, marker not yet written).
+#[cfg(unix)]
+fn observing_npm_stub(bin: &TempDir, witness: &Path, final_dir: &Path, settle: &str) {
+    executable(
+        bin,
+        "npm",
+        &format!(
+            "#!/bin/sh
+set -e
+final={final_dir}
+mkdir -p node_modules/.bin
+printf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/llxprt
+chmod 755 node_modules/.bin/llxprt
+if [ -x \"$final/node_modules/.bin/llxprt\" ] && [ -f \"$final/.jefe-installed\" ]; then
+  state=final-complete
+elif [ -e \"$final/node_modules\" ] || [ -e \"$final/.jefe-installed\" ]; then
+  state=final-partial
+else
+  state=final-absent
+fi
+printf '%s\\t%s\\n' \"$(pwd -P)\" \"$state\" >> {witness}
+sleep {settle}
+",
+            final_dir = shell_quote(final_dir),
+            witness = shell_quote(witness),
+            settle = shell_escape_single(settle)
+        ),
+    );
+}
+
+/// One `cwd\tstate` observation recorded by [`observing_npm_stub`].
+#[cfg(unix)]
+fn observations(witness: &Path) -> Vec<(String, String)> {
+    std::fs::read_to_string(witness)
+        .unwrap_or_else(|error| panic!("read install observations: {error}"))
+        .lines()
+        .map(|line| {
+            let (cwd, state) = line
+                .split_once('\t')
+                .unwrap_or_else(|| panic!("malformed observation line: {line:?}"));
+            (cwd.to_owned(), state.to_owned())
+        })
+        .collect()
+}
+
+/// Physical path of the published install directory, matching the stub's
+/// `pwd -P` so a symlinked temp root (macOS `/var` → `/private/var`) cannot
+/// make a same-directory install look like a staged one.
+#[cfg(unix)]
+fn physical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Resolve a managed candidate, install the observing npm stub over the probe
+/// stub, and return the candidate plus its published install directory.
+///
+/// Resolution happens twice on purpose. The observing stub has to be told the
+/// published install directory, which is only derivable from a resolved
+/// candidate; and the returned candidate must carry a fingerprint of the npm
+/// that actually runs, not of the placeholder it replaced.
+#[cfg(unix)]
+fn observed_candidate(
+    bin: &TempDir,
+    cache_root: &Path,
+    witness: &Path,
+    selector: &str,
+    settle: &str,
+) -> (ResolvedCandidate, PathBuf) {
+    let definition = definition("LLxprt");
+    executable(bin, "npm", "#!/bin/sh\nexit 0\n");
+    let probe = resolve_package(&definition, bin.path(), selector);
+    let final_dir = final_install_dir(&probe, cache_root);
+    observing_npm_stub(bin, witness, &final_dir, settle);
+    (resolve_package(&definition, bin.path(), selector), final_dir)
+}
+
+// ── A1: two OS processes, one install ─────────────────────────────────────
+
+/// Second jefe process for [`concurrent_processes_install_once_and_agree`].
+///
+/// Inert unless the parent test supplies the channel environment, so a normal
+/// `cargo test` run executes it as a no-op.
+#[cfg(unix)]
+#[test]
+fn managed_install_child_process() {
+    let (Some(cache), Some(bin), Some(out), Some(barrier)) = (
+        std::env::var_os(CHILD_CACHE_ENV),
+        std::env::var_os(CHILD_BIN_ENV),
+        std::env::var_os(CHILD_OUT_ENV),
+        std::env::var_os(CHILD_BARRIER_ENV),
+    ) else {
+        return;
+    };
+    let definition = definition("LLxprt");
+    let candidate = resolve_package(&definition, Path::new(&bin), "2.0.0");
+    // Announce readiness, then wait for the parent's start signal, so both
+    // installers enter preparation together however the machine is loaded.
+    let barrier = Path::new(&barrier);
+    let out = Path::new(&out);
+    let ready = barrier.join(format!(
+        "ready-{}",
+        out.file_name()
+            .unwrap_or_else(|| panic!("child report has a file name"))
+            .to_string_lossy()
+    ));
+    std::fs::write(&ready, "ready").unwrap_or_else(|error| panic!("publish readiness: {error}"));
+    await_barrier(&barrier.join(START_MARKER));
+
+    let report = match finalize_local_invocation_at(&candidate, Path::new(&cache), base_now()) {
+        Ok(invocation) => format!("ok\t{}\n", invocation.executable().display()),
+        Err(error) => format!("err\t{error}\n"),
+    };
+    std::fs::write(out, report).unwrap_or_else(|error| panic!("write child report: {error}"));
+}
+
+/// Name of the parent-published start signal.
+#[cfg(unix)]
+const START_MARKER: &str = "start";
+
+/// Block until `path` appears, failing rather than hanging forever.
+#[cfg(unix)]
+fn await_barrier(path: &Path) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    while std::time::Instant::now() < deadline {
+        if path.exists() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    panic!("timed out waiting for {}", path.display());
+}
+
+/// Installer children that are always reaped, even if the test panics.
+#[cfg(unix)]
+struct InstallerProcesses {
+    children: Vec<(PathBuf, std::process::Child)>,
+}
+
+#[cfg(unix)]
+impl InstallerProcesses {
+    /// Start two installer processes, each parked on the start barrier.
+    fn spawn_pair(
+        bin: &TempDir,
+        cache: &TempDir,
+        scratch: &TempDir,
+        barrier: &Path,
+    ) -> Self {
+        let test_binary =
+            std::env::current_exe().unwrap_or_else(|error| panic!("current_exe: {error}"));
+        let mut installers = Self {
+            children: Vec::new(),
+        };
+        for index in 0..2 {
+            let out = scratch.path().join(format!("child-{index}.report"));
+            let child = std::process::Command::new(&test_binary)
+                .args(["--exact", CHILD_TEST_PATH, "--nocapture", "--test-threads=1"])
+                .env(CHILD_CACHE_ENV, cache.path())
+                .env(CHILD_BIN_ENV, bin.path())
+                .env(CHILD_OUT_ENV, &out)
+                .env(CHILD_BARRIER_ENV, barrier)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(
+                    std::fs::File::create(scratch.path().join(format!("child-{index}.stderr")))
+                        .unwrap_or_else(|error| panic!("child stderr file: {error}")),
+                )
+                .spawn()
+                .unwrap_or_else(|error| panic!("spawn installer process: {error}"));
+            installers.children.push((out, child));
+        }
+        installers
+    }
+
+    /// Release both installers together and return what each reported.
+    ///
+    /// Waiting for readiness before signalling is what makes the two
+    /// installers genuinely overlap: without it the test would depend on spawn
+    /// timing and could pass against an unserialized implementation.
+    fn release_and_collect(&mut self, barrier: &Path) -> Vec<String> {
+        for index in 0..self.children.len() {
+            await_barrier(&barrier.join(format!("ready-child-{index}.report")));
+        }
+        std::fs::write(barrier.join(START_MARKER), "go")
+            .unwrap_or_else(|error| panic!("release the start barrier: {error}"));
+        let mut reports = Vec::new();
+        for (out, child) in &mut self.children {
+            let status = child
+                .wait()
+                .unwrap_or_else(|error| panic!("wait for installer process: {error}"));
+            assert!(status.success(), "installer process failed: {status:?}");
+            reports.push(std::fs::read_to_string(&*out).unwrap_or_else(|error| {
+                panic!(
+                    "installer process wrote no report ({}): {error}",
+                    out.display()
+                )
+            }));
+        }
+        reports
+    }
+}
+
+#[cfg(unix)]
+impl Drop for InstallerProcesses {
+    fn drop(&mut self) {
+        for (_, child) in &mut self.children {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn concurrent_processes_install_once_and_agree() {
+    // A1: two jefe processes that both miss the same digest must serialize.
+    // Exactly one runs `npm install`; the other observes a complete cache hit
+    // and resolves the identical executable.
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+    let scratch = tempfile::tempdir().unwrap_or_else(|error| panic!("scratch: {error}"));
+    let witness = scratch.path().join("install-observations.log");
+    let barrier = scratch.path().join("barrier");
+    std::fs::create_dir_all(&barrier).unwrap_or_else(|error| panic!("barrier dir: {error}"));
+    // A one-second install widens the overlap so an unserialized implementation
+    // reliably runs npm twice.
+    let _ = observed_candidate(&bin, cache.path(), &witness, "2.0.0", "1");
+
+    let mut installers = InstallerProcesses::spawn_pair(&bin, &cache, &scratch, &barrier);
+    let reports = installers.release_and_collect(&barrier);
+
+    for report in &reports {
+        assert!(
+            report.starts_with("ok\t"),
+            "both concurrent installers must succeed, got {report:?}"
+        );
+    }
+    assert_eq!(
+        reports[0], reports[1],
+        "concurrent installers must agree on the resolved managed executable"
+    );
+    assert_eq!(
+        observations(&witness).len(),
+        1,
+        "exactly one of two concurrent jefe processes may run npm install"
+    );
+}
+
+// ── A2: staged build, atomic promotion ────────────────────────────────────
+
+#[cfg(unix)]
+#[test]
+fn install_is_staged_outside_the_cache_entry_and_promoted_atomically() {
+    // A2: `npm install` must never build inside the published install
+    // directory, so a concurrent reader cannot observe a half-built tree.
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+    let scratch = tempfile::tempdir().unwrap_or_else(|error| panic!("scratch: {error}"));
+    let witness = scratch.path().join("install-observations.log");
+    let (candidate, final_dir) = observed_candidate(&bin, cache.path(), &witness, "2.0.0", "0");
+
+    let invocation = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("install: {error}"));
+
+    let observed = observations(&witness);
+    assert_eq!(observed.len(), 1, "one install for a cold cache");
+    let (cwd, state) = &observed[0];
+    assert_ne!(
+        Path::new(cwd),
+        physical(&final_dir).as_path(),
+        "npm install must not build inside the published install directory"
+    );
+    assert_eq!(
+        state, "final-absent",
+        "a cold install must publish nothing until the complete tree is promoted"
+    );
+    assert!(
+        invocation.executable().starts_with(&final_dir),
+        "the promoted install must be published at the digest directory: {}",
+        invocation.executable().display()
+    );
+    assert!(
+        final_dir.join(".jefe-installed").exists(),
+        "promotion must publish the install marker together with the tree"
+    );
+    let leftovers: Vec<String> = std::fs::read_dir(cache.path())
+        .unwrap_or_else(|error| panic!("read cache root: {error}"))
+        .filter_map(|entry| entry.ok().map(|entry| entry.file_name()))
+        .filter_map(|name| name.to_str().map(str::to_owned))
+        .filter(|name| name.starts_with('.'))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "a completed install must leave no staging or retired directory: {leftovers:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn promotion_replaces_an_existing_entry_without_exposing_a_partial_tree() {
+    // A2 (re-install): while a replacement install is building, the previously
+    // published tree must remain complete and resolvable.
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+    let scratch = tempfile::tempdir().unwrap_or_else(|error| panic!("scratch: {error}"));
+    let witness = scratch.path().join("install-observations.log");
+    let (candidate, final_dir) =
+        observed_candidate(&bin, cache.path(), &witness, "latest nightly", "0");
+
+    finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("first install: {error}"));
+    let expired = base_now() + super::VOLATILE_SELECTOR_TTL + std::time::Duration::from_secs(1);
+    finalize_local_invocation_at(&candidate, cache.path(), expired)
+        .unwrap_or_else(|error| panic!("re-install: {error}"));
+
+    let observed = observations(&witness);
+    assert_eq!(observed.len(), 2, "the expired entry must be reinstalled");
+    assert_eq!(
+        observed[1].1, "final-complete",
+        "the previously published tree must stay complete while its replacement builds"
+    );
+    assert_ne!(
+        Path::new(&observed[1].0),
+        physical(&final_dir).as_path(),
+        "a replacement install must not build inside the published directory"
+    );
+    assert!(
+        final_dir.join(".jefe-installed").exists(),
+        "the replacement must be published with its marker"
+    );
+}
+
+// ── A3: interrupted install ───────────────────────────────────────────────
+
+#[cfg(unix)]
+#[test]
+fn interrupted_install_leaves_no_cache_hit_and_retries_cleanly() {
+    // A3: an install that dies after writing part of the tree must leave no
+    // marker and no partially published directory, and must not block a later
+    // successful install.
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+    let definition = definition("LLxprt");
+    executable(
+        &bin,
+        "npm",
+        "#!/bin/sh\nmkdir -p node_modules/half-written\nexit 7\n",
+    );
+    let candidate = resolve_package(&definition, bin.path(), "2.0.0");
+    let final_dir = final_install_dir(&candidate, cache.path());
+
+    let failure = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .err()
+        .unwrap_or_else(|| panic!("a failing npm install must surface as an error"));
+    assert!(
+        matches!(failure, PackageRuntimeError::InstallFailed(_)),
+        "npm exit status must surface as InstallFailed, got {failure:?}"
+    );
+    assert!(
+        !final_dir.join(".jefe-installed").exists(),
+        "an interrupted install must not publish an install marker"
+    );
+    assert!(
+        !final_dir.join("node_modules").exists(),
+        "an interrupted install must not publish a partial node_modules tree"
+    );
+
+    executable(
+        &bin,
+        "npm",
+        "#!/bin/sh\nmkdir -p node_modules/.bin\nprintf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/llxprt\nchmod 755 node_modules/.bin/llxprt\n",
+    );
+    let candidate = resolve_package(&definition, bin.path(), "2.0.0");
+    let invocation = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("retry after interrupted install: {error}"));
+    assert!(
+        invocation.executable().starts_with(&final_dir),
+        "the retry must publish a usable managed executable"
+    );
+    assert!(
+        final_dir.join(".jefe-installed").exists(),
+        "the retry must publish the install marker"
+    );
+}
+
+// ── A4/A5: cross-process lock at the preparation boundary ─────────────────
+
+/// Short-ceiling policy so a blocked preparation fails in milliseconds rather
+/// than waiting out the production install timeout.
+#[cfg(unix)]
+fn impatient_policy() -> LockPolicy {
+    LockPolicy {
+        ceiling: std::time::Duration::from_millis(150),
+        poll_interval: std::time::Duration::from_millis(10),
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn a_live_installer_blocks_preparation_with_a_typed_redacted_error() {
+    // A4b + A5: while another installer legitimately holds the digest,
+    // preparation waits and then fails closed — it never steals the lock, never
+    // installs, and never leaks the cache location into the diagnostic.
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+    let definition = definition("LLxprt");
+    executable(
+        &bin,
+        "npm",
+        "#!/bin/sh\nmkdir -p node_modules/.bin\nprintf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/llxprt\nchmod 755 node_modules/.bin/llxprt\n",
+    );
+    let candidate = resolve_package(&definition, bin.path(), "2.0.0");
+    let selection = candidate
+        .package()
+        .unwrap_or_else(|| panic!("candidate carries a package selection"));
+    let digest = super::selection_digest(selection).to_hex();
+    let final_dir = final_install_dir(&candidate, cache.path());
+
+    let _held = crate::runtime::package_install_lock::acquire(
+        &super::install_lock_path(cache.path(), &digest),
+        &digest,
+        LockPolicy::production(),
+    )
+    .unwrap_or_else(|error| panic!("hold the digest lock: {error}"));
+
+    let error = super::prepare_managed_npm_with_lock_policy(
+        &candidate,
+        selection,
+        cache.path(),
+        base_now(),
+        impatient_policy(),
+    )
+    .err()
+    .unwrap_or_else(|| panic!("preparation must not proceed while the digest is locked"));
+
+    assert!(
+        matches!(error, PackageRuntimeError::InstallLockUnavailable(_)),
+        "a held digest must fail closed with a lock error, got {error:?}"
+    );
+    assert!(
+        !final_dir.exists(),
+        "a blocked preparation must not create the install directory"
+    );
+    let diagnostic = error.to_string();
+    assert!(
+        !diagnostic.contains(&cache.path().display().to_string())
+            && !diagnostic.contains(std::path::MAIN_SEPARATOR),
+        "the diagnostic must not embed the cache location: {diagnostic:?}"
+    );
+    assert!(
+        diagnostic.chars().count() <= MAX_DIAGNOSTIC_CHARS,
+        "the diagnostic must be bounded: {diagnostic:?}"
+    );
+}
+
+/// Longest a rendered diagnostic may be: the bounded detail plus the fixed
+/// `Display` prefix each variant prepends.
+#[cfg(unix)]
+const MAX_DIAGNOSTIC_CHARS: usize = crate::runtime::package_install_lock::MAX_DETAIL_CHARS + 64;
+
+#[cfg(unix)]
+#[test]
+fn a_failed_promotion_is_typed_bounded_and_redacted() {
+    // A5: publication failure is its own variant, and the previously published
+    // entry is restored rather than left missing.
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+    let published = cache.path().join("digest");
+    let retired = cache.path().join(".retired-digest");
+    std::fs::create_dir_all(published.join("node_modules"))
+        .unwrap_or_else(|error| panic!("seed published entry: {error}"));
+    std::fs::write(published.join(".jefe-installed"), "marker\n")
+        .unwrap_or_else(|error| panic!("seed marker: {error}"));
+
+    let error = super::promote_staged_install(
+        &cache.path().join(".staging-digest"),
+        &published,
+        &retired,
+        PROMOTION_DIGEST,
+    )
+    .err()
+    .unwrap_or_else(|| panic!("publishing an absent staging directory cannot succeed"));
+
+    assert!(
+        matches!(error, PackageRuntimeError::InstallPromotionFailed(_)),
+        "publication failure must be its own variant, got {error:?}"
+    );
+    let diagnostic = error.to_string();
+    assert!(
+        !diagnostic.contains(&cache.path().display().to_string())
+            && !diagnostic.contains(std::path::MAIN_SEPARATOR),
+        "the diagnostic must not embed the cache location: {diagnostic:?}"
+    );
+    assert!(
+        diagnostic.contains("digest=0123456789ab"),
+        "the diagnostic must correlate to the selector digest: {diagnostic:?}"
+    );
+    assert!(
+        diagnostic.chars().count() <= MAX_DIAGNOSTIC_CHARS,
+        "the diagnostic must be bounded: {diagnostic:?}"
+    );
+    assert!(
+        published.join(".jefe-installed").exists(),
+        "a failed publication must restore the previously published entry"
+    );
+    assert!(
+        !retired.exists(),
+        "a failed publication must not strand the retired entry"
+    );
+}
+
+/// Digest used by the promotion tests that call the boundary directly.
+#[cfg(unix)]
+const PROMOTION_DIGEST: &str = "0123456789abcdef0123456789abcdef";
+
+#[cfg(unix)]
+#[test]
+fn a_promotion_interrupted_after_retiring_restores_the_previous_install() {
+    // A3 (crash between the two publication renames): the published path is
+    // absent while a complete previous tree sits at the retired path. The next
+    // preparation must republish it under the lock instead of requiring a new
+    // network install.
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+    let scratch = tempfile::tempdir().unwrap_or_else(|error| panic!("scratch: {error}"));
+    let witness = scratch.path().join("install-observations.log");
+    let (candidate, final_dir) = observed_candidate(&bin, cache.path(), &witness, "2.0.0", "0");
+
+    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("first install: {error}"));
+    let selection = candidate
+        .package()
+        .unwrap_or_else(|| panic!("candidate carries a package selection"));
+    let digest = super::selection_digest(selection).to_hex();
+    let retired = cache.path().join(format!(".retired-{digest}"));
+    // Reproduce the crash state exactly: published entry retired, nothing
+    // published, staging never renamed into place.
+    std::fs::rename(&final_dir, &retired)
+        .unwrap_or_else(|error| panic!("simulate interrupted promotion: {error}"));
+    assert!(!final_dir.exists(), "setup: the published path is absent");
+
+    let recovered = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("recovery after interrupted promotion: {error}"));
+
+    assert_eq!(
+        recovered.executable(),
+        first.executable(),
+        "the interrupted promotion must republish the previous install"
+    );
+    assert_eq!(
+        observations(&witness).len(),
+        1,
+        "restoring a retired install must not require another npm install"
+    );
+    assert!(
+        !retired.exists(),
+        "the restored install must no longer be retired"
+    );
+}
+
+
+#[cfg(unix)]
+#[test]
+fn a_completed_promotion_discards_a_leftover_retired_tree() {
+    // The mirror of the interrupted case: publication completed but the retired
+    // tree was not discarded. The complete published entry wins and the
+    // leftover is reclaimed, without reinstalling.
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+    let scratch = tempfile::tempdir().unwrap_or_else(|error| panic!("scratch: {error}"));
+    let witness = scratch.path().join("install-observations.log");
+    let (candidate, final_dir) = observed_candidate(&bin, cache.path(), &witness, "2.0.0", "0");
+
+    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("first install: {error}"));
+    let retired = retired_path(&candidate, cache.path());
+    std::fs::create_dir_all(retired.join("node_modules"))
+        .unwrap_or_else(|error| panic!("seed leftover retired entry: {error}"));
+
+    let reconciled = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("reconcile leftover retired tree: {error}"));
+
+    assert_eq!(
+        reconciled.executable(),
+        first.executable(),
+        "the complete published entry must win"
+    );
+    assert_eq!(
+        observations(&witness).len(),
+        1,
+        "reclaiming a leftover tree must not reinstall"
+    );
+    assert!(
+        final_dir.join(".jefe-installed").exists(),
+        "the published entry must be left intact"
+    );
+    assert!(!retired.exists(), "the leftover retired tree must be gone");
+}
+
+#[cfg(unix)]
+#[test]
+fn an_unusable_published_install_is_replaced_by_the_retired_tree() {
+    // A retired tree is the last complete copy of an entry, so it must not be
+    // discarded against a published directory that cannot actually run --
+    // otherwise an offline user loses the only usable install.
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+    let scratch = tempfile::tempdir().unwrap_or_else(|error| panic!("scratch: {error}"));
+    let witness = scratch.path().join("install-observations.log");
+    let (candidate, final_dir) = observed_candidate(&bin, cache.path(), &witness, "2.0.0", "0");
+
+    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("first install: {error}"));
+    let retired = retired_path(&candidate, cache.path());
+    // The complete tree is retired and the published path holds a directory
+    // that exists but carries neither a marker nor the selected binary.
+    std::fs::rename(&final_dir, &retired)
+        .unwrap_or_else(|error| panic!("retire the complete tree: {error}"));
+    std::fs::create_dir_all(final_dir.join("node_modules").join(".bin"))
+        .unwrap_or_else(|error| panic!("seed unusable published entry: {error}"));
+
+    let recovered = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("recovery from an unusable published entry: {error}"));
+
+    assert_eq!(
+        recovered.executable(),
+        first.executable(),
+        "the complete retired tree must be published again"
+    );
+    assert_eq!(
+        observations(&witness).len(),
+        1,
+        "restoring a retired install must not require another npm install"
+    );
+    assert!(
+        !retired.exists(),
+        "the restored install must no longer be retired"
+    );
+}
+
+/// Retired-path sibling for a resolved managed candidate.
+#[cfg(unix)]
+fn retired_path(candidate: &ResolvedCandidate, cache_root: &Path) -> PathBuf {
+    let selection = candidate
+        .package()
+        .unwrap_or_else(|| panic!("candidate carries a package selection"));
+    cache_root.join(format!(
+        ".retired-{}",
+        super::selection_digest(selection).to_hex()
+    ))
+}

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -43,16 +43,9 @@ fn compatible(generation: u64) -> Availability {
 }
 
 #[cfg(unix)]
-fn resolve_package(
-    definition: &AgentDefinition,
-    bin: &TempDir,
-    selector: &str,
-) -> ResolvedCandidate {
-    let snapshot = PathSnapshot::for_platform(
-        AgentExecutablePlatform::Unix,
-        vec![bin.path().to_path_buf()],
-        None,
-    );
+fn resolve_package(definition: &AgentDefinition, bin: &Path, selector: &str) -> ResolvedCandidate {
+    let snapshot =
+        PathSnapshot::for_platform(AgentExecutablePlatform::Unix, vec![bin.to_path_buf()], None);
     let selector =
         VersionSelector::normalize(selector).unwrap_or_else(|error| panic!("selector: {error}"));
     let resolution = AgentCandidateResolver::new(&snapshot, PathBuf::from("/repo"))
@@ -107,7 +100,7 @@ fn local_uvx_is_a_closed_structural_prefix() {
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
     executable(&bin, "uvx", "#!/bin/sh\nexit 0\n");
     let definition = definition("Code Puppy");
-    let candidate = resolve_package(&definition, &bin, "0.0.634");
+    let candidate = resolve_package(&definition, bin.path(), "0.0.634");
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
     let plan = local_base_plan(&definition, &candidate, 4, cache.path());
     assert_eq!(plan.executable, candidate.executable());
@@ -127,7 +120,7 @@ fn local_npm_uses_general_managed_exact_install_after_precheck() {
         "#!/bin/sh\nmkdir -p node_modules/.bin\nprintf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/llxprt\nchmod 755 node_modules/.bin/llxprt\n",
     );
     let definition = definition("LLxprt");
-    let candidate = resolve_package(&definition, &bin, "2.0.0");
+    let candidate = resolve_package(&definition, bin.path(), "2.0.0");
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
     let plan = local_base_plan(&definition, &candidate, 8, cache.path());
     assert!(
@@ -177,7 +170,7 @@ fn remote_npm_prefix_flows_through_the_audited_serializer() {
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
     executable(&bin, "npm", "#!/bin/sh\nexit 0\n");
     let definition = definition("LLxprt");
-    let candidate = resolve_package(&definition, &bin, "latest nightly");
+    let candidate = resolve_package(&definition, bin.path(), "latest nightly");
     let values = LaunchFieldValues::new();
     let settings = remote_settings();
     let request = RemotePlanRequest {
@@ -246,7 +239,7 @@ fn package_probe_executes_the_selected_agent_not_the_runner_version() {
         "#!/bin/sh\nif [ \"$1\" != install ]; then echo runner-version-was-probed; exit 91; fi\nmkdir -p node_modules/.bin\nprintf '#!/bin/sh\\nif [ \"$1\" = --version ]; then echo 1.2.3; else echo --prompt-interactive; fi\\n' > node_modules/.bin/llxprt\nchmod 755 node_modules/.bin/llxprt\n",
     );
     let definition = definition("LLxprt");
-    let candidate = resolve_package(&definition, &bin, "1.2.3");
+    let candidate = resolve_package(&definition, bin.path(), "1.2.3");
     let resolution = CandidateResolution::Resolved(candidate);
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
     let result = crate::runtime::run_local_agent_probe_with_cache(
@@ -275,7 +268,7 @@ fn structural_uvx_probe_executes_the_selected_agent_invocation() {
         "#!/bin/sh\nif [ \"$4\" = --version ]; then echo 0.0.634; else echo --interactive; fi\n",
     );
     let definition = definition("Code Puppy");
-    let candidate = resolve_package(&definition, &bin, "latest");
+    let candidate = resolve_package(&definition, bin.path(), "latest");
     let resolution = CandidateResolution::Resolved(candidate);
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
     let result = crate::runtime::run_local_agent_probe_with_cache(
@@ -300,7 +293,7 @@ fn shipped_unsupported_remote_cell_returns_exact_reason_without_package_effects(
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
     executable(&bin, "uvx", "#!/bin/sh\nexit 99\n");
     let definition = definition("Code Puppy");
-    let candidate = resolve_package(&definition, &bin, "latest");
+    let candidate = resolve_package(&definition, bin.path(), "latest");
     let values = LaunchFieldValues::new();
     let settings = RemoteRepositorySettings {
         enabled: true,
@@ -347,21 +340,30 @@ fn shipped_unsupported_remote_cell_returns_exact_reason_without_package_effects(
 // re-resolves the dist-tag.
 
 #[cfg(unix)]
-fn counting_npm_stub(bin: &TempDir) {
+fn counting_npm_stub(bin: &TempDir, witness: &Path) {
     // Each invocation records one witness line: "present" if a package-lock.json
     // already existed when the stub started, otherwise "absent". Counting lines
     // therefore proves how many times `npm install` ran, and the content proves
-    // whether jefe removed a stale lockfile before re-installing.
+    // whether npm ever observed a prior lockfile.
+    //
+    // The witness path is absolute and outside the managed cache: installs are
+    // staged in a fresh directory and promoted by rename (issue #556), so a
+    // witness written into the install directory would not survive across
+    // installs and could not count them.
     executable(
         bin,
         "npm",
-        "#!/bin/sh
+        &format!(
+            "#!/bin/sh
 set -e
-if [ -f package-lock.json ]; then echo present >> .jefe-lock-witness; else echo absent >> .jefe-lock-witness; fi
+witness={witness}
+if [ -f package-lock.json ]; then echo present >> \"$witness\"; else echo absent >> \"$witness\"; fi
 mkdir -p node_modules/.bin
 printf '#!/bin/sh\nexit 0\n' > node_modules/.bin/llxprt
 chmod 755 node_modules/.bin/llxprt
 ",
+            witness = crate::runtime::commands::shell_escape_single(&witness.to_string_lossy())
+        ),
     );
 }
 
@@ -390,19 +392,25 @@ fn install_dir_of(executable: &Path) -> &Path {
 }
 
 #[cfg(unix)]
-fn witness_lines(install_dir: &Path) -> Vec<String> {
-    let path = install_dir.join(".jefe-lock-witness");
-    std::fs::read_to_string(&path)
+fn witness_lines(witness: &Path) -> Vec<String> {
+    std::fs::read_to_string(witness)
         .unwrap_or_else(|error| panic!("read install witness: {error}"))
         .lines()
         .map(std::string::ToString::to_string)
         .collect()
 }
 
+/// Absolute witness path for [`counting_npm_stub`], kept outside the managed
+/// cache so staged-and-promoted installs cannot discard it.
+#[cfg(unix)]
+fn witness_path(dir: &TempDir) -> PathBuf {
+    dir.path().join("install-witness.log")
+}
+
 #[cfg(unix)]
 fn volatile_npm_candidate(bin: &TempDir, selector: &str) -> ResolvedCandidate {
     let definition = definition("LLxprt");
-    resolve_package(&definition, bin, selector)
+    resolve_package(&definition, bin.path(), selector)
 }
 
 /// A fixed base instant well after the Unix epoch so offsets stay representable.
@@ -416,7 +424,8 @@ fn base_now() -> std::time::SystemTime {
 fn volatile_cache_stays_fresh_within_ttl() {
     // AC2: a re-invocation inside the TTL is a cache hit — npm is not re-run.
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
-    counting_npm_stub(&bin);
+    let witness = witness_path(&bin);
+    counting_npm_stub(&bin, &witness);
     let candidate = volatile_npm_candidate(&bin, "latest nightly");
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
 
@@ -428,7 +437,7 @@ fn volatile_cache_stays_fresh_within_ttl() {
         .unwrap_or_else(|error| panic!("second invocation: {error}"));
 
     assert_eq!(
-        witness_lines(install_dir_of(first.executable())).len(),
+        witness_lines(&witness).len(),
         1,
         "within-TTL re-invocation must be a cache hit (npm not re-run)"
     );
@@ -445,18 +454,19 @@ fn volatile_cache_re_resolves_after_ttl() {
     // AC1: once the install age exceeds the TTL, the cache is a miss and npm
     // re-runs (re-resolving the moving dist-tag).
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
-    counting_npm_stub(&bin);
+    let witness = witness_path(&bin);
+    counting_npm_stub(&bin, &witness);
     let candidate = volatile_npm_candidate(&bin, "latest nightly");
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
 
-    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    finalize_local_invocation_at(&candidate, cache.path(), base_now())
         .unwrap_or_else(|error| panic!("first install: {error}"));
     let expired = base_now() + super::VOLATILE_SELECTOR_TTL + std::time::Duration::from_secs(1);
     finalize_local_invocation_at(&candidate, cache.path(), expired)
         .unwrap_or_else(|error| panic!("expired re-resolve: {error}"));
 
     assert_eq!(
-        witness_lines(install_dir_of(first.executable())).len(),
+        witness_lines(&witness).len(),
         2,
         "past-TTL re-invocation must re-run npm to re-resolve the dist-tag"
     );
@@ -468,7 +478,8 @@ fn volatile_old_marker_without_timestamp_re_installs() {
     // AC3: a legacy/stuck marker (3 lines, no timestamp) for a volatile selector
     // is treated as expired and re-installed, writing a fresh timestamped marker.
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
-    counting_npm_stub(&bin);
+    let witness = witness_path(&bin);
+    counting_npm_stub(&bin, &witness);
     let candidate = volatile_npm_candidate(&bin, "latest nightly");
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
 
@@ -492,7 +503,7 @@ fn volatile_old_marker_without_timestamp_re_installs() {
     std::fs::write(install_dir.join(".jefe-installed"), legacy_marker)
         .unwrap_or_else(|error| panic!("write legacy marker: {error}"));
     assert_eq!(
-        witness_lines(&install_dir).len(),
+        witness_lines(&witness).len(),
         1,
         "setup: one install recorded so far"
     );
@@ -501,7 +512,7 @@ fn volatile_old_marker_without_timestamp_re_installs() {
     finalize_local_invocation_at(&candidate, cache.path(), base_now())
         .unwrap_or_else(|error| panic!("legacy re-resolve: {error}"));
     assert_eq!(
-        witness_lines(&install_dir).len(),
+        witness_lines(&witness).len(),
         2,
         "a timestamp-less volatile marker must trigger a re-install (auto-heal)"
     );
@@ -529,7 +540,8 @@ fn pinned_cache_remains_permanent_hit() {
     // AC4: an explicit (pinned) version is immutable — the cache is a permanent
     // hit regardless of how much time has passed.
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
-    counting_npm_stub(&bin);
+    let witness = witness_path(&bin);
+    counting_npm_stub(&bin, &witness);
     let candidate = volatile_npm_candidate(&bin, "0.10.0-nightly.260720.abc");
     assert!(
         !candidate
@@ -541,14 +553,14 @@ fn pinned_cache_remains_permanent_hit() {
     );
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
 
-    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    finalize_local_invocation_at(&candidate, cache.path(), base_now())
         .unwrap_or_else(|error| panic!("first install: {error}"));
     // Far beyond any TTL: a pinned version must still be a cache hit.
     let far_future = base_now() + std::time::Duration::from_secs(365 * 24 * 60 * 60);
     finalize_local_invocation_at(&candidate, cache.path(), far_future)
         .unwrap_or_else(|error| panic!("pinned re-invocation: {error}"));
     assert_eq!(
-        witness_lines(install_dir_of(first.executable())).len(),
+        witness_lines(&witness).len(),
         1,
         "a pinned version must be a permanent cache hit"
     );
@@ -557,10 +569,15 @@ fn pinned_cache_remains_permanent_hit() {
 #[cfg(unix)]
 #[test]
 fn volatile_re_resolve_removes_stale_lockfile() {
-    // AC5: when a volatile cache expires, jefe removes the stale package-lock.json
-    // before re-running npm so the dist-tag is re-resolved instead of reused.
+    // AC5 (#554): when a volatile cache expires, `npm install` must not observe a
+    // prior package-lock.json, so the dist-tag is re-resolved instead of reused,
+    // and the stale lockfile must not survive into the refreshed cache entry.
+    // Since #556 this is guaranteed structurally: the re-install is built in a
+    // fresh staging directory and promoted by rename, so nothing from the
+    // previous entry can leak into it.
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
-    counting_npm_stub(&bin);
+    let witness = witness_path(&bin);
+    counting_npm_stub(&bin, &witness);
     let candidate = volatile_npm_candidate(&bin, "latest nightly");
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
 
@@ -575,15 +592,11 @@ fn volatile_re_resolve_removes_stale_lockfile() {
     finalize_local_invocation_at(&candidate, cache.path(), expired)
         .unwrap_or_else(|error| panic!("expired re-resolve: {error}"));
 
-    let lines = witness_lines(&install_dir);
-    assert_eq!(
-        lines.len(),
-        2,
-        "expired volatile cache must re-run npm"
-    );
+    let lines = witness_lines(&witness);
+    assert_eq!(lines.len(), 2, "expired volatile cache must re-run npm");
     assert_eq!(
         lines[1], "absent",
-        "the stale package-lock.json must be removed before npm re-resolves (got {lines:?})",
+        "npm must not see the stale package-lock.json when it re-resolves (got {lines:?})",
     );
     assert!(
         !install_dir.join("package-lock.json").exists(),

--- a/src/runtime/session_host.rs
+++ b/src/runtime/session_host.rs
@@ -236,10 +236,10 @@ fn reclaim_owned_temps(digest_directory: &Path, attempt_tag: &str) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if let Some(name) = path.file_name().and_then(|value| value.to_str()) {
-            if name.contains(&expected_suffix) {
-                let _ = fs::remove_file(&path);
-            }
+        if let Some(name) = path.file_name().and_then(|value| value.to_str())
+            && name.contains(&expected_suffix)
+        {
+            let _ = fs::remove_file(&path);
         }
     }
 }

--- a/src/state/new_issue_form_ops.rs
+++ b/src/state/new_issue_form_ops.rs
@@ -440,24 +440,22 @@ impl AppState {
             // exists in the fresh list so the form never holds a stale
             // selection (type, labels, milestone, assignees). Build HashSets
             // for O(1) membership checks instead of O(n*m) nested scans.
-            if d.available_types != types {
-                if let Some(id) = d.type_id.as_ref() {
-                    if !types.iter().any(|t| t.id == *id) {
-                        d.type_id = None;
-                        d.type_name = None;
-                    }
-                }
+            if d.available_types != types
+                && let Some(id) = d.type_id.as_ref()
+                && !types.iter().any(|t| t.id == *id)
+            {
+                d.type_id = None;
+                d.type_name = None;
             }
             if d.available_labels != labels {
                 let label_set: HashSet<&str> = labels.iter().map(String::as_str).collect();
                 d.labels.retain(|l| label_set.contains(l.as_str()));
             }
-            if d.available_milestones != milestones {
-                if let Some(m) = d.milestone.as_ref() {
-                    if !milestones.iter().any(|a| a == m) {
-                        d.milestone = None;
-                    }
-                }
+            if d.available_milestones != milestones
+                && let Some(m) = d.milestone.as_ref()
+                && !milestones.iter().any(|a| a == m)
+            {
+                d.milestone = None;
             }
             if d.available_assignees != assignees {
                 let assignee_set: HashSet<&str> = assignees.iter().map(String::as_str).collect();

--- a/src/state/prs_diff_ops.rs
+++ b/src/state/prs_diff_ops.rs
@@ -85,10 +85,10 @@ impl AppState {
         // Clear the owned Changes error and any PR error propagated from it
         // (issue #376); an unrelated PR error is preserved by text comparison.
         let prev_changes_error = self.prs_state.changes.error.take();
-        if let Some(ref changes_err) = prev_changes_error {
-            if self.prs_state.error.as_deref() == Some(changes_err.as_str()) {
-                self.prs_state.error = None;
-            }
+        if let Some(ref changes_err) = prev_changes_error
+            && self.prs_state.error.as_deref() == Some(changes_err.as_str())
+        {
+            self.prs_state.error = None;
         }
         self.clear_pr_changes_blob_activity();
         true
@@ -325,10 +325,10 @@ impl AppState {
         let owned_error = self.prs_state.changes.error.take();
         // Clear only the PR error slot if it was set by this Changes failure
         // (issue #376); an unrelated PR error is preserved.
-        if let Some(ref err) = owned_error {
-            if self.prs_state.error.as_deref() == Some(err.as_str()) {
-                self.prs_state.error = None;
-            }
+        if let Some(ref err) = owned_error
+            && self.prs_state.error.as_deref() == Some(err.as_str())
+        {
+            self.prs_state.error = None;
         }
         self.prs_state.changes.pending = Some(PrChangesPending {
             scope_repo_id: identity.scope_repo_id,

--- a/src/terminal_init/mod.rs
+++ b/src/terminal_init/mod.rs
@@ -150,27 +150,23 @@ fn prepare_console<P: ConsolePolicy>(mut policy: P) -> Option<PolicyGuard<P>> {
         return None;
     }
 
-    if needs_cp_change {
-        if let Err(error) = policy.set_output_code_page(UTF8_CODE_PAGE) {
-            tracing::warn!(
-                error = %error,
-                "failed to set console output code page to UTF-8; Unicode glyphs may render incorrectly"
-            );
-            return None;
-        }
+    if needs_cp_change && let Err(error) = policy.set_output_code_page(UTF8_CODE_PAGE) {
+        tracing::warn!(
+            error = %error,
+            "failed to set console output code page to UTF-8; Unicode glyphs may render incorrectly"
+        );
+        return None;
     }
 
-    if needs_vt_change {
-        if let Err(error) = policy.enable_virtual_terminal_processing() {
-            tracing::warn!(
-                error = %error,
-                "failed to enable virtual terminal processing; attempting code page rollback"
-            );
-            if needs_cp_change {
-                restore_code_page(&mut policy, original_cp);
-            }
-            return None;
+    if needs_vt_change && let Err(error) = policy.enable_virtual_terminal_processing() {
+        tracing::warn!(
+            error = %error,
+            "failed to enable virtual terminal processing; attempting code page rollback"
+        );
+        if needs_cp_change {
+            restore_code_page(&mut policy, original_cp);
         }
+        return None;
     }
 
     Some(PolicyGuard {

--- a/src/terminal_init/tests.rs
+++ b/src/terminal_init/tests.rs
@@ -111,10 +111,10 @@ impl ConsolePolicy for RecordingPolicy {
         if self.check_fail("set_cp") {
             return Err(std::io::Error::other("injected set_cp failure"));
         }
-        if let Some(log) = &self.restore_log {
-            if let Ok(mut guard) = log.lock() {
-                guard.push(code_page);
-            }
+        if let Some(log) = &self.restore_log
+            && let Ok(mut guard) = log.lock()
+        {
+            guard.push(code_page);
         }
         self.code_page = code_page;
         Ok(())

--- a/tests/jsp_v1_compliance_slice_b.rs
+++ b/tests/jsp_v1_compliance_slice_b.rs
@@ -225,18 +225,17 @@ fn producer_fabricated_adapter_version_fails_executable_qualification() {
 fn producer_missing_process_binding_fails() {
     let mut trace = read_json(&traces_dir().join("producer-trace.json"));
     // Remove process binding from the snapshot
-    if let Some(facts) = trace.get_mut("facts").and_then(Value::as_array_mut) {
-        if let Some(doc) = facts.iter_mut().find_map(|f| {
+    if let Some(facts) = trace.get_mut("facts").and_then(Value::as_array_mut)
+        && let Some(doc) = facts.iter_mut().find_map(|f| {
             if f.get("fact").and_then(Value::as_str) == Some("document") {
                 f.get_mut("document")
             } else {
                 None
             }
-        }) {
-            if doc["kind"] == "snapshot" {
-                doc["process_binding"] = Value::String("unsupported".to_string());
-            }
-        }
+        })
+        && doc["kind"] == "snapshot"
+    {
+        doc["process_binding"] = Value::String("unsupported".to_string());
     }
     let report = validate_producer_trace(&json_bytes(&trace));
     assert!(!report.passed, "missing process binding must fail");
@@ -312,11 +311,10 @@ fn server_unknown_credential_handle_fails() {
     if let Some(interactions) = transcript
         .get_mut("interactions")
         .and_then(Value::as_array_mut)
+        && let Some(first) = interactions.first_mut()
     {
-        if let Some(first) = interactions.first_mut() {
-            first["request"]["credential_handle"] =
-                Value::String("unknown-credential-handle".to_string());
-        }
+        first["request"]["credential_handle"] =
+            Value::String("unknown-credential-handle".to_string());
     }
     let report = validate_server_transcript(&json_bytes(&transcript));
     // The unknown credential should be treated as forbidden (403), not
@@ -336,10 +334,9 @@ fn server_partial_binding_fails() {
     if let Some(interactions) = transcript
         .get_mut("interactions")
         .and_then(Value::as_array_mut)
+        && let Some(first) = interactions.first_mut()
     {
-        if let Some(first) = interactions.first_mut() {
-            first["request"]["principal_handle"] = Value::String("wrong-principal".to_string());
-        }
+        first["request"]["principal_handle"] = Value::String("wrong-principal".to_string());
     }
     let report = validate_server_transcript(&json_bytes(&transcript));
     assert!(
@@ -485,13 +482,11 @@ fn server_activity_value_never_maps_unknown_to_idle() {
         .and_then(Value::as_array_mut)
     {
         for interaction in interactions.iter_mut() {
-            if let Some(response) = interaction.get_mut("response") {
-                if response.get("kind").and_then(Value::as_str) == Some("observation_health_stale")
-                {
-                    if let Some(body) = response.get_mut("body") {
-                        body["native_activity"] = Value::String("unsupported".to_string());
-                    }
-                }
+            if let Some(response) = interaction.get_mut("response")
+                && response.get("kind").and_then(Value::as_str) == Some("observation_health_stale")
+                && let Some(body) = response.get_mut("body")
+            {
+                body["native_activity"] = Value::String("unsupported".to_string());
             }
         }
     }


### PR DESCRIPTION
Delivers the Unix slice of the managed package-cache concurrency work: cross-process serialization and atomic publication. Parent issue is #555; native Windows verification remains #557.

## Problem

The managed install directory jefe-cache-root/selector-digest/ is a **per-machine** resource, but the only guard over it was a **per-process** static Mutex. Two jefe processes that both miss the same digest ran npm install concurrently into one directory. That is #425 Problem B — ECOMPROMISED and ENOTEMPTY under concurrent same-spec installs — reproduced one level above the _npx cache that #431 moved away from.

Installation was also not atomic. package.json, then npm install, then (only on success) the marker, all written directly into the published path. An interrupted install left package.json with no node_modules and no marker, and a concurrent reader could observe a half-built node_modules tree. The cache-hit check was an unprotected two-part read, with nothing stopping a writer from rewriting the tree between the marker read and the binary resolution.

#554 converted this from dormant to live: volatile selectors now reinstall on TTL expiry, so installs are routine rather than once-ever.

## What changed

### A kernel advisory lock, not a hand-rolled one

The digest is guarded by std's File::try_lock — flock on Unix, LockFileEx on Windows — which is exactly the direction the issue proposed. Those APIs are stable std since Rust 1.89, so this needs no new dependency and no unsafe. The lock file is a sibling of the install directory rather than a file inside it, because the directory is now replaced wholesale by rename.

Putting the lock in the kernel is what makes it correct. The lock is attached to the open file description, so the OS releases it when the holder exits for any reason, including SIGKILL. That removes the entire class of problems a userspace lock would otherwise have to solve:

- a legitimate install is **never** declared stale however long it runs — precisely the mistake npm's five-second stale threshold made;
- a crashed holder needs no recovery, so there is no window in which two processes could each decide to recover the same lock;
- no on-disk ownership record exists, so no pid identity, no liveness probing, no file mtime and no wall-clock reasoning enters the protocol;
- the lock file is never unlinked, so no process can remove a lock another process holds.

Waiting is bounded by the install timeout plus a margin and then fails closed. The lock is held from before the cache-hit check through the marker write, binary resolution and fingerprint capture.

The intra-process guard from #382 is retained but keyed by digest rather than global, because preparation now waits on another process while holding it, and a global guard would let one contended digest block every unrelated one.

### Atomic publication

npm install never touches the published path again. The tree is built in a staging directory that always starts empty, the selected binary is verified there, and the marker is written **inside staging** — so the published directory is complete the instant it appears, with no window in which node_modules exists without its marker. Publication renames the previous entry aside and renames staging into place; neither rename ever targets an existing directory, which keeps the sequence valid on Unix and Windows.

Publication is two renames, so a process killed between them would leave the published path absent with a complete tree retired alongside it. Preparation reconciles that state under the lock **before** consulting the cache: a retired tree with no published entry is republished, a retired tree alongside a published entry is discarded. A crash therefore never strands a valid cache entry or forces a network install to recover. A failed publication restores the previous entry, and a restore that itself fails is reported rather than hidden.

Because staging always starts empty, a re-install can never see a previous package-lock.json. That structurally subsumes #554's explicit lockfile removal on a volatile re-resolve; the now-unreachable removal is deleted and #554's behavioral guarantee is still asserted by its own test.

### Typed, bounded, redacted diagnostics

Lock and publication failures get distinct PackageRuntimeError variants. Every detail is truncated and carries the selector digest and the io::ErrorKind — never an absolute cache path, which would embed the user's home directory and therefore the account name. Tests assert the diagnostics contain no path separator at all.

## Acceptance evidence

| # | Requirement | Test |
|---|---|---|
| A1 | Two concurrent OS processes serialize; exactly one npm install; both resolve the identical executable | concurrent_processes_install_once_and_agree |
| A2 | A reader never observes a partially built tree; the build happens outside the published path | install_is_staged_outside_the_cache_entry_and_promoted_atomically, promotion_replaces_an_existing_entry_without_exposing_a_partial_tree |
| A3 | An interrupted install publishes no marker and no partial tree, and retries cleanly | interrupted_install_leaves_no_cache_hit_and_retries_cleanly |
| A3b | A crash between the two publication renames republishes the previous entry with no npm install | a_promotion_interrupted_after_retiring_restores_the_previous_install, a_completed_promotion_discards_a_leftover_retired_tree |
| A4a | A holder killed without releasing leaves the lock immediately available, with no recovery step and no timeout | a_lock_whose_holder_was_killed_is_available_without_recovery |
| A4b | A live holder is never taken over, and the waiter proceeds once it releases | a_lock_held_by_a_live_process_is_never_taken_over |
| A4c | Preparation against a held digest fails closed and creates nothing | a_live_installer_blocks_preparation_with_a_typed_redacted_error |
| A5 | Every new failure variant is distinct, bounded, digest-correlated and path-free | a_lock_that_cannot_be_opened_is_typed_bounded_and_redacted, a_wait_timeout_is_typed_bounded_and_redacted, a_failed_promotion_is_typed_bounded_and_redacted |
| A6 | Existing single-process, #554 TTL, probe and launch behavior unchanged | existing package_runtime tests, tests/issue382 |
| A7 | uvx preparation unchanged | local_uvx_is_a_closed_structural_prefix, structural_uvx_probe_executes_the_selected_agent_invocation |

The contended cases run a genuine second OS process, re-executing the test binary through std::env::current_exe as process_tests.rs and tests/harness_v1.rs already do; no new bin target is added. The two-process install test parks both children on a start barrier and releases them together, so it does not depend on spawn timing or machine load, captures each child's stderr, and reaps children through an RAII guard even if the test panics.

## MSRV correction

File::try_lock is stable since Rust 1.89, so clippy's msrv is corrected from 1.75. That value was already impossible: Cargo.toml sets edition = "2024", which requires Rust 1.85; Cargo.toml declares no rust-version; and every CI job uses the stable toolchain. Nothing was loosened — no threshold was raised, no lint downgraded, no suppression attribute added.

The corrected floor newly surfaces 16 pre-existing collapsible_if and unnecessary_map_or sites across 11 files, because let-chains and is_none_or are 1.88+. Each is clippy's own machine-applicable, semantically identical rewrite; the alternative would have been suppression attributes, which project policy forbids.

## Review

Two independent full-scope reviews plus Open Code Review. Both reviews found a genuine blocker in the first implementation: a hand-rolled stale-takeover protocol built on rename plus read-back is not a compare-and-swap, so two processes recovering the same stale lock could both end up owning it, and an earlier guard could unlink a successor's lock. Rather than patch that, the whole userspace protocol was replaced with the kernel lock, which removes the blocker and several other findings by construction. Remaining accepted findings — crash reconciliation, swallowed rollback failure, metadata errors read as absence, the global mutex, missing digest in promotion diagnostics, and the missing test barrier — are all fixed here. Full triage is recorded in project-plans/issue555-plan.md.

## Deferred

Consumers **outside** preparation are still not insulated from a replacement: a launch that has already resolved an executable path but has not spawned it, and a running agent that loads files by path, are not protected by a lock that is released when preparation returns. That is not a regression — in-place npm install was strictly worse — but closing it needs generation-addressed install directories and a pointer swap, which would change cache-key and path semantics that this issue lists as a non-goal. Filed as #571.

## Verification

cargo xtask ci green on the exact head (fmt, clippy-allows, source-size, architecture, lint, complexity, coverage, build, test): 130 test suites ok, 0 failures, line coverage 70.91%. Rebased onto current main after #568 tightened [lints.rust] and re-verified on the rebased head.

Fixes #556
