### PR TITLE
Admit every launch action on the same evidence (Fixes #587)

### DIFF
--- a/src/app_input/availability.rs
+++ b/src/app_input/availability.rs
@@ -25,7 +25,6 @@ use jefe::agent_candidate::AgentCandidateResolver;
 use jefe::agent_candidate_path::PathSnapshot;
 use jefe::agent_registry::AgentTypeRegistry;
 use jefe::agent_status_view::AgentAvailabilityObservation;
-use jefe::domain::agent_definition::Availability;
 use jefe::domain::effects::AgentAvailabilityProbe;
 
 /// Candidate-only startup publication plus deferred process probes.
@@ -125,29 +124,14 @@ pub(super) fn require_local_kind_available(
     require_local_kind_available_for_target(type_id, available)
 }
 
-enum DirectAvailabilityGate {
-    Cached,
-    RefreshCurrent,
-}
-
+/// Admit or reject one launch attempt before any preparation side effect.
+///
+/// Every launch action — creating an agent, relaunching, Ctrl-r and sending —
+/// uses this one function, so they cannot disagree about whether a runtime is
+/// usable (issue #587).
 pub(super) fn launch_available_or_error(
     app_state: &mut AppStateHandle,
     request: &AgentLaunchRequest,
-) -> bool {
-    launch_availability_or_error(app_state, request, DirectAvailabilityGate::Cached)
-}
-
-pub(super) fn launch_refresh_available_or_error(
-    app_state: &mut AppStateHandle,
-    request: &AgentLaunchRequest,
-) -> bool {
-    launch_availability_or_error(app_state, request, DirectAvailabilityGate::RefreshCurrent)
-}
-
-fn launch_availability_or_error(
-    app_state: &mut AppStateHandle,
-    request: &AgentLaunchRequest,
-    direct_gate: DirectAvailabilityGate,
 ) -> bool {
     let result = {
         let state = app_state.read();
@@ -162,7 +146,6 @@ fn launch_availability_or_error(
                     .iter()
                     .find(|observation| observation.type_id() == &request.type_id),
                 &request.type_id,
-                direct_gate,
             )
         }
     };
@@ -219,37 +202,24 @@ pub(super) fn validate_launch_or_error(
     }
 }
 
-fn launch_availability_result(observation: &AgentAvailabilityObservation) -> Result<(), String> {
-    match observation.availability() {
-        Availability::InstalledCompatible { .. } => Ok(()),
-        Availability::InstalledIncompatible { reason, .. }
-        | Availability::ProbeError { reason, .. } => Err(reason.clone()),
-        Availability::NotFound
-            if observation.pending_generation().is_some()
-                && observation
-                    .candidate_resolution()
-                    .is_some_and(jefe::agent_candidate::CandidateResolution::is_resolved) =>
-        {
-            Ok(())
-        }
-        Availability::NotFound => Err(format!(
-            "{} is not installed on the local PATH",
-            observation.display_name()
-        )),
-    }
-}
-
+/// Admission for a direct (non-package, non-remote) selector.
+///
+/// The startup observation describes the system as it was when jefe started.
+/// A runtime installed or upgraded afterwards does not update it, so a verdict
+/// derived from it can only be stale. The authoritative probe belongs to launch
+/// preparation (issue #553), which resolves and probes from a current snapshot
+/// (issue #575) and fails closed with a typed diagnostic, so admission asks
+/// only whether the agent type is known.
+///
+/// A missing observation is not staleness — it means the type is not in the
+/// published registry at all — so it remains rejected.
 fn direct_availability_result(
     observation: Option<&AgentAvailabilityObservation>,
     type_id: &AgentTypeId,
-    gate: DirectAvailabilityGate,
 ) -> Result<(), String> {
-    let observation =
-        observation.ok_or_else(|| format!("no state-owned availability for {type_id}"))?;
-    match gate {
-        DirectAvailabilityGate::Cached => launch_availability_result(observation),
-        DirectAvailabilityGate::RefreshCurrent => Ok(()),
-    }
+    observation
+        .map(|_| ())
+        .ok_or_else(|| format!("no state-owned availability for {type_id}"))
 }
 
 fn has_package_selector(request: &AgentLaunchRequest) -> bool {
@@ -279,6 +249,7 @@ pub(super) fn require_local_kind_available_for_target(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use jefe::domain::agent_definition::Availability;
     use jefe::domain::{AgentTypeId, RemoteRepositorySettings};
 
     /// A pinned package-runner selector does not require a global snapshot of
@@ -326,46 +297,50 @@ mod tests {
         }
     }
 
+    /// Every direct-selector launch action admits identically.
+    ///
+    /// A startup observation records what the system looked like when jefe
+    /// started. Installing or upgrading a runtime afterwards does not update
+    /// it, so any verdict derived from it is stale. Launch preparation already
+    /// resolves and probes from a current snapshot and fails closed, so
+    /// admission asks only whether the agent type is known — and it must give
+    /// the same answer for creating an agent, relaunching, Ctrl-r and sending
+    /// (issue #587).
     #[test]
-    fn refresh_current_bypasses_stale_cached_failure_but_requires_observation() {
+    fn every_direct_launch_action_admits_on_the_same_evidence() {
         let definition = jefe::domain::agent_definition::AgentDefinition::shipped()
             .into_iter()
             .find(|definition| definition.id.as_str() == "core.llxprt")
             .unwrap_or_else(|| panic!("LLxprt definition must be shipped"));
-        let observation = AgentAvailabilityObservation::new(
-            &definition,
-            true,
+
+        // Each of these is a startup verdict that a later install or upgrade
+        // would invalidate.
+        let stale_verdicts = [
             Availability::ProbeError {
                 code: jefe::domain::agent_definition::ProbeErrorCode::Agte202,
                 reason: "stale startup probe failure".to_owned(),
                 generation: 7,
             },
-        );
+            Availability::InstalledIncompatible {
+                reason: "stale startup incompatibility".to_owned(),
+                generation: 7,
+            },
+            Availability::NotFound,
+        ];
 
-        assert!(
-            direct_availability_result(
-                Some(&observation),
-                &definition.id,
-                DirectAvailabilityGate::Cached,
-            )
-            .is_err()
-        );
-        assert!(
-            direct_availability_result(
-                Some(&observation),
-                &definition.id,
-                DirectAvailabilityGate::RefreshCurrent,
-            )
-            .is_ok()
-        );
-        assert!(
-            direct_availability_result(
-                None,
-                &definition.id,
-                DirectAvailabilityGate::RefreshCurrent,
-            )
-            .is_err()
-        );
+        for availability in stale_verdicts {
+            let observation =
+                AgentAvailabilityObservation::new(&definition, true, availability.clone());
+            assert!(
+                direct_availability_result(Some(&observation), &definition.id).is_ok(),
+                "a startup verdict of {availability:?} must not outlive the startup that \
+                 produced it; launch preparation owns the authoritative probe"
+            );
+        }
+
+        // An unknown agent type is still rejected: that is not staleness, it is
+        // an absent definition.
+        assert!(direct_availability_result(None, &definition.id).is_err());
     }
 
     fn valid_remote() -> RemoteRepositorySettings {
@@ -375,64 +350,6 @@ mod tests {
             host: "build.example.com".to_owned(),
             ..Default::default()
         }
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn pending_resolved_candidate_can_continue_to_authoritative_launch_probe() {
-        let definition = jefe::domain::agent_definition::AgentDefinition::shipped()
-            .into_iter()
-            .find(|definition| definition.id.as_str() == "core.llxprt")
-            .unwrap_or_else(|| panic!("LLxprt definition must be shipped"));
-        let temp = tempfile::tempdir()
-            .unwrap_or_else(|error| panic!("temporary directory must be created: {error}"));
-        let wrapper = temp.path().join("llxprt.cmd");
-        std::fs::write(&wrapper, b"@echo off\r\nexit /b 0\r\n")
-            .unwrap_or_else(|error| panic!("wrapper fixture must be written: {error}"));
-        let path = PathSnapshot::for_platform(
-            jefe::runtime::AgentExecutablePlatform::current(),
-            vec![temp.path().to_path_buf()],
-            std::env::var_os("PATHEXT"),
-        );
-        let resolution =
-            AgentCandidateResolver::new(&path, temp.path().to_path_buf()).resolve(&definition);
-        assert!(resolution.is_resolved(), "wrapper fixture must resolve");
-        let observation = AgentAvailabilityObservation::pending(&definition, true, 1, resolution);
-
-        assert!(
-            launch_availability_result(&observation).is_ok(),
-            "a pending observation is checking a resolved startup candidate; launch preparation owns the authoritative probe"
-        );
-    }
-
-    #[test]
-    fn final_not_found_candidate_remains_rejected() {
-        let definition = jefe::domain::agent_definition::AgentDefinition::shipped()
-            .into_iter()
-            .find(|definition| definition.id.as_str() == "core.llxprt")
-            .unwrap_or_else(|| panic!("LLxprt definition must be shipped"));
-        let observation = AgentAvailabilityObservation::not_found(&definition, true, 1);
-
-        match launch_availability_result(&observation) {
-            Ok(()) => panic!("final NotFound must remain fail-closed"),
-            Err(error) => assert!(error.contains("local PATH")),
-        }
-    }
-
-    #[test]
-    fn malformed_pending_not_found_evidence_remains_rejected() {
-        let definition = jefe::domain::agent_definition::AgentDefinition::shipped()
-            .into_iter()
-            .find(|definition| definition.id.as_str() == "core.llxprt")
-            .unwrap_or_else(|| panic!("LLxprt definition must be shipped"));
-        let observation = AgentAvailabilityObservation::pending(
-            &definition,
-            true,
-            1,
-            jefe::agent_candidate::CandidateResolution::NotFound(Vec::new()),
-        );
-
-        assert!(launch_availability_result(&observation).is_err());
     }
 
     #[cfg(unix)]

--- a/src/app_input/issues_rewrite_dispatch.rs
+++ b/src/app_input/issues_rewrite_dispatch.rs
@@ -37,7 +37,7 @@ pub(super) fn handle_request_issue_rewrite(app_state: &mut AppStateHandle, ctx: 
         Ok(Some(context)) => context,
     };
 
-    if !super::availability::launch_refresh_available_or_error(app_state, &context.signature) {
+    if !super::availability::launch_available_or_error(app_state, &context.signature) {
         return;
     }
 

--- a/src/app_input/issues_send.rs
+++ b/src/app_input/issues_send.rs
@@ -56,7 +56,7 @@ pub(super) fn dispatch_agent_chooser_confirm(app_state: &mut AppStateHandle, ctx
     let prompt = issues_dispatch::format_issue_prompt(&send_info.payload);
     let launch_sig = prepare_issue_launch_signature(send_info.signature, &prompt);
 
-    if !super::availability::launch_refresh_available_or_error(app_state, &launch_sig)
+    if !super::availability::launch_available_or_error(app_state, &launch_sig)
         || !super::availability::validate_launch_or_error(app_state, &launch_sig)
     {
         return;
@@ -254,7 +254,7 @@ fn prepare_confirm_send_target(
 
     // Re-check availability BEFORE prep side effects: the runtime may have
     // been removed while the confirm modal was open.
-    if !super::availability::launch_refresh_available_or_error(app_state, launch_sig)
+    if !super::availability::launch_available_or_error(app_state, launch_sig)
         || !super::availability::validate_launch_or_error(app_state, launch_sig)
     {
         return None;

--- a/src/app_input/prs_orchestration.rs
+++ b/src/app_input/prs_orchestration.rs
@@ -578,7 +578,7 @@ fn dispatch_pr_agent_chooser_confirm(app_state: &mut AppStateHandle, ctx: &Share
     // Availability + target validation BEFORE any prep side effect: a missing
     // agent runtime or an invalid/incomplete remote config must not trigger
     // local or remote prep.
-    if !super::availability::launch_refresh_available_or_error(app_state, &launch_sig)
+    if !super::availability::launch_available_or_error(app_state, &launch_sig)
         || !super::availability::validate_launch_or_error(app_state, &launch_sig)
     {
         return;

--- a/src/app_input/relaunch.rs
+++ b/src/app_input/relaunch.rs
@@ -100,7 +100,7 @@ fn relaunch_preflight_passed(
     let Some((_, signature)) = agent_sig else {
         return true;
     };
-    if !availability::launch_refresh_available_or_error(app_state, &signature) {
+    if !availability::launch_available_or_error(app_state, &signature) {
         return false;
     }
     preflight_or_prompt(app_state, ctx, agent_id, &signature, None)

--- a/src/app_input/transient_issue_send.rs
+++ b/src/app_input/transient_issue_send.rs
@@ -143,7 +143,7 @@ fn transient_issue_availability_and_target(
     ctx: &SharedContext,
     prep: &TransientPrepContext,
 ) -> Option<super::target_resolution::WorkTarget> {
-    if !super::availability::launch_refresh_available_or_error(app_state, &prep.launch_sig)
+    if !super::availability::launch_available_or_error(app_state, &prep.launch_sig)
         || !super::availability::validate_launch_or_error(app_state, &prep.launch_sig)
     {
         fail_transient_agent(app_state, ctx, &prep.agent_id);

--- a/src/app_input/transient_pr_send.rs
+++ b/src/app_input/transient_pr_send.rs
@@ -118,7 +118,7 @@ fn transient_pr_availability_and_target(
     ctx: &SharedContext,
     prep: &TransientPrPrepContext,
 ) -> Option<super::target_resolution::WorkTarget> {
-    if !super::availability::launch_refresh_available_or_error(app_state, &prep.launch_sig)
+    if !super::availability::launch_available_or_error(app_state, &prep.launch_sig)
         || !super::availability::validate_launch_or_error(app_state, &prep.launch_sig)
     {
         super::transient_issue_send::fail_transient_agent(app_state, ctx, &prep.agent_id);


### PR DESCRIPTION
Fixes #587.

## Problem

#575 (PR #582) removed the startup-cached candidate resolution from launch preparation and added a `RefreshCurrent` availability gate that defers the verdict to preparation. That gate reached the send and relaunch paths, but three call sites kept the old `Cached` gate:

| Call site | User action | Gate before |
|---|---|---|
| `modal_handlers.rs:419` | new/edit agent form submit | Cached |
| `modal_handlers.rs:489` | agent-type check behind that form | Cached |
| `agent_lifecycle_ops.rs:133` | kill-and-relaunch (Ctrl-r) | Cached |

Those three are exactly what a user reaches after installing or upgrading a runtime mid-session, so the original symptom survived for the actions most likely to hit it:

- sending an issue to an existing agent worked, because that path refreshed;
- creating an agent of the same type was rejected against the startup snapshot;
- Ctrl-r on an existing agent was rejected the same way.

The effective rule became "some launch actions see the current system and some see the system as it was when jefe started" — neither discoverable nor recoverable without a restart.

## Change

Collapse the two gates into one.

A startup observation describes the system as it was when jefe started and is never refreshed, so any verdict derived from it can only go stale. The authoritative probe belongs to launch preparation (#553), which resolves and probes from a current snapshot (#575) and fails closed with a typed diagnostic. A second verdict derived from the startup snapshot therefore adds no safety and only adds staleness.

Admission now asks whether the agent type is **known**, not whether a past observation **succeeded**. `DirectAvailabilityGate`, `launch_refresh_available_or_error` and `launch_availability_result` are deleted; one entry point remains and all ten call sites use it.

## Safety preserved

A missing observation is still rejected — that means the type is absent from the published registry, which is not staleness.

The fail-closed guarantee for a genuinely absent runtime is unchanged, and is already proved where it now lives: `removed_direct_candidate_reports_current_not_found` in `launch_compose_tests`, added with #575. Remote and package-selector admission are untouched.

Startup observation continues to populate the agent-type list in the UI, which is what it is actually useful for.

## Tests

The three deleted tests asserted the cached-verdict semantics that no longer exist. Their replacement asserts the new rule directly, across every stale verdict a later install or upgrade could invalidate:

`every_direct_launch_action_admits_on_the_same_evidence` — a startup `ProbeError`, `InstalledIncompatible` or `NotFound` all admit, because launch preparation owns the authoritative probe; a missing observation still rejects.

## Verification

- `cargo test --workspace --all-features --locked`: **5273 passed, 0 failed**
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- Net **−83 lines**. No lint, complexity or coverage threshold changed; no suppression directive added. The one dead-code warning this surfaced was resolved by deleting the dead function, not by allowing it.

## Context

This completes the cutover #575 began. With it, a runtime installed or upgraded while jefe is running is usable from every launch action without a restart.

Remaining in this area: #584 (volatile selector resolve-versus-install), #585 (reclaim path for stranded sessions), #586 (harness fixture leak).
