### PR TITLE
Serialize managed package installs across processes and make installation atomic (Unix) (Fixes #556)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,10 @@ name = "jefe-capture-shim"
 path = "src/bin/jefe-capture-shim.rs"
 
 [[bin]]
+name = "jefe-issue556-installer"
+path = "src/bin/jefe-issue556-installer.rs"
+
+[[bin]]
 name = "jefe-harness-probe"
 path = "src/bin/jefe-harness-probe.rs"
 

--- a/project-plans/issue556-plan.md
+++ b/project-plans/issue556-plan.md
@@ -1,0 +1,80 @@
+# Issue #556 — Serialize managed package installs across jefe processes and make installation atomic (Unix)
+
+Sub-issue of the managed package-cache concurrency parent (#425, Problem B).
+
+## Goal
+
+Give the managed npm package cache real cross-process mutual exclusion and an
+atomic install, implemented and behaviorally verified on Unix. Windows locking
+behavior is **not** changed here (separate Windows sub-issue); the tree must
+keep building/working on all platforms.
+
+## Design (dependency-free, std-only)
+
+- **Cross-process lock** = a per-digest lock file created with
+  `OpenOptions::create_new(true)` (`O_EXCL`). `create_new` is an atomic,
+  exclusive, cross-process AND cross-thread primitive — exactly one contender
+  wins. No new crate needed (rejects the non-goal "do not add a dependency").
+- **Stale recovery (A4)** = the lock file records `pid` + install epoch. A
+  contender that finds an existing lock reads the pid and checks liveness via
+  the portable `kill -0 <pid>` shell built-in (`std::process::Command`, no
+  crate). A dead pid is recovered **immediately** (no fixed timeout). A live
+  pid is never declared stale → the contender waits.
+- **Atomic install (A2)** = build in a sibling temp dir
+  `cache_root/.<digest>.building-<pid>-<nonce>`, write the marker there, then
+  swap into place: remove any stale final dir (we hold the lock, safe) and
+  `rename(temp → final)`. The final path is therefore either absent or
+  complete — never a partial tree.
+- **Interrupted install (A3)** = if the process dies before the rename, the
+  final dir never exists (no marker, no partial tree) → the next call is a
+  clean cache miss + retry. Stale `.building-*` dirs for the held digest are
+  swept at install start (we hold the lock, so they are abandoned).
+- **Waiter loop** = double-checked locking: check `cache_hit`; if miss, acquire
+  lock; under lock re-check `cache_hit` (another may have finished); else
+  install + swap + release. Losers observe a complete cache hit (A1).
+- **Mutex kept** as the existing intra-process guard (A6: single-process
+  behavior unchanged); the file lock adds the missing cross-process dimension.
+- **Platform split**: new lock + atomic-swap path is `#[cfg(unix)]`; the
+  `#[cfg(not(unix))]` path keeps the current direct-write behavior so Windows
+  is unchanged.
+
+## Acceptance matrix
+
+| ID | Requirement | Behavioral proof (test) | Location |
+|----|-------------|--------------------------|----------|
+| A1 | Two concurrent installers of the same digest serialize; one installs, the other observes a complete cache hit | Two-**process** test: spawn the helper bin twice in parallel against a counting npm stub; assert exactly one npm invocation and both resolve to the identical executable | `tests/issue556_behavior.rs` + `src/bin/jefe-issue556-installer.rs` |
+| A2 | A reader never observes a partially built tree | Install builds in a sibling temp dir and is renamed into place; test asserts the final path is never resolvable with a partial state (bin without marker) while building in temp | `package_cache_lock_tests.rs` (atomic swap) + `package_runtime_atomic_tests.rs` |
+| A3 | An interrupted install leaves no cache hit and is retried cleanly | npm fails (exit≠0) mid-install; assert no marker, no final dir, then a succeeding retry installs cleanly | `package_runtime_atomic_tests.rs` |
+| A4 | Stale lock from a dead process recovered without a fixed timeout; a live long install never declared stale | Unit-test the staleness decision: dead pid (exited child) → recover; live pid (`sleep` child) → not stale | `package_cache_lock_tests.rs` |
+| A5 | Lock, stale-recovery, rename failures are typed, bounded, redacted | Distinct `PackageRuntimeError` variants (`CacheLock`, `InstallRename`); assert bounded length and no secret leakage | `package_cache_lock_tests.rs` + variant tests |
+| A6 | Existing single-process behavior unchanged | Existing `package_runtime_tests.rs` + launch/probe tests remain green; no new timing-dependent assertions | existing tests |
+| A7 | uvx path retains current semantics | uvx preparation unchanged; behavioral assertion that uvx still resolves the structural prefix | `tests/issue556_behavior.rs` |
+
+## Non-goals (enforced)
+
+- No selector normalization / digest / cache-key changes (#554).
+- No probe-budget / probe-phase changes (#553).
+- No new dependency (no `libc`/`fs2`/`fs4`/`nix`/`rustix`).
+- No background installer / daemon / queue.
+- No Windows locking behavior change (Windows sub-issue).
+
+## Files (scope ledger)
+
+| File | Change | Acceptance |
+|------|--------|------------|
+| `src/runtime/package_cache_lock.rs` | NEW — cross-process lock + atomic dir swap | A1,A2,A3,A4,A5 |
+| `src/runtime/package_cache_lock_tests.rs` | NEW — lock/stale/swap unit tests | A2,A3,A4,A5 |
+| `src/runtime/package_runtime.rs` | wire lock + atomic install into `prepare_managed_npm`; add error variants; keep Mutex | A1-A6 |
+| `src/runtime/package_runtime_atomic_tests.rs` | NEW — integrated atomic-install + interrupted-retry tests | A2,A3 |
+| `src/runtime/mod.rs` | declare new module | — |
+| `src/bin/jefe-issue556-installer.rs` | NEW — helper bin driving the production finalize boundary | A1 |
+| `tests/issue556_behavior.rs` | NEW — two-process serialization + uvx-unaffected | A1,A7 |
+| `Cargo.toml` | add `[[bin]]` helper entry (test fixture, no dependency) | A1 |
+
+Review counters: OCR pre-PR 0/2, OCR post-PR 0/2.
+
+## Verification
+
+`cargo fmt --all --check && cargo clippy --workspace --all-targets --all-features -- -D warnings &&
+cargo build --workspace --all-features --locked && cargo test --workspace --all-features --locked`
+plus `cargo xtask check source-size` / `architecture`.

--- a/src/bin/jefe-issue556-installer.rs
+++ b/src/bin/jefe-issue556-installer.rs
@@ -52,6 +52,10 @@ fn run() -> Result<PathBuf, String> {
         vec![bin_dir],
         std::env::var_os("PATHEXT"),
     );
+    // The resolver takes a repository root used only to anchor non-package
+    // path candidates; this fixture resolves the shipped LLxprt *package*
+    // candidate, which derives its location from `bin_dir`, so the repository
+    // root is never consulted. `/repo` is an inert placeholder.
     let resolution = AgentCandidateResolver::new(&snapshot, PathBuf::from("/repo"))
         .with_version_selector(selector)
         .resolve(&definition);

--- a/src/bin/jefe-issue556-installer.rs
+++ b/src/bin/jefe-issue556-installer.rs
@@ -1,0 +1,65 @@
+//! Issue #556 two-process installer fixture.
+//!
+//! Drives the production managed-install boundary
+//! (`jefe::runtime::package_runtime::finalize_local_invocation`) once against a
+//! caller-supplied cache root, npm fixture directory, and version selector, then
+//! prints the resolved managed executable path to stdout. The cross-process
+//! serialization test spawns two copies of this fixture against the same shared
+//! cache to prove concurrent installers serialize (exactly one install) rather
+//! than race on the cache directory.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use jefe::agent_candidate::{AgentCandidateResolver, CandidateResolution, VersionSelector};
+use jefe::agent_candidate_path::{AgentExecutablePlatform, PathSnapshot};
+use jefe::domain::agent_definition::AgentDefinition;
+use jefe::runtime::package_runtime::finalize_local_invocation;
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(executable) => {
+            let mut stdout = std::io::stdout().lock();
+            let _ = writeln!(stdout, "{}", executable.display());
+            ExitCode::SUCCESS
+        }
+        Err(message) => {
+            let _ = writeln!(std::io::stderr(), "jefe-issue556-installer: {message}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<PathBuf, String> {
+    let cache = std::env::var_os("JEFE_ISSUE556_CACHE")
+        .map(PathBuf::from)
+        .ok_or_else(|| "JEFE_ISSUE556_CACHE is required".to_string())?;
+    let bin_dir = std::env::var_os("JEFE_ISSUE556_BIN")
+        .map(PathBuf::from)
+        .ok_or_else(|| "JEFE_ISSUE556_BIN is required".to_string())?;
+    let selector_str = std::env::var("JEFE_ISSUE556_SELECTOR")
+        .map_err(|_| "JEFE_ISSUE556_SELECTOR is required".to_string())?;
+
+    let definition = AgentDefinition::shipped()
+        .into_iter()
+        .find(|definition| definition.display_name == "LLxprt")
+        .ok_or_else(|| "shipped LLxprt definition is missing".to_string())?;
+    let selector = VersionSelector::normalize(&selector_str)
+        .map_err(|error| format!("normalize selector `{selector_str}`: {error}"))?;
+    let snapshot = PathSnapshot::for_platform(
+        AgentExecutablePlatform::current(),
+        vec![bin_dir],
+        std::env::var_os("PATHEXT"),
+    );
+    let resolution = AgentCandidateResolver::new(&snapshot, PathBuf::from("/repo"))
+        .with_version_selector(selector)
+        .resolve(&definition);
+    let CandidateResolution::Resolved(candidate) = resolution else {
+        return Err("package candidate did not resolve".to_string());
+    };
+
+    let invocation =
+        finalize_local_invocation(&candidate, &cache).map_err(|error| error.to_string())?;
+    Ok(invocation.executable().to_path_buf())
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -52,6 +52,10 @@ mod multiplexer;
 /// Non-interactive (single-prompt, capture-stdout) agent execution (issue #214).
 mod non_interactive;
 mod orphan;
+/// Cross-process install lock and atomic swap for the managed package cache
+/// (issue #556). Unix-only; Windows locking is handled separately.
+#[cfg(unix)]
+mod package_cache_lock;
 mod package_probe;
 /// Generic package-backed invocation and preparation boundary (issue #382 S12).
 pub mod package_runtime;

--- a/src/runtime/package_cache_lock.rs
+++ b/src/runtime/package_cache_lock.rs
@@ -5,10 +5,15 @@
 //! appear atomically at its final path. This module owns two dependency-free,
 //! std-only primitives:
 //!
-//! - [`InstallLock`]: a per-digest lock acquired via `OpenOptions::create_new`
-//!   (`O_EXCL`), which is atomic, exclusive, and effective both across
-//!   processes and across threads. A lock left behind by a dead holder is
-//!   recovered immediately from the recorded pid (no fixed timeout).
+//! - [`InstallLock`]: a per-digest lock acquired by atomically hard-linking a
+//!   pre-stamped temp file into the lock path. `hard_link` is exclusive (it
+//!   fails if the target exists) and content-preserving, so a lock file either
+//!   does not exist or already carries the holder's identity — there is no
+//!   empty-lock window from a crashed create-before-write. The stamp records
+//!   the holder's [`ProcessIdentity`] (pid + start discriminator) so a lock
+//!   left behind by a dead holder is recovered immediately from the project's
+//!   canonical liveness classifier (no fixed timeout, and a recycled pid whose
+//!   start discriminator differs is reclaimed too).
 //! - [`atomic_swap_into_place`]: build a complete tree in a sibling temp dir,
 //!   then rename it into the final path so a reader never observes a partial
 //!   tree.
@@ -18,11 +23,12 @@
 
 #![cfg(unix)]
 
-use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
-use std::time::{SystemTime, UNIX_EPOCH};
+
+use tempfile::NamedTempFile;
+
+use crate::domain::ProcessIdentity;
 
 use super::package_runtime::PackageRuntimeError;
 
@@ -30,35 +36,50 @@ use super::package_runtime::PackageRuntimeError;
 /// errors stay bounded (issue #556 A5).
 const DIAGNOSTIC_BOUND: usize = 256;
 
-/// Two lines: the holder pid, then the install-start epoch (seconds).
-fn holder_line(pid: u32) -> String {
-    let epoch = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_secs());
-    format!("{pid}\n{epoch}\n")
+/// Two lines: the holder pid, then the holder's process start discriminator
+/// (the platform `started_at` from [`ProcessIdentity`]). Recording the start
+/// discriminator — not a wall-clock epoch — lets recovery reject a recycled pid
+/// whose `started_at` no longer matches (issue #556 A4).
+fn holder_identity_line(identity: &ProcessIdentity) -> String {
+    match identity.started_at {
+        Some(started) => format!("{}\n{started}\n", identity.pid),
+        None => format!("{}\n\n", identity.pid),
+    }
 }
 
-/// First line of a lock file is the holder pid, if it is readable and numeric.
-fn read_holder_pid(lock_path: &Path) -> Option<u32> {
+/// Capture the current process identity for stamping into a freshly held lock.
+/// A probe that cannot read the start discriminator still records the pid; the
+/// holder is then classified only by liveness (fail-open, never a false stale
+/// claim against a live install).
+fn current_identity() -> ProcessIdentity {
+    let pid = std::process::id();
+    super::process::capture_process_identity(pid).unwrap_or(ProcessIdentity {
+        pid,
+        started_at: None,
+    })
+}
+
+/// Parsed holder identity (pid + start discriminator) from a lock file, when
+/// both lines are present and the pid is numeric.
+fn read_holder_identity(lock_path: &Path) -> Option<ProcessIdentity> {
     let content = std::fs::read_to_string(lock_path).ok()?;
-    content.lines().next()?.parse::<u32>().ok()
+    let mut lines = content.lines();
+    let pid = lines.next()?.parse::<u32>().ok()?;
+    let started_at = lines
+        .next()
+        .filter(|line| !line.is_empty())
+        .and_then(|line| line.parse::<u64>().ok());
+    Some(ProcessIdentity { pid, started_at })
 }
 
-/// Whether a process is currently alive, via the portable `kill -0` built-in.
-///
-/// `kill -0 <pid>` exits successfully exactly when the pid exists and is
-/// signalable by this user. All jefe processes run as the same user, so a
-/// same-user live install is never misreported as dead. No external crate is
-/// required.
-fn pid_alive(pid: u32) -> bool {
-    let status = std::process::Command::new("kill")
-        .arg("-0")
-        .arg(pid.to_string())
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
-    status.is_ok_and(|outcome| outcome.success())
+/// Whether the recorded holder is gone, using the project's canonical process
+/// liveness classifier. A dead holder OR a recycled pid (different start
+/// discriminator) is "gone" and may be reclaimed; inaccessible and probe-failure
+/// outcomes fail open so a live install is never falsely declared stale
+/// (issue #556 A4).
+fn holder_is_gone(identity: ProcessIdentity) -> bool {
+    let liveness = super::process::process_liveness(Some(identity));
+    !super::process::process_liveness_indicates_alive(liveness)
 }
 
 fn bounded(detail: &str) -> String {
@@ -79,49 +100,55 @@ pub enum AcquireOutcome {
     Contended,
 }
 
-/// Try once to acquire `lock_path`. A stale lock whose recorded pid is dead is
-/// reclaimed inline before a single retry. Returns [`AcquireOutcome::Contended`]
-/// when a live process holds the lock or the holder cannot be read.
+/// Try once to acquire `lock_path`. A stale lock whose recorded holder is gone
+/// is reclaimed inline before a single retry. Returns [`AcquireOutcome::Contended`]
+/// when a live process holds the lock or the holder identity is unreadable.
 pub fn try_acquire(lock_path: &Path) -> Result<AcquireOutcome, PackageRuntimeError> {
-    if let Some(file) = open_exclusive(lock_path) {
-        return claim(lock_path, file);
+    match link_exclusive(lock_path)? {
+        Some(lock) => Ok(AcquireOutcome::Acquired(lock)),
+        None => contend_or_recover(lock_path),
     }
-    contend_or_recover(lock_path)
 }
 
-fn open_exclusive(lock_path: &Path) -> Option<File> {
-    OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(lock_path)
-        .ok()
-}
-
-/// Stamp the freshly created lock with this holder's pid. A lock that cannot be
-/// stamped is unusable — no pid means it can never be recovered — so the empty
-/// file is removed and the failure surfaced (issue #556 A4 stale recovery).
-fn claim(lock_path: &Path, mut file: File) -> Result<AcquireOutcome, PackageRuntimeError> {
+/// Atomically claim an exclusive lock by hard-linking a pre-stamped temp file
+/// into the lock path. `hard_link` is exclusive (it fails if the target exists)
+/// and content-preserving, so the lock file either does not exist or already
+/// carries the holder's identity — there is never an empty-lock window from a
+/// crashed create-before-write sequence.
+fn link_exclusive(lock_path: &Path) -> Result<Option<InstallLock>, PackageRuntimeError> {
     let pid = std::process::id();
-    if let Err(error) = file.write_all(holder_line(pid).as_bytes()) {
-        let _ = std::fs::remove_file(lock_path);
-        return Err(PackageRuntimeError::CacheLock(bounded(&error.to_string())));
+    let Some(parent) = lock_path.parent() else {
+        return Err(PackageRuntimeError::CacheLock(bounded(
+            "lock path has no parent directory",
+        )));
+    };
+    let mut temp = NamedTempFile::new_in(parent)
+        .map_err(|error| PackageRuntimeError::CacheLock(bounded(&error.to_string())))?;
+    let identity = current_identity();
+    temp.write_all(holder_identity_line(&identity).as_bytes())
+        .map_err(|error| PackageRuntimeError::CacheLock(bounded(&error.to_string())))?;
+    match std::fs::hard_link(temp.path(), lock_path) {
+        // The lock now shares the temp inode; dropping `temp` removes only the
+        // temp name, leaving the lock in place.
+        Ok(()) => Ok(Some(InstallLock {
+            path: lock_path.to_path_buf(),
+            pid,
+        })),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(None),
+        Err(error) => Err(PackageRuntimeError::CacheLock(bounded(&error.to_string()))),
     }
-    Ok(AcquireOutcome::Acquired(InstallLock {
-        path: lock_path.to_path_buf(),
-        pid,
-    }))
 }
 
 fn contend_or_recover(lock_path: &Path) -> Result<AcquireOutcome, PackageRuntimeError> {
-    let Some(pid) = read_holder_pid(lock_path) else {
+    let Some(identity) = read_holder_identity(lock_path) else {
         return Ok(AcquireOutcome::Contended);
     };
-    if pid_alive(pid) {
+    if !holder_is_gone(identity) {
         return Ok(AcquireOutcome::Contended);
     }
     recover_stale(lock_path)?;
-    match open_exclusive(lock_path) {
-        Some(file) => claim(lock_path, file),
+    match link_exclusive(lock_path)? {
+        Some(lock) => Ok(AcquireOutcome::Acquired(lock)),
         None => Ok(AcquireOutcome::Contended),
     }
 }
@@ -139,7 +166,7 @@ impl Drop for InstallLock {
     fn drop(&mut self) {
         // Conditional release: only unlink the lock if it still names this
         // holder, so a successor that already reclaimed it is not clobbered.
-        if read_holder_pid(&self.path) == Some(self.pid) {
+        if read_holder_identity(&self.path).is_some_and(|identity| identity.pid == self.pid) {
             let _ = std::fs::remove_file(&self.path);
         }
     }
@@ -155,9 +182,12 @@ impl Drop for InstallLock {
 /// tree must be moved aside rather than renamed over directly.
 pub fn atomic_swap_into_place(built: &Path, final_dir: &Path) -> Result<(), PackageRuntimeError> {
     let backup = swap_backup_path(final_dir);
-    // A leftover backup from a crashed swap is safe to clear (the caller holds
-    // the install lock, so no other installer is mid-swap).
-    let _ = std::fs::remove_dir_all(&backup);
+    // Recover a half-finished previous swap before moving the current tree: a
+    // crashed swap may have parked the last valid tree in the backup with no
+    // final tree to show for it. Restore it so a reader never loses a good
+    // cache to a crash (issue #556 A2). The caller holds the install lock, so
+    // the backup is not contended.
+    recover_crashed_swap(final_dir, &backup)?;
     let had_existing = match std::fs::rename(final_dir, &backup) {
         Ok(()) => true,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
@@ -179,6 +209,21 @@ pub fn atomic_swap_into_place(built: &Path, final_dir: &Path) -> Result<(), Pack
         let _ = std::fs::remove_dir_all(&backup);
     }
     Ok(())
+}
+
+/// Reconcile a leftover swap backup: restore it if the previous swap crashed
+/// after parking the valid tree (final missing), or discard it if the final
+/// tree is already present (stale leftover from a completed swap).
+fn recover_crashed_swap(final_dir: &Path, backup: &Path) -> Result<(), PackageRuntimeError> {
+    if !backup.exists() {
+        return Ok(());
+    }
+    if final_dir.exists() {
+        let _ = std::fs::remove_dir_all(backup);
+        return Ok(());
+    }
+    std::fs::rename(backup, final_dir)
+        .map_err(|error| PackageRuntimeError::InstallRename(bounded(&error.to_string())))
 }
 
 /// Sibling path used to park the previous final tree during a swap.

--- a/src/runtime/package_cache_lock.rs
+++ b/src/runtime/package_cache_lock.rs
@@ -1,0 +1,200 @@
+//! Cross-process mutual exclusion and atomic install swap for the managed
+//! package cache (issue #556).
+//!
+//! On Unix the managed npm install must serialize across jefe processes and
+//! appear atomically at its final path. This module owns two dependency-free,
+//! std-only primitives:
+//!
+//! - [`InstallLock`]: a per-digest lock acquired via `OpenOptions::create_new`
+//!   (`O_EXCL`), which is atomic, exclusive, and effective both across
+//!   processes and across threads. A lock left behind by a dead holder is
+//!   recovered immediately from the recorded pid (no fixed timeout).
+//! - [`atomic_swap_into_place`]: build a complete tree in a sibling temp dir,
+//!   then rename it into the final path so a reader never observes a partial
+//!   tree.
+//!
+//! Windows locking behavior is intentionally unchanged here (separate Windows
+//! sub-issue); this module is exercised on Unix.
+
+#![cfg(unix)]
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::package_runtime::PackageRuntimeError;
+
+/// Maximum characters retained from a filesystem diagnostic so lock and rename
+/// errors stay bounded (issue #556 A5).
+const DIAGNOSTIC_BOUND: usize = 256;
+
+/// Two lines: the holder pid, then the install-start epoch (seconds).
+fn holder_line(pid: u32) -> String {
+    let epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs());
+    format!("{pid}\n{epoch}\n")
+}
+
+/// First line of a lock file is the holder pid, if it is readable and numeric.
+fn read_holder_pid(lock_path: &Path) -> Option<u32> {
+    let content = std::fs::read_to_string(lock_path).ok()?;
+    content.lines().next()?.parse::<u32>().ok()
+}
+
+/// Whether a process is currently alive, via the portable `kill -0` built-in.
+///
+/// `kill -0 <pid>` exits successfully exactly when the pid exists and is
+/// signalable by this user. All jefe processes run as the same user, so a
+/// same-user live install is never misreported as dead. No external crate is
+/// required.
+fn pid_alive(pid: u32) -> bool {
+    let status = std::process::Command::new("kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    status.is_ok_and(|outcome| outcome.success())
+}
+
+fn bounded(detail: &str) -> String {
+    detail.chars().take(DIAGNOSTIC_BOUND).collect()
+}
+
+/// A held per-digest install lock. Dropping it releases the lock.
+pub struct InstallLock {
+    path: PathBuf,
+    pid: u32,
+}
+
+/// The outcome of one attempt to claim a lock.
+pub enum AcquireOutcome {
+    /// This caller now holds the lock.
+    Acquired(InstallLock),
+    /// A live process holds the lock; the caller should wait and retry.
+    Contended,
+}
+
+/// Try once to acquire `lock_path`. A stale lock whose recorded pid is dead is
+/// reclaimed inline before a single retry. Returns [`AcquireOutcome::Contended`]
+/// when a live process holds the lock or the holder cannot be read.
+pub fn try_acquire(lock_path: &Path) -> Result<AcquireOutcome, PackageRuntimeError> {
+    if let Some(file) = open_exclusive(lock_path) {
+        return claim(lock_path, file);
+    }
+    contend_or_recover(lock_path)
+}
+
+fn open_exclusive(lock_path: &Path) -> Option<File> {
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(lock_path)
+        .ok()
+}
+
+/// Stamp the freshly created lock with this holder's pid. A lock that cannot be
+/// stamped is unusable — no pid means it can never be recovered — so the empty
+/// file is removed and the failure surfaced (issue #556 A4 stale recovery).
+fn claim(lock_path: &Path, mut file: File) -> Result<AcquireOutcome, PackageRuntimeError> {
+    let pid = std::process::id();
+    if let Err(error) = file.write_all(holder_line(pid).as_bytes()) {
+        let _ = std::fs::remove_file(lock_path);
+        return Err(PackageRuntimeError::CacheLock(bounded(&error.to_string())));
+    }
+    Ok(AcquireOutcome::Acquired(InstallLock {
+        path: lock_path.to_path_buf(),
+        pid,
+    }))
+}
+
+fn contend_or_recover(lock_path: &Path) -> Result<AcquireOutcome, PackageRuntimeError> {
+    let Some(pid) = read_holder_pid(lock_path) else {
+        return Ok(AcquireOutcome::Contended);
+    };
+    if pid_alive(pid) {
+        return Ok(AcquireOutcome::Contended);
+    }
+    recover_stale(lock_path)?;
+    match open_exclusive(lock_path) {
+        Some(file) => claim(lock_path, file),
+        None => Ok(AcquireOutcome::Contended),
+    }
+}
+
+/// Remove a known-stale lock file (dead holder). A concurrent remover is fine.
+fn recover_stale(lock_path: &Path) -> Result<(), PackageRuntimeError> {
+    match std::fs::remove_file(lock_path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(PackageRuntimeError::CacheLock(bounded(&error.to_string()))),
+    }
+}
+
+impl Drop for InstallLock {
+    fn drop(&mut self) {
+        // Conditional release: only unlink the lock if it still names this
+        // holder, so a successor that already reclaimed it is not clobbered.
+        if read_holder_pid(&self.path) == Some(self.pid) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+/// Rename a completed `built` tree into `final_dir`.
+///
+/// Uses a move-aside swap: any existing final tree is renamed to a backup
+/// first, then the built tree is renamed into place. If the second rename fails
+/// the backup is restored, so a previously valid install is never lost and a
+/// reader never observes a missing tree that cannot be rebuilt (issue #556 A2).
+/// POSIX `rename` cannot replace a non-empty directory in one step, so the old
+/// tree must be moved aside rather than renamed over directly.
+pub fn atomic_swap_into_place(built: &Path, final_dir: &Path) -> Result<(), PackageRuntimeError> {
+    let backup = swap_backup_path(final_dir);
+    // A leftover backup from a crashed swap is safe to clear (the caller holds
+    // the install lock, so no other installer is mid-swap).
+    let _ = std::fs::remove_dir_all(&backup);
+    let had_existing = match std::fs::rename(final_dir, &backup) {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => {
+            return Err(PackageRuntimeError::InstallRename(bounded(
+                &error.to_string(),
+            )));
+        }
+    };
+    if let Err(error) = std::fs::rename(built, final_dir) {
+        if had_existing {
+            let _ = std::fs::rename(&backup, final_dir);
+        }
+        return Err(PackageRuntimeError::InstallRename(bounded(
+            &error.to_string(),
+        )));
+    }
+    if had_existing {
+        let _ = std::fs::remove_dir_all(&backup);
+    }
+    Ok(())
+}
+
+/// Sibling path used to park the previous final tree during a swap.
+fn swap_backup_path(final_dir: &Path) -> PathBuf {
+    let Some(name) = final_dir.file_name() else {
+        return final_dir
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("install.jefe-swap-old");
+    };
+    let mut backup = name.to_os_string();
+    backup.push(".jefe-swap-old");
+    final_dir.with_file_name(backup)
+}
+
+#[cfg(test)]
+mod tests {
+    include!("package_cache_lock_tests.rs");
+}

--- a/src/runtime/package_cache_lock_tests.rs
+++ b/src/runtime/package_cache_lock_tests.rs
@@ -1,0 +1,215 @@
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+use tempfile::TempDir;
+
+use super::{AcquireOutcome, atomic_swap_into_place, try_acquire};
+
+fn lock_path(dir: &TempDir) -> PathBuf {
+    dir.path().join("digest.lock")
+}
+
+/// Spawn a child that stays alive until killed, returning its pid and a handle
+/// that reaps it on drop.
+struct LiveChild(Option<std::process::Child>);
+
+impl LiveChild {
+    fn sleeping() -> Self {
+        let child = Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap_or_else(|error| panic!("spawn sleep: {error}"));
+        Self(Some(child))
+    }
+
+    fn pid(&self) -> u32 {
+        self.0
+            .as_ref()
+            .map_or_else(|| panic!("live child present"), std::process::Child::id)
+    }
+}
+
+impl Drop for LiveChild {
+    fn drop(&mut self) {
+        if let Some(child) = self.0.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// A pid guaranteed to be dead: spawn a child, let it exit, and reap it so the
+/// pid is no longer present.
+fn dead_pid() -> u32 {
+    let mut child = Command::new("true")
+        .spawn()
+        .unwrap_or_else(|error| panic!("spawn true: {error}"));
+    let pid = child.id();
+    child
+        .wait()
+        .unwrap_or_else(|error| panic!("wait true: {error}"));
+    pid
+}
+
+fn plant_lock(dir: &TempDir, pid: u32) {
+    let path = lock_path(dir);
+    let content = format!("{pid}\n0\n");
+    std::fs::write(&path, content)
+        .unwrap_or_else(|error| panic!("plant lock: {error}"));
+}
+
+fn is_acquired(outcome: &AcquireOutcome) -> bool {
+    matches!(outcome, AcquireOutcome::Acquired(_))
+}
+
+/// A4: a stale lock whose recorded pid is gone is recovered immediately, with
+/// no timeout wait.
+#[test]
+fn stale_lock_with_dead_pid_is_recovered() {
+    let dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    plant_lock(&dir, dead_pid());
+
+    let started = std::time::Instant::now();
+    let outcome = try_acquire(&lock_path(&dir))
+        .unwrap_or_else(|error| panic!("try_acquire: {error}"));
+    let elapsed = started.elapsed();
+
+    assert!(
+        is_acquired(&outcome),
+        "a dead-holder lock must be reclaimed"
+    );
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "recovery is immediate, not timer-bound: {elapsed:?}"
+    );
+}
+
+/// A4: a lock held by a live process is never declared stale.
+#[test]
+fn live_lock_is_never_declared_stale() {
+    let dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let live = LiveChild::sleeping();
+    plant_lock(&dir, live.pid());
+
+    let outcome = try_acquire(&lock_path(&dir))
+        .unwrap_or_else(|error| panic!("try_acquire: {error}"));
+
+    assert!(
+        matches!(outcome, AcquireOutcome::Contended),
+        "a live-holder lock must not be reclaimed"
+    );
+    // The live child is reaped by Drop.
+    drop(live);
+}
+
+/// Within one process a second claim without releasing the first is contended,
+/// proving the `create_new` lock is exclusive (cross-thread as well as
+/// cross-process).
+#[test]
+fn acquire_is_exclusive_until_released() {
+    let dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let path = lock_path(&dir);
+
+    let first = try_acquire(&path).unwrap_or_else(|error| panic!("first: {error}"));
+    assert!(is_acquired(&first), "first acquire succeeds");
+    let second = try_acquire(&path).unwrap_or_else(|error| panic!("second: {error}"));
+    assert!(
+        matches!(second, AcquireOutcome::Contended),
+        "a held lock is contended"
+    );
+
+    drop(first);
+    assert!(
+        !path.exists(),
+        "release removes the lock file so a successor can claim it"
+    );
+    let third = try_acquire(&path).unwrap_or_else(|error| panic!("third: {error}"));
+    assert!(is_acquired(&third), "lock is reclaimable after release");
+}
+
+/// A5: lock and rename diagnostics are distinct, typed, and bounded.
+#[test]
+fn lock_and_rename_failures_are_typed_and_bounded() {
+    use crate::runtime::package_runtime::PackageRuntimeError;
+
+    // A rename onto a final path whose parent does not exist fails with a
+    // typed, bounded InstallRename error.
+    let dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let built = dir.path().join("built");
+    std::fs::create_dir_all(&built).unwrap_or_else(|error| panic!("mkdir built: {error}"));
+    let unreachable_final = dir.path().join("missing-parent").join("final");
+    let rename_error = atomic_swap_into_place(&built, &unreachable_final)
+        .err()
+        .unwrap_or_else(|| panic!("expected an InstallRename error"));
+    assert!(
+        matches!(rename_error, PackageRuntimeError::InstallRename(_)),
+        "rename failure is a distinct InstallRename variant: {rename_error:?}"
+    );
+
+    // Removing a directory as a file fails (not NotFound) with a typed,
+    // bounded CacheLock error.
+    let lock_is_a_dir = dir.path().join("i-am-a-directory.lock");
+    std::fs::create_dir_all(&lock_is_a_dir)
+        .unwrap_or_else(|error| panic!("mkdir lock dir: {error}"));
+    let lock_error = super::recover_stale(&lock_is_a_dir)
+        .err()
+        .unwrap_or_else(|| panic!("expected a CacheLock error"));
+    assert!(
+        matches!(lock_error, PackageRuntimeError::CacheLock(_)),
+        "lock failure is a distinct CacheLock variant: {lock_error:?}"
+    );
+    assert!(
+        lock_error.to_string().chars().count() < 2 * super::DIAGNOSTIC_BOUND,
+        "lock diagnostic stays bounded: {lock_error}"
+    );
+
+    // The bounding helper itself truncates unbounded input (redaction).
+    let long = super::bounded(&"x".repeat(2_000));
+    assert_eq!(
+        long.chars().count(),
+        super::DIAGNOSTIC_BOUND,
+        "unbounded detail is truncated to the diagnostic bound"
+    );
+}
+
+/// A2: swapping a built tree into an empty final path installs it complete.
+#[test]
+fn atomic_swap_installs_a_built_tree_into_place() {
+    let dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let built = dir.path().join("built");
+    let final_dir = dir.path().join("final");
+    std::fs::create_dir_all(&built).unwrap_or_else(|error| panic!("mkdir built: {error}"));
+    std::fs::write(built.join(".jefe-installed"), "complete\n")
+        .unwrap_or_else(|error| panic!("marker: {error}"));
+
+    atomic_swap_into_place(&built, &final_dir)
+        .unwrap_or_else(|error| panic!("swap: {error}"));
+
+    assert!(final_dir.join(".jefe-installed").exists(), "final tree is complete");
+    assert!(!built.exists(), "the built temp dir is gone after rename");
+}
+
+/// A2: swapping replaces a stale final directory entirely — no stale content
+/// survives, and the new tree is complete.
+#[test]
+fn atomic_swap_replaces_a_stale_final_directory() {
+    let dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let built = dir.path().join("built");
+    let final_dir = dir.path().join("final");
+    std::fs::create_dir_all(&built).unwrap_or_else(|error| panic!("mkdir built: {error}"));
+    std::fs::write(built.join(".jefe-installed"), "complete\n")
+        .unwrap_or_else(|error| panic!("marker: {error}"));
+    std::fs::create_dir_all(&final_dir).unwrap_or_else(|error| panic!("mkdir final: {error}"));
+    std::fs::write(final_dir.join("stale-artifact"), "old\n")
+        .unwrap_or_else(|error| panic!("stale: {error}"));
+
+    atomic_swap_into_place(&built, &final_dir)
+        .unwrap_or_else(|error| panic!("swap: {error}"));
+
+    assert!(final_dir.join(".jefe-installed").exists(), "new tree is complete");
+    assert!(
+        !final_dir.join("stale-artifact").exists(),
+        "stale final content is fully replaced"
+    );
+}

--- a/src/runtime/package_cache_lock_tests.rs
+++ b/src/runtime/package_cache_lock_tests.rs
@@ -26,7 +26,7 @@ impl LiveChild {
     fn pid(&self) -> u32 {
         self.0
             .as_ref()
-            .map_or_else(|| panic!("live child present"), std::process::Child::id)
+            .map_or_else(|| panic!("live child missing"), std::process::Child::id)
     }
 }
 
@@ -53,8 +53,15 @@ fn dead_pid() -> u32 {
 }
 
 fn plant_lock(dir: &TempDir, pid: u32) {
+    // Stamp the holder's real identity (pid + start discriminator) so the
+    // liveness classifier sees a live holder as alive and a dead/reused one as
+    // gone — matching how a real held lock is stamped by `link_exclusive`.
     let path = lock_path(dir);
-    let content = format!("{pid}\n0\n");
+    let identity = crate::runtime::process::capture_process_identity(pid)
+        .unwrap_or(crate::domain::ProcessIdentity { pid, started_at: None });
+    let started_line =
+        identity.started_at.map_or_else(String::new, |started| started.to_string());
+    let content = format!("{}\n{started_line}\n", identity.pid);
     std::fs::write(&path, content)
         .unwrap_or_else(|error| panic!("plant lock: {error}"));
 }
@@ -212,4 +219,28 @@ fn atomic_swap_replaces_a_stale_final_directory() {
         !final_dir.join("stale-artifact").exists(),
         "stale final content is fully replaced"
     );
+}
+
+/// A2: a leftover swap backup from a crashed previous swap, with no final tree,
+/// is restored before the next swap so a good cache is never lost to a crash.
+#[test]
+fn crashed_swap_restores_the_previous_tree() {
+    let dir = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let final_dir = dir.path().join("final");
+    let backup = super::swap_backup_path(&final_dir);
+    // Simulate a crashed previous swap: the last valid tree is parked in the
+    // backup and the final tree is gone.
+    std::fs::create_dir_all(&backup).unwrap_or_else(|error| panic!("mkdir backup: {error}"));
+    std::fs::write(backup.join(".jefe-installed"), "previous
+")
+        .unwrap_or_else(|error| panic!("previous marker: {error}"));
+
+    super::recover_crashed_swap(&final_dir, &backup)
+        .unwrap_or_else(|error| panic!("recover crashed swap: {error}"));
+
+    assert!(
+        final_dir.join(".jefe-installed").exists(),
+        "the previous valid tree is restored to the final path"
+    );
+    assert!(!backup.exists(), "the backup is consumed by the restore");
 }

--- a/src/runtime/package_runtime.rs
+++ b/src/runtime/package_runtime.rs
@@ -8,6 +8,8 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Mutex;
+#[cfg(unix)]
+use std::time::Instant;
 use std::time::{Duration, SystemTime};
 
 use serde::Serialize;
@@ -97,6 +99,10 @@ pub enum PackageRuntimeError {
     InstallFailed(String),
     /// The selected installed package binary is absent.
     InstalledBinaryMissing { binary: String },
+    /// Cross-process install lock acquisition or stale recovery failed.
+    CacheLock(String),
+    /// The atomic rename of a built install tree into place failed.
+    InstallRename(String),
 }
 
 impl std::fmt::Display for PackageRuntimeError {
@@ -127,6 +133,12 @@ impl std::fmt::Display for PackageRuntimeError {
                 formatter,
                 "managed package binary `{binary}` is missing after install"
             ),
+            Self::CacheLock(detail) => {
+                write!(formatter, "managed package install lock failed: {detail}")
+            }
+            Self::InstallRename(detail) => {
+                write!(formatter, "managed package install rename failed: {detail}")
+            }
         }
     }
 }
@@ -294,9 +306,7 @@ fn append_digest_part(bytes: &mut Vec<u8>, part: &[u8]) {
 }
 
 fn managed_bin_dir(cache_root: &Path, selection: &PackageSelection) -> PathBuf {
-    managed_install_dir(cache_root, selection)
-        .join("node_modules")
-        .join(".bin")
+    bin_dir_within(&managed_install_dir(cache_root, selection))
 }
 
 fn marker_contents(selection: &PackageSelection, now: SystemTime) -> String {
@@ -387,51 +397,50 @@ fn prepare_managed_npm(
     cache_root: &Path,
     now: SystemTime,
 ) -> Result<PackageInvocation, PackageRuntimeError> {
-    let _guard = match INSTALL_LOCK.lock() {
+    // The static guard remains the intra-process invariant; cross-process
+    // exclusion and the atomic install are layered on Unix (issue #556).
+    let _intra_process = match INSTALL_LOCK.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
     let install_dir = managed_install_dir(cache_root, selection);
-    let bin_dir = managed_bin_dir(cache_root, selection);
-    let cache_hit = cache_hit(&install_dir, &bin_dir, selection, now);
-    if !cache_hit {
-        write_package_json(&install_dir, selection)?;
-        // Issue #554: a stale lockfile makes `npm install` reuse the previously
-        // resolved dist-tag target. Drop it for volatile selectors so npm
-        // re-resolves `nightly`/`latest` against the registry. A real failure to
-        // remove an existing lockfile must surface — otherwise npm would silently
-        // reinstall the old target and the freshly stamped marker would freeze
-        // the stale build for another TTL window.
-        if selection.selector().is_volatile() {
-            match std::fs::remove_file(install_dir.join("package-lock.json")) {
-                Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => {
-                    return Err(PackageRuntimeError::InstallDirectory(format!(
-                        "failed to remove stale lockfile for re-resolve: {error}"
-                    )));
-                }
-            }
-        }
-        run_npm_install(candidate, &install_dir)?;
+    #[cfg(unix)]
+    {
+        prepare_managed_npm_atomic(candidate, selection, cache_root, &install_dir, now)
     }
-    let snapshot = PathSnapshot::for_platform(
+    #[cfg(not(unix))]
+    {
+        prepare_managed_npm_direct(candidate, selection, &install_dir, now)
+    }
+}
+
+fn bin_dir_within(install_dir: &Path) -> PathBuf {
+    install_dir.join("node_modules").join(".bin")
+}
+
+fn resolve_binary_in(
+    bin_dir: &Path,
+    selection: &PackageSelection,
+) -> Option<(PathBuf, AgentWrapperKind)> {
+    PathSnapshot::for_platform(
         AgentExecutablePlatform::current(),
-        vec![bin_dir],
+        vec![bin_dir.to_path_buf()],
         std::env::var_os("PATHEXT"),
-    );
-    let Some((executable, wrapper_kind)) = snapshot.resolve_binary(selection.binary()) else {
+    )
+    .resolve_binary(selection.binary())
+}
+
+/// Resolve the installed managed binary and capture its fingerprint. Shared by
+/// the Unix atomic path and the Windows direct path.
+fn resolve_managed_binary(
+    bin_dir: &Path,
+    selection: &PackageSelection,
+) -> Result<PackageInvocation, PackageRuntimeError> {
+    let Some((executable, wrapper_kind)) = resolve_binary_in(bin_dir, selection) else {
         return Err(PackageRuntimeError::InstalledBinaryMissing {
             binary: selection.binary().to_owned(),
         });
     };
-    if !cache_hit {
-        std::fs::write(
-            install_dir.join(INSTALL_MARKER),
-            marker_contents(selection, now),
-        )
-        .map_err(|error| PackageRuntimeError::InstallDirectory(error.to_string()))?;
-    }
     let fingerprint = capture_candidate_fingerprint(&executable)
         .map_err(PackageRuntimeError::InstallDirectory)?;
     Ok(PackageInvocation {
@@ -440,6 +449,232 @@ fn prepare_managed_npm(
         prefix: Vec::new(),
         fingerprint: Some(fingerprint),
     })
+}
+
+/// Issue #554: a stale lockfile makes `npm install` reuse the previously
+/// resolved dist-tag target. Drop it for volatile selectors so npm re-resolves
+/// `nightly`/`latest` against the registry. A real failure to remove an existing
+/// lockfile must surface — otherwise npm would silently reinstall the old target
+/// and the freshly stamped marker would freeze the stale build for another TTL.
+fn remove_stale_lockfile_if_volatile(
+    target_dir: &Path,
+    selection: &PackageSelection,
+) -> Result<(), PackageRuntimeError> {
+    if !selection.selector().is_volatile() {
+        return Ok(());
+    }
+    match std::fs::remove_file(target_dir.join("package-lock.json")) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(PackageRuntimeError::InstallDirectory(format!(
+            "failed to remove stale lockfile for re-resolve: {error}"
+        ))),
+    }
+}
+
+#[cfg(not(unix))]
+fn prepare_managed_npm_direct(
+    candidate: &ResolvedCandidate,
+    selection: &PackageSelection,
+    install_dir: &Path,
+    now: SystemTime,
+) -> Result<PackageInvocation, PackageRuntimeError> {
+    let bin_dir = bin_dir_within(install_dir);
+    let hit = cache_hit(install_dir, &bin_dir, selection, now);
+    if !hit {
+        write_package_json(install_dir, selection)?;
+        remove_stale_lockfile_if_volatile(install_dir, selection)?;
+        run_npm_install(candidate, install_dir)?;
+    }
+    let invocation = resolve_managed_binary(&bin_dir, selection)?;
+    if !hit {
+        std::fs::write(
+            install_dir.join(INSTALL_MARKER),
+            marker_contents(selection, now),
+        )
+        .map_err(|error| PackageRuntimeError::InstallDirectory(error.to_string()))?;
+    }
+    Ok(invocation)
+}
+
+// ── Issue #556: cross-process serialization + atomic install (Unix) ──────────
+
+/// Poll interval while waiting for another process to finish an install.
+#[cfg(unix)]
+const LOCK_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Upper bound on waiting for a contended install. Generous (several material
+/// windows) so a real install always completes first; a genuinely stuck lock is
+/// reported as a typed error rather than hanging forever. This is a safety bound
+/// on the wait, not a stale-detection timer (issue #556 A4).
+#[cfg(unix)]
+const LOCK_WAIT_BUDGET: Duration = Duration::from_millis(
+    crate::domain::agent_definition::limits::PACKAGE_MATERIALIZATION_TIMEOUT_MS * 3,
+);
+
+/// Per-process nonce so concurrent builds in one process never collide.
+#[cfg(unix)]
+static BUILD_NONCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Either the cache is already complete, or this caller won the install.
+#[cfg(unix)]
+enum Need {
+    CacheHit,
+    Install(super::package_cache_lock::InstallLock),
+}
+
+#[cfg(unix)]
+fn prepare_managed_npm_atomic(
+    candidate: &ResolvedCandidate,
+    selection: &PackageSelection,
+    cache_root: &Path,
+    install_dir: &Path,
+    now: SystemTime,
+) -> Result<PackageInvocation, PackageRuntimeError> {
+    let bin_dir = bin_dir_within(install_dir);
+    // Fast path: a complete cache hit needs no cross-process lock.
+    if cache_hit(install_dir, &bin_dir, selection, now) {
+        return resolve_managed_binary(&bin_dir, selection);
+    }
+    let lock_path = install_lock_path(cache_root, selection);
+    match acquire_or_observe_cache(&lock_path, install_dir, &bin_dir, selection, now)? {
+        Need::CacheHit => resolve_managed_binary(&bin_dir, selection),
+        Need::Install(guard) => {
+            // Build atomically under the lock; the guard releases on drop.
+            let outcome = build_and_swap(candidate, selection, install_dir, cache_root, now)
+                .and_then(|()| resolve_managed_binary(&bin_dir, selection));
+            drop(guard);
+            outcome
+        }
+    }
+}
+
+/// Double-checked locking: wait for the cache to complete or the lock to free,
+/// then either observe the cache hit or win the install. A dead holder's lock is
+/// reclaimed immediately (no fixed timeout) inside [`try_acquire`].
+#[cfg(unix)]
+fn acquire_or_observe_cache(
+    lock_path: &Path,
+    install_dir: &Path,
+    bin_dir: &Path,
+    selection: &PackageSelection,
+    now: SystemTime,
+) -> Result<Need, PackageRuntimeError> {
+    use super::package_cache_lock::{AcquireOutcome, try_acquire};
+    let deadline = Instant::now() + LOCK_WAIT_BUDGET;
+    loop {
+        if cache_hit(install_dir, bin_dir, selection, now) {
+            return Ok(Need::CacheHit);
+        }
+        match try_acquire(lock_path)? {
+            AcquireOutcome::Acquired(guard) => {
+                if cache_hit(install_dir, bin_dir, selection, now) {
+                    drop(guard);
+                    return Ok(Need::CacheHit);
+                }
+                return Ok(Need::Install(guard));
+            }
+            AcquireOutcome::Contended => wait_or_bust(deadline)?,
+        }
+    }
+}
+
+#[cfg(unix)]
+fn wait_or_bust(deadline: Instant) -> Result<(), PackageRuntimeError> {
+    if Instant::now() >= deadline {
+        return Err(PackageRuntimeError::CacheLock(
+            "timed out waiting for another process to finish the install".to_string(),
+        ));
+    }
+    std::thread::sleep(LOCK_POLL_INTERVAL);
+    Ok(())
+}
+
+#[cfg(unix)]
+fn build_and_swap(
+    candidate: &ResolvedCandidate,
+    selection: &PackageSelection,
+    install_dir: &Path,
+    cache_root: &Path,
+    now: SystemTime,
+) -> Result<(), PackageRuntimeError> {
+    use super::package_cache_lock::atomic_swap_into_place;
+    // We hold the lock, so any sibling building dir for this digest is abandoned.
+    sweep_stale_build_dirs(cache_root, selection);
+    let temp = new_building_dir(cache_root, selection)?;
+    // Build entirely inside the temp dir, then swap. Any failure after the temp
+    // is created must remove it so failed installs do not accumulate on disk
+    // (issue #556 A3): the final path stays untouched and the retry is clean.
+    let result = build_into_temp(candidate, selection, &temp, now)
+        .and_then(|()| atomic_swap_into_place(&temp, install_dir));
+    if result.is_err() {
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+    result
+}
+
+/// Write the package manifest, run the install, and stamp the completion marker
+/// entirely inside `temp`. Nothing is published to the final path until the
+/// caller swaps the completed tree into place.
+#[cfg(unix)]
+fn build_into_temp(
+    candidate: &ResolvedCandidate,
+    selection: &PackageSelection,
+    temp: &Path,
+    now: SystemTime,
+) -> Result<(), PackageRuntimeError> {
+    write_package_json(temp, selection)?;
+    remove_stale_lockfile_if_volatile(temp, selection)?;
+    run_npm_install(candidate, temp)?;
+    // Gate the marker on a resolvable binary: a broken install is not published,
+    // and bailing before the swap leaves nothing at the final path.
+    if resolve_binary_in(&bin_dir_within(temp), selection).is_none() {
+        return Err(PackageRuntimeError::InstalledBinaryMissing {
+            binary: selection.binary().to_owned(),
+        });
+    }
+    std::fs::write(temp.join(INSTALL_MARKER), marker_contents(selection, now))
+        .map_err(|error| PackageRuntimeError::InstallDirectory(error.to_string()))
+}
+
+#[cfg(unix)]
+fn digest_hex(selection: &PackageSelection) -> String {
+    selection_digest(selection).to_hex()
+}
+
+#[cfg(unix)]
+fn install_lock_path(cache_root: &Path, selection: &PackageSelection) -> PathBuf {
+    cache_root.join(format!("{}.lock", digest_hex(selection)))
+}
+
+#[cfg(unix)]
+fn new_building_dir(
+    cache_root: &Path,
+    selection: &PackageSelection,
+) -> Result<PathBuf, PackageRuntimeError> {
+    let nonce = BUILD_NONCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let dir = cache_root.join(format!(
+        ".{}.building-{}-{}",
+        digest_hex(selection),
+        std::process::id(),
+        nonce
+    ));
+    std::fs::create_dir_all(&dir)
+        .map_err(|error| PackageRuntimeError::InstallDirectory(error.to_string()))?;
+    Ok(dir)
+}
+
+#[cfg(unix)]
+fn sweep_stale_build_dirs(cache_root: &Path, selection: &PackageSelection) {
+    let prefix = format!(".{}.building-", digest_hex(selection));
+    let Ok(entries) = std::fs::read_dir(cache_root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if entry.file_name().to_string_lossy().starts_with(&prefix) {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -500,4 +735,5 @@ mod tests {
     use crate::domain::agent_definition::{AgentDefinition, AgentLaunchPlan, Target};
 
     include!("package_runtime_tests.rs");
+    include!("package_runtime_atomic_tests.rs");
 }

--- a/src/runtime/package_runtime.rs
+++ b/src/runtime/package_runtime.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+#[cfg(windows)]
 use std::sync::Mutex;
 #[cfg(unix)]
 use std::time::Instant;
@@ -36,8 +37,6 @@ const INSTALL_MARKER: &str = ".jefe-installed";
 /// bounds staleness to about twelve hours without hitting the registry on every
 /// launch. Explicit (pinned) selectors are immutable and never expire.
 const VOLATILE_SELECTOR_TTL: Duration = Duration::from_secs(12 * 60 * 60);
-
-static INSTALL_LOCK: Mutex<()> = Mutex::new(());
 
 /// Local managed execution or remote structural execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -397,12 +396,6 @@ fn prepare_managed_npm(
     cache_root: &Path,
     now: SystemTime,
 ) -> Result<PackageInvocation, PackageRuntimeError> {
-    // The static guard remains the intra-process invariant; cross-process
-    // exclusion and the atomic install are layered on Unix (issue #556).
-    let _intra_process = match INSTALL_LOCK.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    };
     let install_dir = managed_install_dir(cache_root, selection);
     #[cfg(unix)]
     {
@@ -479,6 +472,14 @@ fn prepare_managed_npm_direct(
     install_dir: &Path,
     now: SystemTime,
 ) -> Result<PackageInvocation, PackageRuntimeError> {
+    // On Windows (the only non-Unix target) cross-process locking is tracked
+    // separately in the Windows sub-issue; the static guard preserves the
+    // existing intra-process invariant there until that lands (issue #556).
+    static INSTALL_LOCK: Mutex<()> = Mutex::new(());
+    let _intra_process = match INSTALL_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
     let bin_dir = bin_dir_within(install_dir);
     let hit = cache_hit(install_dir, &bin_dir, selection, now);
     if !hit {
@@ -675,6 +676,7 @@ fn sweep_stale_build_dirs(cache_root: &Path, selection: &PackageSelection) {
             let _ = std::fs::remove_dir_all(entry.path());
         }
     }
+    tracing::debug!(target: "jefe::runtime::package_runtime", "swept stale build dirs for digest {}", digest_hex(selection));
 }
 
 #[derive(Serialize)]

--- a/src/runtime/package_runtime_atomic_tests.rs
+++ b/src/runtime/package_runtime_atomic_tests.rs
@@ -1,0 +1,171 @@
+// Issue #556 — atomic managed install: no partial tree at the final path, and
+// an interrupted install is retried cleanly. These drive the production
+// [`finalize_local_invocation_at`] boundary and reuse the package_runtime test
+// helpers (`executable`, `definition`, `resolve_package`).
+
+/// An npm stub that fails on its first invocation and succeeds on the second,
+/// recording each call's working directory one level up so the witness survives
+/// the atomic rebuild.
+fn failing_then_succeeding_npm_stub(bin: &TempDir) {
+    executable(
+        bin,
+        "npm",
+        "#!/bin/sh
+set -e
+count=../.jefe-npm-count
+n=$(cat \"$count\" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo \"$n\" > \"$count\"
+if [ \"$n\" = 1 ]; then
+  exit 1
+fi
+mkdir -p node_modules/.bin
+printf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/llxprt
+chmod 755 node_modules/.bin/llxprt
+",
+    );
+}
+
+/// An npm stub that succeeds, recording the working directory it ran in so the
+/// test can prove the install built in a sibling temp dir, not the final path.
+fn pwd_recording_npm_stub(bin: &TempDir) {
+    executable(
+        bin,
+        "npm",
+        "#!/bin/sh
+set -e
+pwd >> ../.jefe-npm-pwd
+mkdir -p node_modules/.bin
+printf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/llxprt
+chmod 755 node_modules/.bin/llxprt
+",
+    );
+}
+
+fn npm_pinned_candidate(bin: &TempDir, selector: &str) -> ResolvedCandidate {
+    let definition = definition("LLxprt");
+    resolve_package(&definition, bin, selector)
+}
+
+/// A2 + A3: an install that fails mid-build leaves nothing at the final path
+/// (no marker, no partial directory), and a subsequent install retries cleanly.
+#[test]
+fn atomic_install_leaves_no_partial_tree_after_failure_and_retries_cleanly() {
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    failing_then_succeeding_npm_stub(&bin);
+    let candidate = npm_pinned_candidate(&bin, "1.2.3");
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+    let install_dir = managed_install_dir(
+        cache.path(),
+        candidate
+            .package()
+            .unwrap_or_else(|| panic!("managed candidate carries a package selection")),
+    );
+
+    // First attempt fails mid-install (npm exits non-zero).
+    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now());
+    assert!(
+        matches!(first, Err(PackageRuntimeError::InstallFailed(_))),
+        "a mid-install failure surfaces InstallFailed: {first:?}"
+    );
+    assert!(
+        !install_dir.exists(),
+        "A2/A3: a failed install leaves no directory at the final path"
+    );
+    assert!(
+        !install_dir.join(super::INSTALL_MARKER).exists(),
+        "A3: no cache-hit marker is written for a failed install"
+    );
+
+    // A failed install also leaves no orphaned building temp behind (the temp is
+    // removed on the error path so failed installs do not accumulate).
+    let digest = super::selection_digest(
+        candidate
+            .package()
+            .unwrap_or_else(|| panic!("managed candidate carries a package selection")),
+    )
+    .to_hex();
+    let orphaned = std::fs::read_dir(cache.path()).is_ok_and(|entries| {
+        entries.flatten().any(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(&format!(".{digest}.building-"))
+        })
+    });
+    assert!(
+        !orphaned,
+        "A3: a failed install cleans up its sibling building temp"
+    );
+
+    // Retry succeeds: the final tree is complete (marker + binary).
+    let resolved = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("retry install: {error}"));
+    assert!(
+        install_dir.exists(),
+        "the retried install publishes the final tree"
+    );
+    assert!(
+        install_dir.join(super::INSTALL_MARKER).exists(),
+        "the retried install writes the completion marker"
+    );
+    assert!(
+        resolved.executable().starts_with(install_dir),
+        "the resolved binary lives under the final install path"
+    );
+}
+
+/// A2: a successful install builds in a sibling temporary directory and is
+/// renamed into place, so npm never writes to the final path and no building
+/// temp is left behind.
+#[test]
+fn atomic_install_builds_in_a_sibling_temp_then_appears_complete() {
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    pwd_recording_npm_stub(&bin);
+    let candidate = npm_pinned_candidate(&bin, "2.0.0");
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+    let install_dir = managed_install_dir(
+        cache.path(),
+        candidate
+            .package()
+            .unwrap_or_else(|| panic!("managed candidate carries a package selection")),
+    );
+
+    finalize_local_invocation_at(&candidate, cache.path(), base_now())
+        .unwrap_or_else(|error| panic!("install: {error}"));
+
+    // npm ran inside a `.building-*` sibling, never the final digest directory.
+    let pwd = std::fs::read_to_string(cache.path().join(".jefe-npm-pwd"))
+        .unwrap_or_else(|error| panic!("read npm pwd witness: {error}"));
+    let npm_cwd = pwd
+        .lines()
+        .next()
+        .unwrap_or_else(|| panic!("npm recorded its working dir: {pwd:?}"));
+    assert!(
+        std::path::Path::new(npm_cwd)
+            .file_name()
+            .is_some_and(|name| name.to_string_lossy().contains(".building-")),
+        "A2: npm builds in a sibling temp dir, not the final path: {npm_cwd:?}"
+    );
+
+    // The final tree is complete and no building temp lingers.
+    assert!(
+        install_dir.join(super::INSTALL_MARKER).exists(),
+        "the final tree carries the completion marker"
+    );
+    let digest = super::selection_digest(
+        candidate
+            .package()
+            .unwrap_or_else(|| panic!("managed candidate carries a package selection")),
+    )
+    .to_hex();
+    let leftover = std::fs::read_dir(cache.path()).is_ok_and(|entries| {
+        entries
+            .flatten()
+            .any(|entry| entry.file_name().to_string_lossy().starts_with(&format!(".{digest}.building-")))
+    });
+    assert!(
+        !leftover,
+        "A2: no sibling building temp remains after a successful swap"
+    );
+}

--- a/src/runtime/package_runtime_atomic_tests.rs
+++ b/src/runtime/package_runtime_atomic_tests.rs
@@ -85,14 +85,15 @@ fn atomic_install_leaves_no_partial_tree_after_failure_and_retries_cleanly() {
             .unwrap_or_else(|| panic!("managed candidate carries a package selection")),
     )
     .to_hex();
-    let orphaned = std::fs::read_dir(cache.path()).is_ok_and(|entries| {
-        entries.flatten().any(|entry| {
+    let orphaned = match std::fs::read_dir(cache.path()) {
+        Ok(entries) => entries.flatten().any(|entry| {
             entry
                 .file_name()
                 .to_string_lossy()
                 .starts_with(&format!(".{digest}.building-"))
-        })
-    });
+        }),
+        Err(error) => panic!("read cache dir: {error}"),
+    };
     assert!(
         !orphaned,
         "A3: a failed install cleans up its sibling building temp"
@@ -159,11 +160,12 @@ fn atomic_install_builds_in_a_sibling_temp_then_appears_complete() {
             .unwrap_or_else(|| panic!("managed candidate carries a package selection")),
     )
     .to_hex();
-    let leftover = std::fs::read_dir(cache.path()).is_ok_and(|entries| {
-        entries
+    let leftover = match std::fs::read_dir(cache.path()) {
+        Ok(entries) => entries
             .flatten()
-            .any(|entry| entry.file_name().to_string_lossy().starts_with(&format!(".{digest}.building-")))
-    });
+            .any(|entry| entry.file_name().to_string_lossy().starts_with(&format!(".{digest}.building-"))),
+        Err(error) => panic!("read cache dir: {error}"),
+    };
     assert!(
         !leftover,
         "A2: no sibling building temp remains after a successful swap"

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -352,12 +352,19 @@ fn counting_npm_stub(bin: &TempDir) {
     // already existed when the stub started, otherwise "absent". Counting lines
     // therefore proves how many times `npm install` ran, and the content proves
     // whether jefe removed a stale lockfile before re-installing.
+    //
+    // The witness is written one directory level ABOVE the npm working dir
+    // (`../.jefe-lock-witness`). Issue #556 makes the install atomic: npm runs
+    // in a sibling temp dir that is renamed over the final dir, so a witness
+    // written inside the working dir would be replaced on every rebuild. The
+    // cache root (the temp dir's parent) is stable across rebuilds, so the
+    // witness accumulates there for both the atomic (Unix) and direct paths.
     executable(
         bin,
         "npm",
         "#!/bin/sh
 set -e
-if [ -f package-lock.json ]; then echo present >> .jefe-lock-witness; else echo absent >> .jefe-lock-witness; fi
+if [ -f package-lock.json ]; then echo present >> ../.jefe-lock-witness; else echo absent >> ../.jefe-lock-witness; fi
 mkdir -p node_modules/.bin
 printf '#!/bin/sh\nexit 0\n' > node_modules/.bin/llxprt
 chmod 755 node_modules/.bin/llxprt
@@ -389,9 +396,15 @@ fn install_dir_of(executable: &Path) -> &Path {
     }
 }
 
+/// The npm-witness file lives at the cache root (the parent of the install
+/// dir) so it survives the atomic rebuild that replaces the install dir
+/// (issue #556). `install_dir` is the directory owning `.jefe-installed`.
 #[cfg(unix)]
 fn witness_lines(install_dir: &Path) -> Vec<String> {
-    let path = install_dir.join(".jefe-lock-witness");
+    let cache_root = install_dir
+        .parent()
+        .unwrap_or_else(|| panic!("install dir has a cache-root parent: {}", install_dir.display()));
+    let path = cache_root.join(".jefe-lock-witness");
     std::fs::read_to_string(&path)
         .unwrap_or_else(|error| panic!("read install witness: {error}"))
         .lines()

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -403,7 +403,7 @@ fn install_dir_of(executable: &Path) -> &Path {
 fn witness_lines(install_dir: &Path) -> Vec<String> {
     let cache_root = install_dir
         .parent()
-        .unwrap_or_else(|| panic!("install dir has a cache-root parent: {}", install_dir.display()));
+        .unwrap_or_else(|| panic!("install dir is missing its cache-root parent: {}", install_dir.display()));
     let path = cache_root.join(".jefe-lock-witness");
     std::fs::read_to_string(&path)
         .unwrap_or_else(|error| panic!("read install witness: {error}"))

--- a/tests/issue556_behavior.rs
+++ b/tests/issue556_behavior.rs
@@ -1,0 +1,194 @@
+//! Issue #556 — serialize managed package installs across jefe processes and
+//! make installation atomic (Unix).
+//!
+//! A1 is a genuine two-process behavioral test: it spawns two copies of the
+//! `jefe-issue556-installer` fixture (each driving the production
+//! `finalize_local_invocation` boundary) against a shared cache and a counting
+//! npm stub, then asserts exactly one install invocation and one identical
+//! resolved binary. A7 proves the uvx path is unaffected by the new managed
+//! cache locking.
+
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+
+use jefe::agent_candidate::{AgentCandidateResolver, CandidateResolution, VersionSelector};
+use jefe::agent_candidate_path::{AgentExecutablePlatform, PathSnapshot};
+use jefe::domain::agent_definition::AgentDefinition;
+use jefe::runtime::package_runtime::{
+    PackageExecutionTarget, finalize_local_invocation, package_invocation,
+};
+
+/// Path to the two-process installer fixture (set by Cargo for `[[bin]]`
+/// targets of the package under test).
+const INSTALLER_FIXTURE: &str = env!("CARGO_BIN_EXE_jefe-issue556-installer");
+
+fn write_executable(path: &Path, bytes: &[u8]) {
+    fs::write(path, bytes).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+        .unwrap_or_else(|error| panic!("chmod {}: {error}", path.display()));
+}
+
+/// A counting npm stub that sleeps briefly to guarantee two concurrent
+/// installers overlap, then materializes the managed binary. Each invocation
+/// appends a witness line to the cache root (the temp build dir's parent,
+/// surviving the atomic rebuild), so a single line proves the install ran once.
+const COUNTING_NPM: &str = "#!/bin/sh
+set -e
+echo install >> ../.jefe-lock-witness
+sleep 0.3
+mkdir -p node_modules/.bin
+printf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/llxprt
+chmod 755 node_modules/.bin/llxprt
+";
+
+/// A1: two concurrent installers of the same digest serialize — exactly one
+/// performs the install and the other observes a complete cache hit, resolving
+/// to an identical managed binary.
+#[test]
+fn two_concurrent_installers_serialize_to_one_install() {
+    let workspace = tempfile::tempdir().unwrap_or_else(|error| panic!("workspace: {error}"));
+    let bin_dir = workspace.path().join("bin");
+    let cache = workspace.path().join("cache");
+    fs::create_dir_all(&bin_dir).unwrap_or_else(|error| panic!("mkdir bin: {error}"));
+    fs::create_dir_all(&cache).unwrap_or_else(|error| panic!("mkdir cache: {error}"));
+    write_executable(&bin_dir.join("npm"), COUNTING_NPM.as_bytes());
+
+    // Start both installers before waiting on either so they genuinely contend.
+    let first = spawn_installer(&cache, &bin_dir, "2.0.0");
+    let second = spawn_installer(&cache, &bin_dir, "2.0.0");
+
+    let first_output = first
+        .wait_with_output()
+        .unwrap_or_else(|error| panic!("wait first installer: {error}"));
+    let second_output = second
+        .wait_with_output()
+        .unwrap_or_else(|error| panic!("wait second installer: {error}"));
+
+    assert!(
+        first_output.status.success(),
+        "first installer failed: {}",
+        String::from_utf8_lossy(&first_output.stderr)
+    );
+    assert!(
+        second_output.status.success(),
+        "second installer failed: {}",
+        String::from_utf8_lossy(&second_output.stderr)
+    );
+
+    let first_exec = stdout_path(&first_output.stdout, "first");
+    let second_exec = stdout_path(&second_output.stdout, "second");
+    assert_eq!(
+        first_exec, second_exec,
+        "serialized installers resolve an identical managed binary"
+    );
+
+    let witness = fs::read_to_string(cache.join(".jefe-lock-witness"))
+        .unwrap_or_else(|error| panic!("read npm witness: {error}"));
+    let installs = witness.lines().filter(|line| *line == "install").count();
+    assert_eq!(
+        installs, 1,
+        "exactly one of the two concurrent installers performs the install (got {witness:?})"
+    );
+}
+
+fn stdout_path(stdout: &[u8], which: &str) -> String {
+    let text = String::from_utf8(stdout.to_vec())
+        .unwrap_or_else(|error| panic!("{which} stdout utf8: {error}"));
+    let trimmed = text.trim().to_owned();
+    assert!(
+        !trimmed.is_empty(),
+        "{which} installer resolved no managed binary"
+    );
+    trimmed
+}
+
+fn spawn_installer(cache: &Path, bin_dir: &Path, selector: &str) -> Child {
+    let path = std::env::var_os("PATH").unwrap_or_else(|| OsString::from("/usr/bin:/bin"));
+    Command::new(INSTALLER_FIXTURE)
+        .env_clear()
+        .env("PATH", path)
+        .env("JEFE_ISSUE556_CACHE", cache)
+        .env("JEFE_ISSUE556_BIN", bin_dir)
+        .env("JEFE_ISSUE556_SELECTOR", selector)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|error| panic!("spawn installer fixture: {error}"))
+}
+
+fn shipped_code_puppy() -> AgentDefinition {
+    AgentDefinition::shipped()
+        .into_iter()
+        .find(|definition| definition.display_name == "Code Puppy")
+        .unwrap_or_else(|| panic!("shipped Code Puppy definition"))
+}
+
+fn resolve_uvx_candidate(
+    bin_dir: &Path,
+    selector: &str,
+) -> jefe::agent_candidate::ResolvedCandidate {
+    let definition = shipped_code_puppy();
+    write_executable(&bin_dir.join("uvx"), b"#!/bin/sh\nexit 0\n");
+    let snapshot = PathSnapshot::for_platform(
+        AgentExecutablePlatform::current(),
+        vec![bin_dir.to_path_buf()],
+        None,
+    );
+    let selector = VersionSelector::normalize(selector)
+        .unwrap_or_else(|error| panic!("normalize selector: {error}"));
+    let resolution = AgentCandidateResolver::new(&snapshot, bin_dir.to_path_buf())
+        .with_version_selector(selector)
+        .resolve(&definition);
+    let CandidateResolution::Resolved(candidate) = resolution else {
+        panic!("uvx candidate must resolve: {resolution:?}");
+    };
+    candidate
+}
+
+/// A7: the uvx preparation path retains its closed structural semantics and is
+/// unaffected by the managed-cache locking — it never manages the cache.
+#[test]
+fn uvx_preparation_is_unaffected_by_managed_cache_locking() {
+    let workspace = tempfile::tempdir().unwrap_or_else(|error| panic!("workspace: {error}"));
+    let cache = workspace.path().join("cache");
+    fs::create_dir_all(&cache).unwrap_or_else(|error| panic!("mkdir cache: {error}"));
+    let candidate = resolve_uvx_candidate(workspace.path(), "0.0.634");
+
+    let invocation = finalize_local_invocation(&candidate, &cache)
+        .unwrap_or_else(|error| panic!("uvx finalize: {error}"));
+
+    assert_eq!(
+        invocation.executable(),
+        candidate.executable(),
+        "uvx resolves the runner executable, not a managed cache path"
+    );
+    let expected: Vec<OsString> = ["--from", "code-puppy==0.0.634", "code-puppy"]
+        .iter()
+        .map(OsString::from)
+        .collect();
+    assert_eq!(
+        invocation.prefix(),
+        expected.as_slice(),
+        "uvx keeps its closed structural prefix"
+    );
+
+    // The structural remote prefix is also unchanged.
+    let remote = package_invocation(&candidate, PackageExecutionTarget::Remote, &cache)
+        .unwrap_or_else(|error| panic!("remote uvx invocation: {error}"))
+        .unwrap_or_else(|| panic!("remote uvx invocation must exist"));
+    assert_eq!(remote.executable(), Path::new("uvx"));
+    assert_eq!(remote.prefix(), expected.as_slice());
+
+    // uvx preparation never manages the cache: no digest directory is created.
+    let digest_entries = fs::read_dir(&cache).map_or(0, |entries| entries.flatten().count());
+    assert_eq!(
+        digest_entries, 0,
+        "uvx preparation leaves the managed cache untouched"
+    );
+}

--- a/tests/issue556_behavior.rs
+++ b/tests/issue556_behavior.rs
@@ -33,14 +33,21 @@ fn write_executable(path: &Path, bytes: &[u8]) {
         .unwrap_or_else(|error| panic!("chmod {}: {error}", path.display()));
 }
 
-/// A counting npm stub that sleeps briefly to guarantee two concurrent
-/// installers overlap, then materializes the managed binary. Each invocation
-/// appends a witness line to the cache root (the temp build dir's parent,
-/// surviving the atomic rebuild), so a single line proves the install ran once.
+/// A counting npm stub that uses a deterministic barrier instead of a fixed
+/// sleep: once it holds the install lock it records its witness line, signals
+/// `.jefe-lock-started`, then blocks on `.jefe-lock-release` before finishing.
+/// This lets the test guarantee two installers overlap (the second is spawned
+/// only after the first has the lock and is mid-install) without timing
+/// assumptions. Each invocation appends exactly one witness line at the shared
+/// cache root (the temp build dir's parent), surviving the atomic rebuild.
 const COUNTING_NPM: &str = "#!/bin/sh
 set -e
-echo install >> ../.jefe-lock-witness
-sleep 0.3
+cache=\"${JEFE_ISSUE556_CACHE:?cache root required}\"
+echo install >> \"$cache/.jefe-lock-witness\"
+touch \"$cache/.jefe-lock-started\"
+while [ ! -f \"$cache/.jefe-lock-release\" ]; do
+    sleep 0.02
+done
 mkdir -p node_modules/.bin
 printf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/llxprt
 chmod 755 node_modules/.bin/llxprt
@@ -58,9 +65,17 @@ fn two_concurrent_installers_serialize_to_one_install() {
     fs::create_dir_all(&cache).unwrap_or_else(|error| panic!("mkdir cache: {error}"));
     write_executable(&bin_dir.join("npm"), COUNTING_NPM.as_bytes());
 
-    // Start both installers before waiting on either so they genuinely contend.
+    // Start the first installer; it acquires the lock and enters the npm stub,
+    // which records its witness line and blocks on the release marker. Wait for
+    // that started signal so the second installer is guaranteed to contend
+    // against a held lock rather than race on process startup.
     let first = spawn_installer(&cache, &bin_dir, "2.0.0");
+    wait_for_marker(&cache.join(".jefe-lock-started"));
     let second = spawn_installer(&cache, &bin_dir, "2.0.0");
+
+    // Release the held install: the first installer finishes, releases the
+    // lock, and the second installer observes a complete cache hit.
+    touch(&cache.join(".jefe-lock-release"));
 
     let first_output = first
         .wait_with_output()
@@ -94,6 +109,23 @@ fn two_concurrent_installers_serialize_to_one_install() {
         installs, 1,
         "exactly one of the two concurrent installers performs the install (got {witness:?})"
     );
+}
+
+/// Poll until `marker` exists, failing loudly after a bounded deadline so a
+/// misconfigured barrier surfaces immediately instead of hanging the test.
+fn wait_for_marker(marker: &Path) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    while std::time::Instant::now() < deadline {
+        if marker.exists() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    panic!("barrier marker never appeared: {}", marker.display());
+}
+
+fn touch(path: &Path) {
+    fs::write(path, b"").unwrap_or_else(|error| panic!("touch {}: {error}", path.display()));
 }
 
 fn stdout_path(stdout: &[u8], which: &str) -> String {


### PR DESCRIPTION
## Summary

Sub-issue of the managed package-cache concurrency parent (#425 Problem B).

Give the managed npm package cache real cross-process mutual exclusion and an
atomic install on **Unix**, implemented and behaviorally verified here. The
existing `INSTALL_LOCK` static `Mutex` was only an intra-process invariant
guard, not directory-level exclusion, so two `jefe` processes installing the
same digest could race on the cache directory.

This PR replaces that gap with a **dependency-free** cross-process install lock
(`O_EXCL` / `create_new` with pid-based stale recovery via `kill -0`) and an
**atomic install** (build in a sibling temporary directory, then a move-aside
swap into the final path). Windows-specific locking behavior is intentionally
unchanged here (Windows sub-issue).

Fixes #556

## What changes

- **New module `src/runtime/package_cache_lock.rs` (Unix only):**
  - `try_acquire` -> `claim` writes the holder pid, removes an empty lock on a
    write failure (so a half-created lock can never wedge the cache).
  - `contend_or_recover` performs pid-based stale recovery: when the recorded
    pid is gone the stale lock is reclaimed immediately, with **no fixed
    timeout**; a live holder is never declared stale.
  - `atomic_swap_into_place` does a move-aside swap (rename old -> backup,
    rename built -> final, restore the backup if the second rename fails) so the
    final path never holds a partial tree and an existing good tree is never
    lost.
  - `InstallLock` releases conditionally (only unlinks when it still owns the
    recorded pid), so it never deletes a successor's lock.

- **`src/runtime/package_runtime.rs`** dispatches `prepare_managed_npm` to a
  Unix atomic path (`acquire_or_observe_cache` double-checked locking, then
  `build_and_swap` -> `build_into_temp` + sibling-temp swap) and keeps the
  Windows direct-write path unchanged. Temp build dirs are cleaned up on build
  failure, and stale `.building-*` dirs are swept under the lock. Failures
  surface as distinct typed/bounded/redacted `PackageRuntimeError::CacheLock` /
  `InstallRename` variants.

## Acceptance matrix — behavioral evidence

| ID | Requirement | Proof |
|---|---|---|
| A1 | Two concurrent installers of the same digest serialize; exactly one installs, the other observes a complete cache hit | `tests/issue556_behavior.rs::two_concurrent_installers_serialize_to_one_install` — spawns **two OS processes** (via the `jefe-issue556-installer` fixture) against the production `finalize_local_invocation` boundary; asserts exactly one `npm install` invocation and an identical resolved binary from both. |
| A2 | A reader never observes a partially built tree | `package_runtime_atomic_tests.rs::atomic_install_builds_in_a_sibling_temp_then_appears_complete` — npm runs in a `.{digest}.building-*` sibling; the final path is absent during the build and only ever appears complete (binary + marker together) via the swap. |
| A3 | An interrupted install leaves no cache hit and is retried cleanly | `package_runtime_atomic_tests.rs::atomic_install_leaves_no_partial_tree_after_failure_and_retries_cleanly` — a failing-then-succeeding npm stub leaves no marker and no orphaned temp dir, then a clean retry installs. |
| A4 | A stale lock left by a dead process is recovered without a fixed timeout; a live install is never declared stale | `package_cache_lock_tests.rs` — `stale_lock_from_a_dead_holder_is_recovered` (dead pid) and `a_live_holder_is_never_declared_stale` (sleeping child pid). |
| A5 | Lock, stale-recovery, and rename failures are typed, bounded, redacted | `package_cache_lock_tests.rs::lock_failure_is_a_distinct_typed_bounded_variant` — distinct `CacheLock` / `InstallRename` variants, diagnostic bounded to a fixed cap. |
| A6 | Existing single-process behavior unchanged | All prior `package_runtime_tests.rs` + launch/probe tests remain green with no new timing-dependent assertions. |
| A7 | The uvx path retains its current semantics | `tests/issue556_behavior.rs::uvx_preparation_is_unaffected_by_the_managed_cache_lock` — uvx finalize is untouched and leaves the managed cache empty. |

## Non-goals respected

- No change to selector normalization, digest derivation, or cache-key semantics.
- No change to probe budgets or probe phase semantics.
- **No new dependency** (pid liveness uses the `kill -0` shell built-in; locking
  uses `create_new` / `rename` from `std`).
- No background installer, daemon, or queue.
- Windows-specific locking behavior unchanged here (verified separately in the
  Windows sub-issue); the Windows compile + direct-write path is preserved.

## Verification

Local (exact head `10a8962f`, rebased onto current `main`):

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- `cargo build --workspace --all-features --locked` — ok
- `cargo test --workspace --all-features --locked` — 0 failures
- `cargo xtask check architecture` / `cargo xtask check source-size` — ok

Scope: 10 files, ~1180 net changed lines (within the 25-file / 1500-line target).
