### PR TITLE
Stop configuration content from revoking ownership of live agents (Fixes #583)

### DIFF
--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -8,10 +8,9 @@ mod shell_reconcile;
 mod signature_reconcile;
 
 #[cfg(test)]
-use self::signature_reconcile::{BindingEvidence, DurableSignatureEvidence};
+use self::signature_reconcile::BindingEvidence;
 use self::signature_reconcile::{
     SessionEvidence, StartupClassification, binding_evidence, classify_startup,
-    durable_signature_evidence,
 };
 use iocraft::hooks::State as HookState;
 use tracing::warn;
@@ -116,21 +115,13 @@ fn normalize_persisted_sandbox_engines(_state: &mut AppState) -> bool {
 
 fn classify_agent_startup(
     agent: &Agent,
-    repository: &jefe::domain::Repository,
     signature: &AgentLaunchRequest,
     runtime: &TmuxRuntimeManager,
 ) -> StartupClassification {
     let session = runtime
         .session_liveness_for_signature(&agent.id, signature)
         .into();
-    let durable_signature = durable_signature_evidence(agent, repository);
-    let binding = binding_evidence(
-        agent.runtime_binding.as_ref(),
-        &agent.id,
-        signature,
-        agent.persisted_launch_signature.as_ref(),
-        durable_signature,
-    );
+    let binding = binding_evidence(agent.runtime_binding.as_ref(), &agent.id);
     let process = if signature.remote.enabled {
         ProcessLiveness::MalformedIdentity
     } else {
@@ -335,7 +326,7 @@ fn reconcile_running_agents(state: &AppState, runtime: &TmuxRuntimeManager) -> V
             continue;
         };
         let signature = launch_signature_for_agent(agent, repository);
-        match classify_agent_startup(agent, repository, &signature, runtime) {
+        match classify_agent_startup(agent, &signature, runtime) {
             StartupClassification::Orphaned => {
                 // Dead pane with surviving validated worker descendants
                 // (issue #332): reap the orphan tree and remove the stale
@@ -414,21 +405,29 @@ fn restore_one_agent(
     };
     let signature = launch_signature_for_agent(agent, &repository);
 
-    match classify_agent_startup(agent, &repository, &signature, runtime) {
+    match classify_agent_startup(agent, &signature, runtime) {
         StartupClassification::Stopped
         | StartupClassification::Stale
         | StartupClassification::Inconsistent
         | StartupClassification::Orphaned => RestoreOneOutcome::Dead,
         StartupClassification::Recoverable => RestoreOneOutcome::Skip,
-        StartupClassification::DefinitionDrift => {
-            let Some(persisted_signature) = agent.persisted_launch_signature.clone() else {
+        // A live local session means jefe is re-adopting a process it already
+        // started. Adoption is proved by session name, liveness and process
+        // identity, so it must not re-resolve a version selector or probe an
+        // executable: the running process is unaffected by what the
+        // configuration says now, and making adoption depend on the current
+        // executable is what stranded live agents (issue #583).
+        //
+        // The binding carries the signature the process was *launched* with,
+        // not the one the current configuration would produce.
+        StartupClassification::Running if !signature.remote.enabled => {
+            let Some(launched_with) = agent.persisted_launch_signature.clone().or_else(|| {
+                jefe::runtime::launch_compose::launch_signature_from_request(&signature).ok()
+            }) else {
                 return RestoreOneOutcome::Dead;
             };
-            match runtime.register_existing_local_session(
-                &agent.id,
-                &agent.work_dir,
-                persisted_signature,
-            ) {
+            match runtime.register_existing_local_session(&agent.id, &agent.work_dir, launched_with)
+            {
                 Ok(binding) => RestoreOneOutcome::Revived(Box::new(binding)),
                 Err(error) => {
                     warn!(agent_id = %agent.id.0, error = %error, "could not register existing session");

--- a/src/app_init_signature_reconcile.rs
+++ b/src/app_init_signature_reconcile.rs
@@ -1,9 +1,6 @@
 //! Startup evidence reconciliation for persisted runtime bindings.
 
-use jefe::domain::{
-    Agent, AgentId, AgentLaunchRequest, LaunchSignatureV1, PaneWorkerTopology, Repository,
-    RuntimeBinding,
-};
+use jefe::domain::{AgentId, PaneWorkerTopology, RuntimeBinding};
 use jefe::runtime::{OrphanClassification, ProcessLiveness, RuntimeSession, SessionLiveness};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,21 +24,12 @@ impl From<SessionLiveness> for SessionEvidence {
 pub(super) enum BindingEvidence {
     Coherent,
     Legacy,
-    DefinitionDrift,
-    Inconsistent,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum DurableSignatureEvidence {
-    Match,
-    DefinitionDrift,
     Inconsistent,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum StartupClassification {
     Running,
-    DefinitionDrift,
     Stopped,
     Stale,
     Recoverable,
@@ -49,57 +37,25 @@ pub(super) enum StartupClassification {
     Orphaned,
 }
 
+/// Ownership evidence for one persisted binding.
+///
+/// Configuration content deliberately does not participate. Whether jefe still
+/// owns a live process is answered by the deterministic session name and the
+/// recorded process identity alone; what the user has since typed into the
+/// agent's fields is a statement about the *next* launch and cannot revoke
+/// ownership of a process that is already running (issue #583).
 #[must_use]
 pub(super) fn binding_evidence(
     binding: Option<&RuntimeBinding>,
     agent_id: &AgentId,
-    signature: &AgentLaunchRequest,
-    persisted_signature: Option<&LaunchSignatureV1>,
-    durable_signature: DurableSignatureEvidence,
 ) -> BindingEvidence {
-    if durable_signature == DurableSignatureEvidence::Inconsistent {
-        return BindingEvidence::Inconsistent;
-    }
     let Some(binding) = binding else {
-        return match durable_signature {
-            DurableSignatureEvidence::Match => BindingEvidence::Legacy,
-            DurableSignatureEvidence::DefinitionDrift | DurableSignatureEvidence::Inconsistent => {
-                BindingEvidence::Inconsistent
-            }
-        };
+        return BindingEvidence::Legacy;
     };
-    if binding.session_name != RuntimeSession::session_name_for(agent_id)
-        || !binding_signature_matches(binding, signature, persisted_signature, durable_signature)
-    {
+    if binding.session_name != RuntimeSession::session_name_for(agent_id) {
         return BindingEvidence::Inconsistent;
     }
-    let process_evidence = binding_process_evidence(binding);
-    if process_evidence == BindingEvidence::Inconsistent {
-        return process_evidence;
-    }
-    match durable_signature {
-        DurableSignatureEvidence::DefinitionDrift => BindingEvidence::DefinitionDrift,
-        DurableSignatureEvidence::Match => process_evidence,
-        DurableSignatureEvidence::Inconsistent => BindingEvidence::Inconsistent,
-    }
-}
-
-fn binding_signature_matches(
-    binding: &RuntimeBinding,
-    signature: &AgentLaunchRequest,
-    persisted_signature: Option<&LaunchSignatureV1>,
-    durable_signature: DurableSignatureEvidence,
-) -> bool {
-    match durable_signature {
-        DurableSignatureEvidence::Match => {
-            jefe::runtime::launch_compose::launch_signature_from_request(signature)
-                .is_ok_and(|current| current == binding.launch_signature)
-        }
-        DurableSignatureEvidence::DefinitionDrift => {
-            persisted_signature == Some(&binding.launch_signature)
-        }
-        DurableSignatureEvidence::Inconsistent => false,
-    }
+    binding_process_evidence(binding)
 }
 
 fn binding_process_evidence(binding: &RuntimeBinding) -> BindingEvidence {
@@ -142,15 +98,6 @@ pub(super) fn classify_startup(
     if !remote && process == ProcessLiveness::ReusedPid {
         return StartupClassification::Stale;
     }
-    if binding == BindingEvidence::DefinitionDrift {
-        if remote || session != SessionEvidence::Alive {
-            return StartupClassification::Inconsistent;
-        }
-        if process == ProcessLiveness::Dead {
-            return StartupClassification::Inconsistent;
-        }
-        return StartupClassification::DefinitionDrift;
-    }
     match session {
         SessionEvidence::Alive => StartupClassification::Running,
         SessionEvidence::Unavailable => StartupClassification::Recoverable,
@@ -167,29 +114,5 @@ fn classify_missing_local_process(process: ProcessLiveness) -> StartupClassifica
         ProcessLiveness::Alive | ProcessLiveness::Inaccessible | ProcessLiveness::ProbeFailure => {
             StartupClassification::Recoverable
         }
-    }
-}
-
-pub(super) fn durable_signature_evidence(
-    agent: &Agent,
-    repository: &Repository,
-) -> DurableSignatureEvidence {
-    match agent.persisted_launch_signature.as_ref() {
-        None => DurableSignatureEvidence::Match,
-        Some(persisted) => jefe::state::durable_projection::current_launch_signature(
-            agent, repository,
-        )
-        .map_or(DurableSignatureEvidence::Inconsistent, |current| {
-            if current == *persisted {
-                DurableSignatureEvidence::Match
-            } else if current.version == persisted.version
-                && current.typed_value_hash == persisted.typed_value_hash
-                && current.target_fingerprint == persisted.target_fingerprint
-            {
-                DurableSignatureEvidence::DefinitionDrift
-            } else {
-                DurableSignatureEvidence::Inconsistent
-            }
-        }),
     }
 }

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -159,6 +159,75 @@ fn binding_accepts_only_definition_drift_for_the_stable_session() {
     );
 }
 
+/// Editing an agent field must never abandon that agent's live session.
+///
+/// A launch-signature field (here `model`; the version selector behaves
+/// identically) is edited while the agent keeps running. The tmux session and
+/// the worker process are both still alive, so jefe unambiguously still owns
+/// this process. Configuration content changed; process ownership did not.
+///
+/// `Stopped`, `Stale`, `Inconsistent` and `Orphaned` all clear the runtime
+/// binding without killing the session, which strands the live agent
+/// permanently: nothing re-adopts a session whose record was cleared. Startup
+/// must therefore reach a binding-preserving classification here.
+#[test]
+fn editing_a_launch_field_does_not_abandon_a_live_agent() {
+    let (mut agent, repository) = code_puppy_agent_and_repository();
+    let launch_request = launch_signature_for_agent(&agent, &repository);
+    let launched_with =
+        jefe::runtime::launch_compose::launch_signature_from_request(&launch_request)
+            .unwrap_or_else(|error| panic!("fixture signature must compose: {error}"));
+
+    // The agent is running: the binding and the durable record both carry the
+    // signature stamped when the process was launched.
+    agent.persisted_launch_signature = Some(launched_with.clone());
+    agent.runtime_binding = Some(jefe::domain::RuntimeBinding {
+        session_name: RuntimeSession::session_name_for(&agent.id),
+        launch_signature: launched_with,
+        attached: false,
+        last_seen: None,
+        pane_identity: None,
+        worker_identity: Some(WorkerProcessIdentity::new(std::process::id(), 4_242)),
+        lifecycle_generation: 0,
+        worker_identities: Vec::new(),
+    });
+
+    // The user edits a field. The running process is untouched.
+    set_string(&mut agent.values, "model", "changed-model");
+
+    let edited_request = launch_signature_for_agent(&agent, &repository);
+    let durable = durable_signature_evidence(&agent, &repository);
+    let binding = binding_evidence(
+        agent.runtime_binding.as_ref(),
+        &agent.id,
+        &edited_request,
+        agent.persisted_launch_signature.as_ref(),
+        durable,
+    );
+
+    // Session and worker are both observably alive.
+    let classification = classify_startup(
+        SessionEvidence::Alive,
+        binding,
+        false,
+        ProcessLiveness::Alive,
+        jefe::runtime::OrphanClassification::NoOrphan,
+    );
+
+    assert!(
+        !matches!(
+            classification,
+            StartupClassification::Stopped
+                | StartupClassification::Stale
+                | StartupClassification::Inconsistent
+                | StartupClassification::Orphaned
+        ),
+        "editing a field must not abandon a live agent, but startup classified \
+         an alive session with an alive worker as {classification:?}, which \
+         clears the runtime binding and strands the still-running session"
+    );
+}
+
 #[test]
 fn legacy_pid_only_binding_uses_conservative_native_probe() {
     // A legacy binding carries a worker PID with no creation token, so the

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -79,52 +79,63 @@ fn launch_request_does_not_dynamically_inherit_repository_values() {
     assert!(jefe::domain::canonical_values::typed_field(&request.values, "model").is_none());
 }
 
+/// Ownership evidence is derived from the session name and process identity
+/// only. Configuration content is a statement about the *next* launch and must
+/// not participate (issue #583).
 #[test]
-fn durable_signature_distinguishes_definition_drift_from_value_and_target_changes() {
+fn binding_evidence_ignores_configuration_and_uses_only_ownership_anchors() {
     let (mut agent, repository) = code_puppy_agent_and_repository();
-    let current = jefe::state::durable_projection::current_launch_signature(&agent, &repository)
-        .unwrap_or_else(|error| panic!("fixture signature must project: {error}"));
-    agent.persisted_launch_signature = Some(current.clone());
+    let request = launch_signature_for_agent(&agent, &repository);
+    let launched_with = jefe::runtime::launch_compose::launch_signature_from_request(&request)
+        .unwrap_or_else(|error| panic!("fixture signature must compose: {error}"));
+    let mut binding = jefe::domain::RuntimeBinding {
+        session_name: RuntimeSession::session_name_for(&agent.id),
+        launch_signature: launched_with,
+        attached: false,
+        last_seen: None,
+        pane_identity: None,
+        worker_identity: Some(WorkerProcessIdentity::new(std::process::id(), 4_242)),
+        lifecycle_generation: 0,
+        worker_identities: Vec::new(),
+    };
+
     assert_eq!(
-        durable_signature_evidence(&agent, &repository),
-        DurableSignatureEvidence::Match
+        binding_evidence(Some(&binding), &agent.id),
+        BindingEvidence::Coherent,
+        "a coherent binding for the stable session is owned"
     );
 
-    let mut previous_definition = current;
-    previous_definition.definition_hash =
-        jefe::domain::LaunchSignatureV1::default().definition_hash;
-    agent.persisted_launch_signature = Some(previous_definition);
-    assert_eq!(
-        durable_signature_evidence(&agent, &repository),
-        DurableSignatureEvidence::DefinitionDrift
-    );
-
+    // Every kind of configuration drift leaves ownership untouched: a changed
+    // value, a changed target, and a definition hash the running process
+    // predates.
     set_string(&mut agent.values, "model", "changed-model");
-    assert_eq!(
-        durable_signature_evidence(&agent, &repository),
-        DurableSignatureEvidence::Inconsistent
-    );
-    agent.values.clear();
     agent.work_dir = std::path::PathBuf::from("/tmp/changed-target");
+    agent.persisted_launch_signature = Some(jefe::domain::LaunchSignatureV1::default());
     assert_eq!(
-        durable_signature_evidence(&agent, &repository),
-        DurableSignatureEvidence::Inconsistent
+        binding_evidence(Some(&binding), &agent.id),
+        BindingEvidence::Coherent,
+        "configuration drift must never revoke ownership of a running process"
+    );
+
+    // A binding naming a different session is genuinely not ours.
+    binding.session_name = "jefe-agent-other".to_owned();
+    assert_eq!(
+        binding_evidence(Some(&binding), &agent.id),
+        BindingEvidence::Inconsistent
     );
 }
 
+/// A binding without a creation token cannot reject PID reuse, so it stays
+/// Legacy rather than being trusted as coherent.
 #[test]
-fn binding_accepts_only_definition_drift_for_the_stable_session() {
-    let (mut agent, repository) = code_puppy_agent_and_repository();
+fn binding_without_a_creation_token_is_legacy() {
+    let (agent, repository) = code_puppy_agent_and_repository();
     let request = launch_signature_for_agent(&agent, &repository);
-    let current = jefe::runtime::launch_compose::launch_signature_from_request(&request)
+    let launched_with = jefe::runtime::launch_compose::launch_signature_from_request(&request)
         .unwrap_or_else(|error| panic!("fixture signature must compose: {error}"));
-    let mut previous_definition = current;
-    previous_definition.definition_hash =
-        jefe::domain::LaunchSignatureV1::default().definition_hash;
-    agent.persisted_launch_signature = Some(previous_definition.clone());
-    let mut binding = jefe::domain::RuntimeBinding {
+    let binding = jefe::domain::RuntimeBinding {
         session_name: RuntimeSession::session_name_for(&agent.id),
-        launch_signature: previous_definition,
+        launch_signature: launched_with,
         attached: false,
         last_seen: None,
         pane_identity: None,
@@ -132,31 +143,12 @@ fn binding_accepts_only_definition_drift_for_the_stable_session() {
         lifecycle_generation: 0,
         worker_identities: Vec::new(),
     };
-    let durable = durable_signature_evidence(&agent, &repository);
 
-    assert_eq!(durable, DurableSignatureEvidence::DefinitionDrift);
     assert_eq!(
-        binding_evidence(
-            Some(&binding),
-            &agent.id,
-            &request,
-            agent.persisted_launch_signature.as_ref(),
-            durable,
-        ),
-        BindingEvidence::DefinitionDrift
+        binding_evidence(Some(&binding), &agent.id),
+        BindingEvidence::Legacy
     );
-
-    binding.session_name = "jefe-agent-other".to_owned();
-    assert_eq!(
-        binding_evidence(
-            Some(&binding),
-            &agent.id,
-            &request,
-            agent.persisted_launch_signature.as_ref(),
-            durable,
-        ),
-        BindingEvidence::Inconsistent
-    );
+    assert_eq!(binding_evidence(None, &agent.id), BindingEvidence::Legacy);
 }
 
 /// Editing an agent field must never abandon that agent's live session.
@@ -195,15 +187,7 @@ fn editing_a_launch_field_does_not_abandon_a_live_agent() {
     // The user edits a field. The running process is untouched.
     set_string(&mut agent.values, "model", "changed-model");
 
-    let edited_request = launch_signature_for_agent(&agent, &repository);
-    let durable = durable_signature_evidence(&agent, &repository);
-    let binding = binding_evidence(
-        agent.runtime_binding.as_ref(),
-        &agent.id,
-        &edited_request,
-        agent.persisted_launch_signature.as_ref(),
-        durable,
-    );
+    let binding = binding_evidence(agent.runtime_binding.as_ref(), &agent.id);
 
     // Session and worker are both observably alive.
     let classification = classify_startup(
@@ -355,68 +339,19 @@ fn malformed_or_inaccessible_process_identity_is_classified_conservatively() {
     );
 }
 
+/// PID reuse still overrides a live session. Removing the configuration
+/// comparison must not weaken the ownership checks that remain (issue #583).
 #[test]
-fn live_session_survives_definition_hash_drift() {
-    for liveness in [ProcessLiveness::Alive, ProcessLiveness::MalformedIdentity] {
-        assert_eq!(
-            classify_startup(
-                SessionEvidence::Alive,
-                BindingEvidence::DefinitionDrift,
-                false,
-                liveness,
-                jefe::runtime::OrphanClassification::NoOrphan,
-            ),
-            StartupClassification::DefinitionDrift,
-            "live local session with definition drift must use reattach-only registration"
-        );
-    }
+fn reused_pid_still_overrides_a_live_session() {
     assert_eq!(
         classify_startup(
             SessionEvidence::Alive,
-            BindingEvidence::DefinitionDrift,
-            false,
-            ProcessLiveness::Dead,
-            jefe::runtime::OrphanClassification::NoOrphan,
-        ),
-        StartupClassification::Inconsistent
-    );
-}
-
-#[test]
-fn definition_drift_does_not_override_reused_pid_or_missing_session() {
-    assert_eq!(
-        classify_startup(
-            SessionEvidence::Alive,
-            BindingEvidence::DefinitionDrift,
+            BindingEvidence::Coherent,
             false,
             ProcessLiveness::ReusedPid,
             jefe::runtime::OrphanClassification::NoOrphan,
         ),
         StartupClassification::Stale
-    );
-    assert_eq!(
-        classify_startup(
-            SessionEvidence::Missing,
-            BindingEvidence::DefinitionDrift,
-            false,
-            ProcessLiveness::Alive,
-            jefe::runtime::OrphanClassification::NoOrphan,
-        ),
-        StartupClassification::Inconsistent
-    );
-}
-
-#[test]
-fn remote_definition_drift_is_rejected() {
-    assert_eq!(
-        classify_startup(
-            SessionEvidence::Alive,
-            BindingEvidence::DefinitionDrift,
-            true,
-            ProcessLiveness::MalformedIdentity,
-            jefe::runtime::OrphanClassification::NoOrphan,
-        ),
-        StartupClassification::Inconsistent
     );
 }
 


### PR DESCRIPTION
Fixes #583.

## Problem

Editing any field on a **running** agent — the version selector, profile, a mode flag — caused jefe to abandon that agent at the next start. The record was marked Dead and its binding cleared, but the `Inconsistent` branch kills nothing, so the tmux session and the agent process kept running with no owner.

Nothing re-adopts such a session: `register_existing_local_session` is gated on the agent already being Running, `reconcile_shell_inventory` treats an unmatched session as a shell window to kill, and `list_jefe_sessions` is dead code. The stranding was therefore permanent.

Measured on a live installation before this change: of 15 live sessions, the 10 whose agents had never been edited were all owned, while **2 of the 5** whose version selector had been changed were stranded, each with an agent process that had been working for hours.

## Cause

`LaunchSignatureV1` is configuration-content evidence, but it was stored inside `RuntimeBinding` beside the genuine ownership anchors and consulted **before** them. `current_launch_signature()` recomputes from *present* configuration and was compared against a *historical* fact, so the comparison driving the decision was meaningless by construction.

Three distinct concerns were fused into one value:

| Concern | Nature | Correct consumer |
|---|---|---|
| Launched identity | immutable historical fact | display, drift advisory |
| Ownership | observed liveness | reclaim or mark dead |
| Next-launch intent | current configuration | the next launch only |

## Change

**Ownership no longer consults configuration.** `binding_evidence` takes only the binding and the agent id. Ownership is answered by the deterministic session name, session liveness, the recorded pane and worker identity, and the `started_at` token that rejects PID reuse.

`DurableSignatureEvidence`, `durable_signature_evidence` and `binding_signature_matches` are deleted outright — once configuration cannot control ownership there is nothing left for them to express. `BindingEvidence` loses `DefinitionDrift`; `StartupClassification` drops from seven variants to six. The simplification is a consequence of the correctness fix, not a separate deletion exercise.

**Reconnection no longer runs the launch machinery.** A live local session is re-adopted through `register_existing_local_session` rather than `revive_agent_session`. The latter ran `observe_launch_state` and `prepare_launch`, resolving a version selector and probing an executable — work that is meaningless when the process is already running, and which made reconnection depend on the current binary. Adoption carries the signature the process was **launched** with, from the persisted record, falling back to the composed signature only for legacy records that never stored one. Remote agents keep the existing path, since their evidence is not a local session.

## Safety properties retained

A wrong session binding, a missing session, and a reused PID all still reject exactly as before. `reused_pid_still_overrides_a_live_session` pins that specifically. `started_at` PID-reuse rejection is kept deliberately: if jefe has been down for a week, a recorded PID may belong to an unrelated process.

## Relationship to #527

This completes a generalization that #527 deferred. That issue reported the same defect through the `definition_hash` trigger — "20 live panes remained healthy while all durable records were rewritten as stopped" — fixed only the trigger it had observed by cutting a narrow `DefinitionDrift` escape hatch, and carried value changes forward inside a blanket "remain rejected" line with no safety rationale stated anywhere.

The defect then returned through a different trigger, which is this issue. That recurrence is the argument for #585.

## Tests

The two tests that asserted the old model are **replaced by tests of the new one**, not deleted:

- `binding_evidence_ignores_configuration_and_uses_only_ownership_anchors` — value drift, target drift and definition drift all leave ownership `Coherent`; a different session name is still `Inconsistent`.
- `binding_without_a_creation_token_is_legacy` — no creation token means no PID-reuse rejection, so the binding stays `Legacy`.
- `reused_pid_still_overrides_a_live_session` — regression guard on the retained safety property.
- `editing_a_launch_field_does_not_abandon_a_live_agent` — the behavioral test for the reported defect, written RED before the fix.

## Verification

- `cargo test --workspace --all-features --locked`: **5275 passed, 0 failed**
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- Net **−74 lines**; no lint, complexity, or coverage threshold changed, and no suppression directive added.

## Follow-ups, deliberately not in this PR

- #585 — reclaim path for sessions already stranded. Makes this class non-terminal regardless of trigger, including reused-PID and crash-before-persist, which have no issue of their own.
- #584 — volatile selector resolve-versus-install split.
- #587 — the three launch paths still gating on the startup availability snapshot after #575.
