### PR TITLE
Declare and enforce the psmux behavioural contract (Fixes #540)

### DIFF
--- a/project-plans/issue540-plan.md
+++ b/project-plans/issue540-plan.md
@@ -1,0 +1,126 @@
+# Issue #540 — Versioned, behavioural psmux compatibility contract
+
+Sub-issue of epic #539. Restores invariant **I2**, epic criteria **E1/E2**.
+
+> jefe must never execute against a multiplexer binary whose behaviour it has not
+> verified, and every semantic jefe depends on must be asserted against that binary
+> rather than assumed from tmux.
+
+## Grounding evidence gathered before planning
+
+Measured on 2026-08-01 against psmux `3.3.7 (05cc5d4)` (installed, WinGet) and a local
+build of `acoliver/psmux@1a8b6d5` (which carries the merged fixes for psmux#509/#510/#443):
+
+| Probe | installed 05cc5d4 | fork 1a8b6d5 |
+|---|---|---|
+| `-L <ns> display-message -p '#{pid}'` | **`22440` for *every* namespace**, including one with no server at all | resolves within the namespace, but still changes per session: `9008` → `17784` → `3832` |
+| `-L <ns> display-message -p '#{server_instance}'` | unsupported | **stable**: `883b25f5…` across three sessions; differs per namespace; errors cleanly when no server |
+| server processes per `-L` namespace | 4 | 4 |
+
+This is a live instance of exactly the class #540 exists to prevent. jefe pins
+`SERVER_IDENTITY_FORMAT = "#{pid}|#{version}"` (`server_health_io.rs:13`) on the tmux
+assumption that `#{pid}` identifies *the server for this socket*. On psmux there is one
+server **process per session**, so `#{pid}` names whichever server answered. Adding a
+session therefore looks like a server restart. Upstream's fix (psmux#509) deliberately
+does **not** change `#{pid}`; it adds `#{server_instance}` as the stable namespace token.
+
+Consequence in production today: jefe's persisted state claims three agents `running`
+while only one session exists. The two phantoms are unreachable and un-relaunchable.
+
+This is recorded here because it is the strongest available justification for V5 (a
+mechanical check on format strings): no version gate would have caught it, and the
+symptom surfaced three layers away from the cause.
+
+## Non-goals (explicit)
+
+- **Not bundling or vendoring psmux.** Maintainer decision D = REJECT. The refusal path
+  is therefore the only path when the contract is unmet, which is why the diagnostic
+  quality in V2/V3 is a deliverable and not a nicety.
+- **Not a CI version matrix.** Decision C = REJECT (runner queue is the bottleneck). CI
+  continues to qualify one pinned version; cross-version work happens locally via the
+  `JEFE_PSMUX_BIN` override (decision A = ADOPT).
+- **Not moving past psmux 3.3.7.** That evaluation moved to #547 (which owns
+  multiplexer-binary isolation, deliverables 7–9).
+- **Not per-agent `Replaced` evaluation.** #541 V5 owns "a `Replaced` server with a
+  surviving host process must not mark that agent `ServerLost`". #540 supplies the
+  *correct identity input*; #541 decides what to do with a genuine replacement.
+- **Not the ownership anchor.** #542.
+- **Not removing the launch-pipeline hard gates.** #544.
+
+## Contract surface, as measured
+
+Verbs issued from production `src/` (occurrence counts):
+`set-option` 14, `send-keys` 10, `capture-pane` 10, `has-session` 6, `list-windows` 6,
+`list-sessions` 5, `list-panes` 5, `display-message` 5, `new-session` 5, `kill-server` 5,
+`attach-session` 4, `kill-session` 4, `unbind-key` 3, `select-window` 3,
+`show-options` 1, `new-window` 1.
+
+Format strings: `#{number}` 38, `#{session_name}` 11, `#{pane_pid}` 10, `#{window_name}` 9,
+`#{pane_dead}` 7, `#{version}` 3, `#{pid}` 3, `#{window_index}` 3, `#{next_display_index}` 2,
+`#{history_size}` 2, `#{pane_dead_signal}` 1, `#{pane_index}` 1.
+(`#{pr_number}`, `#{issue_number}`, `#{n}`, `#{thread_idx}`, `#{dup_num}` are jefe's own
+template syntax, not multiplexer formats — the V5 checker must not confuse the two.)
+
+Known behavioural divergences already patched ad hoc, which V6 must fold into the contract:
+`exit-empty off` (`server_health_io.rs:120`, `app_shell_liveness.rs:59`), F12 prefix
+override (`action_projection.rs:647,651`), PageUp root-table unbind
+(`action_projection.rs:151,733`), `remain-on-exit` (`psmux_driver.rs:292`).
+
+V4's tmux-derived constant: `PROMPT_COMPACTION_THRESHOLD_BYTES = 10_000`
+(`fresh_prompt.rs:87`), referenced by 12 assertions in `prompt_compaction_tests.rs` and
+paired with `TMUX_PANE_COMMAND_LIMIT_BYTES`.
+
+## Acceptance matrix
+
+| ID | Criterion | Slice | Proof |
+|---|---|---|---|
+| V1 | Conformance suite passes every contract item against a qualified psmux | S2 | suite green in `windows_native` |
+| V2 | Unqualified binary (wrong version; and a stub that answers `-V` correctly but violates one item) ⇒ refusal naming the failing item | S3 | stub-binary tests |
+| V3 | No qualified psmux ⇒ failure at **startup**, before session-creation code is reachable | S3 | test asserts ordering |
+| V4 | Pane-command byte limit **measured** against the live binary; threshold derived; tmux constant deleted | S4 | probe test + constant absent |
+| V5 | Build fails if production code uses a verb/format not declared in the contract | S5 | `cargo xtask` check |
+| V6 | Each retired workaround has a conformance assertion, or removal evidence | S6 | per-item assertion |
+| V7 | Binary-provenance mismatch under a running jefe is detected | S7 | SHA256 manifest test |
+
+## Bounded vertical slices
+
+- **S1 — contract surface module.** One enumerated table: verb / format / option / limit,
+  each with expected response shape. Pure data + types, no I/O. Includes
+  `#{server_instance}` as a *capability-gated* item (present on psmux ≥ #509, absent on
+  3.3.7 release).
+- **S2 — conformance runner (V1).** Executes S1's surface against the resolved binary,
+  one assertion per item. Boundary module; deterministic classification of results.
+- **S3 — startup qualification + refusal (V2, V3).** Moves the gate from session creation
+  to startup. Refusal names binary path, observed version, failing item, and remedy.
+  Must run against a `JEFE_PSMUX_BIN` override (decision A) and still enforce.
+- **S4 — measured pane-command budget (V4).** Probe the live limit; derive the threshold;
+  delete `PROMPT_COMPACTION_THRESHOLD_BYTES`; re-express the 12 dependent assertions
+  against the measured value.
+- **S5 — mechanical surface check (V5).** `xtask` lint: every multiplexer verb/format in
+  production code must appear in S1. Must distinguish jefe's own `#{…}` template syntax.
+- **S6 — retire workarounds into the contract (V6).**
+- **S7 — provenance (V7).** SHA256 manifest; detect the binary changing under a running jefe.
+- **S8 — server identity migration.** Adopt `#{server_instance}` where the contract says
+  it is available, keep `#{pid}` only as a documented-unstable fallback for pre-#509
+  builds, and make "namespace has no server" a distinct observation from "identity
+  changed". Directly fixes the phantom-agent failure above.
+
+Order: S1 → S2 → S3 → S5 → S8 → S6 → S4 → S7.
+S8 sits after S5 so the checker exists before the format string is swapped.
+
+## Scope ledger
+
+Epic #539 suspends the file/line budget. Expected paths:
+`src/runtime/{contract*,server_health*.rs,commands.rs,multiplexer.rs,psmux_driver.rs,liveness.rs}`,
+`src/app_init*.rs`, `src/…/fresh_prompt.rs`, `xtask/src/`, `tests/`.
+
+## Open question for the maintainer (not blocking S1–S3)
+
+S8 changes which format string jefe trusts for server identity. On a pre-#509 psmux
+(including the currently installed 3.3.7 release) `#{server_instance}` does not exist, so
+the stable identity is simply **unavailable**. Per #541's fail-closed direction, the
+honest reading is "identity unknown" — which must not be treated as a restart. That
+implies jefe on an old psmux stops attempting server-replacement detection rather than
+continuing to guess from `#{pid}`. Flagging because it is a deliberate capability
+reduction on unfixed binaries, and the alternative (keep guessing) is what produced the
+phantom agents.

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -53,6 +53,10 @@ fn apply_startup_warning(state: &mut AppState, warning: Option<String>) {
 /// Kept free of I/O so both verdicts can be exercised directly. Both are
 /// reported when both fail: showing only the first would send the operator
 /// round the loop twice (issue #540).
+///
+/// Windows-only because the psmux contract is: other platforms run tmux and
+/// have nothing to qualify against it.
+#[cfg(windows)]
 fn startup_multiplexer_warning(
     qualification: &jefe::runtime::MultiplexerQualification,
     provenance: Option<&jefe::runtime::ProvenanceVerdict>,

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -48,17 +48,72 @@ fn apply_startup_warning(state: &mut AppState, warning: Option<String>) {
     }
 }
 
+/// Compose the startup diagnostic from what qualification and provenance found.
+///
+/// Kept free of I/O so both verdicts can be exercised directly. Both are
+/// reported when both fail: showing only the first would send the operator
+/// round the loop twice (issue #540).
+fn startup_multiplexer_warning(
+    qualification: &jefe::runtime::MultiplexerQualification,
+    provenance: Option<&jefe::runtime::ProvenanceVerdict>,
+) -> Option<String> {
+    let mut problems: Vec<&str> = Vec::new();
+
+    if let jefe::runtime::MultiplexerQualification::Refused { message } = qualification {
+        problems.push(message);
+    }
+    if let Some(
+        jefe::runtime::ProvenanceVerdict::Unqualified { diagnostic }
+        | jefe::runtime::ProvenanceVerdict::Changed { diagnostic },
+    ) = provenance
+    {
+        problems.push(diagnostic);
+    }
+
+    (!problems.is_empty()).then(|| {
+        problems.join(
+            "
+
+",
+        )
+    })
+}
+
 #[cfg(windows)]
 fn windows_multiplexer_startup_warning() -> Option<String> {
-    let result = MultiplexerPlan::current().and_then(|plan| plan.preflight(&[]));
-    match result {
-        Ok(version) => {
-            tracing::info!(%version, "native Windows multiplexer preflight succeeded");
+    // The version gate used to run at first `new-session`, so an unusable
+    // multiplexer was discovered only when starting an agent. Version,
+    // conformance and provenance are all settled here instead (issue #540).
+    let plan = match MultiplexerPlan::current() {
+        Ok(plan) => plan,
+        Err(error) => {
+            warn!(error = %error, "native Windows multiplexer could not be resolved");
+            return Some(format!("psmux preflight warning: {error}"));
+        }
+    };
+
+    let qualification = jefe::runtime::qualify_multiplexer_for_startup(&plan);
+    let provenance = jefe::runtime::fingerprint_multiplexer(&plan).map(|fingerprint| {
+        // No manifest ships yet, so every binary is unrecognised. Verifying
+        // against an empty manifest would refuse every install, so provenance
+        // reports only once digests are recorded; the fingerprint is taken
+        // regardless so a mid-session replacement can still be detected.
+        let manifest = jefe::runtime::ProvenanceManifest::default();
+        if manifest.is_empty() {
+            jefe::runtime::ProvenanceVerdict::Qualified
+        } else {
+            manifest.verify(&fingerprint)
+        }
+    });
+
+    match startup_multiplexer_warning(&qualification, provenance.as_ref()) {
+        None => {
+            tracing::info!("native Windows multiplexer qualified at startup");
             None
         }
-        Err(error) => {
-            warn!(error = %error, "native Windows multiplexer preflight failed");
-            Some(format!("psmux preflight warning: {error}"))
+        Some(warning) => {
+            warn!(warning = %warning, "native Windows multiplexer qualification failed");
+            Some(warning)
         }
     }
 }

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -416,6 +416,7 @@ fn published_agent_enablement_is_separate_from_availability() {
 /// could launch jefe, navigate the UI, and only discover the multiplexer was
 /// unusable when starting an agent. A refusal must therefore surface at
 /// startup, carrying the detail needed to act on it.
+#[cfg(windows)]
 #[test]
 fn a_refused_multiplexer_is_reported_at_startup() {
     let qualification = jefe::runtime::MultiplexerQualification::Refused {
@@ -431,6 +432,7 @@ fn a_refused_multiplexer_is_reported_at_startup() {
 
 /// A qualified binary with nothing wrong produces no noise, or the warning
 /// surface stops being read.
+#[cfg(windows)]
 #[test]
 fn a_qualified_multiplexer_is_silent() {
     let qualification = jefe::runtime::MultiplexerQualification::Qualified {
@@ -449,6 +451,7 @@ fn a_qualified_multiplexer_is_silent() {
 /// Provenance is checked at startup alongside version and conformance, so an
 /// unrecognised binary is reported even when it behaves correctly. Behaving
 /// correctly is not evidence of being the binary jefe qualified.
+#[cfg(windows)]
 #[test]
 fn an_unqualified_provenance_is_reported_even_when_conformance_passes() {
     let qualification = jefe::runtime::MultiplexerQualification::Qualified {
@@ -467,6 +470,7 @@ fn an_unqualified_provenance_is_reported_even_when_conformance_passes() {
 
 /// Both problems at once must both be reported; showing only the first would
 /// send the operator round the loop twice.
+#[cfg(windows)]
 #[test]
 fn conformance_and_provenance_problems_are_both_reported() {
     let qualification = jefe::runtime::MultiplexerQualification::Refused {

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -409,3 +409,76 @@ fn published_agent_enablement_is_separate_from_availability() {
         .unwrap_or_else(|error| panic!("type id must parse: {error}"));
     assert!(agent_type_enabled(migration.published(), &absent));
 }
+
+// -- Startup multiplexer qualification (issue #540 req 3) -----------------
+
+/// The issue's complaint is that the gate ran at first `new-session`, so a user
+/// could launch jefe, navigate the UI, and only discover the multiplexer was
+/// unusable when starting an agent. A refusal must therefore surface at
+/// startup, carrying the detail needed to act on it.
+#[test]
+fn a_refused_multiplexer_is_reported_at_startup() {
+    let qualification = jefe::runtime::MultiplexerQualification::Refused {
+        message: "psmux at C:/tools/psmux.exe (3.3.6) lacks set-option -s exit-empty".to_owned(),
+    };
+
+    let warning = startup_multiplexer_warning(&qualification, None)
+        .unwrap_or_else(|| panic!("a refusal must reach the operator at startup"));
+
+    assert!(warning.contains("C:/tools/psmux.exe"), "{warning}");
+    assert!(warning.contains("exit-empty"), "{warning}");
+}
+
+/// A qualified binary with nothing wrong produces no noise, or the warning
+/// surface stops being read.
+#[test]
+fn a_qualified_multiplexer_is_silent() {
+    let qualification = jefe::runtime::MultiplexerQualification::Qualified {
+        report: jefe::runtime::ConformanceReport::default(),
+    };
+
+    assert_eq!(
+        startup_multiplexer_warning(
+            &qualification,
+            Some(&jefe::runtime::ProvenanceVerdict::Qualified)
+        ),
+        None,
+    );
+}
+
+/// Provenance is checked at startup alongside version and conformance, so an
+/// unrecognised binary is reported even when it behaves correctly. Behaving
+/// correctly is not evidence of being the binary jefe qualified.
+#[test]
+fn an_unqualified_provenance_is_reported_even_when_conformance_passes() {
+    let qualification = jefe::runtime::MultiplexerQualification::Qualified {
+        report: jefe::runtime::ConformanceReport::default(),
+    };
+    let provenance = jefe::runtime::ProvenanceVerdict::Unqualified {
+        diagnostic: "the multiplexer on PATH is not one jefe has qualified: C:/x/psmux.exe"
+            .to_owned(),
+    };
+
+    let warning = startup_multiplexer_warning(&qualification, Some(&provenance))
+        .unwrap_or_else(|| panic!("unknown provenance must be surfaced"));
+
+    assert!(warning.contains("C:/x/psmux.exe"), "{warning}");
+}
+
+/// Both problems at once must both be reported; showing only the first would
+/// send the operator round the loop twice.
+#[test]
+fn conformance_and_provenance_problems_are_both_reported() {
+    let qualification = jefe::runtime::MultiplexerQualification::Refused {
+        message: "missing display-message -p".to_owned(),
+    };
+    let provenance = jefe::runtime::ProvenanceVerdict::Unqualified {
+        diagnostic: "unrecognised digest deadbeef".to_owned(),
+    };
+
+    let warning = startup_multiplexer_warning(&qualification, Some(&provenance))
+        .unwrap_or_else(|| panic!("both problems must surface"));
+
+    assert!(warning.contains("display-message"), "{warning}");
+    assert!(warning.contains("deadbeef"), "{warning}");
+}

--- a/src/app_input/fresh_prompt.rs
+++ b/src/app_input/fresh_prompt.rs
@@ -59,45 +59,42 @@ pub(super) fn fresh_prompt_instruction(
     }
 }
 
+/// Bytes of the pane command reserved for everything that is not prompt
+/// content: env-scrub prefix, executable path, mode flags, instruction framing
+/// and â€” on Windows â€” the environment block, which `CreateProcess` counts
+/// against the same ceiling.
+const PANE_COMMAND_FRAMING_RESERVE_BYTES: usize = 6_000;
+
 /// Maximum prompt content length (in bytes) before truncation.
 ///
-/// Cross-platform safe bound that stays well under the smallest OS
-/// command-line length limit (Windows CreateProcess: ~32 KB). The
-/// `ISSUE_DELIVERY_WORKFLOW` appendix adds ~1.3 KB for issues.
+/// Derived from the measured pane-command budget for the platform rather than
+/// fixed, so a re-measurement moves this instead of silently invalidating it.
+/// The `ISSUE_DELIVERY_WORKFLOW` appendix adds ~1.3 KB for issues.
 ///
-/// Note: the binding constraint on Unix is **tmux's pane-command limit**
-/// (~16,340 bytes on tmux 3.x), not the OS `ARG_MAX`. Prompt content that
-/// exceeds [`PROMPT_COMPACTION_THRESHOLD_BYTES`] is compacted to a preview +
-/// `gh` fetch reference well before this ceiling, so truncation is a
-/// last-resort safety net only (issue #409).
-pub(super) const MAX_PROMPT_CONTENT_BYTES: usize = 24_000;
+/// The constraint is **not** the multiplexer. psmux was measured to impose no
+/// pane-command limit of its own; the boundary tracks the shell's command-line
+/// ceiling, and it is reached *silently* â€” psmux exits 0 and creates the
+/// session while the command never runs. Content over
+/// [`PROMPT_COMPACTION_THRESHOLD_BYTES`] is compacted to a preview + `gh` fetch
+/// reference well before this ceiling, so truncation stays a last-resort safety
+/// net (issues #409, #540).
+pub(super) const MAX_PROMPT_CONTENT_BYTES: usize =
+    jefe::runtime::pane_command_budget().bytes - PANE_COMMAND_FRAMING_RESERVE_BYTES;
 
 /// Prompt content length (in bytes) above which the body is compacted to a
 /// short preview + `gh issue/pr view --comments` fetch reference instead of
 /// being inlined verbatim.
 ///
-/// Sized so that the compacted prompt — including metadata, base prompt, the
-/// `ISSUE_DELIVERY_WORKFLOW` appendix (~1.3 KB for issues), and the
-/// instruction framing — stays comfortably under tmux's pane-command limit
-/// ([`TMUX_PANE_COMMAND_LIMIT_BYTES`]).
+/// Held at a third of the measured budget so the compacted prompt â€” metadata,
+/// base prompt, the `ISSUE_DELIVERY_WORKFLOW` appendix and the instruction
+/// framing â€” stays well inside it. Sizing this against tmux's limit was how a
+/// macOS measurement came to govern a Windows launch (issue #540).
 ///
 /// The agent runs in a checked-out git repo with `gh` available and
-/// authenticated, so it can fetch the full live issue/PR content itself —
+/// authenticated, so it can fetch the full live issue/PR content itself â€”
 /// strictly better than a truncated copy (issue #409).
-pub(super) const PROMPT_COMPACTION_THRESHOLD_BYTES: usize = 10_000;
-
-/// Measured tmux pane-command length limit on tmux 3.7b (macOS): 16,330 bytes
-/// OK, 16,340 bytes TOO LONG. We use 16,000 as a conservative safety margin.
-///
-/// This is the binding constraint on Unix — not the OS `ARG_MAX` (macOS:
-/// 1,048,576). tmux imposes this internal limit on the total pane command
-/// string length, which includes env-scrub prefix, executable, mode flags,
-/// and the inlined prompt instruction.
-///
-/// Only referenced by tests (the production compaction threshold is sized
-/// with enough headroom that this limit is never checked at runtime).
-#[cfg(test)]
-pub(super) const TMUX_PANE_COMMAND_LIMIT_BYTES: usize = 16_000;
+pub(super) const PROMPT_COMPACTION_THRESHOLD_BYTES: usize =
+    jefe::runtime::pane_command_budget().bytes / 3;
 
 /// Maximum number of bytes of preview content to show before the fetch
 /// reference in a compacted prompt.
@@ -137,7 +134,7 @@ pub(super) fn compact_prompt_content(content: &str, fetch_command: &str) -> Stri
         "{preview}
 
 \
-         [... {omitted} more bytes omitted — run the command below to fetch the full content ...]
+         [... {omitted} more bytes omitted â€” run the command below to fetch the full content ...]
 
 \
          Fetch the full content with: {fetch_command}
@@ -376,7 +373,7 @@ mod tests {
     #[test]
     fn truncate_cuts_at_char_boundary_for_multibyte_utf8() {
         let filler = "a".repeat(MAX_PROMPT_CONTENT_BYTES - 2);
-        let content = format!("{filler}🎉🎉");
+        let content = format!("{filler}ðŸŽ‰ðŸŽ‰");
         let truncated = truncate_prompt_content(&content);
         assert!(truncated.contains('a'));
         assert!(truncated.contains("[... prompt truncated"));

--- a/src/app_input/fresh_prompt.rs
+++ b/src/app_input/fresh_prompt.rs
@@ -61,7 +61,7 @@ pub(super) fn fresh_prompt_instruction(
 
 /// Bytes of the pane command reserved for everything that is not prompt
 /// content: env-scrub prefix, executable path, mode flags, instruction framing
-/// and â€” on Windows â€” the environment block, which `CreateProcess` counts
+/// and — on Windows — the environment block, which `CreateProcess` counts
 /// against the same ceiling.
 const PANE_COMMAND_FRAMING_RESERVE_BYTES: usize = 6_000;
 
@@ -73,7 +73,7 @@ const PANE_COMMAND_FRAMING_RESERVE_BYTES: usize = 6_000;
 ///
 /// The constraint is **not** the multiplexer. psmux was measured to impose no
 /// pane-command limit of its own; the boundary tracks the shell's command-line
-/// ceiling, and it is reached *silently* â€” psmux exits 0 and creates the
+/// ceiling, and it is reached *silently* — psmux exits 0 and creates the
 /// session while the command never runs. Content over
 /// [`PROMPT_COMPACTION_THRESHOLD_BYTES`] is compacted to a preview + `gh` fetch
 /// reference well before this ceiling, so truncation stays a last-resort safety
@@ -85,13 +85,13 @@ pub(super) const MAX_PROMPT_CONTENT_BYTES: usize =
 /// short preview + `gh issue/pr view --comments` fetch reference instead of
 /// being inlined verbatim.
 ///
-/// Held at a third of the measured budget so the compacted prompt â€” metadata,
+/// Held at a third of the measured budget so the compacted prompt — metadata,
 /// base prompt, the `ISSUE_DELIVERY_WORKFLOW` appendix and the instruction
-/// framing â€” stays well inside it. Sizing this against tmux's limit was how a
+/// framing — stays well inside it. Sizing this against tmux's limit was how a
 /// macOS measurement came to govern a Windows launch (issue #540).
 ///
 /// The agent runs in a checked-out git repo with `gh` available and
-/// authenticated, so it can fetch the full live issue/PR content itself â€”
+/// authenticated, so it can fetch the full live issue/PR content itself —
 /// strictly better than a truncated copy (issue #409).
 pub(super) const PROMPT_COMPACTION_THRESHOLD_BYTES: usize =
     jefe::runtime::pane_command_budget().bytes / 3;
@@ -134,7 +134,7 @@ pub(super) fn compact_prompt_content(content: &str, fetch_command: &str) -> Stri
         "{preview}
 
 \
-         [... {omitted} more bytes omitted â€” run the command below to fetch the full content ...]
+         [... {omitted} more bytes omitted — run the command below to fetch the full content ...]
 
 \
          Fetch the full content with: {fetch_command}

--- a/src/app_input/prompt_compaction_tests.rs
+++ b/src/app_input/prompt_compaction_tests.rs
@@ -10,11 +10,10 @@
 
 use super::fresh_prompt::{
     FreshPromptKind, ISSUE_DELIVERY_WORKFLOW, MAX_PROMPT_CONTENT_BYTES,
-    PROMPT_COMPACTION_THRESHOLD_BYTES, TMUX_PANE_COMMAND_LIMIT_BYTES, compact_prompt_content,
-    fresh_prompt_instruction,
+    PROMPT_COMPACTION_THRESHOLD_BYTES, compact_prompt_content, fresh_prompt_instruction,
 };
 
-// ── Threshold consistency ────────────────────────────────────────────────
+// â”€â”€ Threshold consistency â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// The compaction threshold must be strictly less than the max-content budget
 /// so a prompt that is exactly at the threshold is NOT also truncated (which
@@ -24,7 +23,7 @@ const _: () = assert!(
     "compaction threshold must be strictly below max content bytes to prevent double-processing"
 );
 
-// ── Large prompt produces compact reference ──────────────────────────────
+// â”€â”€ Large prompt produces compact reference â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// A large prompt (content exceeds the threshold) must be compacted by
 /// `fresh_prompt_instruction`: the instruction must NOT contain the full body,
@@ -56,7 +55,7 @@ fn large_issue_prompt_produces_gh_fetch_reference() {
     );
 }
 
-// ── Small prompt is inlined unchanged ───────────────────────────────────
+// â”€â”€ Small prompt is inlined unchanged â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// A small prompt (under the threshold) must pass through `compact_prompt_content`
 /// unchanged.
@@ -89,7 +88,7 @@ fn large_pr_prompt_produces_gh_fetch_reference() {
     );
 }
 
-// ── Threshold-boundary prompt ────────────────────────────────────────────
+// â”€â”€ Threshold-boundary prompt â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// A prompt exactly at the threshold must be inlined (boundary inclusive).
 #[test]
@@ -119,10 +118,10 @@ fn prompt_one_byte_over_threshold_is_compacted() {
     );
 }
 
-// ── Compaction preserves the issue delivery workflow ─────────────────────
+// â”€â”€ Compaction preserves the issue delivery workflow â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// The ISSUE_DELIVERY_WORKFLOW appendix must still be appended for compacted
-/// issue prompts — compaction only replaces the body, not the workflow rules.
+/// issue prompts â€” compaction only replaces the body, not the workflow rules.
 #[test]
 fn compacted_issue_prompt_still_includes_delivery_workflow() {
     // Build a compacted prompt body, then pass it through fresh_prompt_instruction
@@ -140,7 +139,7 @@ fn compacted_issue_prompt_still_includes_delivery_workflow() {
     );
 }
 
-// ── Compacted prompt stays under tmux pane limit ────────────────────────
+// â”€â”€ Compacted prompt stays under tmux pane limit â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// The compacted instruction (with workflow) must stay well under the tmux
 /// pane-command limit (~16,340 bytes). This is the core invariant that
@@ -154,14 +153,15 @@ fn compacted_prompt_with_workflow_stays_under_tmux_pane_limit() {
     let instruction = fresh_prompt_instruction(FreshPromptKind::Issue, &compacted_body);
 
     assert!(
-        instruction.len() < TMUX_PANE_COMMAND_LIMIT_BYTES,
-        "compacted issue instruction must stay under the tmux pane-command limit \
-         ({TMUX_PANE_COMMAND_LIMIT_BYTES} bytes), got {} bytes",
+        instruction.len() < jefe::runtime::pane_command_budget().bytes,
+        "compacted issue instruction must stay under the measured pane-command \
+         budget ({} bytes), got {} bytes",
+        jefe::runtime::pane_command_budget().bytes,
         instruction.len()
     );
 }
 
-// ── format_issue_prompt compacts large body ─────────────────────────────
+// â”€â”€ format_issue_prompt compacts large body â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// The issue prompt formatter must compact the body when it is large,
 /// replacing it with a preview + `gh issue view` reference, while keeping
@@ -249,7 +249,7 @@ fn format_issue_prompt_inlines_small_body() {
     );
 }
 
-// ── format_pr_prompt compacts large body ─────────────────────────────────
+// â”€â”€ format_pr_prompt compacts large body â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// The PR prompt formatter must compact the body when it is large, using
 /// `gh pr view` for the fetch reference.
@@ -355,5 +355,42 @@ fn format_pr_prompt_compacts_large_focused_comment() {
     assert!(
         prompt.contains("gh pr view 7 --repo owner/repo --comments"),
         "compacted PR comment must reference gh pr view:\n{prompt}"
+    );
+}
+
+// -- Budget derivation (issue #540 V4) ------------------------------------
+
+/// The prompt ceiling is derived from the measured pane-command budget, so a
+/// re-measurement moves it rather than silently invalidating it. The reserve
+/// covers the framing that shares the same command line.
+#[test]
+fn the_prompt_ceiling_is_derived_from_the_measured_budget() {
+    let budget = jefe::runtime::pane_command_budget().bytes;
+
+    assert!(
+        MAX_PROMPT_CONTENT_BYTES < budget,
+        "prompt ceiling {MAX_PROMPT_CONTENT_BYTES} must stay under the budget {budget}",
+    );
+    assert!(
+        budget - MAX_PROMPT_CONTENT_BYTES >= 4_000,
+        "the framing around the prompt needs headroom; budget {budget} leaves only {}",
+        budget - MAX_PROMPT_CONTENT_BYTES,
+    );
+}
+
+/// Compaction happens well before truncation, and both sit inside the budget.
+/// Sizing compaction against tmux was how a macOS measurement came to govern a
+/// Windows launch.
+#[test]
+fn compaction_engages_well_inside_the_budget() {
+    let budget = jefe::runtime::pane_command_budget().bytes;
+
+    // That compaction precedes truncation is already proven at compile time by
+    // the `const _` assertion above; what needs asserting here is the relation
+    // to the measured budget.
+    assert!(
+        PROMPT_COMPACTION_THRESHOLD_BYTES * 2 < budget,
+        "compaction must leave room for the framing it does not control: \
+         threshold {PROMPT_COMPACTION_THRESHOLD_BYTES}, budget {budget}",
     );
 }

--- a/src/app_input/prompt_compaction_tests.rs
+++ b/src/app_input/prompt_compaction_tests.rs
@@ -13,7 +13,7 @@ use super::fresh_prompt::{
     PROMPT_COMPACTION_THRESHOLD_BYTES, compact_prompt_content, fresh_prompt_instruction,
 };
 
-// â”€â”€ Threshold consistency â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Threshold consistency ────────────────────────────────────────────────
 
 /// The compaction threshold must be strictly less than the max-content budget
 /// so a prompt that is exactly at the threshold is NOT also truncated (which
@@ -23,7 +23,7 @@ const _: () = assert!(
     "compaction threshold must be strictly below max content bytes to prevent double-processing"
 );
 
-// â”€â”€ Large prompt produces compact reference â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Large prompt produces compact reference ──────────────────────────────
 
 /// A large prompt (content exceeds the threshold) must be compacted by
 /// `fresh_prompt_instruction`: the instruction must NOT contain the full body,
@@ -55,7 +55,7 @@ fn large_issue_prompt_produces_gh_fetch_reference() {
     );
 }
 
-// â”€â”€ Small prompt is inlined unchanged â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Small prompt is inlined unchanged ───────────────────────────────────
 
 /// A small prompt (under the threshold) must pass through `compact_prompt_content`
 /// unchanged.
@@ -88,7 +88,7 @@ fn large_pr_prompt_produces_gh_fetch_reference() {
     );
 }
 
-// â”€â”€ Threshold-boundary prompt â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Threshold-boundary prompt ────────────────────────────────────────────
 
 /// A prompt exactly at the threshold must be inlined (boundary inclusive).
 #[test]
@@ -118,10 +118,10 @@ fn prompt_one_byte_over_threshold_is_compacted() {
     );
 }
 
-// â”€â”€ Compaction preserves the issue delivery workflow â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Compaction preserves the issue delivery workflow ─────────────────────
 
 /// The ISSUE_DELIVERY_WORKFLOW appendix must still be appended for compacted
-/// issue prompts â€” compaction only replaces the body, not the workflow rules.
+/// issue prompts — compaction only replaces the body, not the workflow rules.
 #[test]
 fn compacted_issue_prompt_still_includes_delivery_workflow() {
     // Build a compacted prompt body, then pass it through fresh_prompt_instruction
@@ -139,7 +139,7 @@ fn compacted_issue_prompt_still_includes_delivery_workflow() {
     );
 }
 
-// â”€â”€ Compacted prompt stays under tmux pane limit â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Compacted prompt stays under tmux pane limit ────────────────────────
 
 /// The compacted instruction (with workflow) must stay well under the tmux
 /// pane-command limit (~16,340 bytes). This is the core invariant that
@@ -161,7 +161,7 @@ fn compacted_prompt_with_workflow_stays_under_tmux_pane_limit() {
     );
 }
 
-// â”€â”€ format_issue_prompt compacts large body â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── format_issue_prompt compacts large body ─────────────────────────────
 
 /// The issue prompt formatter must compact the body when it is large,
 /// replacing it with a preview + `gh issue view` reference, while keeping
@@ -249,7 +249,7 @@ fn format_issue_prompt_inlines_small_body() {
     );
 }
 
-// â”€â”€ format_pr_prompt compacts large body â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── format_pr_prompt compacts large body ─────────────────────────────────
 
 /// The PR prompt formatter must compact the body when it is large, using
 /// `gh pr view` for the fetch reference.

--- a/src/app_shell_liveness.rs
+++ b/src/app_shell_liveness.rs
@@ -17,7 +17,7 @@
 //! `Dead`, binding-clear, and durable-save path.
 
 #[cfg(windows)]
-use std::cell::Cell;
+use std::cell::RefCell;
 use std::collections::HashMap;
 
 use tracing::debug;
@@ -144,10 +144,10 @@ async fn handle_windows_cycle(
 ) {
     let observation = match MultiplexerPlan::current() {
         Ok(plan) => {
-            let prior = *pinned_prior;
-            let applied = *applied_exit_empty;
+            let prior = pinned_prior.clone();
+            let applied = applied_exit_empty.clone();
             let (observation, next_applied) = smol::unblock(move || {
-                let cell = Cell::new(applied);
+                let cell = RefCell::new(applied);
                 let observation = observe_server_liveness(&plan, prior.as_ref(), &cell);
                 (observation, cell.into_inner())
             })
@@ -163,7 +163,7 @@ async fn handle_windows_cycle(
 
     match observation {
         ServerLivenessObservation::Healthy(current) => {
-            *pinned_prior = current.or(*pinned_prior);
+            *pinned_prior = current.or_else(|| pinned_prior.clone());
             reconcile_healthy_agents(app_state, ctx, running_targets).await;
         }
         ServerLivenessObservation::Gone | ServerLivenessObservation::Replaced(_) => {

--- a/src/runtime/commands.rs
+++ b/src/runtime/commands.rs
@@ -136,9 +136,12 @@ fn multiplexer_cmd_status(plan: &MultiplexerPlan, args: &[&str]) -> Result<(), S
 }
 
 /// Prefix value that preserves `C-b`; Jefe intercepts F12 before forwarding.
+///
+/// Derived from the `reserved-prefix-key` divergence rather than spelled here,
+/// so the value and the psmux behaviour that forces it stay together (#540).
 #[must_use]
 const fn local_prefix_value() -> &'static str {
-    if cfg!(windows) { "F12" } else { "None" }
+    super::multiplexer_contract::prefix_value_for_platform(cfg!(windows))
 }
 
 #[cfg(test)]

--- a/src/runtime/commands_root_keys.rs
+++ b/src/runtime/commands_root_keys.rs
@@ -10,7 +10,11 @@
 use super::{local_prefix_value, prefix_options_for_passthrough};
 
 /// The root-table `PageUp` unbind command for transparent Page-key delivery.
-pub(super) const PAGE_UP_ROOT_UNBIND: &[&str] = &["unbind-key", "-T", "root", "PageUp"];
+///
+/// Defined by the declared divergence rather than spelled again here, so the
+/// remediation and the expectation it satisfies cannot drift apart (#540).
+pub(super) const PAGE_UP_ROOT_UNBIND: [&str; 4] =
+    crate::runtime::multiplexer_contract::PAGE_UP_ROOT_UNBIND_COMMAND;
 
 /// Configure multiplexer prefix keys and root-table bindings for transparent
 /// child input (#200, #260, #465).
@@ -40,7 +44,7 @@ pub(super) fn configure_prefix_with(
         }
     }
     if cfg!(windows) {
-        apply(PAGE_UP_ROOT_UNBIND)?;
+        apply(&PAGE_UP_ROOT_UNBIND)?;
     }
     Ok(())
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -135,8 +135,9 @@ pub use process::{
     classify_process_observation, process_liveness, process_liveness_indicates_alive,
 };
 pub use server_health::{
-    ServerHealth, ServerIdentity, ServerLivenessEvidence, ServerLivenessObservation,
-    classify_server_health, classify_server_liveness, parse_server_identity_output,
+    ServerHealth, ServerIdentity, ServerInstanceToken, ServerLivenessEvidence,
+    ServerLivenessObservation, classify_server_health, classify_server_liveness,
+    parse_server_identity_output,
 };
 pub use server_health_io::observe_server_liveness;
 pub use session::{RuntimeSession, TerminalCell, TerminalCellStyle, TerminalSnapshot};

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -49,6 +49,7 @@ mod manager;
 mod manager_identity;
 mod manager_passthrough;
 mod multiplexer;
+mod multiplexer_contract;
 /// Non-interactive (single-prompt, capture-stdout) agent execution (issue #214).
 mod non_interactive;
 mod orphan;
@@ -117,6 +118,10 @@ pub use manager::{
 pub use multiplexer::{
     AgentPaneLaunch, LocalPlatform, MultiplexerCapability, MultiplexerError, MultiplexerIsolation,
     MultiplexerPlan, MultiplexerVersion, ProbeObservation, classify_probe,
+};
+pub use multiplexer_contract::{
+    ContractCapability, ContractItem, ContractItemKind, ResponseShape, contract_item,
+    contract_items,
 };
 pub use non_interactive::{NON_INTERACTIVE_TIMEOUT, run_non_interactive};
 /// Descendant-process observation and validated orphan-tree reaping (issue #332).

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -122,10 +122,11 @@ pub use multiplexer::{
     MultiplexerPlan, MultiplexerVersion, ProbeObservation, classify_probe,
 };
 pub use multiplexer_conformance::{
-    ConformanceFinding, ConformanceReport, ConformanceVerdict, ProbeOutcome, ProbePlan,
-    classify_contract_probe, probe_plan_for, summarize_conformance,
+    ConformanceFinding, ConformanceReport, ConformanceVerdict, MultiplexerQualification,
+    ProbeOutcome, ProbePlan, classify_contract_probe, probe_plan_for, qualification_from_report,
+    summarize_conformance,
 };
-pub use multiplexer_conformance_io::qualify_multiplexer;
+pub use multiplexer_conformance_io::{qualify_multiplexer, qualify_multiplexer_for_startup};
 pub use multiplexer_contract::{
     ContractCapability, ContractItem, ContractItemKind, ResponseShape, contract_item,
     contract_items,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -49,6 +49,8 @@ mod manager;
 mod manager_identity;
 mod manager_passthrough;
 mod multiplexer;
+mod multiplexer_conformance;
+mod multiplexer_conformance_io;
 mod multiplexer_contract;
 /// Non-interactive (single-prompt, capture-stdout) agent execution (issue #214).
 mod non_interactive;
@@ -119,6 +121,11 @@ pub use multiplexer::{
     AgentPaneLaunch, LocalPlatform, MultiplexerCapability, MultiplexerError, MultiplexerIsolation,
     MultiplexerPlan, MultiplexerVersion, ProbeObservation, classify_probe,
 };
+pub use multiplexer_conformance::{
+    ConformanceFinding, ConformanceReport, ConformanceVerdict, ProbeOutcome, ProbePlan,
+    classify_contract_probe, probe_plan_for, summarize_conformance,
+};
+pub use multiplexer_conformance_io::qualify_multiplexer;
 pub use multiplexer_contract::{
     ContractCapability, ContractItem, ContractItemKind, ResponseShape, contract_item,
     contract_items,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -125,8 +125,8 @@ pub use multiplexer::{
 };
 pub use multiplexer_conformance::{
     ConformanceFinding, ConformanceReport, ConformanceVerdict, MultiplexerQualification,
-    ProbeOutcome, ProbePlan, classify_contract_probe, probe_plan_for, qualification_from_report,
-    summarize_conformance,
+    ProbeOutcome, ProbePlan, classify_contract_probe, probe_ordered_items, probe_plan_for,
+    probe_rank, qualification_from_report, summarize_conformance,
 };
 pub use multiplexer_conformance_io::{
     fingerprint_multiplexer, qualify_multiplexer, qualify_multiplexer_for_startup,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -131,6 +131,10 @@ pub use multiplexer_contract::{
     ContractCapability, ContractItem, ContractItemKind, ResponseShape, contract_item,
     contract_items,
 };
+pub use multiplexer_contract::{
+    Divergence, declared_divergences, divergence, exit_empty_remediation, page_up_root_unbind,
+    psmux_session_routing_vars,
+};
 pub use non_interactive::{NON_INTERACTIVE_TIMEOUT, run_non_interactive};
 /// Descendant-process observation and validated orphan-tree reaping (issue #332).
 pub use orphan::{

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -128,8 +128,8 @@ pub use multiplexer_conformance::{
 };
 pub use multiplexer_conformance_io::{qualify_multiplexer, qualify_multiplexer_for_startup};
 pub use multiplexer_contract::{
-    ContractCapability, ContractItem, ContractItemKind, ResponseShape, contract_item,
-    contract_items,
+    BudgetSource, ContractCapability, ContractItem, ContractItemKind, PaneCommandBudget,
+    ResponseShape, contract_item, contract_items, pane_command_budget,
 };
 pub use multiplexer_contract::{
     Divergence, declared_divergences, divergence, exit_empty_remediation, page_up_root_unbind,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -61,6 +61,8 @@ pub mod package_runtime;
 mod pane_capture;
 mod preflight;
 mod process;
+/// SHA256 provenance verification for the multiplexer binary (issue #540).
+pub mod provenance;
 /// Pure server-health classification contract (issue #493 Slice 1).
 mod server_health;
 mod server_health_io;
@@ -126,14 +128,16 @@ pub use multiplexer_conformance::{
     ProbeOutcome, ProbePlan, classify_contract_probe, probe_plan_for, qualification_from_report,
     summarize_conformance,
 };
-pub use multiplexer_conformance_io::{qualify_multiplexer, qualify_multiplexer_for_startup};
+pub use multiplexer_conformance_io::{
+    fingerprint_multiplexer, qualify_multiplexer, qualify_multiplexer_for_startup,
+};
 pub use multiplexer_contract::{
     BudgetSource, ContractCapability, ContractItem, ContractItemKind, PaneCommandBudget,
     ResponseShape, contract_item, contract_items, pane_command_budget,
 };
 pub use multiplexer_contract::{
     Divergence, declared_divergences, divergence, exit_empty_remediation, page_up_root_unbind,
-    psmux_session_routing_vars,
+    prefix_value_for_platform, psmux_session_routing_vars,
 };
 pub use non_interactive::{NON_INTERACTIVE_TIMEOUT, run_non_interactive};
 /// Descendant-process observation and validated orphan-tree reaping (issue #332).
@@ -150,6 +154,10 @@ pub use preflight::{
 pub use process::{
     ProcessIdentityError, ProcessLiveness, ProcessObservation, capture_process_identity,
     classify_process_observation, process_liveness, process_liveness_indicates_alive,
+};
+pub use provenance::{
+    BinaryFingerprint, PINNED_PSMUX_ARCHIVE_SHA256, ProvenanceManifest, ProvenanceVerdict,
+    sha256_hex,
 };
 pub use server_health::{
     ServerHealth, ServerIdentity, ServerInstanceToken, ServerLivenessEvidence,

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -208,6 +208,18 @@ impl MultiplexerPlan {
         &self.executable
     }
 
+    /// Derive a plan for the same binary against different isolation.
+    ///
+    /// Contract conformance probing needs a namespace it owns outright, so that
+    /// verbs which would be destructive against live agents are exercised only
+    /// on sessions the prober created (issue #540).
+    pub fn with_isolation(
+        &self,
+        isolation: MultiplexerIsolation,
+    ) -> Result<Self, MultiplexerError> {
+        Self::for_platform(self.platform, self.executable.clone(), isolation)
+    }
+
     /// Return the platform-correct arguments prepended to every local command.
     #[must_use]
     pub fn base_args(&self) -> &[OsString] {

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -24,7 +24,7 @@ const UNIX_INSTALL_GUIDANCE: &str =
 /// base args already carry `-f NUL`. `pub(super)` so the local attach command
 /// builder can share the exact same list instead of duplicating it.
 pub(super) const PSMUX_INHERITED_SESSION_VARS: [&str; 2] =
-    ["PSMUX_SESSION", "PSMUX_TARGET_SESSION"];
+    super::multiplexer_contract::PSMUX_SESSION_ROUTING_VARS;
 
 /// Local operating-system policy used to select a multiplexer implementation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/runtime/multiplexer_conformance.rs
+++ b/src/runtime/multiplexer_conformance.rs
@@ -12,6 +12,9 @@
 //! absence would let jefe run against something that is not the multiplexer it
 //! needs. Both mistakes are silent, so the difference is encoded in types.
 
+use std::fmt::Write as _;
+use std::path::Path;
+
 use super::multiplexer_contract::{
     ContractCapability, ContractItem, ContractItemKind, ResponseShape,
 };
@@ -104,7 +107,7 @@ pub enum ProbePlan {
 ///
 /// Every returned command targets `scratch_session` explicitly. The runner
 /// creates and destroys its own namespace, so verbs that would be destructive
-/// against live agent state — `kill-session`, `kill-server`, `send-keys` — are
+/// against live agent state Ã¢â‚¬â€ `kill-session`, `kill-server`, `send-keys` Ã¢â‚¬â€ are
 /// safe here precisely because they never address the caller's namespace.
 #[must_use]
 pub fn probe_plan_for(item: &ContractItem, scratch_session: &str) -> ProbePlan {
@@ -280,4 +283,65 @@ fn describe_stderr(stderr: &str) -> String {
     } else {
         trimmed.to_owned()
     }
+}
+
+/// The outcome of qualifying a multiplexer binary at startup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MultiplexerQualification {
+    /// The binary honours every required item. The report is retained so
+    /// callers can degrade against capabilities it lacks.
+    Qualified { report: ConformanceReport },
+    /// The binary may not be used, with the operator-facing explanation.
+    Refused { message: String },
+}
+
+/// Environment variable that points jefe at a specific multiplexer build.
+const OVERRIDE_VARIABLE: &str = "JEFE_PSMUX_BIN";
+
+/// Turn a conformance report into a startup decision.
+///
+/// jefe does not ship or install psmux, so when it refuses to run the message
+/// is the entire remedy the operator receives. It therefore names the binary
+/// rejected, the version found there, every failing requirement, and how to
+/// supply a working build.
+#[must_use]
+pub fn qualification_from_report(
+    executable: &Path,
+    version: Option<String>,
+    report: ConformanceReport,
+) -> MultiplexerQualification {
+    if report.is_qualified() {
+        return MultiplexerQualification::Qualified { report };
+    }
+
+    let mut message = format!(
+        "the multiplexer at {} does not meet jefe's requirements.\n  version found: {}\n",
+        executable.display(),
+        version.unwrap_or_else(|| "unknown (the binary did not report one)".to_owned()),
+    );
+
+    message.push_str("  failing requirements:\n");
+    for violation in report.violations() {
+        let kind = match violation.kind {
+            ContractItemKind::Verb => "command",
+            ContractItemKind::Format => "format",
+            ContractItemKind::ServerOption => "server option",
+        };
+        let detail = match &violation.verdict {
+            ConformanceVerdict::Violated { detail } => detail.as_str(),
+            // Only violations are listed: a capability the build merely
+            // predates is not a defect, and naming it would send the operator
+            // after a fault that does not exist.
+            _ => continue,
+        };
+        let _ = writeln!(message, "    - {kind} `{}`: {detail}", violation.name);
+    }
+
+    let _ = write!(
+        message,
+        "  remedy: install a psmux build that satisfies the requirements above, \
+         or set {OVERRIDE_VARIABLE} to the full path of one.",
+    );
+
+    MultiplexerQualification::Refused { message }
 }

--- a/src/runtime/multiplexer_conformance.rs
+++ b/src/runtime/multiplexer_conformance.rs
@@ -51,7 +51,11 @@ pub struct ConformanceFinding {
 }
 
 /// The result of probing a binary against the whole contract surface.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// The default is an empty report: nothing probed, so nothing found. It is not
+/// a passing result, and `is_qualified` treats it as such only because an
+/// absence of violations is all that can be said about an absence of probes.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ConformanceReport {
     findings: Vec<ConformanceFinding>,
 }

--- a/src/runtime/multiplexer_conformance.rs
+++ b/src/runtime/multiplexer_conformance.rs
@@ -109,12 +109,21 @@ pub enum ProbePlan {
 
 /// Decide how to probe one item inside a throwaway namespace.
 ///
-/// Every returned command targets `scratch_session` explicitly. The runner
-/// creates and destroys its own namespace, so verbs that would be destructive
-/// against live agent state Ã¢â‚¬â€ `kill-session`, `kill-server`, `send-keys` Ã¢â‚¬â€ are
-/// safe here precisely because they never address the caller's namespace.
+/// Commands target `scratch_session`, the session the runner brings up and
+/// leaves standing for the duration of the check. The lifecycle verbs are the
+/// exception: `new-session` and `kill-session` address `disposable_session`
+/// instead, so creating one does not collide with the session already standing
+/// and destroying one does not pull the floor out from under later probes.
+///
+/// Namespace isolation keeps these verbs away from the caller's agents. It does
+/// not make them harmless to the run itself, which is a separate problem and
+/// was originally conflated with the first.
 #[must_use]
-pub fn probe_plan_for(item: &ContractItem, scratch_session: &str) -> ProbePlan {
+pub fn probe_plan_for(
+    item: &ContractItem,
+    scratch_session: &str,
+    disposable_session: &str,
+) -> ProbePlan {
     match item.kind {
         ContractItemKind::Format => ProbePlan::Command {
             args: vec![
@@ -132,11 +141,11 @@ pub fn probe_plan_for(item: &ContractItem, scratch_session: &str) -> ProbePlan {
                 item.name.to_owned(),
             ],
         },
-        ContractItemKind::Verb => verb_probe_plan(item.name, scratch_session),
+        ContractItemKind::Verb => verb_probe_plan(item.name, scratch_session, disposable_session),
     }
 }
 
-fn verb_probe_plan(name: &str, scratch_session: &str) -> ProbePlan {
+fn verb_probe_plan(name: &str, scratch_session: &str, disposable_session: &str) -> ProbePlan {
     let target = || vec!["-t".to_owned(), scratch_session.to_owned()];
     let with = |verb: &str, rest: Vec<String>| {
         let mut args = vec![verb.to_owned()];
@@ -183,15 +192,54 @@ fn verb_probe_plan(name: &str, scratch_session: &str) -> ProbePlan {
                 String::new(),
             ],
         ),
-        // Safe only because the runner owns this namespace outright.
-        "kill-session" => with("kill-session", target()),
+        // Kills the session `new-session` just made, never the one the rest of
+        // the probes depend on.
+        "kill-session" => with(
+            "kill-session",
+            vec!["-t".to_owned(), disposable_session.to_owned()],
+        ),
+        // Ends the namespace outright, so the runner probes it last.
         "kill-server" => with("kill-server", vec![]),
         "new-session" => with(
             "new-session",
-            vec!["-d".to_owned(), "-s".to_owned(), scratch_session.to_owned()],
+            vec![
+                "-d".to_owned(),
+                "-s".to_owned(),
+                disposable_session.to_owned(),
+            ],
         ),
         other => with(other, vec![]),
     }
+}
+
+/// When an item may be probed, relative to the others.
+///
+/// Probing is otherwise declaration-ordered. These verbs dismantle the very
+/// environment the remaining probes need, so running them in place made every
+/// later item fail with "no server running" and reported twenty violations for
+/// one ordering mistake.
+#[must_use]
+pub fn probe_rank(item: &ContractItem) -> u8 {
+    match item.name {
+        // Depends on the session `new-session` created.
+        "kill-session" => 1,
+        // Ends the namespace; nothing can be probed afterwards.
+        "kill-server" => 2,
+        _ => 0,
+    }
+}
+
+/// The contract surface in the order it is safe to probe.
+///
+/// A stable sort, so declaration order still governs everything that has no
+/// ordering constraint of its own.
+#[must_use]
+pub fn probe_ordered_items() -> Vec<&'static ContractItem> {
+    let mut items: Vec<&'static ContractItem> = super::multiplexer_contract::contract_items()
+        .iter()
+        .collect();
+    items.sort_by_key(|item| probe_rank(item));
+    items
 }
 
 /// Classify one probe against the item it was gathered for.
@@ -222,7 +270,28 @@ pub fn classify_contract_probe(item: &ContractItem, outcome: &ProbeOutcome) -> C
         // is a legitimate one. `has-session` returning non-zero means the
         // session is absent, not that the verb is unsupported.
         ResponseShape::ExitStatusOnly => ConformanceVerdict::Satisfied,
+        // A verb declared to produce no output is judged by whether it
+        // succeeded. Requiring stdout from `kill-session` or `new-window`
+        // condemns every correct implementation for behaving as declared.
+        ResponseShape::NoOutput => classify_silent(item, exit_code, outcome),
         _ => classify_output(item, exit_code, outcome),
+    }
+}
+
+fn classify_silent(
+    item: &ContractItem,
+    exit_code: i32,
+    outcome: &ProbeOutcome,
+) -> ConformanceVerdict {
+    if exit_code == 0 {
+        return ConformanceVerdict::Satisfied;
+    }
+    ConformanceVerdict::Violated {
+        detail: format!(
+            "probing `{}` exited {exit_code}: {}",
+            item.name,
+            describe_stderr(&outcome.stderr),
+        ),
     }
 }
 

--- a/src/runtime/multiplexer_conformance.rs
+++ b/src/runtime/multiplexer_conformance.rs
@@ -180,7 +180,14 @@ fn verb_probe_plan(name: &str, scratch_session: &str, disposable_session: &str) 
         ),
         "unbind-key" => with("unbind-key", vec!["-T".to_owned(), "root".to_owned()]),
         "select-window" => with("select-window", target()),
-        "new-window" => with("new-window", vec!["-d".to_owned()]),
+        // Targeted like every other session-scoped verb. Untargeted it lands in
+        // whatever session the multiplexer considers current, which during the
+        // run is whichever session was touched last rather than a session the
+        // probe chose.
+        "new-window" => with(
+            "new-window",
+            vec!["-d".to_owned(), "-t".to_owned(), scratch_session.to_owned()],
+        ),
         // An empty literal key sequence: exercises the verb without typing
         // anything into the pane.
         "send-keys" => with(

--- a/src/runtime/multiplexer_conformance.rs
+++ b/src/runtime/multiplexer_conformance.rs
@@ -1,0 +1,283 @@
+//! Classifying a multiplexer's answers against the declared contract
+//! (issue #540).
+//!
+//! Deliberately free of I/O: probes are executed at the boundary and the
+//! results classified here, so every verdict is reachable in a test without a
+//! live binary.
+//!
+//! The distinction this module exists to preserve is between *absent* and
+//! *wrong*. A psmux predating upstream#509 renders `#{server_instance}` as
+//! empty text and still exits zero. Treating that as a violation would reject
+//! every released build; treating a required format's empty answer as an
+//! absence would let jefe run against something that is not the multiplexer it
+//! needs. Both mistakes are silent, so the difference is encoded in types.
+
+use super::multiplexer_contract::{
+    ContractCapability, ContractItem, ContractItemKind, ResponseShape,
+};
+
+/// What a probe of the multiplexer produced.
+///
+/// `exit_code` is `None` when the process could not be run or was terminated by
+/// a signal, which is never evidence about an optional capability.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProbeOutcome {
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// The verdict for one contract item.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConformanceVerdict {
+    /// The multiplexer honours the item.
+    Satisfied,
+    /// A capability-gated item this build predates. Qualification still passes;
+    /// callers must degrade rather than assume the item is present.
+    Unsupported,
+    /// The multiplexer failed to honour a required item.
+    Violated { detail: String },
+}
+
+/// One item's outcome, retained for reporting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConformanceFinding {
+    pub kind: ContractItemKind,
+    pub name: &'static str,
+    pub verdict: ConformanceVerdict,
+}
+
+/// The result of probing a binary against the whole contract surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConformanceReport {
+    findings: Vec<ConformanceFinding>,
+}
+
+impl ConformanceReport {
+    /// Whether the binary may be used at all.
+    ///
+    /// Unsupported optional items do not disqualify a build; they reduce what
+    /// jefe may rely on.
+    #[must_use]
+    pub fn is_qualified(&self) -> bool {
+        self.violations().is_empty()
+    }
+
+    /// Every item the binary failed to honour, for an actionable refusal.
+    #[must_use]
+    pub fn violations(&self) -> Vec<&ConformanceFinding> {
+        self.findings
+            .iter()
+            .filter(|finding| matches!(finding.verdict, ConformanceVerdict::Violated { .. }))
+            .collect()
+    }
+
+    /// Whether a named item is actually available on this binary.
+    ///
+    /// An item that was never probed is reported as unavailable rather than
+    /// assumed present, so a caller cannot depend on evidence not gathered.
+    #[must_use]
+    pub fn supports(&self, name: &str) -> bool {
+        self.findings
+            .iter()
+            .any(|finding| finding.name == name && finding.verdict == ConformanceVerdict::Satisfied)
+    }
+
+    #[must_use]
+    pub fn findings(&self) -> &[ConformanceFinding] {
+        &self.findings
+    }
+}
+
+/// How an item is to be probed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbePlan {
+    /// Arguments to run against the throwaway conformance namespace.
+    Command { args: Vec<String> },
+    /// Needs a controlling terminal, so it cannot be exercised
+    /// non-interactively. Its availability is established when the dashboard
+    /// attaches rather than by a probe that would block forever.
+    RequiresTerminal,
+}
+
+/// Decide how to probe one item inside a throwaway namespace.
+///
+/// Every returned command targets `scratch_session` explicitly. The runner
+/// creates and destroys its own namespace, so verbs that would be destructive
+/// against live agent state — `kill-session`, `kill-server`, `send-keys` — are
+/// safe here precisely because they never address the caller's namespace.
+#[must_use]
+pub fn probe_plan_for(item: &ContractItem, scratch_session: &str) -> ProbePlan {
+    match item.kind {
+        ContractItemKind::Format => ProbePlan::Command {
+            args: vec![
+                "display-message".to_owned(),
+                "-p".to_owned(),
+                "-t".to_owned(),
+                scratch_session.to_owned(),
+                format!("#{{{}}}", item.name),
+            ],
+        },
+        ContractItemKind::ServerOption => ProbePlan::Command {
+            args: vec![
+                "show-options".to_owned(),
+                "-s".to_owned(),
+                item.name.to_owned(),
+            ],
+        },
+        ContractItemKind::Verb => verb_probe_plan(item.name, scratch_session),
+    }
+}
+
+fn verb_probe_plan(name: &str, scratch_session: &str) -> ProbePlan {
+    let target = || vec!["-t".to_owned(), scratch_session.to_owned()];
+    let with = |verb: &str, rest: Vec<String>| {
+        let mut args = vec![verb.to_owned()];
+        args.extend(rest);
+        ProbePlan::Command { args }
+    };
+
+    match name {
+        // Attaching needs a TTY and would block a non-interactive probe.
+        "attach-session" => ProbePlan::RequiresTerminal,
+        "has-session" => with("has-session", target()),
+        "list-sessions" => with("list-sessions", vec![]),
+        "list-panes" => with("list-panes", target()),
+        "list-windows" => with("list-windows", target()),
+        "display-message" => with(
+            "display-message",
+            vec![
+                "-p".to_owned(),
+                "-t".to_owned(),
+                scratch_session.to_owned(),
+                "#{session_name}".to_owned(),
+            ],
+        ),
+        "capture-pane" => with(
+            "capture-pane",
+            vec!["-p".to_owned(), "-t".to_owned(), scratch_session.to_owned()],
+        ),
+        "show-options" => with("show-options", vec!["-s".to_owned()]),
+        "set-option" => with(
+            "set-option",
+            vec!["-s".to_owned(), "exit-empty".to_owned(), "off".to_owned()],
+        ),
+        "unbind-key" => with("unbind-key", vec!["-T".to_owned(), "root".to_owned()]),
+        "select-window" => with("select-window", target()),
+        "new-window" => with("new-window", vec!["-d".to_owned()]),
+        // An empty literal key sequence: exercises the verb without typing
+        // anything into the pane.
+        "send-keys" => with(
+            "send-keys",
+            vec![
+                "-t".to_owned(),
+                scratch_session.to_owned(),
+                "-l".to_owned(),
+                String::new(),
+            ],
+        ),
+        // Safe only because the runner owns this namespace outright.
+        "kill-session" => with("kill-session", target()),
+        "kill-server" => with("kill-server", vec![]),
+        "new-session" => with(
+            "new-session",
+            vec!["-d".to_owned(), "-s".to_owned(), scratch_session.to_owned()],
+        ),
+        other => with(other, vec![]),
+    }
+}
+
+/// Classify one probe against the item it was gathered for.
+#[must_use]
+pub fn classify_contract_probe(item: &ContractItem, outcome: &ProbeOutcome) -> ConformanceVerdict {
+    let Some(exit_code) = outcome.exit_code else {
+        return ConformanceVerdict::Violated {
+            detail: format!(
+                "the multiplexer could not be executed while probing `{}`: {}",
+                item.name,
+                describe_stderr(&outcome.stderr),
+            ),
+        };
+    };
+
+    if mentions_unknown_command(&outcome.stderr) {
+        return ConformanceVerdict::Violated {
+            detail: format!(
+                "the multiplexer does not recognise `{}`: {}",
+                item.name,
+                describe_stderr(&outcome.stderr),
+            ),
+        };
+    }
+
+    match item.response {
+        // The exit status *is* the answer, so any status the binary understood
+        // is a legitimate one. `has-session` returning non-zero means the
+        // session is absent, not that the verb is unsupported.
+        ResponseShape::ExitStatusOnly => ConformanceVerdict::Satisfied,
+        _ => classify_output(item, exit_code, outcome),
+    }
+}
+
+fn classify_output(
+    item: &ContractItem,
+    exit_code: i32,
+    outcome: &ProbeOutcome,
+) -> ConformanceVerdict {
+    if exit_code != 0 {
+        return ConformanceVerdict::Violated {
+            detail: format!(
+                "probing `{}` exited {exit_code}: {}",
+                item.name,
+                describe_stderr(&outcome.stderr),
+            ),
+        };
+    }
+
+    if !outcome.stdout.trim().is_empty() {
+        return ConformanceVerdict::Satisfied;
+    }
+
+    // An empty render is the documented way an older multiplexer reports an
+    // unknown format variable: it substitutes nothing and still succeeds.
+    match item.capability {
+        ContractCapability::SincePsmuxNamespaceToken => ConformanceVerdict::Unsupported,
+        ContractCapability::Always => ConformanceVerdict::Violated {
+            detail: format!(
+                "`{}` is required but the multiplexer rendered it as empty",
+                item.name,
+            ),
+        },
+    }
+}
+
+/// Collect classified items into a report.
+#[must_use]
+pub fn summarize_conformance(
+    findings: impl IntoIterator<Item = (&'static ContractItem, ConformanceVerdict)>,
+) -> ConformanceReport {
+    ConformanceReport {
+        findings: findings
+            .into_iter()
+            .map(|(item, verdict)| ConformanceFinding {
+                kind: item.kind,
+                name: item.name,
+                verdict,
+            })
+            .collect(),
+    }
+}
+
+fn mentions_unknown_command(stderr: &str) -> bool {
+    let lowered = stderr.to_ascii_lowercase();
+    lowered.contains("unknown command") || lowered.contains("ambiguous command")
+}
+
+fn describe_stderr(stderr: &str) -> String {
+    let trimmed = stderr.trim();
+    if trimmed.is_empty() {
+        "no diagnostic output".to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}

--- a/src/runtime/multiplexer_conformance.rs
+++ b/src/runtime/multiplexer_conformance.rs
@@ -273,7 +273,15 @@ pub fn classify_contract_probe(item: &ContractItem, outcome: &ProbeOutcome) -> C
         // A verb declared to produce no output is judged by whether it
         // succeeded. Requiring stdout from `kill-session` or `new-window`
         // condemns every correct implementation for behaving as declared.
-        ResponseShape::NoOutput => classify_silent(item, exit_code, outcome),
+        //
+        // Pane content is the same case for a different reason: what
+        // `capture-pane` prints belongs to the pane, not to the multiplexer. A
+        // freshly created pane has produced nothing yet, so demanding output
+        // tests how fast a shell draws its prompt rather than whether the verb
+        // works.
+        ResponseShape::NoOutput | ResponseShape::RawPaneContent => {
+            classify_silent(item, exit_code, outcome)
+        }
         _ => classify_output(item, exit_code, outcome),
     }
 }

--- a/src/runtime/multiplexer_conformance_io.rs
+++ b/src/runtime/multiplexer_conformance_io.rs
@@ -11,7 +11,7 @@
 //! session the runner has already brought up. Both are handled explicitly --
 //! lifecycle verbs address their own disposable session, and are probed last.
 
-use std::process::Stdio;
+use std::process::{Command, Stdio};
 
 use super::liveness::run_tmux_with_timeout;
 use super::multiplexer_conformance::{
@@ -58,12 +58,32 @@ fn run_contract_probes(plan: &MultiplexerPlan) -> ConformanceReport {
     summarize_conformance(findings)
 }
 
-fn execute_probe(plan: &MultiplexerPlan, args: &[String]) -> ProbeOutcome {
+/// Client variables a multiplexer uses to detect that it is being run from
+/// inside one of its own panes.
+///
+/// jefe scrubs these everywhere else it invokes the multiplexer (#171). The
+/// conformance runner did not, so when jefe itself started inside a pane the
+/// probes inherited them and the multiplexer refused to nest -- reporting the
+/// binary as non-conforming for correctly declining to create a session inside
+/// itself. Qualification must ask the same question jefe will ask later, in the
+/// same environment.
+const NESTING_VARS_TO_SCRUB: &[&str] = &["TMUX", "TMUX_PANE", "TMUX_TMPDIR"];
+
+/// Build the command one probe runs, with the nesting variables scrubbed.
+fn probe_command(plan: &MultiplexerPlan, args: &[String]) -> Command {
     let mut command = plan.command();
     command
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    for variable in NESTING_VARS_TO_SCRUB {
+        command.env_remove(variable);
+    }
+    command
+}
+
+fn execute_probe(plan: &MultiplexerPlan, args: &[String]) -> ProbeOutcome {
+    let mut command = probe_command(plan, args);
 
     match run_tmux_with_timeout(&mut command) {
         Ok(output) => ProbeOutcome {
@@ -185,4 +205,29 @@ fn conformance_namespace() -> String {
 #[must_use]
 pub fn fingerprint_multiplexer(plan: &MultiplexerPlan) -> Option<BinaryFingerprint> {
     BinaryFingerprint::measure(plan.executable()).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NESTING_VARS_TO_SCRUB, probe_command};
+    use crate::runtime::MultiplexerPlan;
+
+    /// jefe may itself be started from inside a multiplexer pane. A probe that
+    /// inherited the client variables would make the multiplexer refuse to
+    /// nest, and qualification would condemn a correct binary for correctly
+    /// declining to create a session inside itself (#171, #540).
+    #[test]
+    fn probes_do_not_inherit_the_pane_jefe_was_launched_from() {
+        let Ok(plan) = MultiplexerPlan::current() else {
+            return;
+        };
+        let command = probe_command(&plan, &["list-sessions".to_owned()]);
+
+        for variable in NESTING_VARS_TO_SCRUB {
+            let removed = command
+                .get_envs()
+                .any(|(key, value)| key == std::ffi::OsStr::new(variable) && value.is_none());
+            assert!(removed, "{variable} is not scrubbed from probe commands");
+        }
+    }
 }

--- a/src/runtime/multiplexer_conformance_io.rs
+++ b/src/runtime/multiplexer_conformance_io.rs
@@ -11,7 +11,7 @@
 //! session the runner has already brought up. Both are handled explicitly --
 //! lifecycle verbs address their own disposable session, and are probed last.
 
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 use super::liveness::run_tmux_with_timeout;
 use super::multiplexer_conformance::{
@@ -58,32 +58,12 @@ fn run_contract_probes(plan: &MultiplexerPlan) -> ConformanceReport {
     summarize_conformance(findings)
 }
 
-/// Client variables a multiplexer uses to detect that it is being run from
-/// inside one of its own panes.
-///
-/// jefe scrubs these everywhere else it invokes the multiplexer (#171). The
-/// conformance runner did not, so when jefe itself started inside a pane the
-/// probes inherited them and the multiplexer refused to nest -- reporting the
-/// binary as non-conforming for correctly declining to create a session inside
-/// itself. Qualification must ask the same question jefe will ask later, in the
-/// same environment.
-const NESTING_VARS_TO_SCRUB: &[&str] = &["TMUX", "TMUX_PANE", "TMUX_TMPDIR"];
-
-/// Build the command one probe runs, with the nesting variables scrubbed.
-fn probe_command(plan: &MultiplexerPlan, args: &[String]) -> Command {
+fn execute_probe(plan: &MultiplexerPlan, args: &[String]) -> ProbeOutcome {
     let mut command = plan.command();
     command
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    for variable in NESTING_VARS_TO_SCRUB {
-        command.env_remove(variable);
-    }
-    command
-}
-
-fn execute_probe(plan: &MultiplexerPlan, args: &[String]) -> ProbeOutcome {
-    let mut command = probe_command(plan, args);
 
     match run_tmux_with_timeout(&mut command) {
         Ok(output) => ProbeOutcome {
@@ -205,29 +185,4 @@ fn conformance_namespace() -> String {
 #[must_use]
 pub fn fingerprint_multiplexer(plan: &MultiplexerPlan) -> Option<BinaryFingerprint> {
     BinaryFingerprint::measure(plan.executable()).ok()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{NESTING_VARS_TO_SCRUB, probe_command};
-    use crate::runtime::MultiplexerPlan;
-
-    /// jefe may itself be started from inside a multiplexer pane. A probe that
-    /// inherited the client variables would make the multiplexer refuse to
-    /// nest, and qualification would condemn a correct binary for correctly
-    /// declining to create a session inside itself (#171, #540).
-    #[test]
-    fn probes_do_not_inherit_the_pane_jefe_was_launched_from() {
-        let Ok(plan) = MultiplexerPlan::current() else {
-            return;
-        };
-        let command = probe_command(&plan, &["list-sessions".to_owned()]);
-
-        for variable in NESTING_VARS_TO_SCRUB {
-            let removed = command
-                .get_envs()
-                .any(|(key, value)| key == std::ffi::OsStr::new(variable) && value.is_none());
-            assert!(removed, "{variable} is not scrubbed from probe commands");
-        }
-    }
 }

--- a/src/runtime/multiplexer_conformance_io.rs
+++ b/src/runtime/multiplexer_conformance_io.rs
@@ -10,8 +10,8 @@ use std::process::Stdio;
 
 use super::liveness::run_tmux_with_timeout;
 use super::multiplexer_conformance::{
-    ConformanceReport, ConformanceVerdict, ProbeOutcome, ProbePlan, classify_contract_probe,
-    probe_plan_for, summarize_conformance,
+    ConformanceReport, ConformanceVerdict, MultiplexerQualification, ProbeOutcome, ProbePlan,
+    classify_contract_probe, probe_plan_for, qualification_from_report, summarize_conformance,
 };
 use super::multiplexer_contract::{ContractItem, contract_items};
 use super::{MultiplexerIsolation, MultiplexerPlan};
@@ -101,6 +101,36 @@ pub fn qualify_multiplexer(plan: &MultiplexerPlan) -> ConformanceReport {
     let _ = execute_probe(&scratch, &["kill-server".to_owned()]);
 
     report
+}
+
+/// Qualify the multiplexer jefe is about to use, at startup.
+///
+/// Returns the report when the binary may be used, or an operator-facing
+/// refusal naming the binary, the version found, every failing requirement and
+/// the remedy. jefe neither ships nor installs psmux, so this message is the
+/// whole of what an operator gets to act on.
+///
+/// The probe runs against the resolved binary, which honours the
+/// `JEFE_PSMUX_BIN` override: pointing jefe at a specific build changes which
+/// binary is qualified, never whether qualification applies.
+#[must_use]
+pub fn qualify_multiplexer_for_startup(plan: &MultiplexerPlan) -> MultiplexerQualification {
+    let report = qualify_multiplexer(plan);
+    qualification_from_report(plan.executable(), probe_version(plan), report)
+}
+
+/// Ask the binary for its version, for the refusal message.
+///
+/// A binary too broken to answer yields `None`, which the refusal reports as
+/// unknown rather than implying a version it never observed.
+fn probe_version(plan: &MultiplexerPlan) -> Option<String> {
+    let outcome = execute_probe(plan, &["-V".to_owned()]);
+    let reported = outcome.stdout.trim();
+    if outcome.exit_code == Some(0) && !reported.is_empty() {
+        Some(reported.to_owned())
+    } else {
+        None
+    }
 }
 
 /// Derive a plan addressing isolation reserved for conformance probing.

--- a/src/runtime/multiplexer_conformance_io.rs
+++ b/src/runtime/multiplexer_conformance_io.rs
@@ -1,0 +1,127 @@
+//! Executing the declared contract against a real multiplexer binary
+//! (issue #540).
+//!
+//! The runner owns a throwaway `-L` namespace for the duration of the check and
+//! destroys it afterwards. That isolation is what makes probing otherwise
+//! destructive verbs safe: `kill-session` and `kill-server` are exercised
+//! against sessions the runner created, never against the caller's agents.
+
+use std::process::Stdio;
+
+use super::liveness::run_tmux_with_timeout;
+use super::multiplexer_conformance::{
+    ConformanceReport, ConformanceVerdict, ProbeOutcome, ProbePlan, classify_contract_probe,
+    probe_plan_for, summarize_conformance,
+};
+use super::multiplexer_contract::{ContractItem, contract_items};
+use super::{MultiplexerIsolation, MultiplexerPlan};
+
+/// Session created inside the throwaway namespace for session-addressed probes.
+const SCRATCH_SESSION: &str = "jefe-conformance";
+
+/// Probe `plan`'s binary against the whole declared contract surface.
+///
+/// `plan` must already address an isolated namespace reserved for this check;
+/// [`qualify_multiplexer`] is the entry point that arranges that.
+fn run_contract_probes(plan: &MultiplexerPlan) -> ConformanceReport {
+    let findings: Vec<(&'static ContractItem, ConformanceVerdict)> = contract_items()
+        .iter()
+        .map(|item| {
+            let verdict = match probe_plan_for(item, SCRATCH_SESSION) {
+                // Attaching needs a controlling terminal. Reporting it as
+                // satisfied would be a claim no probe supports, so it is
+                // recorded as unverified capability instead.
+                ProbePlan::RequiresTerminal => ConformanceVerdict::Unsupported,
+                ProbePlan::Command { args } => {
+                    let outcome = execute_probe(plan, &args);
+                    classify_contract_probe(item, &outcome)
+                }
+            };
+            (item, verdict)
+        })
+        .collect();
+
+    summarize_conformance(findings)
+}
+
+fn execute_probe(plan: &MultiplexerPlan, args: &[String]) -> ProbeOutcome {
+    let mut command = plan.command();
+    command
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    match run_tmux_with_timeout(&mut command) {
+        Ok(output) => ProbeOutcome {
+            exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        },
+        Err(()) => ProbeOutcome {
+            exit_code: None,
+            stdout: String::new(),
+            stderr: "the multiplexer did not answer within the probe timeout".to_owned(),
+        },
+    }
+}
+
+/// Qualify a multiplexer binary against the declared contract.
+///
+/// Creates a throwaway namespace, probes it, and tears it down. The teardown is
+/// best-effort and unconditional: leaving a stray server behind would leak the
+/// very kind of orphan the runtime spends effort reaping.
+#[must_use]
+pub fn qualify_multiplexer(plan: &MultiplexerPlan) -> ConformanceReport {
+    let Some(scratch) = scratch_plan(plan) else {
+        return summarize_conformance(contract_items().iter().map(|item| {
+            (
+                item,
+                ConformanceVerdict::Violated {
+                    detail: "could not reserve an isolated namespace to probe in".to_owned(),
+                },
+            )
+        }));
+    };
+
+    // Bring the namespace up before probing. A failure here is not fatal on its
+    // own: the probes will report precisely which items the binary could not
+    // honour, which is a better diagnosis than "setup failed".
+    let _ = execute_probe(
+        &scratch,
+        &[
+            "new-session".to_owned(),
+            "-d".to_owned(),
+            "-s".to_owned(),
+            SCRATCH_SESSION.to_owned(),
+        ],
+    );
+
+    let report = run_contract_probes(&scratch);
+
+    let _ = execute_probe(&scratch, &["kill-server".to_owned()]);
+
+    report
+}
+
+/// Derive a plan addressing isolation reserved for conformance probing.
+///
+/// The scratch isolation matches the kind the caller uses, so the probe
+/// exercises the same addressing mode production traffic will.
+fn scratch_plan(plan: &MultiplexerPlan) -> Option<MultiplexerPlan> {
+    let name = conformance_namespace();
+    let isolation = match plan.isolation() {
+        MultiplexerIsolation::Namespace(_) => MultiplexerIsolation::Namespace(name),
+        MultiplexerIsolation::Socket(_) => {
+            MultiplexerIsolation::Socket(std::env::temp_dir().join(name))
+        }
+    };
+    plan.with_isolation(isolation).ok()
+}
+
+/// Namespace name for the throwaway server.
+///
+/// Includes this process's PID so two jefe processes qualifying at once cannot
+/// tear down each other's scratch server mid-probe.
+fn conformance_namespace() -> String {
+    format!("jefe-conformance-{}", std::process::id())
+}

--- a/src/runtime/multiplexer_conformance_io.rs
+++ b/src/runtime/multiplexer_conformance_io.rs
@@ -14,6 +14,7 @@ use super::multiplexer_conformance::{
     classify_contract_probe, probe_plan_for, qualification_from_report, summarize_conformance,
 };
 use super::multiplexer_contract::{ContractItem, contract_items};
+use super::provenance::BinaryFingerprint;
 use super::{MultiplexerIsolation, MultiplexerPlan};
 
 /// Session created inside the throwaway namespace for session-addressed probes.
@@ -154,4 +155,15 @@ fn scratch_plan(plan: &MultiplexerPlan) -> Option<MultiplexerPlan> {
 /// tear down each other's scratch server mid-probe.
 fn conformance_namespace() -> String {
     format!("jefe-conformance-{}", std::process::id())
+}
+
+/// Fingerprint the binary being qualified, so a later check can tell whether it
+/// changed underneath the running process (issue #540 V7).
+///
+/// A binary that cannot be read yields `None`; provenance then says nothing
+/// rather than inventing a digest, which is the same rule the rest of the
+/// qualification follows.
+#[must_use]
+pub fn fingerprint_multiplexer(plan: &MultiplexerPlan) -> Option<BinaryFingerprint> {
+    BinaryFingerprint::measure(plan.executable()).ok()
 }

--- a/src/runtime/multiplexer_conformance_io.rs
+++ b/src/runtime/multiplexer_conformance_io.rs
@@ -2,16 +2,22 @@
 //! (issue #540).
 //!
 //! The runner owns a throwaway `-L` namespace for the duration of the check and
-//! destroys it afterwards. That isolation is what makes probing otherwise
-//! destructive verbs safe: `kill-session` and `kill-server` are exercised
-//! against sessions the runner created, never against the caller's agents.
+//! destroys it afterwards. That isolation keeps `kill-session` and `kill-server`
+//! away from the caller's agents.
+//!
+//! Isolation alone is not enough, and originally this module claimed it was.
+//! Those verbs are equally destructive to the run itself: `kill-server` ends the
+//! namespace every later probe depends on, and `new-session` collides with the
+//! session the runner has already brought up. Both are handled explicitly --
+//! lifecycle verbs address their own disposable session, and are probed last.
 
 use std::process::Stdio;
 
 use super::liveness::run_tmux_with_timeout;
 use super::multiplexer_conformance::{
     ConformanceReport, ConformanceVerdict, MultiplexerQualification, ProbeOutcome, ProbePlan,
-    classify_contract_probe, probe_plan_for, qualification_from_report, summarize_conformance,
+    classify_contract_probe, probe_ordered_items, probe_plan_for, qualification_from_report,
+    summarize_conformance,
 };
 use super::multiplexer_contract::{ContractItem, contract_items};
 use super::provenance::BinaryFingerprint;
@@ -20,15 +26,22 @@ use super::{MultiplexerIsolation, MultiplexerPlan};
 /// Session created inside the throwaway namespace for session-addressed probes.
 const SCRATCH_SESSION: &str = "jefe-conformance";
 
+/// The session the lifecycle verbs create and destroy.
+///
+/// Distinct from [`SCRATCH_SESSION`] so that probing `new-session` does not
+/// collide with the session the runner already brought up, and probing
+/// `kill-session` does not remove the one later probes still need.
+const DISPOSABLE_SESSION: &str = "jefe-conformance-disposable";
+
 /// Probe `plan`'s binary against the whole declared contract surface.
 ///
 /// `plan` must already address an isolated namespace reserved for this check;
 /// [`qualify_multiplexer`] is the entry point that arranges that.
 fn run_contract_probes(plan: &MultiplexerPlan) -> ConformanceReport {
-    let findings: Vec<(&'static ContractItem, ConformanceVerdict)> = contract_items()
-        .iter()
+    let findings: Vec<(&'static ContractItem, ConformanceVerdict)> = probe_ordered_items()
+        .into_iter()
         .map(|item| {
-            let verdict = match probe_plan_for(item, SCRATCH_SESSION) {
+            let verdict = match probe_plan_for(item, SCRATCH_SESSION, DISPOSABLE_SESSION) {
                 // Attaching needs a controlling terminal. Reporting it as
                 // satisfied would be a claim no probe supports, so it is
                 // recorded as unverified capability instead.
@@ -152,9 +165,15 @@ fn scratch_plan(plan: &MultiplexerPlan) -> Option<MultiplexerPlan> {
 /// Namespace name for the throwaway server.
 ///
 /// Includes this process's PID so two jefe processes qualifying at once cannot
-/// tear down each other's scratch server mid-probe.
+/// tear down each other's scratch server mid-probe, and a per-invocation
+/// counter so two qualifications *within* one process cannot either. The PID
+/// alone was not enough: the teardown of one run killed the server another was
+/// still probing, which reads as the binary failing rather than the runner
+/// colliding with itself.
 fn conformance_namespace() -> String {
-    format!("jefe-conformance-{}", std::process::id())
+    static INVOCATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let invocation = INVOCATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    format!("jefe-conformance-{}-{invocation}", std::process::id())
 }
 
 /// Fingerprint the binary being qualified, so a later check can tell whether it

--- a/src/runtime/multiplexer_contract.rs
+++ b/src/runtime/multiplexer_contract.rs
@@ -305,3 +305,92 @@ pub fn contract_item(kind: ContractItemKind, name: &str) -> Option<&'static Cont
         .iter()
         .find(|item| item.kind == kind && item.name == name)
 }
+
+/// A behaviour where psmux differs from the tmux jefe was written against.
+///
+/// Each began as a patch at the point a symptom appeared. A patch records that
+/// something was wrong; it does not record what jefe requires, so the next
+/// divergence gets found the same way -- in production. Declaring them states
+/// the expectation, cites what discovered it, and gives the remediation one
+/// definition instead of a literal repeated wherever it was needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Divergence {
+    pub name: &'static str,
+    /// What jefe requires of the multiplexer.
+    pub expectation: &'static str,
+    /// What jefe does to obtain it.
+    pub remediation: &'static str,
+    /// The issue that discovered the divergence.
+    pub discovered_by: &'static str,
+}
+
+static DIVERGENCES: &[Divergence] = &[
+    Divergence {
+        name: "exit-empty",
+        expectation: "a namespace outlives its sessions: the server must not exit when its \
+                      last session closes, because losing it loses the namespace identity \
+                      bound to it",
+        remediation: "set-option -s exit-empty off, once per observed server identity",
+        discovered_by: "issue #493",
+    },
+    Divergence {
+        name: "root-page-up-binding",
+        expectation: "Page keys reach the child unintercepted; psmux ships a default \
+                      root-table PageUp binding that tmux does not, and it consumes the key \
+                      before the agent sees it",
+        remediation: "unbind-key -T root PageUp during session setup",
+        discovered_by: "issue #465",
+    },
+    Divergence {
+        name: "inherited-session-routing",
+        expectation: "jefe must not appear nested inside a parent session; psmux exports \
+                      session-routing variables that children inherit, and a jefe process \
+                      inheriting them addresses the wrong session",
+        remediation: "remove PSMUX_SESSION and PSMUX_TARGET_SESSION from every local command \
+                      environment",
+        discovered_by: "issue #260",
+    },
+];
+
+/// Session-routing variables that must never be inherited.
+///
+/// `PSMUX_CLAUDE_TEAMMATE_MODE` and `PSMUX_CONFIG_FILE` are deliberately absent:
+/// team mode is not session routing, and the plan's base args already carry
+/// their own config selection.
+pub const PSMUX_SESSION_ROUTING_VARS: [&str; 2] = ["PSMUX_SESSION", "PSMUX_TARGET_SESSION"];
+
+/// The `exit-empty` remediation, as issued.
+pub const EXIT_EMPTY_REMEDIATION: [&str; 4] = ["set-option", "-s", "exit-empty", "off"];
+
+/// The root-table `PageUp` unbind, as issued.
+pub const PAGE_UP_ROOT_UNBIND_COMMAND: [&str; 4] = ["unbind-key", "-T", "root", "PageUp"];
+
+/// Every declared divergence.
+#[must_use]
+pub fn declared_divergences() -> &'static [Divergence] {
+    DIVERGENCES
+}
+
+/// Look up one declared divergence.
+#[must_use]
+pub fn divergence(name: &str) -> Option<&'static Divergence> {
+    DIVERGENCES.iter().find(|entry| entry.name == name)
+}
+
+/// Session-routing variables that must be scrubbed.
+#[must_use]
+pub const fn psmux_session_routing_vars() -> [&'static str; 2] {
+    PSMUX_SESSION_ROUTING_VARS
+}
+
+/// The `exit-empty` remediation command.
+#[must_use]
+pub const fn exit_empty_remediation() -> [&'static str; 4] {
+    EXIT_EMPTY_REMEDIATION
+}
+
+/// The root-table `PageUp` unbind command.
+#[must_use]
+pub const fn page_up_root_unbind() -> [&'static str; 4] {
+    PAGE_UP_ROOT_UNBIND_COMMAND
+}

--- a/src/runtime/multiplexer_contract.rs
+++ b/src/runtime/multiplexer_contract.rs
@@ -32,7 +32,7 @@ pub enum ContractCapability {
 pub enum ContractItemKind {
     /// A command word such as `has-session`.
     Verb,
-    /// A `#{â€¦}` format variable.
+    /// A `#{Ã¢â‚¬Â¦}` format variable.
     Format,
     /// A server option set through `set-option -s`.
     ServerOption,
@@ -342,6 +342,15 @@ static DIVERGENCES: &[Divergence] = &[
         discovered_by: "issue #465",
     },
     Divergence {
+        name: "reserved-prefix-key",
+        expectation: "the prefix key can be released so keystrokes reach the agent \
+                      untouched; psmux still reserves C-b when the prefix option is set to \
+                      None, which tmux honours, so there is no way to have no prefix at all",
+        remediation: "assign the prefix to jefe-owned F12 on Windows, which jefe intercepts \
+                      before forwarding, rather than the None that psmux ignores",
+        discovered_by: "issue #446, observed on psmux 3.3.6",
+    },
+    Divergence {
         name: "inherited-session-routing",
         expectation: "jefe must not appear nested inside a parent session; psmux exports \
                       session-routing variables that children inherit, and a jefe process \
@@ -468,5 +477,21 @@ pub const fn pane_command_budget() -> PaneCommandBudget {
             measured_on: "tmux 3.7b, macOS",
             evidence: POSIX_EVIDENCE,
         }
+    }
+}
+
+/// The Windows prefix key, set by the `reserved-prefix-key` divergence.
+///
+/// `None` is the value that would mean "no prefix", but psmux ignores it and
+/// keeps `C-b` reserved, so a key jefe owns is assigned instead.
+pub const WINDOWS_RESERVED_PREFIX_REPLACEMENT: &str = "F12";
+
+/// The prefix value for a platform, derived from the declared divergence.
+#[must_use]
+pub const fn prefix_value_for_platform(windows: bool) -> &'static str {
+    if windows {
+        WINDOWS_RESERVED_PREFIX_REPLACEMENT
+    } else {
+        "None"
     }
 }

--- a/src/runtime/multiplexer_contract.rs
+++ b/src/runtime/multiplexer_contract.rs
@@ -32,7 +32,7 @@ pub enum ContractCapability {
 pub enum ContractItemKind {
     /// A command word such as `has-session`.
     Verb,
-    /// A `#{…}` format variable.
+    /// A `#{â€¦}` format variable.
     Format,
     /// A server option set through `set-option -s`.
     ServerOption,
@@ -393,4 +393,80 @@ pub const fn exit_empty_remediation() -> [&'static str; 4] {
 #[must_use]
 pub const fn page_up_root_unbind() -> [&'static str; 4] {
     PAGE_UP_ROOT_UNBIND_COMMAND
+}
+
+/// What actually imposes the pane-command ceiling.
+///
+/// Naming this matters: jefe carried a limit attributed to the multiplexer
+/// which measurement showed the multiplexer does not impose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetSource {
+    /// The multiplexer refuses the command itself, as tmux 3.x does.
+    MultiplexerPaneCommand,
+    /// The Windows `CreateProcess` command-line ceiling, reached through the
+    /// PowerShell launch chain.
+    WindowsCreateProcess,
+    /// A POSIX shell/`ARG_MAX` ceiling.
+    PosixShell,
+}
+
+/// A pane-command budget with the observation that produced it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PaneCommandBudget {
+    /// Usable bytes for the whole pane command.
+    pub bytes: usize,
+    /// What imposes the ceiling.
+    pub source: BudgetSource,
+    /// What it was measured against.
+    pub measured_on: &'static str,
+    /// The observation, so a reader can re-derive rather than trust it.
+    pub evidence: &'static str,
+}
+
+#[cfg(windows)]
+/// Measured evidence behind the Windows budget.
+///
+/// psmux exits 0 and creates the session whether or not the command survives,
+/// so the boundary was found by having the command write its own payload and
+/// comparing the bytes that arrived.
+const WINDOWS_EVIDENCE: &str = "psmux fork 1a8b6d5 on Windows: via PowerShell (jefe's launch \
+                                chain) 32,649 bytes delivered, 32,658 dropped; via cmd.exe \
+                                8,164 delivered, 8,172 dropped. psmux reports success in both \
+                                failing cases -- exit 0, session created, command never runs. \
+                                The boundary tracks the shell, so the multiplexer imposes no \
+                                pane-command limit of its own.";
+
+#[cfg(not(windows))]
+const POSIX_EVIDENCE: &str = "tmux 3.7b on macOS refuses a pane command at ~16,340 bytes, and \
+                              reports the refusal. Retained for the tmux path only; the cmd.exe \
+                              ceiling measured on Windows (8,164 delivered / 8,172 dropped) is \
+                              narrower still, which is why the source is recorded alongside the \
+                              number.";
+
+/// The measured pane-command budget for this platform.
+///
+/// Windows is sized to the PowerShell chain jefe actually launches through,
+/// held below the largest command observed to arrive intact.
+#[must_use]
+pub const fn pane_command_budget() -> PaneCommandBudget {
+    #[cfg(windows)]
+    {
+        PaneCommandBudget {
+            // Under the 32,649 observed to arrive, with margin for the
+            // environment block CreateProcess counts against the same ceiling.
+            bytes: 30_000,
+            source: BudgetSource::WindowsCreateProcess,
+            measured_on: "psmux fork 1a8b6d5, Windows PowerShell launch chain",
+            evidence: WINDOWS_EVIDENCE,
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        PaneCommandBudget {
+            bytes: 16_000,
+            source: BudgetSource::MultiplexerPaneCommand,
+            measured_on: "tmux 3.7b, macOS",
+            evidence: POSIX_EVIDENCE,
+        }
+    }
 }

--- a/src/runtime/multiplexer_contract.rs
+++ b/src/runtime/multiplexer_contract.rs
@@ -1,0 +1,313 @@
+//! The enumerated psmux/tmux contract surface jefe depends on (issue #540).
+//!
+//! psmux is an external, unbundled binary that jefe treats as a drop-in tmux.
+//! It is not one, and the delta has been discovered one production incident at
+//! a time: the pane-command byte budget calibrated against macOS tmux (#433), a
+//! default `PageUp` root binding tmux does not ship (#465), a server that
+//! auto-exits when empty (#493), and `#{pid}` naming a per-session server
+//! rather than the `-L` namespace (#540).
+//!
+//! This module is the authoritative list of every verb, format string and
+//! server option jefe issues, with the response shape each must produce. It is
+//! pure data: the conformance runner asserts these against the live binary, and
+//! the mechanical surface check fails the build when production code uses
+//! something absent from here.
+
+/// Whether an item exists on every supported multiplexer or only on builds
+/// carrying a specific upstream change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContractCapability {
+    /// Present on every multiplexer jefe supports.
+    Always,
+    /// Present only on psmux builds carrying the stable per-namespace server
+    /// identity (upstream psmux#509). Older builds render the format as empty
+    /// text and still exit zero, so absence is detectable without a version
+    /// comparison.
+    SincePsmuxNamespaceToken,
+}
+
+/// The category of a contract item, so lookups cannot confuse a verb with a
+/// format string that happens to share a name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContractItemKind {
+    /// A command word such as `has-session`.
+    Verb,
+    /// A `#{…}` format variable.
+    Format,
+    /// A server option set through `set-option -s`.
+    ServerOption,
+}
+
+/// The shape of the response an item produces, which is what the conformance
+/// runner asserts. Checking for stdout that never arrives is as wrong as
+/// failing to check stdout that does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseShape {
+    /// The answer is the process exit status; stdout carries nothing useful.
+    ExitStatusOnly,
+    /// Exactly one line of output.
+    SingleLine,
+    /// One line per session.
+    LinePerSession,
+    /// One line per pane.
+    LinePerPane,
+    /// One line per window.
+    LinePerWindow,
+    /// Raw terminal content, whose shape depends on the pane rather than a
+    /// format string.
+    RawPaneContent,
+    /// Success is signalled by exit status and no output is produced.
+    NoOutput,
+}
+
+/// One declared dependency on the multiplexer.
+#[derive(Debug, Clone, Copy)]
+pub struct ContractItem {
+    pub kind: ContractItemKind,
+    /// The verb, format variable, or option name, without `#{}` decoration.
+    pub name: &'static str,
+    pub response: ResponseShape,
+    pub capability: ContractCapability,
+    /// Whether the value identifies the `-L` namespace itself and therefore
+    /// stays constant while that namespace is up.
+    ///
+    /// Only meaningful for [`ContractItemKind::Format`]. This is the field that
+    /// separates a namespace identity from the identity of whichever process
+    /// answered, and getting it wrong is the #540 defect.
+    pub namespace_stable: bool,
+    /// Why jefe depends on this, so a future reader can tell a load-bearing
+    /// item from an incidental one.
+    pub rationale: &'static str,
+}
+
+const fn verb(
+    name: &'static str,
+    response: ResponseShape,
+    rationale: &'static str,
+) -> ContractItem {
+    ContractItem {
+        kind: ContractItemKind::Verb,
+        name,
+        response,
+        capability: ContractCapability::Always,
+        namespace_stable: false,
+        rationale,
+    }
+}
+
+const fn format(
+    name: &'static str,
+    namespace_stable: bool,
+    capability: ContractCapability,
+    rationale: &'static str,
+) -> ContractItem {
+    ContractItem {
+        kind: ContractItemKind::Format,
+        name,
+        response: ResponseShape::SingleLine,
+        capability,
+        namespace_stable,
+        rationale,
+    }
+}
+
+const fn server_option(name: &'static str, rationale: &'static str) -> ContractItem {
+    ContractItem {
+        kind: ContractItemKind::ServerOption,
+        name,
+        response: ResponseShape::NoOutput,
+        capability: ContractCapability::Always,
+        namespace_stable: false,
+        rationale,
+    }
+}
+
+/// The authoritative contract surface.
+///
+/// Adding a verb or format to production code without adding it here is a
+/// policy violation the mechanical check reports.
+static CONTRACT: &[ContractItem] = &[
+    // --- verbs ---
+    verb(
+        "has-session",
+        ResponseShape::ExitStatusOnly,
+        "authoritative existence check for a named session; the only probe that \
+         answered correctly while the server identity probe was misreporting",
+    ),
+    verb(
+        "list-sessions",
+        ResponseShape::LinePerSession,
+        "enumerates live sessions for liveness reconciliation",
+    ),
+    verb(
+        "list-panes",
+        ResponseShape::LinePerPane,
+        "reads pane death state and pane leader PIDs",
+    ),
+    verb(
+        "list-windows",
+        ResponseShape::LinePerWindow,
+        "enumerates windows for pane addressing and display indices",
+    ),
+    verb(
+        "display-message",
+        ResponseShape::SingleLine,
+        "evaluates format strings, including the server identity probe",
+    ),
+    verb(
+        "new-session",
+        ResponseShape::NoOutput,
+        "creates the agent session",
+    ),
+    verb(
+        "new-window",
+        ResponseShape::NoOutput,
+        "creates additional windows within an agent session",
+    ),
+    verb(
+        "attach-session",
+        ResponseShape::RawPaneContent,
+        "attaches the dashboard to an agent session",
+    ),
+    verb(
+        "kill-session",
+        ResponseShape::NoOutput,
+        "terminates one agent session",
+    ),
+    verb(
+        "kill-server",
+        ResponseShape::NoOutput,
+        "terminates the namespace during teardown and test cleanup",
+    ),
+    verb(
+        "capture-pane",
+        ResponseShape::RawPaneContent,
+        "reads pane contents for the dashboard view",
+    ),
+    verb(
+        "send-keys",
+        ResponseShape::NoOutput,
+        "delivers prompts and control keys to the agent",
+    ),
+    verb(
+        "select-window",
+        ResponseShape::NoOutput,
+        "moves focus between windows",
+    ),
+    verb(
+        "set-option",
+        ResponseShape::NoOutput,
+        "applies server and session options, including the exit-empty workaround",
+    ),
+    verb(
+        "show-options",
+        ResponseShape::SingleLine,
+        "reads back an applied option to confirm it took effect",
+    ),
+    verb(
+        "unbind-key",
+        ResponseShape::NoOutput,
+        "removes the psmux-only default root-table PageUp binding (#465)",
+    ),
+    // --- format strings ---
+    format(
+        "server_instance",
+        true,
+        ContractCapability::SincePsmuxNamespaceToken,
+        "stable identity of the -L namespace; the only namespace-stable identity \
+         available, minted by the first server and reported by all of them (psmux#509)",
+    ),
+    format(
+        "pid",
+        false,
+        ContractCapability::Always,
+        "PID of whichever per-session server answered the request. NOT the \
+         namespace: psmux runs one server process per session, so this changes \
+         when a session is merely added (#540)",
+    ),
+    format(
+        "version",
+        false,
+        ContractCapability::Always,
+        "multiplexer version, paired with the identity probe",
+    ),
+    format(
+        "session_name",
+        false,
+        ContractCapability::Always,
+        "maps a session back to its agent",
+    ),
+    format(
+        "pane_dead",
+        false,
+        ContractCapability::Always,
+        "reports whether a pane's process has exited",
+    ),
+    format(
+        "pane_dead_signal",
+        false,
+        ContractCapability::Always,
+        "distinguishes a signalled pane death from a clean exit",
+    ),
+    format(
+        "pane_pid",
+        false,
+        ContractCapability::Always,
+        "PID of the pane leader. On Windows this is the session host, not the \
+         agent worker below it (#543)",
+    ),
+    format(
+        "pane_index",
+        false,
+        ContractCapability::Always,
+        "addresses a pane within its window",
+    ),
+    format(
+        "window_index",
+        false,
+        ContractCapability::Always,
+        "addresses a window within its session",
+    ),
+    format(
+        "window_name",
+        false,
+        ContractCapability::Always,
+        "identifies windows in the dashboard",
+    ),
+    format(
+        "history_size",
+        false,
+        ContractCapability::Always,
+        "sizes scrollback reads",
+    ),
+    format(
+        "next_display_index",
+        false,
+        ContractCapability::Always,
+        "allocates the next window display index",
+    ),
+    // --- server options ---
+    server_option(
+        "exit-empty",
+        "psmux servers auto-exit when empty, which tmux does not do in our \
+         configuration; disabling it keeps a namespace alive between sessions (#493)",
+    ),
+];
+
+/// Return the full contract surface.
+#[must_use]
+pub fn contract_items() -> &'static [ContractItem] {
+    CONTRACT
+}
+
+/// Look up one declared item by kind and name.
+///
+/// Returns `None` for anything not declared, which is what lets the mechanical
+/// surface check treat an unknown verb or format as a policy violation rather
+/// than silently trusting it.
+#[must_use]
+pub fn contract_item(kind: ContractItemKind, name: &str) -> Option<&'static ContractItem> {
+    CONTRACT
+        .iter()
+        .find(|item| item.kind == kind && item.name == name)
+}

--- a/src/runtime/multiplexer_contract.rs
+++ b/src/runtime/multiplexer_contract.rs
@@ -280,12 +280,6 @@ static CONTRACT: &[ContractItem] = &[
         ContractCapability::Always,
         "sizes scrollback reads",
     ),
-    format(
-        "next_display_index",
-        false,
-        ContractCapability::Always,
-        "allocates the next window display index",
-    ),
     // --- server options ---
     server_option(
         "exit-empty",

--- a/src/runtime/provenance.rs
+++ b/src/runtime/provenance.rs
@@ -1,0 +1,320 @@
+//! Provenance verification for the multiplexer binary (issue #540).
+//!
+//! CI downloads a pinned psmux archive and refuses it unless the SHA256
+//! matches. User machines verified nothing beyond parsing `-V`, so whatever
+//! `psmux.exe` was first on `PATH` was trusted.
+//!
+//! The archive digest cannot be applied to a binary on `PATH`: it covers the
+//! zip, not the extracted executable, and a user's psmux may have arrived by
+//! another route. Claiming otherwise would be a check that looks like
+//! verification and is not. What jefe can state honestly is narrower -- it
+//! records the fingerprint of the binary it qualified, refuses one it has never
+//! qualified, and detects the binary changing underneath a running process.
+//!
+//! SHA-256 is implemented here rather than added as a dependency, and is
+//! checked against the published NIST vectors in
+//! `tests/runtime_provenance.rs`.
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+/// The psmux archive digest CI pins, recorded so the provenance of the
+/// qualified release is stated rather than implied.
+pub const PINNED_PSMUX_ARCHIVE_SHA256: &str =
+    "60ff7b236f64184921cef3c1ff2611aa5a36fcc7ed8e2a58e968b8ded57f6028";
+
+const ROUND_CONSTANTS: [u32; 64] = [
+    0x428a_2f98,
+    0x7137_4491,
+    0xb5c0_fbcf,
+    0xe9b5_dba5,
+    0x3956_c25b,
+    0x59f1_11f1,
+    0x923f_82a4,
+    0xab1c_5ed5,
+    0xd807_aa98,
+    0x1283_5b01,
+    0x2431_85be,
+    0x550c_7dc3,
+    0x72be_5d74,
+    0x80de_b1fe,
+    0x9bdc_06a7,
+    0xc19b_f174,
+    0xe49b_69c1,
+    0xefbe_4786,
+    0x0fc1_9dc6,
+    0x240c_a1cc,
+    0x2de9_2c6f,
+    0x4a74_84aa,
+    0x5cb0_a9dc,
+    0x76f9_88da,
+    0x983e_5152,
+    0xa831_c66d,
+    0xb003_27c8,
+    0xbf59_7fc7,
+    0xc6e0_0bf3,
+    0xd5a7_9147,
+    0x06ca_6351,
+    0x1429_2967,
+    0x27b7_0a85,
+    0x2e1b_2138,
+    0x4d2c_6dfc,
+    0x5338_0d13,
+    0x650a_7354,
+    0x766a_0abb,
+    0x81c2_c92e,
+    0x9272_2c85,
+    0xa2bf_e8a1,
+    0xa81a_664b,
+    0xc24b_8b70,
+    0xc76c_51a3,
+    0xd192_e819,
+    0xd699_0624,
+    0xf40e_3585,
+    0x106a_a070,
+    0x19a4_c116,
+    0x1e37_6c08,
+    0x2748_774c,
+    0x34b0_bcb5,
+    0x391c_0cb3,
+    0x4ed8_aa4a,
+    0x5b9c_ca4f,
+    0x682e_6ff3,
+    0x748f_82ee,
+    0x78a5_636f,
+    0x84c8_7814,
+    0x8cc7_0208,
+    0x90be_fffa,
+    0xa450_6ceb,
+    0xbef9_a3f7,
+    0xc671_78f2,
+];
+
+const INITIAL_STATE: [u32; 8] = [
+    0x6a09_e667,
+    0xbb67_ae85,
+    0x3c6e_f372,
+    0xa54f_f53a,
+    0x510e_527f,
+    0x9b05_688c,
+    0x1f83_d9ab,
+    0x5be0_cd19,
+];
+
+/// SHA-256 of `bytes`, lowercase hex.
+#[must_use]
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut state = INITIAL_STATE;
+
+    // Pad: 0x80, zeroes, then the bit length as big-endian u64.
+    let mut padded = bytes.to_vec();
+    padded.push(0x80);
+    while padded.len() % 64 != 56 {
+        padded.push(0);
+    }
+    let bit_len = (bytes.len() as u64).wrapping_mul(8);
+    padded.extend_from_slice(&bit_len.to_be_bytes());
+
+    for block in padded.chunks_exact(64) {
+        compress(&mut state, block);
+    }
+
+    state.iter().fold(String::new(), |mut hex, word| {
+        // Writing to a String cannot fail.
+        let _ = write!(hex, "{word:08x}");
+        hex
+    })
+}
+
+fn compress(state: &mut [u32; 8], block: &[u8]) {
+    let mut schedule = [0u32; 64];
+    for (index, slot) in schedule.iter_mut().take(16).enumerate() {
+        let start = index * 4;
+        *slot = u32::from_be_bytes([
+            block[start],
+            block[start + 1],
+            block[start + 2],
+            block[start + 3],
+        ]);
+    }
+    for index in 16..64 {
+        let s0 = schedule[index - 15].rotate_right(7)
+            ^ schedule[index - 15].rotate_right(18)
+            ^ (schedule[index - 15] >> 3);
+        let s1 = schedule[index - 2].rotate_right(17)
+            ^ schedule[index - 2].rotate_right(19)
+            ^ (schedule[index - 2] >> 10);
+        schedule[index] = schedule[index - 16]
+            .wrapping_add(s0)
+            .wrapping_add(schedule[index - 7])
+            .wrapping_add(s1);
+    }
+
+    // Named for the FIPS 180-4 working variables a..h, kept as an array so the
+    // single-letter names the specification uses do not leak into scope.
+    let mut work = *state;
+
+    for (word, constant) in schedule.iter().zip(ROUND_CONSTANTS.iter()) {
+        let s1 = work[4].rotate_right(6) ^ work[4].rotate_right(11) ^ work[4].rotate_right(25);
+        let choose = (work[4] & work[5]) ^ ((!work[4]) & work[6]);
+        let temp1 = work[7]
+            .wrapping_add(s1)
+            .wrapping_add(choose)
+            .wrapping_add(*constant)
+            .wrapping_add(*word);
+        let s0 = work[0].rotate_right(2) ^ work[0].rotate_right(13) ^ work[0].rotate_right(22);
+        let majority = (work[0] & work[1]) ^ (work[0] & work[2]) ^ (work[1] & work[2]);
+        let temp2 = s0.wrapping_add(majority);
+
+        work[7] = work[6];
+        work[6] = work[5];
+        work[5] = work[4];
+        work[4] = work[3].wrapping_add(temp1);
+        work[3] = work[2];
+        work[2] = work[1];
+        work[1] = work[0];
+        work[0] = temp1.wrapping_add(temp2);
+    }
+
+    for (slot, value) in state.iter_mut().zip(work) {
+        *slot = slot.wrapping_add(value);
+    }
+}
+
+/// What jefe observed about a multiplexer binary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BinaryFingerprint {
+    path: String,
+    len: u64,
+    sha256: String,
+}
+
+impl BinaryFingerprint {
+    /// Record a fingerprint.
+    #[must_use]
+    pub fn new(path: impl Into<String>, len: u64, sha256: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            len,
+            sha256: sha256.into(),
+        }
+    }
+
+    /// Fingerprint the binary at `path` by reading it.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying I/O error if the binary cannot be read.
+    pub fn measure(path: &Path) -> std::io::Result<Self> {
+        let bytes = std::fs::read(path)?;
+        Ok(Self {
+            path: path.display().to_string(),
+            len: bytes.len() as u64,
+            sha256: sha256_hex(&bytes),
+        })
+    }
+
+    /// The recorded digest.
+    #[must_use]
+    pub fn sha256(&self) -> &str {
+        &self.sha256
+    }
+
+    /// The path observed.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// The length observed.
+    #[must_use]
+    pub const fn len_bytes(&self) -> u64 {
+        self.len
+    }
+
+    /// Whether the binary changed since this fingerprint was taken.
+    ///
+    /// The digest decides, so a replacement of identical length is still
+    /// caught; the length is carried only to make the diagnostic legible.
+    #[must_use]
+    pub fn detect_change(&self, current: &Self) -> ProvenanceVerdict {
+        if self.sha256 == current.sha256 {
+            return ProvenanceVerdict::Qualified;
+        }
+        ProvenanceVerdict::Changed {
+            diagnostic: format!(
+                "the multiplexer binary changed while jefe was running.\n  \
+                 path:      {}\n  \
+                 qualified: {} ({} bytes)\n  \
+                 now:       {} ({} bytes)\n\
+                 jefe qualified the earlier binary and cannot vouch for this one. \
+                 Restart jefe to re-qualify, or restore the binary it started with.",
+                current.path, self.sha256, self.len, current.sha256, current.len,
+            ),
+        }
+    }
+}
+
+/// The outcome of a provenance check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProvenanceVerdict {
+    /// The binary is one jefe qualified.
+    Qualified,
+    /// The binary is not one jefe has qualified.
+    Unqualified {
+        /// Operator-facing diagnostic naming path, digest and remedy.
+        diagnostic: String,
+    },
+    /// The binary changed underneath a running jefe.
+    Changed {
+        /// Operator-facing diagnostic showing both digests.
+        diagnostic: String,
+    },
+}
+
+/// The set of binary digests jefe has qualified.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ProvenanceManifest {
+    qualified: Vec<String>,
+}
+
+impl ProvenanceManifest {
+    /// Build a manifest from known-qualified digests.
+    #[must_use]
+    pub fn with_qualified(digests: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            qualified: digests.into_iter().collect(),
+        }
+    }
+
+    /// Whether any digest is recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.qualified.is_empty()
+    }
+
+    /// Check a fingerprint against the manifest.
+    #[must_use]
+    pub fn verify(&self, fingerprint: &BinaryFingerprint) -> ProvenanceVerdict {
+        if self
+            .qualified
+            .iter()
+            .any(|digest| digest == &fingerprint.sha256)
+        {
+            return ProvenanceVerdict::Qualified;
+        }
+        ProvenanceVerdict::Unqualified {
+            diagnostic: format!(
+                "the multiplexer on PATH is not one jefe has qualified.\n  \
+                 path:   {}\n  \
+                 sha256: {}\n  \
+                 bytes:  {}\n\
+                 jefe verifies the release archive {PINNED_PSMUX_ARCHIVE_SHA256} in CI, but \
+                 cannot tell where this executable came from. Install the pinned release, or \
+                 point JEFE_PSMUX_BIN at a binary you trust and record this digest as \
+                 qualified.",
+                fingerprint.path, fingerprint.sha256, fingerprint.len,
+            ),
+        }
+    }
+}

--- a/src/runtime/server_health.rs
+++ b/src/runtime/server_health.rs
@@ -7,17 +7,55 @@
 
 use crate::domain::ServerProcessIdentity;
 use crate::runtime::MultiplexerVersion;
-/// Composite identity of one runtime server instance: the operating-system
-/// process plus the multiplexer version hosting it. Two identities are the
-/// same server only when both components agree.
+/// Stable identity of one `-L` multiplexer namespace.
+///
+/// psmux runs one server *process per session*, so the process answering a
+/// request is not the namespace (issue #540, upstream psmux#509). This token is
+/// minted by the first server in a namespace and reported by every server in
+/// it, so it stays constant while the namespace is up and changes only after a
+/// genuine restart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerInstanceToken(String);
+
+impl ServerInstanceToken {
+    /// Build a token from probe output, treating blank text as absent.
+    ///
+    /// A multiplexer that does not implement the token renders the format
+    /// variable as an empty string rather than failing, so "blank" is the
+    /// capability signal for a build predating psmux#509.
+    #[must_use]
+    pub fn parse(raw: &str) -> Option<Self> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(Self(trimmed.to_owned()))
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Composite identity of one runtime server instance.
+///
+/// Carries the operating-system process, the multiplexer version hosting it,
+/// and — where the multiplexer supplies one — the stable token of the
+/// namespace it serves.
 ///
 /// The process component is a [`ServerProcessIdentity`], so the multiplexer
 /// server can never be compared against, or substituted for, a pane leader or
 /// an agent worker (issue #543).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServerIdentity {
     pub process: ServerProcessIdentity,
     pub multiplexer: MultiplexerVersion,
+    /// `None` on a multiplexer that does not report a namespace token. The
+    /// namespace is then simply not identifiable, and the process identity is
+    /// the only (weaker) evidence available.
+    pub instance: Option<ServerInstanceToken>,
 }
 
 impl ServerIdentity {
@@ -26,6 +64,21 @@ impl ServerIdentity {
         Self {
             process,
             multiplexer,
+            instance: None,
+        }
+    }
+
+    /// Build an identity anchored to a namespace token.
+    #[must_use]
+    pub const fn with_instance(
+        process: ServerProcessIdentity,
+        multiplexer: MultiplexerVersion,
+        instance: ServerInstanceToken,
+    ) -> Self {
+        Self {
+            process,
+            multiplexer,
+            instance: Some(instance),
         }
     }
 }
@@ -67,8 +120,23 @@ pub fn classify_server_health(
         (None, Some(_)) => ServerHealth::Healthy,
         (Some(_), None) => ServerHealth::Gone,
         (Some(previous), Some(current)) => {
-            // A changed PID or a changed creation token both indicate a
-            // distinct process instance now occupying the server role.
+            // Where both observations carry a namespace token it is decisive:
+            // psmux answers from whichever of the namespace's per-session
+            // servers replied, so the answering PID changes when a session is
+            // merely added and says nothing about a restart (issue #540).
+            if let (Some(previous_instance), Some(current_instance)) =
+                (previous.instance.as_ref(), current.instance.as_ref())
+            {
+                return if previous_instance == current_instance {
+                    ServerHealth::Healthy
+                } else {
+                    ServerHealth::Replaced
+                };
+            }
+            // No namespace token on at least one side, so fall back to the
+            // process identity. This is the weaker pre-psmux#509 evidence and
+            // is why a multiplexer without the token cannot distinguish "a
+            // session was added" from "the server restarted".
             if previous.process.pid() == current.process.pid()
                 && previous.process.started_at() == current.process.started_at()
             {
@@ -218,26 +286,37 @@ fn stderr_indicates_no_server(stderr: &str) -> bool {
         .any(|marker| lower.contains(marker))
 }
 
-/// Parse the `display-message -p '#{pid}|#{version}'` output of one server
-/// probe into a [`ServerIdentity`] (issue #493 Stack A).
+/// Parse the server-identity probe output into a [`ServerIdentity`]
+/// (issue #493 Stack A, extended by issue #540).
 ///
-/// Expected form: `<pid>|<major>.<minor>.<patch>` (e.g. `4321|3.3.7`). The
-/// PID supplies the process identity; `started_at` defaults to `1` because
-/// the multiplexer `display-message` format string does not expose a creation
-/// token, and the probe distinguishes server replacement via a PID change
-/// rather than a creation-token change (the per-agent
-/// [`crate::domain::ProcessIdentity`] service remains the authoritative
-/// reuse-safe check).
+/// Two forms are accepted:
+/// - `<instance>|<pid>|<version>` — the current probe. A multiplexer without
+///   psmux#509 renders `#{server_instance}` as empty text rather than failing,
+///   so `|22440|3.3.7` is a valid answer meaning "no namespace token here" and
+///   yields an identity with `instance: None`.
+/// - `<pid>|<version>` — the pre-#540 form, still accepted so a probe answered
+///   by an older code path parses rather than failing open.
+///
+/// The PID supplies the process identity; `started_at` defaults to `1` because
+/// `display-message` exposes no creation token for the server process (the
+/// per-agent [`crate::domain::ProcessIdentity`] service remains the
+/// authoritative reuse-safe check).
 ///
 /// Returns `None` for any malformed input so the caller fails open.
 #[must_use]
 pub fn parse_server_identity_output(output: &str) -> Option<ServerIdentity> {
     let trimmed = output.trim();
-    let (pid_raw, version_raw) = trimmed.split_once('|')?;
+    let fields: Vec<&str> = trimmed.split('|').collect();
+    let (instance_raw, pid_raw, version_raw) = match fields.as_slice() {
+        [instance, pid, version] => (Some(*instance), *pid, *version),
+        [pid, version] => (None, *pid, *version),
+        _ => return None,
+    };
     let pid: u32 = pid_raw.trim().parse().ok()?;
     let version = MultiplexerVersion::parse(version_raw.trim()).ok()?;
-    Some(ServerIdentity::new(
-        ServerProcessIdentity::new(pid, 1),
-        version,
-    ))
+    let process = ServerProcessIdentity::new(pid, 1);
+    match instance_raw.and_then(ServerInstanceToken::parse) {
+        Some(instance) => Some(ServerIdentity::with_instance(process, version, instance)),
+        None => Some(ServerIdentity::new(process, version)),
+    }
 }

--- a/src/runtime/server_health_io.rs
+++ b/src/runtime/server_health_io.rs
@@ -126,7 +126,7 @@ fn apply_exit_empty_if_new_identity(
         return;
     }
     let mut command = plan.command();
-    command.args(["set-option", "-s", "exit-empty", "off"]);
+    command.args(super::multiplexer_contract::EXIT_EMPTY_REMEDIATION);
     match run_tmux_with_timeout(&mut command) {
         Ok(output) if output.status.success() => *applied.borrow_mut() = current,
         Ok(output) => tracing::warn!(

--- a/src/runtime/server_health_io.rs
+++ b/src/runtime/server_health_io.rs
@@ -1,6 +1,6 @@
 //! Multiplexer server-health I/O for the Windows liveness observer.
 
-use std::cell::Cell;
+use std::cell::RefCell;
 use std::process::Stdio;
 
 use super::liveness::run_tmux_with_timeout;
@@ -10,13 +10,22 @@ use super::server_health::{
 };
 use super::{MultiplexerIsolation, MultiplexerPlan, capture_process_identity};
 
-const SERVER_IDENTITY_FORMAT: &str = "#{pid}|#{version}";
+/// Server-identity probe format (issue #540).
+///
+/// `#{server_instance}` is the stable `-L` namespace token added by
+/// upstream psmux#509. It leads the format deliberately: a multiplexer that
+/// predates it renders the variable as empty text and still answers
+/// successfully, so one format string works against both and a blank leading
+/// field is the capability signal. `#{pid}` names whichever of the namespace's
+/// per-session servers replied and is retained only as weaker fallback
+/// evidence.
+const SERVER_IDENTITY_FORMAT: &str = "#{server_instance}|#{pid}|#{version}";
 
 /// Probe the local multiplexer server and classify it against the pinned identity.
 pub fn observe_server_liveness(
     plan: &MultiplexerPlan,
     prior: Option<&ServerIdentity>,
-    applied_exit_empty: &Cell<Option<ServerIdentity>>,
+    applied_exit_empty: &RefCell<Option<ServerIdentity>>,
 ) -> ServerLivenessObservation {
     let evidence = capture_server_identity_evidence(plan);
     let observation = classify_observation(prior, &evidence);
@@ -105,21 +114,21 @@ fn log_server_observation(
 fn apply_exit_empty_if_new_identity(
     plan: &MultiplexerPlan,
     observation: &ServerLivenessObservation,
-    applied: &Cell<Option<ServerIdentity>>,
+    applied: &RefCell<Option<ServerIdentity>>,
 ) {
     let current = match observation {
         ServerLivenessObservation::Healthy(Some(id)) | ServerLivenessObservation::Replaced(id) => {
-            Some(*id)
+            Some(id.clone())
         }
         _ => None,
     };
-    if current.is_none() || applied.get() == current {
+    if current.is_none() || *applied.borrow() == current {
         return;
     }
     let mut command = plan.command();
     command.args(["set-option", "-s", "exit-empty", "off"]);
     match run_tmux_with_timeout(&mut command) {
-        Ok(output) if output.status.success() => applied.set(current),
+        Ok(output) if output.status.success() => *applied.borrow_mut() = current,
         Ok(output) => tracing::warn!(
             namespace = ?plan.isolation(),
             stderr = %String::from_utf8_lossy(&output.stderr).trim(),

--- a/tests/psmux_server_loss.rs
+++ b/tests/psmux_server_loss.rs
@@ -113,5 +113,5 @@ fn native_psmux_server_loss_is_observed_without_empty_inventory_reconciliation()
         panic!("expected replacement server observation, got {replacement:?}");
     };
     assert_ne!(second.process, first.process);
-    assert_eq!(*applied.borrow(), Some(second.clone()));
+    assert_eq!(*applied.borrow(), Some(second));
 }

--- a/tests/psmux_server_loss.rs
+++ b/tests/psmux_server_loss.rs
@@ -1,6 +1,6 @@
 #![cfg(all(windows, feature = "psmux-smoke"))]
 
-use std::cell::Cell;
+use std::cell::RefCell;
 use std::path::PathBuf;
 use std::process::{Command, Output};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -81,9 +81,9 @@ fn native_psmux_server_loss_is_observed_without_empty_inventory_reconciliation()
         "create first server session",
     );
 
-    let applied = Cell::new(None);
+    let applied = RefCell::new(None);
     let baseline = observe_server_liveness(&plan, None, &applied);
-    let ServerLivenessObservation::Healthy(Some(first)) = baseline else {
+    let ServerLivenessObservation::Healthy(Some(first)) = baseline.clone() else {
         panic!("expected a healthy first server observation, got {baseline:?}");
     };
     let option = run(&plan, &["show-options", "-s", "exit-empty"]);
@@ -96,7 +96,7 @@ fn native_psmux_server_loss_is_observed_without_empty_inventory_reconciliation()
         observe_server_liveness(&plan, Some(&first), &applied),
         baseline
     );
-    assert_eq!(applied.get(), Some(first));
+    assert_eq!(*applied.borrow(), Some(first.clone()));
 
     assert_success(&run(&plan, &["kill-server"]), "terminate owned server");
     assert_eq!(
@@ -113,5 +113,5 @@ fn native_psmux_server_loss_is_observed_without_empty_inventory_reconciliation()
         panic!("expected replacement server observation, got {replacement:?}");
     };
     assert_ne!(second.process, first.process);
-    assert_eq!(applied.get(), Some(second));
+    assert_eq!(*applied.borrow(), Some(second.clone()));
 }

--- a/tests/runtime_multiplexer_conformance.rs
+++ b/tests/runtime_multiplexer_conformance.rs
@@ -1,0 +1,216 @@
+//! Classifying a multiplexer's answers against the declared contract
+//! (issue #540 slice S2).
+//!
+//! The runner's whole job is to tell three outcomes apart: the binary honours
+//! an item, the binary lacks an optional item, and the binary is not the
+//! multiplexer jefe requires. Conflating the middle case with either of the
+//! others is how jefe would either reject every released psmux or depend on a
+//! format that renders as nothing.
+
+use jefe::runtime::{
+    ConformanceVerdict, ContractItemKind, ProbeOutcome, ProbePlan, classify_contract_probe,
+    contract_item, contract_items, probe_plan_for, summarize_conformance,
+};
+
+const SCRATCH: &str = "jefe-conformance-scratch";
+
+fn probe(exit_code: i32, stdout: &str) -> ProbeOutcome {
+    ProbeOutcome {
+        exit_code: Some(exit_code),
+        stdout: stdout.to_owned(),
+        stderr: String::new(),
+    }
+}
+
+fn format_item(name: &str) -> &'static jefe::runtime::ContractItem {
+    contract_item(ContractItemKind::Format, name)
+        .unwrap_or_else(|| panic!("{name} must be declared in the contract"))
+}
+
+fn verb_item(name: &str) -> &'static jefe::runtime::ContractItem {
+    contract_item(ContractItemKind::Verb, name)
+        .unwrap_or_else(|| panic!("{name} must be declared in the contract"))
+}
+
+/// A multiplexer predating psmux#509 renders `#{server_instance}` as empty text
+/// and still exits zero. That is a missing optional capability, not a broken
+/// binary, and must not fail qualification.
+#[test]
+fn an_absent_optional_format_is_unsupported_rather_than_a_failure() {
+    let verdict = classify_contract_probe(format_item("server_instance"), &probe(0, ""));
+
+    assert_eq!(
+        verdict,
+        ConformanceVerdict::Unsupported,
+        "an empty render of a capability-gated format means the build predates it",
+    );
+}
+
+/// The same empty answer for a format every multiplexer must provide means the
+/// binary is not what jefe requires.
+#[test]
+fn an_absent_required_format_fails_qualification() {
+    let verdict = classify_contract_probe(format_item("pane_pid"), &probe(0, ""));
+
+    assert!(
+        matches!(verdict, ConformanceVerdict::Violated { .. }),
+        "a required format rendering empty must fail, got {verdict:?}",
+    );
+}
+
+/// A format that answers is satisfied regardless of capability gating.
+#[test]
+fn a_format_that_answers_is_satisfied() {
+    assert_eq!(
+        classify_contract_probe(
+            format_item("server_instance"),
+            &probe(0, "19cd066a5ec1d650")
+        ),
+        ConformanceVerdict::Satisfied,
+    );
+    assert_eq!(
+        classify_contract_probe(format_item("pane_pid"), &probe(0, "22440")),
+        ConformanceVerdict::Satisfied,
+    );
+}
+
+/// `has-session` reports through its exit status, so a non-zero exit is a
+/// legitimate answer about a missing session rather than a contract violation.
+/// Only a failure to understand the verb is a violation.
+#[test]
+fn a_verb_answering_by_exit_status_is_satisfied_even_when_it_reports_absence() {
+    assert_eq!(
+        classify_contract_probe(verb_item("has-session"), &probe(1, "")),
+        ConformanceVerdict::Satisfied,
+        "exit 1 from has-session means 'no such session', not 'verb unsupported'",
+    );
+}
+
+/// A multiplexer that does not recognise a verb fails qualification.
+#[test]
+fn an_unrecognised_verb_fails_qualification() {
+    let outcome = ProbeOutcome {
+        exit_code: Some(1),
+        stdout: String::new(),
+        stderr: "unknown command: unbind-key".to_owned(),
+    };
+
+    assert!(
+        matches!(
+            classify_contract_probe(verb_item("unbind-key"), &outcome),
+            ConformanceVerdict::Violated { .. }
+        ),
+        "an unknown command must fail qualification",
+    );
+}
+
+/// A binary that could not be executed at all is a violation, not an absence.
+#[test]
+fn a_binary_that_never_ran_fails_qualification() {
+    let outcome = ProbeOutcome {
+        exit_code: None,
+        stdout: String::new(),
+        stderr: "program not found".to_owned(),
+    };
+
+    assert!(
+        matches!(
+            classify_contract_probe(verb_item("has-session"), &outcome),
+            ConformanceVerdict::Violated { .. }
+        ),
+        "failing to run the binary must never be reported as an optional absence",
+    );
+}
+
+/// A build lacking only optional items still qualifies, and the summary says so
+/// without claiming the optional item is present.
+#[test]
+fn a_build_missing_only_optional_items_still_qualifies() {
+    let findings = vec![
+        (verb_item("has-session"), ConformanceVerdict::Satisfied),
+        (format_item("pane_pid"), ConformanceVerdict::Satisfied),
+        (
+            format_item("server_instance"),
+            ConformanceVerdict::Unsupported,
+        ),
+    ];
+
+    let report = summarize_conformance(findings);
+
+    assert!(
+        report.is_qualified(),
+        "a missing optional capability must not disqualify a build",
+    );
+    assert!(
+        !report.supports("server_instance"),
+        "an unsupported item must not be reported as available",
+    );
+    assert!(report.supports("pane_pid"));
+}
+
+/// A build violating a required item does not qualify, and the report names
+/// every violation so the refusal can be actionable.
+#[test]
+fn a_build_violating_a_required_item_does_not_qualify() {
+    let findings = vec![
+        (verb_item("has-session"), ConformanceVerdict::Satisfied),
+        (
+            format_item("pane_pid"),
+            ConformanceVerdict::Violated {
+                detail: "rendered empty".to_owned(),
+            },
+        ),
+    ];
+
+    let report = summarize_conformance(findings);
+
+    assert!(!report.is_qualified());
+    let violations = report.violations();
+    assert_eq!(violations.len(), 1);
+    assert_eq!(violations[0].name, "pane_pid");
+}
+
+/// The runner owns a throwaway namespace, so every session-addressed probe must
+/// name that scratch session. A probe that omitted the target would be
+/// evaluated against whatever session the multiplexer considers current --
+/// which, in the caller's namespace, is a live agent.
+#[test]
+fn every_session_addressed_probe_names_the_scratch_session() {
+    for item in contract_items() {
+        let ProbePlan::Command { args } = probe_plan_for(item, SCRATCH) else {
+            continue;
+        };
+        if let Some(index) = args.iter().position(|arg| arg == "-t") {
+            assert_eq!(
+                args.get(index + 1).map(String::as_str),
+                Some(SCRATCH),
+                "`{}` targets something other than the scratch session",
+                item.name,
+            );
+        }
+    }
+}
+
+/// Attaching needs a controlling terminal, so probing it non-interactively
+/// would block rather than answer.
+#[test]
+fn attaching_is_not_probed_non_interactively() {
+    let item = contract_item(ContractItemKind::Verb, "attach-session")
+        .unwrap_or_else(|| panic!("attach-session must be declared"));
+
+    assert_eq!(probe_plan_for(item, SCRATCH), ProbePlan::RequiresTerminal);
+}
+
+/// A format probe must ask for that format and nothing else, or a passing
+/// verdict would be evidence about the wrong variable.
+#[test]
+fn a_format_probe_requests_exactly_that_format() {
+    let item = contract_item(ContractItemKind::Format, "pane_pid")
+        .unwrap_or_else(|| panic!("pane_pid must be declared"));
+
+    let ProbePlan::Command { args } = probe_plan_for(item, SCRATCH) else {
+        panic!("a format must be probed by command");
+    };
+
+    assert!(args.contains(&"#{pane_pid}".to_owned()), "got {args:?}");
+}

--- a/tests/runtime_multiplexer_conformance.rs
+++ b/tests/runtime_multiplexer_conformance.rs
@@ -325,3 +325,24 @@ fn a_silent_verb_that_fails_is_still_violated() {
         ConformanceVerdict::Violated { .. }
     ));
 }
+
+/// `capture-pane` prints whatever the pane holds. A pane created moments ago
+/// holds nothing, so failing the verb for empty output measures how quickly a
+/// shell paints its prompt rather than whether the multiplexer can capture
+/// (#540).
+#[test]
+fn capturing_an_empty_pane_is_not_a_violation() {
+    let item = contract_item(ContractItemKind::Verb, "capture-pane")
+        .unwrap_or_else(|| panic!("capture-pane declared"));
+    let outcome = ProbeOutcome {
+        exit_code: Some(0),
+        stdout: String::new(),
+        stderr: String::new(),
+    };
+
+    assert_eq!(
+        classify_contract_probe(item, &outcome),
+        ConformanceVerdict::Satisfied,
+        "an empty pane is a valid capture, not a missing capability"
+    );
+}

--- a/tests/runtime_multiplexer_conformance.rs
+++ b/tests/runtime_multiplexer_conformance.rs
@@ -8,8 +8,9 @@
 //! format that renders as nothing.
 
 use jefe::runtime::{
-    ConformanceVerdict, ContractItemKind, ProbeOutcome, ProbePlan, classify_contract_probe,
-    contract_item, contract_items, probe_ordered_items, probe_plan_for, summarize_conformance,
+    ConformanceVerdict, ContractItem, ContractItemKind, ProbeOutcome, ProbePlan,
+    classify_contract_probe, contract_item, contract_items, probe_ordered_items, probe_plan_for,
+    summarize_conformance,
 };
 
 const DISPOSABLE: &str = "jefe-conformance-disposable";
@@ -23,12 +24,12 @@ fn probe(exit_code: i32, stdout: &str) -> ProbeOutcome {
     }
 }
 
-fn format_item(name: &str) -> &'static jefe::runtime::ContractItem {
+fn format_item(name: &str) -> &'static ContractItem {
     contract_item(ContractItemKind::Format, name)
         .unwrap_or_else(|| panic!("{name} must be declared in the contract"))
 }
 
-fn verb_item(name: &str) -> &'static jefe::runtime::ContractItem {
+fn verb_item(name: &str) -> &'static ContractItem {
     contract_item(ContractItemKind::Verb, name)
         .unwrap_or_else(|| panic!("{name} must be declared in the contract"))
 }
@@ -221,6 +222,16 @@ fn a_format_probe_requests_exactly_that_format() {
     };
 
     assert!(args.contains(&"#{pane_pid}".to_owned()), "got {args:?}");
+
+    // "exactly that format" is the point: a probe carrying a second variable
+    // could be satisfied by the other one substituting, and the item under test
+    // would be passed without ever being rendered.
+    let requested: Vec<&String> = args.iter().filter(|arg| arg.contains("#{")).collect();
+    assert_eq!(
+        requested,
+        vec![&"#{pane_pid}".to_owned()],
+        "a format probe must request one variable and no others: {args:?}"
+    );
 }
 
 // -- Probe safety against the runner's own environment (issue #540) --------

--- a/tests/runtime_multiplexer_conformance.rs
+++ b/tests/runtime_multiplexer_conformance.rs
@@ -9,9 +9,10 @@
 
 use jefe::runtime::{
     ConformanceVerdict, ContractItemKind, ProbeOutcome, ProbePlan, classify_contract_probe,
-    contract_item, contract_items, probe_plan_for, summarize_conformance,
+    contract_item, contract_items, probe_ordered_items, probe_plan_for, summarize_conformance,
 };
 
+const DISPOSABLE: &str = "jefe-conformance-disposable";
 const SCRATCH: &str = "jefe-conformance-scratch";
 
 fn probe(exit_code: i32, stdout: &str) -> ProbeOutcome {
@@ -171,20 +172,24 @@ fn a_build_violating_a_required_item_does_not_qualify() {
 }
 
 /// The runner owns a throwaway namespace, so every session-addressed probe must
-/// name that scratch session. A probe that omitted the target would be
-/// evaluated against whatever session the multiplexer considers current --
-/// which, in the caller's namespace, is a live agent.
+/// name a session the runner itself created. A probe that omitted the target
+/// would be evaluated against whatever session the multiplexer considers
+/// current -- which, in the caller's namespace, is a live agent.
+///
+/// Either runner-owned session is acceptable: the lifecycle verbs deliberately
+/// address the disposable one so that creating and destroying a session cannot
+/// disturb the standing session the other probes rely on.
 #[test]
-fn every_session_addressed_probe_names_the_scratch_session() {
+fn every_session_addressed_probe_names_a_runner_owned_session() {
     for item in contract_items() {
-        let ProbePlan::Command { args } = probe_plan_for(item, SCRATCH) else {
+        let ProbePlan::Command { args } = probe_plan_for(item, SCRATCH, DISPOSABLE) else {
             continue;
         };
         if let Some(index) = args.iter().position(|arg| arg == "-t") {
-            assert_eq!(
-                args.get(index + 1).map(String::as_str),
-                Some(SCRATCH),
-                "`{}` targets something other than the scratch session",
+            let target = args.get(index + 1).map(String::as_str);
+            assert!(
+                target == Some(SCRATCH) || target == Some(DISPOSABLE),
+                "`{}` targets {target:?}, which the runner does not own",
                 item.name,
             );
         }
@@ -198,7 +203,10 @@ fn attaching_is_not_probed_non_interactively() {
     let item = contract_item(ContractItemKind::Verb, "attach-session")
         .unwrap_or_else(|| panic!("attach-session must be declared"));
 
-    assert_eq!(probe_plan_for(item, SCRATCH), ProbePlan::RequiresTerminal);
+    assert_eq!(
+        probe_plan_for(item, SCRATCH, DISPOSABLE),
+        ProbePlan::RequiresTerminal
+    );
 }
 
 /// A format probe must ask for that format and nothing else, or a passing
@@ -208,9 +216,112 @@ fn a_format_probe_requests_exactly_that_format() {
     let item = contract_item(ContractItemKind::Format, "pane_pid")
         .unwrap_or_else(|| panic!("pane_pid must be declared"));
 
-    let ProbePlan::Command { args } = probe_plan_for(item, SCRATCH) else {
+    let ProbePlan::Command { args } = probe_plan_for(item, SCRATCH, DISPOSABLE) else {
         panic!("a format must be probed by command");
     };
 
     assert!(args.contains(&"#{pane_pid}".to_owned()), "got {args:?}");
+}
+
+// -- Probe safety against the runner's own environment (issue #540) --------
+
+/// `new-session` must not try to create the session the runner already brought
+/// up, or the very first probe fails with "duplicate session" and every later
+/// one inherits the wreckage.
+#[test]
+fn creating_a_session_does_not_collide_with_the_standing_one() {
+    let item = contract_item(ContractItemKind::Verb, "new-session")
+        .unwrap_or_else(|| panic!("new-session declared"));
+    let ProbePlan::Command { args } = probe_plan_for(item, SCRATCH, DISPOSABLE) else {
+        panic!("new-session is probed by command");
+    };
+
+    assert!(args.contains(&DISPOSABLE.to_owned()), "{args:?}");
+    assert!(
+        !args.contains(&SCRATCH.to_owned()),
+        "probing new-session must not target the standing session: {args:?}"
+    );
+}
+
+/// `kill-session` must remove the disposable session, never the one the
+/// remaining probes still depend on.
+#[test]
+fn killing_a_session_spares_the_standing_one() {
+    let item = contract_item(ContractItemKind::Verb, "kill-session")
+        .unwrap_or_else(|| panic!("kill-session declared"));
+    let ProbePlan::Command { args } = probe_plan_for(item, SCRATCH, DISPOSABLE) else {
+        panic!("kill-session is probed by command");
+    };
+
+    assert!(args.contains(&DISPOSABLE.to_owned()), "{args:?}");
+    assert!(
+        !args.contains(&SCRATCH.to_owned()),
+        "probing kill-session must not destroy the standing session: {args:?}"
+    );
+}
+
+/// `kill-server` ends the namespace, so anything probed after it fails with
+/// "no server running". It must be last, and `kill-session` must follow the
+/// `new-session` whose session it removes.
+#[test]
+fn destructive_verbs_are_probed_after_everything_they_would_destroy() {
+    let order: Vec<&str> = probe_ordered_items().iter().map(|item| item.name).collect();
+
+    let position = |name: &str| {
+        order
+            .iter()
+            .position(|candidate| *candidate == name)
+            .unwrap_or_else(|| panic!("{name} is probed"))
+    };
+
+    assert_eq!(
+        position("kill-server"),
+        order.len() - 1,
+        "kill-server must be probed last: {order:?}"
+    );
+    assert!(
+        position("new-session") < position("kill-session"),
+        "kill-session must follow the new-session it removes: {order:?}"
+    );
+    assert!(
+        position("exit-empty") < position("kill-server"),
+        "every non-destructive item must be probed before the server dies: {order:?}"
+    );
+}
+
+/// A verb declared to produce no output is judged by its exit status. Demanding
+/// stdout from `kill-session` condemned every correct implementation.
+#[test]
+fn a_silent_verb_succeeds_on_exit_status_alone() {
+    let item = contract_item(ContractItemKind::Verb, "kill-session")
+        .unwrap_or_else(|| panic!("kill-session declared"));
+    let outcome = ProbeOutcome {
+        exit_code: Some(0),
+        stdout: String::new(),
+        stderr: String::new(),
+    };
+
+    assert_eq!(
+        classify_contract_probe(item, &outcome),
+        ConformanceVerdict::Satisfied,
+        "a verb that declares no output must not be failed for producing none"
+    );
+}
+
+/// The same silence with a failing status is still a violation: the fix must
+/// not turn the check off.
+#[test]
+fn a_silent_verb_that_fails_is_still_violated() {
+    let item = contract_item(ContractItemKind::Verb, "kill-session")
+        .unwrap_or_else(|| panic!("kill-session declared"));
+    let outcome = ProbeOutcome {
+        exit_code: Some(1),
+        stdout: String::new(),
+        stderr: "no such session".to_owned(),
+    };
+
+    assert!(matches!(
+        classify_contract_probe(item, &outcome),
+        ConformanceVerdict::Violated { .. }
+    ));
 }

--- a/tests/runtime_multiplexer_contract.rs
+++ b/tests/runtime_multiplexer_contract.rs
@@ -25,6 +25,8 @@ fn the_contract_declares_every_format_the_runtime_depends_on() {
         "session_name",
         "window_index",
         "window_name",
+        "version",
+        "history_size",
     ] {
         assert!(
             contract_item(ContractItemKind::Format, name).is_some(),
@@ -123,6 +125,21 @@ fn every_declared_item_states_its_response_shape() {
             "contract item `{}` must record why jefe depends on it",
             item.name,
         );
+        // The shape is what the runner routes on, so a format declared as
+        // producing nothing would be judged by its exit status and its
+        // substitution never checked -- the check would pass without ever
+        // looking at the answer.
+        if item.kind == ContractItemKind::Format {
+            assert!(
+                !matches!(
+                    item.response,
+                    ResponseShape::NoOutput | ResponseShape::ExitStatusOnly
+                ),
+                "format #{{{}}} declares a shape that produces no output, so its \
+                 substitution would never be examined",
+                item.name,
+            );
+        }
     }
 }
 

--- a/tests/runtime_multiplexer_contract.rs
+++ b/tests/runtime_multiplexer_contract.rs
@@ -1,0 +1,137 @@
+//! The enumerated psmux/tmux contract surface (issue #540 slice S1).
+//!
+//! jefe treats psmux as a drop-in tmux and discovers the difference one
+//! production incident at a time (#433 byte budget, #465 PageUp binding, #493
+//! `exit-empty`, #540 `#{pid}` namespace semantics). These tests pin the
+//! authoritative list of what jefe depends on, so a conformance runner (S2) can
+//! assert each item against the live binary and a mechanical check (S5) can
+//! fail the build on an undeclared use.
+
+use jefe::runtime::{
+    ContractCapability, ContractItemKind, ResponseShape, contract_item, contract_items,
+};
+
+/// Every format string production code issues must be declared, or the
+/// conformance suite cannot assert its response shape.
+#[test]
+fn the_contract_declares_every_format_the_runtime_depends_on() {
+    for name in [
+        "pane_dead",
+        "pane_dead_signal",
+        "pane_index",
+        "pane_pid",
+        "pid",
+        "server_instance",
+        "session_name",
+        "window_index",
+        "window_name",
+    ] {
+        assert!(
+            contract_item(ContractItemKind::Format, name).is_some(),
+            "format #{{{name}}} is used by the runtime but not declared in the contract",
+        );
+    }
+}
+
+/// Every verb production code issues must be declared.
+#[test]
+fn the_contract_declares_every_verb_the_runtime_issues() {
+    for name in [
+        "attach-session",
+        "capture-pane",
+        "display-message",
+        "has-session",
+        "kill-server",
+        "kill-session",
+        "list-panes",
+        "list-sessions",
+        "list-windows",
+        "new-session",
+        "new-window",
+        "select-window",
+        "send-keys",
+        "set-option",
+        "show-options",
+        "unbind-key",
+    ] {
+        assert!(
+            contract_item(ContractItemKind::Verb, name).is_some(),
+            "verb `{name}` is issued by the runtime but not declared in the contract",
+        );
+    }
+}
+
+/// `#{server_instance}` only exists on builds carrying upstream psmux#509.
+/// Declaring it unconditionally would make the conformance suite reject every
+/// currently-released psmux; declaring it as always-present would let jefe
+/// depend on a token that is not there (issue #540).
+#[test]
+fn the_namespace_token_is_gated_behind_its_upstream_capability() {
+    let item = contract_item(ContractItemKind::Format, "server_instance")
+        .unwrap_or_else(|| panic!("the namespace token must be declared"));
+
+    assert_eq!(
+        item.capability,
+        ContractCapability::SincePsmuxNamespaceToken,
+        "the namespace token must be capability-gated, not assumed present",
+    );
+}
+
+/// `#{pid}` is always available but answers for whichever per-session server
+/// replied, so the contract must not present it as a namespace identity.
+#[test]
+fn the_server_pid_is_always_available_but_never_a_namespace_identity() {
+    let item = contract_item(ContractItemKind::Format, "pid")
+        .unwrap_or_else(|| panic!("#{{pid}} must be declared"));
+
+    assert_eq!(item.capability, ContractCapability::Always);
+    assert!(
+        !item.namespace_stable,
+        "#{{pid}} names the answering server process, not the -L namespace",
+    );
+
+    let token = contract_item(ContractItemKind::Format, "server_instance")
+        .unwrap_or_else(|| panic!("the namespace token must be declared"));
+    assert!(
+        token.namespace_stable,
+        "the namespace token is the only namespace-stable identity jefe has",
+    );
+}
+
+/// A verb jefe never issues must not be declared: the surface is the
+/// authoritative list, so padding it would blunt the S5 mechanical check.
+#[test]
+fn an_undeclared_name_is_not_found() {
+    assert!(contract_item(ContractItemKind::Verb, "list-buffers").is_none());
+    assert!(contract_item(ContractItemKind::Format, "client_tty").is_none());
+}
+
+/// Each declaration must carry a response shape, since that is what the
+/// conformance runner asserts against the live binary.
+#[test]
+fn every_declared_item_states_its_response_shape() {
+    let items = contract_items();
+    assert!(!items.is_empty(), "the contract surface must not be empty");
+
+    for item in items {
+        assert!(
+            !item.name.is_empty(),
+            "a contract item must name the verb or format it governs",
+        );
+        assert!(
+            !item.rationale.is_empty(),
+            "contract item `{}` must record why jefe depends on it",
+            item.name,
+        );
+    }
+}
+
+/// `has-session` answers through its exit status, not stdout. Asserting that
+/// here keeps the conformance runner from checking output that never comes.
+#[test]
+fn has_session_answers_through_exit_status() {
+    let item = contract_item(ContractItemKind::Verb, "has-session")
+        .unwrap_or_else(|| panic!("has-session must be declared"));
+
+    assert_eq!(item.response, ResponseShape::ExitStatusOnly);
+}

--- a/tests/runtime_multiplexer_divergences.rs
+++ b/tests/runtime_multiplexer_divergences.rs
@@ -1,0 +1,124 @@
+//! Declared behavioural divergences from tmux (issue #540 slice S6/V6).
+//!
+//! Each of these began as a patch applied where a symptom surfaced: a server
+//! that vanished under jefe (#493), Page keys swallowed before reaching the
+//! agent (#465), and jefe believing it was nested inside a parent session. A
+//! patch records that something was wrong; it does not record what jefe
+//! *requires*, so the next divergence is found the same way — in production.
+//!
+//! Declaring them turns each scar into a stated expectation the conformance
+//! runner can assert, and gives the remediation a single definition instead of
+//! a literal repeated wherever it was needed.
+
+use jefe::runtime::{
+    Divergence, declared_divergences, divergence, exit_empty_remediation, page_up_root_unbind,
+    psmux_session_routing_vars,
+};
+
+fn find(name: &str) -> &'static Divergence {
+    divergence(name).unwrap_or_else(|| panic!("divergence `{name}` must be declared"))
+}
+
+/// A divergence with no issue behind it is folklore: nobody can tell whether it
+/// is still needed or what would prove it fixed.
+#[test]
+fn every_divergence_cites_what_discovered_it() {
+    let divergences = declared_divergences();
+    assert!(!divergences.is_empty());
+
+    for entry in divergences {
+        assert!(
+            !entry.discovered_by.is_empty(),
+            "divergence `{}` must cite the issue that found it",
+            entry.name,
+        );
+        assert!(
+            !entry.expectation.is_empty(),
+            "divergence `{}` must state what jefe requires",
+            entry.name,
+        );
+        assert!(
+            !entry.remediation.is_empty(),
+            "divergence `{}` must state what jefe does about it",
+            entry.name,
+        );
+    }
+}
+
+/// psmux servers exit when their last session closes, which tmux does not do in
+/// jefe's configuration. Losing the server loses the namespace identity with
+/// it, so the expectation is that a namespace outlives its sessions.
+#[test]
+fn the_server_must_outlive_its_last_session() {
+    let entry = find("exit-empty");
+
+    assert!(
+        entry.discovered_by.contains("493"),
+        "got {}",
+        entry.discovered_by,
+    );
+    assert_eq!(
+        exit_empty_remediation(),
+        ["set-option", "-s", "exit-empty", "off"],
+    );
+}
+
+/// psmux ships a default root-table `PageUp` binding that tmux does not. Left
+/// in place it consumes the key before the agent sees it, so scrollback keys
+/// never reach the child.
+#[test]
+fn page_keys_must_reach_the_child_unintercepted() {
+    let entry = find("root-page-up-binding");
+
+    assert!(
+        entry.discovered_by.contains("465"),
+        "got {}",
+        entry.discovered_by,
+    );
+    assert_eq!(
+        page_up_root_unbind(),
+        ["unbind-key", "-T", "root", "PageUp"],
+    );
+}
+
+/// psmux exports session-routing variables into the environment its children
+/// inherit. A jefe process that inherits them believes it is running inside a
+/// parent session and addresses the wrong one.
+#[test]
+fn session_routing_variables_must_not_be_inherited() {
+    let entry = find("inherited-session-routing");
+
+    assert_eq!(
+        psmux_session_routing_vars(),
+        ["PSMUX_SESSION", "PSMUX_TARGET_SESSION"],
+    );
+    assert!(
+        entry.expectation.to_lowercase().contains("nested")
+            || entry.expectation.to_lowercase().contains("inherit"),
+        "the expectation must say what goes wrong: {}",
+        entry.expectation,
+    );
+}
+
+/// The team-mode and config variables are deliberately retained: they are not
+/// session routing, and scrubbing them would change behaviour jefe wants.
+#[test]
+fn only_session_routing_variables_are_scrubbed() {
+    let scrubbed = psmux_session_routing_vars();
+
+    assert!(
+        !scrubbed.contains(&"PSMUX_CLAUDE_TEAMMATE_MODE"),
+        "team mode is not session routing and must survive: {scrubbed:?}",
+    );
+    assert!(
+        !scrubbed.contains(&"PSMUX_CONFIG_FILE"),
+        "the config variable is not session routing: {scrubbed:?}",
+    );
+}
+
+/// An undeclared name must not resolve, so the declarations stay the single
+/// list rather than one of several.
+#[test]
+fn an_undeclared_divergence_is_not_found() {
+    assert!(divergence("remain-on-exit-forever").is_none());
+}

--- a/tests/runtime_multiplexer_divergences.rs
+++ b/tests/runtime_multiplexer_divergences.rs
@@ -4,7 +4,7 @@
 //! that vanished under jefe (#493), Page keys swallowed before reaching the
 //! agent (#465), and jefe believing it was nested inside a parent session. A
 //! patch records that something was wrong; it does not record what jefe
-//! *requires*, so the next divergence is found the same way — in production.
+//! *requires*, so the next divergence is found the same way â€” in production.
 //!
 //! Declaring them turns each scar into a stated expectation the conformance
 //! runner can assert, and gives the remediation a single definition instead of
@@ -12,7 +12,7 @@
 
 use jefe::runtime::{
     Divergence, declared_divergences, divergence, exit_empty_remediation, page_up_root_unbind,
-    psmux_session_routing_vars,
+    prefix_value_for_platform, psmux_session_routing_vars,
 };
 
 fn find(name: &str) -> &'static Divergence {
@@ -121,4 +121,41 @@ fn only_session_routing_variables_are_scrubbed() {
 #[test]
 fn an_undeclared_divergence_is_not_found() {
     assert!(divergence("remain-on-exit-forever").is_none());
+}
+
+/// The prefix override is version-specific and, per the issue, had "no
+/// assertion that it is still true". Declaring it records the psmux behaviour
+/// that forces the choice, so a future re-check has something to test against
+/// rather than a bare constant.
+#[test]
+fn the_reserved_prefix_key_divergence_is_declared() {
+    let entry = find("reserved-prefix-key");
+
+    assert!(
+        entry.discovered_by.contains("446"),
+        "got {}",
+        entry.discovered_by,
+    );
+    assert!(
+        entry.expectation.contains("C-b"),
+        "the expectation must name the key psmux keeps reserved: {}",
+        entry.expectation,
+    );
+    assert!(
+        entry.discovered_by.contains("3.3.6"),
+        "a version-specific quirk must record the version it was seen on: {}",
+        entry.discovered_by,
+    );
+}
+
+/// The remediation applies to Windows only; tmux honours `None`, so releasing
+/// the prefix there needs no substitute key.
+#[test]
+fn only_the_psmux_platform_needs_a_substitute_prefix() {
+    assert_eq!(prefix_value_for_platform(true), "F12");
+    assert_eq!(
+        prefix_value_for_platform(false),
+        "None",
+        "tmux honours None, so no key needs to be spent there",
+    );
 }

--- a/tests/runtime_multiplexer_divergences.rs
+++ b/tests/runtime_multiplexer_divergences.rs
@@ -4,7 +4,7 @@
 //! that vanished under jefe (#493), Page keys swallowed before reaching the
 //! agent (#465), and jefe believing it was nested inside a parent session. A
 //! patch records that something was wrong; it does not record what jefe
-//! *requires*, so the next divergence is found the same way â€” in production.
+//! *requires*, so the next divergence is found the same way — in production.
 //!
 //! Declaring them turns each scar into a stated expectation the conformance
 //! runner can assert, and gives the remediation a single definition instead of

--- a/tests/runtime_multiplexer_qualification.rs
+++ b/tests/runtime_multiplexer_qualification.rs
@@ -1,0 +1,188 @@
+//! Startup qualification and its refusal message (issue #540 slices V2/V3).
+//!
+//! The maintainer decision on this issue was to reject bundling psmux. That
+//! makes the refusal itself the product surface: when jefe declines to run, the
+//! message is the entire remedy the operator gets. It must therefore name the
+//! binary it rejected, the version it found there, what specifically failed,
+//! and what to do about it.
+
+use std::path::PathBuf;
+
+use jefe::runtime::{
+    ConformanceVerdict, ContractItemKind, MultiplexerQualification, contract_item,
+    qualification_from_report, summarize_conformance,
+};
+
+fn item(kind: ContractItemKind, name: &str) -> &'static jefe::runtime::ContractItem {
+    contract_item(kind, name).unwrap_or_else(|| panic!("{name} must be declared"))
+}
+
+fn refusal_for(
+    findings: Vec<(&'static jefe::runtime::ContractItem, ConformanceVerdict)>,
+    version: Option<&str>,
+) -> String {
+    let report = summarize_conformance(findings);
+    let qualification = qualification_from_report(
+        &PathBuf::from(r"C:\Tools\psmux\psmux.exe"),
+        version.map(str::to_owned),
+        report,
+    );
+
+    match qualification {
+        MultiplexerQualification::Refused { message } => message,
+        MultiplexerQualification::Qualified { .. } => {
+            panic!("expected a refusal for these findings")
+        }
+    }
+}
+
+fn violation(name: &str) -> ConformanceVerdict {
+    ConformanceVerdict::Violated {
+        detail: format!("{name} rendered empty"),
+    }
+}
+
+/// The operator has to know which binary was rejected: the override and the
+/// PATH lookup can resolve to different installs, and "psmux is unsupported"
+/// without a path does not say which one to fix.
+#[test]
+fn a_refusal_names_the_binary_it_rejected() {
+    let message = refusal_for(
+        vec![(
+            item(ContractItemKind::Format, "pane_pid"),
+            violation("pane_pid"),
+        )],
+        Some("3.3.7"),
+    );
+
+    assert!(
+        message.contains(r"C:\Tools\psmux\psmux.exe"),
+        "refusal must name the rejected binary, got: {message}",
+    );
+}
+
+/// Naming the version found is what turns "unsupported" into "you have X".
+#[test]
+fn a_refusal_names_the_version_it_found() {
+    let message = refusal_for(
+        vec![(
+            item(ContractItemKind::Format, "pane_pid"),
+            violation("pane_pid"),
+        )],
+        Some("3.3.7"),
+    );
+
+    assert!(
+        message.contains("3.3.7"),
+        "refusal must name the version found, got: {message}",
+    );
+}
+
+/// A binary too broken to report a version must say so rather than imply one.
+#[test]
+fn a_refusal_admits_when_the_version_is_unknown() {
+    let message = refusal_for(
+        vec![(
+            item(ContractItemKind::Verb, "has-session"),
+            violation("has-session"),
+        )],
+        None,
+    );
+
+    assert!(
+        message.to_lowercase().contains("unknown"),
+        "an undetermined version must be stated, not omitted: {message}",
+    );
+}
+
+/// Reporting only the first failure would send the operator round the loop
+/// once per defect.
+#[test]
+fn a_refusal_names_every_failing_requirement() {
+    let message = refusal_for(
+        vec![
+            (
+                item(ContractItemKind::Format, "pane_pid"),
+                violation("pane_pid"),
+            ),
+            (
+                item(ContractItemKind::Verb, "unbind-key"),
+                violation("unbind-key"),
+            ),
+        ],
+        Some("3.3.7"),
+    );
+
+    assert!(message.contains("pane_pid"), "got: {message}");
+    assert!(message.contains("unbind-key"), "got: {message}");
+}
+
+/// Since jefe will not install psmux for the operator, the refusal must say how
+/// to supply a working one.
+#[test]
+fn a_refusal_states_the_remedy_including_the_override() {
+    let message = refusal_for(
+        vec![(
+            item(ContractItemKind::Format, "pane_pid"),
+            violation("pane_pid"),
+        )],
+        Some("3.3.7"),
+    );
+
+    assert!(
+        message.contains("JEFE_PSMUX_BIN"),
+        "refusal must name the override that lets an operator point at a good build: {message}",
+    );
+}
+
+/// An optional capability this build predates is not a failure and must not
+/// appear in the refusal, or the operator chases a defect that is not there.
+#[test]
+fn a_refusal_does_not_list_merely_unsupported_capabilities() {
+    let message = refusal_for(
+        vec![
+            (
+                item(ContractItemKind::Format, "pane_pid"),
+                violation("pane_pid"),
+            ),
+            (
+                item(ContractItemKind::Format, "server_instance"),
+                ConformanceVerdict::Unsupported,
+            ),
+        ],
+        Some("3.3.7"),
+    );
+
+    assert!(
+        !message.contains("server_instance"),
+        "an unsupported optional capability is not a failing requirement: {message}",
+    );
+}
+
+/// A build honouring every required item qualifies, and carries its report so
+/// callers can degrade against optional capabilities.
+#[test]
+fn a_conforming_build_qualifies_and_retains_its_report() {
+    let report = summarize_conformance(vec![
+        (
+            item(ContractItemKind::Format, "pane_pid"),
+            ConformanceVerdict::Satisfied,
+        ),
+        (
+            item(ContractItemKind::Format, "server_instance"),
+            ConformanceVerdict::Unsupported,
+        ),
+    ]);
+
+    let qualification =
+        qualification_from_report(&PathBuf::from("psmux"), Some("3.3.7".to_owned()), report);
+
+    let MultiplexerQualification::Qualified { report } = qualification else {
+        panic!("a build honouring every required item must qualify");
+    };
+    assert!(report.supports("pane_pid"));
+    assert!(
+        !report.supports("server_instance"),
+        "qualification must not upgrade an unsupported capability to available",
+    );
+}

--- a/tests/runtime_multiplexer_real_binary.rs
+++ b/tests/runtime_multiplexer_real_binary.rs
@@ -1,0 +1,71 @@
+//! Qualification against the psmux binary jefe will actually use (issue #540).
+//!
+//! The rest of the conformance tests drive the classifier with constructed
+//! outcomes, which is why they all passed while the runner was incapable of
+//! qualifying a real binary: the probes collided with their own scratch
+//! session, tore down their own server midway, and judged output-free verbs by
+//! their empty stdout.
+//!
+//! Requirement 2 asks for a suite that runs against the actual runtime binary.
+//! That is this file, and nothing weaker substitutes for it.
+
+use jefe::runtime::{MultiplexerPlan, MultiplexerQualification, qualify_multiplexer_for_startup};
+
+/// Whether this environment promises a usable psmux.
+///
+/// CI sets `JEFE_REQUIRE_PSMUX` on the native Windows job. Where it is set, a
+/// missing binary is a failure rather than a reason to skip -- a test that
+/// quietly does nothing is how a broken runner survives a green build.
+fn psmux_is_required() -> bool {
+    std::env::var("JEFE_REQUIRE_PSMUX").is_ok_and(|value| value == "1")
+}
+
+#[test]
+fn the_multiplexer_jefe_will_use_qualifies() {
+    let plan = match MultiplexerPlan::current() {
+        Ok(plan) => plan,
+        Err(error) => {
+            assert!(
+                !psmux_is_required(),
+                "JEFE_REQUIRE_PSMUX is set but no multiplexer could be resolved: {error}"
+            );
+            return;
+        }
+    };
+
+    match qualify_multiplexer_for_startup(&plan) {
+        MultiplexerQualification::Qualified { .. } => {}
+        MultiplexerQualification::Refused { message } => {
+            panic!(
+                "the binary jefe is configured to use failed its own contract.\n\
+                 A refusal here means either psmux regressed or the conformance \
+                 runner is wrong; the runner has been wrong before.\n\n{message}"
+            );
+        }
+    }
+}
+
+/// Qualification must be repeatable. The runner creates and destroys sessions,
+/// so a first run that leaves state behind would make a second run disagree --
+/// which is exactly the collision that made the original runner refuse every
+/// binary after its own setup.
+#[test]
+fn qualifying_twice_gives_the_same_answer() {
+    let Ok(plan) = MultiplexerPlan::current() else {
+        return;
+    };
+
+    let first = qualify_multiplexer_for_startup(&plan);
+    let second = qualify_multiplexer_for_startup(&plan);
+
+    let describe = |qualification: &MultiplexerQualification| match qualification {
+        MultiplexerQualification::Qualified { .. } => "qualified".to_owned(),
+        MultiplexerQualification::Refused { message } => format!("refused: {message}"),
+    };
+
+    assert_eq!(
+        describe(&first),
+        describe(&second),
+        "qualification left state behind that changed the second answer"
+    );
+}

--- a/tests/runtime_multiplexer_real_binary.rs
+++ b/tests/runtime_multiplexer_real_binary.rs
@@ -22,14 +22,18 @@ fn psmux_is_required() -> bool {
 
 #[test]
 fn the_multiplexer_jefe_will_use_qualifies() {
+    // Only an environment that promises psmux can be held to psmux's contract.
+    // Elsewhere -- a Linux coverage run, a developer box with plain tmux -- a
+    // refusal is the honest answer rather than a defect, so asserting one would
+    // fail the build for the runner behaving correctly.
+    if !psmux_is_required() {
+        return;
+    }
+
     let plan = match MultiplexerPlan::current() {
         Ok(plan) => plan,
         Err(error) => {
-            assert!(
-                !psmux_is_required(),
-                "JEFE_REQUIRE_PSMUX is set but no multiplexer could be resolved: {error}"
-            );
-            return;
+            panic!("JEFE_REQUIRE_PSMUX is set but no multiplexer could be resolved: {error}");
         }
     };
 
@@ -51,6 +55,9 @@ fn the_multiplexer_jefe_will_use_qualifies() {
 /// binary after its own setup.
 #[test]
 fn qualifying_twice_gives_the_same_answer() {
+    if !psmux_is_required() {
+        return;
+    }
     let Ok(plan) = MultiplexerPlan::current() else {
         return;
     };

--- a/tests/runtime_pane_command_budget.rs
+++ b/tests/runtime_pane_command_budget.rs
@@ -1,0 +1,88 @@
+//! Measured pane-command budget (issue #540 slice S4/V4).
+//!
+//! jefe sized its prompt limits against tmux 3.7b on macOS, where the
+//! multiplexer itself refuses a pane command over ~16,340 bytes. That number
+//! describes neither the multiplexer nor the platform jefe now runs on.
+//!
+//! Measured against psmux (fork build 1a8b6d5) on Windows:
+//!
+//! | path                        | largest delivered | smallest dropped |
+//! |-----------------------------|-------------------|------------------|
+//! | pwsh (jefe's launch chain)  | 32,649            | 32,658           |
+//! | cmd.exe                     | 8,164             | 8,172            |
+//!
+//! Two things follow. psmux imposes no limit of its own -- the boundary tracks
+//! the shell's command-line ceiling, not the multiplexer. And the failure is
+//! silent: psmux exits 0, the session is created, and the command never runs.
+//! A budget that is merely documented cannot catch that, so it is declared with
+//! its provenance and asserted against the prompt limits that depend on it.
+
+use jefe::runtime::{BudgetSource, pane_command_budget};
+
+/// A budget with no recorded provenance is the failure being corrected: a
+/// number nobody can re-derive, attributed to the wrong component.
+#[test]
+fn the_budget_records_where_it_came_from() {
+    let budget = pane_command_budget();
+
+    assert!(budget.bytes > 0);
+    assert!(
+        !budget.measured_on.is_empty(),
+        "the budget must say what it was measured against",
+    );
+    assert!(
+        !budget.evidence.is_empty(),
+        "the budget must carry the observation that produced it",
+    );
+}
+
+/// The constraint is the shell's command line, not the multiplexer. Attributing
+/// it to the multiplexer is what produced a tmux number on a psmux system.
+#[test]
+fn the_budget_is_not_attributed_to_the_multiplexer() {
+    let budget = pane_command_budget();
+
+    assert_ne!(
+        budget.source,
+        BudgetSource::MultiplexerPaneCommand,
+        "psmux imposes no pane-command limit; measurement showed the boundary \
+         tracking the shell's ceiling instead",
+    );
+}
+
+/// On Windows the launch chain runs through PowerShell, whose ceiling is the
+/// CreateProcess command-line limit -- roughly twice the tmux figure jefe was
+/// sized against, and reached silently.
+#[cfg(windows)]
+#[test]
+fn the_windows_budget_reflects_the_measured_powershell_ceiling() {
+    let budget = pane_command_budget();
+
+    assert_eq!(budget.source, BudgetSource::WindowsCreateProcess);
+    assert!(
+        budget.bytes <= 32_649,
+        "the budget must not exceed the largest command observed to arrive \
+         intact (32,649), got {}",
+        budget.bytes,
+    );
+    assert!(
+        budget.bytes >= 16_000,
+        "sizing Windows to tmux's ~16 KB would keep the inherited number, \
+         got {}",
+        budget.bytes,
+    );
+}
+
+/// The cmd.exe ceiling is far below the pwsh one and below the current
+/// compaction threshold. Recording it keeps the difference visible rather than
+/// leaving it to be rediscovered by a silent non-launch.
+#[test]
+fn the_narrower_shell_ceiling_is_recorded() {
+    let budget = pane_command_budget();
+
+    assert!(
+        budget.evidence.contains("8,1") || budget.evidence.contains("8164"),
+        "the cmd.exe boundary belongs in the evidence: {}",
+        budget.evidence,
+    );
+}

--- a/tests/runtime_pane_command_budget.rs
+++ b/tests/runtime_pane_command_budget.rs
@@ -17,7 +17,11 @@
 //! A budget that is merely documented cannot catch that, so it is declared with
 //! its provenance and asserted against the prompt limits that depend on it.
 
-use jefe::runtime::{BudgetSource, pane_command_budget};
+use jefe::runtime::pane_command_budget;
+// Every assertion naming a specific source is Windows-only, because that is
+// where the budget was measured.
+#[cfg(windows)]
+use jefe::runtime::BudgetSource;
 
 /// A budget with no recorded provenance is the failure being corrected: a
 /// number nobody can re-derive, attributed to the wrong component.
@@ -38,6 +42,12 @@ fn the_budget_records_where_it_came_from() {
 
 /// The constraint is the shell's command line, not the multiplexer. Attributing
 /// it to the multiplexer is what produced a tmux number on a psmux system.
+///
+/// Windows-only, because that is where the claim was measured and where it
+/// holds: psmux imposes no pane-command limit of its own. tmux does, so on
+/// other platforms attributing the budget to the multiplexer is the correct
+/// answer rather than the inherited mistake.
+#[cfg(windows)]
 #[test]
 fn the_budget_is_not_attributed_to_the_multiplexer() {
     let budget = pane_command_budget();

--- a/tests/runtime_provenance.rs
+++ b/tests/runtime_provenance.rs
@@ -1,0 +1,133 @@
+//! Multiplexer provenance verification (issue #540 slice S7/V7).
+//!
+//! CI downloads a pinned psmux archive and refuses it unless the SHA256 matches.
+//! User machines verify nothing beyond parsing `-V`, so whatever `psmux.exe`
+//! happens to be first on `PATH` is trusted.
+//!
+//! The archive digest cannot be applied directly to a binary on `PATH`: it
+//! covers the zip, not the extracted executable, and a user's psmux may have
+//! arrived by another route entirely. So the guarantee jefe can actually make
+//! is narrower and stated as such -- it records the fingerprint of the binary it
+//! qualified, refuses one it has never qualified, and detects the binary
+//! changing underneath a running process.
+//!
+//! SHA-256 is implemented in-crate rather than pulled in as a dependency, and
+//! is checked against the published NIST vectors below.
+
+use jefe::runtime::{
+    BinaryFingerprint, PINNED_PSMUX_ARCHIVE_SHA256, ProvenanceManifest, ProvenanceVerdict,
+    sha256_hex,
+};
+
+/// Published NIST vectors. A hand-rolled digest that is not checked against
+/// them is worth less than no check at all, because it would fail closed on
+/// correct binaries or open on wrong ones.
+#[test]
+fn the_digest_matches_the_published_vectors() {
+    assert_eq!(
+        sha256_hex(b""),
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+    assert_eq!(
+        sha256_hex(b"abc"),
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+    assert_eq!(
+        sha256_hex(b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+        "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+    );
+}
+
+/// Multi-block input exercises the message schedule across chunk boundaries,
+/// which a single-block implementation would pass while still being wrong.
+#[test]
+fn the_digest_spans_block_boundaries() {
+    assert_eq!(
+        sha256_hex(&b"a".repeat(1_000_000))[..16],
+        *"cdc76e5c9914fb92",
+    );
+}
+
+/// The CI-pinned archive digest is carried so provenance can be stated rather
+/// than implied, and must be the value CI actually enforces.
+#[test]
+fn the_pinned_archive_digest_is_recorded() {
+    assert_eq!(
+        PINNED_PSMUX_ARCHIVE_SHA256,
+        "60ff7b236f64184921cef3c1ff2611aa5a36fcc7ed8e2a58e968b8ded57f6028",
+    );
+}
+
+/// A binary jefe has qualified is accepted.
+#[test]
+fn a_qualified_binary_is_accepted() {
+    let fingerprint = BinaryFingerprint::new("C:/tools/psmux.exe", 1024, sha256_hex(b"psmux"));
+    let manifest = ProvenanceManifest::with_qualified([fingerprint.sha256().to_owned()]);
+
+    assert_eq!(manifest.verify(&fingerprint), ProvenanceVerdict::Qualified);
+}
+
+/// An unrecognised binary is refused, and the refusal must name the path and
+/// the digest -- a verdict the operator cannot act on is not a failure mode.
+#[test]
+fn an_unqualified_binary_is_refused_with_something_to_act_on() {
+    let fingerprint = BinaryFingerprint::new("C:/other/psmux.exe", 99, sha256_hex(b"stranger"));
+    let manifest = ProvenanceManifest::with_qualified([sha256_hex(b"psmux")]);
+
+    let verdict = manifest.verify(&fingerprint);
+    let ProvenanceVerdict::Unqualified { diagnostic } = verdict else {
+        panic!("an unknown binary must be refused, got {verdict:?}");
+    };
+
+    assert!(diagnostic.contains("C:/other/psmux.exe"), "{diagnostic}");
+    assert!(
+        diagnostic.contains(&sha256_hex(b"stranger")),
+        "{diagnostic}"
+    );
+}
+
+/// The case the issue calls out: the binary is replaced while jefe is running.
+/// Comparing against what was qualified at startup is what makes that visible.
+#[test]
+fn a_binary_swapped_underneath_a_running_jefe_is_detected() {
+    let qualified = BinaryFingerprint::new("C:/tools/psmux.exe", 1024, sha256_hex(b"psmux"));
+    let now = BinaryFingerprint::new("C:/tools/psmux.exe", 2048, sha256_hex(b"replacement"));
+
+    let verdict = qualified.detect_change(&now);
+    let ProvenanceVerdict::Changed { diagnostic } = verdict else {
+        panic!("a replaced binary must be detected, got {verdict:?}");
+    };
+
+    assert!(diagnostic.contains("C:/tools/psmux.exe"), "{diagnostic}");
+    assert!(
+        diagnostic.contains(&sha256_hex(b"psmux"))
+            && diagnostic.contains(&sha256_hex(b"replacement")),
+        "the diagnostic must show both digests so the change is legible: {diagnostic}",
+    );
+}
+
+/// Re-reading the same unchanged binary must not be reported as a change, or
+/// the check would fire constantly and be ignored.
+#[test]
+fn an_unchanged_binary_is_not_reported_as_changed() {
+    let qualified = BinaryFingerprint::new("C:/tools/psmux.exe", 1024, sha256_hex(b"psmux"));
+    let again = BinaryFingerprint::new("C:/tools/psmux.exe", 1024, sha256_hex(b"psmux"));
+
+    assert_eq!(
+        qualified.detect_change(&again),
+        ProvenanceVerdict::Qualified
+    );
+}
+
+/// Length is part of the fingerprint, but the digest decides. A same-length
+/// replacement must still be caught.
+#[test]
+fn a_same_length_replacement_is_still_caught() {
+    let qualified = BinaryFingerprint::new("C:/tools/psmux.exe", 1024, sha256_hex(b"psmux"));
+    let swapped = BinaryFingerprint::new("C:/tools/psmux.exe", 1024, sha256_hex(b"other"));
+
+    assert!(matches!(
+        qualified.detect_change(&swapped),
+        ProvenanceVerdict::Changed { .. },
+    ));
+}

--- a/tests/runtime_provenance.rs
+++ b/tests/runtime_provenance.rs
@@ -58,7 +58,7 @@ fn the_pinned_archive_digest_is_recorded() {
     );
 }
 
-/// A binary jefe has qualified is accepted.
+/// A binary that jefe has qualified is accepted.
 #[test]
 fn a_qualified_binary_is_accepted() {
     let fingerprint = BinaryFingerprint::new("C:/tools/psmux.exe", 1024, sha256_hex(b"psmux"));

--- a/tests/runtime_server_health.rs
+++ b/tests/runtime_server_health.rs
@@ -243,3 +243,53 @@ fn server_lost_status_is_distinct_variant() {
     assert_ne!(AgentStatus::ServerLost, AgentStatus::Running);
     assert_ne!(AgentStatus::ServerLost, AgentStatus::Errored);
 }
+
+/// psmux runs one server process per session, so `#{pid}` names whichever
+/// server answered the request rather than the `-L` namespace. Measured on
+/// 2026-08-01: creating sessions in one namespace moved `#{pid}` through
+/// 9008 -> 17784 -> 3832 while the namespace itself never restarted.
+///
+/// Adding a session must therefore not be reported as a replaced server. The
+/// stable answer is psmux's `#{server_instance}` token, which held constant
+/// across those same three probes (issue #540, upstream psmux#509).
+#[test]
+fn a_session_added_to_a_namespace_is_not_a_replaced_server() {
+    // Same namespace instance token, different answering server process.
+    let before = parse_server_identity_output("883b25f5379f199a|9008|3.3.7").unwrap_or_else(|| {
+        panic!("a server identity probe must parse the namespace instance token")
+    });
+    let after = parse_server_identity_output("883b25f5379f199a|3832|3.3.7").unwrap_or_else(|| {
+        panic!("a server identity probe must parse the namespace instance token")
+    });
+
+    let observation = classify_server_liveness(
+        Some(&before),
+        &ServerLivenessEvidence::command_succeeded("883b25f5379f199a|3832|3.3.7", ""),
+    );
+
+    assert_eq!(
+        classify_server_health(Some(&before), Some(&after), true),
+        ServerHealth::Healthy,
+        "a namespace that merely gained a session has not been replaced",
+    );
+    assert!(
+        matches!(observation, ServerLivenessObservation::Healthy(_)),
+        "adding a session must not be observed as a replaced server, got {observation:?}",
+    );
+}
+
+/// Two different `-L` namespaces are different servers even if a PID is
+/// recycled between them, so the instance token must decide (issue #540).
+#[test]
+fn a_different_namespace_instance_is_a_replaced_server() {
+    let ours = parse_server_identity_output("883b25f5379f199a|9008|3.3.7")
+        .unwrap_or_else(|| panic!("namespace instance token must parse"));
+    let theirs = parse_server_identity_output("f3cb9da032325298|9008|3.3.7")
+        .unwrap_or_else(|| panic!("namespace instance token must parse"));
+
+    assert_eq!(
+        classify_server_health(Some(&ours), Some(&theirs), true),
+        ServerHealth::Replaced,
+        "a different namespace instance is a different server even at the same PID",
+    );
+}

--- a/tests/runtime_server_health.rs
+++ b/tests/runtime_server_health.rs
@@ -252,15 +252,19 @@ fn server_lost_status_is_distinct_variant() {
 /// Adding a session must therefore not be reported as a replaced server. The
 /// stable answer is psmux's `#{server_instance}` token, which held constant
 /// across those same three probes (issue #540, upstream psmux#509).
+/// Parse a probe line, naming the input in the failure so a regression says
+/// which line stopped parsing rather than only that one did.
+fn parse_identity(output: &str) -> ServerIdentity {
+    parse_server_identity_output(output).unwrap_or_else(|| {
+        panic!("a server identity probe must parse the namespace instance token, got {output:?}")
+    })
+}
+
 #[test]
 fn a_session_added_to_a_namespace_is_not_a_replaced_server() {
     // Same namespace instance token, different answering server process.
-    let before = parse_server_identity_output("883b25f5379f199a|9008|3.3.7").unwrap_or_else(|| {
-        panic!("a server identity probe must parse the namespace instance token")
-    });
-    let after = parse_server_identity_output("883b25f5379f199a|3832|3.3.7").unwrap_or_else(|| {
-        panic!("a server identity probe must parse the namespace instance token")
-    });
+    let before = parse_identity("883b25f5379f199a|9008|3.3.7");
+    let after = parse_identity("883b25f5379f199a|3832|3.3.7");
 
     let observation = classify_server_liveness(
         Some(&before),

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -10,12 +10,13 @@ use std::process::ExitCode;
 
 use crate::architecture;
 use crate::clippy_policy;
+use crate::multiplexer_surface;
 use crate::process::{CommandFailed, CommandPlan, repo_path};
 use crate::source_size;
 use crate::toolchain;
 use crate::windows_coverage;
 
-/// The aggregate `ci` ordering — fmt, clippy-allow policy, source-size policy,
+/// The aggregate `ci` ordering â€” fmt, clippy-allow policy, source-size policy,
 /// architecture policy, strict clippy, complexity clippy, coverage, locked
 /// build, locked test (A1). Each step fails fast.
 const CI_STEPS: &[&str] = &[
@@ -23,6 +24,7 @@ const CI_STEPS: &[&str] = &[
     "check-clippy-allows",
     "check-source-size",
     "check-architecture",
+    "check-multiplexer-surface",
     "lint",
     "complexity",
     "coverage",
@@ -103,7 +105,7 @@ fn exit(result: Result<(), CommandFailed>) -> ExitCode {
 
 // --- aggregate commands -----------------------------------------------------
 
-/// `cargo xtask ci` — the full gate in CI order (A1). Fail-fast: the first
+/// `cargo xtask ci` â€” the full gate in CI order (A1). Fail-fast: the first
 /// failing step aborts and its exit code propagates.
 fn run_ci() -> Result<(), CommandFailed> {
     let root = repo_path("").map_err(|err| CommandFailed {
@@ -126,6 +128,7 @@ fn run_ci_step(step: &str, root: &Path) -> Result<(), CommandFailed> {
         "check-clippy-allows" => clippy_policy::run_repo_check(root),
         "check-source-size" => source_size::run_repo_check(root),
         "check-architecture" => architecture::run_repo_check(root),
+        "check-multiplexer-surface" => multiplexer_surface::run_repo_check(root),
         "lint" => lint_plan().run_inherit(),
         "complexity" => complexity_plan().run_inherit(),
         "coverage" => run_coverage(),
@@ -141,7 +144,7 @@ fn run_ci_step(step: &str, root: &Path) -> Result<(), CommandFailed> {
     }
 }
 
-/// `cargo xtask quick` — replaces `make quick-check` (A2).
+/// `cargo xtask quick` â€” replaces `make quick-check` (A2).
 fn run_quick() -> Result<(), CommandFailed> {
     let fmt = CommandPlan::new("cargo").arg("fmt").run_inherit();
     fmt?;
@@ -152,7 +155,7 @@ fn run_quick() -> Result<(), CommandFailed> {
     CommandPlan::new("cargo").args(["test", "-q"]).run_inherit()
 }
 
-/// `cargo xtask trim-cache` — replaces `make trim-cache` (A3). Coverage clean
+/// `cargo xtask trim-cache` â€” replaces `make trim-cache` (A3). Coverage clean
 /// + removal of `target/debug/incremental`, using platform-aware paths.
 fn run_trim_cache() -> Result<(), CommandFailed> {
     toolchain::coverage_clean_plan().run_inherit()?;
@@ -223,7 +226,7 @@ fn run_coverage() -> Result<(), CommandFailed> {
     toolchain::coverage_plan()?.run_inherit()
 }
 
-/// `cargo xtask coverage-windows` — enforce a floor per Windows-only module.
+/// `cargo xtask coverage-windows` â€” enforce a floor per Windows-only module.
 ///
 /// The workspace coverage gate runs on Ubuntu, where these modules are
 /// compiled out, so it can never observe them. This gate names the module that
@@ -291,7 +294,9 @@ fn run_windows_coverage() -> Result<(), CommandFailed> {
 
 fn run_check(rest: &[String]) -> Result<(), CommandFailed> {
     let Some(target) = rest.first() else {
-        eprintln!("usage: cargo xtask check <clippy-allows|source-size|architecture>");
+        eprintln!(
+            "usage: cargo xtask check <clippy-allows|source-size|architecture|multiplexer-surface>"
+        );
         return Err(usage_error("check", "missing policy name"));
     };
     let root = repo_path("").map_err(|err| CommandFailed {
@@ -305,6 +310,7 @@ fn run_check(rest: &[String]) -> Result<(), CommandFailed> {
         "clippy-allows" => clippy_policy::run_repo_check(&root),
         "source-size" => source_size::run_repo_check(&root),
         "architecture" => architecture::run_repo_check(&root),
+        "multiplexer-surface" => multiplexer_surface::run_repo_check(&root),
         other => {
             eprintln!("error: unknown check target `{other}`");
             Err(usage_error("check", "unknown policy name"))

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -16,7 +16,7 @@ use crate::source_size;
 use crate::toolchain;
 use crate::windows_coverage;
 
-/// The aggregate `ci` ordering â€” fmt, clippy-allow policy, source-size policy,
+/// The aggregate `ci` ordering — fmt, clippy-allow policy, source-size policy,
 /// architecture policy, strict clippy, complexity clippy, coverage, locked
 /// build, locked test (A1). Each step fails fast.
 const CI_STEPS: &[&str] = &[
@@ -105,7 +105,7 @@ fn exit(result: Result<(), CommandFailed>) -> ExitCode {
 
 // --- aggregate commands -----------------------------------------------------
 
-/// `cargo xtask ci` â€” the full gate in CI order (A1). Fail-fast: the first
+/// `cargo xtask ci` — the full gate in CI order (A1). Fail-fast: the first
 /// failing step aborts and its exit code propagates.
 fn run_ci() -> Result<(), CommandFailed> {
     let root = repo_path("").map_err(|err| CommandFailed {
@@ -144,7 +144,7 @@ fn run_ci_step(step: &str, root: &Path) -> Result<(), CommandFailed> {
     }
 }
 
-/// `cargo xtask quick` â€” replaces `make quick-check` (A2).
+/// `cargo xtask quick` — replaces `make quick-check` (A2).
 fn run_quick() -> Result<(), CommandFailed> {
     let fmt = CommandPlan::new("cargo").arg("fmt").run_inherit();
     fmt?;
@@ -155,7 +155,7 @@ fn run_quick() -> Result<(), CommandFailed> {
     CommandPlan::new("cargo").args(["test", "-q"]).run_inherit()
 }
 
-/// `cargo xtask trim-cache` â€” replaces `make trim-cache` (A3). Coverage clean
+/// `cargo xtask trim-cache` — replaces `make trim-cache` (A3). Coverage clean
 /// + removal of `target/debug/incremental`, using platform-aware paths.
 fn run_trim_cache() -> Result<(), CommandFailed> {
     toolchain::coverage_clean_plan().run_inherit()?;
@@ -226,7 +226,7 @@ fn run_coverage() -> Result<(), CommandFailed> {
     toolchain::coverage_plan()?.run_inherit()
 }
 
-/// `cargo xtask coverage-windows` â€” enforce a floor per Windows-only module.
+/// `cargo xtask coverage-windows` — enforce a floor per Windows-only module.
 ///
 /// The workspace coverage gate runs on Ubuntu, where these modules are
 /// compiled out, so it can never observe them. This gate names the module that

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod architecture;
 pub mod cli;
 pub mod clippy_policy;
+pub mod multiplexer_surface;
 pub mod process;
 pub mod source_size;
 pub mod toolchain;

--- a/xtask/src/multiplexer_surface.rs
+++ b/xtask/src/multiplexer_surface.rs
@@ -11,7 +11,7 @@
 //!   capability jefe does not need, which can reject a serviceable binary.
 //!
 //! Rust shares the `#{...}` spelling whenever a literal `#` precedes a
-//! placeholder â€” `format!("... #{ordinal}")` names a variable in scope, and
+//! placeholder — `format!("... #{ordinal}")` names a variable in scope, and
 //! `format!("#{next_display_index}")` builds an agent's display identifier.
 //! Neither is a multiplexer format, so occurrences inside a formatting macro
 //! are not counted.
@@ -81,7 +81,7 @@ impl Violation {
 
 /// Read the declared format names out of the contract source.
 ///
-/// Matches the `format("name", â€¦)` declarations rather than every string in the
+/// Matches the `format("name", …)` declarations rather than every string in the
 /// file, so rationale prose cannot be mistaken for a declaration.
 #[must_use]
 pub fn declared_surface(contract_source: &str) -> Surface {
@@ -130,9 +130,9 @@ pub fn format_usages(source: &str) -> BTreeSet<String> {
     used
 }
 
-/// Whether a line carries a bare `{â€¦}` placeholder.
+/// Whether a line carries a bare `{…}` placeholder.
 ///
-/// A multiplexer format spells every variable `#{â€¦}`, so an unprefixed brace
+/// A multiplexer format spells every variable `#{…}`, so an unprefixed brace
 /// means the line is a Rust format string. This catches the case the macro name
 /// alone cannot: a `format!` whose literal sits on a later line, as in
 /// `"read capture record '{name}' #{ordinal}: {err}"`.

--- a/xtask/src/multiplexer_surface.rs
+++ b/xtask/src/multiplexer_surface.rs
@@ -1,0 +1,280 @@
+//! Multiplexer contract surface policy (jefe issue #540, V5).
+//!
+//! jefe declares every psmux verb and format string it depends on in
+//! `src/runtime/multiplexer_contract.rs`. A declaration nobody enforces drifts,
+//! so this policy fails the build in both directions:
+//!
+//! * a format used in the runtime but never declared is a dependency the
+//!   conformance suite will never assert, which is how divergence from tmux
+//!   went unnoticed until it caused an incident;
+//! * a format declared but never used makes the conformance suite demand a
+//!   capability jefe does not need, which can reject a serviceable binary.
+//!
+//! Rust shares the `#{...}` spelling whenever a literal `#` precedes a
+//! placeholder â€” `format!("... #{ordinal}")` names a variable in scope, and
+//! `format!("#{next_display_index}")` builds an agent's display identifier.
+//! Neither is a multiplexer format, so occurrences inside a formatting macro
+//! are not counted.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use crate::process::CommandFailed;
+
+/// Directories that build multiplexer commands. Formats elsewhere in the tree
+/// belong to jefe's own templating and are outside this policy.
+const SCAN_ROOTS: &[&str] = &["src/runtime", "src/harness"];
+
+/// The contract module the declarations are read from.
+const CONTRACT_PATH: &str = "src/runtime/multiplexer_contract.rs";
+
+/// Rust formatting macros whose arguments use `{...}` placeholders.
+const FORMATTING_MACROS: &[&str] = &[
+    "format!",
+    "write!",
+    "writeln!",
+    "print!",
+    "println!",
+    "eprint!",
+    "eprintln!",
+    "panic!",
+    "assert!",
+    "assert_eq!",
+    "assert_ne!",
+    "unreachable!",
+    "todo!",
+];
+
+/// Names declared in the contract.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Surface {
+    pub formats: BTreeSet<String>,
+}
+
+/// A breach of the declared surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Violation {
+    /// Used by the runtime but absent from the contract.
+    UsedButNotDeclared { name: String, files: Vec<String> },
+    /// Declared in the contract but used nowhere.
+    DeclaredButNotUsed { name: String },
+}
+
+impl Violation {
+    /// Operator-facing description.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            Self::UsedButNotDeclared { name, files } => format!(
+                "format `#{{{name}}}` is used but not declared in {CONTRACT_PATH} \
+                 (seen in: {}). Declare it, or stop depending on it.",
+                files.join(", "),
+            ),
+            Self::DeclaredButNotUsed { name } => format!(
+                "format `#{{{name}}}` is declared in {CONTRACT_PATH} but used nowhere. \
+                 Remove it, or the conformance suite will demand a capability jefe \
+                 does not need.",
+            ),
+        }
+    }
+}
+
+/// Read the declared format names out of the contract source.
+///
+/// Matches the `format("name", â€¦)` declarations rather than every string in the
+/// file, so rationale prose cannot be mistaken for a declaration.
+#[must_use]
+pub fn declared_surface(contract_source: &str) -> Surface {
+    let mut formats = BTreeSet::new();
+    let mut rest = contract_source;
+
+    while let Some(start) = rest.find("format(") {
+        rest = &rest[start + "format(".len()..];
+        let Some(open) = rest.find('"') else { break };
+        let after_open = &rest[open + 1..];
+        let Some(close) = after_open.find('"') else {
+            break;
+        };
+        let name = &after_open[..close];
+        // A declaration's first argument is the bare variable name; anything
+        // containing punctuation is prose that happened to follow the keyword.
+        if !name.is_empty()
+            && name
+                .chars()
+                .all(|character| character.is_ascii_lowercase() || character == '_')
+        {
+            formats.insert(name.to_owned());
+        }
+        rest = after_open;
+    }
+
+    Surface { formats }
+}
+
+/// Collect the multiplexer format names a source file uses.
+#[must_use]
+pub fn format_usages(source: &str) -> BTreeSet<String> {
+    let mut used = BTreeSet::new();
+
+    for line in source.lines() {
+        if FORMATTING_MACROS
+            .iter()
+            .any(|formatting_macro| line.contains(formatting_macro))
+            || holds_rust_placeholder(line)
+        {
+            continue;
+        }
+        collect_line_usages(line, &mut used);
+    }
+
+    used
+}
+
+/// Whether a line carries a bare `{â€¦}` placeholder.
+///
+/// A multiplexer format spells every variable `#{â€¦}`, so an unprefixed brace
+/// means the line is a Rust format string. This catches the case the macro name
+/// alone cannot: a `format!` whose literal sits on a later line, as in
+/// `"read capture record '{name}' #{ordinal}: {err}"`.
+fn holds_rust_placeholder(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    line.match_indices('{').any(|(index, _)| {
+        let preceded_by_hash = index > 0 && bytes[index - 1] == b'#';
+        // `{{` is an escaped brace, not a placeholder.
+        let escaped = bytes.get(index + 1) == Some(&b'{');
+        !preceded_by_hash && !escaped
+    })
+}
+
+fn collect_line_usages(line: &str, used: &mut BTreeSet<String>) {
+    let bytes = line.as_bytes();
+    let mut index = 0;
+    while let Some(offset) = line[index..].find("#{") {
+        let start = index + offset + 2;
+        let Some(end_offset) = line[start..].find('}') else {
+            break;
+        };
+        let end = start + end_offset;
+        let name = &line[start..end];
+        if !name.is_empty()
+            && name
+                .chars()
+                .all(|character| character.is_ascii_lowercase() || character == '_')
+        {
+            used.insert(name.to_owned());
+        }
+        index = end.min(bytes.len());
+        if index >= line.len() {
+            break;
+        }
+    }
+}
+
+/// Compare declared against used.
+#[must_use]
+pub fn surface_violations(declared: &BTreeSet<String>, used: &BTreeSet<String>) -> Vec<Violation> {
+    let mut violations = Vec::new();
+
+    for name in used.difference(declared) {
+        violations.push(Violation::UsedButNotDeclared {
+            name: name.clone(),
+            files: Vec::new(),
+        });
+    }
+    for name in declared.difference(used) {
+        violations.push(Violation::DeclaredButNotUsed { name: name.clone() });
+    }
+
+    violations
+}
+
+/// Run the policy across the repository.
+///
+/// # Errors
+/// Returns `CommandFailed` when the declared surface and its use diverge.
+pub fn run_repo_check(root: &Path) -> Result<(), CommandFailed> {
+    let contract_source = std::fs::read_to_string(root.join(CONTRACT_PATH)).map_err(|error| {
+        failure(format!(
+            "could not read the contract at {CONTRACT_PATH}: {error}"
+        ))
+    })?;
+    let declared = declared_surface(&contract_source).formats;
+
+    let mut used = BTreeSet::new();
+    let mut sources_by_name: Vec<(String, String)> = Vec::new();
+    for scan_root in SCAN_ROOTS {
+        for file in rust_sources(&root.join(scan_root)) {
+            let Ok(text) = std::fs::read_to_string(&file) else {
+                continue;
+            };
+            let relative = file
+                .strip_prefix(root)
+                .unwrap_or(&file)
+                .display()
+                .to_string();
+            // The contract itself names every format it declares; counting
+            // those would make every declaration self-justifying.
+            if relative.replace('\\', "/").ends_with(CONTRACT_PATH) {
+                continue;
+            }
+            let file_usages = format_usages(&text);
+            for name in &file_usages {
+                sources_by_name.push((name.clone(), relative.clone()));
+            }
+            used.extend(file_usages);
+        }
+    }
+
+    let violations: Vec<Violation> = surface_violations(&declared, &used)
+        .into_iter()
+        .map(|violation| match violation {
+            Violation::UsedButNotDeclared { name, .. } => {
+                let files = sources_by_name
+                    .iter()
+                    .filter(|(usage, _)| usage == &name)
+                    .map(|(_, file)| file.clone())
+                    .collect();
+                Violation::UsedButNotDeclared { name, files }
+            }
+            declared @ Violation::DeclaredButNotUsed { .. } => declared,
+        })
+        .collect();
+
+    if violations.is_empty() {
+        return Ok(());
+    }
+
+    for violation in &violations {
+        eprintln!("ERROR: {}", violation.describe());
+    }
+    Err(failure(format!(
+        "Found {} multiplexer surface violation(s).",
+        violations.len()
+    )))
+}
+
+fn rust_sources(directory: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let Ok(entries) = std::fs::read_dir(directory) else {
+        return files;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            files.extend(rust_sources(&path));
+        } else if path.extension().is_some_and(|extension| extension == "rs") {
+            files.push(path);
+        }
+    }
+    files
+}
+
+fn failure(message: String) -> CommandFailed {
+    CommandFailed {
+        program: "xtask".into(),
+        args: vec!["check".into(), "multiplexer-surface".into()],
+        status: Some(1),
+        stdout: Vec::new(),
+        stderr: message.into_bytes(),
+    }
+}

--- a/xtask/tests/command_plans.rs
+++ b/xtask/tests/command_plans.rs
@@ -17,6 +17,7 @@ fn ci_runs_steps_in_the_documented_order() {
             "check-clippy-allows",
             "check-source-size",
             "check-architecture",
+            "check-multiplexer-surface",
             "lint",
             "complexity",
             "coverage",

--- a/xtask/tests/multiplexer_surface_fixtures.rs
+++ b/xtask/tests/multiplexer_surface_fixtures.rs
@@ -1,0 +1,134 @@
+//! Mechanical enforcement of the declared multiplexer surface (jefe #540, V5).
+//!
+//! The contract only stays true if the build refuses code that steps outside
+//! it. These fixtures drive the policy over source text directly, so the check
+//! is exercised without depending on the repository's current contents.
+
+use std::collections::BTreeSet;
+
+use xtask::multiplexer_surface::{Violation, declared_surface, format_usages, surface_violations};
+
+/// A miniature stand-in for `src/runtime/multiplexer_contract.rs`.
+const CONTRACT: &str = r#"
+    format(
+        "pane_pid",
+        false,
+        ContractCapability::Always,
+        "PID of the pane leader",
+    ),
+    format(
+        "server_instance",
+        true,
+        ContractCapability::SincePsmuxNamespaceToken,
+        "stable namespace token",
+    ),
+"#;
+
+fn declared() -> BTreeSet<String> {
+    declared_surface(CONTRACT).formats
+}
+
+/// The contract is only authoritative if the declarations can be read back out
+/// of it.
+#[test]
+fn the_declared_formats_are_read_from_the_contract_source() {
+    let formats = declared();
+
+    assert!(formats.contains("pane_pid"), "got {formats:?}");
+    assert!(formats.contains("server_instance"), "got {formats:?}");
+    assert_eq!(formats.len(), 2, "got {formats:?}");
+}
+
+/// Reaching for a format nobody declared is the drift this check exists to
+/// stop: it is a dependency the conformance suite will never assert.
+#[test]
+fn a_format_used_without_being_declared_is_a_violation() {
+    let used = format_usages("const F: &str = \"#{client_tty}\";");
+    let violations = surface_violations(&declared(), &used);
+
+    assert!(
+        violations.iter().any(|violation| matches!(
+            violation,
+            Violation::UsedButNotDeclared { name, .. } if name == "client_tty"
+        )),
+        "got {violations:?}",
+    );
+}
+
+/// A declaration nothing uses is equally wrong: it makes the conformance suite
+/// demand a capability jefe does not need, which can reject a serviceable
+/// binary.
+#[test]
+fn a_format_declared_without_being_used_is_a_violation() {
+    let used = format_usages("const F: &str = \"#{pane_pid}\";");
+    let violations = surface_violations(&declared(), &used);
+
+    assert!(
+        violations.iter().any(|violation| matches!(
+            violation,
+            Violation::DeclaredButNotUsed { name } if name == "server_instance"
+        )),
+        "got {violations:?}",
+    );
+}
+
+/// Rust's own interpolation shares the `#{...}` spelling when a literal `#`
+/// precedes a placeholder. `format!("... #{ordinal}")` names a variable in
+/// scope, not a multiplexer format, and must not be mistaken for one.
+#[test]
+fn rust_interpolation_is_not_mistaken_for_a_multiplexer_format() {
+    let source = r#"
+        HarnessError::process(format!("read capture record '{name}' #{ordinal}: {err}"))
+    "#;
+
+    let used = format_usages(source);
+
+    assert!(
+        !used.contains("ordinal"),
+        "a Rust format placeholder is not a multiplexer format: {used:?}",
+    );
+}
+
+/// The same spelling used to build an agent's display identifier is also not a
+/// multiplexer format.
+#[test]
+fn a_display_identifier_is_not_a_multiplexer_format() {
+    let used = format_usages(r##"agent.display_id = format!("#{next_display_index}");"##);
+
+    assert!(!used.contains("next_display_index"), "got {used:?}");
+}
+
+/// A source honouring the contract exactly produces no violations.
+#[test]
+fn a_conforming_source_has_no_violations() {
+    let used =
+        format_usages("const A: &str = \"#{pane_pid}\";\nconst B: &str = \"#{server_instance}\";");
+
+    assert!(surface_violations(&declared(), &used).is_empty());
+}
+
+/// A `format!` whose literal sits on a later line cannot be recognised by the
+/// macro name alone. A bare `{name}` placeholder alongside gives it away: a
+/// multiplexer format spells every variable `#{...}`.
+#[test]
+fn a_rust_format_literal_on_its_own_line_is_still_not_a_multiplexer_format() {
+    let used = format_usages("    \"read capture start record '{name}' #{ordinal}: {err}\"");
+
+    assert!(
+        !used.contains("ordinal"),
+        "a literal carrying bare placeholders is a Rust format string: {used:?}",
+    );
+}
+
+/// The discriminator must not reject genuine multiplexer formats, which spell
+/// every variable with the `#` prefix.
+#[test]
+fn a_composite_multiplexer_format_is_still_recognised() {
+    let used = format_usages(
+        "const PANE_FORMAT: &str = \"#{session_name}:#{window_index}.#{pane_index}\";",
+    );
+
+    assert!(used.contains("session_name"), "got {used:?}");
+    assert!(used.contains("window_index"), "got {used:?}");
+    assert!(used.contains("pane_index"), "got {used:?}");
+}


### PR DESCRIPTION
## Summary

Fixes #540. Sub-issue of the Windows runtime-architecture epic #539.

jefe treats psmux as tmux and finds out where that is false one bug at a time. The dependency was expressed as a version floor plus a scatter of undocumented workarounds, so there was no single place stating what jefe needs from a multiplexer, no way to check a binary provides it, and no way to tell whether a workaround was still needed. This replaces that with a declared behavioural contract that is mechanically enforced.

The governing rule: **a check that cannot fail is not a check.** Every gate here is demonstrated failing before it is relied on.

### What changed, by requirement

**1 — Single enumerated surface.** `src/runtime/multiplexer_contract.rs` declares every verb, format and option jefe uses (16 / 10 / 1), each with its purpose and whether jefe can degrade without it.

**1 (mechanical) — `cargo xtask check multiplexer-surface`.** Declaration rots unless something enforces it, so this fails the build in *both* directions: used-but-not-declared, and declared-but-not-used. It immediately caught an error I had made in the declaration itself — I had declared `#{next_display_index}`, which is not a psmux format at all but a Rust `format!` placeholder building an agent display ID, and it found `#{ordinal}` used but undeclared. That is the check earning its place on its first real run.

**2 — Behavioural conformance against the real binary.** `qualify_multiplexer` probes the actual executable in a throwaway namespace rather than trusting the version string.

**3 — Settled at startup.** Previously the gate ran at first `new-session`, so a user could launch jefe, navigate the UI, and discover the multiplexer was unusable only when starting an agent. Version, conformance and provenance are now settled during startup. When conformance *and* provenance both fail, both are reported — showing only the first sends the operator round the loop twice.

**4 — Measured, not inherited.** `TMUX_PANE_COMMAND_LIMIT_BYTES` was a tmux number with no evidence behind it. I measured psmux instead, and the result changed the model: **psmux imposes no pane-command limit of its own — the boundary tracks the shell.** Via PowerShell (jefe's real chain) 32,649 bytes were delivered and 32,658 dropped, at the CreateProcess ceiling of ~32,767. Via cmd.exe the wall was 8,164 — and a *no-multiplexer* cmd.exe control failed at the same point, which is what proves the limit is the shell's. Both prompt constants are now derived from a budget carrying its own provenance (value, source, date, method).

**5 — Provenance.** See the note below; this is the item that needs your decision.

**6 — Workarounds retired.** `exit-empty off`, the PageUp root-table unbind, the `TMUX*`/`PSMUX_*` env scrub, and the F12 prefix override are now declared divergences carrying expectation, remediation, discovering issue and observed version. Production reads the remediation from the declaration instead of hardcoding it, so the workaround and its justification cannot drift apart.

### Two things I got wrong, and fixed

**I dropped the F12 divergence and told you three of the four were real.** I grepped `F12`, found help text and key routing, and concluded it was jefe UI. Wrong F12. The issue means the prefix *override* — `commands.rs` forcing the prefix on Windows because psmux still reserves `C-b` when the option is `None`, which tmux honours. It is now the fourth divergence (`d432a902`), recorded with the version it was observed on, since the issue's specific complaint is that it had no assertion it was still true.

**I built the startup check and never called it.** After the provenance commit, `qualify_multiplexer_for_startup` and `fingerprint_multiplexer` were reachable but referenced by nothing; startup still ran only a version preflight. Requirement 3 would have been "implemented" with the user-visible behaviour completely unchanged. Wired in `04be7ac2`.

## Needs your decision

**A dependency question.** Requirement 5 needs SHA-256 and no hashing crate is in the workspace. Adding a dependency is a stop-for-approval item, so I implemented it in-crate and verified it against the published NIST vectors including a multi-block input — an unchecked hand-rolled digest is worse than none, since it fails closed on good binaries or open on bad ones. **If you would rather take `sha2`, every call site is behind `sha256_hex` and the swap is small.** Your call.

**What provenance can honestly promise.** The requirement says to perform "the same SHA256 verification the CI installer performs". That is not directly possible: `PSMUX_SHA256` digests the release *archive*, not the extracted `psmux.exe`, and a user's psmux may have arrived by another route. Comparing a PATH binary against it would look like verification and prove nothing. So this delivers the narrower true guarantee — record the fingerprint of the binary jefe qualified, refuse one it has never qualified, and **detect the binary changing underneath a running jefe** (which the requirement names explicitly). The pinned archive digest is carried so the qualified release's provenance is stated rather than implied. Provenance stays quiet until a manifest of qualified digests ships, because verifying against an empty manifest would refuse every install and teach operators to ignore the warning.

**Verification criterion not yet met.** The issue requires every item demonstrated in a `windows_native` run where the native steps *actually executed*. That is CI's to prove; I will confirm it on this PR rather than assert it here.

## Follow-up filed separately

The S4 measurements surfaced a defect outside this issue's scope: **when the pane command is dropped, psmux exits 0 and creates the session anyway.** A naïve probe reports success at 60,000 bytes. An agent can therefore appear launched while never having started, and nothing currently detects it. That belongs with the launch-pipeline hard gates in **#544**.

## Deliberately out of scope

- Escalating the startup warning to a refusal to start → **#544**.
- Moving past the 3.3.7 floor / multiplexer-binary isolation → **#547**.
- Fail-closed liveness and per-agent `Replaced` → **#541**; ownership anchor → **#542**.
- CI version matrix and bundling psmux — both rejected by maintainer decision (3–4 h runner queue; the refusal path is the product surface).

**Open question in the plan:** on pre-#509 psmux the stable server-identity token does not exist. Should jefe fail closed and stop attempting server-replacement detection rather than guessing from `#{pid}`? That guess is what produced the phantom agents in the currently-stuck instance.

## Pre-push checklist

- [x] `cargo fmt --all --check` — 0
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — 0
- [x] `cargo build --workspace --all-features --locked` — 0
- [x] `cargo xtask check source-size` / `architecture` / `clippy-allows` / `multiplexer-surface` — all 0
- [x] `cargo test --workspace --all-features --locked` — **74 suites, 5148 passed, 0 failed**
- [x] Rebased onto `origin/main` (`a2782c22`); correct ancestry, no conflicts

All gates run at the exact pushed head.

## Testing notes

RED was demonstrated for every behavioural claim:

- The surface check was run against the real repo and **caught a genuine error in my own declaration** before it was trusted.
- Provenance: 8 tests including NIST vectors, unqualified-refusal diagnostics, and swap detection — including a **same-length replacement**, since the digest decides and length is carried only for legibility.
- Startup: 4 tests proving a refusal reaches the operator, a qualified binary stays silent, provenance is reported even when conformance passes (behaving correctly is not evidence of being the binary jefe qualified), and both problems surface together.
- The budget was established by six successive probe scripts. Exit codes proved useless — psmux reports success while dropping the command — so measurement switched to payload writeback, then binary search on both shells, then a no-multiplexer control.

**Scope:** 29 files, +3254/−101. Above the standing target; epic #539 suspends the budget for its sub-issues, and requirement 1 is inherently repo-wide.

## Reviewers & Assignees

@acoliver — the `sha2`-vs-in-crate decision and the narrowed provenance guarantee are the two points that need an explicit call.
