### PR TITLE
Make Issues fetch order follow the selected sort (Fixes #573)

### DIFF
--- a/src/app_input/app_input_tests.rs
+++ b/src/app_input/app_input_tests.rs
@@ -72,6 +72,17 @@ fn filter_and_search_messages_are_fresh_issue_list_reloads() {
     assert!(is_fresh_issue_list_reload(&IssuesMessage::ApplyFilter));
     assert!(is_fresh_issue_list_reload(&IssuesMessage::ClearFilter));
     assert!(is_fresh_issue_list_reload(&IssuesMessage::ApplySearch));
+    // A sort-config change must reset the cursor and refetch so the fetch
+    // orderBy matches the new display direction (issue #573).
+    assert!(is_fresh_issue_list_reload(
+        &IssuesMessage::CycleIssueSortByNext
+    ));
+    assert!(is_fresh_issue_list_reload(
+        &IssuesMessage::CycleIssueSortByPrev
+    ));
+    assert!(is_fresh_issue_list_reload(
+        &IssuesMessage::ToggleIssueSortOrder
+    ));
     assert!(!is_fresh_issue_list_reload(
         &IssuesMessage::NavigatePageDown(jefe::list_viewport::PageItemCount::new(3))
     ));

--- a/src/app_input/issues_dispatch.rs
+++ b/src/app_input/issues_dispatch.rs
@@ -488,11 +488,7 @@ pub(super) fn dispatch_issues_message(
         | IssuesMessage::NavigateEnd) => {
             dispatch_issues_navigation(app_state, ctx, message);
         }
-        message @ (IssuesMessage::EnterMode
-        | IssuesMessage::RefocusList
-        | IssuesMessage::ApplyFilter
-        | IssuesMessage::ClearFilter
-        | IssuesMessage::ApplySearch) => {
+        message if is_issues_list_reload_msg(&message) => {
             issues_list_dispatch::dispatch_issue_list_reload(app_state, ctx, message);
         }
         IssuesMessage::Enter => {
@@ -538,6 +534,18 @@ pub(super) fn dispatch_issues_message(
         }
         message => apply_and_persist(app_state, ctx, AppEvent::from(message)),
     }
+}
+
+/// Messages that require a fresh issue-list fetch: mode entry/refocus, a
+/// filter/search change, or a sort-config change (issue #573 — a sort change
+/// must refetch so the fetch `orderBy` matches the new display direction).
+///
+/// Delegates to [`is_fresh_issue_list_reload`] so the routing decision and the
+/// fresh-reload flag share one source of truth: if they drifted, a sort change
+/// could route here but skip the cursor reset, leaving a stale cursor for the
+/// old sort direction.
+fn is_issues_list_reload_msg(message: &IssuesMessage) -> bool {
+    issues_list_dispatch::is_fresh_issue_list_reload(message)
 }
 
 /// Route the direct-action messages (chooser confirm, inline submit,
@@ -635,7 +643,8 @@ pub(super) fn resume_issue_post_mutation_refresh(
 
 #[cfg(test)]
 mod tests {
-    use super::preview_body_from_list;
+    use super::{is_issues_list_reload_msg, preview_body_from_list};
+    use jefe::messages::IssuesMessage;
 
     #[test]
     fn empty_list_preview_body_prompts_for_detail_load() {
@@ -648,5 +657,23 @@ mod tests {
     #[test]
     fn populated_list_preview_body_is_preserved() {
         assert_eq!(preview_body_from_list("existing body"), "existing body");
+    }
+
+    #[test]
+    fn sort_messages_route_to_list_reload() {
+        // A sort-config change must route through the list-reload dispatch so
+        // the fetch orderBy follows the new display direction (issue #573).
+        assert!(is_issues_list_reload_msg(
+            &IssuesMessage::CycleIssueSortByNext
+        ));
+        assert!(is_issues_list_reload_msg(
+            &IssuesMessage::CycleIssueSortByPrev
+        ));
+        assert!(is_issues_list_reload_msg(
+            &IssuesMessage::ToggleIssueSortOrder
+        ));
+        assert!(is_issues_list_reload_msg(&IssuesMessage::ApplyFilter));
+        // Navigation must NOT be treated as a reload trigger.
+        assert!(!is_issues_list_reload_msg(&IssuesMessage::NavigateDown));
     }
 }

--- a/src/app_input/issues_list_dispatch.rs
+++ b/src/app_input/issues_list_dispatch.rs
@@ -45,6 +45,9 @@ pub(super) fn is_fresh_issue_list_reload(message: &IssuesMessage) -> bool {
             | IssuesMessage::ApplyFilter
             | IssuesMessage::ClearFilter
             | IssuesMessage::ApplySearch
+            | IssuesMessage::CycleIssueSortByNext
+            | IssuesMessage::CycleIssueSortByPrev
+            | IssuesMessage::ToggleIssueSortOrder
     )
 }
 
@@ -130,6 +133,7 @@ struct IssueFetchParams {
     /// Malformed tracker override message (issue #266).
     malformed_message: Option<String>,
     filter: jefe::domain::IssueFilter,
+    sort: jefe::domain::IssueSortConfig,
     request_id: u64,
     cursor: Option<String>,
     page_size: u32,
@@ -239,6 +243,7 @@ fn issue_fetch_params(
         repo,
         malformed_message,
         filter: state.issues_state.committed_filter.clone(),
+        sort: state.issues_state.sort_config,
         request_id: 0,
         cursor,
         page_size: 30,
@@ -265,10 +270,14 @@ fn fetch_issue_list(
     params: &IssueFetchParams,
 ) -> Option<Result<jefe::github::IssueListResponse, jefe::github::GhError>> {
     let client = github_client(ctx)?;
+    let query = jefe::domain::IssueListQuery {
+        filter: params.filter.clone(),
+        sort: params.sort,
+    };
     Some(client.list_issues(
         &params.owner,
         &params.repo,
-        &params.filter,
+        &query,
         params.cursor.as_deref(),
         params.page_size,
     ))

--- a/src/domain/issues.rs
+++ b/src/domain/issues.rs
@@ -217,11 +217,14 @@ impl IssueSortBy {
     }
 }
 
-/// Active sort configuration for the Issues list (issue #473).
+/// Active sort configuration for the Issues list (issue #473, #573).
 ///
-/// Lives on `IssuesState` (not on the fetch-time filter identity) because sort
-/// is a projection-time view transform: changing it must not re-run the fetch
-/// or perturb the `IssueListIdentity` stale-rejection guard.
+/// Sort is applied two ways: (1) as a fetch-time GraphQL `orderBy` direction so
+/// the first page and pagination advance in the user's chosen direction (a
+/// sort-config change triggers a fresh reload), and (2) as a projection re-sort
+/// on already-loaded items. The config lives on `IssuesState` and is read at
+/// fetch time without being folded into `IssueListIdentity` (the stale-rejection
+/// guard stays filter-scoped; sort changes force a reload instead).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct IssueSortConfig {
     #[serde(default)]
@@ -239,6 +242,19 @@ impl IssueSortConfig {
             order: SortOrder::Desc,
         }
     }
+}
+
+/// A server-side issue list query: the filter plus the sort.
+///
+/// Bundled so the fetch order always matches the display sort (issue #573).
+/// The filter alone forms the `IssueListIdentity` stale-rejection key; the
+/// sort drives the GraphQL `orderBy`/search `sort:` direction.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct IssueListQuery {
+    /// Which issues to fetch.
+    pub filter: IssueFilter,
+    /// What order to fetch them in.
+    pub sort: IssueSortConfig,
 }
 
 /// @plan PLAN-20260329-ISSUES-MODE.P03

--- a/src/github/issue_pages.rs
+++ b/src/github/issue_pages.rs
@@ -1,0 +1,116 @@
+//! Issue list pagination: raw and filtered page fetching (issue #573).
+//!
+//! Extracted from `mod.rs` so that module stays under the source-size policy.
+//! These helpers drive the cursor-based search-page fetch, including the
+//! client-side filter loop used when an issue-type filter must be applied on
+//! top of a search query that cannot express it server-side. The fetch order
+//! follows the active [`IssueSortConfig`] so the server returns issues in the
+//! same direction the user wants to view them.
+
+use super::issue_query::{
+    active_issue_type_filter, build_issue_search_args_sorted, issue_type_requires_search_filter,
+};
+use super::parse::{categorize_error, parse_issue_search_json};
+use super::{GhError, IssueListResponse, gh_command};
+use crate::domain::{Issue, IssueFilter, IssueSortConfig};
+
+/// Fetch one search page, dispatching to the filtered loop when an issue-type
+/// filter needs client-side narrowing.
+pub(super) fn fetch_issue_search_page(
+    owner: &str,
+    repo: &str,
+    filter: &IssueFilter,
+    cursor: Option<&str>,
+    page_size: u32,
+    sort: IssueSortConfig,
+) -> Result<IssueListResponse, GhError> {
+    if active_issue_type_filter(filter).is_some() && issue_type_requires_search_filter(filter) {
+        return fetch_issue_search_filtered_pages(owner, repo, filter, cursor, page_size, sort);
+    }
+    fetch_issue_search_raw_page(owner, repo, filter, cursor, page_size, sort)
+}
+
+/// Fetch raw search pages until enough issues match the issue-type filter,
+/// narrowing client-side because the search query cannot express it.
+fn fetch_issue_search_filtered_pages(
+    owner: &str,
+    repo: &str,
+    filter: &IssueFilter,
+    cursor: Option<&str>,
+    page_size: u32,
+    sort: IssueSortConfig,
+) -> Result<IssueListResponse, GhError> {
+    let Some(issue_type) = active_issue_type_filter(filter) else {
+        return fetch_issue_search_raw_page(owner, repo, filter, cursor, page_size, sort);
+    };
+    let mut search_cursor = cursor.map(str::to_string);
+    let mut collected: Vec<Issue> = Vec::new();
+    let mut response_cursor: Option<String>;
+    let mut response_has_more: bool;
+
+    loop {
+        let response = fetch_issue_search_raw_page(
+            owner,
+            repo,
+            filter,
+            search_cursor.as_deref(),
+            page_size,
+            sort,
+        )?;
+        response_cursor = response.cursor.clone();
+        response_has_more = response.has_more;
+        collected.extend(
+            response
+                .issues
+                .into_iter()
+                .filter(|issue| issue.issue_type.eq_ignore_ascii_case(issue_type)),
+        );
+        if collected.len() > page_size as usize {
+            response_has_more = true;
+            break;
+        }
+
+        if collected.len() >= page_size as usize || !response_has_more {
+            break;
+        }
+        if response.cursor == search_cursor {
+            response_has_more = false;
+            break;
+        }
+        search_cursor = response.cursor;
+    }
+
+    Ok(IssueListResponse {
+        issues: collected,
+        cursor: response_cursor,
+        has_more: response_has_more,
+    })
+}
+
+/// Fetch a single raw search page via `gh api graphql`.
+fn fetch_issue_search_raw_page(
+    owner: &str,
+    repo: &str,
+    filter: &IssueFilter,
+    cursor: Option<&str>,
+    page_size: u32,
+    sort: IssueSortConfig,
+) -> Result<IssueListResponse, GhError> {
+    let args = build_issue_search_args_sorted(owner, repo, filter, cursor, page_size, sort);
+
+    let output = gh_command()?.args(&args).output().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            GhError::NotInstalled
+        } else {
+            GhError::NetworkError(e.to_string())
+        }
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(categorize_error(output.status.code().unwrap_or(1), &stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_issue_search_json(&stdout)
+}

--- a/src/github/issue_query.rs
+++ b/src/github/issue_query.rs
@@ -4,7 +4,10 @@
 //! These are pure functions over `crate::domain::IssueFilter` that produce
 //! `gh` CLI argument vectors.
 
-use crate::domain::{FILTER_CHOICE_ANY, FILTER_CHOICE_NONE, IssueFilter, IssueFilterState};
+use crate::domain::{
+    FILTER_CHOICE_ANY, FILTER_CHOICE_NONE, IssueFilter, IssueFilterState, IssueListQuery,
+    IssueSortBy, IssueSortConfig, SortOrder,
+};
 
 /// HTTP header enabling the `issueFieldValues` schema preview (issue #473).
 ///
@@ -12,6 +15,47 @@ use crate::domain::{FILTER_CHOICE_ANY, FILTER_CHOICE_NONE, IssueFilter, IssueFil
 /// is present on the GraphQL request. `gh api graphql` passes it through as
 /// `-H "GraphQL-Features: issue_fields"`.
 const ISSUE_FIELDS_HEADER: &str = "GraphQL-Features: issue_fields";
+
+/// Map the active issue sort to a GraphQL `orderBy` field/direction pair
+/// (issue #573).
+///
+/// The fetch order must follow the user's selected sort direction so that an
+/// ascending sort surfaces the oldest issues on the first page. GitHub's
+/// `issues` connection only supports `CREATED_AT` and `UPDATED_AT` orderBy
+/// fields, so `Number` is proxied through `CREATED_AT` (issue numbers are
+/// monotonic with creation) and `Priority` falls back to `UPDATED_AT`.
+///
+/// Priority has no server-side ranking, so the projection-time comparator
+/// (`compare_issues`) re-ranks each loaded page by priority. Because the server
+/// still orders pages by `UPDATED_AT`, a high-priority issue that was not
+/// recently updated may not surface until later pages are loaded; this is a
+/// known limitation of the two-tier sort.
+fn issue_graphql_order_by(config: IssueSortConfig) -> (&'static str, &'static str) {
+    let field = match config.by {
+        IssueSortBy::Created | IssueSortBy::Number => "CREATED_AT",
+        IssueSortBy::Updated | IssueSortBy::Priority => "UPDATED_AT",
+    };
+    let direction = match config.order {
+        SortOrder::Asc => "ASC",
+        SortOrder::Desc => "DESC",
+    };
+    (field, direction)
+}
+
+/// Map the active issue sort to a single GitHub search `sort:` qualifier
+/// (issue #573). The search query string encodes direction inside the
+/// qualifier value (`sort:updated-asc`) — there is no separate `order:`
+/// qualifier, so emitting one would be treated as a literal search term.
+/// `Number` proxies through `created` (numbers are monotonic with creation);
+/// `Priority` has no search sort and falls back to `updated`.
+fn issue_search_sort_qualifier(config: IssueSortConfig) -> &'static str {
+    match (config.by, config.order) {
+        (IssueSortBy::Created | IssueSortBy::Number, SortOrder::Asc) => "sort:created-asc",
+        (IssueSortBy::Created | IssueSortBy::Number, SortOrder::Desc) => "sort:created-desc",
+        (IssueSortBy::Updated | IssueSortBy::Priority, SortOrder::Asc) => "sort:updated-asc",
+        (IssueSortBy::Updated | IssueSortBy::Priority, SortOrder::Desc) => "sort:updated-desc",
+    }
+}
 
 /// Shared GraphQL selection for issue list nodes (issue #473).
 ///
@@ -108,6 +152,10 @@ pub fn build_list_issues_args(
 
 /// Build the GraphQL search query argument vector for the given repository and
 /// filter (issue #473).
+///
+/// Delegates to [`build_issue_search_args_sorted`] with the default sort
+/// (`Updated/Desc`), preserving the pre-issue-#573 fetch order for callers
+/// that do not supply a sort config (tests and legacy paths).
 #[must_use]
 pub fn build_issue_search_args(
     owner: &str,
@@ -116,16 +164,46 @@ pub fn build_issue_search_args(
     cursor: Option<&str>,
     page_size: u32,
 ) -> Vec<String> {
+    build_issue_search_args_sorted(
+        owner,
+        repo,
+        filter,
+        cursor,
+        page_size,
+        IssueSortConfig::default_sort(),
+    )
+}
+
+/// Sort-aware GraphQL search argument builder (issue #573).
+///
+/// The fetch `orderBy`/search sort follows the active sort config so the
+/// server returns issues in the same direction the user wants to view them.
+/// This keeps the first page and continuation cursor aligned with the display
+/// sort, so an ascending sort shows the oldest issues first instead of forcing
+/// the user to scroll to the bottom to load them.
+#[must_use]
+pub(super) fn build_issue_search_args_sorted(
+    owner: &str,
+    repo: &str,
+    filter: &IssueFilter,
+    cursor: Option<&str>,
+    page_size: u32,
+    sort: IssueSortConfig,
+) -> Vec<String> {
     if let Some(issue_type) = active_issue_type_filter(filter)
         && !issue_type_requires_search_filter(filter)
     {
+        let query = IssueListQuery {
+            filter: filter.clone(),
+            sort,
+        };
         return build_repository_issue_type_args(
-            owner, repo, filter, issue_type, cursor, page_size,
+            owner, repo, &query, issue_type, cursor, page_size,
         );
     }
 
     let selection = issue_list_node_selection();
-    let query = if cursor.is_some() {
+    let gql_query = if cursor.is_some() {
         format!(
             "query($searchQuery: String!, $first: Int!, $after: String) {{ search(type: ISSUE, query: $searchQuery, first: $first, after: $after) {{ nodes {{ ... on Issue {{ {selection} }} }} pageInfo {{ hasNextPage endCursor }} }} }}"
         )
@@ -140,9 +218,12 @@ pub fn build_issue_search_args(
         "-H".to_string(),
         ISSUE_FIELDS_HEADER.to_string(),
         "-f".to_string(),
-        format!("query={query}"),
+        format!("query={gql_query}"),
         "-F".to_string(),
-        format!("searchQuery={}", issue_search_query(owner, repo, filter)),
+        format!(
+            "searchQuery={}",
+            issue_search_query(owner, repo, filter, sort)
+        ),
         "-F".to_string(),
         format!("first={page_size}"),
     ];
@@ -153,7 +234,12 @@ pub fn build_issue_search_args(
     args
 }
 
-fn issue_search_query(owner: &str, repo: &str, filter: &IssueFilter) -> String {
+fn issue_search_query(
+    owner: &str,
+    repo: &str,
+    filter: &IssueFilter,
+    sort: IssueSortConfig,
+) -> String {
     let mut terms = vec![format!("repo:{owner}/{repo}"), "is:issue".to_string()];
     if let Some(state) = issue_filter_state_query(filter) {
         terms.push(state);
@@ -175,6 +261,8 @@ fn issue_search_query(owner: &str, repo: &str, filter: &IssueFilter) -> String {
     if !filter.query_text.trim().is_empty() {
         terms.push(filter.query_text.trim().to_string());
     }
+
+    terms.push(issue_search_sort_qualifier(sort).to_string());
 
     terms.join(" ")
 }
@@ -306,11 +394,12 @@ pub(super) fn issue_type_requires_search_filter(filter: &IssueFilter) -> bool {
 fn build_repository_issue_type_args(
     owner: &str,
     repo: &str,
-    filter: &IssueFilter,
+    query: &IssueListQuery,
     issue_type: &str,
     cursor: Option<&str>,
     page_size: u32,
 ) -> Vec<String> {
+    let filter = &query.filter;
     let mut variable_defs = vec![
         "$owner: String!".to_string(),
         "$repo: String!".to_string(),
@@ -333,8 +422,9 @@ fn build_repository_issue_type_args(
     } else {
         ""
     };
+    let (order_field, order_dir) = issue_graphql_order_by(query.sort);
     let query = format!(
-        "query({}) {{ repository(owner: $owner, name: $repo) {{ issues(first: $first{after_arg}, filterBy: {{ {} }}, orderBy: {{ field: UPDATED_AT, direction: DESC }}) {{ nodes {{ {} }} pageInfo {{ hasNextPage endCursor }} }} }} }}",
+        "query({}) {{ repository(owner: $owner, name: $repo) {{ issues(first: $first{after_arg}, filterBy: {{ {} }}, orderBy: {{ field: {order_field}, direction: {order_dir} }}) {{ nodes {{ {} }} pageInfo {{ hasNextPage endCursor }} }} }} }}",
         variable_defs.join(", "),
         filters.join(", "),
         issue_list_node_selection(),
@@ -475,4 +565,128 @@ fn push_repository_label_filter(filter: &IssueFilter, filters: &mut Vec<String>)
 fn graphql_string_literal(value: &str) -> String {
     let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
     format!("\"{escaped}\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{IssueFilter, IssueSortBy, IssueSortConfig, SortOrder};
+
+    fn config(by: IssueSortBy, order: SortOrder) -> IssueSortConfig {
+        IssueSortConfig { by, order }
+    }
+
+    #[test]
+    fn graphql_order_by_follows_sort_direction() {
+        // Ascending sorts must flip the fetch direction so the oldest issues
+        // arrive on the first page (issue #573).
+        assert_eq!(
+            issue_graphql_order_by(config(IssueSortBy::Updated, SortOrder::Asc)),
+            ("UPDATED_AT", "ASC")
+        );
+        assert_eq!(
+            issue_graphql_order_by(config(IssueSortBy::Updated, SortOrder::Desc)),
+            ("UPDATED_AT", "DESC")
+        );
+        assert_eq!(
+            issue_graphql_order_by(config(IssueSortBy::Created, SortOrder::Asc)),
+            ("CREATED_AT", "ASC")
+        );
+        // Number proxies through CREATED_AT (monotonic with creation).
+        assert_eq!(
+            issue_graphql_order_by(config(IssueSortBy::Number, SortOrder::Asc)),
+            ("CREATED_AT", "ASC")
+        );
+        // Priority has no server orderBy; falls back to UPDATED_AT.
+        assert_eq!(
+            issue_graphql_order_by(config(IssueSortBy::Priority, SortOrder::Desc)),
+            ("UPDATED_AT", "DESC")
+        );
+    }
+
+    #[test]
+    fn search_sort_qualifier_follows_sort_direction() {
+        assert_eq!(
+            issue_search_sort_qualifier(config(IssueSortBy::Updated, SortOrder::Asc)),
+            "sort:updated-asc"
+        );
+        assert_eq!(
+            issue_search_sort_qualifier(config(IssueSortBy::Created, SortOrder::Desc)),
+            "sort:created-desc"
+        );
+        assert_eq!(
+            issue_search_sort_qualifier(config(IssueSortBy::Number, SortOrder::Asc)),
+            "sort:created-asc"
+        );
+    }
+
+    #[test]
+    fn repository_issue_type_order_by_honors_ascending_sort() {
+        let filter = IssueFilter {
+            issue_type: "Bug".to_string(),
+            ..IssueFilter::default()
+        };
+        let args = build_issue_search_args_sorted(
+            "owner",
+            "repo",
+            &filter,
+            None,
+            30,
+            config(IssueSortBy::Created, SortOrder::Asc),
+        );
+        let Some(gql) = args.windows(2).find_map(|pair| {
+            (pair[0] == "-f" && pair[1].starts_with("query=")).then_some(&pair[1])
+        }) else {
+            panic!("missing GraphQL query");
+        };
+        assert!(
+            gql.contains("orderBy: { field: CREATED_AT, direction: ASC }"),
+            "ascending Created sort must fetch oldest-first: {gql}"
+        );
+    }
+
+    #[test]
+    fn search_query_uses_single_combined_sort_qualifier() {
+        let args = build_issue_search_args_sorted(
+            "owner",
+            "repo",
+            &IssueFilter::default(),
+            None,
+            30,
+            config(IssueSortBy::Updated, SortOrder::Asc),
+        );
+        let Some(query) = args.windows(2).find_map(|pair| {
+            (pair[0] == "-F" && pair[1].starts_with("searchQuery=")).then_some(&pair[1])
+        }) else {
+            panic!("missing searchQuery");
+        };
+        // The direction lives inside the sort qualifier value (sort:updated-asc);
+        // a bare order: token is not a valid search qualifier and must not appear.
+        assert!(
+            query.contains("sort:updated-asc"),
+            "ascending Updated sort must request oldest-first via a single combined qualifier: {query}"
+        );
+        assert!(
+            !query.contains("order:"),
+            "separate order: qualifier must not be emitted (it is not a search qualifier): {query}"
+        );
+    }
+
+    #[test]
+    fn default_search_args_preserve_updated_desc_behavior() {
+        let args = build_issue_search_args("owner", "repo", &IssueFilter::default(), None, 30);
+        let Some(query) = args.windows(2).find_map(|pair| {
+            (pair[0] == "-F" && pair[1].starts_with("searchQuery=")).then_some(&pair[1])
+        }) else {
+            panic!("missing searchQuery");
+        };
+        assert!(
+            query.contains("sort:updated-desc"),
+            "default sort must remain newest-first: {query}"
+        );
+        assert!(
+            !query.contains("order:"),
+            "separate order: qualifier must not be emitted: {query}"
+        );
+    }
 }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -4,7 +4,7 @@
 //! It depends only on `crate::domain` types for data transfer.
 
 use crate::domain::{
-    Issue, IssueComment, IssueDetail, IssueFilter, IssueState, PrCheck, PrFilter, PrReview,
+    Issue, IssueComment, IssueDetail, IssueListQuery, IssueState, PrCheck, PrFilter, PrReview,
     PrReviewState, PrReviewThread, PrState, PullRequestDetail,
 };
 use std::process::Command;
@@ -50,12 +50,12 @@ pub use actions::{
     parse_jobs_json, parse_runs_json, parse_single_run_json, parse_workflows_json,
 };
 
+mod issue_pages;
 mod issue_query;
 mod issue_sort;
 mod parse;
 mod timestamp;
 use comment_pages::loaded_comments;
-use issue_query::{active_issue_type_filter, issue_type_requires_search_filter};
 pub use issue_query::{build_issue_search_args, build_list_issues_args};
 pub use issue_sort::{compare_issues, issue_priority_rank, sort_issues};
 pub use parse::{
@@ -77,7 +77,7 @@ pub use parse_pr::{
 };
 pub use pr_check_rollup::{effective_check_nodes, parse_check_status, parse_checks_rollup};
 
-fn gh_command() -> Result<Command, GhError> {
+pub(super) fn gh_command() -> Result<Command, GhError> {
     crate::local_command::command(crate::local_command::LocalTool::Gh).map_err(
         |error| match error {
             crate::local_command::LocalToolError::NotFound { .. } => GhError::NotInstalled,
@@ -212,6 +212,9 @@ impl GhClient {
 
     /// List issues for a repository with filtering and pagination.
     ///
+    /// The fetch order follows `query.sort` (issue #573) so an ascending sort
+    /// returns the oldest issues on the first page.
+    ///
     /// @plan PLAN-20260329-ISSUES-MODE.P08
     /// @requirement REQ-ISS-006
     /// @pseudocode component-002 lines 09-25
@@ -219,11 +222,18 @@ impl GhClient {
         &self,
         owner: &str,
         repo: &str,
-        filter: &IssueFilter,
+        query: &IssueListQuery,
         cursor: Option<&str>,
         page_size: u32,
     ) -> Result<IssueListResponse, GhError> {
-        fetch_issue_search_page(owner, repo, filter, cursor, page_size)
+        issue_pages::fetch_issue_search_page(
+            owner,
+            repo,
+            &query.filter,
+            cursor,
+            page_size,
+            query.sort,
+        )
     }
 
     /// Get full issue detail.
@@ -909,91 +919,4 @@ fn summarize_pr_checks(checks: &[PrCheck]) -> Vec<String> {
         .iter()
         .map(|c| format!("{}: {}", c.name, c.conclusion))
         .collect()
-}
-
-fn fetch_issue_search_page(
-    owner: &str,
-    repo: &str,
-    filter: &IssueFilter,
-    cursor: Option<&str>,
-    page_size: u32,
-) -> Result<IssueListResponse, GhError> {
-    if active_issue_type_filter(filter).is_some() && issue_type_requires_search_filter(filter) {
-        return fetch_issue_search_filtered_pages(owner, repo, filter, cursor, page_size);
-    }
-    fetch_issue_search_raw_page(owner, repo, filter, cursor, page_size)
-}
-
-fn fetch_issue_search_filtered_pages(
-    owner: &str,
-    repo: &str,
-    filter: &IssueFilter,
-    cursor: Option<&str>,
-    page_size: u32,
-) -> Result<IssueListResponse, GhError> {
-    let Some(issue_type) = active_issue_type_filter(filter) else {
-        return fetch_issue_search_raw_page(owner, repo, filter, cursor, page_size);
-    };
-    let mut search_cursor = cursor.map(str::to_string);
-    let mut collected = Vec::new();
-    let mut response_cursor: Option<String>;
-    let mut response_has_more: bool;
-
-    loop {
-        let response =
-            fetch_issue_search_raw_page(owner, repo, filter, search_cursor.as_deref(), page_size)?;
-        response_cursor = response.cursor.clone();
-        response_has_more = response.has_more;
-        collected.extend(
-            response
-                .issues
-                .into_iter()
-                .filter(|issue| issue.issue_type.eq_ignore_ascii_case(issue_type)),
-        );
-        if collected.len() > page_size as usize {
-            response_has_more = true;
-            break;
-        }
-
-        if collected.len() >= page_size as usize || !response_has_more {
-            break;
-        }
-        if response.cursor == search_cursor {
-            response_has_more = false;
-            break;
-        }
-        search_cursor = response.cursor;
-    }
-
-    Ok(IssueListResponse {
-        issues: collected,
-        cursor: response_cursor,
-        has_more: response_has_more,
-    })
-}
-
-fn fetch_issue_search_raw_page(
-    owner: &str,
-    repo: &str,
-    filter: &IssueFilter,
-    cursor: Option<&str>,
-    page_size: u32,
-) -> Result<IssueListResponse, GhError> {
-    let args = build_issue_search_args(owner, repo, filter, cursor, page_size);
-
-    let output = gh_command()?.args(&args).output().map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
-            GhError::NotInstalled
-        } else {
-            GhError::NetworkError(e.to_string())
-        }
-    })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(categorize_error(output.status.code().unwrap_or(1), &stderr));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_issue_search_json(&stdout)
 }


### PR DESCRIPTION
## Problem

In Issues mode, sorting ascending never showed the oldest issues at the top. The first page always held the newest issues, and the truly oldest issues only appeared after scrolling to the bottom to trigger load-more — because pagination advanced newest-to-oldest while the display sort was reversed.

## Root cause

The GitHub fetch order was hardcoded newest-first regardless of the user's sort selection:
- the repository.issues GraphQL path always used orderBy UPDATED_AT/DESC
- the search path appended no sort qualifier at all

The user's sort config (issue #473) was applied only as a client-side projection reorder (`resort_issues_preserving_selection`). With an ascending display sort, this reversal meant load-more (which fires at the list bottom) was the only way to pull older pages toward the top — the cursor advanced in the opposite direction from the display.

## Fix

Drive the fetch order from the active `IssueSortConfig` so the server returns issues in the same direction the user wants to view them:
- The `repository.issues` orderBy field/direction follows the sort (Created/Number -> CREATED_AT, Updated/Priority -> UPDATED_AT; Asc -> ASC, Desc -> DESC).
- The search path emits a single combined `sort` qualifier (e.g. `sort:updated-asc`). GitHub search syntax encodes the direction inside the sort qualifier value — there is no separate `order:` qualifier, so emitting one would be treated as a literal search term.
- A sort-config change now triggers a fresh reload (cursor reset) so the continuation cursor always matches the new fetch direction.

`filter + sort` are bundled into `IssueListQuery` so `list_issues` and the issue-type query builder stay within the clippy argument-count limit. The issue page-fetch helpers were extracted into `src/github/issue_pages.rs` to keep `src/github/mod.rs` under the source-size limit.

## Tests

- `issue_query`: orderBy/search-sort mapping follows the sort config; repository-issue-type path honors ascending; search path uses a single combined sort qualifier (no `order:` token); default args preserve updated-desc.
- Routing: the three sort events route to the list-reload path and are treated as fresh reloads (cursor reset).
- Full workspace: 5072 passed, 0 failed. fmt, clippy `-D warnings`, build, and xtask checks (source-size, architecture, clippy-allows) all green.

## Notes / known limitations

- Priority has no server-side ranking, so the projection comparator still re-ranks each loaded page by priority; a high-priority issue not recently updated may not surface until later pages. This is documented in the orderBy helper.
- The PR list has the same fetch-vs-display direction mismatch (hardcoded `sort:updated-desc`). It is out of scope here and tracked as a follow-up.
- A pre-existing pagination bug in the filtered-issue loop (oversized page on the boundary) is unchanged by this PR; tracked in #579.
