### PR TITLE
Reclaim live sessions that lost their runtime binding (Fixes #585)

### DIFF
--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -664,15 +664,62 @@ fn reclaim_unbound_sessions(
         return false;
     }
 
-    let mut adopted = Vec::new();
-    let mut ambiguous = Vec::new();
-    let mut unowned = Vec::new();
-    let mut revived = Vec::new();
-
-    let Ok(mut ctx_guard) = ctx_arc.lock() else {
+    let decisions = reclaim::classify_reclaimable(&observed, &candidates);
+    let Some(outcome) = adopt_reclaimable(&*app_state, ctx_arc, decisions) else {
         return false;
     };
-    for decision in reclaim::classify_reclaimable(&observed, &candidates) {
+    let ReclaimOutcome {
+        adopted,
+        ambiguous,
+        unowned,
+        revived,
+    } = outcome;
+
+    let report = reclaim::reclaim_report(&adopted, &ambiguous, &unowned);
+    if revived.is_empty() && report.is_none() {
+        return false;
+    }
+    let mut state = app_state.write();
+    apply_restored_state(&mut state, revived, Vec::new(), report);
+    true
+}
+
+/// What one reclaim pass established.
+struct ReclaimOutcome {
+    adopted: Vec<AgentId>,
+    ambiguous: Vec<String>,
+    unowned: Vec<String>,
+    revived: Vec<RevivedAgent>,
+}
+
+/// Drive the runtime for each classified session.
+///
+/// Returns `None` when the runtime lock is unusable, which is the one case
+/// where the pass declines entirely rather than reporting a partial result.
+fn adopt_reclaimable(
+    app_state: &HookState<AppState>,
+    ctx_arc: &std::sync::Arc<std::sync::Mutex<crate::AppContext>>,
+    decisions: Vec<reclaim::ReclaimDecision>,
+) -> Option<ReclaimOutcome> {
+    // A poisoned runtime lock means an earlier panic left the runtime in an
+    // unknown state, so reclaim declines rather than adopting against it. Say
+    // so: skipping silently would make a live agent look abandoned for a reason
+    // the user could never see, which is the very failure this pass exists to
+    // end.
+    let mut ctx_guard = match ctx_arc.lock() {
+        Ok(guard) => guard,
+        Err(error) => {
+            warn!(error = %error, "runtime lock poisoned; skipping session reclaim this startup");
+            return None;
+        }
+    };
+    let mut outcome = ReclaimOutcome {
+        adopted: Vec::new(),
+        ambiguous: Vec::new(),
+        unowned: Vec::new(),
+        revived: Vec::new(),
+    };
+    for decision in decisions {
         match decision {
             reclaim::ReclaimDecision::Adopt(agent_id) => {
                 let Some((work_dir, signature)) = reclaim_inputs(app_state, &agent_id) else {
@@ -683,8 +730,8 @@ fn reclaim_unbound_sessions(
                     .register_existing_local_session(&agent_id, &work_dir, signature)
                 {
                     Ok(binding) => {
-                        adopted.push(agent_id.clone());
-                        revived.push(RevivedAgent {
+                        outcome.adopted.push(agent_id.clone());
+                        outcome.revived.push(RevivedAgent {
                             agent_id,
                             binding: Box::new(binding),
                         });
@@ -694,19 +741,11 @@ fn reclaim_unbound_sessions(
                     }
                 }
             }
-            reclaim::ReclaimDecision::Ambiguous(session) => ambiguous.push(session),
-            reclaim::ReclaimDecision::Unowned(session) => unowned.push(session),
+            reclaim::ReclaimDecision::Ambiguous(session) => outcome.ambiguous.push(session),
+            reclaim::ReclaimDecision::Unowned(session) => outcome.unowned.push(session),
         }
     }
-    drop(ctx_guard);
-
-    let report = reclaim::reclaim_report(&adopted, &ambiguous, &unowned);
-    if revived.is_empty() && report.is_none() {
-        return false;
-    }
-    let mut state = app_state.write();
-    apply_restored_state(&mut state, revived, Vec::new(), report);
-    true
+    Some(outcome)
 }
 
 /// Work directory and launched-with signature for one reclaim candidate.

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -2,6 +2,8 @@
 
 #[path = "app_init_orphan_reconcile.rs"]
 mod orphan_reconcile;
+#[path = "app_init_reclaim.rs"]
+mod reclaim;
 #[path = "app_init_shell_reconcile.rs"]
 mod shell_reconcile;
 #[path = "app_init_signature_reconcile.rs"]
@@ -567,10 +569,15 @@ pub fn restore_runtime_sessions(app_state: &mut HookState<AppState>, ctx: &Share
         apply_restored_state(&mut state, revived_running, newly_dead, runtime_warning);
     }
 
+    // Reclaim runs after restore has settled so it sees the bindings restore
+    // actually established, and before shell reconciliation so an adopted
+    // session's shell window is normalized like any other (issue #585).
+    let reclaimed = reclaim_unbound_sessions(app_state, ctx_arc);
+
     if let Some(warning) = shell_reconcile::reconcile_shell_inventory(app_state, ctx) {
         append_warning(&mut app_state.write(), warning);
     }
-    if state_changed {
+    if state_changed || reclaimed {
         let request = durable_save_request(&mut app_state.write());
         schedule_durable_save(ctx, request);
     }
@@ -620,6 +627,112 @@ fn revive_agent_session(
             ReviveOutcome::Died
         }
     }
+}
+
+/// Re-bind live sessions whose records startup left unbound (issue #585).
+///
+/// Runs after the restore pass has settled, so it sees the bindings restore
+/// actually established rather than the ones the document claimed. A record is
+/// eligible only when it holds no binding at that point, which excludes both a
+/// healthy agent and one deliberately left alone as `Recoverable`.
+///
+/// Adoption goes through `register_existing_local_session`, so session
+/// liveness, pane and worker identity, and PID-reuse rejection all still apply:
+/// this pass widens *what may be reconsidered*, never what counts as proof.
+/// Nothing here launches, sends, kills, or mutates configuration.
+fn reclaim_unbound_sessions(
+    app_state: &mut HookState<AppState>,
+    ctx_arc: &std::sync::Arc<std::sync::Mutex<crate::AppContext>>,
+) -> bool {
+    let candidates: Vec<(AgentId, String)> = {
+        let state = app_state.read();
+        state
+            .agents
+            .iter()
+            .filter(|agent| agent.runtime_binding.is_none())
+            .filter(|agent| {
+                state
+                    .repository_for_agent(&agent.id)
+                    .is_some_and(|repository| !repository.remote.enabled)
+            })
+            .map(|agent| (agent.id.clone(), reclaim::expected_session(&agent.id)))
+            .collect()
+    };
+
+    let observed = jefe::runtime::list_jefe_sessions();
+    if observed.is_empty() {
+        return false;
+    }
+
+    let mut adopted = Vec::new();
+    let mut ambiguous = Vec::new();
+    let mut unowned = Vec::new();
+    let mut revived = Vec::new();
+
+    let Ok(mut ctx_guard) = ctx_arc.lock() else {
+        return false;
+    };
+    for decision in reclaim::classify_reclaimable(&observed, &candidates) {
+        match decision {
+            reclaim::ReclaimDecision::Adopt(agent_id) => {
+                let Some((work_dir, signature)) = reclaim_inputs(app_state, &agent_id) else {
+                    continue;
+                };
+                match ctx_guard
+                    .runtime
+                    .register_existing_local_session(&agent_id, &work_dir, signature)
+                {
+                    Ok(binding) => {
+                        adopted.push(agent_id.clone());
+                        revived.push(RevivedAgent {
+                            agent_id,
+                            binding: Box::new(binding),
+                        });
+                    }
+                    Err(error) => {
+                        warn!(agent_id = %agent_id.0, error = %error, "could not reclaim live session");
+                    }
+                }
+            }
+            reclaim::ReclaimDecision::Ambiguous(session) => ambiguous.push(session),
+            reclaim::ReclaimDecision::Unowned(session) => unowned.push(session),
+        }
+    }
+    drop(ctx_guard);
+
+    let report = reclaim::reclaim_report(&adopted, &ambiguous, &unowned);
+    if revived.is_empty() && report.is_none() {
+        return false;
+    }
+    let mut state = app_state.write();
+    apply_restored_state(&mut state, revived, Vec::new(), report);
+    true
+}
+
+/// Work directory and launched-with signature for one reclaim candidate.
+///
+/// The binding carries the signature the process was *launched* with, taken
+/// from the persisted record; the current configuration is deliberately not
+/// consulted, because it describes the next launch rather than this process
+/// (issue #583).
+fn reclaim_inputs(
+    app_state: &HookState<AppState>,
+    agent_id: &AgentId,
+) -> Option<(std::path::PathBuf, jefe::domain::LaunchSignatureV1)> {
+    let state = app_state.read();
+    let inputs = {
+        let agent = state.agents.iter().find(|agent| agent.id == *agent_id)?;
+        let repository = state.repository_for_agent(agent_id)?;
+        let signature = agent.persisted_launch_signature.clone().or_else(|| {
+            jefe::runtime::launch_compose::launch_signature_from_request(
+                &launch_signature_for_agent(agent, repository),
+            )
+            .ok()
+        })?;
+        (agent.work_dir.clone(), signature)
+    };
+    drop(state);
+    Some(inputs)
 }
 
 /// Apply restored session results to app state and persist.

--- a/src/app_init_reclaim.rs
+++ b/src/app_init_reclaim.rs
@@ -1,0 +1,118 @@
+//! Startup reclaim of live sessions that lost their runtime binding.
+//!
+//! Startup restore walks persisted records and asks whether to believe each
+//! one. That treats the durable document as authority and the live system as
+//! suspect, which is backwards: tmux is ground truth and the document is a
+//! cache of it. A live session that no record claims is not an anomaly to
+//! ignore, it is evidence the cache is wrong.
+//!
+//! Without a reclaim pass, any defect that clears a binding without killing the
+//! session strands the agent permanently: `register_existing_local_session` is
+//! reachable only for an agent already believed to be running, and nothing
+//! observes sessions the document does not already know about. The stranded
+//! agent keeps a worktree, an API budget and a tmux session, doing work nobody
+//! can see or stop. This module closes that class rather than any one trigger.
+//!
+//! Matching is deliberately **forward**: an expected session name is computed
+//! from each record and compared against what was observed. It is never parsed
+//! backwards out of a session name, because
+//! [`RuntimeSession::session_name_for`] is lossy — it collapses every character
+//! outside `[A-Za-z0-9_-]` to `_`, so two distinct agent ids can produce one
+//! session name. Where they do, the match is ambiguous and nothing is adopted.
+
+use jefe::domain::AgentId;
+use jefe::runtime::RuntimeSession;
+
+/// What startup should do about one observed live session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ReclaimDecision {
+    /// Exactly one record expects this session name; re-bind it.
+    Adopt(AgentId),
+    /// More than one record expects this session name, so ownership cannot be
+    /// established. Adopt nothing and say so.
+    Ambiguous(String),
+    /// A live jefe session that no record claims. Report it; never kill it,
+    /// because the process may be doing real work and this pass has no
+    /// authority to decide otherwise.
+    Unowned(String),
+}
+
+/// Classify every observed session against the records eligible for reclaim.
+///
+/// `candidates` are the records that startup did **not** already bind, paired
+/// with the session name each one expects. Records that restore already revived
+/// are excluded by the caller, so a healthy agent is never reconsidered here.
+///
+/// Deterministic and side-effect free: the caller owns observation and the
+/// re-binding that follows.
+#[must_use]
+pub(super) fn classify_reclaimable(
+    observed: &[String],
+    candidates: &[(AgentId, String)],
+) -> Vec<ReclaimDecision> {
+    observed
+        .iter()
+        .map(|session| {
+            let mut matches = candidates
+                .iter()
+                .filter(|(_, expected)| expected == session)
+                .map(|(agent_id, _)| agent_id);
+            match (matches.next(), matches.next()) {
+                (Some(agent_id), None) => ReclaimDecision::Adopt(agent_id.clone()),
+                (Some(_), Some(_)) => ReclaimDecision::Ambiguous(session.clone()),
+                (None, _) => ReclaimDecision::Unowned(session.clone()),
+            }
+        })
+        .collect()
+}
+
+/// Expected session name for one agent record.
+#[must_use]
+pub(super) fn expected_session(agent_id: &AgentId) -> String {
+    RuntimeSession::session_name_for(agent_id)
+}
+
+/// Human-readable summary of a completed reclaim pass.
+///
+/// Returns `None` when there is nothing worth telling the user, so a normal
+/// startup stays silent. Adoption is reported rather than performed quietly:
+/// re-binding an agent changes what the dashboard shows and what the user can
+/// act on, and that should never be a surprise.
+#[must_use]
+pub(super) fn reclaim_report(
+    adopted: &[AgentId],
+    ambiguous: &[String],
+    unowned: &[String],
+) -> Option<String> {
+    let mut parts = Vec::new();
+    if !adopted.is_empty() {
+        let names = adopted
+            .iter()
+            .map(|agent_id| agent_id.0.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        parts.push(format!(
+            "reattached {} still-running agent(s) that had lost their binding: {names}",
+            adopted.len()
+        ));
+    }
+    if !ambiguous.is_empty() {
+        parts.push(format!(
+            "{} live session(s) matched more than one agent and were left alone: {}",
+            ambiguous.len(),
+            ambiguous.join(", ")
+        ));
+    }
+    if !unowned.is_empty() {
+        parts.push(format!(
+            "{} live jefe session(s) match no agent and were left running: {}",
+            unowned.len(),
+            unowned.join(", ")
+        ));
+    }
+    (!parts.is_empty()).then(|| parts.join("; "))
+}
+
+#[cfg(test)]
+#[path = "app_init_reclaim_tests.rs"]
+mod tests;

--- a/src/app_init_reclaim_tests.rs
+++ b/src/app_init_reclaim_tests.rs
@@ -1,0 +1,109 @@
+//! Behavioural tests for startup reclaim classification.
+
+use super::*;
+
+fn agent(id: &str) -> AgentId {
+    AgentId(id.to_owned())
+}
+
+fn candidate(id: &str) -> (AgentId, String) {
+    let agent_id = agent(id);
+    let session = expected_session(&agent_id);
+    (agent_id, session)
+}
+
+/// A live session whose record startup did not bind is adopted.
+///
+/// This is the whole point of the pass: the agent is alive, the record exists,
+/// and before this nothing would ever reconnect them (issue #585).
+#[test]
+fn a_live_session_whose_record_lost_its_binding_is_adopted() {
+    let candidates = vec![candidate("agent-1"), candidate("agent-2")];
+    let observed = vec![expected_session(&agent("agent-2"))];
+
+    assert_eq!(
+        classify_reclaimable(&observed, &candidates),
+        vec![ReclaimDecision::Adopt(agent("agent-2"))]
+    );
+}
+
+/// A live session no record claims is reported, never adopted and never killed.
+#[test]
+fn a_live_session_matching_no_record_is_reported_not_adopted() {
+    let candidates = vec![candidate("agent-1")];
+    let observed = vec!["jefe-agent-unknown".to_owned()];
+
+    assert_eq!(
+        classify_reclaimable(&observed, &candidates),
+        vec![ReclaimDecision::Unowned("jefe-agent-unknown".to_owned())]
+    );
+}
+
+/// `session_name_for` is lossy, so two ids can collide onto one session name.
+///
+/// Ownership cannot be established from a collided name, so nothing is adopted.
+/// Matching forward is what makes this detectable at all: parsing an id back
+/// out of the name would silently pick one of the two.
+#[test]
+fn an_ambiguous_session_name_adopts_nothing() {
+    // Both ids sanitize to `jefe-agent_1`.
+    let dotted = candidate("agent.1");
+    let scored = candidate("agent_1");
+    assert_eq!(
+        dotted.1, scored.1,
+        "fixture requires a genuine sanitizer collision"
+    );
+    let session = dotted.1.clone();
+    let candidates = vec![dotted, scored];
+
+    assert_eq!(
+        classify_reclaimable(std::slice::from_ref(&session), &candidates),
+        vec![ReclaimDecision::Ambiguous(session)]
+    );
+}
+
+/// An agent whose session is genuinely gone is never resurrected: reclaim only
+/// ever considers sessions that were actually observed alive.
+#[test]
+fn a_record_without_a_live_session_is_not_reclaimed() {
+    let candidates = vec![candidate("agent-1")];
+
+    assert!(classify_reclaimable(&[], &candidates).is_empty());
+}
+
+/// Records that startup already bound are excluded by the caller, so a healthy
+/// agent's session is not reconsidered and cannot be double-bound.
+#[test]
+fn a_session_with_no_eligible_candidate_is_unowned_rather_than_adopted() {
+    let observed = vec![expected_session(&agent("agent-live"))];
+
+    assert_eq!(
+        classify_reclaimable(&observed, &[]),
+        vec![ReclaimDecision::Unowned(expected_session(&agent(
+            "agent-live"
+        )))]
+    );
+}
+
+/// A quiet startup says nothing.
+#[test]
+fn an_uneventful_reclaim_reports_nothing() {
+    assert_eq!(reclaim_report(&[], &[], &[]), None);
+}
+
+/// Adoption is announced, never silent, and each class is distinguishable.
+#[test]
+fn the_report_names_what_was_adopted_and_what_was_left_alone() {
+    let report = reclaim_report(
+        &[agent("agent-1")],
+        &["jefe-agent_1".to_owned()],
+        &["jefe-agent-stray".to_owned()],
+    )
+    .unwrap_or_else(|| panic!("a report is expected when something happened"));
+
+    assert!(report.contains("reattached 1"), "{report}");
+    assert!(report.contains("agent-1"), "{report}");
+    assert!(report.contains("more than one agent"), "{report}");
+    assert!(report.contains("jefe-agent-stray"), "{report}");
+    assert!(report.contains("left running"), "{report}");
+}

--- a/src/app_init_reclaim_tests.rs
+++ b/src/app_init_reclaim_tests.rs
@@ -1,4 +1,4 @@
-//! Behavioural tests for startup reclaim classification.
+//! Behavioral tests for startup reclaim classification.
 
 use super::*;
 

--- a/src/runtime/liveness.rs
+++ b/src/runtime/liveness.rs
@@ -516,7 +516,9 @@ fn run_child_with_timeout(
 }
 
 /// List all jefe-managed tmux sessions.
-#[allow(dead_code)]
+///
+/// Used by startup reclaim to observe sessions the durable document does not
+/// know about (issue #585).
 pub fn list_jefe_sessions() -> Vec<String> {
     let Ok(mut command) = tmux_command() else {
         return Vec::new();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -117,8 +117,8 @@ pub use gh_auth::{AuthRunResult, run_device_auth};
 pub use liveness::{
     LivenessIdentity, SessionLiveness, WorkerDisposition, alive_session_set, batch_liveness_check,
     batch_liveness_check_with_identity, check_remote_session_alive, check_session_alive,
-    classify_worker_disposition, parse_alive_sessions, parse_pane_alive, pid_alive,
-    reconcile_dead_agents, reconcile_dead_agents_with_identity, session_liveness,
+    classify_worker_disposition, list_jefe_sessions, parse_alive_sessions, parse_pane_alive,
+    pid_alive, reconcile_dead_agents, reconcile_dead_agents_with_identity, session_liveness,
 };
 pub use manager::{
     AttachInputs, HISTORY_LINE_CAP, LivenessCheck, RuntimeManager, TmuxRuntimeManager,


### PR DESCRIPTION
Fixes #585.

## Problem

Startup walked persisted records and asked whether to believe each one. That treats the durable document as authority and the live system as suspect, which is backwards — tmux is ground truth and the document is a cache of it. A live session that no record claims is not an anomaly to ignore; it is evidence the cache is wrong.

So any defect that cleared a binding without killing the session stranded the agent **permanently**:

- `register_existing_local_session` was reachable only for an agent already believed to be Running (`app_init.rs:405-406` gate).
- `reconcile_shell_inventory` treated an unmatched session as a shell window to kill.
- `list_jefe_sessions` existed and was **never called** — dead code.

Nothing observed sessions the document did not already know about. A stranded agent kept a worktree, an API budget and a tmux session, doing work nobody could see or stop.

Measured on a live installation: 2 of 15 live sessions were stranded this way, each with an agent process that had been working for hours, neither recoverable through any UI action.

## Why the class and not the trigger

#527 fixed one trigger (`definition_hash` drift, after 20 live panes were rewritten as stopped). The defect returned through a different trigger, which was #583. Two further triggers have no issue at all:

- `ProcessLiveness::ReusedPid` or `MalformedIdentity` while the session is alive
- a crash between spawning an agent and persisting its binding

#537 is a fifth. Fixing each individually leaves the class open, and the class has demonstrably reopened at least once. This makes the *consequence* non-terminal however the binding was lost, including ways not yet identified.

## Change

A reclaim pass at startup, in a new `app_init_reclaim` module.

**Ordering.** It runs after restore has settled, so it sees the bindings restore actually established rather than the ones the document claimed, and before shell reconciliation so an adopted session's shell window is normalized like any other.

**Eligibility.** A record qualifies only when it then holds no binding, which excludes both a healthy agent and one deliberately left alone as `Recoverable`. Remote records are excluded — their evidence is not a local session.

**Forward matching.** An expected session name is computed from each record and compared against what was observed; it is never parsed backwards out of a name. `RuntimeSession::session_name_for` is **lossy** — it collapses every character outside `[A-Za-z0-9_-]` to `_` (`src/runtime/session.rs:104-116`) — so two distinct agent ids can produce one session name. Where they do, the match is ambiguous and nothing is adopted. A backwards parse would have hidden that by silently picking one of the two.

## Safety properties

Adoption goes through `register_existing_local_session`, so session liveness, pane and worker identity, and `started_at` PID-reuse rejection all still apply. **This pass widens what may be reconsidered, never what counts as proof.**

- No launch, no send, no kill, no configuration mutation.
- The binding carries the signature the process was **launched** with, from the persisted record — not what the current configuration would produce (#583).
- An agent whose session is genuinely gone is never resurrected: only observed-live sessions are ever considered.
- A live session matching no record is reported and **left running**. This pass has no authority to decide that someone else's process should die.

## Reporting

Adoption is announced, not silent — re-binding an agent changes what the dashboard shows and what the user can act on. A quiet startup stays quiet (`reclaim_report` returns `None` when nothing happened). Each class is distinguishable in the message: adopted, ambiguous, unowned.

## Tests

Seven behavioural tests on the pure classifier:

- `a_live_session_whose_record_lost_its_binding_is_adopted` — the point of the pass
- `a_live_session_matching_no_record_is_reported_not_adopted`
- `an_ambiguous_session_name_adopts_nothing` — uses a genuine sanitizer collision (`agent.1` and `agent_1` both yield `jefe-agent_1`) and asserts the fixture really collides
- `a_record_without_a_live_session_is_not_reclaimed`
- `a_session_with_no_eligible_candidate_is_unowned_rather_than_adopted`
- `an_uneventful_reclaim_reports_nothing`
- `the_report_names_what_was_adopted_and_what_was_left_alone`

## Verification

- `cargo test --workspace --all-features --locked`: **5345 passed, 0 failed**
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- No lint, complexity or coverage threshold changed; no suppression directive added. Two clippy findings surfaced during development (`significant_drop_in_scrutinee`, `cloned_ref_to_slice_refs`) were fixed rather than allowed, and the `#[allow(dead_code)]` on `list_jefe_sessions` was **removed** because the function is now used.

## Not in this PR

Reaping unowned sessions. They are reported and left alone deliberately; deciding to kill an unrecognised process is a separate product decision with its own risk.
