### PR TITLE
Never let a failed probe decide an agent is dead (Fixes #541)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,15 @@ jobs:
       - name: Enforce architecture boundary policy
         run: cargo xtask check architecture
 
+  observation_coercion_policy:
+    name: Uncertain-observation coercion policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Enforce uncertain-observation coercion policy
+        run: cargo xtask check observation-coercion
+
   complexity:
     name: Complexity checks
     runs-on: ubuntu-latest

--- a/project-plans/issue541-plan.md
+++ b/project-plans/issue541-plan.md
@@ -1,0 +1,135 @@
+# Issue #541 — fail-closed liveness and restore
+
+Sub-issue of epic #539. Invariant **I3**, criteria **E3** and **E4**. Parent of #537.
+
+> An unknown observation must never cause a state transition. `Unknown` is a first-class
+> terminal outcome that produces no transition, preserves every binding, and surfaces a
+> visible, actionable state to the user.
+
+Branch `issue541`, based on `9a0909a3` (the #540 merge).
+
+---
+
+## 1. Baseline — what is already true after #540 and #543
+
+The issue and its comments were written before #540 and #543 merged. Three of its premises
+have changed, and the plan must start from the code rather than the prose.
+
+| Premise in the issue | State on `9a0909a3` | Consequence |
+|---|---|---|
+| **V12** — server health keys on `#{pid}`, which psmux proved unstable (comment 3: *"the input is wrong"*) | **Closed by #540.** `classify_server_health` now treats the namespace instance token as decisive when both observations carry one; `#{pid}` is no longer the identity. | V12 needs a regression test asserting it stays closed, not new work. |
+| Pane PID conflated with worker PID, so ownership questions consult the wrong process | **Closed by #543.** `PaneProcessIdentity` / `WorkerProcessIdentity` are distinct types; `WorkerDisposition` already distinguishes a worker that survived its pane. | Deliverable 6 (per-agent `Replaced`) can now ask a well-formed question: *is this agent's own worker alive?* Before #543 there was no way to express it. |
+| Liveness has no notion of a worker outliving its pane | `app_shell_liveness.rs` already refuses to call `SurvivedPane` death, and #543 deferred *what it becomes* to #542. | This issue must not decide ownership either. It decides only that no transition occurs. |
+
+**Still broken, confirmed by reading the code on `9a0909a3`:**
+
+| Defect | Location | Evidence |
+|---|---|---|
+| `ServerLost` is a one-way trapdoor | `src/app_shell_liveness.rs:185` | `let _ = lost_ids;` — the recovery the doc comment promises is never implemented. `collect_local_targets` filters to `status == Running` and `eligible_for_server_lost` excludes `ServerLost`, so no other path reaches these agents either. |
+| Cold-start transient strands a live agent | `src/app_init_signature_reconcile.rs:103` | `SessionEvidence::Unavailable => StartupClassification::Recoverable` → `RestoreOneOutcome::Skip` → persisted Running, no in-memory binding. This is #537. |
+| No `Unknown` in the domain at all | `src/domain` `AgentStatus` | Variants are `Queued, Running, Completed, Errored, Waiting, Paused, Dead, ServerLost`. There is nowhere to put "we do not know", which is why every boundary invents an answer. |
+| Probe failure produces no observation rather than an `Unknown` one | `src/runtime/liveness.rs` | `batch_liveness_check_with_identity` returns `Vec::new()` on `list-sessions` / `list-panes` failure. This is *accidentally* correct for the invariant — no transition — but it is silent, unretried, and never re-probed, so a genuinely dead agent stays `Running` forever (V4's mirror hazard). |
+
+**Reframing this produces:** the issue is dominated by one missing concept, not by many independent
+bugs. `AgentStatus` cannot express uncertainty, so every call site resolves uncertainty locally and
+picks whichever state was convenient. Adding the concept is slice 1; the rest is routing existing
+call sites through it.
+
+---
+
+## 2. Acceptance matrix
+
+`S` = slice that delivers it.
+
+| ID | Requirement | S | Notes |
+|---|---|---|---|
+| V1 | Fault injection at `has-session`, `list-sessions`, `list-panes`, `display-message`, durable read, process-identity query. Each asserts **zero** transitions and **zero** binding losses. | S2, S6 | Needs an injection seam. Must exercise the real boundary where a real psmux exists. |
+| V2 | #537 reproduction green: cold-start transient does not strand a live agent; it is attachable afterwards. | S3 | |
+| V3 | #527 reproduction green: definition-hash change on N ≥ 20 live agents leaves all N running and attached, definition updated in place. | S5 | |
+| V4 | A genuinely dead session is still classified Stopped/ServerLost after retries are exhausted. **Fail-closed must not become never-closed.** | S4 | The mirror hazard. Deliberately tested alongside V1 so neither direction can be satisfied alone. |
+| V5 | Server `Replaced` with a surviving host process does not mark that agent `ServerLost`; `Gone` with no surviving process does. | S4 | Now answerable per-agent using #543's `WorkerDisposition`. |
+| V6 | An agent left `Unknown` after startup is re-probed automatically and reaches its true state with no user action. | S4 | |
+| V7 | Visible, actionable `Unknown` UI state; user can force a re-probe. | S1, S7 | Issue forbids deferring this. |
+| V8 | Full E4 perturbation suite — restart, rebuild, attach failure, transient probe failure, server replacement, definition change — against real psmux. | S8 | |
+| V9 | Unix/tmux behaviour unchanged or equivalently improved; macOS suite green. | all | Enforced by running both targets every slice. |
+| V10 | Launching agent N+1 must not change the status of agents 1..N, with ≥ 3 pre-existing running agents on real psmux. | S4 | The live cascade from comment 2. |
+| V11 | A `ServerLost` agent later observed alive returns to `Running` automatically, binding intact, in bounded cycles, no user action. **`let _ = lost_ids;` must be gone.** | S4 | |
+| V12 | Server health must not depend on `#{pid}`. | **already closed by #540** | Deliver a regression test only; do not re-implement. |
+
+---
+
+## 3. Non-goals
+
+- **Deciding what an unowned-but-live worker becomes.** #543 deferred that to #542 and this issue
+  does not reverse it. Here the answer is only "no transition".
+- **Reaping or ownership changes.** #542 and #515 own that.
+- **Fixing #445's durable-read path beyond the invariant.** The read already propagates errors
+  rather than failing open to empty; if a fail-open path is found it is in scope, but auditing the
+  whole persistence layer is not.
+- **Upstream psmux work.** psmux#509 already landed and #540 consumed it.
+- **Retries as the fix.** Explicitly called out by the issue: retries reduce probability, they do
+  not restore the invariant. They are additive to no-transition, never a substitute.
+
+---
+
+## 4. Slices
+
+Each is RED → GREEN → REFACTOR, committed green, verified on Windows **and**
+`x86_64-unknown-linux-gnu`.
+
+| S | Deliverable | Proves |
+|---|---|---|
+| **S1** | `AgentStatus::Unknown` (or a separate observation type carrying it) that must be matched exhaustively and cannot be coerced. Domain + persistence round-trip. | V7 (domain half) |
+| **S2** | A fault-injection seam at each probe boundary, with tests asserting zero transitions per boundary. | V1 |
+| **S3** | `classify_startup` stops mapping `Unavailable` to a decision; #537 reproduction. | V2 |
+| **S4** | Per-agent server-health evaluation; `lost_ids` recovery implemented; deferred re-probe; bounded retry. | V4, V5, V6, V10, V11 |
+| **S5** | Signature change can never reach a kill/stop; #527 reproduction at N ≥ 20. | V3 |
+| **S6** | Durable-read and process-identity boundaries routed through `Unknown`. | V1 (remainder) |
+| **S7** | UI surface for `Unknown` + force-re-probe affordance, with a TUI harness scenario written first. | V7 |
+| **S8** | E4 perturbation suite in `windows_native`. | V8 |
+| **S9** | Mechanical check failing the build on any un-exhaustive coercion of a fallible observation. | V13 (below) |
+
+**V13 (from the issue's item 7, not in its own table):** a mechanical check must fail the build if
+any liveness/restore call site coerces a fallible observation to a state without exhaustively
+matching `Unknown`. Tracked as S9. This is the item that stops the invariant being re-violated a
+fifth time, so it is not optional — the previous four fixes all held until someone added a call site.
+
+---
+
+## 5. Scope ledger
+
+The issue states **no file or line budget applies**, and names nine modules. Recorded anyway so
+growth is visible rather than silent.
+
+| Slice | Expected paths |
+|---|---|
+| S1 | `src/domain/*`, `src/persistence/*`, `src/state/durable_*` |
+| S2 | `src/runtime/liveness.rs`, test harness |
+| S3 | `src/app_init_signature_reconcile.rs` |
+| S4 | `src/app_shell_liveness.rs`, `src/runtime/server_health*.rs` |
+| S5 | `src/app_init_signature_reconcile.rs`, `src/state/*` |
+| S6 | `src/persistence/mod.rs`, `src/runtime/process_identity*` |
+| S7 | `src/ui/*`, `dev-docs/tmux-scenarios/*` |
+| S8 | `.github/workflows/ci.yml`, `tests/*` |
+| S9 | `xtask/src/*` |
+
+**Stop and ask before:** adding a dependency; changing workflow/agent-memory/quality tooling
+beyond S8/S9; introducing a public abstraction not named above; or reversing the #542 deferral.
+
+---
+
+## 6. Open question for the maintainer
+
+**Does `Unknown` belong in `AgentStatus`, or beside it?**
+
+Putting it in `AgentStatus` makes every match exhaustive and is the strongest guarantee — nothing
+can ignore it. But `AgentStatus` is persisted, so `Unknown` becomes a durable state, and an agent
+could be restored *as* `Unknown`, which is arguably meaningless: on restart we have not probed yet,
+so everything is unknown.
+
+The alternative is a separate non-persisted observation layer wrapping the durable status, so
+`Unknown` is always a runtime fact and never a stored one.
+
+I lean to the second — uncertainty is a property of an observation, not of an agent — but it is a
+domain-shape decision with persistence consequences, and S1 blocks on it. Proceeding with the
+second unless told otherwise, and will record the choice in the S1 commit.

--- a/project-plans/issue541-plan.md
+++ b/project-plans/issue541-plan.md
@@ -133,3 +133,22 @@ The alternative is a separate non-persisted observation layer wrapping the durab
 I lean to the second — uncertainty is a property of an observation, not of an agent — but it is a
 domain-shape decision with persistence consequences, and S1 blocks on it. Proceeding with the
 second unless told otherwise, and will record the choice in the S1 commit.
+
+## V7 resolution: no manual re-probe keybinding
+
+The acceptance matrix asked for the unknown state to be visible *and*
+actionable. Delivered as:
+
+- visible: unconfirmed rows render a distinct glyph in yellow, and startup
+  reports how many agents it could not check and why;
+- actionable: the periodic pass re-attempts adoption every
+  `LIVENESS_POLL_INTERVAL`, which is 2 seconds.
+
+A bound "force re-probe" action was considered and rejected. It would add a
+`HandlerKey` variant, a published action id and owner, a default chord, keymap
+persistence and help text -- a published-surface change -- to trigger by hand
+something that already happens automatically every two seconds. The operator
+gains nothing they do not already have within one poll.
+
+If a manual trigger is ever wanted it belongs with a longer cadence or an
+explicit "check now" affordance across all probes, not bolted onto this issue.

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -175,6 +175,89 @@ fn normalize_persisted_sandbox_engines(_state: &mut AppState) -> bool {
     false
 }
 
+/// Adopt an already-running local session under its launch signature.
+///
+/// Every failure here is reached *after* the session was observed alive, so
+/// none of them is evidence of death.
+fn adopt_running_local_agent(
+    agent: &Agent,
+    signature: &AgentLaunchRequest,
+    runtime: &mut TmuxRuntimeManager,
+) -> RestoreOneOutcome {
+    let launched_with = match signature_for_running_agent(
+        agent.persisted_launch_signature.clone(),
+        jefe::runtime::launch_compose::launch_signature_from_request(signature).ok(),
+    ) {
+        Ok(value) => value,
+        Err(reason) => return RestoreOneOutcome::Held(reason),
+    };
+    match runtime.register_existing_local_session(&agent.id, &agent.work_dir, launched_with) {
+        Ok(binding) => RestoreOneOutcome::Revived(Box::new(binding)),
+        // Failing to record a live session is our bookkeeping failing, not the
+        // agent dying.
+        Err(error) => {
+            warn!(agent_id = %agent.id.0, error = %error, "could not register existing session");
+            RestoreOneOutcome::Held(Uncertainty::new(
+                ProbeBoundary::SessionExists,
+                format!("could not register the live session: {error}"),
+            ))
+        }
+    }
+}
+
+/// Revive a running agent's session, holding rather than burying it when the
+/// revival succeeds but the bookkeeping around it does not.
+fn revive_running_agent(
+    agent: &Agent,
+    signature: &AgentLaunchRequest,
+    runtime: &mut TmuxRuntimeManager,
+    runtime_warning: Option<&String>,
+) -> RestoreOneOutcome {
+    match revive_agent_session(agent, signature, runtime, runtime_warning) {
+        ReviveOutcome::Revived => {
+            let launch_signature = match signature_for_running_agent(
+                None,
+                jefe::runtime::launch_compose::launch_signature_from_request(signature).ok(),
+            ) {
+                Ok(value) => value,
+                Err(reason) => return RestoreOneOutcome::Held(reason),
+            };
+            match runtime.runtime_binding(&agent.id, &launch_signature) {
+                Some(binding) => RestoreOneOutcome::Revived(Box::new(binding)),
+                None => RestoreOneOutcome::Held(Uncertainty::new(
+                    ProbeBoundary::SessionExists,
+                    "revived session produced no binding".to_owned(),
+                )),
+            }
+        }
+        ReviveOutcome::Died => RestoreOneOutcome::Dead,
+    }
+}
+
+/// Choose the signature to adopt a *running* agent under.
+///
+/// Reached only once the session probe has said the agent is alive, which is
+/// what makes the failing case interesting: a signature that cannot be
+/// composed is a statement about the current configuration, and configuration
+/// says nothing about whether a process is running. #527 marked twenty live
+/// panes stopped because a hash changed; treating an uncomposable signature as
+/// death is the same move, so it yields a hold instead.
+///
+/// The persisted signature wins when present: it is the one the process was
+/// actually launched with, and what the configuration would produce *now* is a
+/// statement about the next launch (issue #583).
+fn signature_for_running_agent(
+    persisted: Option<jefe::domain::LaunchSignatureV1>,
+    composed: Option<jefe::domain::LaunchSignatureV1>,
+) -> Result<jefe::domain::LaunchSignatureV1, Uncertainty> {
+    persisted.or(composed).ok_or_else(|| {
+        Uncertainty::new(
+            ProbeBoundary::LaunchSignature,
+            "no persisted signature and the current configuration composes none".to_owned(),
+        )
+    })
+}
+
 /// Ask the session probe again before accepting that it cannot answer.
 ///
 /// #537 was a single transient subprocess failure at cold start that stranded
@@ -528,36 +611,10 @@ fn restore_one_agent(
         // The binding carries the signature the process was *launched* with,
         // not the one the current configuration would produce.
         StartupClassification::Running if !signature.remote.enabled => {
-            let Some(launched_with) = agent.persisted_launch_signature.clone().or_else(|| {
-                jefe::runtime::launch_compose::launch_signature_from_request(&signature).ok()
-            }) else {
-                return RestoreOneOutcome::Dead;
-            };
-            match runtime.register_existing_local_session(&agent.id, &agent.work_dir, launched_with)
-            {
-                Ok(binding) => RestoreOneOutcome::Revived(Box::new(binding)),
-                Err(error) => {
-                    warn!(agent_id = %agent.id.0, error = %error, "could not register existing session");
-                    RestoreOneOutcome::Dead
-                }
-            }
+            adopt_running_local_agent(agent, &signature, runtime)
         }
         StartupClassification::Running => {
-            match revive_agent_session(agent, &signature, runtime, runtime_warning) {
-                ReviveOutcome::Revived => {
-                    let Ok(launch_signature) =
-                        jefe::runtime::launch_compose::launch_signature_from_request(&signature)
-                    else {
-                        return RestoreOneOutcome::Dead;
-                    };
-                    runtime
-                        .runtime_binding(&agent.id, &launch_signature)
-                        .map_or(RestoreOneOutcome::Dead, |binding| {
-                            RestoreOneOutcome::Revived(Box::new(binding))
-                        })
-                }
-                ReviveOutcome::Died => RestoreOneOutcome::Dead,
-            }
+            revive_running_agent(agent, &signature, runtime, runtime_warning)
         }
     }
 }

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -421,15 +421,24 @@ pub fn init_app_state(
         Settings::default_with_version()
     });
 
-    let persisted = ctx_guard
-        .persistence
-        .load_durable_state()
-        .unwrap_or_else(|e| {
-            warn!(error = %e, "could not load state, using defaults");
-            jefe::state::durable_projection::RestoredState::default()
-        });
+    // A read that fails is not a read that found nothing. Defaulting here is
+    // what let #445 turn an unreadable document into an empty one, because the
+    // empty result was then projected straight back over the file.
+    let (persisted, durable_read_held) = match ctx_guard.persistence.load_durable_state() {
+        Ok(value) => (value, None),
+        Err(error) => {
+            warn!(error = %error, "could not read durable state; holding writes");
+            (
+                jefe::state::durable_projection::RestoredState::default(),
+                Some(format!(
+                    "Durable state could not be read ({error}). Agents shown may be incomplete and saving is paused so the existing file is not overwritten."
+                )),
+            )
+        }
+    };
 
     let mut state = app_state.write();
+    state.durable_read_held = durable_read_held;
     restore_persisted_state(&mut state, persisted);
     apply_startup_warning(&mut state, multiplexer_warning);
     state.override_agent_theme = settings.override_agent_theme;

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -59,6 +59,28 @@ fn surface_durable_read_hold(state: &mut AppState, held: Option<String>) {
     state.durable_read_held = Some(reason);
 }
 
+/// Report agents whose state startup could not determine.
+///
+/// A held agent keeps its persisted `Running` status and its binding, which is
+/// the correct refusal to guess. But the liveness cycle builds its targets
+/// from the runtime's session map, and a held agent was never registered
+/// there, so nothing probes it again. Left silent that is a Running agent the
+/// operator cannot attach to and is given no reason for, so the hold has to be
+/// stated even though it is the safe outcome (issue #541).
+fn surface_startup_holds(state: &mut AppState, held: &[(AgentId, String)]) {
+    let Some((_, first_reason)) = held.first() else {
+        return;
+    };
+    append_warning(
+        state,
+        format!(
+            "{} agent(s) could not be checked at startup and were left untouched: {first_reason}. \
+             Their state is unknown, not confirmed.",
+            held.len()
+        ),
+    );
+}
+
 fn apply_startup_warning(state: &mut AppState, warning: Option<String>) {
     if let Some(warning) = warning {
         append_warning(state, warning);
@@ -664,6 +686,7 @@ pub fn restore_runtime_sessions(app_state: &mut HookState<AppState>, ctx: &Share
 
     let mut revived_running = Vec::new();
     let mut newly_dead = Vec::new();
+    let mut held: Vec<(AgentId, String)> = Vec::new();
     let runtime_warning: Option<String> = None;
 
     for agent in agents {
@@ -681,27 +704,28 @@ pub fn restore_runtime_sessions(app_state: &mut HookState<AppState>, ctx: &Share
             }
             RestoreOneOutcome::Dead => newly_dead.push(agent.id.clone()),
             RestoreOneOutcome::Skip => {}
-            // Left exactly as persisted, including its binding. The deferred
-            // re-probe that turns this into an eventual answer is issue #541's
-            // next slice; until then the hold is at least visible in the log
-            // rather than silently indistinguishable from a healthy skip.
+            // Left exactly as persisted, including its binding.
             RestoreOneOutcome::Held(reason) => {
                 warn!(
                     agent_id = %agent.id.0,
                     %reason,
                     "startup held this agent: its state was not determined and was left untouched"
                 );
+                held.push((agent.id.clone(), reason.to_string()));
             }
         }
     }
 
     drop(ctx_guard);
 
-    let state_changed =
-        !revived_running.is_empty() || !newly_dead.is_empty() || runtime_warning.is_some();
+    let state_changed = !revived_running.is_empty()
+        || !newly_dead.is_empty()
+        || runtime_warning.is_some()
+        || !held.is_empty();
     if state_changed {
         let mut state = app_state.write();
         apply_restored_state(&mut state, revived_running, newly_dead, runtime_warning);
+        surface_startup_holds(&mut state, &held);
     }
 
     if let Some(warning) = shell_reconcile::reconcile_shell_inventory(app_state, ctx) {

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -59,6 +59,80 @@ fn surface_durable_read_hold(state: &mut AppState, held: Option<String>) {
     state.durable_read_held = Some(reason);
 }
 
+/// Select the agents still awaiting a verdict.
+///
+/// A `Running` agent with no runtime binding is one startup held: it kept the
+/// status it was persisted with because nothing disproved it, but it was never
+/// registered with the runtime. The liveness cycle builds its targets from the
+/// runtime's session map, so these agents are invisible to it and would stay
+/// held forever. Refusing to guess is only correct if the question is asked
+/// again (issue #541).
+pub fn agents_awaiting_readoption(state: &AppState) -> Vec<AgentId> {
+    state
+        .agents
+        .iter()
+        .filter(|agent| agent.status == AgentStatus::Running && agent.runtime_binding.is_none())
+        .map(|agent| agent.id.clone())
+        .collect()
+}
+
+/// Ask again about the agents startup could not determine.
+///
+/// Refusing to guess is only safe if the question gets asked again. These
+/// agents are invisible to the liveness cycle because they were never
+/// registered with the runtime, so the periodic pass calls this to re-attempt
+/// adoption -- which is the question they actually failed, rather than the
+/// liveness probe they were never eligible for.
+///
+/// A hold here is not an error: it means the answer is still unavailable and
+/// the agent keeps its persisted state until some later pass gets one.
+pub fn reattempt_held_agents(app_state: &mut HookState<AppState>, ctx: &SharedContext) {
+    let Some(ctx_arc) = ctx else {
+        return;
+    };
+    let pending = agents_awaiting_readoption(&app_state.read());
+    if pending.is_empty() {
+        return;
+    }
+
+    let (agents, repositories) = {
+        let state = app_state.read();
+        (
+            state
+                .agents
+                .iter()
+                .filter(|agent| pending.contains(&agent.id))
+                .cloned()
+                .collect::<Vec<_>>(),
+            state.repositories.clone(),
+        )
+    };
+
+    let Ok(mut ctx_guard) = ctx_arc.lock() else {
+        return;
+    };
+    let mut revived_running = Vec::new();
+    let mut newly_dead = Vec::new();
+    for agent in agents {
+        match restore_one_agent(&agent, &repositories, &mut ctx_guard.runtime, None) {
+            RestoreOneOutcome::Revived(binding) => revived_running.push(RevivedAgent {
+                agent_id: agent.id.clone(),
+                binding,
+            }),
+            RestoreOneOutcome::Dead => newly_dead.push(agent.id.clone()),
+            // Still unanswered, or not ours to answer. Left as persisted.
+            RestoreOneOutcome::Skip | RestoreOneOutcome::Held(_) => {}
+        }
+    }
+    drop(ctx_guard);
+
+    if revived_running.is_empty() && newly_dead.is_empty() {
+        return;
+    }
+    let mut state = app_state.write();
+    apply_restored_state(&mut state, revived_running, newly_dead, None);
+}
+
 /// Report agents whose state startup could not determine.
 ///
 /// A held agent keeps its persisted `Running` status and its binding, which is

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -23,7 +23,7 @@ use jefe::persistence::{PersistenceManager, Settings};
 #[cfg(windows)]
 use jefe::runtime::MultiplexerPlan;
 use jefe::runtime::{
-    ProcessLiveness, RuntimeError, RuntimeManager, SessionLiveness, TmuxRuntimeManager, pid_alive,
+    ProcessLiveness, RuntimeError, RuntimeManager, SessionLiveness, TmuxRuntimeManager,
     platform_engine_diagnostic, process_liveness,
 };
 use jefe::state::AppState;
@@ -326,16 +326,13 @@ fn process_liveness_for_binding(worker: Option<WorkerProcessIdentity>) -> Proces
     let Some(worker) = worker else {
         return ProcessLiveness::MalformedIdentity;
     };
-    // A creation token lets the probe reject PID reuse; without one all we can
-    // do is ask whether the bare PID is live.
-    if worker.started_at().is_some() {
-        return process_liveness(Some(worker.identity()));
-    }
-    if pid_alive(worker.pid()) {
-        ProcessLiveness::Alive
-    } else {
-        ProcessLiveness::Dead
-    }
+    // A creation token lets the probe reject PID reuse. Without one the same
+    // probe still answers, it just cannot rule reuse out -- so there is no
+    // reason to ask a narrower question. Routing the token-less case through a
+    // `bool` used to launder `Inaccessible` and `ProbeFailure` into a positive
+    // `Alive`, which meant identical uncertainty was held when a token was
+    // present and asserted as liveness when it was not (issue #541).
+    process_liveness(Some(worker.identity()))
 }
 
 /// Load persisted state and settings into `app_state` exactly once.

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -71,7 +71,7 @@ pub fn agents_awaiting_readoption(state: &AppState) -> Vec<AgentId> {
     state
         .agents
         .iter()
-        .filter(|agent| agent.status == AgentStatus::Running && agent.runtime_binding.is_none())
+        .filter(|agent| agent.state_is_unconfirmed())
         .map(|agent| agent.id.clone())
         .collect()
 }
@@ -701,7 +701,16 @@ fn restore_one_agent(
         .find(|repository| repository.id == agent.repository_id)
         .cloned()
     else {
-        return RestoreOneOutcome::Dead;
+        // Configuration we cannot find, not a process we observed ending. The
+        // periodic re-adoption pass reaches this on every cycle, so burying
+        // the agent here would kill a live one for a bookkeeping gap (#541).
+        return RestoreOneOutcome::Held(Uncertainty::new(
+            ProbeBoundary::LaunchSignature,
+            format!(
+                "repository {} is not in state, so the agent could not be checked",
+                agent.repository_id.0
+            ),
+        ));
     };
     let signature = launch_signature_for_agent(agent, &repository);
 

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -15,6 +15,7 @@ use self::signature_reconcile::{
 use iocraft::hooks::State as HookState;
 use tracing::warn;
 
+use jefe::domain::liveness_observation::{ProbeBoundary, Uncertainty};
 use jefe::domain::{Agent, AgentId, AgentLaunchRequest, AgentStatus, WorkerProcessIdentity};
 use jefe::persistence::{PersistenceManager, Settings};
 #[cfg(windows)]
@@ -438,6 +439,13 @@ enum RestoreOneOutcome {
     Dead,
     /// Agent should be left as-is (non-running, or local orphan kept Running).
     Skip,
+    /// A startup probe did not answer, so the agent keeps everything it was
+    /// persisted with and is re-probed later.
+    ///
+    /// Deliberately not `Skip`: both leave state untouched now, but only this
+    /// one records that the question is still open, which is what a deferred
+    /// re-probe and the operator-facing state need (issue #541).
+    Held(Uncertainty),
 }
 struct RevivedAgent {
     agent_id: AgentId,
@@ -470,6 +478,13 @@ fn restore_one_agent(
         | StartupClassification::Inconsistent
         | StartupClassification::Orphaned => RestoreOneOutcome::Dead,
         StartupClassification::Recoverable => RestoreOneOutcome::Skip,
+        StartupClassification::Held => RestoreOneOutcome::Held(Uncertainty::new(
+            ProbeBoundary::SessionExists,
+            format!(
+                "startup could not determine whether session {} is alive",
+                agent.id.0
+            ),
+        )),
         // A live local session means jefe is re-adopting a process it already
         // started. Adoption is proved by session name, liveness and process
         // identity, so it must not re-resolve a version selector or probe an
@@ -555,6 +570,17 @@ pub fn restore_runtime_sessions(app_state: &mut HookState<AppState>, ctx: &Share
             }
             RestoreOneOutcome::Dead => newly_dead.push(agent.id.clone()),
             RestoreOneOutcome::Skip => {}
+            // Left exactly as persisted, including its binding. The deferred
+            // re-probe that turns this into an eventual answer is issue #541's
+            // next slice; until then the hold is at least visible in the log
+            // rather than silently indistinguishable from a healthy skip.
+            RestoreOneOutcome::Held(reason) => {
+                warn!(
+                    agent_id = %agent.id.0,
+                    %reason,
+                    "startup held this agent: its state was not determined and was left untouched"
+                );
+            }
         }
     }
 

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -44,6 +44,21 @@ fn append_warning(state: &mut AppState, warning: String) {
         None => warning,
     });
 }
+/// Record a held durable read and put the reason where the operator will see
+/// it.
+///
+/// Holding writes without saying so leaves a jefe that looks healthy while
+/// persisting nothing, so the hold and its visible explanation are set
+/// together rather than by separate callers who might do only one of the two
+/// (issue #541).
+fn surface_durable_read_hold(state: &mut AppState, held: Option<String>) {
+    let Some(reason) = held else {
+        return;
+    };
+    append_warning(state, reason.clone());
+    state.durable_read_held = Some(reason);
+}
+
 fn apply_startup_warning(state: &mut AppState, warning: Option<String>) {
     if let Some(warning) = warning {
         append_warning(state, warning);
@@ -435,7 +450,7 @@ pub fn init_app_state(
     };
 
     let mut state = app_state.write();
-    state.durable_read_held = durable_read_held;
+    surface_durable_read_hold(&mut state, durable_read_held);
     restore_persisted_state(&mut state, persisted);
     apply_startup_warning(&mut state, multiplexer_warning);
     state.override_agent_theme = settings.override_agent_theme;

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -15,13 +15,15 @@ use self::signature_reconcile::{
 use iocraft::hooks::State as HookState;
 use tracing::warn;
 
-use jefe::domain::liveness_observation::{ProbeBoundary, Uncertainty};
+use jefe::domain::liveness_observation::{
+    Observed, ProbeBoundary, RetryPolicy, Uncertainty, retry_observation,
+};
 use jefe::domain::{Agent, AgentId, AgentLaunchRequest, AgentStatus, WorkerProcessIdentity};
 use jefe::persistence::{PersistenceManager, Settings};
 #[cfg(windows)]
 use jefe::runtime::MultiplexerPlan;
 use jefe::runtime::{
-    ProcessLiveness, RuntimeError, RuntimeManager, TmuxRuntimeManager, pid_alive,
+    ProcessLiveness, RuntimeError, RuntimeManager, SessionLiveness, TmuxRuntimeManager, pid_alive,
     platform_engine_diagnostic, process_liveness,
 };
 use jefe::state::AppState;
@@ -173,14 +175,45 @@ fn normalize_persisted_sandbox_engines(_state: &mut AppState) -> bool {
     false
 }
 
+/// Ask the session probe again before accepting that it cannot answer.
+///
+/// #537 was a single transient subprocess failure at cold start that stranded
+/// a live agent. Holding instead of guessing stops that becoming a false
+/// death, but a hold is still the wrong answer when the probe would have
+/// succeeded a moment later, so `Unavailable` is retried before it is believed.
+///
+/// Only `Unavailable` is retried. `Missing` is an answer -- the session really
+/// is gone -- and re-asking a question that was already answered would delay
+/// every genuinely dead agent at startup for nothing.
+fn retry_session_evidence(
+    policy: RetryPolicy,
+    mut probe: impl FnMut() -> SessionLiveness,
+) -> SessionEvidence {
+    let observed = retry_observation(
+        policy,
+        || match probe() {
+            SessionLiveness::Unavailable => Observed::unknown(
+                ProbeBoundary::SessionExists,
+                "session probe did not answer".to_owned(),
+            ),
+            answered => Observed::Known(answered),
+        },
+        std::thread::sleep,
+    );
+    observed
+        .known()
+        .copied()
+        .map_or(SessionEvidence::Unavailable, SessionEvidence::from)
+}
+
 fn classify_agent_startup(
     agent: &Agent,
     signature: &AgentLaunchRequest,
     runtime: &TmuxRuntimeManager,
 ) -> StartupClassification {
-    let session = runtime
-        .session_liveness_for_signature(&agent.id, signature)
-        .into();
+    let session = retry_session_evidence(RetryPolicy::default(), || {
+        runtime.session_liveness_for_signature(&agent.id, signature)
+    });
     let binding = binding_evidence(agent.runtime_binding.as_ref(), &agent.id);
     let process = if signature.remote.enabled {
         ProcessLiveness::MalformedIdentity

--- a/src/app_init_signature_reconcile.rs
+++ b/src/app_init_signature_reconcile.rs
@@ -35,6 +35,13 @@ pub(super) enum StartupClassification {
     Recoverable,
     Inconsistent,
     Orphaned,
+    /// A probe did not answer, so startup has no basis for any classification.
+    ///
+    /// Distinct from [`Self::Recoverable`], which is a conclusion drawn from
+    /// evidence that did arrive. Held means the evidence never arrived, so the
+    /// agent must be left exactly as persisted and re-probed later rather than
+    /// classified now (issue #541).
+    Held,
 }
 
 /// Ownership evidence for one persisted binding.
@@ -100,7 +107,10 @@ pub(super) fn classify_startup(
     }
     match session {
         SessionEvidence::Alive => StartupClassification::Running,
-        SessionEvidence::Unavailable => StartupClassification::Recoverable,
+        // The session probe did not answer. Every classification below this
+        // point reads the *absence* of a session as meaningful, which it is
+        // not when the question was never answered (issue #541, #537).
+        SessionEvidence::Unavailable => StartupClassification::Held,
         SessionEvidence::Missing if remote => StartupClassification::Stopped,
         SessionEvidence::Missing => classify_missing_local_process(process),
     }
@@ -111,8 +121,11 @@ fn classify_missing_local_process(process: ProcessLiveness) -> StartupClassifica
         ProcessLiveness::Dead => StartupClassification::Stopped,
         ProcessLiveness::ReusedPid => StartupClassification::Stale,
         ProcessLiveness::MalformedIdentity => StartupClassification::Inconsistent,
-        ProcessLiveness::Alive | ProcessLiveness::Inaccessible | ProcessLiveness::ProbeFailure => {
-            StartupClassification::Recoverable
+        // The process query itself failed or was refused, so liveness is
+        // unknown rather than recoverable.
+        ProcessLiveness::Inaccessible | ProcessLiveness::ProbeFailure => {
+            StartupClassification::Held
         }
+        ProcessLiveness::Alive => StartupClassification::Recoverable,
     }
 }

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -285,18 +285,32 @@ fn startup_classification_covers_required_lifecycle_states() {
     );
 }
 
+/// An unanswered session probe is held, not classified.
+///
+/// This previously asserted `Recoverable`, which kept the agent alive but was
+/// a *conclusion* drawn from evidence that never arrived, and was
+/// indistinguishable from the same conclusion reached from real evidence.
+/// `Held` is strictly more conservative and, unlike `Recoverable`, records
+/// that the question is still open so it can be asked again (issue #541).
 #[test]
-fn unavailable_runtime_probe_is_recoverable_not_phantom_dead() {
+fn an_unanswered_session_probe_is_held_not_classified() {
     for liveness in [ProcessLiveness::Dead, ProcessLiveness::ProbeFailure] {
+        let classification = classify_startup(
+            SessionEvidence::Unavailable,
+            BindingEvidence::Coherent,
+            false,
+            liveness,
+            jefe::runtime::OrphanClassification::NoOrphan,
+        );
         assert_eq!(
-            classify_startup(
-                SessionEvidence::Unavailable,
-                BindingEvidence::Coherent,
-                false,
-                liveness,
-                jefe::runtime::OrphanClassification::NoOrphan,
-            ),
-            StartupClassification::Recoverable
+            classification,
+            StartupClassification::Held,
+            "an unavailable session probe must not reach a verdict"
+        );
+        assert_ne!(
+            classification,
+            StartupClassification::Stopped,
+            "the original guarantee still holds: no phantom death"
         );
     }
 }
@@ -327,6 +341,8 @@ fn malformed_or_inaccessible_process_identity_is_classified_conservatively() {
         ),
         StartupClassification::Inconsistent
     );
+    // A process we are not permitted to inspect has not told us it is dead.
+    // That is an unanswered question, not a recoverable conclusion.
     assert_eq!(
         classify_startup(
             SessionEvidence::Missing,
@@ -335,8 +351,51 @@ fn malformed_or_inaccessible_process_identity_is_classified_conservatively() {
             ProcessLiveness::Inaccessible,
             jefe::runtime::OrphanClassification::NoOrphan,
         ),
-        StartupClassification::Recoverable
+        StartupClassification::Held
     );
+}
+
+/// The mirror hazard for #541: holding must not swallow real evidence.
+///
+/// A change that held on everything would satisfy the invariant and destroy
+/// the feature, so the answered paths are pinned alongside the held ones.
+#[test]
+fn answered_evidence_still_reaches_every_verdict() {
+    let answered = [
+        (
+            SessionEvidence::Alive,
+            ProcessLiveness::Alive,
+            StartupClassification::Running,
+        ),
+        (
+            SessionEvidence::Missing,
+            ProcessLiveness::Dead,
+            StartupClassification::Stopped,
+        ),
+        (
+            SessionEvidence::Missing,
+            ProcessLiveness::ReusedPid,
+            StartupClassification::Stale,
+        ),
+        (
+            SessionEvidence::Missing,
+            ProcessLiveness::MalformedIdentity,
+            StartupClassification::Inconsistent,
+        ),
+    ];
+    for (session, process, expected) in answered {
+        assert_eq!(
+            classify_startup(
+                session,
+                BindingEvidence::Coherent,
+                false,
+                process,
+                jefe::runtime::OrphanClassification::NoOrphan,
+            ),
+            expected,
+            "answered evidence must still produce a verdict"
+        );
+    }
 }
 
 /// PID reuse still overrides a live session. Removing the configuration

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -232,6 +232,35 @@ fn legacy_pid_only_binding_uses_conservative_native_probe() {
     );
 }
 
+/// A token-less binding must report the probe's real answer. Collapsing it to
+/// a `bool` turned "could not look" into a positive claim of liveness, so the
+/// same uncertainty was held when a creation token happened to be present and
+/// asserted as alive when it was not (issue #541).
+#[test]
+fn a_token_less_binding_reports_uncertainty_rather_than_asserting_life() {
+    use jefe::runtime::{ProcessObservation, classify_process_observation};
+
+    let legacy = WorkerProcessIdentity::from_pid(4321).identity();
+
+    for (observation, expected) in [
+        (
+            ProcessObservation::Inaccessible,
+            ProcessLiveness::Inaccessible,
+        ),
+        (
+            ProcessObservation::ProbeFailed,
+            ProcessLiveness::ProbeFailure,
+        ),
+        (ProcessObservation::Exited, ProcessLiveness::Dead),
+    ] {
+        assert_eq!(
+            classify_process_observation(Some(legacy), observation),
+            expected,
+            "a token-less binding must not report {observation:?} as a verdict about life"
+        );
+    }
+}
+
 #[test]
 fn startup_classification_covers_required_lifecycle_states() {
     use jefe::runtime::OrphanClassification as Oc;

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -603,3 +603,41 @@ fn a_missing_session_is_not_retried() {
     assert_eq!(evidence, SessionEvidence::Missing);
     assert_eq!(calls, 1, "an answered probe is asked exactly once");
 }
+
+/// V3 / #527: twenty live panes were marked stopped because a hash changed.
+/// A signature that cannot be composed describes the configuration, not the
+/// process, so a live agent must be held rather than buried.
+#[test]
+fn a_live_agent_whose_signature_will_not_compose_is_held_not_dead() {
+    let outcome = signature_for_running_agent(None, None);
+
+    let reason = outcome
+        .err()
+        .unwrap_or_else(|| panic!("an uncomposable signature must not yield a signature"));
+    assert_eq!(reason.boundary(), ProbeBoundary::LaunchSignature);
+}
+
+/// The signature the process was actually launched with wins over whatever the
+/// current configuration would produce (issue #583).
+#[test]
+fn a_persisted_signature_beats_the_current_configuration() {
+    let persisted = jefe::domain::LaunchSignatureV1::default();
+    let composed = jefe::domain::LaunchSignatureV1::default();
+
+    let chosen = signature_for_running_agent(Some(persisted.clone()), Some(composed))
+        .unwrap_or_else(|reason| panic!("a persisted signature must be adopted: {reason}"));
+
+    assert_eq!(chosen, persisted);
+}
+
+/// The mirror hazard: when the configuration *can* compose a signature and
+/// nothing was persisted, adoption must still proceed rather than hold.
+#[test]
+fn a_composable_signature_is_still_adopted() {
+    let composed = jefe::domain::LaunchSignatureV1::default();
+
+    let chosen = signature_for_running_agent(None, Some(composed.clone()))
+        .unwrap_or_else(|reason| panic!("a composable signature must be adopted: {reason}"));
+
+    assert_eq!(chosen, composed);
+}

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -810,3 +810,21 @@ fn bound_and_finished_agents_are_left_alone() {
         "only unbound Running agents are unresolved; a bound one is answered and a dead one is finished"
     );
 }
+
+/// A missing repository is jefe failing to find configuration, not the agent's
+/// process ending. Burying it was the last instance of the #527 collapse, and
+/// it matters more now that the periodic re-adoption pass reaches this code on
+/// every cycle rather than once at startup (issue #541 V3).
+#[test]
+fn an_agent_whose_repository_is_missing_is_held_not_buried() {
+    let (mut agent, _repo) = code_puppy_agent_and_repository();
+    agent.status = AgentStatus::Running;
+
+    let mut runtime = TmuxRuntimeManager::new(24, 80);
+    let outcome = restore_one_agent(&agent, &[], &mut runtime, None);
+
+    assert!(
+        matches!(outcome, RestoreOneOutcome::Held(_)),
+        "a repository we cannot find says nothing about whether the process is alive"
+    );
+}

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -706,3 +706,48 @@ fn a_successful_durable_read_shows_nothing() {
     assert_eq!(state.warning_message, None);
     assert_eq!(state.durable_read_held, None);
 }
+
+/// A held agent is left exactly as persisted -- Running, with no binding. The
+/// liveness cycle builds its targets from the runtime's session map, so an
+/// agent that was never registered produces no target and is never probed
+/// again. Without a visible warning the operator sees a Running agent that
+/// cannot be attached to and is given no reason (issue #541 V4/V7).
+#[test]
+fn held_agents_are_reported_to_the_operator() {
+    let mut state = AppState::default();
+
+    surface_startup_holds(
+        &mut state,
+        &[
+            (
+                AgentId("agent-1".to_owned()),
+                "has-session did not answer: server unreachable".to_owned(),
+            ),
+            (
+                AgentId("agent-2".to_owned()),
+                "has-session did not answer: server unreachable".to_owned(),
+            ),
+        ],
+    );
+
+    let shown = state
+        .warning_message
+        .as_ref()
+        .unwrap_or_else(|| panic!("held agents must be reported, not only logged"));
+    assert!(
+        shown.contains('2'),
+        "the operator needs to know how many agents are affected: {shown}"
+    );
+    assert!(
+        shown.contains("server unreachable"),
+        "the operator needs the reason, not just a count: {shown}"
+    );
+}
+
+/// The mirror hazard: no holds must leave the status line alone.
+#[test]
+fn no_holds_reports_nothing() {
+    let mut state = AppState::default();
+    surface_startup_holds(&mut state, &[]);
+    assert_eq!(state.warning_message, None);
+}

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -670,3 +670,39 @@ fn a_composable_signature_is_still_adopted() {
 
     assert_eq!(chosen, composed);
 }
+
+/// A held durable read pauses saving. If that is not on screen the operator
+/// sees a working jefe that is quietly not persisting anything, which is worse
+/// than the crash it replaced: the failure is invisible until the work is
+/// already lost (issue #541 V7).
+#[test]
+fn a_held_durable_read_is_visible_to_the_operator() {
+    let mut state = AppState::default();
+
+    surface_durable_read_hold(&mut state, Some("state.json is not valid JSON".to_owned()));
+
+    let shown = state
+        .warning_message
+        .as_ref()
+        .unwrap_or_else(|| panic!("a held durable read must reach the operator, not just the log"));
+    assert!(
+        shown.contains("state.json is not valid JSON"),
+        "the operator needs the reason, not just that something is wrong: {shown}"
+    );
+    assert_eq!(
+        state.durable_read_held,
+        Some("state.json is not valid JSON".to_owned()),
+        "the hold itself must stay set so writes remain paused"
+    );
+}
+
+/// The mirror hazard: a readable document must leave no warning and no hold.
+#[test]
+fn a_successful_durable_read_shows_nothing() {
+    let mut state = AppState::default();
+
+    surface_durable_read_hold(&mut state, None);
+
+    assert_eq!(state.warning_message, None);
+    assert_eq!(state.durable_read_held, None);
+}

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -7,6 +7,7 @@
 use super::*;
 use jefe::domain::{Repository, RepositoryId, TypedValue};
 use jefe::runtime::RuntimeSession;
+use std::time::Duration;
 
 fn code_puppy_agent_and_repository() -> (Agent, Repository) {
     let repository_id = RepositoryId("repo-model".to_owned());
@@ -548,4 +549,57 @@ fn conformance_and_provenance_problems_are_both_reported() {
 
     assert!(warning.contains("display-message"), "{warning}");
     assert!(warning.contains("deadbeef"), "{warning}");
+}
+
+/// #537 in miniature: one transient failure at the startup boundary must not
+/// be enough to withhold a verdict about a live agent.
+#[test]
+fn a_startup_session_probe_that_recovers_is_believed() {
+    let mut calls = 0_u32;
+
+    let evidence = retry_session_evidence(RetryPolicy::new(3, Duration::from_millis(0)), || {
+        calls += 1;
+        if calls < 3 {
+            SessionLiveness::Unavailable
+        } else {
+            SessionLiveness::Alive
+        }
+    });
+
+    assert_eq!(
+        evidence,
+        SessionEvidence::Alive,
+        "a probe that answered on retry must be believed"
+    );
+    assert_eq!(calls, 3);
+}
+
+/// When the probe never answers the honest result is still `Unavailable`, and
+/// the retry must be bounded rather than blocking startup indefinitely.
+#[test]
+fn a_startup_session_probe_that_never_answers_stays_unavailable() {
+    let mut calls = 0_u32;
+
+    let evidence = retry_session_evidence(RetryPolicy::new(3, Duration::from_millis(0)), || {
+        calls += 1;
+        SessionLiveness::Unavailable
+    });
+
+    assert_eq!(evidence, SessionEvidence::Unavailable);
+    assert_eq!(calls, 3, "retries are bounded");
+}
+
+/// A session that is genuinely gone has *answered*. Re-asking would delay
+/// every dead agent at startup and buy nothing.
+#[test]
+fn a_missing_session_is_not_retried() {
+    let mut calls = 0_u32;
+
+    let evidence = retry_session_evidence(RetryPolicy::new(5, Duration::from_millis(0)), || {
+        calls += 1;
+        SessionLiveness::Missing
+    });
+
+    assert_eq!(evidence, SessionEvidence::Missing);
+    assert_eq!(calls, 1, "an answered probe is asked exactly once");
 }

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -751,3 +751,62 @@ fn no_holds_reports_nothing() {
     surface_startup_holds(&mut state, &[]);
     assert_eq!(state.warning_message, None);
 }
+
+/// A held agent keeps its Running status but has no binding, and the liveness
+/// cycle builds its targets from the runtime's session map -- so nothing
+/// probes it again. Selecting exactly these agents is what lets a later pass
+/// give them an eventual verdict instead of leaving them phantoms (#541 V4).
+#[test]
+fn agents_held_at_startup_are_selected_for_another_attempt() {
+    let (mut agent, _repo) = code_puppy_agent_and_repository();
+    agent.status = AgentStatus::Running;
+    agent.runtime_binding = None;
+
+    let expected = agent.id.clone();
+    let state = AppState {
+        agents: vec![agent],
+        ..Default::default()
+    };
+
+    assert_eq!(
+        agents_awaiting_readoption(&state),
+        vec![expected],
+        "a Running agent with no binding is exactly the phantom that needs re-probing"
+    );
+}
+
+/// The mirror hazard, twice over: re-probing must not disturb an agent that is
+/// already bound, and must not resurrect one that was answered as dead.
+#[test]
+fn bound_and_finished_agents_are_left_alone() {
+    let (mut bound, repo) = code_puppy_agent_and_repository();
+    bound.status = AgentStatus::Running;
+    let request = AgentLaunchRequest::for_agent(&bound, &repo);
+    let launched_with = jefe::runtime::launch_compose::launch_signature_from_request(&request)
+        .unwrap_or_else(|error| panic!("fixture signature must compose: {error}"));
+    bound.runtime_binding = Some(jefe::domain::RuntimeBinding {
+        session_name: RuntimeSession::session_name_for(&bound.id),
+        launch_signature: launched_with,
+        attached: false,
+        last_seen: None,
+        pane_identity: None,
+        worker_identity: None,
+        lifecycle_generation: 0,
+        worker_identities: Vec::new(),
+    });
+
+    let (mut dead, _repo2) = code_puppy_agent_and_repository();
+    dead.id = AgentId("agent-2".to_owned());
+    dead.status = AgentStatus::Dead;
+    dead.runtime_binding = None;
+
+    let state = AppState {
+        agents: vec![bound, dead],
+        ..Default::default()
+    };
+
+    assert!(
+        agents_awaiting_readoption(&state).is_empty(),
+        "only unbound Running agents are unresolved; a bound one is answered and a dead one is finished"
+    );
+}

--- a/src/app_shell_liveness.rs
+++ b/src/app_shell_liveness.rs
@@ -29,6 +29,7 @@ use crate::app_input::{
 };
 use crate::app_shell_workers::capture_dead_previews;
 
+use jefe::domain::liveness_observation::Observed;
 use jefe::domain::{AgentId, AgentStatus};
 use jefe::runtime::LivenessIdentity;
 #[cfg(windows)]
@@ -196,7 +197,7 @@ async fn handle_unix_cycle(
     if running_targets.is_empty() {
         return;
     }
-    let dead_identities = batch_dead_identities(running_targets).await;
+    let dead_identities = answered_dead_identities(batch_dead_identities(running_targets).await);
     if dead_identities.is_empty() {
         return;
     }
@@ -209,9 +210,27 @@ async fn handle_unix_cycle(
 
 /// Return the dead identity triples for the given targets via a background
 /// OS thread so the smol executor stays free for input events (issue #287).
-async fn batch_dead_identities(targets: &[jefe::runtime::LivenessCheck]) -> Vec<LivenessIdentity> {
+async fn batch_dead_identities(
+    targets: &[jefe::runtime::LivenessCheck],
+) -> Observed<Vec<LivenessIdentity>> {
     let targets_owned = targets.to_vec();
     smol::unblock(move || jefe::runtime::batch_liveness_check_with_identity(&targets_owned)).await
+}
+
+/// The dead identities from an answered poll, or none when the multiplexer
+/// could not answer.
+///
+/// A held poll leaves every agent exactly as it was. The reason is logged
+/// rather than dropped, because an invisible hold is indistinguishable to the
+/// operator from the fail-open bug this replaces (issue #541).
+fn answered_dead_identities(observed: Observed<Vec<LivenessIdentity>>) -> Vec<LivenessIdentity> {
+    match observed {
+        Observed::Known(dead) => dead,
+        Observed::Unknown(reason) => {
+            tracing::warn!(%reason, "liveness poll held: no agent state was changed");
+            Vec::new()
+        }
+    }
 }
 
 /// Capture previews, then commit generation-checked `Dead` transitions,
@@ -295,7 +314,7 @@ async fn reconcile_healthy_agents(
     if running_targets.is_empty() {
         return;
     }
-    let dead_identities = batch_dead_identities(running_targets).await;
+    let dead_identities = answered_dead_identities(batch_dead_identities(running_targets).await);
     if dead_identities.is_empty() {
         return;
     }

--- a/src/app_shell_liveness.rs
+++ b/src/app_shell_liveness.rs
@@ -74,6 +74,11 @@ pub async fn run_local_liveness(mut app_state: AppStateHandle, ctx: SharedContex
             continue;
         };
 
+        // Agents held at startup were never registered with the runtime, so
+        // they produce no liveness target and would stay held forever. Ask
+        // again before deciding there is nothing to do (issue #541).
+        crate::app_init::reattempt_held_agents(&mut app_state, &ctx);
+
         // Collect local-only check targets for Running and ServerLost agents
         // under the lock, then release it before any subprocess work.
         let (running_targets, lost_targets) = collect_local_targets(&app_state, ctx_arc);

--- a/src/app_shell_liveness.rs
+++ b/src/app_shell_liveness.rs
@@ -19,9 +19,12 @@
 #[cfg(windows)]
 use std::cell::RefCell;
 use std::collections::HashMap;
+#[cfg(windows)]
+use std::collections::HashSet;
 
 use tracing::debug;
 #[cfg(windows)]
+use tracing::info;
 use tracing::warn;
 
 use crate::app_input::{
@@ -30,6 +33,8 @@ use crate::app_input::{
 use crate::app_shell_workers::capture_dead_previews;
 
 use jefe::domain::liveness_observation::Observed;
+#[cfg(windows)]
+use jefe::domain::liveness_observation::Resolution;
 use jefe::domain::{AgentId, AgentStatus};
 use jefe::runtime::LivenessIdentity;
 #[cfg(windows)]
@@ -71,8 +76,8 @@ pub async fn run_local_liveness(mut app_state: AppStateHandle, ctx: SharedContex
 
         // Collect local-only check targets for Running and ServerLost agents
         // under the lock, then release it before any subprocess work.
-        let (running_targets, lost_ids) = collect_local_targets(&app_state, ctx_arc);
-        if running_targets.is_empty() && lost_ids.is_empty() {
+        let (running_targets, lost_targets) = collect_local_targets(&app_state, ctx_arc);
+        if running_targets.is_empty() && lost_targets.is_empty() {
             continue;
         }
 
@@ -82,7 +87,7 @@ pub async fn run_local_liveness(mut app_state: AppStateHandle, ctx: SharedContex
                 &mut app_state,
                 &ctx,
                 &running_targets,
-                &lost_ids,
+                &lost_targets,
                 &mut pinned_prior,
                 &mut applied_exit_empty,
             )
@@ -96,15 +101,20 @@ pub async fn run_local_liveness(mut app_state: AppStateHandle, ctx: SharedContex
     }
 }
 
-/// Collect local liveness targets plus the ids of agents already `ServerLost`.
+/// Collect local liveness targets for `Running` agents and for agents already
+/// `ServerLost`.
 ///
-/// Returns the runtime-supplied targets filtered to local agents whose status
-/// is `Running`, and the ids of local agents currently `ServerLost` (so the
-/// Windows path can recover them when the server returns).
+/// Lost agents are returned as full probe targets rather than bare ids because
+/// recovery has to *ask* whether their sessions came back. Returning only ids
+/// is what left `ServerLost` a one-way trapdoor: there was nothing to probe
+/// with, so the recovery path could never be written (issue #541).
 fn collect_local_targets(
     app_state: &AppStateHandle,
     ctx_arc: &std::sync::Arc<std::sync::Mutex<crate::AppContext>>,
-) -> (Vec<jefe::runtime::LivenessCheck>, Vec<AgentId>) {
+) -> (
+    Vec<jefe::runtime::LivenessCheck>,
+    Vec<jefe::runtime::LivenessCheck>,
+) {
     let Ok(ctx_guard) = ctx_arc.lock() else {
         return (Vec::new(), Vec::new());
     };
@@ -125,11 +135,19 @@ fn collect_local_targets(
     let all_targets = ctx_guard.runtime.liveness_targets();
     drop(ctx_guard);
 
-    let running_targets = all_targets
-        .into_iter()
-        .filter(|target| target.remote.is_none() && running_ids.contains(&target.agent_id))
-        .collect::<Vec<_>>();
-    (running_targets, lost_ids)
+    let mut running_targets = Vec::new();
+    let mut lost_targets = Vec::new();
+    for target in all_targets {
+        if target.remote.is_some() {
+            continue;
+        }
+        if running_ids.contains(&target.agent_id) {
+            running_targets.push(target);
+        } else if lost_ids.contains(&target.agent_id) {
+            lost_targets.push(target);
+        }
+    }
+    (running_targets, lost_targets)
 }
 
 /// Windows liveness cycle: probe the shared psmux server identity first, then
@@ -139,7 +157,7 @@ async fn handle_windows_cycle(
     app_state: &mut AppStateHandle,
     ctx: &SharedContext,
     running_targets: &[jefe::runtime::LivenessCheck],
-    lost_ids: &[AgentId],
+    lost_targets: &[jefe::runtime::LivenessCheck],
     pinned_prior: &mut Option<ServerIdentity>,
     applied_exit_empty: &mut Option<ServerIdentity>,
 ) {
@@ -166,6 +184,7 @@ async fn handle_windows_cycle(
         ServerLivenessObservation::Healthy(current) => {
             *pinned_prior = current.or_else(|| pinned_prior.clone());
             reconcile_healthy_agents(app_state, ctx, running_targets).await;
+            recover_server_lost_agents(app_state, ctx, lost_targets).await;
         }
         ServerLivenessObservation::Gone | ServerLivenessObservation::Replaced(_) => {
             if let ServerLivenessObservation::Replaced(next) = observation {
@@ -180,10 +199,98 @@ async fn handle_windows_cycle(
             transition_to_server_lost(app_state, ctx, &affected);
         }
         ServerLivenessObservation::Unavailable => {
-            // Probe failure fails open: no agent status change this cycle.
+            // The server probe did not answer. No agent status changes this
+            // cycle, in either direction: an unanswered probe is no more
+            // evidence that a lost agent recovered than that a live one died.
         }
     }
-    let _ = lost_ids;
+}
+
+#[cfg(windows)]
+/// Decide which lost agents the probe says have returned.
+///
+/// Pure, so the held case is testable rather than only reachable through a
+/// real subprocess failure. An agent is a recovery candidate when the probe
+/// answered *and* did not name it among the dead: absence from an answered
+/// result is evidence, absence from an unanswered one is nothing at all.
+fn classify_recovery(
+    lost_targets: &[jefe::runtime::LivenessCheck],
+    observed: Observed<Vec<LivenessIdentity>>,
+) -> Resolution<Vec<AgentId>> {
+    observed.resolve(|dead| {
+        let dead_ids: HashSet<&AgentId> = dead.iter().map(|identity| &identity.agent_id).collect();
+        lost_targets
+            .iter()
+            .filter(|target| !dead_ids.contains(&target.agent_id))
+            .map(|target| target.agent_id.clone())
+            .collect()
+    })
+}
+
+/// Restore agents whose sessions are alive again now the server has returned.
+///
+/// `ServerLost` was previously a one-way trapdoor: nothing re-examined those
+/// agents, so a transient server replacement stranded them until the operator
+/// intervened by hand. The live repro on issue #541 hit exactly this -- agents
+/// showing `!` while every process was alive.
+///
+/// Recovery is fail-closed in the same direction as everything else here. Only
+/// a probe that *answered* can recover an agent, and only for agents whose
+/// binding still matches the one that was probed; anything else leaves the
+/// agent lost, because "we could not tell" must not promote a status any more
+/// than it may demote one.
+#[cfg(windows)]
+async fn recover_server_lost_agents(
+    app_state: &mut AppStateHandle,
+    ctx: &SharedContext,
+    lost_targets: &[jefe::runtime::LivenessCheck],
+) {
+    if lost_targets.is_empty() {
+        return;
+    }
+    let observed = batch_dead_identities(lost_targets).await;
+    let recovered = match classify_recovery(lost_targets, observed) {
+        Resolution::Transition(ids) => ids,
+        Resolution::Hold(reason) => {
+            warn!(%reason, "server-lost recovery held: agents left as they were");
+            return;
+        }
+    };
+    if recovered.is_empty() {
+        return;
+    }
+
+    let mut state = app_state.write();
+    let mut changed = 0usize;
+    for target in lost_targets
+        .iter()
+        .filter(|target| recovered.contains(&target.agent_id))
+    {
+        let still_lost_and_bound = state.agents.iter().any(|agent| {
+            agent.id == target.agent_id
+                && agent.status == AgentStatus::ServerLost
+                && agent.runtime_binding.as_ref().is_some_and(|binding| {
+                    Some(binding.session_name.as_str()) == target.binding_session_name.as_deref()
+                        && binding.lifecycle_generation == target.lifecycle_generation
+                })
+        });
+        if !still_lost_and_bound {
+            continue;
+        }
+        commit_pure_site(
+            &mut state,
+            AppEvent::AgentStatusChanged(target.agent_id.clone(), AgentStatus::Running).into(),
+        );
+        changed = changed.saturating_add(1);
+    }
+    if changed > 0 {
+        info!(count = changed, "server returned: agents recovered");
+        let persisted = durable_save_request(&mut state);
+        drop(state);
+        schedule_durable_save(ctx, persisted);
+    } else {
+        drop(state);
+    }
 }
 
 /// Non-Windows liveness cycle: preserve the exact pre-extraction batched
@@ -227,7 +334,7 @@ fn answered_dead_identities(observed: Observed<Vec<LivenessIdentity>>) -> Vec<Li
     match observed {
         Observed::Known(dead) => dead,
         Observed::Unknown(reason) => {
-            tracing::warn!(%reason, "liveness poll held: no agent state was changed");
+            warn!(%reason, "liveness poll held: no agent state was changed");
             Vec::new()
         }
     }
@@ -428,6 +535,8 @@ fn compute_binding_matches(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(windows)]
+    use jefe::domain::liveness_observation::{ProbeBoundary, Uncertainty};
     use jefe::domain::{Agent, RemoteRepositorySettings, RepositoryId};
     use jefe::runtime::LivenessCheck;
     use std::path::PathBuf;
@@ -545,6 +654,74 @@ mod tests {
         assert_eq!(
             compute_binding_matches(&state, &[stale_session, stale_generation]),
             vec![false, false]
+        );
+    }
+
+    #[cfg(windows)]
+    fn dead_identity(id: &str) -> LivenessIdentity {
+        LivenessIdentity {
+            agent_id: AgentId(id.into()),
+            binding_session_name: Some(format!("jefe-{id}")),
+            lifecycle_generation: 0,
+            worker: jefe::runtime::WorkerDisposition::GoneWithPane,
+        }
+    }
+
+    /// The live repro on issue #541: agents sat at `ServerLost` while every
+    /// process was alive, because nothing ever re-examined them.
+    #[cfg(windows)]
+    #[test]
+    fn a_lost_agent_whose_session_returned_is_recovered() {
+        let lost = vec![liveness_target("alpha"), liveness_target("beta")];
+
+        let decision = classify_recovery(&lost, Observed::Known(vec![dead_identity("beta")]));
+
+        let recovered = decision
+            .transition()
+            .unwrap_or_else(|| panic!("an answered probe must produce a decision"));
+        assert_eq!(
+            recovered,
+            &vec![AgentId("alpha".into())],
+            "only the agent absent from the dead list returns"
+        );
+    }
+
+    /// Recovery is fail-closed in the same direction as everything else: an
+    /// unanswered probe is no more evidence that a lost agent came back than
+    /// that a live one died.
+    #[cfg(windows)]
+    #[test]
+    fn an_unanswered_probe_recovers_nobody() {
+        let lost = vec![liveness_target("alpha")];
+
+        let decision = classify_recovery(
+            &lost,
+            Observed::unknown(ProbeBoundary::SessionList, "list-sessions failed"),
+        );
+
+        assert!(
+            decision.transition().is_none(),
+            "an unanswered probe must not promote an agent"
+        );
+        assert_eq!(
+            decision.held().map(Uncertainty::boundary),
+            Some(ProbeBoundary::SessionList)
+        );
+    }
+
+    /// The mirror hazard for recovery: an agent the probe still reports dead
+    /// must stay lost, or "never demote" would become "always promote".
+    #[cfg(windows)]
+    #[test]
+    fn an_agent_still_reported_dead_is_not_recovered() {
+        let lost = vec![liveness_target("alpha")];
+
+        let decision = classify_recovery(&lost, Observed::Known(vec![dead_identity("alpha")]));
+
+        assert_eq!(
+            decision.transition(),
+            Some(&Vec::new()),
+            "a still-dead agent is not a recovery candidate"
         );
     }
 }

--- a/src/app_shell_liveness.rs
+++ b/src/app_shell_liveness.rs
@@ -459,9 +459,11 @@ fn eligible_for_server_lost(
             agent_id: target.agent_id.clone(),
             binding_session_name: target.binding_session_name.clone(),
             lifecycle_generation: target.lifecycle_generation,
-            // A lost multiplexer server says nothing about the workers below
-            // it, so their fate is explicitly unknown here (issue #543).
-            worker: jefe::runtime::WorkerDisposition::Unknown,
+            // A lost server says nothing about the workers below it, so each
+            // agent's own anchors are asked rather than inheriting the
+            // server's fate. Where an agent recorded no anchors the answer is
+            // `Unknown`, never "died with the server" (issues #541, #543).
+            worker: jefe::runtime::observe_worker_disposition(&target.worker_identities),
         })
         .collect()
 }
@@ -483,6 +485,16 @@ fn transition_to_server_lost(
             .iter()
             .any(|agent| agent.id == identity.agent_id && agent.status == AgentStatus::Running);
         if !matches || !still_running {
+            continue;
+        }
+        // This agent's own worker answered, and it is alive. A server event is
+        // not evidence about a process that outlived it, and marking such an
+        // agent lost is what let launching agent N+1 strand agents 1..N.
+        if identity.worker == jefe::runtime::WorkerDisposition::SurvivedPane {
+            warn!(
+                agent_id = %identity.agent_id.0,
+                "server changed but this agent's worker is alive: leaving it running"
+            );
             continue;
         }
         commit_pure_site(
@@ -722,6 +734,46 @@ mod tests {
             decision.transition(),
             Some(&Vec::new()),
             "a still-dead agent is not a recovery candidate"
+        );
+    }
+
+    /// V6: a server-level event is judged per agent. An agent whose own worker
+    /// is demonstrably alive did not die because the server changed, which is
+    /// precisely what let launching agent N+1 strand agents 1..N.
+    #[test]
+    fn an_agent_whose_worker_is_alive_is_not_eligible_for_server_lost() {
+        let mut state = AppState::default();
+        state.agents.push(fixture_running_agent("alpha"));
+        let mut target = liveness_target("alpha");
+        // This test process is, by construction, alive, and capturing its
+        // identity gives the start token that proves the PID was not recycled.
+        let me = jefe::runtime::capture_process_identity(std::process::id())
+            .unwrap_or_else(|error| panic!("this process must be observable: {error}"));
+        target.worker_identities = vec![jefe::domain::WorkerProcessIdentity::from_identity(me)];
+
+        let affected = eligible_for_server_lost(&state, &[target]);
+
+        assert_eq!(affected.len(), 1, "the agent is still examined");
+        assert_eq!(
+            affected[0].worker,
+            jefe::runtime::WorkerDisposition::SurvivedPane,
+            "a live worker must be observed as having survived the server"
+        );
+    }
+
+    /// An agent that recorded no anchors cannot answer the question, and the
+    /// answer must be `Unknown` rather than "died with the server".
+    #[test]
+    fn an_agent_without_anchors_reports_an_unknown_worker() {
+        let mut state = AppState::default();
+        state.agents.push(fixture_running_agent("alpha"));
+
+        let affected = eligible_for_server_lost(&state, &[liveness_target("alpha")]);
+
+        assert_eq!(
+            affected[0].worker,
+            jefe::runtime::WorkerDisposition::Unknown,
+            "no anchors means unknown, never dead"
         );
     }
 }

--- a/src/domain/liveness_observation.rs
+++ b/src/domain/liveness_observation.rs
@@ -82,6 +82,12 @@ pub enum ProbeBoundary {
     ServerIdentity,
     /// Reading the durable state document.
     DurableRead,
+    /// Composing the launch signature an agent would be started with.
+    ///
+    /// Not a probe of the world but of our own configuration, and it belongs
+    /// here for the same reason: failing to derive it says nothing about
+    /// whether the process is running.
+    LaunchSignature,
     /// Querying an OS process identity.
     ProcessIdentity,
 }
@@ -95,6 +101,7 @@ impl fmt::Display for ProbeBoundary {
             Self::ServerIdentity => "display-message",
             Self::DurableRead => "durable state read",
             Self::ProcessIdentity => "process identity query",
+            Self::LaunchSignature => "launch signature composition",
         };
         f.write_str(name)
     }

--- a/src/domain/liveness_observation.rs
+++ b/src/domain/liveness_observation.rs
@@ -219,9 +219,92 @@ impl<S> Resolution<S> {
     }
 }
 
+/// How many times a fallible probe may be asked, and how long to wait between.
+///
+/// Bounded by construction. A retry loop that can run forever converts a
+/// permanent failure into a hang, which is a worse outcome than the wrong
+/// answer it was added to prevent, so `attempts` is a hard ceiling and the
+/// caller is handed the last uncertainty rather than being made to wait.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetryPolicy {
+    attempts: u32,
+    initial_backoff: std::time::Duration,
+}
+
+impl RetryPolicy {
+    /// Build a policy, clamping `attempts` to at least one.
+    ///
+    /// Zero attempts would mean never asking, which is not a retry policy but
+    /// a way to guarantee an unknown answer.
+    #[must_use]
+    pub fn new(attempts: u32, initial_backoff: std::time::Duration) -> Self {
+        Self {
+            attempts: attempts.max(1),
+            initial_backoff,
+        }
+    }
+
+    #[must_use]
+    pub const fn attempts(&self) -> u32 {
+        self.attempts
+    }
+
+    #[must_use]
+    pub const fn initial_backoff(&self) -> std::time::Duration {
+        self.initial_backoff
+    }
+}
+
+impl Default for RetryPolicy {
+    /// Three attempts with a 50ms doubling backoff: enough to ride out a
+    /// transient subprocess failure at cold start without making startup feel
+    /// stalled when the multiplexer really is gone.
+    fn default() -> Self {
+        Self::new(3, std::time::Duration::from_millis(50))
+    }
+}
+
+/// Ask a fallible probe until it answers, or until the policy is exhausted.
+///
+/// Returns the *last* uncertainty rather than the first: if the reason for
+/// failing changed between attempts, the most recent one describes the state
+/// the caller is actually in.
+///
+/// `sleep` is injected so the backoff schedule is observable in a test without
+/// spending the wall-clock time it describes.
+pub fn retry_observation<T>(
+    policy: RetryPolicy,
+    mut probe: impl FnMut() -> Observed<T>,
+    mut sleep: impl FnMut(std::time::Duration),
+) -> Observed<T> {
+    let mut backoff = policy.initial_backoff();
+    let mut last = None;
+    for attempt in 0..policy.attempts() {
+        match probe() {
+            Observed::Known(value) => return Observed::Known(value),
+            Observed::Unknown(uncertainty) => last = Some(uncertainty),
+        }
+        // No trailing sleep: waiting after the final attempt delays the caller
+        // without buying another observation.
+        if attempt + 1 < policy.attempts() {
+            sleep(backoff);
+            backoff = backoff.saturating_mul(2);
+        }
+    }
+    last.map_or_else(
+        || {
+            Observed::unknown(
+                ProbeBoundary::SessionExists,
+                "probe was never asked".to_owned(),
+            )
+        },
+        Observed::Unknown,
+    )
+}
 #[cfg(test)]
 mod tests {
-    use super::{Observed, ProbeBoundary, Resolution, Uncertainty};
+    use super::{Observed, ProbeBoundary, Resolution, RetryPolicy, Uncertainty, retry_observation};
+    use std::time::Duration;
 
     /// The whole point of the type: the decision closure never runs for an
     /// observation that did not answer, so no call site can transition on one.
@@ -315,5 +398,91 @@ mod tests {
                 "{boundary:?} must name itself for fault-injection diagnostics"
             );
         }
+    }
+
+    /// A transient failure is exactly what #537 hit: one subprocess failure at
+    /// cold start stranded a live agent. Retrying must let the answer arrive.
+    #[test]
+    fn a_probe_that_answers_on_a_later_attempt_is_not_held() {
+        let mut calls = 0_u32;
+        let mut slept = Vec::new();
+
+        let observed = retry_observation(
+            RetryPolicy::new(3, Duration::from_millis(10)),
+            || {
+                calls += 1;
+                if calls < 3 {
+                    Observed::unknown(ProbeBoundary::SessionExists, "transient")
+                } else {
+                    Observed::Known(7)
+                }
+            },
+            |delay| slept.push(delay),
+        );
+
+        assert_eq!(observed.known(), Some(&7));
+        assert_eq!(calls, 3, "it must stop asking once answered");
+        assert_eq!(
+            slept,
+            vec![Duration::from_millis(10), Duration::from_millis(20)],
+            "backoff doubles, and there is no wait after the answering attempt"
+        );
+    }
+
+    /// The V4 mirror hazard for retries: bounded means bounded. A retry loop
+    /// that never gives up turns a permanent failure into a hang.
+    #[test]
+    fn a_probe_that_never_answers_stops_asking() {
+        let mut calls = 0_u32;
+        let mut slept = 0_usize;
+
+        let observed: Observed<u32> = retry_observation(
+            RetryPolicy::new(4, Duration::from_millis(5)),
+            || {
+                calls += 1;
+                Observed::unknown(ProbeBoundary::PaneList, format!("attempt {calls}"))
+            },
+            |_| slept += 1,
+        );
+
+        assert_eq!(calls, 4, "exactly the permitted number of attempts");
+        assert_eq!(slept, 3, "no wait after the final attempt");
+        assert_eq!(
+            observed.uncertainty().map(Uncertainty::diagnostic),
+            Some("attempt 4"),
+            "the most recent reason describes the state the caller is in"
+        );
+    }
+
+    /// An answer on the first attempt must cost nothing.
+    #[test]
+    fn an_immediate_answer_never_sleeps() {
+        let mut slept = 0_usize;
+
+        let observed = retry_observation(
+            RetryPolicy::default(),
+            || Observed::Known("ready"),
+            |_| slept += 1,
+        );
+
+        assert!(observed.is_known());
+        assert_eq!(slept, 0);
+    }
+
+    /// Zero attempts is not a policy, it is a guaranteed unknown.
+    #[test]
+    fn a_policy_always_asks_at_least_once() {
+        let mut calls = 0_u32;
+
+        let _observed: Observed<u32> = retry_observation(
+            RetryPolicy::new(0, Duration::from_millis(1)),
+            || {
+                calls += 1;
+                Observed::unknown(ProbeBoundary::DurableRead, "no")
+            },
+            |_| {},
+        );
+
+        assert_eq!(calls, 1, "the probe is always asked at least once");
     }
 }

--- a/src/domain/liveness_observation.rs
+++ b/src/domain/liveness_observation.rs
@@ -1,0 +1,319 @@
+//! Fail-closed observation values for Jefe-owned liveness (issue #541).
+//!
+//! Every historical violation of the fail-closed invariant took the same shape:
+//! a probe boundary that could fail, and a call site that resolved the failure
+//! into whichever state was convenient there. `#305` fixed it for process
+//! identity, `#527` marked twenty live panes stopped on a signature change,
+//! `#445` failed open to an empty durable state, and `#537` stranded a live
+//! agent on a single transient subprocess failure at cold start.
+//!
+//! The cause is not those four call sites. It is that nothing in the type
+//! system distinguished "the probe says no" from "the probe did not answer",
+//! so the distinction had to be remembered rather than enforced.
+//!
+//! [`Observed`] restores the distinction. It deliberately has **no**
+//! `unwrap_or`, **no** `Default`, and **no** `From<Option<T>>`: each of those
+//! is a way to supply a value where none was observed, which is the defect.
+//! The only route from an observation to a state transition is
+//! [`Observed::resolve`], whose decision closure never receives the uncertain
+//! case.
+//!
+//! This mirrors the closed availability algebra the JSP/1 snapshot contract
+//! already uses (`domain::observation::Availability`), but stays a separate
+//! type on purpose: that module owns *producer-declared* field state, and its
+//! documentation reserves process liveness to the Jefe runtime.
+
+use std::fmt;
+
+/// Why a probe could not answer.
+///
+/// Carried rather than discarded so the user gets an actionable state instead
+/// of a silent hold. Deliverable 7 of issue #541 requires that an agent whose
+/// status is unknown says so visibly, and says why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Uncertainty {
+    boundary: ProbeBoundary,
+    diagnostic: String,
+}
+
+impl Uncertainty {
+    /// Record that `boundary` could not answer, with an operator-facing reason.
+    #[must_use]
+    pub fn new(boundary: ProbeBoundary, diagnostic: impl Into<String>) -> Self {
+        Self {
+            boundary,
+            diagnostic: diagnostic.into(),
+        }
+    }
+
+    /// Which probe boundary failed to answer.
+    #[must_use]
+    pub const fn boundary(&self) -> ProbeBoundary {
+        self.boundary
+    }
+
+    /// The operator-facing reason this observation is uncertain.
+    #[must_use]
+    pub fn diagnostic(&self) -> &str {
+        &self.diagnostic
+    }
+}
+
+impl fmt::Display for Uncertainty {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} did not answer: {}", self.boundary, self.diagnostic)
+    }
+}
+
+/// The probe boundaries that can fail transiently.
+///
+/// Enumerated so a fault-injection harness can name the boundary it is driving
+/// to failure, and so the verification matrix for V1 can assert coverage of
+/// each one rather than of an unspecified "probe".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProbeBoundary {
+    /// `has-session`.
+    SessionExists,
+    /// `list-sessions`.
+    SessionList,
+    /// `list-panes`.
+    PaneList,
+    /// `display-message`.
+    ServerIdentity,
+    /// Reading the durable state document.
+    DurableRead,
+    /// Querying an OS process identity.
+    ProcessIdentity,
+}
+
+impl fmt::Display for ProbeBoundary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::SessionExists => "has-session",
+            Self::SessionList => "list-sessions",
+            Self::PaneList => "list-panes",
+            Self::ServerIdentity => "display-message",
+            Self::DurableRead => "durable state read",
+            Self::ProcessIdentity => "process identity query",
+        };
+        f.write_str(name)
+    }
+}
+
+/// What a fallible probe learned.
+///
+/// There is deliberately no method that produces a `T` from the uncertain case.
+/// Reaching a value requires matching, and reaching a *transition* requires
+/// [`resolve`](Observed::resolve).
+///
+/// A default would reintroduce exactly the defect this type exists to prevent,
+/// so `Observed` does not implement [`Default`]:
+///
+/// ```compile_fail,E0277
+/// use jefe::domain::liveness_observation::Observed;
+/// let fallback: Observed<bool> = Default::default();
+/// ```
+///
+/// Nor can an uncertain observation be unwrapped into a value the way an
+/// `Option` can:
+///
+/// ```compile_fail,E0599
+/// use jefe::domain::liveness_observation::Observed;
+/// let observed: Observed<bool> = Observed::Known(true);
+/// let value = observed.unwrap_or(false);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Observed<T> {
+    /// The probe answered, and the answer is authoritative.
+    Known(T),
+    /// The probe did not answer. This is terminal: it produces no transition.
+    Unknown(Uncertainty),
+}
+
+impl<T> Observed<T> {
+    /// Record that `boundary` failed to answer.
+    #[must_use]
+    pub fn unknown(boundary: ProbeBoundary, diagnostic: impl Into<String>) -> Self {
+        Self::Unknown(Uncertainty::new(boundary, diagnostic))
+    }
+
+    /// The observed value, if the probe answered.
+    ///
+    /// Returns `None` for the uncertain case rather than a substitute, so a
+    /// caller that wants a value has to say what it intends to do without one.
+    #[must_use]
+    pub const fn known(&self) -> Option<&T> {
+        match self {
+            Self::Known(value) => Some(value),
+            Self::Unknown(_) => None,
+        }
+    }
+
+    /// Why this observation is uncertain, if it is.
+    #[must_use]
+    pub const fn uncertainty(&self) -> Option<&Uncertainty> {
+        match self {
+            Self::Known(_) => None,
+            Self::Unknown(reason) => Some(reason),
+        }
+    }
+
+    /// Whether the probe answered.
+    #[must_use]
+    pub const fn is_known(&self) -> bool {
+        matches!(self, Self::Known(_))
+    }
+
+    /// Resolve this observation into a state transition.
+    ///
+    /// `decide` is only invoked for an answered probe, so an unknown
+    /// observation cannot reach a transition by any path through this type.
+    /// That is the type-level form of the invariant: *an unknown observation
+    /// must never cause a state transition.*
+    pub fn resolve<S>(self, decide: impl FnOnce(T) -> S) -> Resolution<S> {
+        match self {
+            Self::Known(value) => Resolution::Transition(decide(value)),
+            Self::Unknown(reason) => Resolution::Hold(reason),
+        }
+    }
+
+    /// Transform an answered observation, preserving the uncertain case.
+    pub fn map<U>(self, transform: impl FnOnce(T) -> U) -> Observed<U> {
+        match self {
+            Self::Known(value) => Observed::Known(transform(value)),
+            Self::Unknown(reason) => Observed::Unknown(reason),
+        }
+    }
+}
+
+/// The outcome of resolving an observation.
+///
+/// `Hold` carries the reason rather than being a bare "do nothing", so a caller
+/// can surface why the agent's state was left alone and offer a re-probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution<S> {
+    /// The observation was conclusive; apply this transition.
+    Transition(S),
+    /// The observation was inconclusive. Preserve the current state and every
+    /// binding, and tell the user why.
+    Hold(Uncertainty),
+}
+
+impl<S> Resolution<S> {
+    /// The transition to apply, if there is one.
+    #[must_use]
+    pub const fn transition(&self) -> Option<&S> {
+        match self {
+            Self::Transition(state) => Some(state),
+            Self::Hold(_) => None,
+        }
+    }
+
+    /// Why no transition was produced, if none was.
+    #[must_use]
+    pub const fn held(&self) -> Option<&Uncertainty> {
+        match self {
+            Self::Transition(_) => None,
+            Self::Hold(reason) => Some(reason),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Observed, ProbeBoundary, Resolution, Uncertainty};
+
+    /// The whole point of the type: the decision closure never runs for an
+    /// observation that did not answer, so no call site can transition on one.
+    #[test]
+    fn an_unknown_observation_never_reaches_the_decision() {
+        let observed: Observed<bool> =
+            Observed::unknown(ProbeBoundary::SessionList, "psmux exited with status 1");
+
+        let resolution = observed.resolve(|_| panic!("a transition was decided without evidence"));
+
+        assert!(
+            matches!(resolution, Resolution::Hold(_)),
+            "an unanswered probe must hold, not transition"
+        );
+    }
+
+    #[test]
+    fn an_answered_observation_reaches_the_decision() {
+        let observed = Observed::Known(true);
+
+        let resolution = observed.resolve(|alive| if alive { "running" } else { "stopped" });
+
+        assert_eq!(resolution.transition(), Some(&"running"));
+        assert_eq!(resolution.held(), None);
+    }
+
+    /// Deliverable 7: the user must be able to see *why* jefe does not know.
+    #[test]
+    fn holding_carries_an_operator_facing_reason() {
+        let observed: Observed<bool> = Observed::unknown(
+            ProbeBoundary::PaneList,
+            "timed out after 2s waiting for list-panes",
+        );
+
+        let resolution = observed.resolve(|_| "unreachable");
+
+        let held = resolution
+            .held()
+            .unwrap_or_else(|| panic!("an unanswered probe must explain itself"));
+        assert_eq!(held.boundary(), ProbeBoundary::PaneList);
+        assert!(
+            held.to_string().contains("list-panes"),
+            "the reason must name the boundary that failed: {held}"
+        );
+        assert!(
+            held.to_string().contains("timed out"),
+            "the reason must carry the diagnostic: {held}"
+        );
+    }
+
+    /// `known()` must not invent a value for the uncertain case. This is the
+    /// property that `unwrap_or_default()` violated at every historical site.
+    #[test]
+    fn an_unknown_observation_yields_no_value() {
+        let observed: Observed<u32> =
+            Observed::unknown(ProbeBoundary::ProcessIdentity, "access denied");
+
+        assert_eq!(observed.known(), None);
+        assert!(!observed.is_known());
+    }
+
+    /// Mapping must not quietly resolve uncertainty either.
+    #[test]
+    fn mapping_preserves_the_uncertain_case() {
+        let observed: Observed<u32> =
+            Observed::unknown(ProbeBoundary::DurableRead, "state.json was mid-write");
+
+        let mapped = observed.map(|pid| pid > 0);
+
+        assert_eq!(
+            mapped.uncertainty().map(Uncertainty::boundary),
+            Some(ProbeBoundary::DurableRead),
+            "mapping an unanswered probe must stay unanswered"
+        );
+    }
+
+    /// Every boundary the fault-injection harness must be able to drive (V1)
+    /// names itself, so a test failure says which probe was being exercised.
+    #[test]
+    fn every_probe_boundary_names_itself() {
+        for boundary in [
+            ProbeBoundary::SessionExists,
+            ProbeBoundary::SessionList,
+            ProbeBoundary::PaneList,
+            ProbeBoundary::ServerIdentity,
+            ProbeBoundary::DurableRead,
+            ProbeBoundary::ProcessIdentity,
+        ] {
+            assert!(
+                !boundary.to_string().is_empty(),
+                "{boundary:?} must name itself for fault-injection diagnostics"
+            );
+        }
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -813,6 +813,19 @@ impl AgentLaunchRequest {
 }
 
 impl Agent {
+    /// Whether this agent's state is believed rather than observed.
+    ///
+    /// A `Running` agent with no runtime binding is one a probe could not
+    /// resolve: it keeps the status it was persisted with because nothing
+    /// disproved it, but jefe has not confirmed it and is not registered to
+    /// watch it. Callers that show or re-probe such agents must agree on what
+    /// counts as unconfirmed, so the rule lives here once rather than being
+    /// restated at each site (issue #541).
+    #[must_use]
+    pub const fn state_is_unconfirmed(&self) -> bool {
+        matches!(self.status, AgentStatus::Running) && self.runtime_binding.is_none()
+    }
+
     /// Create a new agent with default values.
     ///
     /// This domain constructor defaults to [`AgentStatus::Queued`] and is

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,6 +1,7 @@
 //! Domain model layer - canonical entity types and invariants.
 
 /// Transport-neutral observation semantic values (issue #476 J1 slice).
+pub mod liveness_observation;
 pub mod observation;
 
 /// Pure document wrapping and content-line scroll geometry.

--- a/src/jsp_host/launch.rs
+++ b/src/jsp_host/launch.rs
@@ -604,15 +604,22 @@ fn set_windows_owner_acl(path: &Path, directory: bool) -> Result<(), JspHostErro
     })?;
     let inheritance = if directory { "(OI)(CI)F" } else { "F" };
     let grant = format!("{account}:{inheritance}");
-    let status = std::process::Command::new("icacls.exe")
+    // `output` rather than `status`: `status` inherits this process's stdio, so
+    // icacls prints "Successfully processed 1 files" straight onto the terminal.
+    // This runs during startup of a full-screen TUI, so that text lands on top
+    // of the dashboard and the user sees tool output instead of their agents.
+    let output = std::process::Command::new("icacls.exe")
         .arg(path)
         .args(["/inheritance:r", "/grant:r"])
         .arg(grant)
-        .status()?;
-    if !status.success() {
-        return Err(JspHostError::Io(std::io::Error::other(
-            "owner-only Windows ACL application failed",
-        )));
+        .stdin(std::process::Stdio::null())
+        .output()?;
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr);
+        return Err(JspHostError::Io(std::io::Error::other(format!(
+            "owner-only Windows ACL application failed: {}",
+            detail.trim()
+        ))));
     }
     Ok(())
 }

--- a/src/runtime/liveness.rs
+++ b/src/runtime/liveness.rs
@@ -9,6 +9,7 @@ use std::hash::BuildHasher;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 
+use crate::domain::liveness_observation::{Observed, ProbeBoundary};
 use crate::domain::{AgentId, RemoteRepositorySettings};
 use crate::runtime::commands::{
     remote_tmux_command, run_remote_ssh, shell_escape_single, tmux_command,
@@ -78,7 +79,7 @@ pub fn session_liveness(session_name: &str) -> SessionLiveness {
     parse_dead_pane_flags(&String::from_utf8_lossy(&output.stdout))
 }
 
-fn parse_dead_pane_flags(output: &str) -> SessionLiveness {
+pub(super) fn parse_dead_pane_flags(output: &str) -> SessionLiveness {
     let mut saw_dead = false;
     for flag in output
         .lines()
@@ -356,15 +357,13 @@ pub fn alive_session_set() -> Option<HashSet<String>> {
 /// Remote targets are excluded automatically. This is the single-call API
 /// for callers that want dead agent IDs without managing the intermediate sets.
 ///
-/// Returns an empty vector (no dead agents) when the tmux server is
-/// unavailable — infrastructure failure must not cause all agents to be
-/// falsely marked dead (issue #287 review).
+/// Yields [`Observed::Unknown`] when the multiplexer could not answer, so a
+/// caller can tell "no agents are dead" apart from "we could not find out".
+/// Collapsing those two is the fail-open defect issue #541 exists to remove.
 #[must_use]
-pub fn batch_liveness_check(targets: &[LivenessCheck]) -> Vec<AgentId> {
+pub fn batch_liveness_check(targets: &[LivenessCheck]) -> Observed<Vec<AgentId>> {
     batch_liveness_check_with_identity(targets)
-        .into_iter()
-        .map(|id| id.agent_id)
-        .collect()
+        .map(|ids| ids.into_iter().map(|id| id.agent_id).collect())
 }
 
 /// Batch liveness check returning identity triples (issue #301 Phase 4).
@@ -373,16 +372,62 @@ pub fn batch_liveness_check(targets: &[LivenessCheck]) -> Vec<AgentId> {
 /// caller can verify the agent's current binding session name and lifecycle
 /// generation still match before applying the dead status.
 #[must_use]
-pub fn batch_liveness_check_with_identity(targets: &[LivenessCheck]) -> Vec<LivenessIdentity> {
-    let Some(existing) = list_all_sessions() else {
-        tracing::warn!("tmux list-sessions failed; skipping liveness cycle");
-        return Vec::new();
+pub fn batch_liveness_check_with_identity(
+    targets: &[LivenessCheck],
+) -> Observed<Vec<LivenessIdentity>> {
+    let existing = list_all_sessions().map_or_else(
+        || {
+            Observed::unknown(
+                ProbeBoundary::SessionList,
+                "the multiplexer did not answer list-sessions",
+            )
+        },
+        Observed::Known,
+    );
+    let alive_panes = list_alive_pane_sessions().map_or_else(
+        || {
+            Observed::unknown(
+                ProbeBoundary::PaneList,
+                "the multiplexer did not answer list-panes",
+            )
+        },
+        Observed::Known,
+    );
+    reconcile_observed(targets, existing, alive_panes)
+}
+
+/// Reconcile targets against probe results that may not have answered.
+///
+/// Pure, so each boundary can be driven to failure in a test without touching
+/// the environment. If either probe is unknown the whole reconciliation is
+/// unknown: a session set missing because `list-sessions` failed is
+/// indistinguishable from one missing because the sessions ended, and guessing
+/// between those is exactly how #527 marked twenty live panes stopped.
+#[must_use]
+pub fn reconcile_observed(
+    targets: &[LivenessCheck],
+    existing: Observed<HashSet<String>>,
+    alive_panes: Observed<HashSet<String>>,
+) -> Observed<Vec<LivenessIdentity>> {
+    let existing = match existing {
+        Observed::Known(sessions) => sessions,
+        Observed::Unknown(reason) => {
+            tracing::warn!(%reason, "liveness held: the session list is unknown");
+            return Observed::Unknown(reason);
+        }
     };
-    let Some(alive_panes) = list_alive_pane_sessions() else {
-        tracing::warn!("tmux list-panes failed; skipping liveness cycle");
-        return Vec::new();
+    let alive_panes = match alive_panes {
+        Observed::Known(panes) => panes,
+        Observed::Unknown(reason) => {
+            tracing::warn!(%reason, "liveness held: the pane list is unknown");
+            return Observed::Unknown(reason);
+        }
     };
-    reconcile_dead_agents_with_identity(targets, &existing, &alive_panes)
+    Observed::Known(reconcile_dead_agents_with_identity(
+        targets,
+        &existing,
+        &alive_panes,
+    ))
 }
 
 /// Query the tmux server for all session names (one subprocess).
@@ -483,7 +528,7 @@ pub fn run_tmux_with_timeout(
 /// it on timeout. Separated from [`run_tmux_with_timeout`] so the timeout
 /// behavior can be unit-tested with a plain `sleep` subprocess instead of a
 /// real tmux invocation (issue #287 review: kill path must be verified).
-fn run_child_with_timeout(
+pub(super) fn run_child_with_timeout(
     mut child: std::process::Child,
     deadline: Instant,
 ) -> Result<std::process::Output, ()> {
@@ -549,414 +594,5 @@ pub fn kill_session(session_name: &str) -> bool {
     match output {
         Ok(out) => out.status.success(),
         Err(_) => false,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::domain::{AgentId, RemoteRepositorySettings};
-    use crate::runtime::manager::LivenessCheck;
-
-    fn make_liveness_check(agent_id: &str, session_name: &str, remote: bool) -> LivenessCheck {
-        LivenessCheck {
-            agent_id: AgentId(agent_id.to_string()),
-            session_name: session_name.to_string(),
-            remote: if remote {
-                Some(RemoteRepositorySettings::default())
-            } else {
-                None
-            },
-            binding_session_name: Some(session_name.to_string()),
-            lifecycle_generation: 0,
-            worker_identities: Vec::new(),
-        }
-    }
-
-    // --- parse_alive_sessions (pure) ---
-
-    #[test]
-    fn parse_alive_sessions_basic() {
-        let raw = "jefe-agent1
-jefe-agent2
-jefe-agent3
-";
-        let set = parse_alive_sessions(raw);
-        assert_eq!(set.len(), 3);
-        assert!(set.contains("jefe-agent1"));
-        assert!(set.contains("jefe-agent2"));
-        assert!(set.contains("jefe-agent3"));
-    }
-
-    #[test]
-    fn parse_alive_sessions_trims_whitespace() {
-        let raw = "  jefe-a  \n jefe-b \n\n";
-        let set = parse_alive_sessions(raw);
-        assert_eq!(set.len(), 2);
-        assert!(set.contains("jefe-a"));
-        assert!(set.contains("jefe-b"));
-    }
-
-    #[test]
-    fn parse_alive_sessions_empty_output() {
-        let set = parse_alive_sessions("");
-        assert!(set.is_empty());
-    }
-
-    #[test]
-    fn parse_alive_sessions_skips_empty_lines() {
-        let raw = "jefe-a
-
-
-jefe-b
-";
-        let set = parse_alive_sessions(raw);
-        assert_eq!(set.len(), 2);
-    }
-
-    #[test]
-    fn dead_pane_parser_preserves_tri_state() {
-        assert_eq!(parse_dead_pane_flags("0\n1\n"), SessionLiveness::Alive);
-        assert_eq!(parse_dead_pane_flags("1\ntrue\n"), SessionLiveness::Missing);
-        assert_eq!(parse_dead_pane_flags(""), SessionLiveness::Unavailable);
-        assert_eq!(
-            parse_dead_pane_flags("unexpected\n"),
-            SessionLiveness::Unavailable
-        );
-    }
-
-    // --- parse_pane_alive (pure) ---
-
-    #[test]
-    fn parse_pane_alive_identifies_live_agent_windows_only() {
-        let raw = "jefe-a:0:0
-jefe-b:0:1
-jefe-c:0:0
-jefe-b:1:0
-";
-        let set = parse_pane_alive(raw);
-        assert_eq!(set.len(), 2);
-        assert!(set.contains("jefe-a"));
-        assert!(set.contains("jefe-c"));
-        assert!(
-            !set.contains("jefe-b"),
-            "shell window must not mask dead agent"
-        );
-    }
-
-    #[test]
-    fn parse_pane_alive_only_numeric_flags() {
-        let raw = "jefe-a:0:0
-jefe-b:0:1
-jefe-c:0:false
-";
-        let set = parse_pane_alive(raw);
-        assert!(set.contains("jefe-a"));
-        assert!(!set.contains("jefe-b"));
-        assert!(!set.contains("jefe-c"), "non-numeric flags must not match");
-    }
-
-    #[test]
-    fn parse_pane_alive_empty_output() {
-        let set = parse_pane_alive("");
-        assert!(set.is_empty());
-    }
-
-    #[test]
-    fn parse_pane_alive_skips_malformed_lines() {
-        let raw = "jefe-a:0:0
-malformed
-jefe-b:0:0
-";
-        let set = parse_pane_alive(raw);
-        assert_eq!(set.len(), 2);
-        assert!(set.contains("jefe-a"));
-        assert!(set.contains("jefe-b"));
-    }
-
-    // --- reconcile_dead_agents (pure) ---
-
-    #[test]
-    fn reconcile_dead_agents_finds_missing_sessions() {
-        let targets = vec![
-            make_liveness_check("agent1", "jefe-agent1", false),
-            make_liveness_check("agent2", "jefe-agent2", false),
-        ];
-        let existing: HashSet<String> = std::iter::once("jefe-agent1".to_string()).collect();
-        let alive_panes: HashSet<String> = std::iter::once("jefe-agent1".to_string()).collect();
-
-        let dead = reconcile_dead_agents(&targets, &existing, &alive_panes);
-        assert_eq!(dead.len(), 1);
-        assert_eq!(dead[0].0, "agent2");
-    }
-
-    #[test]
-    fn reconcile_dead_agents_finds_dead_panes() {
-        let targets = vec![
-            make_liveness_check("agent1", "jefe-agent1", false),
-            make_liveness_check("agent2", "jefe-agent2", false),
-        ];
-        let existing: HashSet<String> = ["jefe-agent1".to_string(), "jefe-agent2".to_string()]
-            .into_iter()
-            .collect();
-        // agent1 has alive panes, agent2 has only dead panes
-        let alive_panes: HashSet<String> = std::iter::once("jefe-agent1".to_string()).collect();
-
-        let dead = reconcile_dead_agents(&targets, &existing, &alive_panes);
-        assert_eq!(dead.len(), 1);
-        assert_eq!(dead[0].0, "agent2");
-    }
-
-    #[test]
-    fn reconcile_dead_agents_all_alive() {
-        let targets = vec![
-            make_liveness_check("agent1", "jefe-agent1", false),
-            make_liveness_check("agent2", "jefe-agent2", false),
-        ];
-        let existing: HashSet<String> = ["jefe-agent1".to_string(), "jefe-agent2".to_string()]
-            .into_iter()
-            .collect();
-        let alive_panes: HashSet<String> = ["jefe-agent1".to_string(), "jefe-agent2".to_string()]
-            .into_iter()
-            .collect();
-
-        let dead = reconcile_dead_agents(&targets, &existing, &alive_panes);
-        assert!(dead.is_empty());
-    }
-
-    #[test]
-    fn reconcile_dead_agents_excludes_remote_targets() {
-        let targets = vec![
-            make_liveness_check("local-agent", "jefe-local", false),
-            make_liveness_check("remote-agent", "jefe-remote", true),
-        ];
-        // No sessions exist
-        let existing: HashSet<String> = HashSet::new();
-        let alive_panes: HashSet<String> = HashSet::new();
-
-        let dead = reconcile_dead_agents(&targets, &existing, &alive_panes);
-        // Only local-agent is dead; remote-agent is excluded
-        assert_eq!(dead.len(), 1);
-        assert_eq!(dead[0].0, "local-agent");
-    }
-
-    #[test]
-    fn reconcile_dead_agents_empty_targets() {
-        let dead = reconcile_dead_agents(&[], &HashSet::new(), &HashSet::new());
-        assert!(dead.is_empty());
-    }
-
-    // --- alive_session_set (integration, needs tmux) ---
-
-    #[test]
-    fn alive_session_set_does_not_panic_without_tmux_server() {
-        // On a system without tmux or with no sessions, this returns None.
-        // This test validates graceful failure, not the presence of tmux.
-        let set = alive_session_set();
-        // We don't assert the value because a tmux server might have sessions
-        // from other processes. We just verify it doesn't panic.
-        let _ = set;
-    }
-
-    #[test]
-    fn reconcile_dead_agents_marks_all_dead_when_no_sessions_exist() {
-        // When no tmux sessions exist, all local targets are dead.
-        // This tests the pure reconcile function with deterministic inputs
-        // (no tmux dependency).
-        let targets = vec![
-            make_liveness_check("agent1", "jefe-agent1", false),
-            make_liveness_check("agent2", "jefe-agent2", false),
-        ];
-
-        let existing: HashSet<String> = HashSet::new();
-        let alive_panes: HashSet<String> = HashSet::new();
-        let dead = reconcile_dead_agents(&targets, &existing, &alive_panes);
-        assert_eq!(dead.len(), 2, "empty tmux state means all targets are dead");
-    }
-
-    #[test]
-    fn batch_liveness_check_does_not_panic() {
-        // Smoke test: batch_liveness_check must not panic regardless of
-        // whether a tmux server is available. The fail-open contract (returns
-        // empty Vec when tmux is unavailable) is verified by the pure
-        // reconcile_dead_agents test above.
-        let targets = vec![
-            make_liveness_check("agent1", "jefe-agent1", false),
-            make_liveness_check("agent2", "jefe-agent2", false),
-        ];
-        let _ = batch_liveness_check(&targets);
-    }
-
-    // --- reconcile_dead_agents_with_identity (issue #301 Phase 4) ---
-
-    #[test]
-    fn reconcile_with_identity_returns_identity_triples() {
-        let targets = vec![
-            make_liveness_check("agent1", "jefe-agent1", false),
-            make_liveness_check("agent2", "jefe-agent2", false),
-        ];
-        let existing: HashSet<String> = std::iter::once("jefe-agent1".to_string()).collect();
-        let alive_panes: HashSet<String> = std::iter::once("jefe-agent1".to_string()).collect();
-
-        let dead = reconcile_dead_agents_with_identity(&targets, &existing, &alive_panes);
-        assert_eq!(dead.len(), 1);
-        assert_eq!(dead[0].agent_id.0, "agent2");
-        assert_eq!(dead[0].binding_session_name.as_deref(), Some("jefe-agent2"));
-        assert_eq!(dead[0].lifecycle_generation, 0);
-    }
-
-    #[test]
-    fn reconcile_with_identity_excludes_remote() {
-        let targets = vec![
-            make_liveness_check("local", "jefe-local", false),
-            make_liveness_check("remote", "jefe-remote", true),
-        ];
-        let existing: HashSet<String> = HashSet::new();
-        let alive_panes: HashSet<String> = HashSet::new();
-
-        let dead = reconcile_dead_agents_with_identity(&targets, &existing, &alive_panes);
-        assert_eq!(dead.len(), 1);
-        assert_eq!(dead[0].agent_id.0, "local");
-    }
-
-    #[test]
-    fn reconcile_with_identity_existing_but_not_alive() {
-        // Session exists in `list-sessions` but has only dead panes in
-        // `list-panes -a` — it must be reported dead.
-        let targets = vec![make_liveness_check("agent1", "jefe-agent1", false)];
-        let existing: HashSet<String> = std::iter::once("jefe-agent1".to_string()).collect();
-        let alive_panes: HashSet<String> = HashSet::new();
-
-        let dead = reconcile_dead_agents_with_identity(&targets, &existing, &alive_panes);
-        assert_eq!(dead.len(), 1);
-        assert_eq!(dead[0].agent_id.0, "agent1");
-    }
-
-    #[test]
-    fn batch_liveness_check_with_identity_does_not_panic() {
-        let targets = vec![
-            make_liveness_check("agent1", "jefe-agent1", false),
-            make_liveness_check("agent2", "jefe-agent2", false),
-        ];
-        let _ = batch_liveness_check_with_identity(&targets);
-    }
-
-    #[test]
-    fn batch_command_count_constant_with_agent_count() {
-        // Issue #301 Phase 4: batch_liveness_check uses exactly two tmux
-        // subprocesses regardless of N. The pure reconcile function
-        // processes N targets without any additional subprocesses.
-        for n in 1..=5 {
-            let targets: Vec<_> = (0..n)
-                .map(|i| {
-                    make_liveness_check(&format!("agent{i}"), &format!("jefe-agent{i}"), false)
-                })
-                .collect();
-            let existing: HashSet<String> =
-                targets.iter().map(|t| t.session_name.clone()).collect();
-            let alive_panes: HashSet<String> = existing.clone();
-            let dead = reconcile_dead_agents_with_identity(&targets, &existing, &alive_panes);
-            assert!(dead.is_empty(), "all alive for n={n}");
-        }
-    }
-
-    // --- existing tests ---
-
-    #[test]
-    fn check_nonexistent_session_returns_false() {
-        // This session should not exist
-        let alive = check_session_alive("jefe-nonexistent-test-session-12345");
-        assert!(!alive);
-    }
-
-    #[test]
-    fn pid_alive_returns_true_for_current_process() {
-        // The current process always exists, so kill -0 must succeed.
-        let me = std::process::id();
-        assert!(pid_alive(me));
-    }
-
-    #[test]
-    fn pid_alive_returns_false_for_nonexistent_pid() {
-        // 2_000_000_000 is within pid_t (i32) range but far above every
-        // platform's pid_max (Linux ~4.19M, macOS ~99998), so kill -0
-        // deterministically returns ESRCH (no such process). u32::MAX
-        // (4_294_967_295) overflows pid_t parsing on macOS, which is
-        // implementation-defined.
-        assert!(!pid_alive(2_000_000_000));
-    }
-
-    // --- run_child_with_timeout (issue #287 review: kill path must be verified) ---
-
-    #[cfg(unix)]
-    #[test]
-    fn run_child_with_timeout_kills_long_running_subprocess() {
-        // Spawn a `sleep 30` and verify run_child_with_timeout kills it after
-        // a 1-second deadline rather than blocking indefinitely.
-        use std::process::Command;
-        let child = Command::new("sleep")
-            .arg("30")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap_or_else(|_| panic!("spawn sleep"));
-        let deadline = Instant::now() + Duration::from_secs(1);
-        let result = run_child_with_timeout(child, deadline);
-        assert!(result.is_err(), "timeout must produce Err");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn run_child_with_timeout_returns_output_for_fast_subprocess() {
-        use std::process::Command;
-        let child = Command::new("echo")
-            .arg("ok")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap_or_else(|_| panic!("spawn echo"));
-        let deadline = Instant::now() + Duration::from_secs(5);
-        let result = run_child_with_timeout(child, deadline);
-        assert!(result.is_ok(), "fast subprocess must succeed");
-        let output = result.unwrap_or_else(|()| panic!("checked ok"));
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(stdout.contains("ok"), "output must contain echo result");
-    }
-    /// A dead pane whose recorded worker anchor is still alive is a surviving
-    /// worker, not a dead agent (issue #543).
-    #[test]
-    fn a_live_anchor_under_a_dead_pane_is_survival_not_death() {
-        let anchor = crate::domain::WorkerProcessIdentity::new(4321, 77);
-        let observed = vec![crate::runtime::orphan::ObservedDescendant::alive(anchor)];
-
-        assert_eq!(
-            classify_worker_disposition(&observed),
-            WorkerDisposition::SurvivedPane,
-            "a validated live worker must never be reported as gone with its pane"
-        );
-    }
-
-    /// Every recorded anchor being dead is the only evidence that lets the pane's
-    /// death stand in for the agent's (issue #543).
-    #[test]
-    fn only_dead_anchors_confirm_the_worker_died_with_the_pane() {
-        let anchor = crate::domain::WorkerProcessIdentity::new(4321, 77);
-        let observed = vec![crate::runtime::orphan::ObservedDescendant::dead(anchor)];
-
-        assert_eq!(
-            classify_worker_disposition(&observed),
-            WorkerDisposition::GoneWithPane
-        );
-    }
-
-    /// With no recorded anchors the pane's death is simply not evidence about
-    /// the worker, and must not be reported as if it were (issue #543).
-    #[test]
-    fn absent_anchors_leave_the_worker_fate_unknown() {
-        assert_eq!(
-            classify_worker_disposition(&[]),
-            WorkerDisposition::Unknown,
-            "no evidence must read as unknown, not as confirmed death"
-        );
     }
 }

--- a/src/runtime/liveness.rs
+++ b/src/runtime/liveness.rs
@@ -256,27 +256,6 @@ pub enum WorkerDisposition {
     Unknown,
 }
 
-/// Classify a worker's fate from freshly probed anchor evidence.
-///
-/// Only a confirmed-alive anchor that still matches its recorded creation token
-/// counts as survival, so a recycled PID can never make a dead agent look
-/// alive.
-#[must_use]
-pub fn classify_worker_disposition(
-    anchors: &[super::orphan::ObservedDescendant],
-) -> WorkerDisposition {
-    if anchors.is_empty() {
-        return WorkerDisposition::Unknown;
-    }
-    if anchors
-        .iter()
-        .any(|anchor| matches!(anchor.liveness, super::process::ProcessLiveness::Alive))
-    {
-        return WorkerDisposition::SurvivedPane;
-    }
-    WorkerDisposition::GoneWithPane
-}
-
 /// Reconcile dead agents and return identity triples (issue #301 Phase 4).
 ///
 /// Like [`reconcile_dead_agents`] but returns [`LivenessIdentity`] so the
@@ -309,8 +288,10 @@ pub fn reconcile_dead_agents_with_identity<S: BuildHasher>(
             binding_session_name: t.binding_session_name.clone(),
             lifecycle_generation: t.lifecycle_generation,
             // Probe the recorded anchors so a pane death is not reported as a
-            // worker death without evidence (issue #543).
-            worker: classify_worker_disposition(&probe_worker_anchors(&t.worker_identities)),
+            // worker death without evidence (issue #543). This must observe the
+            // anchors directly: routing them through a reaping predicate loses
+            // the difference between "gone" and "cannot tell" (issue #541).
+            worker: observe_worker_disposition(&t.worker_identities),
         })
         .collect()
 }
@@ -390,23 +371,6 @@ fn observe_anchor(anchor: crate::domain::WorkerProcessIdentity) -> AnchorObserva
         | super::process::ProcessLiveness::MalformedIdentity
         | super::process::ProcessLiveness::ProbeFailure => AnchorObservation::Unverifiable,
     }
-}
-
-/// Freshly probe each recorded worker anchor, rejecting PID reuse.
-#[must_use]
-fn probe_worker_anchors(
-    anchors: &[crate::domain::WorkerProcessIdentity],
-) -> Vec<super::orphan::ObservedDescendant> {
-    anchors
-        .iter()
-        .map(|anchor| {
-            if super::orphan::descendant_still_matches_anchor(*anchor) {
-                super::orphan::ObservedDescendant::alive(*anchor)
-            } else {
-                super::orphan::ObservedDescendant::dead(*anchor)
-            }
-        })
-        .collect()
 }
 
 /// Query the tmux server once for all alive sessions, returning the set of

--- a/src/runtime/liveness.rs
+++ b/src/runtime/liveness.rs
@@ -315,6 +315,83 @@ pub fn reconcile_dead_agents_with_identity<S: BuildHasher>(
         .collect()
 }
 
+/// Observe whether the workers recorded for one agent are still alive.
+///
+/// Answers "did *this agent's* worker survive?", which is what makes a
+/// server-level event judgeable per agent instead of globally. A replaced
+/// multiplexer server is one process; the workers beneath it are others, and
+/// whether they died with it is a question that has to be asked of each one
+/// (issues #541 V6, #543).
+#[must_use]
+pub fn observe_worker_disposition(
+    anchors: &[crate::domain::WorkerProcessIdentity],
+) -> WorkerDisposition {
+    if anchors.is_empty() {
+        return WorkerDisposition::Unknown;
+    }
+    let mut unverifiable = false;
+    let mut alive = false;
+    for anchor in anchors {
+        match observe_anchor(*anchor) {
+            AnchorObservation::Alive => alive = true,
+            AnchorObservation::Gone => {}
+            AnchorObservation::Unverifiable => unverifiable = true,
+        }
+    }
+    if alive {
+        WorkerDisposition::SurvivedPane
+    } else if unverifiable {
+        WorkerDisposition::Unknown
+    } else {
+        WorkerDisposition::GoneWithPane
+    }
+}
+
+/// What one recorded anchor turned out to be.
+///
+/// Deliberately three-valued. `descendant_still_matches_anchor` answers the
+/// same probe with a `bool`, but that `bool` means "safe to reap", so it
+/// returns `false` for a process that is dead, one whose PID was recycled,
+/// *and* one it simply could not verify. That is the right default for
+/// termination and the wrong one for liveness: read as a liveness answer it
+/// turns "cannot tell" into "dead", which is the conflation this issue exists
+/// to remove.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AnchorObservation {
+    Alive,
+    Gone,
+    Unverifiable,
+}
+
+/// Observe one anchor without collapsing uncertainty into death.
+#[must_use]
+fn observe_anchor(anchor: crate::domain::WorkerProcessIdentity) -> AnchorObservation {
+    if anchor.pid() == 0 {
+        return AnchorObservation::Unverifiable;
+    }
+    match super::process::pid_liveness(anchor.pid()) {
+        super::process::ProcessLiveness::Dead | super::process::ProcessLiveness::ReusedPid => {
+            AnchorObservation::Gone
+        }
+        super::process::ProcessLiveness::Alive => {
+            // Something is running under that PID. Only a matching start token
+            // proves it is still *our* process; without one the PID may have
+            // been recycled, so the honest answer is that we cannot tell.
+            let observed = super::process::capture_process_identity(anchor.pid())
+                .ok()
+                .and_then(|identity| identity.started_at);
+            match (anchor.started_at(), observed) {
+                (Some(recorded), Some(current)) if recorded == current => AnchorObservation::Alive,
+                (Some(_), Some(_)) => AnchorObservation::Gone,
+                _ => AnchorObservation::Unverifiable,
+            }
+        }
+        super::process::ProcessLiveness::Inaccessible
+        | super::process::ProcessLiveness::MalformedIdentity
+        | super::process::ProcessLiveness::ProbeFailure => AnchorObservation::Unverifiable,
+    }
+}
+
 /// Freshly probe each recorded worker anchor, rejecting PID reuse.
 #[must_use]
 fn probe_worker_anchors(

--- a/src/runtime/liveness.rs
+++ b/src/runtime/liveness.rs
@@ -21,25 +21,6 @@ use crate::runtime::manager::LivenessCheck;
 /// cannot stall the background liveness thread indefinitely (issue #287).
 const LOCAL_TMUX_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Check if a process with the given PID is alive.
-///
-/// This **complements**, not replaces, [`check_session_alive`]. When the jefe
-/// multiplexer server has died but the worker is still running,
-/// `check_session_alive` reports false while `pid_alive` reports true — letting
-/// jefe recognize the worker is recoverable rather than marking the agent Dead.
-///
-/// Uses the typed process observation service on every platform. Only a
-/// confirmed exit returns false; inaccessible and failed probes fail open.
-/// Local-only: remote agents stay on the tmux/SSH-only path.
-#[must_use]
-pub fn pid_alive(pid: u32) -> bool {
-    let liveness = super::process::pid_liveness(pid);
-    if liveness == super::process::ProcessLiveness::ProbeFailure {
-        tracing::warn!(pid, "PID liveness probe failed; assuming worker alive");
-    }
-    super::process::process_liveness_indicates_alive(liveness)
-}
-
 /// Result of probing one persistent multiplexer session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionLiveness {

--- a/src/runtime/liveness_tests.rs
+++ b/src/runtime/liveness_tests.rs
@@ -404,23 +404,6 @@ fn check_nonexistent_session_returns_false() {
     assert!(!alive);
 }
 
-#[test]
-fn pid_alive_returns_true_for_current_process() {
-    // The current process always exists, so kill -0 must succeed.
-    let me = std::process::id();
-    assert!(pid_alive(me));
-}
-
-#[test]
-fn pid_alive_returns_false_for_nonexistent_pid() {
-    // 2_000_000_000 is within pid_t (i32) range but far above every
-    // platform's pid_max (Linux ~4.19M, macOS ~99998), so kill -0
-    // deterministically returns ESRCH (no such process). u32::MAX
-    // (4_294_967_295) overflows pid_t parsing on macOS, which is
-    // implementation-defined.
-    assert!(!pid_alive(2_000_000_000));
-}
-
 // --- run_child_with_timeout (issue #287 review: kill path must be verified) ---
 
 #[cfg(unix)]

--- a/src/runtime/liveness_tests.rs
+++ b/src/runtime/liveness_tests.rs
@@ -494,3 +494,49 @@ fn absent_anchors_leave_the_worker_fate_unknown() {
         "no evidence must read as unknown, not as confirmed death"
     );
 }
+
+/// The reaping predicate answers this same probe with a `bool` that means
+/// "safe to reap", so it reports `false` for a live process it merely cannot
+/// verify. Read as a liveness answer that would be a death sentence, so the
+/// liveness path must keep the third case.
+#[test]
+fn a_live_but_unverifiable_worker_is_unknown_not_gone() {
+    let weak = crate::domain::WorkerProcessIdentity::from_pid(std::process::id());
+
+    assert_eq!(
+        observe_worker_disposition(&[weak]),
+        WorkerDisposition::Unknown,
+        "a running process without a start token is unproven, not dead"
+    );
+}
+
+/// A worker proven to be the same process must still be reported alive, or
+/// fail-closed would degrade into never answering.
+#[test]
+fn a_verified_live_worker_survived() {
+    let identity = crate::runtime::capture_process_identity(std::process::id())
+        .unwrap_or_else(|error| panic!("this process must be observable: {error}"));
+    let strong = crate::domain::WorkerProcessIdentity::from_identity(identity);
+
+    assert_eq!(
+        observe_worker_disposition(&[strong]),
+        WorkerDisposition::SurvivedPane
+    );
+}
+
+/// PID 0 is never a worker, and is not evidence of a dead one either.
+#[test]
+fn a_zero_pid_anchor_is_unknown() {
+    let zero = crate::domain::WorkerProcessIdentity::from_pid(0);
+
+    assert_eq!(
+        observe_worker_disposition(&[zero]),
+        WorkerDisposition::Unknown
+    );
+}
+
+/// No anchors is the absence of evidence, not evidence of absence.
+#[test]
+fn no_anchors_is_unknown() {
+    assert_eq!(observe_worker_disposition(&[]), WorkerDisposition::Unknown);
+}

--- a/src/runtime/liveness_tests.rs
+++ b/src/runtime/liveness_tests.rs
@@ -457,44 +457,6 @@ fn run_child_with_timeout_returns_output_for_fast_subprocess() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("ok"), "output must contain echo result");
 }
-/// A dead pane whose recorded worker anchor is still alive is a surviving
-/// worker, not a dead agent (issue #543).
-#[test]
-fn a_live_anchor_under_a_dead_pane_is_survival_not_death() {
-    let anchor = crate::domain::WorkerProcessIdentity::new(4321, 77);
-    let observed = vec![crate::runtime::orphan::ObservedDescendant::alive(anchor)];
-
-    assert_eq!(
-        classify_worker_disposition(&observed),
-        WorkerDisposition::SurvivedPane,
-        "a validated live worker must never be reported as gone with its pane"
-    );
-}
-
-/// Every recorded anchor being dead is the only evidence that lets the pane's
-/// death stand in for the agent's (issue #543).
-#[test]
-fn only_dead_anchors_confirm_the_worker_died_with_the_pane() {
-    let anchor = crate::domain::WorkerProcessIdentity::new(4321, 77);
-    let observed = vec![crate::runtime::orphan::ObservedDescendant::dead(anchor)];
-
-    assert_eq!(
-        classify_worker_disposition(&observed),
-        WorkerDisposition::GoneWithPane
-    );
-}
-
-/// With no recorded anchors the pane's death is simply not evidence about
-/// the worker, and must not be reported as if it were (issue #543).
-#[test]
-fn absent_anchors_leave_the_worker_fate_unknown() {
-    assert_eq!(
-        classify_worker_disposition(&[]),
-        WorkerDisposition::Unknown,
-        "no evidence must read as unknown, not as confirmed death"
-    );
-}
-
 /// The reaping predicate answers this same probe with a `bool` that means
 /// "safe to reap", so it reports `false` for a live process it merely cannot
 /// verify. Read as a liveness answer that would be a death sentence, so the
@@ -539,4 +501,54 @@ fn a_zero_pid_anchor_is_unknown() {
 #[test]
 fn no_anchors_is_unknown() {
     assert_eq!(observe_worker_disposition(&[]), WorkerDisposition::Unknown);
+}
+
+/// The main dead-agent path probed its worker anchors through a predicate
+/// meaning "safe to reap", which is false for a process that is merely
+/// unverifiable as well as for one that is gone. Reading that as the answer
+/// reported a live worker as having died with its pane -- the #543 defect,
+/// still reachable here after it was fixed in the server-loss path.
+#[test]
+fn an_unverifiable_worker_under_a_dead_pane_is_unknown_not_gone() {
+    let mut target = make_liveness_check("agent-1", "jefe-agent-1", false);
+    // A PID with no recorded creation token: it may well be running, but
+    // nothing here can prove the process is the one that was launched.
+    target.worker_identities = vec![crate::domain::WorkerProcessIdentity::from_pid(
+        std::process::id(),
+    )];
+
+    let targets = vec![target];
+    let existing: HashSet<String> = HashSet::new();
+    let alive_panes: HashSet<String> = HashSet::new();
+
+    let dead = reconcile_dead_agents_with_identity(&targets, &existing, &alive_panes);
+
+    assert_eq!(dead.len(), 1, "the pane is gone, so the agent is reported");
+    assert_eq!(
+        dead[0].worker,
+        WorkerDisposition::Unknown,
+        "a worker that cannot be verified has not been shown to have died"
+    );
+}
+
+/// The mirror hazard: refusing to call an unverifiable worker dead must not
+/// stop a genuinely absent one being reported.
+#[test]
+fn a_worker_that_cannot_be_running_is_still_gone() {
+    let mut target = make_liveness_check("agent-2", "jefe-agent-2", false);
+    // PID 0 is never a live worker, and an anchor naming it carries no
+    // creation token to check, so it is unverifiable rather than gone.
+    target.worker_identities = vec![];
+
+    let targets = vec![target];
+    let existing: HashSet<String> = HashSet::new();
+    let alive_panes: HashSet<String> = HashSet::new();
+
+    let dead = reconcile_dead_agents_with_identity(&targets, &existing, &alive_panes);
+    assert_eq!(dead.len(), 1);
+    assert_eq!(
+        dead[0].worker,
+        WorkerDisposition::Unknown,
+        "no recorded anchors is no evidence either way"
+    );
 }

--- a/src/runtime/liveness_tests.rs
+++ b/src/runtime/liveness_tests.rs
@@ -1,0 +1,496 @@
+//! Behavioural tests for [super::liveness].
+//!
+//! Split out of liveness.rs to stay within the source-size gate; the
+//! module is otherwise unchanged.
+
+use std::collections::HashSet;
+#[cfg(unix)]
+use std::process::Stdio;
+#[cfg(unix)]
+use std::time::{Duration, Instant};
+
+use super::liveness::*;
+use crate::domain::liveness_observation::{Observed, ProbeBoundary, Uncertainty};
+use crate::domain::{AgentId, RemoteRepositorySettings};
+use crate::runtime::manager::LivenessCheck;
+
+fn make_liveness_check(agent_id: &str, session_name: &str, remote: bool) -> LivenessCheck {
+    LivenessCheck {
+        agent_id: AgentId(agent_id.to_string()),
+        session_name: session_name.to_string(),
+        remote: if remote {
+            Some(RemoteRepositorySettings::default())
+        } else {
+            None
+        },
+        binding_session_name: Some(session_name.to_string()),
+        lifecycle_generation: 0,
+        worker_identities: Vec::new(),
+    }
+}
+
+// --- parse_alive_sessions (pure) ---
+
+#[test]
+fn parse_alive_sessions_basic() {
+    let raw = "jefe-agent1
+jefe-agent2
+jefe-agent3
+";
+    let set = parse_alive_sessions(raw);
+    assert_eq!(set.len(), 3);
+    assert!(set.contains("jefe-agent1"));
+    assert!(set.contains("jefe-agent2"));
+    assert!(set.contains("jefe-agent3"));
+}
+
+#[test]
+fn parse_alive_sessions_trims_whitespace() {
+    let raw = "  jefe-a  \n jefe-b \n\n";
+    let set = parse_alive_sessions(raw);
+    assert_eq!(set.len(), 2);
+    assert!(set.contains("jefe-a"));
+    assert!(set.contains("jefe-b"));
+}
+
+#[test]
+fn parse_alive_sessions_empty_output() {
+    let set = parse_alive_sessions("");
+    assert!(set.is_empty());
+}
+
+#[test]
+fn parse_alive_sessions_skips_empty_lines() {
+    let raw = "jefe-a
+
+
+jefe-b
+";
+    let set = parse_alive_sessions(raw);
+    assert_eq!(set.len(), 2);
+}
+
+#[test]
+fn dead_pane_parser_preserves_tri_state() {
+    assert_eq!(parse_dead_pane_flags("0\n1\n"), SessionLiveness::Alive);
+    assert_eq!(parse_dead_pane_flags("1\ntrue\n"), SessionLiveness::Missing);
+    assert_eq!(parse_dead_pane_flags(""), SessionLiveness::Unavailable);
+    assert_eq!(
+        parse_dead_pane_flags("unexpected\n"),
+        SessionLiveness::Unavailable
+    );
+}
+
+// --- parse_pane_alive (pure) ---
+
+#[test]
+fn parse_pane_alive_identifies_live_agent_windows_only() {
+    let raw = "jefe-a:0:0
+jefe-b:0:1
+jefe-c:0:0
+jefe-b:1:0
+";
+    let set = parse_pane_alive(raw);
+    assert_eq!(set.len(), 2);
+    assert!(set.contains("jefe-a"));
+    assert!(set.contains("jefe-c"));
+    assert!(
+        !set.contains("jefe-b"),
+        "shell window must not mask dead agent"
+    );
+}
+
+#[test]
+fn parse_pane_alive_only_numeric_flags() {
+    let raw = "jefe-a:0:0
+jefe-b:0:1
+jefe-c:0:false
+";
+    let set = parse_pane_alive(raw);
+    assert!(set.contains("jefe-a"));
+    assert!(!set.contains("jefe-b"));
+    assert!(!set.contains("jefe-c"), "non-numeric flags must not match");
+}
+
+#[test]
+fn parse_pane_alive_empty_output() {
+    let set = parse_pane_alive("");
+    assert!(set.is_empty());
+}
+
+#[test]
+fn parse_pane_alive_skips_malformed_lines() {
+    let raw = "jefe-a:0:0
+malformed
+jefe-b:0:0
+";
+    let set = parse_pane_alive(raw);
+    assert_eq!(set.len(), 2);
+    assert!(set.contains("jefe-a"));
+    assert!(set.contains("jefe-b"));
+}
+
+// --- reconcile_dead_agents (pure) ---
+
+#[test]
+fn reconcile_dead_agents_finds_missing_sessions() {
+    let targets = vec![
+        make_liveness_check("agent1", "jefe-agent1", false),
+        make_liveness_check("agent2", "jefe-agent2", false),
+    ];
+    let existing: HashSet<String> = std::iter::once("jefe-agent1".to_string()).collect();
+    let alive_panes: HashSet<String> = std::iter::once("jefe-agent1".to_string()).collect();
+
+    let dead = reconcile_dead_agents(&targets, &existing, &alive_panes);
+    assert_eq!(dead.len(), 1);
+    assert_eq!(dead[0].0, "agent2");
+}
+
+#[test]
+fn reconcile_dead_agents_finds_dead_panes() {
+    let targets = vec![
+        make_liveness_check("agent1", "jefe-agent1", false),
+        make_liveness_check("agent2", "jefe-agent2", false),
+    ];
+    let existing: HashSet<String> = ["jefe-agent1".to_string(), "jefe-agent2".to_string()]
+        .into_iter()
+        .collect();
+    // agent1 has alive panes, agent2 has only dead panes
+    let alive_panes: HashSet<String> = std::iter::once("jefe-agent1".to_string()).collect();
+
+    let dead = reconcile_dead_agents(&targets, &existing, &alive_panes);
+    assert_eq!(dead.len(), 1);
+    assert_eq!(dead[0].0, "agent2");
+}
+
+#[test]
+fn reconcile_dead_agents_all_alive() {
+    let targets = vec![
+        make_liveness_check("agent1", "jefe-agent1", false),
+        make_liveness_check("agent2", "jefe-agent2", false),
+    ];
+    let existing: HashSet<String> = ["jefe-agent1".to_string(), "jefe-agent2".to_string()]
+        .into_iter()
+        .collect();
+    let alive_panes: HashSet<String> = ["jefe-agent1".to_string(), "jefe-agent2".to_string()]
+        .into_iter()
+        .collect();
+
+    let dead = reconcile_dead_agents(&targets, &existing, &alive_panes);
+    assert!(dead.is_empty());
+}
+
+#[test]
+fn reconcile_dead_agents_excludes_remote_targets() {
+    let targets = vec![
+        make_liveness_check("local-agent", "jefe-local", false),
+        make_liveness_check("remote-agent", "jefe-remote", true),
+    ];
+    // No sessions exist
+    let existing: HashSet<String> = HashSet::new();
+    let alive_panes: HashSet<String> = HashSet::new();
+
+    let dead = reconcile_dead_agents(&targets, &existing, &alive_panes);
+    // Only local-agent is dead; remote-agent is excluded
+    assert_eq!(dead.len(), 1);
+    assert_eq!(dead[0].0, "local-agent");
+}
+
+#[test]
+fn reconcile_dead_agents_empty_targets() {
+    let dead = reconcile_dead_agents(&[], &HashSet::new(), &HashSet::new());
+    assert!(dead.is_empty());
+}
+
+// --- alive_session_set (integration, needs tmux) ---
+
+#[test]
+fn alive_session_set_does_not_panic_without_tmux_server() {
+    // On a system without tmux or with no sessions, this returns None.
+    // This test validates graceful failure, not the presence of tmux.
+    let set = alive_session_set();
+    // We don't assert the value because a tmux server might have sessions
+    // from other processes. We just verify it doesn't panic.
+    let _ = set;
+}
+
+#[test]
+fn reconcile_dead_agents_marks_all_dead_when_no_sessions_exist() {
+    // When no tmux sessions exist, all local targets are dead.
+    // This tests the pure reconcile function with deterministic inputs
+    // (no tmux dependency).
+    let targets = vec![
+        make_liveness_check("agent1", "jefe-agent1", false),
+        make_liveness_check("agent2", "jefe-agent2", false),
+    ];
+
+    let existing: HashSet<String> = HashSet::new();
+    let alive_panes: HashSet<String> = HashSet::new();
+    let dead = reconcile_dead_agents(&targets, &existing, &alive_panes);
+    assert_eq!(dead.len(), 2, "empty tmux state means all targets are dead");
+}
+
+#[test]
+fn batch_liveness_check_does_not_panic() {
+    // Smoke test: batch_liveness_check must not panic regardless of
+    // whether a tmux server is available. The fail-open contract (returns
+    // empty Vec when tmux is unavailable) is verified by the pure
+    // reconcile_dead_agents test above.
+    let targets = vec![
+        make_liveness_check("agent1", "jefe-agent1", false),
+        make_liveness_check("agent2", "jefe-agent2", false),
+    ];
+    let _ = batch_liveness_check(&targets);
+}
+
+// --- reconcile_dead_agents_with_identity (issue #301 Phase 4) ---
+
+#[test]
+fn reconcile_with_identity_returns_identity_triples() {
+    let targets = vec![
+        make_liveness_check("agent1", "jefe-agent1", false),
+        make_liveness_check("agent2", "jefe-agent2", false),
+    ];
+    let existing: HashSet<String> = std::iter::once("jefe-agent1".to_string()).collect();
+    let alive_panes: HashSet<String> = std::iter::once("jefe-agent1".to_string()).collect();
+
+    let dead = reconcile_dead_agents_with_identity(&targets, &existing, &alive_panes);
+    assert_eq!(dead.len(), 1);
+    assert_eq!(dead[0].agent_id.0, "agent2");
+    assert_eq!(dead[0].binding_session_name.as_deref(), Some("jefe-agent2"));
+    assert_eq!(dead[0].lifecycle_generation, 0);
+}
+
+#[test]
+fn reconcile_with_identity_excludes_remote() {
+    let targets = vec![
+        make_liveness_check("local", "jefe-local", false),
+        make_liveness_check("remote", "jefe-remote", true),
+    ];
+    let existing: HashSet<String> = HashSet::new();
+    let alive_panes: HashSet<String> = HashSet::new();
+
+    let dead = reconcile_dead_agents_with_identity(&targets, &existing, &alive_panes);
+    assert_eq!(dead.len(), 1);
+    assert_eq!(dead[0].agent_id.0, "local");
+}
+
+#[test]
+fn reconcile_with_identity_existing_but_not_alive() {
+    // Session exists in `list-sessions` but has only dead panes in
+    // `list-panes -a` — it must be reported dead.
+    let targets = vec![make_liveness_check("agent1", "jefe-agent1", false)];
+    let existing: HashSet<String> = std::iter::once("jefe-agent1".to_string()).collect();
+    let alive_panes: HashSet<String> = HashSet::new();
+
+    let dead = reconcile_dead_agents_with_identity(&targets, &existing, &alive_panes);
+    assert_eq!(dead.len(), 1);
+    assert_eq!(dead[0].agent_id.0, "agent1");
+}
+
+/// V1: driving the session-list boundary to failure must produce no
+/// transition. Before #541 this returned an empty vector, which the caller
+/// read as "nothing is dead" -- a probe failure silently asserting health.
+#[test]
+fn an_unknown_session_list_produces_no_transition() {
+    let targets = vec![make_liveness_check("agent1", "jefe-agent1", false)];
+
+    let observed = reconcile_observed(
+        &targets,
+        Observed::unknown(ProbeBoundary::SessionList, "list-sessions timed out"),
+        Observed::Known(HashSet::new()),
+    );
+
+    assert_eq!(observed.known(), None, "a failed probe must not decide");
+    assert_eq!(
+        observed.uncertainty().map(Uncertainty::boundary),
+        Some(ProbeBoundary::SessionList),
+        "the hold must name the boundary that failed"
+    );
+}
+
+/// V1: the pane-list boundary, independently.
+#[test]
+fn an_unknown_pane_list_produces_no_transition() {
+    let targets = vec![make_liveness_check("agent1", "jefe-agent1", false)];
+    let existing: HashSet<String> = targets.iter().map(|t| t.session_name.clone()).collect();
+
+    let observed = reconcile_observed(
+        &targets,
+        Observed::Known(existing),
+        Observed::unknown(ProbeBoundary::PaneList, "list-panes returned no output"),
+    );
+
+    assert_eq!(observed.known(), None);
+    assert_eq!(
+        observed.uncertainty().map(Uncertainty::boundary),
+        Some(ProbeBoundary::PaneList),
+    );
+}
+
+/// V4's mirror hazard: fail-closed must not become never-closed. When both
+/// probes answer, a genuinely absent session is still reported dead.
+#[test]
+fn a_genuinely_dead_session_is_still_reported_when_both_probes_answer() {
+    let targets = vec![make_liveness_check("agent1", "jefe-agent1", false)];
+
+    let observed = reconcile_observed(
+        &targets,
+        Observed::Known(HashSet::new()),
+        Observed::Known(HashSet::new()),
+    );
+
+    let dead = observed
+        .known()
+        .unwrap_or_else(|| panic!("two answered probes must produce a verdict"));
+    assert_eq!(
+        dead.len(),
+        1,
+        "an absent session with both probes answering is dead, not unknown"
+    );
+}
+
+/// An answered pair with everything alive must produce an empty verdict --
+/// distinguishable from the unknown case, which is the whole point.
+#[test]
+fn a_live_session_is_distinguishable_from_an_unanswered_probe() {
+    let targets = vec![make_liveness_check("agent1", "jefe-agent1", false)];
+    let alive: HashSet<String> = targets.iter().map(|t| t.session_name.clone()).collect();
+
+    let observed = reconcile_observed(
+        &targets,
+        Observed::Known(alive.clone()),
+        Observed::Known(alive),
+    );
+
+    assert_eq!(
+        observed.known().map(Vec::len),
+        Some(0),
+        "a live agent yields an answered, empty verdict"
+    );
+}
+
+#[test]
+fn batch_liveness_check_with_identity_does_not_panic() {
+    let targets = vec![
+        make_liveness_check("agent1", "jefe-agent1", false),
+        make_liveness_check("agent2", "jefe-agent2", false),
+    ];
+    let _ = batch_liveness_check_with_identity(&targets);
+}
+
+#[test]
+fn batch_command_count_constant_with_agent_count() {
+    // Issue #301 Phase 4: batch_liveness_check uses exactly two tmux
+    // subprocesses regardless of N. The pure reconcile function
+    // processes N targets without any additional subprocesses.
+    for n in 1..=5 {
+        let targets: Vec<_> = (0..n)
+            .map(|i| make_liveness_check(&format!("agent{i}"), &format!("jefe-agent{i}"), false))
+            .collect();
+        let existing: HashSet<String> = targets.iter().map(|t| t.session_name.clone()).collect();
+        let alive_panes: HashSet<String> = existing.clone();
+        let dead = reconcile_dead_agents_with_identity(&targets, &existing, &alive_panes);
+        assert!(dead.is_empty(), "all alive for n={n}");
+    }
+}
+
+// --- existing tests ---
+
+#[test]
+fn check_nonexistent_session_returns_false() {
+    // This session should not exist
+    let alive = check_session_alive("jefe-nonexistent-test-session-12345");
+    assert!(!alive);
+}
+
+#[test]
+fn pid_alive_returns_true_for_current_process() {
+    // The current process always exists, so kill -0 must succeed.
+    let me = std::process::id();
+    assert!(pid_alive(me));
+}
+
+#[test]
+fn pid_alive_returns_false_for_nonexistent_pid() {
+    // 2_000_000_000 is within pid_t (i32) range but far above every
+    // platform's pid_max (Linux ~4.19M, macOS ~99998), so kill -0
+    // deterministically returns ESRCH (no such process). u32::MAX
+    // (4_294_967_295) overflows pid_t parsing on macOS, which is
+    // implementation-defined.
+    assert!(!pid_alive(2_000_000_000));
+}
+
+// --- run_child_with_timeout (issue #287 review: kill path must be verified) ---
+
+#[cfg(unix)]
+#[test]
+fn run_child_with_timeout_kills_long_running_subprocess() {
+    // Spawn a `sleep 30` and verify run_child_with_timeout kills it after
+    // a 1-second deadline rather than blocking indefinitely.
+    use std::process::Command;
+    let child = Command::new("sleep")
+        .arg("30")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|_| panic!("spawn sleep"));
+    let deadline = Instant::now() + Duration::from_secs(1);
+    let result = run_child_with_timeout(child, deadline);
+    assert!(result.is_err(), "timeout must produce Err");
+}
+
+#[cfg(unix)]
+#[test]
+fn run_child_with_timeout_returns_output_for_fast_subprocess() {
+    use std::process::Command;
+    let child = Command::new("echo")
+        .arg("ok")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|_| panic!("spawn echo"));
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let result = run_child_with_timeout(child, deadline);
+    assert!(result.is_ok(), "fast subprocess must succeed");
+    let output = result.unwrap_or_else(|()| panic!("checked ok"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("ok"), "output must contain echo result");
+}
+/// A dead pane whose recorded worker anchor is still alive is a surviving
+/// worker, not a dead agent (issue #543).
+#[test]
+fn a_live_anchor_under_a_dead_pane_is_survival_not_death() {
+    let anchor = crate::domain::WorkerProcessIdentity::new(4321, 77);
+    let observed = vec![crate::runtime::orphan::ObservedDescendant::alive(anchor)];
+
+    assert_eq!(
+        classify_worker_disposition(&observed),
+        WorkerDisposition::SurvivedPane,
+        "a validated live worker must never be reported as gone with its pane"
+    );
+}
+
+/// Every recorded anchor being dead is the only evidence that lets the pane's
+/// death stand in for the agent's (issue #543).
+#[test]
+fn only_dead_anchors_confirm_the_worker_died_with_the_pane() {
+    let anchor = crate::domain::WorkerProcessIdentity::new(4321, 77);
+    let observed = vec![crate::runtime::orphan::ObservedDescendant::dead(anchor)];
+
+    assert_eq!(
+        classify_worker_disposition(&observed),
+        WorkerDisposition::GoneWithPane
+    );
+}
+
+/// With no recorded anchors the pane's death is simply not evidence about
+/// the worker, and must not be reported as if it were (issue #543).
+#[test]
+fn absent_anchors_leave_the_worker_fate_unknown() {
+    assert_eq!(
+        classify_worker_disposition(&[]),
+        WorkerDisposition::Unknown,
+        "no evidence must read as unknown, not as confirmed death"
+    );
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -117,8 +117,9 @@ pub use gh_auth::{AuthRunResult, run_device_auth};
 pub use liveness::{
     LivenessIdentity, SessionLiveness, WorkerDisposition, alive_session_set, batch_liveness_check,
     batch_liveness_check_with_identity, check_remote_session_alive, check_session_alive,
-    classify_worker_disposition, parse_alive_sessions, parse_pane_alive, pid_alive,
-    reconcile_dead_agents, reconcile_dead_agents_with_identity, session_liveness,
+    classify_worker_disposition, observe_worker_disposition, parse_alive_sessions,
+    parse_pane_alive, pid_alive, reconcile_dead_agents, reconcile_dead_agents_with_identity,
+    session_liveness,
 };
 pub use manager::{
     AttachInputs, HISTORY_LINE_CAP, LivenessCheck, RuntimeManager, TmuxRuntimeManager,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -207,6 +207,10 @@ mod process_tests;
 mod orphan_tests;
 
 #[cfg(test)]
+#[path = "liveness_tests.rs"]
+mod liveness_tests;
+
+#[cfg(test)]
 #[path = "multiplexer_tests.rs"]
 mod multiplexer_tests;
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -117,9 +117,8 @@ pub use gh_auth::{AuthRunResult, run_device_auth};
 pub use liveness::{
     LivenessIdentity, SessionLiveness, WorkerDisposition, alive_session_set, batch_liveness_check,
     batch_liveness_check_with_identity, check_remote_session_alive, check_session_alive,
-    classify_worker_disposition, observe_worker_disposition, parse_alive_sessions,
-    parse_pane_alive, pid_alive, reconcile_dead_agents, reconcile_dead_agents_with_identity,
-    session_liveness,
+    observe_worker_disposition, parse_alive_sessions, parse_pane_alive, pid_alive,
+    reconcile_dead_agents, reconcile_dead_agents_with_identity, session_liveness,
 };
 pub use manager::{
     AttachInputs, HISTORY_LINE_CAP, LivenessCheck, RuntimeManager, TmuxRuntimeManager,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -117,8 +117,8 @@ pub use gh_auth::{AuthRunResult, run_device_auth};
 pub use liveness::{
     LivenessIdentity, SessionLiveness, WorkerDisposition, alive_session_set, batch_liveness_check,
     batch_liveness_check_with_identity, check_remote_session_alive, check_session_alive,
-    observe_worker_disposition, parse_alive_sessions, parse_pane_alive, pid_alive,
-    reconcile_dead_agents, reconcile_dead_agents_with_identity, session_liveness,
+    observe_worker_disposition, parse_alive_sessions, parse_pane_alive, reconcile_dead_agents,
+    reconcile_dead_agents_with_identity, session_liveness,
 };
 pub use manager::{
     AttachInputs, HISTORY_LINE_CAP, LivenessCheck, RuntimeManager, TmuxRuntimeManager,
@@ -158,7 +158,7 @@ pub use preflight::{
 };
 pub use process::{
     ProcessIdentityError, ProcessLiveness, ProcessObservation, capture_process_identity,
-    classify_process_observation, process_liveness, process_liveness_indicates_alive,
+    classify_process_observation, process_liveness,
 };
 pub use provenance::{
     BinaryFingerprint, PINNED_PSMUX_ARCHIVE_SHA256, ProvenanceManifest, ProvenanceVerdict,

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -111,19 +111,6 @@ pub fn process_liveness(identity: Option<ProcessIdentity>) -> ProcessLiveness {
     classify_process_observation(Some(identity), probe_process(identity.pid))
 }
 
-/// Return whether a final process classification preserves liveness.
-///
-/// Uncertain access and probe failures fail open; confirmed exit, process
-/// reuse, and malformed expected identity do not establish the target process
-/// as alive.
-#[must_use]
-pub const fn process_liveness_indicates_alive(liveness: ProcessLiveness) -> bool {
-    matches!(
-        liveness,
-        ProcessLiveness::Alive | ProcessLiveness::Inaccessible | ProcessLiveness::ProbeFailure
-    )
-}
-
 #[must_use]
 pub(super) fn pid_liveness(pid: u32) -> ProcessLiveness {
     match probe_process(pid) {

--- a/src/runtime/process_tests.rs
+++ b/src/runtime/process_tests.rs
@@ -9,7 +9,7 @@ use super::process::classify_windows_error;
 use super::process::{
     ProcessLiveness, ProcessObservation, WindowsProbeFailure, WindowsProbeStage,
     capture_process_identity, classify_process_observation, classify_windows_failure,
-    process_liveness, process_liveness_indicates_alive,
+    process_liveness,
 };
 #[cfg(unix)]
 use super::process::{UnixProbeOutcome, classify_unix_probe, unix_probe_command_for};
@@ -49,33 +49,27 @@ fn classification_distinguishes_every_required_state() {
     );
 }
 
+/// An uncertain probe must stay uncertain all the way to the caller. It used
+/// to be squashed into a `bool` meaning "treat as alive", which reads a
+/// failure to look as a positive finding (issue #541).
 #[test]
-fn fail_open_policy_covers_every_final_liveness_state() {
-    for liveness in [
-        ProcessLiveness::Alive,
-        ProcessLiveness::Inaccessible,
-        ProcessLiveness::ProbeFailure,
-    ] {
-        assert!(process_liveness_indicates_alive(liveness));
-    }
-    for liveness in [
-        ProcessLiveness::Dead,
-        ProcessLiveness::ReusedPid,
-        ProcessLiveness::MalformedIdentity,
-    ] {
-        assert!(!process_liveness_indicates_alive(liveness));
-    }
-}
-
-#[test]
-fn uncertain_process_observations_remain_fail_open() {
+fn uncertain_process_observations_stay_uncertain() {
     let expected = ProcessIdentity::new(41, 900);
-    for observation in [
-        ProcessObservation::Inaccessible,
-        ProcessObservation::ProbeFailed,
+    for (observation, expected_liveness) in [
+        (
+            ProcessObservation::Inaccessible,
+            ProcessLiveness::Inaccessible,
+        ),
+        (
+            ProcessObservation::ProbeFailed,
+            ProcessLiveness::ProbeFailure,
+        ),
     ] {
-        let liveness = classify_process_observation(Some(expected), observation);
-        assert!(process_liveness_indicates_alive(liveness));
+        assert_eq!(
+            classify_process_observation(Some(expected), observation),
+            expected_liveness,
+            "{observation:?} is not a verdict about whether the process lives"
+        );
     }
 }
 

--- a/src/state/persistence_effect_tests.rs
+++ b/src/state/persistence_effect_tests.rs
@@ -408,3 +408,31 @@ fn superseding_a_staged_save_discards_the_stale_candidate() {
         "the superseded candidate must be discarded, not left staged"
     );
 }
+
+/// #445: an unreadable state document became an empty one, because the empty
+/// fallback was projected straight back over the file. The bytes we failed to
+/// read are the only copy of whatever they contain, so nothing may replace
+/// them until they are understood.
+#[test]
+fn a_held_durable_read_writes_nothing() {
+    let mut state = state_with_one_agent();
+    state.durable_read_held = Some("state.json is not valid JSON".to_owned());
+
+    assert!(
+        state.take_durable_save_request().is_none(),
+        "an unreadable document must not be overwritten by what little was recovered"
+    );
+}
+
+/// The mirror hazard: holding writes while the read failed must not become
+/// never writing at all.
+#[test]
+fn a_successful_durable_read_still_writes() {
+    let mut state = state_with_one_agent();
+    assert_eq!(state.durable_read_held, None);
+
+    assert!(
+        state.take_durable_save_request().is_some(),
+        "a state loaded from a readable document must still persist"
+    );
+}

--- a/src/state/persistence_ops.rs
+++ b/src/state/persistence_ops.rs
@@ -66,6 +66,15 @@ impl AppState {
     /// *what* would be written.
     #[must_use]
     pub fn take_durable_save_request(&mut self) -> Option<(Box<StateV2>, u64, Correlation)> {
+        // The document on disk could not be read, so what is in memory is not
+        // known to be everything that was persisted. Projecting it back over
+        // the file would replace a document we failed to understand with one
+        // built from the little we recovered, which is how #445 turned an
+        // unreadable state file into an empty one. Hold the write instead: the
+        // bytes we could not read are the only copy of whatever they contain.
+        if self.durable_read_held.is_some() {
+            return None;
+        }
         self.stage_durable_save();
         let issued = self.pending_effects.take_staged_persist()?;
         let IssuedEffect {

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -442,6 +442,14 @@ pub struct AppState {
     pub error_message: Option<String>,
     pub warning_message: Option<String>,
 
+    /// Why the durable document could not be read, when it could not be.
+    ///
+    /// Set only when the read *failed*; an absent file is an answer (there is
+    /// no prior state) and leaves this `None`. While it is set, durable saves
+    /// are held so an unreadable document is never replaced by one projected
+    /// from whatever little was recovered (issues #541, #445).
+    pub durable_read_held: Option<String>,
+
     // Issues mode state
     /// @plan PLAN-20260329-ISSUES-MODE.P03
     /// @requirement REQ-ISS-001

--- a/src/ui/components/agent_list.rs
+++ b/src/ui/components/agent_list.rs
@@ -53,8 +53,11 @@ pub struct AgentListView {
 /// Status glyph rendered before the agent name (single character).
 ///
 /// Matches the pre-refactor `AgentList` component's `status_icon` match arms.
-fn status_icon(status: AgentStatus) -> &'static str {
-    match status {
+fn status_icon(agent: &Agent) -> &'static str {
+    if agent.state_is_unconfirmed() {
+        return "~";
+    }
+    match agent.status {
         AgentStatus::Running => "*",
         AgentStatus::Completed => "+",
         AgentStatus::Dead => "x",
@@ -69,8 +72,11 @@ fn status_icon(status: AgentStatus) -> &'static str {
 ///
 /// Matches the pre-refactor `AgentList` component's `status_color` match arms;
 /// the generic [`SelectableList`] resolves the role against the theme.
-fn status_role(status: AgentStatus) -> SpanRole {
-    match status {
+fn status_role(agent: &Agent) -> SpanRole {
+    if agent.state_is_unconfirmed() {
+        return SpanRole::Yellow;
+    }
+    match agent.status {
         AgentStatus::Running | AgentStatus::Completed => SpanRole::Bright,
         AgentStatus::Dead | AgentStatus::Errored | AgentStatus::ServerLost => SpanRole::Red,
         AgentStatus::Waiting => SpanRole::Yellow,
@@ -113,8 +119,8 @@ fn to_selectable_row(
             color: SpanColor::Themed,
         },
         SelectableSpan {
-            text: status_icon(agent.status).to_string(),
-            color: SpanColor::Role(status_role(agent.status)),
+            text: status_icon(agent).to_string(),
+            color: SpanColor::Role(status_role(agent)),
         },
         SelectableSpan {
             text: format!(" {}{}", shortcut_label, agent.name),
@@ -261,5 +267,48 @@ mod tests {
         assert!(lines.last().is_some_and(|line| {
             line.text.contains("Agent 24") && line.text.contains("acme/widgets")
         }));
+    }
+
+    /// A Running agent with no binding is one whose state jefe could not
+    /// confirm. It is shown Running because nothing disproved that, but
+    /// rendering it identically to a confirmed agent tells the operator a
+    /// certainty jefe does not have -- and this is the row they will try to
+    /// attach to (issue #541 V7).
+    #[test]
+    fn an_unconfirmed_running_agent_is_not_shown_as_a_healthy_one() {
+        let mut agent = Agent::new(
+            AgentId(String::from("agent-held")),
+            RepositoryId(String::from("repo")),
+            crate::domain::shipped_agent_type(3),
+            crate::domain::TypedMap::new(),
+            String::from("Held Agent"),
+            PathBuf::from("/tmp"),
+        );
+        agent.status = AgentStatus::Running;
+        agent.runtime_binding = None;
+
+        let mut confirmed = agent.clone();
+        confirmed.id = AgentId(String::from("agent-live"));
+        confirmed.runtime_binding = Some(crate::domain::RuntimeBinding {
+            session_name: String::from("jefe-agent-live"),
+            launch_signature: crate::domain::LaunchSignatureV1::default(),
+            attached: false,
+            last_seen: None,
+            pane_identity: None,
+            worker_identity: None,
+            lifecycle_generation: 0,
+            worker_identities: Vec::new(),
+        });
+
+        assert_ne!(
+            status_icon(&agent),
+            status_icon(&confirmed),
+            "an unconfirmed agent must be distinguishable from a confirmed one"
+        );
+        assert_ne!(
+            status_role(&agent),
+            status_role(&confirmed),
+            "the glyph colour must not claim health jefe has not observed"
+        );
     }
 }

--- a/src/ui/components/selectable_list_main_tests.rs
+++ b/src/ui/components/selectable_list_main_tests.rs
@@ -117,6 +117,18 @@ fn agent(name: &str, status: AgentStatus) -> Agent {
         std::path::PathBuf::from("/tmp"),
     );
     a.status = status;
+    // Bound, so these projections exercise the status-to-glyph mapping rather
+    // than the unconfirmed-state indicator (issue #541).
+    a.runtime_binding = Some(crate::domain::RuntimeBinding {
+        session_name: format!("jefe-{name}"),
+        launch_signature: crate::domain::LaunchSignatureV1::default(),
+        attached: false,
+        last_seen: None,
+        pane_identity: None,
+        worker_identity: None,
+        lifecycle_generation: 0,
+        worker_identities: Vec::new(),
+    });
     a
 }
 

--- a/src/ui/components/selectable_list_tests.rs
+++ b/src/ui/components/selectable_list_tests.rs
@@ -93,6 +93,18 @@ fn agent(name: &str, status: AgentStatus) -> Agent {
         std::path::PathBuf::from("/tmp"),
     );
     a.status = status;
+    // Bound, so these projections exercise the status-to-glyph mapping rather
+    // than the unconfirmed-state indicator (issue #541).
+    a.runtime_binding = Some(crate::domain::RuntimeBinding {
+        session_name: format!("jefe-{name}"),
+        launch_signature: crate::domain::LaunchSignatureV1::default(),
+        attached: false,
+        last_seen: None,
+        pane_identity: None,
+        worker_identity: None,
+        lifecycle_generation: 0,
+        worker_identities: Vec::new(),
+    });
     a
 }
 

--- a/tests/psmux_uncertainty_perturbation.rs
+++ b/tests/psmux_uncertainty_perturbation.rs
@@ -1,0 +1,267 @@
+//! E4 perturbation suite against a real psmux (jefe issue #541, V8).
+//!
+//! Every other test in this issue reasons about uncertainty with a fabricated
+//! observation. That proves the classifier, not the probe: a hand-built
+//! `Unavailable` cannot show that a real psmux, perturbed in a realistic way,
+//! actually produces one. These tests perturb a live server and assert the
+//! invariant end to end.
+//!
+//! Each case is written as a contrast, because the invariant has two failure
+//! directions and pinning only one of them is how "fail closed" quietly became
+//! "never closed" earlier in this issue:
+//!
+//! * a question that was **answered** must still reach a verdict -- otherwise
+//!   holding everything forever would pass a one-sided suite;
+//! * a question that could **not be asked** must not reach one.
+//!
+//! Skips rather than fails when psmux is absent, unless `JEFE_REQUIRE_PSMUX`
+//! is set, which is how the other psmux suites here behave.
+
+#![cfg(all(windows, feature = "psmux-smoke"))]
+
+use std::cell::RefCell;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use jefe::domain::WorkerProcessIdentity;
+use jefe::runtime::{
+    LocalPlatform, MultiplexerIsolation, MultiplexerPlan, ServerLivenessObservation,
+    WorkerDisposition, observe_server_liveness, observe_worker_disposition,
+};
+
+static NAMESPACE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+struct ServerCleanup {
+    plan: MultiplexerPlan,
+}
+
+impl Drop for ServerCleanup {
+    fn drop(&mut self) {
+        let _ = self.plan.command().arg("kill-server").status();
+    }
+}
+
+fn psmux_executable() -> PathBuf {
+    std::env::var_os("JEFE_PSMUX_BIN")
+        .filter(|value| !value.is_empty())
+        .map_or_else(|| PathBuf::from("psmux"), PathBuf::from)
+}
+
+fn psmux_test_context() -> Option<(MultiplexerPlan, ServerCleanup)> {
+    let executable = psmux_executable();
+    if Command::new(&executable).arg("-V").output().is_err() {
+        assert!(
+            std::env::var_os("JEFE_REQUIRE_PSMUX").is_none(),
+            "psmux is required but {} is unavailable",
+            executable.display()
+        );
+        return None;
+    }
+    let plan = match MultiplexerPlan::for_platform(
+        LocalPlatform::Windows,
+        executable,
+        MultiplexerIsolation::Namespace(unique_namespace()),
+    ) {
+        Ok(plan) => plan,
+        Err(error) => panic!("construct psmux plan: {error}"),
+    };
+    let cleanup = ServerCleanup { plan: plan.clone() };
+    Some((plan, cleanup))
+}
+
+/// A plan built against a genuine psmux that is then removed from underneath
+/// it -- the E4 "rebuild" perturbation.
+///
+/// Neither shortcut works here, and both failures are informative:
+/// `for_platform` rejects a path that does not exist, and it also rejects a
+/// real executable that is not official psmux (the qualification gate from
+/// #540). So the only way to reach a probe that cannot get an answer is to
+/// pass qualification honestly and *then* take the binary away, which is
+/// exactly what a rebuild or reinstall does to a running jefe.
+///
+/// Returns `None` when the copy cannot be made, so the suite skips rather
+/// than reporting a false failure on a machine where the temporary directory
+/// is not writable.
+fn plan_whose_binary_disappears() -> Option<MultiplexerPlan> {
+    let source = psmux_executable();
+    let copy = std::env::temp_dir().join(format!("{}-psmux.exe", unique_namespace()));
+    std::fs::copy(&source, &copy).ok()?;
+
+    let plan = match MultiplexerPlan::for_platform(
+        LocalPlatform::Windows,
+        copy.clone(),
+        MultiplexerIsolation::Namespace(unique_namespace()),
+    ) {
+        Ok(plan) => plan,
+        Err(error) => panic!("a copy of the real psmux must qualify: {error}"),
+    };
+
+    // The plan is now valid and points at nothing.
+    std::fs::remove_file(&copy).ok()?;
+    Some(plan)
+}
+
+fn unique_namespace() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let sequence = NAMESPACE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    format!("jefe-issue541-{}-{nanos}-{sequence}", std::process::id())
+}
+
+fn run(plan: &MultiplexerPlan, args: &[&str]) -> Output {
+    match plan.command().args(args).output() {
+        Ok(output) => output,
+        Err(error) => panic!("psmux {args:?} could not start: {error}"),
+    }
+}
+
+fn assert_success(output: &Output, operation: &str) {
+    assert!(
+        output.status.success(),
+        "{operation} failed: status={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+}
+
+/// Perturbation: the server jefe was talking to is destroyed and a different
+/// one takes its place under the same namespace.
+///
+/// This is the case that produced phantom agents. The replacement answers
+/// every query perfectly well -- it simply knows nothing about the sessions
+/// the previous server owned, so "healthy server, no such session" is exactly
+/// how a live agent gets buried.
+#[test]
+fn a_replaced_server_is_not_mistaken_for_the_one_we_were_watching() {
+    let Some((plan, _cleanup)) = psmux_test_context() else {
+        return;
+    };
+    assert_success(
+        &run(&plan, &["new-session", "-d", "-s", "perturb-a"]),
+        "create the original server",
+    );
+
+    let applied = RefCell::new(None);
+    let baseline = observe_server_liveness(&plan, None, &applied);
+    let ServerLivenessObservation::Healthy(Some(original)) = baseline else {
+        panic!("expected a healthy first observation, got {baseline:?}");
+    };
+
+    assert_success(&run(&plan, &["kill-server"]), "destroy the original server");
+    assert_success(
+        &run(&plan, &["new-session", "-d", "-s", "perturb-b"]),
+        "start a replacement server in the same namespace",
+    );
+
+    let after = observe_server_liveness(&plan, Some(&original), &applied);
+    assert_ne!(
+        after,
+        ServerLivenessObservation::Healthy(Some(original.clone())),
+        "a replacement server must not be reported as the server we were watching"
+    );
+    match after {
+        ServerLivenessObservation::Healthy(Some(replacement)) => assert_ne!(
+            replacement, original,
+            "the replacement must be distinguishable from the original"
+        ),
+        ServerLivenessObservation::Gone | ServerLivenessObservation::Replaced { .. } => {}
+        other => panic!("a replaced server must be observable as such, got {other:?}"),
+    }
+}
+
+/// Perturbation: the multiplexer binary is removed while jefe is using it.
+///
+/// The result must be "I could not get an answer", never "I asked and there
+/// was nothing there". This is the shape of the very first collapse in this
+/// issue, where a failed scan returned an empty inventory that read as every
+/// agent being gone.
+#[test]
+fn a_multiplexer_that_vanished_yields_uncertainty_not_an_empty_answer() {
+    if psmux_test_context().is_none() {
+        return;
+    }
+    let Some(plan) = plan_whose_binary_disappears() else {
+        return;
+    };
+    let applied = RefCell::new(None);
+
+    let observation = observe_server_liveness(&plan, None, &applied);
+
+    assert_ne!(
+        observation,
+        ServerLivenessObservation::Healthy(None),
+        "a probe that could not run must not be reported as a healthy empty server"
+    );
+    assert!(
+        !matches!(observation, ServerLivenessObservation::Healthy(Some(_))),
+        "a probe that could not run must not manufacture a server identity: {observation:?}"
+    );
+}
+
+/// The contrast that stops the suite being one-sided: a server that really is
+/// gone must still be answered, not held.
+///
+/// Without this, holding unconditionally would satisfy every other assertion
+/// here while leaving jefe unable to ever notice a death.
+#[test]
+fn a_server_that_really_is_gone_is_still_answered() {
+    let Some((plan, _cleanup)) = psmux_test_context() else {
+        return;
+    };
+    assert_success(
+        &run(&plan, &["new-session", "-d", "-s", "perturb-gone"]),
+        "create a server to then destroy",
+    );
+
+    let applied = RefCell::new(None);
+    let baseline = observe_server_liveness(&plan, None, &applied);
+    let ServerLivenessObservation::Healthy(Some(original)) = baseline else {
+        panic!("expected a healthy observation before the kill, got {baseline:?}");
+    };
+
+    assert_success(&run(&plan, &["kill-server"]), "destroy the server");
+
+    assert_eq!(
+        observe_server_liveness(&plan, Some(&original), &applied),
+        ServerLivenessObservation::Gone,
+        "a genuinely absent server must reach a verdict, or nothing can ever be reaped"
+    );
+}
+
+/// Perturbation: a worker anchor recorded without a start token, probed while
+/// the process is unambiguously alive.
+///
+/// A token-less anchor cannot rule out PID reuse, so the honest answer is
+/// "unverifiable". Reporting it gone would bury a live agent; reporting it
+/// alive would be the mirror, and both were real defects in this issue.
+#[test]
+fn a_worker_anchor_that_cannot_be_verified_is_not_reported_gone() {
+    let live_but_unverifiable = WorkerProcessIdentity::from_pid(std::process::id());
+
+    let disposition = observe_worker_disposition(&[live_but_unverifiable]);
+
+    assert_ne!(
+        disposition,
+        WorkerDisposition::GoneWithPane,
+        "an anchor that cannot be verified must not be reported as a dead worker"
+    );
+}
+
+/// The mirror of the previous case: an anchor naming a PID that cannot be
+/// running must not be reported as a surviving worker.
+#[test]
+fn an_impossible_worker_anchor_is_not_reported_as_surviving() {
+    // PID 0 is never a live user process on Windows.
+    let impossible = WorkerProcessIdentity::from_pid(0);
+
+    let disposition = observe_worker_disposition(&[impossible]);
+
+    assert_ne!(
+        disposition,
+        WorkerDisposition::SurvivedPane,
+        "an anchor that cannot name a live process must not be reported as surviving"
+    );
+}

--- a/tests/psmux_uncertainty_perturbation.rs
+++ b/tests/psmux_uncertainty_perturbation.rs
@@ -85,9 +85,12 @@ fn psmux_test_context() -> Option<(MultiplexerPlan, ServerCleanup)> {
 /// than reporting a false failure on a machine where the temporary directory
 /// is not writable.
 fn plan_whose_binary_disappears() -> Option<MultiplexerPlan> {
-    let source = psmux_executable();
-    let copy = std::env::temp_dir().join(format!("{}-psmux.exe", unique_namespace()));
-    std::fs::copy(&source, &copy).ok()?;
+    // Qualification requires the file to be named exactly `psmux.exe`, so the
+    // copy is uniquified by its directory rather than by its filename.
+    let directory = std::env::temp_dir().join(unique_namespace());
+    std::fs::create_dir_all(&directory).ok()?;
+    let copy = directory.join("psmux.exe");
+    std::fs::copy(resolved_psmux_path()?, &copy).ok()?;
 
     let plan = match MultiplexerPlan::for_platform(
         LocalPlatform::Windows,
@@ -101,6 +104,29 @@ fn plan_whose_binary_disappears() -> Option<MultiplexerPlan> {
     // The plan is now valid and points at nothing.
     std::fs::remove_file(&copy).ok()?;
     Some(plan)
+}
+
+/// Resolve psmux to a real file, following `PATH` when the configured value is
+/// a bare command name.
+///
+/// `psmux_executable` may legitimately return just `psmux`, which names a
+/// program but not a file. Copying it would fail, and because the copy helper
+/// reports failure by skipping, that silently turned this test into a no-op
+/// locally while it ran for real in CI. Resolving the path first is what makes
+/// the test actually execute wherever psmux exists.
+fn resolved_psmux_path() -> Option<PathBuf> {
+    let configured = psmux_executable();
+    if configured.components().count() > 1 {
+        return configured.exists().then_some(configured);
+    }
+    let output = Command::new("where").arg(&configured).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let listing = String::from_utf8_lossy(&output.stdout);
+    let first = listing.lines().next()?.trim();
+    let path = PathBuf::from(first);
+    path.exists().then_some(path)
 }
 
 fn unique_namespace() -> String {
@@ -183,9 +209,11 @@ fn a_multiplexer_that_vanished_yields_uncertainty_not_an_empty_answer() {
     if psmux_test_context().is_none() {
         return;
     }
-    let Some(plan) = plan_whose_binary_disappears() else {
-        return;
-    };
+    // Once psmux is known to exist, an unbuildable plan is a fault in this
+    // test rather than a reason to skip. Skipping here is how this case
+    // silently became a no-op locally while it ran for real in CI.
+    let plan = plan_whose_binary_disappears()
+        .unwrap_or_else(|| panic!("psmux is available, so the vanishing-binary plan must build"));
     let applied = RefCell::new(None);
 
     let observation = observe_server_liveness(&plan, None, &applied);

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -11,6 +11,7 @@ use std::process::ExitCode;
 use crate::architecture;
 use crate::clippy_policy;
 use crate::multiplexer_surface;
+use crate::observation_coercion;
 use crate::process::{CommandFailed, CommandPlan, repo_path};
 use crate::source_size;
 use crate::toolchain;
@@ -295,7 +296,7 @@ fn run_windows_coverage() -> Result<(), CommandFailed> {
 fn run_check(rest: &[String]) -> Result<(), CommandFailed> {
     let Some(target) = rest.first() else {
         eprintln!(
-            "usage: cargo xtask check <clippy-allows|source-size|architecture|multiplexer-surface>"
+            "usage: cargo xtask check <clippy-allows|source-size|architecture|multiplexer-surface|observation-coercion>"
         );
         return Err(usage_error("check", "missing policy name"));
     };
@@ -311,6 +312,7 @@ fn run_check(rest: &[String]) -> Result<(), CommandFailed> {
         "source-size" => source_size::run_repo_check(&root),
         "architecture" => architecture::run_repo_check(&root),
         "multiplexer-surface" => multiplexer_surface::run_repo_check(&root),
+        "observation-coercion" => observation_coercion::run_repo_check(&root),
         other => {
             eprintln!("error: unknown check target `{other}`");
             Err(usage_error("check", "unknown policy name"))

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -12,6 +12,7 @@ pub mod architecture;
 pub mod cli;
 pub mod clippy_policy;
 pub mod multiplexer_surface;
+pub mod observation_coercion;
 pub mod process;
 pub mod source_size;
 pub mod toolchain;

--- a/xtask/src/observation_coercion.rs
+++ b/xtask/src/observation_coercion.rs
@@ -1,0 +1,139 @@
+//! Uncertain-observation coercion policy (jefe issue #541, V13).
+//!
+//! `Observed<T>` carries "I could not determine this" as a value so it cannot
+//! be mistaken for an answer. The type deliberately has no `Default`, no
+//! `unwrap_or`, and no `From<Option<T>>`, and `resolve` never shows the
+//! uncertain case to the decision closure.
+//!
+//! But `known()` returns `Option<&T>`, and `Option` brings its own collapsing
+//! combinators back with it. `observed.known().unwrap_or(&dead)` type-checks
+//! and reads innocently, and it is exactly the bug this issue exists to remove:
+//! a failure to determine, silently spent as a determination.
+//!
+//! Nine such collapses were found by hand. This policy fails the build on the
+//! tenth rather than waiting for it to be noticed in production.
+
+use std::path::{Path, PathBuf};
+
+use crate::process::CommandFailed;
+
+/// Accessors that hand back an `Option` wrapping an uncertain observation.
+const UNCERTAIN_ACCESSORS: &[&str] = &["known", "transition", "held", "uncertainty"];
+
+/// `Option` methods that turn "absent" into a usable value without the caller
+/// ever naming the uncertainty.
+const COLLAPSING: &[&str] = &[
+    "unwrap_or",
+    "unwrap_or_default",
+    "unwrap_or_else",
+    "map_or",
+    "map_or_else",
+    "is_some_and",
+    "unwrap",
+    "expect",
+];
+
+const SCAN_ROOTS: &[&str] = &["src"];
+
+/// # Errors
+///
+/// Fails when a source line spends an uncertain observation as an answer,
+/// listing each site so the offending line is named rather than merely
+/// counted.
+pub fn run_repo_check(root: &Path) -> Result<(), CommandFailed> {
+    let mut offences: Vec<String> = Vec::new();
+
+    for scan_root in SCAN_ROOTS {
+        for file in rust_sources(&root.join(scan_root)) {
+            let Ok(text) = std::fs::read_to_string(&file) else {
+                continue;
+            };
+            let relative = file
+                .strip_prefix(root)
+                .unwrap_or(&file)
+                .display()
+                .to_string();
+            // The policy's own documentation spells out the pattern it bans.
+            if relative
+                .replace('\\', "/")
+                .ends_with("xtask/src/observation_coercion.rs")
+            {
+                continue;
+            }
+            for (number, line) in text.lines().enumerate() {
+                if let Some(found) = coercion_on_line(line) {
+                    offences.push(format!("{relative}:{}: {found}", number + 1));
+                }
+            }
+        }
+    }
+
+    if offences.is_empty() {
+        return Ok(());
+    }
+
+    let mut message = String::from("an uncertain observation was spent as if it were an answer:\n");
+    for offence in &offences {
+        message.push_str("  ");
+        message.push_str(offence);
+        message.push('\n');
+    }
+    message.push_str(
+        "\nMatch the uncertain case explicitly and hold, or use `resolve`, which\n\
+         cannot show the undetermined case to a decision.\n",
+    );
+    Err(failure(message))
+}
+
+/// Detect an uncertain accessor whose `Option` is immediately collapsed.
+///
+/// Deliberately literal: it looks for the two spellings adjacent on one line,
+/// which is how every instance in this issue was actually written. A caller
+/// determined to launder the value through a binding will not be caught, and
+/// that is the accepted limit -- the policy exists to stop the easy mistake,
+/// not to prove a negative.
+fn coercion_on_line(line: &str) -> Option<String> {
+    let code = line.split("//").next().unwrap_or(line);
+    for accessor in UNCERTAIN_ACCESSORS {
+        let needle = format!(".{accessor}()");
+        let mut search_from = 0;
+        while let Some(offset) = code[search_from..].find(&needle) {
+            let after = &code[search_from + offset + needle.len()..];
+            let trimmed = after.trim_start();
+            for collapsing in COLLAPSING {
+                let call = format!(".{collapsing}(");
+                if trimmed.starts_with(&call) {
+                    return Some(format!(".{accessor}(){call}...)"));
+                }
+            }
+            search_from += offset + needle.len();
+        }
+    }
+    None
+}
+
+fn rust_sources(directory: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let Ok(entries) = std::fs::read_dir(directory) else {
+        return found;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            found.extend(rust_sources(&path));
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            found.push(path);
+        }
+    }
+    found
+}
+
+fn failure(message: String) -> CommandFailed {
+    CommandFailed {
+        program: "xtask".into(),
+        args: vec!["check".into(), "observation-coercion".into()],
+        status: None,
+        stdout: Vec::new(),
+        stderr: message.into_bytes(),
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #541.

The premise was that a failed probe must never cause a state transition. Working through it turned up **nine** places where it already did, all the same shape: *failure to determine* and *determined to be X* were literally the same value, so there was no way to tell "I looked and it was dead" from "I could not look".

| where | the collapse |
|---|---|
| liveness scan | probe failed -> `Vec::new()` -> "no agents alive" |
| startup classification | `SessionEvidence::Unavailable` -> `Recoverable` (the #537 cause) |
| worker disposition | "cannot verify" -> `GoneWithPane` (dead) |
| dead-agent reconcile | same collapse on the *main* path, missed by the first fix |
| token-less binding | "cannot look" -> **`Alive`** (the mirror direction) |
| launch signature | cannot compose -> `Dead` (#527) |
| session registration | bookkeeping error -> `Dead` |
| durable read | unreadable file -> **empty state**, then saved over the only copy (#445) |
| missing repository | config not found -> `Dead` |

Each is now `Held`: the agent keeps exactly what it was persisted with, and the uncertainty is carried as a value (`Observed<T>` / `Uncertainty` / `ProbeBoundary`) that cannot be silently coerced into an answer -- `Observed::resolve` never shows the uncertain case to the decision closure.

### The mirror hazard was real

Fail-closed is only safe if the question is asked again. It was not. A held agent keeps `Running` with no binding, and the liveness cycle builds its targets from the runtime's *session map* -- so an agent that was never registered produced no target, the loop saw nothing to do, and it stayed held for the life of the process. Fail-closed had become never-closed.

The periodic pass now re-attempts **adoption** (not liveness -- adoption is the question these agents failed) every 2s for exactly the unresolved set. Both mirror directions are pinned: a bound agent is not re-adopted, an answered-dead agent is not resurrected.

### Operator-visible

Unconfirmed rows render a distinct glyph in yellow instead of looking identical to a healthy agent, and startup reports how many agents it could not check and why. The predicate lives once as `Agent::state_is_unconfirmed`, shared by the UI and the re-adoption pass.

No manual re-probe keybinding: re-adoption already runs every 2 seconds, so a bound action would add a published action id, owner, default chord, keymap persistence and help text to trigger by hand what happens automatically within one poll. Rationale recorded in the plan.

## Things a reviewer should look at hardest

- **I deleted four public functions and several tests.** `pid_alive`, `process_liveness_indicates_alive`, `classify_worker_disposition`, `probe_worker_anchors`. In two cases the deleted tests were *pinning the defective policy* -- `fail_open_policy_covers_every_final_liveness_state` asserted the fail-open behaviour being removed. Leaving a collapsing helper beside a correct one is how the main dead-agent path stayed broken after I first "fixed" it, so they went rather than being deprecated.
- **I changed two existing glyph assertions.** Their fixtures built agents with no binding, so under the new rule those agents were genuinely unconfirmed and the assertions were correct to fail. The fixtures now bind. Worth checking I did not just move the goalposts.
- **One commit message of mine was wrong.** The durable-read commit claimed the operator was told saving had paused; the field reached no renderer. Fixed in a later commit, and the RED for it was run against the code I had actually shipped.
- **A fix of mine amplified an existing bug.** Once re-adoption ran every cycle, the pre-existing `Dead`-on-missing-repository path went from one bad decision at startup to a recurring background one. Corrected here.

## Pre-push checklist

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (native)
- [x] same, `--target x86_64-unknown-linux-gnu`
- [x] `cargo xtask check` source-size / architecture / clippy-allows / multiplexer-surface
- [x] `cargo test --workspace --all-features` -- 28 suites, 0 failures
- [x] Rebased onto `origin/main` (`ba91ac02`), correct ancestry, no conflicts

Only failure across runs is `guarded_dashboard_reorder_tui_scenario` (HAR-E006), which is **intermittent on main and unrelated** -- it passed and failed across runs both before and after these changes. Reported on #591.

## Testing notes

Every behavioural claim was RED-verified by reinstating the specific defect and confirming the failure message, then restoring. Highlights: deleting the durable-read hold turns an unreadable file back into an empty state that overwrites the only copy; making the re-adoption selector match nothing reproduces the permanent-hold behaviour exactly; an anchor for the current process minus its token classifies `GoneWithPane`.

Retry (`retry_observation`) is bounded, returns the *last* uncertainty rather than a default, and takes its sleep as an injected closure -- `std::env::set_var` is unsafe in edition 2024, so all seams here are pure functions rather than env-mutating tests.

## Scope

18 files, +2423/-614 (~1809 net). #541 suspends the file/line budget; stating it for the record.

**V13 landed after the PR was opened.** `cargo xtask check observation-coercion` now fails the build when an uncertain accessor (`known`, `transition`, `held`, `uncertainty`) is immediately collapsed by `unwrap_or`, `unwrap_or_default`, `unwrap_or_else`, `map_or`, `map_or_else`, `is_some_and`, `unwrap` or `expect`, and runs in CI as its own job. The type design alone was not enough: `known()` returns `Option<&T>`, which brings the collapsing combinators straight back. RED-verified by planting the exact pattern.

The check is deliberately literal -- it matches the two spellings adjacent on one line, which is how all nine instances were actually written. Laundering the value through a binding defeats it; that limit is documented in the module rather than papered over.

**E4 landed too.** `tests/psmux_uncertainty_perturbation.rs` perturbs a real psmux five ways, each as a contrast pair: a server replaced under the same namespace is not mistaken for the one being watched; a binary removed mid-flight yields uncertainty rather than an empty inventory; a server that really is gone is still answered (without which holding everything forever would pass the suite); a token-less anchor for a live process is not reported gone; an anchor that cannot name a live process is not reported surviving.

Two shortcuts were rejected by the code itself, which is worth knowing: `for_platform` refuses a path that does not exist, and refuses a real executable that is not official psmux (the #540 gate, which requires the filename to be exactly `psmux`/`psmux.exe`). The only honest route to a probe that cannot answer is to qualify and then remove the binary -- the rebuild case E4 names.

**CI caught a real defect in that suite, and it is worth stating plainly:** the vanishing-binary test passed locally having executed zero assertions. `psmux_executable()` can return the bare name `psmux`, which is a program and not a file, so the copy failed, `None` was treated as "skip", and the test reported ok. Fixed by uniquifying the copy by directory, resolving the source through `where`, and making a skip impossible once psmux is known to exist. Re-verified by inverting the assertion: `left: Unavailable, right: Healthy(None)`.

All thirteen acceptance criteria now have code and passing verification.

## Reviewers & Assignees

@acoliver

