### PR TITLE
Resolve moving dist-tags instead of trusting them for twelve hours (Fixes #584)

### DIFF
--- a/src/runtime/package_runtime.rs
+++ b/src/runtime/package_runtime.rs
@@ -9,7 +9,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use serde::Serialize;
 
@@ -35,13 +35,14 @@ const INSTALL_MARKER: &str = ".jefe-installed";
 const STAGING_PREFIX: &str = ".staging-";
 const RETIRED_PREFIX: &str = ".retired-";
 
-/// How long a volatile-selector install (a moving dist-tag such as `nightly`)
-/// is trusted before jefe re-resolves it against the registry (issue #554).
+/// Budget for the metadata-only query that resolves a moving dist-tag to a
+/// concrete version (issue #584).
 ///
-/// Nightlies publish roughly daily; trusting an install for ~half that cadence
-/// bounds staleness to about twelve hours without hitting the registry on every
-/// launch. Explicit (pinned) selectors are immutable and never expire.
-const VOLATILE_SELECTOR_TTL: Duration = Duration::from_secs(12 * 60 * 60);
+/// This reads registry metadata and downloads no package content, so it is far
+/// cheaper than an install and is given a correspondingly small budget. When it
+/// is exceeded the cached install is used, so a slow registry delays a launch
+/// by at most this much rather than failing it.
+const VERSION_RESOLVE_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Per-digest intra-process install guards (issue #382, narrowed by #556).
 ///
@@ -252,17 +253,16 @@ pub fn finalize_local_invocation(
     candidate: &ResolvedCandidate,
     cache_root: &Path,
 ) -> Result<PackageInvocation, PackageRuntimeError> {
-    finalize_local_invocation_at(candidate, cache_root, SystemTime::now())
+    finalize_local_invocation_inner(candidate, cache_root)
 }
 
-/// Time-injected core of [`finalize_local_invocation`] for deterministic tests.
+/// Core of [`finalize_local_invocation`].
 ///
-/// `now` stamps the install marker and gates the volatile-selector freshness
-/// check (issue #554); production callers pass [`SystemTime::now`].
-pub fn finalize_local_invocation_at(
+/// Freshness of a volatile selector is decided by the version its dist-tag
+/// currently resolves to, not by a clock, so no time is injected (issue #584).
+pub fn finalize_local_invocation_inner(
     candidate: &ResolvedCandidate,
     cache_root: &Path,
-    now: SystemTime,
 ) -> Result<PackageInvocation, PackageRuntimeError> {
     let Some(selection) = candidate.package() else {
         return Ok(PackageInvocation {
@@ -273,7 +273,7 @@ pub fn finalize_local_invocation_at(
         });
     };
     if selection.runner() == PackageRunnerKind::Npm {
-        prepare_managed_npm(candidate, selection, cache_root, now)
+        prepare_managed_npm(candidate, selection, cache_root)
     } else {
         package_invocation(candidate, PackageExecutionTarget::Local, cache_root)?
             .ok_or(PackageRuntimeError::InvalidSelection)
@@ -346,7 +346,18 @@ fn bin_dir_of(install_dir: &Path) -> PathBuf {
     install_dir.join("node_modules").join(".bin")
 }
 
-fn marker_contents(selection: &PackageSelection, now: SystemTime) -> String {
+/// Contents of the install marker for a completed install.
+///
+/// A volatile selector records the concrete version the tag resolved to on a
+/// fourth line, so a later preparation can tell "the tag still points here"
+/// from "the tag has moved" without consulting a clock (issue #584). A pinned
+/// selector keeps the three-line form: an explicit version never moves, so its
+/// cache entry is permanent.
+///
+/// `resolved` is `None` only when the registry could not be reached during an
+/// install, which leaves the marker in the three-line form and makes the next
+/// preparation re-resolve rather than trust an unverified tree.
+fn marker_contents(selection: &PackageSelection, resolved: Option<&str>) -> String {
     let effective = selection
         .selector()
         .effective(selection.runner())
@@ -357,26 +368,24 @@ fn marker_contents(selection: &PackageSelection, now: SystemTime) -> String {
         selection.binary(),
         effective
     );
-    // Issue #554: volatile selectors carry an install-time epoch on a 4th line so
-    // the cache can expire and re-resolve the moving dist-tag. Pinned selectors
-    // keep the legacy 3-line marker (a permanent hit — explicit versions never
-    // change).
     if !selection.selector().is_volatile() {
         return base;
     }
-    let secs = now
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_secs());
-    format!("{base}{secs}\n")
+    resolved.map_or_else(|| base.clone(), |version| format!("{base}{version}\n"))
 }
 
-/// Whether the stored marker identifies this selection AND, for volatile
-/// selectors, was installed within [`VOLATILE_SELECTOR_TTL`] of `now`.
+/// Whether the cached install satisfies this selection.
+///
+/// Identity must always match. For a volatile selector the cached install must
+/// additionally be the version the tag currently points at: `resolved` carries
+/// that version when the registry answered, and is `None` when it did not. A
+/// `None` therefore keeps the cached install rather than failing the launch —
+/// offline is a condition to ride out, not an error to raise (issue #584).
 fn cache_hit(
     install_dir: &Path,
     bin_dir: &Path,
     selection: &PackageSelection,
-    now: SystemTime,
+    resolved: Option<&str>,
 ) -> bool {
     let Ok(stored) = std::fs::read_to_string(install_dir.join(INSTALL_MARKER)) else {
         return false;
@@ -384,7 +393,10 @@ fn cache_hit(
     if !marker_identity_matches(&stored, selection) {
         return false;
     }
-    if selection.selector().is_volatile() && !marker_install_is_fresh(&stored, now) {
+    if selection.selector().is_volatile()
+        && let Some(resolved) = resolved
+        && stored.split('\n').nth(3) != Some(resolved)
+    {
         return false;
     }
     PathSnapshot::for_platform(
@@ -394,6 +406,44 @@ fn cache_hit(
     )
     .resolve_binary(selection.binary())
     .is_some()
+}
+
+/// Resolve a moving dist-tag to the concrete version it currently points at.
+///
+/// Returns `None` when the registry cannot be reached or answers unusably. That
+/// is deliberate and is the offline path: the caller keeps the cached install
+/// instead of failing, because a user without a network should still be able to
+/// launch the build they already have (issue #584).
+///
+/// Only the resolve is performed here; no package content is downloaded.
+fn resolve_volatile_version(
+    candidate: &ResolvedCandidate,
+    selection: &PackageSelection,
+) -> Option<String> {
+    let spec = selection
+        .selector()
+        .package_spec(selection.runner(), selection.package())?;
+    let arguments = [
+        OsString::from("view"),
+        OsString::from(spec),
+        OsString::from("version"),
+    ];
+    let mut command =
+        command_for_path(candidate.executable(), candidate.wrapper_kind(), &arguments);
+    command.stdin(Stdio::null());
+    let output =
+        run_command_capture_with_timeout(command, VERSION_RESOLVE_TIMEOUT, "jefe package resolve")
+            .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    // A version never contains a newline or whitespace; anything else means the
+    // registry answered with something this code should not act on.
+    if version.is_empty() || version.split_whitespace().count() != 1 {
+        return None;
+    }
+    Some(version)
 }
 
 /// Whether the stored marker's package/binary/effective lines match `selection`.
@@ -407,40 +457,12 @@ fn marker_identity_matches(stored: &str, selection: &PackageSelection) -> bool {
         && lines.next() == Some(selection.binary())
         && lines.next() == Some(effective)
 }
-
-/// Whether a volatile selector's marker install-time line is still within TTL.
-///
-/// A missing or unparseable 4th line (a legacy/stuck 3-line marker) is treated
-/// as expired so the install is rebuilt and auto-healed (issue #554).
-fn marker_install_is_fresh(stored: &str, now: SystemTime) -> bool {
-    let Some(secs_str) = stored.split('\n').nth(3) else {
-        return false;
-    };
-    let Ok(secs) = secs_str.parse::<u64>() else {
-        return false;
-    };
-    let Some(installed) = SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(secs)) else {
-        return false;
-    };
-    // A future-dated marker (clock skew) is treated as expired: re-resolve
-    // rather than trust an untrusted timestamp.
-    now.duration_since(installed)
-        .is_ok_and(|age| age < VOLATILE_SELECTOR_TTL)
-}
-
 fn prepare_managed_npm(
     candidate: &ResolvedCandidate,
     selection: &PackageSelection,
     cache_root: &Path,
-    now: SystemTime,
 ) -> Result<PackageInvocation, PackageRuntimeError> {
-    prepare_managed_npm_with_lock_policy(
-        candidate,
-        selection,
-        cache_root,
-        now,
-        LockPolicy::production(),
-    )
+    prepare_managed_npm_with_lock_policy(candidate, selection, cache_root, LockPolicy::production())
 }
 
 /// Lock-policy-injected core of [`prepare_managed_npm`].
@@ -452,7 +474,6 @@ fn prepare_managed_npm_with_lock_policy(
     candidate: &ResolvedCandidate,
     selection: &PackageSelection,
     cache_root: &Path,
-    now: SystemTime,
     policy: LockPolicy,
 ) -> Result<PackageInvocation, PackageRuntimeError> {
     let digest = selection_digest(selection).to_hex();
@@ -480,9 +501,25 @@ fn prepare_managed_npm_with_lock_policy(
         package_install_lock::acquire(&install_lock_path(cache_root, &digest), &digest, policy)?;
     reconcile_interrupted_promotion(&install_dir, &retired, selection, &digest)?;
 
-    if !cache_hit(&install_dir, &bin_dir, selection, now) {
+    // Resolve before consulting the cache: for a volatile selector the cached
+    // tree is only a hit when it holds the version the tag points at *now*. A
+    // pinned selector never moves, so it is never resolved and never reaches
+    // the registry.
+    let resolved = selection
+        .selector()
+        .is_volatile()
+        .then(|| resolve_volatile_version(candidate, selection))
+        .flatten();
+    if selection.selector().is_volatile() && resolved.is_none() {
+        tracing::warn!(
+            package = selection.package(),
+            "could not resolve dist-tag against the registry; using the cached install if present"
+        );
+    }
+
+    if !cache_hit(&install_dir, &bin_dir, selection, resolved.as_deref()) {
         let staging = cache_root.join(format!("{STAGING_PREFIX}{digest}"));
-        build_staged_install(candidate, selection, &staging, now)?;
+        build_staged_install(candidate, selection, &staging, resolved.as_deref())?;
         promote_staged_install(&staging, &install_dir, &retired, &digest)?;
     }
 
@@ -527,7 +564,7 @@ fn build_staged_install(
     candidate: &ResolvedCandidate,
     selection: &PackageSelection,
     staging: &Path,
-    now: SystemTime,
+    resolved: Option<&str>,
 ) -> Result<(), PackageRuntimeError> {
     remove_tree(staging).map_err(|error| {
         PackageRuntimeError::InstallDirectory(format!("failed to reset staging: {error}"))
@@ -548,7 +585,7 @@ fn build_staged_install(
     }
     std::fs::write(
         staging.join(INSTALL_MARKER),
-        marker_contents(selection, now),
+        marker_contents(selection, resolved),
     )
     .map_err(|error| PackageRuntimeError::InstallDirectory(error.to_string()))
 }

--- a/src/runtime/package_runtime.rs
+++ b/src/runtime/package_runtime.rs
@@ -438,12 +438,32 @@ fn resolve_volatile_version(
         return None;
     }
     let version = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    // A version never contains a newline or whitespace; anything else means the
-    // registry answered with something this code should not act on.
-    if version.is_empty() || version.split_whitespace().count() != 1 {
-        return None;
-    }
-    Some(version)
+    is_plausible_version(&version).then_some(version)
+}
+
+/// Whether a registry answer is shaped like a version this code may act on.
+///
+/// The answer is the one input here that jefe does not control, so it is
+/// validated rather than trusted. It is written verbatim into a newline
+/// delimited marker and compared against a later answer, so anything carrying
+/// whitespace, a control character, or unbounded length is rejected outright
+/// instead of being allowed to corrupt the marker.
+///
+/// `is_ascii_graphic` admits exactly printable non-space ASCII, which excludes
+/// every control character, NUL, and the newline that delimits the marker.
+///
+/// This deliberately does not enforce semver: npm dist-tags legitimately point
+/// at prerelease and build-metadata forms, and rejecting an unfamiliar but
+/// harmless shape would break a launch for no safety gain.
+fn is_plausible_version(version: &str) -> bool {
+    /// Generous next to any real version, small enough to bound a marker line.
+    const MAX_VERSION_LEN: usize = 256;
+
+    !version.is_empty()
+        && version.len() <= MAX_VERSION_LEN
+        && version
+            .chars()
+            .all(|character| character.is_ascii_graphic())
 }
 
 /// Whether the stored marker's package/binary/effective lines match `selection`.

--- a/src/runtime/package_runtime_lock_tests.rs
+++ b/src/runtime/package_runtime_lock_tests.rs
@@ -79,6 +79,10 @@ final={final_dir}
 versions={versions}
 # A metadata-only resolve records no observation and installs nothing.
 if [ \"$1\" = view ]; then
+  if [ \"$#\" -ne 3 ] || [ \"$3\" != version ]; then
+    echo \"unexpected npm view invocation: $*\" >&2
+    exit 64
+  fi
   if [ -f \"$versions\" ]; then cat \"$versions\"; exit 0; else exit 1; fi
 fi
 mkdir -p node_modules/.bin

--- a/src/runtime/package_runtime_lock_tests.rs
+++ b/src/runtime/package_runtime_lock_tests.rs
@@ -76,6 +76,11 @@ fn observing_npm_stub(bin: &TempDir, witness: &Path, final_dir: &Path, settle: &
             "#!/bin/sh
 set -e
 final={final_dir}
+versions={versions}
+# A metadata-only resolve records no observation and installs nothing.
+if [ \"$1\" = view ]; then
+  if [ -f \"$versions\" ]; then cat \"$versions\"; exit 0; else exit 1; fi
+fi
 mkdir -p node_modules/.bin
 printf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/llxprt
 chmod 755 node_modules/.bin/llxprt
@@ -90,10 +95,24 @@ printf '%s\\t%s\\n' \"$(pwd -P)\" \"$state\" >> {witness}
 sleep {settle}
 ",
             final_dir = shell_quote(final_dir),
+            versions = shell_quote(&observed_version_path(witness)),
             witness = shell_quote(witness),
             settle = shell_escape_single(settle)
         ),
     );
+}
+
+/// File the observing stub reads to answer `npm view ... version`.
+#[cfg(unix)]
+fn observed_version_path(witness: &Path) -> PathBuf {
+    witness.with_file_name("published-version.txt")
+}
+
+/// Move the dist-tag so the next preparation re-resolves and reinstalls.
+#[cfg(unix)]
+fn publish_observed_version(witness: &Path, version: &str) {
+    std::fs::write(observed_version_path(witness), format!("{version}\n"))
+        .unwrap_or_else(|error| panic!("publish version: {error}"));
 }
 
 /// One `cwd\tstate` observation recorded by [`observing_npm_stub`].
@@ -138,6 +157,7 @@ fn observed_candidate(
     executable(bin, "npm", "#!/bin/sh\nexit 0\n");
     let probe = resolve_package(&definition, bin.path(), selector);
     let final_dir = final_install_dir(&probe, cache_root);
+    publish_observed_version(witness, "1.0.0");
     observing_npm_stub(bin, witness, &final_dir, settle);
     (resolve_package(&definition, bin.path(), selector), final_dir)
 }
@@ -174,7 +194,7 @@ fn managed_install_child_process() {
     std::fs::write(&ready, "ready").unwrap_or_else(|error| panic!("publish readiness: {error}"));
     await_barrier(&barrier.join(START_MARKER));
 
-    let report = match finalize_local_invocation_at(&candidate, Path::new(&cache), base_now()) {
+    let report = match finalize_local_invocation_inner(&candidate, Path::new(&cache)) {
         Ok(invocation) => format!("ok\t{}\n", invocation.executable().display()),
         Err(error) => format!("err\t{error}\n"),
     };
@@ -326,7 +346,7 @@ fn install_is_staged_outside_the_cache_entry_and_promoted_atomically() {
     let witness = scratch.path().join("install-observations.log");
     let (candidate, final_dir) = observed_candidate(&bin, cache.path(), &witness, "2.0.0", "0");
 
-    let invocation = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    let invocation = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("install: {error}"));
 
     let observed = observations(&witness);
@@ -374,14 +394,18 @@ fn promotion_replaces_an_existing_entry_without_exposing_a_partial_tree() {
     let (candidate, final_dir) =
         observed_candidate(&bin, cache.path(), &witness, "latest nightly", "0");
 
-    finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("first install: {error}"));
-    let expired = base_now() + super::VOLATILE_SELECTOR_TTL + std::time::Duration::from_secs(1);
-    finalize_local_invocation_at(&candidate, cache.path(), expired)
+    publish_observed_version(&witness, "2.0.0");
+    finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("re-install: {error}"));
 
     let observed = observations(&witness);
-    assert_eq!(observed.len(), 2, "the expired entry must be reinstalled");
+    assert_eq!(
+        observed.len(),
+        2,
+        "a moved dist-tag must reinstall the published entry"
+    );
     assert_eq!(
         observed[1].1, "final-complete",
         "the previously published tree must stay complete while its replacement builds"
@@ -416,7 +440,7 @@ fn interrupted_install_leaves_no_cache_hit_and_retries_cleanly() {
     let candidate = resolve_package(&definition, bin.path(), "2.0.0");
     let final_dir = final_install_dir(&candidate, cache.path());
 
-    let failure = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    let failure = finalize_local_invocation_inner(&candidate, cache.path())
         .err()
         .unwrap_or_else(|| panic!("a failing npm install must surface as an error"));
     assert!(
@@ -438,7 +462,7 @@ fn interrupted_install_leaves_no_cache_hit_and_retries_cleanly() {
         "#!/bin/sh\nmkdir -p node_modules/.bin\nprintf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/llxprt\nchmod 755 node_modules/.bin/llxprt\n",
     );
     let candidate = resolve_package(&definition, bin.path(), "2.0.0");
-    let invocation = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    let invocation = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("retry after interrupted install: {error}"));
     assert!(
         invocation.executable().starts_with(&final_dir),
@@ -494,7 +518,6 @@ fn a_live_installer_blocks_preparation_with_a_typed_redacted_error() {
         &candidate,
         selection,
         cache.path(),
-        base_now(),
         impatient_policy(),
     )
     .err()
@@ -592,7 +615,7 @@ fn a_promotion_interrupted_after_retiring_restores_the_previous_install() {
     let witness = scratch.path().join("install-observations.log");
     let (candidate, final_dir) = observed_candidate(&bin, cache.path(), &witness, "2.0.0", "0");
 
-    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    let first = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("first install: {error}"));
     let selection = candidate
         .package()
@@ -605,7 +628,7 @@ fn a_promotion_interrupted_after_retiring_restores_the_previous_install() {
         .unwrap_or_else(|error| panic!("simulate interrupted promotion: {error}"));
     assert!(!final_dir.exists(), "setup: the published path is absent");
 
-    let recovered = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    let recovered = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("recovery after interrupted promotion: {error}"));
 
     assert_eq!(
@@ -637,13 +660,13 @@ fn a_completed_promotion_discards_a_leftover_retired_tree() {
     let witness = scratch.path().join("install-observations.log");
     let (candidate, final_dir) = observed_candidate(&bin, cache.path(), &witness, "2.0.0", "0");
 
-    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    let first = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("first install: {error}"));
     let retired = retired_path(&candidate, cache.path());
     std::fs::create_dir_all(retired.join("node_modules"))
         .unwrap_or_else(|error| panic!("seed leftover retired entry: {error}"));
 
-    let reconciled = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    let reconciled = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("reconcile leftover retired tree: {error}"));
 
     assert_eq!(
@@ -675,7 +698,7 @@ fn an_unusable_published_install_is_replaced_by_the_retired_tree() {
     let witness = scratch.path().join("install-observations.log");
     let (candidate, final_dir) = observed_candidate(&bin, cache.path(), &witness, "2.0.0", "0");
 
-    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    let first = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("first install: {error}"));
     let retired = retired_path(&candidate, cache.path());
     // The complete tree is retired and the published path holds a directory
@@ -685,7 +708,7 @@ fn an_unusable_published_install_is_replaced_by_the_retired_tree() {
     std::fs::create_dir_all(final_dir.join("node_modules").join(".bin"))
         .unwrap_or_else(|error| panic!("seed unusable published entry: {error}"));
 
-    let recovered = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    let recovered = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("recovery from an unusable published entry: {error}"));
 
     assert_eq!(

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -468,11 +468,15 @@ fn a_registry_version_answer_is_validated_before_it_is_trusted() {
         );
     }
 
-    // A newline would forge an extra marker line; the rest are control or
-    // unbounded answers that must never reach the marker.
+    // Production trims the registry answer before validating, so a *trailing*
+    // newline never reaches the validator; it is included here to pin that the
+    // validator would reject it anyway. An *embedded* newline is the case that
+    // matters, because it would forge an extra marker line. The rest are
+    // control, whitespace or unbounded answers.
     for rejected in [
         "",
         "1.0.0\n2.0.0",
+        "1.0.0\n",
         "1.0.0 2.0.0",
         "1.0.0\u{0}",
         "1.0.0\t",
@@ -579,7 +583,8 @@ fn volatile_selector_uses_the_cached_install_when_the_registry_is_unreachable() 
 #[test]
 fn volatile_marker_without_a_resolved_version_re_installs() {
     // AC3: a legacy/stuck marker (3 lines, no timestamp) for a volatile selector
-    // is treated as expired and re-installed, writing a fresh timestamped marker.
+    // is treated as stale and re-installed, writing a marker that records the
+// version the dist-tag resolved to.
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
     let witness = witness_path(&bin);
     counting_npm_stub(&bin, &witness);
@@ -590,7 +595,7 @@ fn volatile_marker_without_a_resolved_version_re_installs() {
         .unwrap_or_else(|error| panic!("first install: {error}"));
     let install_dir = install_dir_of(first.executable()).to_path_buf();
     // Simulate a stuck/legacy cache: overwrite the marker with the old 3-line
-    // form (no install-time line) while keeping the binary present.
+    // form (no resolved-version line) while keeping the binary present.
     let selection = candidate
         .package()
         .unwrap_or_else(|| panic!("volatile candidate carries a package selection"));
@@ -624,7 +629,7 @@ fn volatile_marker_without_a_resolved_version_re_installs() {
     let lines: Vec<&str> = refreshed.lines().collect();
     assert!(
         lines.len() >= 4,
-        "refreshed volatile marker must carry an install-time line: {refreshed:?}"
+        "refreshed volatile marker must carry a resolved-version line: {refreshed:?}"
     );
     // The identity lines must be preserved across the refresh (no corruption).
     assert_eq!(lines[0], selection.package(), "package line preserved");

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 use super::{
-    PackageExecutionTarget, finalize_local_invocation, finalize_local_invocation_at,
+    PackageExecutionTarget, finalize_local_invocation, finalize_local_invocation_inner,
     package_invocation,
 };
 use crate::agent_candidate::{AgentCandidateResolver, CandidateResolution, VersionSelector};
@@ -350,6 +350,15 @@ fn counting_npm_stub(bin: &TempDir, witness: &Path) {
     // staged in a fresh directory and promoted by rename (issue #556), so a
     // witness written into the install directory would not survive across
     // installs and could not count them.
+    // `npm view <spec> version` answers from a version file the test controls,
+    // so a test can move the dist-tag without a registry (issue #584). Only a
+    // real `npm install` records a witness line, so counting lines still counts
+    // installs and never counts resolves.
+    let version_file = version_path_for(witness);
+    if std::fs::read_to_string(&version_file).is_err() {
+        std::fs::write(&version_file, "1.0.0\n")
+            .unwrap_or_else(|error| panic!("seed version file: {error}"));
+    }
     executable(
         bin,
         "npm",
@@ -357,14 +366,39 @@ fn counting_npm_stub(bin: &TempDir, witness: &Path) {
             "#!/bin/sh
 set -e
 witness={witness}
+versions={versions}
+if [ \"$1\" = view ]; then
+  if [ -f \"$versions\" ]; then cat \"$versions\"; exit 0; else exit 1; fi
+fi
 if [ -f package-lock.json ]; then echo present >> \"$witness\"; else echo absent >> \"$witness\"; fi
 mkdir -p node_modules/.bin
 printf '#!/bin/sh\nexit 0\n' > node_modules/.bin/llxprt
 chmod 755 node_modules/.bin/llxprt
 ",
-            witness = crate::runtime::commands::shell_escape_single(&witness.to_string_lossy())
+            witness = crate::runtime::commands::shell_escape_single(&witness.to_string_lossy()),
+            versions =
+                crate::runtime::commands::shell_escape_single(&version_file.to_string_lossy())
         ),
     );
+}
+
+/// Path of the file the npm stub reads to answer `npm view ... version`.
+#[cfg(unix)]
+fn version_path_for(witness: &Path) -> PathBuf {
+    witness.with_file_name("published-version.txt")
+}
+
+/// Move the dist-tag: the next `npm view` reports `version`.
+#[cfg(unix)]
+fn publish_version(witness: &Path, version: &str) {
+    std::fs::write(version_path_for(witness), format!("{version}\n"))
+        .unwrap_or_else(|error| panic!("publish version: {error}"));
+}
+
+/// Make the registry unreachable: `npm view` exits non-zero.
+#[cfg(unix)]
+fn make_registry_unreachable(witness: &Path) {
+    let _ = std::fs::remove_file(version_path_for(witness));
 }
 
 /// Install directory owning a managed executable.
@@ -413,33 +447,28 @@ fn volatile_npm_candidate(bin: &TempDir, selector: &str) -> ResolvedCandidate {
     resolve_package(&definition, bin.path(), selector)
 }
 
-/// A fixed base instant well after the Unix epoch so offsets stay representable.
-#[cfg(unix)]
-fn base_now() -> std::time::SystemTime {
-    std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000)
-}
-
 #[cfg(unix)]
 #[test]
-fn volatile_cache_stays_fresh_within_ttl() {
-    // AC2: a re-invocation inside the TTL is a cache hit — npm is not re-run.
+fn volatile_cache_hits_while_the_tag_has_not_moved() {
+    // The dist-tag still resolves to the installed version, so preparation is a
+    // cache hit however much time has passed: freshness is decided by what the
+    // tag points at, not by a clock (issue #584).
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
     let witness = witness_path(&bin);
     counting_npm_stub(&bin, &witness);
+    publish_version(&witness, "0.11.0-nightly.1");
     let candidate = volatile_npm_candidate(&bin, "latest nightly");
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
 
-    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    let first = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("first install: {error}"));
-    let within_ttl =
-        base_now() + super::VOLATILE_SELECTOR_TTL - std::time::Duration::from_secs(1);
-    let second = finalize_local_invocation_at(&candidate, cache.path(), within_ttl)
+    let second = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("second invocation: {error}"));
 
     assert_eq!(
         witness_lines(&witness).len(),
         1,
-        "within-TTL re-invocation must be a cache hit (npm not re-run)"
+        "an unmoved dist-tag must be a cache hit; npm install must not re-run"
     );
     assert_eq!(
         first.executable(),
@@ -450,31 +479,62 @@ fn volatile_cache_stays_fresh_within_ttl() {
 
 #[cfg(unix)]
 #[test]
-fn volatile_cache_re_resolves_after_ttl() {
-    // AC1: once the install age exceeds the TTL, the cache is a miss and npm
-    // re-runs (re-resolving the moving dist-tag).
+fn volatile_cache_reinstalls_as_soon_as_the_tag_moves() {
+    // A newly published nightly is picked up on the very next launch, with no
+    // timer to wait out (issue #584).
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
     let witness = witness_path(&bin);
     counting_npm_stub(&bin, &witness);
+    publish_version(&witness, "0.11.0-nightly.1");
     let candidate = volatile_npm_candidate(&bin, "latest nightly");
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
 
-    finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("first install: {error}"));
-    let expired = base_now() + super::VOLATILE_SELECTOR_TTL + std::time::Duration::from_secs(1);
-    finalize_local_invocation_at(&candidate, cache.path(), expired)
-        .unwrap_or_else(|error| panic!("expired re-resolve: {error}"));
+    publish_version(&witness, "0.11.0-nightly.2");
+    finalize_local_invocation_inner(&candidate, cache.path())
+        .unwrap_or_else(|error| panic!("re-resolve after tag moved: {error}"));
 
     assert_eq!(
         witness_lines(&witness).len(),
         2,
-        "past-TTL re-invocation must re-run npm to re-resolve the dist-tag"
+        "a moved dist-tag must re-install immediately, without waiting out a TTL"
     );
 }
 
 #[cfg(unix)]
 #[test]
-fn volatile_old_marker_without_timestamp_re_installs() {
+fn volatile_selector_uses_the_cached_install_when_the_registry_is_unreachable() {
+    // Offline is a condition to ride out, not an error to raise: the build the
+    // user already has must still launch (issue #584).
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let witness = witness_path(&bin);
+    counting_npm_stub(&bin, &witness);
+    publish_version(&witness, "0.11.0-nightly.1");
+    let candidate = volatile_npm_candidate(&bin, "latest nightly");
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+
+    let online = finalize_local_invocation_inner(&candidate, cache.path())
+        .unwrap_or_else(|error| panic!("first install: {error}"));
+    make_registry_unreachable(&witness);
+    let offline = finalize_local_invocation_inner(&candidate, cache.path())
+        .unwrap_or_else(|error| panic!("offline preparation must still succeed: {error}"));
+
+    assert_eq!(
+        witness_lines(&witness).len(),
+        1,
+        "an unreachable registry must not trigger a reinstall"
+    );
+    assert_eq!(
+        online.executable(),
+        offline.executable(),
+        "offline preparation must reuse the cached managed executable"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn volatile_marker_without_a_resolved_version_re_installs() {
     // AC3: a legacy/stuck marker (3 lines, no timestamp) for a volatile selector
     // is treated as expired and re-installed, writing a fresh timestamped marker.
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
@@ -483,7 +543,7 @@ fn volatile_old_marker_without_timestamp_re_installs() {
     let candidate = volatile_npm_candidate(&bin, "latest nightly");
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
 
-    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    let first = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("first install: {error}"));
     let install_dir = install_dir_of(first.executable()).to_path_buf();
     // Simulate a stuck/legacy cache: overwrite the marker with the old 3-line
@@ -509,7 +569,7 @@ fn volatile_old_marker_without_timestamp_re_installs() {
     );
 
     // Any `now` should treat the timestamp-less marker as expired.
-    finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("legacy re-resolve: {error}"));
     assert_eq!(
         witness_lines(&witness).len(),
@@ -527,9 +587,9 @@ fn volatile_old_marker_without_timestamp_re_installs() {
     assert_eq!(lines[0], selection.package(), "package line preserved");
     assert_eq!(lines[1], selection.binary(), "binary line preserved");
     assert_eq!(lines[2], effective, "effective-selector line preserved");
-    assert!(
-        lines[3].parse::<u64>().is_ok(),
-        "the 4th line must be a valid install-time epoch, got {:?}",
+    assert_eq!(
+        lines[3], "1.0.0",
+        "the 4th line must record the version the dist-tag resolved to, got {:?}",
         lines[3]
     );
 }
@@ -553,11 +613,11 @@ fn pinned_cache_remains_permanent_hit() {
     );
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
 
-    finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("first install: {error}"));
-    // Far beyond any TTL: a pinned version must still be a cache hit.
-    let far_future = base_now() + std::time::Duration::from_secs(365 * 24 * 60 * 60);
-    finalize_local_invocation_at(&candidate, cache.path(), far_future)
+    // A pinned version never moves, so it is never re-resolved and is a
+    // permanent cache hit.
+    finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("pinned re-invocation: {error}"));
     assert_eq!(
         witness_lines(&witness).len(),
@@ -581,19 +641,19 @@ fn volatile_re_resolve_removes_stale_lockfile() {
     let candidate = volatile_npm_candidate(&bin, "latest nightly");
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
 
-    let first = finalize_local_invocation_at(&candidate, cache.path(), base_now())
+    let first = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("first install: {error}"));
     let install_dir = install_dir_of(first.executable()).to_path_buf();
     // Plant a stale lockfile exactly where npm would leave it.
     std::fs::write(install_dir.join("package-lock.json"), "stale-lockfile")
         .unwrap_or_else(|error| panic!("plant stale lockfile: {error}"));
 
-    let expired = base_now() + super::VOLATILE_SELECTOR_TTL + std::time::Duration::from_secs(1);
-    finalize_local_invocation_at(&candidate, cache.path(), expired)
-        .unwrap_or_else(|error| panic!("expired re-resolve: {error}"));
+    publish_version(&witness, "0.11.0-nightly.2");
+    finalize_local_invocation_inner(&candidate, cache.path())
+        .unwrap_or_else(|error| panic!("re-resolve after tag moved: {error}"));
 
     let lines = witness_lines(&witness);
-    assert_eq!(lines.len(), 2, "expired volatile cache must re-run npm");
+    assert_eq!(lines.len(), 2, "a moved dist-tag must re-run npm");
     assert_eq!(
         lines[1], "absent",
         "npm must not see the stale package-lock.json when it re-resolves (got {lines:?})",

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -368,6 +368,10 @@ set -e
 witness={witness}
 versions={versions}
 if [ \"$1\" = view ]; then
+  if [ \"$#\" -ne 3 ] || [ \"$3\" != version ]; then
+    echo \"unexpected npm view invocation: $*\" >&2
+    exit 64
+  fi
   if [ -f \"$versions\" ]; then cat \"$versions\"; exit 0; else exit 1; fi
 fi
 if [ -f package-lock.json ]; then echo present >> \"$witness\"; else echo absent >> \"$witness\"; fi
@@ -445,6 +449,45 @@ fn witness_path(dir: &TempDir) -> PathBuf {
 fn volatile_npm_candidate(bin: &TempDir, selector: &str) -> ResolvedCandidate {
     let definition = definition("LLxprt");
     resolve_package(&definition, bin.path(), selector)
+}
+
+/// The registry answer is the one input here jefe does not control, so it is
+/// validated rather than trusted before it reaches the marker (issue #584).
+#[test]
+fn a_registry_version_answer_is_validated_before_it_is_trusted() {
+    use super::is_plausible_version;
+
+    for accepted in [
+        "1.0.0",
+        "0.11.0-nightly.260801.19ac22acc",
+        "2.0.0-rc.1+build.5",
+    ] {
+        assert!(
+            is_plausible_version(accepted),
+            "a legitimate dist-tag answer must be accepted: {accepted:?}"
+        );
+    }
+
+    // A newline would forge an extra marker line; the rest are control or
+    // unbounded answers that must never reach the marker.
+    for rejected in [
+        "",
+        "1.0.0\n2.0.0",
+        "1.0.0 2.0.0",
+        "1.0.0\u{0}",
+        "1.0.0\t",
+        "1.0.0\u{7f}",
+    ] {
+        assert!(
+            !is_plausible_version(rejected),
+            "a malformed registry answer must be rejected: {rejected:?}"
+        );
+    }
+
+    assert!(
+        !is_plausible_version(&"9".repeat(257)),
+        "an unbounded registry answer must be rejected"
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Fixes #584.

## Problem

A volatile selector such as `nightly` was trusted for a flat twelve hours after install (`VOLATILE_SELECTOR_TTL`) and never re-checked inside that window, so jefe kept launching yesterday's build while a newer nightly sat published. Outside the window it reinstalled unconditionally, even when nothing had changed.

The timer was wrong in both directions: stale inside it, wasteful outside it.

## Cause

Resolve and install were one decision. Asking "what does this tag point at right now" required paying for a full install, so a clock was substituted for an answer.

The two operations have very different costs:

- **Resolve** — reads registry metadata, downloads no package content. Cheap.
- **Install** — materialises the tree. Expensive.

## Change

Separate them.

Resolving is cheap enough to do on every launch of a volatile selector. Installing now happens **only when the resolved version differs from the one the cache already holds**. The install marker's fourth line changes meaning accordingly — from an install epoch to the concrete version the tag resolved to — which is what makes "the tag still points here" distinguishable from "the tag has moved" without consulting a clock.

`VOLATILE_SELECTOR_TTL` and `marker_install_is_fresh` are deleted, along with the `SystemTime` injection that existed solely to make the timer testable. There is no staleness window left to bound.

A **pinned** selector is never resolved and never reaches the registry: an explicit version cannot move, so its cache entry stays permanent.

| Selector | Behaviour |
|---|---|
| `""` (blank) | resolved from PATH at launch; untouched by this change |
| `"0.10.0"` (pinned) | immutable; permanent cache hit; no registry contact |
| `"nightly"` / `"latest"` | resolved each launch; installed only when the version changes |

## Offline

An unreachable registry keeps the cached install rather than failing the launch. Network I/O is genuinely external and unpredictable, which is this project's stated exception to fail-fast, and a user without a network should still be able to run the build they already have. The fallback emits a warning rather than passing silently.

When there is **no** cached install and the registry is unreachable, the install itself fails with its existing typed, redacted diagnostic — unchanged.

## Tests

The two TTL tests are replaced by tests of what actually matters:

- `volatile_cache_hits_while_the_tag_has_not_moved` — an unmoved tag is a cache hit however much time passes.
- `volatile_cache_reinstalls_as_soon_as_the_tag_moves` — a newly published nightly is picked up on the very next launch, with no timer to wait out.
- `volatile_selector_uses_the_cached_install_when_the_registry_is_unreachable` — offline reuses the cached executable and does not reinstall.

`pinned_cache_remains_permanent_hit` still passes unchanged, and `volatile_marker_without_a_resolved_version_re_installs` (formerly the legacy-3-line-marker test) now asserts the fourth line records the resolved version.

Both npm stubs learned to answer `npm view` from a file the test controls, so a test can move a dist-tag without a registry. Crucially they record a witness line **only for a real install**, so counting witness lines still counts installs and never counts resolves.

## Verification

- `cargo test --workspace --all-features --locked`: **5337 passed, 0 failed**
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- No lint, complexity or coverage threshold changed; no suppression directive added. The one clippy finding this surfaced (`or_fun_call`) was fixed, not allowed.

## Not in this PR

Surfacing the offline fallback in the UI rather than only in the log. It is a `warn!` today; the user-facing surface belongs with the diagnostics work rather than here.

## Context

This closes the last of the version-selector behaviours: a blank selector resolves from PATH at launch (#575), every launch action admits on the same current evidence (#587), configuration changes no longer disturb running agents (#583), and a moving dist-tag now actually moves.
