### PR TITLE
Refresh direct agent evidence before launch (Fixes #575)

### DIFF
--- a/dev-docs/tmux-scenarios/v1/issue575-direct-upgrade-launch.json
+++ b/dev-docs/tmux-scenarios/v1/issue575-direct-upgrade-launch.json
@@ -1,0 +1,101 @@
+{
+  "schema": 1,
+  "name": "issue575-direct-upgrade-launch",
+  "platform": "macos",
+  "terminal": { "cols": 140, "rows": 40 },
+  "workspace": {
+    "mode": 448,
+    "dirs": [
+      { "path": "config", "mode": 448 },
+      { "path": "repo", "mode": 493 },
+      { "path": "repo/.git", "mode": 448 },
+      { "path": "repo/.git/refs", "mode": 448 },
+      { "path": "repo/.git/refs/heads", "mode": 448 },
+      { "path": "repo/.git/objects", "mode": 448 },
+      { "path": "repo/.git/objects/info", "mode": 448 },
+      { "path": "repo/.git/objects/pack", "mode": 448 }
+    ],
+    "files": [
+      {
+        "path": "bin/llxprt",
+        "content": {
+          "utf8": "#!/bin/sh\ncase \"${1:-}\" in\n  --version) printf '0.10.0\\n' ;;\n  --help) printf '%s\\n' '--prompt-interactive --profile-load --sandbox --sandbox-engine --yolo --approval-mode --continue' ;;\n  *) exec llxprt-agent \"$@\" ;;\nesac\n"
+        },
+        "mode": 493
+      },
+      {
+        "path": "repo/.git/HEAD",
+        "content": { "utf8": "ref: refs/heads/main\n" },
+        "mode": 384
+      },
+      {
+        "path": "repo/.git/config",
+        "content": { "utf8": "[core]\n\trepositoryformatversion = 0\n\tbare = false\n" },
+        "mode": 384
+      },
+      {
+        "path": "config/settings.toml",
+        "content": { "utf8": "settings_schema = 2\n" },
+        "mode": 384
+      },
+      {
+        "path": "config/state.json",
+        "content": {
+          "utf8": "{\n  \"schema_version\": 1,\n  \"repositories\": [{\n    \"id\": \"repo-575\",\n    \"name\": \"Issue 575\",\n    \"slug\": \"issue-575\",\n    \"base_dir\": \".\",\n    \"default_profile\": \"glm\",\n    \"default_code_puppy_model\": \"\",\n    \"github_repo\": \"owner/repo-575\",\n    \"github_issue_pr_repo\": \"\",\n    \"remote\": {\"enabled\": false, \"login_user\": \"\", \"host\": \"\", \"port\": null},\n    \"issue_base_prompt\": \"\",\n    \"default_agent_kind\": \"llxprt\",\n    \"agent_ids\": [\"agent-575\"]\n  }],\n  \"agents\": [{\n    \"id\": \"agent-575\",\n    \"display_id\": \"agent-575\",\n    \"repository_id\": \"repo-575\",\n    \"shortcut_slot\": 2,\n    \"name\": \"branch-575\",\n    \"description\": \"\",\n    \"work_dir\": \".\",\n    \"profile\": \"glm\",\n    \"code_puppy_model\": \"\",\n    \"code_puppy_yolo\": null,\n    \"code_puppy_quick_resume\": false,\n    \"mode_flags\": [\"--yolo\"],\n    \"llxprt_debug\": \"\",\n    \"pass_continue\": false,\n    \"sandbox_enabled\": false,\n    \"sandbox_engine\": \"podman\",\n    \"sandbox_flags\": \"\",\n    \"agent_kind\": \"llxprt\",\n    \"status\": \"Queued\",\n    \"runtime_binding\": null\n  }],\n  \"selected_repository_index\": 0,\n  \"selected_agent_index\": 0,\n  \"hide_idle_repositories\": false,\n  \"last_selected_agent_by_repo\": [],\n  \"pane_focus\": \"Agents\",\n  \"terminal_focused\": false,\n  \"user_preferences\": {}\n}\n"
+        },
+        "mode": 384
+      }
+    ],
+    "env": [
+      { "name": "PATH", "value": "${workspace}/bin:/usr/bin:/bin" }
+    ]
+  },
+  "steps": [
+    {
+      "op": "capture",
+      "name": "llxprt-agent",
+      "path": "bin/llxprt-agent",
+      "behavior": {
+        "stdout": "",
+        "stderr": "",
+        "exit_code": 0,
+        "stdin_limit": 0,
+        "hang": false,
+        "spawn_child_hang": false
+      }
+    },
+    {
+      "op": "launch",
+      "argv": ["jefe", "--config", "${workspace}/config"],
+      "env": [],
+      "cwd": "repo"
+    },
+    { "op": "wait", "source": "frame", "literal": "branch-575", "timeout_ms": 15000 },
+    {
+      "op": "write",
+      "file": {
+        "path": "bin/llxprt",
+        "content": {
+          "utf8": "#!/bin/sh\n# stable replacement installed after Jefe's startup observation\ncase \"${1:-}\" in\n  --version) printf '0.11.0-nightly.260801.19ac22acc\\n' ;;\n  --help) printf '%s\\n' '--prompt-interactive --profile-load --sandbox --sandbox-engine --yolo --approval-mode --continue' ;;\n  *) exec llxprt-agent \"$@\" ;;\nesac\n"
+        },
+        "mode": 493
+      }
+    },
+    { "op": "key", "key": "l", "modifiers": [] },
+    { "op": "wait", "source": "frame", "literal": "Running", "timeout_ms": 15000 },
+    {
+      "op": "assert-frame",
+      "contains": ["branch-575", "Running"],
+      "absent": ["AGT-E203", "candidate fingerprint changed"]
+    },
+    { "op": "key", "key": "e", "modifiers": [] },
+    { "op": "wait", "source": "frame", "literal": "Errors", "timeout_ms": 15000 },
+    {
+      "op": "assert-frame",
+      "contains": ["Errors", "No errors recorded."],
+      "absent": ["AGT-E203", "candidate fingerprint changed"]
+    },
+    { "op": "finish" }
+  ],
+  "secrets": []
+}

--- a/project-plans/issue575-plan.md
+++ b/project-plans/issue575-plan.md
@@ -77,14 +77,14 @@ or unrelated refactor is authorized.
 ## Review and verification ledger
 
 - Local OCR: `1 / 2` — reviewed 21 supported changed files; seven findings triaged. Fixed signed/subsecond timestamp capture, fingerprint diagnostics, typed refresh gating and tests, discarded duplicate probe, recapture logging, and implicit fixture target mutation. Four files timed out in OCR subtasks and remain covered by the full reviewer cycle and local gates.
-- PR OCR: `0 / 2`
+- PR OCR: `1 / 2` — six findings triaged. Fixed typed fingerprint capture errors and modification-time failure propagation. Rejected the diagnostic-format compatibility claim because `CandidateFingerprint::Display` is an internal diagnostic with no parser contract; rejected both cached-availability findings because A2/A4/A5 require the immediate authoritative launch probe to discover current installed, incompatible, failed, or removed state; rejected the private test-fixture interpolation warning because every value is a hardcoded trusted version literal.
 - rustreviewer / DeepThinker: one clean full-review cycle requested over all changed and untracked files; review remediation used the complete available findings plus OCR.
 - RED evidence: the issue TUI fixture failed before implementation because the upgraded agent became `Dead` instead of `Running`; the stable replacement and race-boundary runtime tests also established the intended behavior.
 - Fast verification: `cargo xtask quick` passes after review remediation.
 - TUI verification: `direct_upgrade_fixture_launches_replacement_without_stale_error` passes, including an empty Errors screen and unchanged persisted selector/version data.
 - Windows structural verification: `cargo check --target x86_64-pc-windows-msvc --all-features` passes.
-- Exact-head verification: `cargo xtask ci` passes after remediation; line coverage is 71.26% (30% floor).
-- Native Windows CI: pending PR checks.
+- Exact-head verification: `cargo xtask ci` passes after PR review remediation; line coverage remains above the 30% floor.
+- Native Windows CI: passed on PR #582, including MSVC + psmux, Windows Clippy, and Windows coverage floors.
 - Deferred findings: none
 
 ## Completion contract

--- a/project-plans/issue575-plan.md
+++ b/project-plans/issue575-plan.md
@@ -1,0 +1,96 @@
+# Issue #575 — Re-resolve blank-selector executable after an in-session upgrade
+
+> A blank-selector local agent currently launches from the startup-captured
+> `ResolvedCandidate`. Replacing the direct executable while Jefe remains open
+> therefore makes every attempt reuse stale fingerprint evidence and fail with
+> `AGT-E203`. Launch preparation must freshly resolve direct candidates while
+> preserving the fail-closed probe-to-execution fingerprint boundary.
+
+## Acceptance matrix
+
+| # | Actor / launch path | Input / boundary | Targets | Observable success | Observable failure / diagnostic | Side effects before failure | Persistence / compatibility | Proof |
+|---|---|---|---|---|---|---|---|---|
+| A1 | Existing local agent launch, relaunch, or send | Blank selector; executable unchanged since startup observation | Unix and Windows direct executable/wrapper forms | Existing launch behavior remains unchanged | Existing attributable probe diagnostics | Existing probe/preflight effects only | No persisted-agent mutation | Direct-launch regression test |
+| A2 | Existing local agent launch, relaunch, or send | Blank selector; executable replaced after startup and stable/compatible during fresh probe | Unix and Windows | Same action freshly resolves, advances generation, probes, and launches replacement | No stale `AGT-E203` for superseded startup evidence | Fresh probe, then normal authorized launch | Durable agent configuration remains unchanged | Executable replacement behavior test plus TUI scenario proving success and no error |
+| A3 | Existing local agent launch, relaunch, or send | Candidate changes after fresh probe evidence but before execution | Unix and Windows | None | `AGT-E203` remains attributable and fail-closed | Zero agent-launch side effects after mismatch | No stale plan is persisted or executed | Deterministic execution-boundary race test |
+| A4 | Existing local agent launch, relaunch, or send | Replacement resolves but is incompatible or probe fails | Local | None | Current typed incompatibility/probe diagnostic | Probe only; no launch | Existing record remains recoverable | Incompatible/probe-failure behavior tests |
+| A5 | Existing local agent launch, relaunch, or send | Direct executable removed or no current candidate resolves | Local | None | Current NotFound/unavailable diagnostic | No launch | Existing record remains intact | Removed-candidate behavior test |
+| A6 | Explicit version-selector launch | Nonblank npm/uvx selector | Existing supported targets | Existing package resolution/materialization/probe/launch behavior | Existing package diagnostics | Existing contract | No selector migration | Package-selector regression tests |
+
+## Non-goals
+
+- Removing or weakening executable fingerprint checks.
+- Trusting an incompatible or unprobeable replacement.
+- Changing npm/uvx selector semantics or package-cache ownership.
+- Changing remote candidate resolution.
+- Mutating or pinning persisted selector data.
+- Adding filesystem watching, polling, or a hot-reload subsystem.
+- Redesigning availability UI or error history.
+
+## Vertical slices
+
+### Slice 1 — Direct replacement recovery
+
+- **Rows:** A1, A2, A4, A5.
+- **Owner / boundary:** runtime launch composition and candidate/probe generation reconciliation.
+- **Allowed paths:** `src/runtime/launch_compose.rs`, its existing tests, a bounded issue behavior test, and the issue TUI scenario.
+- **RED:** first update/add the TUI scenario so a stable executable replacement must proceed without `AGT-E203`; add a runtime behavior fixture that replaces a direct executable after startup evidence and currently reproduces stale `AGT-E203`.
+- **GREEN:** direct launch preparation captures a fresh target-appropriate `PathSnapshot`, resolves once, computes generation from startup/current keys, and probes the fresh resolution. Current NotFound/incompatible/probe failures remain typed.
+- **Non-goals:** no state publication, watcher, package, remote, or persistence changes.
+- **Verification:** focused scenario/test, `cargo xtask quick`, and the required full gate.
+- **Stop for approval:** any need for a new public abstraction/subsystem, state/persistence redesign, dependency/workflow/quality-tool change, or unrelated refactor.
+
+### Slice 2 — Preserve post-evidence race safety and selector compatibility
+
+- **Rows:** A2, A3, A6.
+- **Owner / boundary:** immutable plan authorization and runtime execution guard.
+- **Allowed paths:** existing runtime guard tests and package-selector tests; production guard code only if RED demonstrates a missing boundary.
+- **RED:** deterministic replacement after fresh evidence must prove no stale candidate executes; retain package-selector regression coverage.
+- **GREEN:** post-evidence replacement remains `AGT-E203` with zero launch side effects while stable direct replacement launches; explicit selectors remain unchanged.
+- **Non-goals:** no new execution mechanism or package behavior.
+- **Verification:** focused guard/package tests, issue TUI scenario, `cargo xtask quick`, full gate, and native Windows CI.
+- **Stop for approval:** any new process-management abstraction or behavior absent from A1–A6.
+
+## Expected paths / architectural layers
+
+- `src/runtime/launch_compose.rs` — launch-time direct resolution and generation reconciliation.
+- Existing runtime behavioral tests and/or `tests/issue575_behavior.rs` — replacement, current failure, and selector regression evidence.
+- Existing execution-guard tests — post-probe fingerprint race evidence if not already sufficient.
+- `dev-docs/tmux-scenarios/issue575/` and its fixture registration — UI-visible stable-upgrade/no-error proof.
+- `src/runtime/agent_probe.rs` or `src/app_input/availability.rs` only if RED proves the existing contracts cannot carry the required evidence cleanly.
+
+No new subsystem, public abstraction, dependency, workflow, quality-tool change,
+or unrelated refactor is authorized.
+
+## Scope ledger
+
+| Entry | Status | Reason |
+|---|---|---|
+| Fresh direct-candidate resolution during launch preparation | In scope | A2 |
+| Probe-generation reconciliation from startup and fresh keys | In scope | A2/A3 |
+| Preserve post-evidence fingerprint mismatch rejection | In scope | A3 |
+| Current-candidate typed failure diagnostics | In scope | A4/A5 |
+| Explicit-selector regression protection | In scope | A6 |
+| Filesystem watching/general hot reload | Rejected | Explicit non-goal |
+| Package cache or remote resolver changes | Rejected | Different ownership and semantics |
+
+## Review and verification ledger
+
+- Local OCR: `1 / 2` — reviewed 21 supported changed files; seven findings triaged. Fixed signed/subsecond timestamp capture, fingerprint diagnostics, typed refresh gating and tests, discarded duplicate probe, recapture logging, and implicit fixture target mutation. Four files timed out in OCR subtasks and remain covered by the full reviewer cycle and local gates.
+- PR OCR: `0 / 2`
+- rustreviewer / DeepThinker: one clean full-review cycle requested over all changed and untracked files; review remediation used the complete available findings plus OCR.
+- RED evidence: the issue TUI fixture failed before implementation because the upgraded agent became `Dead` instead of `Running`; the stable replacement and race-boundary runtime tests also established the intended behavior.
+- Fast verification: `cargo xtask quick` passes after review remediation.
+- TUI verification: `direct_upgrade_fixture_launches_replacement_without_stale_error` passes, including an empty Errors screen and unchanged persisted selector/version data.
+- Windows structural verification: `cargo check --target x86_64-pc-windows-msvc --all-features` passes.
+- Exact-head verification: `cargo xtask ci` passes after remediation; line coverage is 71.26% (30% floor).
+- Native Windows CI: pending PR checks.
+- Deferred findings: none
+
+## Completion contract
+
+Complete only when every row has behavioral evidence, a stable pre-launch
+replacement creates no user-visible stale error, a post-evidence replacement
+remains fail-closed, exact-head local verification and required CI (including
+native Windows) pass, reviews are triaged within their counters, the PR is
+conflict-free, and every changed file maps to this ledger.

--- a/src/agent_candidate.rs
+++ b/src/agent_candidate.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::agent_candidate_fingerprint::CandidateFingerprint;
+pub(crate) use crate::agent_candidate_fingerprint::capture_candidate_fingerprint;
 use crate::agent_candidate_path::{AgentWrapperKind, PathSnapshot, resolve_repository_local};
 use crate::domain::agent_definition::type_id::{CandidateKind, ExecutableCandidate};
 use crate::domain::agent_definition::{AgentDefinition, DefinitionSha256};
@@ -540,36 +541,6 @@ impl ResolveOne {
     fn skip(reason: CandidateSkip) -> Self {
         Self::Skip(reason)
     }
-}
-
-pub(crate) fn capture_candidate_fingerprint(path: &Path) -> Result<CandidateFingerprint, String> {
-    let canonical = std::fs::canonicalize(path).map_err(|error| error.to_string())?;
-    let metadata = std::fs::metadata(&canonical).map_err(|error| error.to_string())?;
-    let mtime_secs = metadata
-        .modified()
-        .ok()
-        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-        .map_or(0, |duration| {
-            i64::try_from(duration.as_secs()).unwrap_or(i64::MAX)
-        });
-    let (dev, ino) = capture_dev_ino(&metadata);
-    Ok(CandidateFingerprint::new(
-        canonical,
-        dev,
-        ino,
-        metadata.len(),
-        mtime_secs,
-    ))
-}
-
-#[cfg(unix)]
-fn capture_dev_ino(metadata: &std::fs::Metadata) -> (Option<u64>, Option<u64>) {
-    use std::os::unix::fs::MetadataExt;
-    (Some(metadata.dev()), Some(metadata.ino()))
-}
-#[cfg(not(unix))]
-fn capture_dev_ino(_metadata: &std::fs::Metadata) -> (Option<u64>, Option<u64>) {
-    (None, None)
 }
 
 #[cfg(test)]

--- a/src/agent_candidate.rs
+++ b/src/agent_candidate.rs
@@ -528,7 +528,10 @@ impl<'a> AgentCandidateResolver<'a> {
                 fingerprint,
                 launch,
             }),
-            Err(detail) => ResolveOne::skip(CandidateSkip::FingerprintCapture { index, detail }),
+            Err(error) => ResolveOne::skip(CandidateSkip::FingerprintCapture {
+                index,
+                detail: error.to_string(),
+            }),
         }
     }
 }

--- a/src/agent_candidate_fingerprint.rs
+++ b/src/agent_candidate_fingerprint.rs
@@ -14,6 +14,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// Stable physical fingerprint of one resolved executable.
 ///
@@ -118,11 +119,57 @@ impl CandidateFingerprint {
     }
 }
 
+/// Failure to capture authoritative physical executable evidence.
+#[derive(Debug, Error)]
+pub(crate) enum FingerprintCaptureError {
+    /// The supplied executable path could not be canonicalized.
+    #[error("canonicalize executable {}: {source}", path.display())]
+    Canonicalize {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// Metadata for the canonical executable could not be read.
+    #[error("read executable metadata {}: {source}", path.display())]
+    Metadata {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// The executable modification time could not be read.
+    #[error("read executable modification time {}: {source}", path.display())]
+    Modified {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// Windows physical-file identity capture failed.
+    #[cfg(windows)]
+    #[error("capture Windows file identity for {}: {detail}", path.display())]
+    WindowsFileKey { path: PathBuf, detail: String },
+}
+
 /// Capture one executable fingerprint using the platform's physical file key.
-pub(crate) fn capture_candidate_fingerprint(path: &Path) -> Result<CandidateFingerprint, String> {
-    let canonical = std::fs::canonicalize(path).map_err(|error| error.to_string())?;
-    let metadata = std::fs::metadata(&canonical).map_err(|error| error.to_string())?;
-    let (mtime_secs, mtime_nanos) = metadata.modified().map(timestamp_parts).unwrap_or_default();
+pub(crate) fn capture_candidate_fingerprint(
+    path: &Path,
+) -> Result<CandidateFingerprint, FingerprintCaptureError> {
+    let canonical =
+        std::fs::canonicalize(path).map_err(|source| FingerprintCaptureError::Canonicalize {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let metadata =
+        std::fs::metadata(&canonical).map_err(|source| FingerprintCaptureError::Metadata {
+            path: canonical.clone(),
+            source,
+        })?;
+    let modified = metadata
+        .modified()
+        .map_err(|source| FingerprintCaptureError::Modified {
+            path: canonical.clone(),
+            source,
+        })?;
+    let (mtime_secs, mtime_nanos) = timestamp_parts(modified);
     #[cfg(unix)]
     let (dev, ino) = capture_file_key(&metadata, &canonical);
     #[cfg(windows)]
@@ -167,14 +214,17 @@ fn capture_file_key(metadata: &std::fs::Metadata, _path: &Path) -> (Option<u64>,
 fn capture_file_key(
     _metadata: &std::fs::Metadata,
     path: &Path,
-) -> Result<(Option<u64>, Option<u64>), String> {
+) -> Result<(Option<u64>, Option<u64>), FingerprintCaptureError> {
     use winsafe::{HFILE, co};
 
-    let path = path
+    let path_text = path
         .to_str()
-        .ok_or_else(|| "canonical executable path is not Unicode".to_owned())?;
+        .ok_or_else(|| FingerprintCaptureError::WindowsFileKey {
+            path: path.to_path_buf(),
+            detail: "canonical executable path is not Unicode".to_owned(),
+        })?;
     let (handle, _) = HFILE::CreateFile(
-        path,
+        path_text,
         co::GENERIC::READ,
         Some(co::FILE_SHARE::READ | co::FILE_SHARE::WRITE | co::FILE_SHARE::DELETE),
         None,
@@ -184,10 +234,16 @@ fn capture_file_key(
         None,
         None,
     )
-    .map_err(|error| error.to_string())?;
-    let information = handle
-        .GetFileInformationByHandle()
-        .map_err(|error| error.to_string())?;
+    .map_err(|error| FingerprintCaptureError::WindowsFileKey {
+        path: path.to_path_buf(),
+        detail: error.to_string(),
+    })?;
+    let information = handle.GetFileInformationByHandle().map_err(|error| {
+        FingerprintCaptureError::WindowsFileKey {
+            path: path.to_path_buf(),
+            detail: error.to_string(),
+        }
+    })?;
     Ok((
         Some(u64::from(information.dwVolumeSerialNumber)),
         Some(information.nFileIndex()),

--- a/src/agent_candidate_fingerprint.rs
+++ b/src/agent_candidate_fingerprint.rs
@@ -1,7 +1,7 @@
 //! Physical fingerprint of a resolved executable candidate (issue #382 CW-02 S2).
 //!
 //! Per the issue's deterministic algorithm #2, an executable is canonicalized,
-//! opened, and fingerprinted as `(canonical path, device/inode where available,
+//! opened, and fingerprinted as `(canonical path, platform-native file key,
 //! size, mtime)` before probe. This module owns that pure value type; the
 //! resolver ([`crate::agent_candidate`]) populates it after canonicalization
 //! and metadata capture. The fingerprint participates in launch-generation
@@ -9,13 +9,9 @@
 //! is therefore `Eq`/`Hash`-stable. It deliberately excludes any
 //! installation-specific identity or capability: those live in the probe
 //! result, not the physical fingerprint.
-//!
-//! `dev`/`ino` are captured only where the platform exposes them (Unix).
-//! Where unavailable the field is `None`; the remaining `(canonical path,
-//! size, mtime)` triple is still a stable per-file fingerprint within a host.
 
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -29,20 +25,19 @@ use serde::{Deserialize, Serialize};
 pub struct CandidateFingerprint {
     /// Canonical absolute path of the resolved executable.
     canonical_path: PathBuf,
-    /// Device id of the file's containing device, where the platform exposes
-    /// it (Unix). `None` on platforms without a stable device id.
+    /// Device or volume id of the file's containing device.
     #[serde(default)]
     dev: Option<u64>,
-    /// Inode number of the file, where the platform exposes it (Unix). `None`
-    /// on platforms without a stable inode.
+    /// Inode or Windows file-index identity of the physical file.
     #[serde(default)]
     ino: Option<u64>,
     /// File size in bytes at fingerprint time.
     size: u64,
-    /// Last-modification time, in seconds since the Unix epoch, at fingerprint
-    /// time. Captured as a plain integer so the type stays `Hash`/`Eq` without
-    /// a `SystemTime` platform representation.
+    /// Last-modification time, in seconds since the Unix epoch.
     mtime_secs: i64,
+    /// Subsecond nanoseconds retained so rapid in-place rewrites are distinct.
+    #[serde(default)]
+    mtime_nanos: u32,
 }
 
 impl CandidateFingerprint {
@@ -59,12 +54,24 @@ impl CandidateFingerprint {
         size: u64,
         mtime_secs: i64,
     ) -> Self {
+        Self::with_mtime_nanos(canonical_path, dev, ino, size, mtime_secs, 0)
+    }
+
+    fn with_mtime_nanos(
+        canonical_path: PathBuf,
+        dev: Option<u64>,
+        ino: Option<u64>,
+        size: u64,
+        mtime_secs: i64,
+        mtime_nanos: u32,
+    ) -> Self {
         Self {
             canonical_path,
             dev,
             ino,
             size,
             mtime_secs,
+            mtime_nanos,
         }
     }
 
@@ -98,14 +105,93 @@ impl CandidateFingerprint {
         self.mtime_secs
     }
 
-    /// Whether the dev/inode pair is present.
-    ///
-    /// On Unix the pair is the strongest identity signal; on platforms without
-    /// it the resolver relies on the `(canonical path, size, mtime)` triple.
+    /// Subsecond nanoseconds of the last-modification time.
+    #[must_use]
+    pub const fn mtime_nanos(&self) -> u32 {
+        self.mtime_nanos
+    }
+
+    /// Whether the platform-native physical file key is present.
     #[must_use]
     pub fn has_dev_ino(&self) -> bool {
         self.dev.is_some() && self.ino.is_some()
     }
+}
+
+/// Capture one executable fingerprint using the platform's physical file key.
+pub(crate) fn capture_candidate_fingerprint(path: &Path) -> Result<CandidateFingerprint, String> {
+    let canonical = std::fs::canonicalize(path).map_err(|error| error.to_string())?;
+    let metadata = std::fs::metadata(&canonical).map_err(|error| error.to_string())?;
+    let (mtime_secs, mtime_nanos) = metadata.modified().map(timestamp_parts).unwrap_or_default();
+    #[cfg(unix)]
+    let (dev, ino) = capture_file_key(&metadata, &canonical);
+    #[cfg(windows)]
+    let (dev, ino) = capture_file_key(&metadata, &canonical)?;
+    Ok(CandidateFingerprint::with_mtime_nanos(
+        canonical,
+        dev,
+        ino,
+        metadata.len(),
+        mtime_secs,
+        mtime_nanos,
+    ))
+}
+
+fn timestamp_parts(time: std::time::SystemTime) -> (i64, u32) {
+    match time.duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => (
+            i64::try_from(duration.as_secs()).unwrap_or(i64::MAX),
+            duration.subsec_nanos(),
+        ),
+        Err(error) => {
+            let duration = error.duration();
+            let seconds = i64::try_from(duration.as_secs()).unwrap_or(i64::MAX);
+            if duration.subsec_nanos() == 0 {
+                (seconds.saturating_neg(), 0)
+            } else {
+                (
+                    seconds.saturating_neg().saturating_sub(1),
+                    1_000_000_000 - duration.subsec_nanos(),
+                )
+            }
+        }
+    }
+}
+#[cfg(unix)]
+fn capture_file_key(metadata: &std::fs::Metadata, _path: &Path) -> (Option<u64>, Option<u64>) {
+    use std::os::unix::fs::MetadataExt;
+    (Some(metadata.dev()), Some(metadata.ino()))
+}
+
+#[cfg(windows)]
+fn capture_file_key(
+    _metadata: &std::fs::Metadata,
+    path: &Path,
+) -> Result<(Option<u64>, Option<u64>), String> {
+    use winsafe::{HFILE, co};
+
+    let path = path
+        .to_str()
+        .ok_or_else(|| "canonical executable path is not Unicode".to_owned())?;
+    let (handle, _) = HFILE::CreateFile(
+        path,
+        co::GENERIC::READ,
+        Some(co::FILE_SHARE::READ | co::FILE_SHARE::WRITE | co::FILE_SHARE::DELETE),
+        None,
+        co::DISPOSITION::OPEN_EXISTING,
+        co::FILE_ATTRIBUTE::NORMAL,
+        None,
+        None,
+        None,
+    )
+    .map_err(|error| error.to_string())?;
+    let information = handle
+        .GetFileInformationByHandle()
+        .map_err(|error| error.to_string())?;
+    Ok((
+        Some(u64::from(information.dwVolumeSerialNumber)),
+        Some(information.nFileIndex()),
+    ))
 }
 
 impl fmt::Display for CandidateFingerprint {
@@ -113,10 +199,11 @@ impl fmt::Display for CandidateFingerprint {
         // Diagnostic surface only; never includes secret-bearing content.
         write!(
             f,
-            "{}(size={}, mtime={}",
+            "{}(size={}, mtime={}.{:09}",
             self.canonical_path.display(),
             self.size,
             self.mtime_secs,
+            self.mtime_nanos,
         )?;
         if let (Some(dev), Some(ino)) = (self.dev, self.ino) {
             write!(f, ", dev={dev}, ino={ino}")?;

--- a/src/agent_candidate_fingerprint_tests.rs
+++ b/src/agent_candidate_fingerprint_tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for [`CandidateFingerprint`].
 
-use super::CandidateFingerprint;
+use super::{CandidateFingerprint, FingerprintCaptureError, capture_candidate_fingerprint};
 
 #[test]
 fn new_captures_all_fields() {
@@ -90,4 +90,21 @@ fn display_includes_subsecond_modification_time() {
     );
 
     assert!(fp.to_string().contains("mtime=4.123456789"));
+}
+
+#[test]
+fn missing_executable_reports_typed_canonicalize_error() {
+    let missing =
+        std::env::temp_dir().join(format!("jefe-missing-fingerprint-{}", std::process::id()));
+
+    let error = capture_candidate_fingerprint(&missing)
+        .err()
+        .unwrap_or_else(|| panic!("missing executable must fail fingerprint capture"));
+    match error {
+        FingerprintCaptureError::Canonicalize { path, source } => {
+            assert_eq!(path, missing);
+            assert_eq!(source.kind(), std::io::ErrorKind::NotFound);
+        }
+        other => panic!("expected canonicalize error, got {other}"),
+    }
 }

--- a/src/agent_candidate_fingerprint_tests.rs
+++ b/src/agent_candidate_fingerprint_tests.rs
@@ -68,3 +68,26 @@ fn display_includes_path_size_mtime_and_dev_ino_when_present() {
     assert!(s.contains("dev=7"), "{s}");
     assert!(s.contains("ino=8"), "{s}");
 }
+
+#[test]
+fn timestamp_parts_preserve_pre_epoch_sign_and_subseconds() {
+    let before = std::time::UNIX_EPOCH - std::time::Duration::from_millis(250);
+    let after = std::time::UNIX_EPOCH + std::time::Duration::from_millis(250);
+
+    assert_eq!(super::timestamp_parts(before), (-1, 750_000_000));
+    assert_eq!(super::timestamp_parts(after), (0, 250_000_000));
+}
+
+#[test]
+fn display_includes_subsecond_modification_time() {
+    let fp = CandidateFingerprint::with_mtime_nanos(
+        std::path::PathBuf::from("/bin/llxprt"),
+        Some(7),
+        Some(8),
+        3,
+        4,
+        123_456_789,
+    );
+
+    assert!(fp.to_string().contains("mtime=4.123456789"));
+}

--- a/src/app_input/availability.rs
+++ b/src/app_input/availability.rs
@@ -125,9 +125,29 @@ pub(super) fn require_local_kind_available(
     require_local_kind_available_for_target(type_id, available)
 }
 
+enum DirectAvailabilityGate {
+    Cached,
+    RefreshCurrent,
+}
+
 pub(super) fn launch_available_or_error(
     app_state: &mut AppStateHandle,
     request: &AgentLaunchRequest,
+) -> bool {
+    launch_availability_or_error(app_state, request, DirectAvailabilityGate::Cached)
+}
+
+pub(super) fn launch_refresh_available_or_error(
+    app_state: &mut AppStateHandle,
+    request: &AgentLaunchRequest,
+) -> bool {
+    launch_availability_or_error(app_state, request, DirectAvailabilityGate::RefreshCurrent)
+}
+
+fn launch_availability_or_error(
+    app_state: &mut AppStateHandle,
+    request: &AgentLaunchRequest,
+    direct_gate: DirectAvailabilityGate,
 ) -> bool {
     let result = {
         let state = app_state.read();
@@ -136,12 +156,14 @@ pub(super) fn launch_available_or_error(
         } else if has_package_selector(request) {
             Ok(())
         } else {
-            state
-                .agent_type_availability
-                .iter()
-                .find(|observation| observation.type_id() == &request.type_id)
-                .ok_or_else(|| format!("no state-owned availability for {}", request.type_id))
-                .and_then(launch_availability_result)
+            direct_availability_result(
+                state
+                    .agent_type_availability
+                    .iter()
+                    .find(|observation| observation.type_id() == &request.type_id),
+                &request.type_id,
+                direct_gate,
+            )
         }
     };
     match result {
@@ -217,6 +239,19 @@ fn launch_availability_result(observation: &AgentAvailabilityObservation) -> Res
     }
 }
 
+fn direct_availability_result(
+    observation: Option<&AgentAvailabilityObservation>,
+    type_id: &AgentTypeId,
+    gate: DirectAvailabilityGate,
+) -> Result<(), String> {
+    let observation =
+        observation.ok_or_else(|| format!("no state-owned availability for {type_id}"))?;
+    match gate {
+        DirectAvailabilityGate::Cached => launch_availability_result(observation),
+        DirectAvailabilityGate::RefreshCurrent => Ok(()),
+    }
+}
+
 fn has_package_selector(request: &AgentLaunchRequest) -> bool {
     matches!(
         typed_field(&request.values, "version_selector"),
@@ -289,6 +324,48 @@ mod tests {
             remote: RemoteRepositorySettings::default(),
             operation: jefe::domain::agent_definition::Operation::Normal,
         }
+    }
+
+    #[test]
+    fn refresh_current_bypasses_stale_cached_failure_but_requires_observation() {
+        let definition = jefe::domain::agent_definition::AgentDefinition::shipped()
+            .into_iter()
+            .find(|definition| definition.id.as_str() == "core.llxprt")
+            .unwrap_or_else(|| panic!("LLxprt definition must be shipped"));
+        let observation = AgentAvailabilityObservation::new(
+            &definition,
+            true,
+            Availability::ProbeError {
+                code: jefe::domain::agent_definition::ProbeErrorCode::Agte202,
+                reason: "stale startup probe failure".to_owned(),
+                generation: 7,
+            },
+        );
+
+        assert!(
+            direct_availability_result(
+                Some(&observation),
+                &definition.id,
+                DirectAvailabilityGate::Cached,
+            )
+            .is_err()
+        );
+        assert!(
+            direct_availability_result(
+                Some(&observation),
+                &definition.id,
+                DirectAvailabilityGate::RefreshCurrent,
+            )
+            .is_ok()
+        );
+        assert!(
+            direct_availability_result(
+                None,
+                &definition.id,
+                DirectAvailabilityGate::RefreshCurrent,
+            )
+            .is_err()
+        );
     }
 
     fn valid_remote() -> RemoteRepositorySettings {

--- a/src/app_input/issues_rewrite_dispatch.rs
+++ b/src/app_input/issues_rewrite_dispatch.rs
@@ -37,7 +37,7 @@ pub(super) fn handle_request_issue_rewrite(app_state: &mut AppStateHandle, ctx: 
         Ok(Some(context)) => context,
     };
 
-    if !super::availability::launch_available_or_error(app_state, &context.signature) {
+    if !super::availability::launch_refresh_available_or_error(app_state, &context.signature) {
         return;
     }
 

--- a/src/app_input/issues_send.rs
+++ b/src/app_input/issues_send.rs
@@ -56,7 +56,7 @@ pub(super) fn dispatch_agent_chooser_confirm(app_state: &mut AppStateHandle, ctx
     let prompt = issues_dispatch::format_issue_prompt(&send_info.payload);
     let launch_sig = prepare_issue_launch_signature(send_info.signature, &prompt);
 
-    if !super::availability::launch_available_or_error(app_state, &launch_sig)
+    if !super::availability::launch_refresh_available_or_error(app_state, &launch_sig)
         || !super::availability::validate_launch_or_error(app_state, &launch_sig)
     {
         return;
@@ -254,7 +254,7 @@ fn prepare_confirm_send_target(
 
     // Re-check availability BEFORE prep side effects: the runtime may have
     // been removed while the confirm modal was open.
-    if !super::availability::launch_available_or_error(app_state, launch_sig)
+    if !super::availability::launch_refresh_available_or_error(app_state, launch_sig)
         || !super::availability::validate_launch_or_error(app_state, launch_sig)
     {
         return None;

--- a/src/app_input/prs_orchestration.rs
+++ b/src/app_input/prs_orchestration.rs
@@ -578,7 +578,7 @@ fn dispatch_pr_agent_chooser_confirm(app_state: &mut AppStateHandle, ctx: &Share
     // Availability + target validation BEFORE any prep side effect: a missing
     // agent runtime or an invalid/incomplete remote config must not trigger
     // local or remote prep.
-    if !super::availability::launch_available_or_error(app_state, &launch_sig)
+    if !super::availability::launch_refresh_available_or_error(app_state, &launch_sig)
         || !super::availability::validate_launch_or_error(app_state, &launch_sig)
     {
         return;

--- a/src/app_input/relaunch.rs
+++ b/src/app_input/relaunch.rs
@@ -100,7 +100,7 @@ fn relaunch_preflight_passed(
     let Some((_, signature)) = agent_sig else {
         return true;
     };
-    if !availability::launch_available_or_error(app_state, &signature) {
+    if !availability::launch_refresh_available_or_error(app_state, &signature) {
         return false;
     }
     preflight_or_prompt(app_state, ctx, agent_id, &signature, None)

--- a/src/app_input/relaunch_tests.rs
+++ b/src/app_input/relaunch_tests.rs
@@ -93,7 +93,19 @@ fn attach_failure_is_preserved_as_distinct_relaunch_diagnostic() {
     let attach_error =
         RuntimeError::AttachFailed("session exited before the viewer became ready".to_owned());
     let mut runtime = StubRuntimeManager::with_attach_failure(attach_error.clone());
-    let plan = authorized_launch_plan(&AgentLaunchPlan::default());
+    let fixture_plan = AgentLaunchPlan {
+        target: jefe::domain::agent_definition::Target::Remote(
+            jefe::domain::agent_definition::RemoteTarget {
+                user: "fixture".to_owned(),
+                host: "example.invalid".to_owned(),
+                port: None,
+                run_as_user: String::new(),
+                canonical_cwd: std::path::PathBuf::from("/tmp/work"),
+            },
+        ),
+        ..AgentLaunchPlan::default()
+    };
+    let plan = authorized_launch_plan(&fixture_plan);
     if let Err(error) = runtime.spawn_session(&agent_id, &plan, None) {
         panic!("test session should spawn: {error}");
     }

--- a/src/app_input/transient_issue_send.rs
+++ b/src/app_input/transient_issue_send.rs
@@ -143,7 +143,7 @@ fn transient_issue_availability_and_target(
     ctx: &SharedContext,
     prep: &TransientPrepContext,
 ) -> Option<super::target_resolution::WorkTarget> {
-    if !super::availability::launch_available_or_error(app_state, &prep.launch_sig)
+    if !super::availability::launch_refresh_available_or_error(app_state, &prep.launch_sig)
         || !super::availability::validate_launch_or_error(app_state, &prep.launch_sig)
     {
         fail_transient_agent(app_state, ctx, &prep.agent_id);

--- a/src/app_input/transient_pr_send.rs
+++ b/src/app_input/transient_pr_send.rs
@@ -118,7 +118,7 @@ fn transient_pr_availability_and_target(
     ctx: &SharedContext,
     prep: &TransientPrPrepContext,
 ) -> Option<super::target_resolution::WorkTarget> {
-    if !super::availability::launch_available_or_error(app_state, &prep.launch_sig)
+    if !super::availability::launch_refresh_available_or_error(app_state, &prep.launch_sig)
         || !super::availability::validate_launch_or_error(app_state, &prep.launch_sig)
     {
         super::transient_issue_send::fail_transient_agent(app_state, ctx, &prep.agent_id);

--- a/src/runtime/agent_execution_guard.rs
+++ b/src/runtime/agent_execution_guard.rs
@@ -166,6 +166,15 @@ pub struct AuthorizationRejection {
 }
 
 impl AuthorizationRejection {
+    /// Construct the fail-closed executable-fingerprint mismatch diagnostic.
+    #[must_use]
+    pub(crate) const fn executable_fingerprint() -> Self {
+        Self {
+            code: ProbeErrorCode::Agte203,
+            dimension: StaleDimension::ExecutableFingerprint,
+        }
+    }
+
     /// The closed stale-generation code (`AGT-E203`).
     #[must_use]
     pub const fn code(&self) -> ProbeErrorCode {

--- a/src/runtime/agent_preflight.rs
+++ b/src/runtime/agent_preflight.rs
@@ -35,7 +35,8 @@
 use std::fmt;
 use std::process::Command;
 
-use crate::domain::agent_definition::types::AgentLaunchPlan;
+use crate::agent_candidate_fingerprint::capture_candidate_fingerprint;
+use crate::domain::agent_definition::types::{AgentLaunchPlan, Target};
 use crate::runtime::agent_execution_guard::{
     AuthorizationRejection, AuthorizationResult, AuthorizedExecution, ExecutionEvidence,
     authorize_execution,
@@ -341,7 +342,8 @@ impl AuthorizedLaunchPlan {
         &self,
         inspector: &dyn SandboxInspector,
     ) -> Result<PreflightCleared<'_>, LaunchProofError> {
-        let authorized = match authorize_execution(&self.plan, &self.evidence) {
+        let current_evidence = self.current_execution_evidence()?;
+        let authorized = match authorize_execution(&self.plan, &current_evidence) {
             AuthorizationResult::Authorized(authorized) => authorized,
             AuthorizationResult::Rejected(error) => {
                 return Err(LaunchProofError::Authorization(error));
@@ -351,6 +353,31 @@ impl AuthorizedLaunchPlan {
             PreparationOutcome::Cleared(cleared) => Ok(cleared),
             PreparationOutcome::Unavailable(reason) => Err(LaunchProofError::Preflight(reason)),
         }
+    }
+
+    fn current_execution_evidence(&self) -> Result<ExecutionEvidence, LaunchProofError> {
+        let executable_fingerprint =
+            match self.plan.target {
+                Target::Local { .. } => capture_candidate_fingerprint(&self.plan.executable)
+                    .map_err(|error| {
+                        tracing::warn!(
+                            %error,
+                            executable = %self.plan.executable.display(),
+                            "failed to recapture local executable fingerprint before launch"
+                        );
+                        LaunchProofError::Authorization(
+                            AuthorizationRejection::executable_fingerprint(),
+                        )
+                    })?,
+                Target::Remote(_) => self.evidence.executable_fingerprint().clone(),
+            };
+        Ok(ExecutionEvidence::new(
+            *self.evidence.definition_sha256(),
+            executable_fingerprint,
+            self.evidence.probe_generation(),
+            self.evidence.target_generation(),
+            self.evidence.activation_generation(),
+        ))
     }
 }
 

--- a/src/runtime/agent_probe.rs
+++ b/src/runtime/agent_probe.rs
@@ -11,7 +11,7 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 use crate::agent_candidate::{CandidateGenerationKey, CandidateResolution, ResolvedCandidate};
-use crate::agent_candidate_fingerprint::CandidateFingerprint;
+use crate::agent_candidate_fingerprint::{CandidateFingerprint, capture_candidate_fingerprint};
 use crate::agent_candidate_path::AgentWrapperKind;
 use crate::domain::agent_definition::limits::{
     LOCAL_PROBE_TIMEOUT_MS, PACKAGE_MATERIALIZATION_TIMEOUT_MS, REMOTE_PROBE_TIMEOUT_MS,
@@ -495,41 +495,10 @@ fn command_with_args(program: &OsStr, argv: &[OsString]) -> Command {
 }
 
 fn fingerprint_changed(candidate: &ResolvedCandidate) -> bool {
-    match capture_fingerprint(candidate.executable()) {
-        Some(current) => &current != candidate.fingerprint(),
-        None => true,
+    match capture_candidate_fingerprint(candidate.executable()) {
+        Ok(current) => &current != candidate.fingerprint(),
+        Err(_) => true,
     }
-}
-
-fn capture_fingerprint(path: &Path) -> Option<CandidateFingerprint> {
-    let canonical = std::fs::canonicalize(path).ok()?;
-    let metadata = std::fs::metadata(&canonical).ok()?;
-    let mtime_secs = metadata
-        .modified()
-        .ok()
-        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-        .map_or(0, |duration| {
-            i64::try_from(duration.as_secs()).unwrap_or(i64::MAX)
-        });
-    let (dev, ino) = capture_dev_ino(&metadata);
-    Some(CandidateFingerprint::new(
-        canonical,
-        dev,
-        ino,
-        metadata.len(),
-        mtime_secs,
-    ))
-}
-
-#[cfg(unix)]
-fn capture_dev_ino(metadata: &std::fs::Metadata) -> (Option<u64>, Option<u64>) {
-    use std::os::unix::fs::MetadataExt;
-    (Some(metadata.dev()), Some(metadata.ino()))
-}
-
-#[cfg(not(unix))]
-fn capture_dev_ino(_metadata: &std::fs::Metadata) -> (Option<u64>, Option<u64>) {
-    (None, None)
 }
 
 fn compatible(identity: String, capabilities: Vec<String>, generation: u64) -> Availability {

--- a/src/runtime/launch_compose.rs
+++ b/src/runtime/launch_compose.rs
@@ -33,8 +33,6 @@ use super::package_runtime::{finalize_local_invocation, managed_package_cache_ro
 /// Current state-owned evidence from which one launch attempt is derived.
 #[derive(Debug, Clone)]
 pub struct LaunchStateEvidence {
-    availability: crate::domain::agent_definition::Availability,
-    resolution: Option<CandidateResolution>,
     candidate_generation_key: Option<CandidateGenerationKey>,
     probe_generation: u64,
     target_generation: u64,
@@ -51,8 +49,6 @@ impl LaunchStateEvidence {
         activation_generation: u64,
     ) -> Self {
         Self {
-            availability: observation.availability().clone(),
-            resolution: observation.candidate_resolution().cloned(),
             candidate_generation_key: observation.candidate_generation_key().cloned(),
             probe_generation: observation.generation(),
             target_generation,
@@ -121,6 +117,15 @@ pub fn prepare_launch(
     configuration: &AgentLaunchRequest,
     state_evidence: &LaunchStateEvidence,
 ) -> Result<PreparedLaunch, RuntimeError> {
+    let snapshot = PathSnapshot::current();
+    prepare_launch_with_snapshot(configuration, state_evidence, &snapshot)
+}
+
+fn prepare_launch_with_snapshot(
+    configuration: &AgentLaunchRequest,
+    state_evidence: &LaunchStateEvidence,
+    local_snapshot: &PathSnapshot,
+) -> Result<PreparedLaunch, RuntimeError> {
     let definition = definition_for(configuration)?;
     validate_support_before_effects(&definition, configuration)?;
     let selector = version_selector(&configuration.values)?;
@@ -134,7 +139,13 @@ pub fn prepare_launch(
             state_evidence.probe_generation,
         )?
     } else {
-        local_candidate(&definition, configuration, &selector, state_evidence)?
+        local_candidate_with_snapshot(
+            &definition,
+            configuration,
+            &selector,
+            state_evidence,
+            local_snapshot,
+        )?
     };
     let preflight = preflight_contract(&definition, &configuration.values)?;
     let plan = immutable_plan(ImmutablePlanInputs {
@@ -267,10 +278,7 @@ pub fn observe_launch_state(
     let key = candidate.generation_key(&definition);
     let generation = next_probe_generation(None, &key, u64::default())
         .map_err(|error| RuntimeError::SpawnFailed(error.to_string()))?;
-    let probe = run_local_agent_probe(&definition, &resolution, generation);
     Ok(LaunchStateEvidence {
-        availability: probe.availability().clone(),
-        resolution: Some(resolution),
         candidate_generation_key: Some(key),
         probe_generation: generation,
         target_generation: u64::default(),
@@ -339,22 +347,16 @@ fn support_target(configuration: &AgentLaunchRequest) -> Target {
     }
 }
 
-fn local_candidate(
+fn local_candidate_with_snapshot(
     definition: &AgentDefinition,
     configuration: &AgentLaunchRequest,
     selector: &VersionSelector,
     state_evidence: &LaunchStateEvidence,
+    snapshot: &PathSnapshot,
 ) -> Result<CandidateEvidence, RuntimeError> {
-    let resolution = if selector.is_direct() {
-        state_evidence.resolution.clone().ok_or_else(|| {
-            RuntimeError::SpawnFailed("state has no resolved local executable evidence".into())
-        })?
-    } else {
-        let snapshot = PathSnapshot::current();
-        AgentCandidateResolver::new(&snapshot, configuration.work_dir.clone())
-            .with_version_selector(selector.clone())
-            .resolve(definition)
-    };
+    let resolution = AgentCandidateResolver::new(snapshot, configuration.work_dir.clone())
+        .with_version_selector(selector.clone())
+        .resolve(definition);
     let candidate = resolved_candidate(&resolution)?;
     let current_key = candidate.generation_key(definition);
     let generation = next_probe_generation(
@@ -363,17 +365,6 @@ fn local_candidate(
         state_evidence.probe_generation,
     )
     .map_err(|error| RuntimeError::SpawnFailed(error.to_string()))?;
-    if selector.is_direct()
-        && !matches!(
-            state_evidence.availability,
-            crate::domain::agent_definition::Availability::InstalledCompatible { .. }
-                | crate::domain::agent_definition::Availability::NotFound
-        )
-    {
-        return Err(RuntimeError::SpawnFailed(
-            "state-owned local availability is not compatible".into(),
-        ));
-    }
     let probe = run_local_agent_probe(definition, &resolution, generation);
     let invocation = finalize_local_invocation(candidate, &managed_package_cache_root())
         .map_err(|error| RuntimeError::SpawnFailed(error.to_string()))?;

--- a/src/runtime/launch_compose_tests.rs
+++ b/src/runtime/launch_compose_tests.rs
@@ -258,3 +258,154 @@ fn remote_normal_and_resume_emit_only_selected_continuation() {
         }
     }
 }
+
+#[cfg(unix)]
+fn write_direct_fixture(path: &std::path::Path, version: &str, exit_code: i32) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let body = format!("#!/bin/sh\nprintf '{version}\\n'\nexit {exit_code}\n");
+    std::fs::write(path, body).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
+    let mut permissions = std::fs::metadata(path)
+        .unwrap_or_else(|error| panic!("metadata {}: {error}", path.display()))
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions)
+        .unwrap_or_else(|error| panic!("chmod {}: {error}", path.display()));
+}
+
+#[cfg(unix)]
+fn direct_fixture(
+    generation: u64,
+) -> (
+    tempfile::TempDir,
+    AgentDefinition,
+    AgentLaunchRequest,
+    LaunchStateEvidence,
+) {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let bin = root.path().join("bin");
+    std::fs::create_dir(&bin).unwrap_or_else(|error| panic!("create bin: {error}"));
+    let executable = bin.join("llxprt");
+    write_direct_fixture(&executable, "0.10.0", 0);
+    let definition = llxprt();
+    let snapshot = PathSnapshot::for_platform(
+        crate::agent_candidate_path::AgentExecutablePlatform::Unix,
+        vec![bin],
+        None,
+    );
+    let resolution =
+        AgentCandidateResolver::new(&snapshot, root.path().to_path_buf()).resolve(&definition);
+    let mut observation =
+        AgentAvailabilityObservation::pending(&definition, true, generation, resolution.clone());
+    let probe = run_local_agent_probe(&definition, &resolution, generation);
+    assert!(observation.apply_probe_result(generation, probe.availability().clone()));
+    let request = AgentLaunchRequest {
+        type_id: definition.id.clone(),
+        values: typed_values(false),
+        work_dir: root.path().to_path_buf(),
+        remote: RemoteRepositorySettings::default(),
+        operation: Operation::Normal,
+    };
+    let evidence = LaunchStateEvidence::from_observation(&observation, 0, 0);
+    (root, definition, request, evidence)
+}
+
+#[cfg(unix)]
+fn direct_snapshot(root: &std::path::Path) -> PathSnapshot {
+    PathSnapshot::for_platform(
+        crate::agent_candidate_path::AgentExecutablePlatform::Unix,
+        vec![root.join("bin")],
+        None,
+    )
+}
+
+#[cfg(unix)]
+#[test]
+fn unchanged_direct_candidate_retains_probe_generation() {
+    let (root, _definition, request, evidence) = direct_fixture(7);
+    let prepared = prepare_launch_with_snapshot(&request, &evidence, &direct_snapshot(root.path()))
+        .unwrap_or_else(|error| panic!("unchanged direct candidate must prepare: {error}"));
+
+    assert_eq!(prepared.plan().probe_generation, 7);
+}
+
+#[cfg(unix)]
+#[test]
+fn stable_direct_replacement_advances_generation_and_reprobes_current_file() {
+    let (root, _definition, request, evidence) = direct_fixture(7);
+    let executable = root.path().join("bin/llxprt");
+    let replacement = root.path().join("bin/llxprt.next");
+    write_direct_fixture(&replacement, "0.11.0", 0);
+    std::fs::rename(&replacement, &executable)
+        .unwrap_or_else(|error| panic!("replace {}: {error}", executable.display()));
+
+    let prepared = prepare_launch_with_snapshot(&request, &evidence, &direct_snapshot(root.path()))
+        .unwrap_or_else(|error| panic!("stable replacement must prepare: {error}"));
+
+    assert_eq!(prepared.plan().probe_generation, 8);
+}
+
+#[cfg(unix)]
+#[test]
+fn removed_direct_candidate_reports_current_not_found() {
+    let (root, _definition, request, evidence) = direct_fixture(7);
+    let executable = root.path().join("bin/llxprt");
+    std::fs::remove_file(&executable)
+        .unwrap_or_else(|error| panic!("remove {}: {error}", executable.display()));
+
+    let error = prepare_launch_with_snapshot(&request, &evidence, &direct_snapshot(root.path()))
+        .err()
+        .unwrap_or_else(|| panic!("removed direct candidate must fail"));
+
+    assert!(
+        error
+            .to_string()
+            .contains("configured agent executable was not found")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn failing_direct_replacement_reports_current_probe_error() {
+    let (root, _definition, request, evidence) = direct_fixture(7);
+    let executable = root.path().join("bin/llxprt");
+    let replacement = root.path().join("bin/llxprt.next");
+    write_direct_fixture(&replacement, "0.11.0", 9);
+    std::fs::rename(&replacement, &executable)
+        .unwrap_or_else(|error| panic!("replace {}: {error}", executable.display()));
+
+    let error = prepare_launch_with_snapshot(&request, &evidence, &direct_snapshot(root.path()))
+        .err()
+        .unwrap_or_else(|| panic!("failing replacement must reject launch"));
+
+    assert!(error.to_string().contains("AGT-E202"));
+}
+
+#[cfg(unix)]
+#[test]
+fn post_evidence_replacement_is_rejected_before_stub_session_effects() {
+    use crate::domain::AgentId;
+    use crate::runtime::{RuntimeManager, StubRuntimeManager};
+
+    let (root, _definition, request, evidence) = direct_fixture(7);
+    let prepared = prepare_launch_with_snapshot(&request, &evidence, &direct_snapshot(root.path()))
+        .unwrap_or_else(|error| panic!("initial launch must prepare: {error}"));
+    let executable = root.path().join("bin/llxprt");
+    let replacement = root.path().join("bin/llxprt.next");
+    write_direct_fixture(&replacement, "0.12.0", 0);
+    std::fs::rename(&replacement, &executable)
+        .unwrap_or_else(|error| panic!("replace {}: {error}", executable.display()));
+
+    let agent_id = AgentId("issue575-race".to_owned());
+    let mut manager = StubRuntimeManager::default();
+    let error = manager
+        .spawn_session(&agent_id, prepared.authorized(), None)
+        .err()
+        .unwrap_or_else(|| panic!("post-evidence replacement must fail closed"));
+
+    let crate::runtime::RuntimeError::SpawnFailed(reason) = error else {
+        panic!("fingerprint mismatch must be a spawn failure");
+    };
+    assert!(reason.contains("AGT-E203"), "{reason}");
+    assert!(!manager.session_exists(&agent_id));
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -245,6 +245,15 @@ mod tests {
     fn fixture_plan(work_dir: &str) -> AgentLaunchPlan {
         AgentLaunchPlan {
             cwd: PathBuf::from(work_dir),
+            target: crate::domain::agent_definition::Target::Remote(
+                crate::domain::agent_definition::RemoteTarget {
+                    user: "fixture".to_owned(),
+                    host: "example.invalid".to_owned(),
+                    port: None,
+                    run_as_user: String::new(),
+                    canonical_cwd: PathBuf::from(work_dir),
+                },
+            ),
             ..AgentLaunchPlan::default()
         }
     }

--- a/src/runtime/package_runtime.rs
+++ b/src/runtime/package_runtime.rs
@@ -497,7 +497,7 @@ fn prepare_managed_npm_with_lock_policy(
         });
     };
     let fingerprint = capture_candidate_fingerprint(&executable)
-        .map_err(PackageRuntimeError::InstallDirectory)?;
+        .map_err(|error| PackageRuntimeError::InstallDirectory(error.to_string()))?;
     Ok(PackageInvocation {
         executable,
         wrapper_kind,

--- a/src/runtime/stub_manager.rs
+++ b/src/runtime/stub_manager.rs
@@ -296,10 +296,16 @@ mod tests {
 
     fn fixture_plan() -> crate::domain::agent_definition::AgentLaunchPlan {
         crate::domain::agent_definition::AgentLaunchPlan {
+            target: crate::domain::agent_definition::Target::Remote(
+                crate::domain::agent_definition::RemoteTarget {
+                    user: "fixture".to_owned(),
+                    host: "example.invalid".to_owned(),
+                    port: None,
+                    run_as_user: String::new(),
+                    canonical_cwd: std::path::PathBuf::from("/tmp/work"),
+                },
+            ),
             cwd: std::path::PathBuf::from("/tmp/work"),
-            target: crate::domain::agent_definition::Target::Local {
-                canonical_cwd: std::path::PathBuf::from("/tmp/work"),
-            },
             ..crate::domain::agent_definition::AgentLaunchPlan::default()
         }
     }

--- a/src/services/runtime_effect_adapter_tests.rs
+++ b/src/services/runtime_effect_adapter_tests.rs
@@ -47,9 +47,15 @@ fn manager_with_session(agent_id: &AgentId) -> StubRuntimeManager {
     let mut manager = StubRuntimeManager::default();
     let plan = crate::domain::agent_definition::AgentLaunchPlan {
         cwd: std::path::PathBuf::from("/tmp/agent"),
-        target: crate::domain::agent_definition::Target::Local {
-            canonical_cwd: std::path::PathBuf::from("/tmp/agent"),
-        },
+        target: crate::domain::agent_definition::Target::Remote(
+            crate::domain::agent_definition::RemoteTarget {
+                user: "fixture".to_owned(),
+                host: "example.invalid".to_owned(),
+                port: None,
+                run_as_user: String::new(),
+                canonical_cwd: std::path::PathBuf::from("/tmp/agent"),
+            },
+        ),
         ..crate::domain::agent_definition::AgentLaunchPlan::default()
     };
     let authorized = crate::runtime::test_support::authorized_launch_plan(&plan);

--- a/tests/harness_v1_fixtures.rs
+++ b/tests/harness_v1_fixtures.rs
@@ -69,6 +69,11 @@ fn run_fixture(name: &str) -> RunOutcome {
     if name == "llxprt-continue-field.json" {
         installs.push(("gh".to_string(), repo_path("scripts/issue520-gh-shim.sh")));
         installs.push(("git".to_string(), repo_path("scripts/issue520-git-shim.sh")));
+    }
+    if matches!(
+        name,
+        "llxprt-continue-field.json" | "issue575-direct-upgrade-launch.json"
+    ) {
         installs.push((
             "tmux".to_string(),
             repo_path("scripts/issue520-tmux-shim.sh"),
@@ -152,6 +157,29 @@ fn config_path_fixture_runs_the_real_provider_free_binary() {
 fn panic_capture_fixture_projects_silent_error_without_raw_terminal_output() {
     let outcome = run_fixture("panic-capture-errors.json");
     assert_passed("panic-capture-errors", &outcome);
+    cleanup(&outcome);
+}
+
+#[test]
+fn direct_upgrade_fixture_launches_replacement_without_stale_error() {
+    let outcome = run_fixture("issue575-direct-upgrade-launch.json");
+    assert_passed("issue575-direct-upgrade-launch", &outcome);
+    let capture = outcome
+        .report
+        .captures
+        .iter()
+        .find(|capture| capture.name == "llxprt-agent")
+        .unwrap_or_else(|| panic!("LLxprt launch capture must be reported"));
+    assert_eq!(
+        capture.invocations.len(),
+        1,
+        "the upgraded executable must launch in the original action"
+    );
+    let state =
+        std::fs::read_to_string(Path::new(&outcome.report.workspace).join("config/state.json"))
+            .unwrap_or_else(|error| panic!("read persisted issue575 state: {error}"));
+    assert!(state.contains("branch-575"));
+    assert!(!state.contains("0.11.0-nightly.260801.19ac22acc"));
     cleanup(&outcome);
 }
 

--- a/tests/issue553_behavior.rs
+++ b/tests/issue553_behavior.rs
@@ -339,16 +339,24 @@ fn validate_launch_accepts_without_executing_a_probe() {
     );
 }
 
-/// A7 contrast: the authoritative preparation boundary does probe the same
-/// fixture, which is what makes the assertion above meaningful.
+/// A7 contrast: launch-state observation remains process-free; the
+/// authoritative preparation boundary performs the single probe.
 #[test]
 fn launch_preparation_still_probes_the_same_candidate() {
     let agent = RecordingAgent::new();
     let request = agent.request();
 
     let evidence = jefe::runtime::launch_compose::observe_launch_state(&request);
+    assert!(evidence.is_ok(), "fixture must be observable: {evidence:?}");
+    assert!(
+        agent.invocations().is_empty(),
+        "observation must not execute the agent: {:?}",
+        agent.invocations()
+    );
 
-    assert!(evidence.is_ok(), "fixture must be probeable: {evidence:?}");
+    let prepared = evidence
+        .and_then(|evidence| jefe::runtime::launch_compose::prepare_launch(&request, &evidence));
+    assert!(prepared.is_ok(), "fixture must prepare: {prepared:?}");
     assert_eq!(
         agent.invocations(),
         vec!["--version".to_owned()],

--- a/tests/runtime/runtime_lifecycle.rs
+++ b/tests/runtime/runtime_lifecycle.rs
@@ -10,7 +10,7 @@ use crate::support::{TestOptionExt, TestResultExt, authorized_launch_plan};
 
 use std::path::PathBuf;
 
-use jefe::domain::agent_definition::{AgentLaunchPlan, Target};
+use jefe::domain::agent_definition::{AgentLaunchPlan, RemoteTarget, Target};
 use jefe::domain::{Agent, AgentId, RepositoryId};
 use jefe::runtime::{AuthorizedLaunchPlan, RuntimeError, RuntimeManager, StubRuntimeManager};
 
@@ -28,9 +28,13 @@ fn make_agent(id: &str, repo_id: &str) -> Agent {
 fn make_signature(agent: &Agent) -> AuthorizedLaunchPlan {
     let plan = AgentLaunchPlan {
         cwd: agent.work_dir.clone(),
-        target: Target::Local {
+        target: Target::Remote(RemoteTarget {
+            user: "fixture".to_owned(),
+            host: "example.invalid".to_owned(),
+            port: None,
+            run_as_user: String::new(),
             canonical_cwd: agent.work_dir.clone(),
-        },
+        }),
         ..AgentLaunchPlan::default()
     };
     authorized_launch_plan(&plan)

--- a/tests/runtime/terminal_focus_routing.rs
+++ b/tests/runtime/terminal_focus_routing.rs
@@ -10,7 +10,7 @@ use crate::support::{TestResultExt, authorized_launch_plan};
 
 use std::path::PathBuf;
 
-use jefe::domain::agent_definition::{AgentLaunchPlan, Target};
+use jefe::domain::agent_definition::{AgentLaunchPlan, RemoteTarget, Target};
 use jefe::domain::{Agent, AgentId, RepositoryId};
 use jefe::runtime::{AuthorizedLaunchPlan, RuntimeError, RuntimeManager, StubRuntimeManager};
 use jefe::state::transition::TransitionExt;
@@ -30,9 +30,13 @@ fn make_agent(id: &str, repo_id: &str) -> Agent {
 fn make_signature(agent: &Agent) -> AuthorizedLaunchPlan {
     let plan = AgentLaunchPlan {
         cwd: agent.work_dir.clone(),
-        target: Target::Local {
+        target: Target::Remote(RemoteTarget {
+            user: "fixture".to_owned(),
+            host: "example.invalid".to_owned(),
+            port: None,
+            run_as_user: String::new(),
             canonical_cwd: agent.work_dir.clone(),
-        },
+        }),
         ..AgentLaunchPlan::default()
     };
     authorized_launch_plan(&plan)


### PR DESCRIPTION
## Summary

- Re-resolve direct local agent candidates from a fresh launch-time PATH snapshot for existing-agent launch, relaunch, issue-send, and PR-send actions.
- Advance probe generations when executable evidence changes, while preserving the AGT-E203 fingerprint check immediately before runtime effects.
- Share cross-platform executable fingerprint capture across resolver, probe, and execution authorization, including Windows volume/file identity and subsecond timestamps.
- Keep initial agent creation, remote targets, explicit npm/uvx selectors, and persisted blank selectors unchanged.

## Behavioral proof

- Direct executable unchanged: generation is retained and launch preparation succeeds.
- Stable in-session executable replacement: generation advances, current identity is probed, and launch succeeds in the original action.
- Removed or probe-failing replacement: current typed NotFound or AGT-E202 diagnostic is returned.
- Post-evidence replacement: AGT-E203 is returned before a runtime session is created.
- TUI scenario upgrades LLxprt after startup, launches the replacement, verifies Running, verifies an empty Errors screen, and confirms no version was pinned into durable state.

## Verification

- cargo xtask ci
- cargo check --target x86_64-pc-windows-msvc --all-features
- cargo test --test harness_v1_fixtures direct_upgrade_fixture_launches_replacement_without_stale_error -- --nocapture
- Local Open Code Review completed and all seven findings were triaged/remediated.

Fixes #575
