### PR TITLE
Route reorder scenario teardown through the harness tmux driver (Fixes #574)

### DIFF
--- a/tests/core/tmux_harness_docs_contracts.rs
+++ b/tests/core/tmux_harness_docs_contracts.rs
@@ -147,6 +147,53 @@ fn the_superseded_scenario_parser_is_absent() {
         );
     }
 }
+/// Issue #574: no integration-test source under `tests/` may construct a bare
+/// direct `tmux` process. The harness owns all tmux access through
+/// `TmuxDriver`, which pins every call to the private `-L jefe-harness-<pid>`
+/// socket and scrubs the inherited tmux client env (#171, #173). A bare
+/// command in a test resolves against the socket named by an inherited
+/// `$TMUX` — exactly the bug #574 fixed: the reorder scenario's hand-rolled
+/// cleanup issued a session kill on the outer server while never reaching the
+/// harness session it was written to remove. Integration tests must route
+/// every tmux operation through the driver (or `run_tmux_v1`) so teardown and
+/// isolation stay a single source of truth.
+///
+/// The needle is assembled with `concat!` so its contiguous form never appears
+/// in this file's own source, keeping the scan self-clean.
+///
+/// Scope: like the sibling doc/workflow contracts in this file, this is a
+/// pragmatic source-text scan, not a data-flow analysis. It catches a direct
+/// literal `tmux` `Command` construction (the exact shape of the #574
+/// regression) but not variable indirection such as binding `"tmux"` to a
+/// variable and passing that to `Command::new`. New integration tests must keep
+/// routing tmux access through the driver, which is the real invariant; this
+/// scan is the tripwire that stops the direct form coming back, not a static
+/// analyzer.
+#[test]
+fn no_test_suite_source_constructs_a_bare_tmux_command() {
+    let tests_dir = repo_path("tests");
+    let mut rust_files = Vec::new();
+    collect_rust_sources(&tests_dir, &mut rust_files);
+    assert!(
+        !rust_files.is_empty(),
+        "expected to find integration-test sources under tests/"
+    );
+
+    let needle = concat!("Command::", "new(\"tmux\")");
+    let mut hits = Vec::new();
+    for file in &rust_files {
+        let source = std::fs::read_to_string(file)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", file.display()));
+        if source.contains(needle) {
+            hits.push(file.display().to_string());
+        }
+    }
+    assert!(
+        hits.is_empty(),
+        "integration tests must route tmux access through TmuxDriver (issue #574); \
+         found a bare direct tmux command in: {hits:?}"
+    );
+}
 
 fn shipped_scenario_paths() -> Vec<PathBuf> {
     let dir = repo_path("dev-docs/tmux-scenarios");
@@ -171,6 +218,26 @@ fn read_json_paths(dir: &Path) -> Vec<PathBuf> {
         }
     }
     found
+}
+
+/// Recursively collect every `.rs` file under `dir` (issue #574 contract scan).
+///
+/// Read failures panic rather than skip the subtree: this is a contract test,
+/// so silently swallowing a `read_dir` error would let a violating file pass
+/// undetected — the opposite of the test's intent.
+fn collect_rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = std::fs::read_dir(dir)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", dir.display()));
+    for entry in entries {
+        let path = entry
+            .unwrap_or_else(|err| panic!("failed to read entry in {}: {err}", dir.display()))
+            .path();
+        if path.is_dir() {
+            collect_rust_sources(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
 }
 
 fn read_repo_text(relative_path: impl AsRef<Path>) -> String {

--- a/tests/ui/dashboard_reorder_tui.rs
+++ b/tests/ui/dashboard_reorder_tui.rs
@@ -5,7 +5,6 @@
 //! tmux or the jefe binary are unavailable.
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use jefe::harness::TmuxDriver;
 use jefe::harness::v1::parse_scenario_v1;
@@ -94,18 +93,6 @@ fn unique_session(label: &str) -> String {
     format!("jefe-reorder-{label}-{pid}-{nanos}")
 }
 
-struct TmuxSessionCleanup {
-    name: String,
-}
-
-impl Drop for TmuxSessionCleanup {
-    fn drop(&mut self) {
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &self.name])
-            .output();
-    }
-}
-
 #[test]
 fn guarded_dashboard_reorder_tui_scenario() {
     let tmux = TmuxDriver::new();
@@ -145,9 +132,6 @@ fn guarded_dashboard_reorder_tui_scenario() {
     .unwrap_or_else(|e| panic!("parse scenario: {e:?}"));
 
     let session_name = unique_session("scenario");
-    let _cleanup = TmuxSessionCleanup {
-        name: session_name.clone(),
-    };
 
     let request = TmuxRunRequest {
         session: session_name,


### PR DESCRIPTION
## Summary

Fixes #574.

`tests/ui/dashboard_reorder_tui.rs` started its tmux session on the harness's private socket (`-L jefe-harness-<pid>`, env-scrubbed) via `run_tmux_v1` → `TmuxDriver`, but its own cleanup ran a bare `tmux kill-session` with **no `-L`, no `-f /dev/null`, and no env scrub**. When the suite runs inside a tmux pane (the normal case while working in jefe), `$TMUX` is inherited and that `kill-session` is dispatched against the **outer** server — never the harness session it was written to remove. The guard had been silently dead since it was added; real teardown already happened via `TmuxSessionGuard` on the correct socket.

This is exactly the class of bug #171 and #375 were filed to close.

## Changes

- **`tests/ui/dashboard_reorder_tui.rs`** — Dropped the hand-rolled `TmuxSessionCleanup` (and its now-unused `std::process::Command` import). Teardown is owned solely by `run_tmux_v1`'s `TmuxSessionGuard`, which calls `cleanup_session` on the private harness socket with `keep_session: false`. This makes `TmuxDriver` the single source of truth for the socket + env scrub, so the two cannot drift (#173 reasoning).
- **`tests/core/tmux_harness_docs_contracts.rs`** — Added a contract test `no_test_suite_source_constructs_a_bare_tmux_command` that scans every `.rs` file under `tests/` for a direct `Command::new("tmux")` construction and fails if any is found. This is the tripwire that would have caught the original bug and stops it coming back. (The needle is assembled with `concat!` so it never self-matches in the contract file's own source.)

## Acceptance matrix

| # | Behavior | Proof |
|---|----------|-------|
| AC1 | Reorder teardown removes the harness session from the **harness** socket and issues no tmux command against an inherited `$TMUX` server, on both normal and panic/unwind paths | Hand-rolled guard removed; `run_tmux_v1` → `TmuxSessionGuard` owns teardown on `jefe-harness-<pid>` with `keep_session: false` |
| AC2 | No test sends a session/server-destroying tmux command to the inherited server when run inside a tmux pane | New contract test asserts zero bare `Command::new("tmux")` in `tests/` |
| AC3 | Teardown shares one source of truth for socket + env scrub with `TmuxDriver` | No hand-rolled tmux `Command` remains in the test suite; driver is the sole owner |
| AC4 | Proving test (repo scan) | `no_test_suite_source_constructs_a_bare_tmux_command` |

## Non-goals (per issue)

- No change to `TmuxDriver`'s isolation strategy (already correct).
- No change to psmux drivers or Windows smoke tests.
- No change to what the reorder scenario asserts.

The deliberate read-only `tmux list-sessions` probe of the *default* server in `src/harness/tmux_driver_tests.rs` is untouched (it is outside the `tests/` scan and is the intended isolation assertion).

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo build --workspace --all-features --locked` ✅
- `cargo test --workspace --all-features --locked` ✅ (67 result batches, 0 failures)
- New contract test proven RED before the fix (it flagged `dashboard_reorder_tui.rs`) and GREEN after.
