### PR TITLE
Reap the multiplexer server the harness app owns (Fixes #586)

### DIFF
--- a/dev-docs/tmux-scenarios/v1/jsp-llxprt-preview-native.json
+++ b/dev-docs/tmux-scenarios/v1/jsp-llxprt-preview-native.json
@@ -58,7 +58,7 @@
       "env": [
         {
           "name": "JEFE_SOCKET_PATH",
-          "value": "/tmp/jefe-jsp-preview-native.sock"
+          "value": "${workspace}/s"
         },
         {
           "name": "JEFE_LOG_FILE",

--- a/dev-docs/tmux-scenarios/v1/jsp-llxprt-preview.json
+++ b/dev-docs/tmux-scenarios/v1/jsp-llxprt-preview.json
@@ -58,7 +58,7 @@
       "env": [
         {
           "name": "JEFE_SOCKET_PATH",
-          "value": "/tmp/jefe-jsp-preview.sock"
+          "value": "${workspace}/s"
         },
         {
           "name": "JEFE_LOG_FILE",

--- a/src/harness/v1/app_socket.rs
+++ b/src/harness/v1/app_socket.rs
@@ -1,0 +1,73 @@
+//! Reaping the multiplexer server the application under test owns (issue #586).
+//!
+//! The harness kills the launched process group at teardown, which is enough
+//! for anything that stays in it. A tmux server does not: it daemonizes, so it
+//! detaches from the group and survives with no parent. A scenario that points
+//! the application at a socket therefore leaks one server per run, and the
+//! agents inside it, until something kills them by hand.
+//!
+//! The harness cannot reach these through its own cleanup, because
+//! `TmuxDriver::kill_harness_server` and the signal guard both target the
+//! harness's private `-L jefe-harness-<pid>` socket, and the application's
+//! server is somewhere else entirely.
+//!
+//! # Why containment decides this, not presence
+//!
+//! `JEFE_SOCKET_PATH` is a scenario-supplied value, and a scenario could name
+//! any path on the machine — including the developer's real
+//! `jefe-<uid>.sock`. Reaping whatever it names would let a test kill live
+//! agents doing real work. So the socket is reaped **only** when it lies inside
+//! the run's own workspace, which is created and destroyed by this run and
+//! cannot belong to anyone else. Anything outside is left strictly alone.
+//!
+//! That rule also pushes scenarios toward per-run sockets, which is what fixes
+//! the second half of the defect: a fixed shared path collides between
+//! concurrent runs and leaves stale sockets behind.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Environment variable naming the socket the application will serve on.
+pub const APP_SOCKET_ENV: &str = "JEFE_SOCKET_PATH";
+
+/// Decide which multiplexer socket, if any, this run is responsible for
+/// reaping.
+///
+/// Returns the socket only when the resolved environment names one **and** it
+/// is contained by `workspace_root`. A socket outside the workspace belongs to
+/// someone else and is never touched, however the scenario got it there.
+#[must_use]
+pub fn socket_to_reap(
+    environment: &BTreeMap<String, String>,
+    workspace_root: &Path,
+) -> Option<PathBuf> {
+    let raw = environment.get(APP_SOCKET_ENV)?;
+    if raw.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(raw);
+    // A relative path cannot be shown to be contained, so it is not reaped.
+    // Jefe itself ignores a relative `JEFE_SOCKET_PATH` for the same reason.
+    if !path.is_absolute() {
+        return None;
+    }
+    contained(&path, workspace_root).then_some(path)
+}
+
+/// Whether `path` lies within `root`, comparing canonicalized ancestors so a
+/// symlinked or `..`-laden path cannot claim containment it does not have.
+fn contained(path: &Path, root: &Path) -> bool {
+    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    // The socket file itself may not exist yet, so canonicalize its parent.
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let canonical_parent = parent
+        .canonicalize()
+        .unwrap_or_else(|_| parent.to_path_buf());
+    canonical_parent.starts_with(&canonical_root)
+}
+
+#[cfg(test)]
+#[path = "app_socket_tests.rs"]
+mod tests;

--- a/src/harness/v1/app_socket_tests.rs
+++ b/src/harness/v1/app_socket_tests.rs
@@ -111,3 +111,47 @@ fn a_workspace_relative_socket_fits_the_unix_socket_path_limit() {
         socket.display()
     );
 }
+
+/// A symlink inside the workspace pointing outside does not buy containment.
+///
+/// This is the reason containment is decided on canonicalized ancestors rather
+/// than on the path as written: a scenario could otherwise place a link in its
+/// own workspace and have the harness reap a server anywhere on the machine.
+#[cfg(unix)]
+#[test]
+fn a_symlink_escaping_the_workspace_is_not_reaped() {
+    let root = workspace();
+    let elsewhere = workspace();
+    let link = root.path().join("escape");
+    std::os::unix::fs::symlink(elsewhere.path(), &link)
+        .unwrap_or_else(|error| panic!("symlink fixture: {error}"));
+    let through_link = link.join("s");
+
+    assert_eq!(
+        socket_to_reap(&env_with(&through_link.to_string_lossy()), root.path()),
+        None,
+        "a socket reached through a symlink out of the workspace must not be reaped"
+    );
+}
+
+/// A sibling directory sharing a string prefix with the workspace is outside it.
+///
+/// `Path::starts_with` matches whole components, not raw string prefixes, so
+/// `<root>-extra` is correctly not contained by `<root>`. This test exists to
+/// keep that guarantee explicit: if containment were ever rewritten as a string
+/// comparison, a neighbouring directory would silently become reapable.
+#[test]
+fn a_sibling_sharing_a_name_prefix_is_not_reaped() {
+    let parent = workspace();
+    let root = parent.path().join("ws");
+    let sibling = parent.path().join("ws-extra");
+    std::fs::create_dir(&root).unwrap_or_else(|error| panic!("root fixture: {error}"));
+    std::fs::create_dir(&sibling).unwrap_or_else(|error| panic!("sibling fixture: {error}"));
+    let socket = sibling.join("s");
+
+    assert_eq!(
+        socket_to_reap(&env_with(&socket.to_string_lossy()), &root),
+        None,
+        "a sibling whose name merely starts with the workspace name is not inside it"
+    );
+}

--- a/src/harness/v1/app_socket_tests.rs
+++ b/src/harness/v1/app_socket_tests.rs
@@ -1,0 +1,113 @@
+//! Behavioral tests for application-socket reaping (issue #586).
+
+use super::*;
+
+fn env_with(value: &str) -> BTreeMap<String, String> {
+    let mut environment = BTreeMap::new();
+    environment.insert(APP_SOCKET_ENV.to_owned(), value.to_owned());
+    environment
+}
+
+fn workspace() -> tempfile::TempDir {
+    tempfile::tempdir().unwrap_or_else(|error| panic!("workspace temp dir: {error}"))
+}
+
+/// A per-run socket inside the workspace is this run's to clean up.
+#[test]
+fn a_socket_inside_the_workspace_is_reaped() {
+    let root = workspace();
+    let socket = root.path().join("jefe.sock");
+    let environment = env_with(&socket.to_string_lossy());
+
+    assert_eq!(socket_to_reap(&environment, root.path()), Some(socket));
+}
+
+/// A socket outside the workspace belongs to someone else.
+///
+/// This is the property that keeps a scenario from killing the developer's real
+/// jefe server and every live agent in it.
+#[test]
+fn a_socket_outside_the_workspace_is_never_reaped() {
+    let root = workspace();
+    let elsewhere = workspace();
+    let ambient = elsewhere.path().join("jefe-501.sock");
+
+    assert_eq!(
+        socket_to_reap(&env_with(&ambient.to_string_lossy()), root.path()),
+        None
+    );
+}
+
+/// The fixed shared path this defect was reported against is refused.
+#[test]
+fn the_fixed_shared_tmp_socket_is_never_reaped() {
+    let root = workspace();
+
+    assert_eq!(
+        socket_to_reap(&env_with("/tmp/jefe-jsp-preview.sock"), root.path()),
+        None,
+        "a shared /tmp socket is not this run's to kill, which is exactly why \
+         scenarios must use a per-run path instead"
+    );
+}
+
+/// Traversal out of the workspace does not buy containment.
+#[test]
+fn a_path_escaping_the_workspace_with_dotdot_is_not_reaped() {
+    let root = workspace();
+    let escaping = root.path().join("..").join("escaped.sock");
+
+    assert_eq!(
+        socket_to_reap(&env_with(&escaping.to_string_lossy()), root.path()),
+        None
+    );
+}
+
+/// Nothing to reap when the scenario never asked for a socket.
+#[test]
+fn an_absent_or_empty_socket_variable_reaps_nothing() {
+    let root = workspace();
+
+    assert_eq!(socket_to_reap(&BTreeMap::new(), root.path()), None);
+    assert_eq!(socket_to_reap(&env_with(""), root.path()), None);
+}
+
+/// A relative path cannot be shown to be contained, so it is left alone.
+///
+/// Jefe ignores a relative `JEFE_SOCKET_PATH` for the same reason.
+#[test]
+fn a_relative_socket_path_is_not_reaped() {
+    let root = workspace();
+
+    assert_eq!(socket_to_reap(&env_with("jefe.sock"), root.path()), None);
+}
+
+/// A workspace-relative socket must still fit the kernel's `sun_path` limit.
+///
+/// This is not theoretical margin. On macOS the temp directory canonicalizes
+/// through `/private`, which costs 57 bytes before the workspace name is even
+/// added, and the workspace name carries a pid, a sequence and a nanosecond
+/// hex stamp. `${workspace}/jefe.sock` measures 107 bytes against a 104-byte
+/// kernel limit and would simply fail to bind; the one-character name the
+/// scenarios use measures 99.
+///
+/// Pinning it here means a future rename of the workspace prefix fails this
+/// test instead of silently breaking the preview scenarios at run time.
+#[test]
+fn a_workspace_relative_socket_fits_the_unix_socket_path_limit() {
+    /// The same conservative bound `runtime::socket` applies, below the
+    /// 104-byte macOS and 108-byte Linux kernel limits.
+    const SAFE_LIMIT: usize = 100;
+
+    let workspace = crate::harness::v1::workspace::Workspace::allocate()
+        .unwrap_or_else(|error| panic!("workspace must allocate: {error}"));
+    let socket = workspace.root().join("s");
+    let length = socket.as_os_str().len();
+
+    assert!(
+        length <= SAFE_LIMIT,
+        "a workspace-relative socket must fit the sun_path limit, but {} is {length} bytes; \
+         either the workspace name grew or the socket name did",
+        socket.display()
+    );
+}

--- a/src/harness/v1/mod.rs
+++ b/src/harness/v1/mod.rs
@@ -12,6 +12,7 @@ pub mod action_capture_sink;
 #[cfg(test)]
 #[path = "action_capture_tests.rs"]
 mod action_capture_tests;
+pub mod app_socket;
 pub mod capture;
 pub mod contract;
 pub mod env;

--- a/src/harness/v1/mod.rs
+++ b/src/harness/v1/mod.rs
@@ -12,6 +12,9 @@ pub mod action_capture_sink;
 #[cfg(test)]
 #[path = "action_capture_tests.rs"]
 mod action_capture_tests;
+// Serves the Unix PTY runner only; gated with it so the Windows build does
+// not carry a module whose tests need the Unix-only workspace.
+#[cfg(unix)]
 pub mod app_socket;
 pub mod capture;
 pub mod contract;

--- a/src/harness/v1/runner.rs
+++ b/src/harness/v1/runner.rs
@@ -74,6 +74,7 @@ pub fn run(scenario: &ScenarioV1, config: &RunnerConfig) -> RunOutcome {
         config,
         workspace,
         session: None,
+        app_socket: None,
         capture_names: Vec::new(),
         report: Report::new(&scenario.name, &root),
     };
@@ -102,6 +103,9 @@ struct RunState<'a> {
     config: &'a RunnerConfig,
     workspace: Workspace,
     session: Option<PtySession>,
+    /// Multiplexer socket the application under test owns, when this run is
+    /// responsible for reaping it (issue #586).
+    app_socket: Option<std::path::PathBuf>,
     capture_names: Vec<String>,
     report: Report,
 }
@@ -134,6 +138,7 @@ impl RunState<'_> {
             });
             if let Err(err) = result {
                 self.cleanup_after_failure();
+                self.reap_app_socket();
                 return Some(err);
             }
         }
@@ -219,10 +224,35 @@ impl RunState<'_> {
         }
         let argv = interpolate_argv(argv, &root)?;
         let resolved = resolve_program(&argv, &environment)?;
+        // A tmux server the application starts daemonizes out of the launched
+        // process group, so killing that group at teardown never reaches it.
+        // Remember the socket now, while the resolved environment is in hand,
+        // so teardown can reap it (issue #586).
+        self.app_socket = super::app_socket::socket_to_reap(&environment, self.workspace.root());
         let session =
             PtySession::launch(&resolved, &environment, &cwd_abs, self.scenario.terminal)?;
         self.session = Some(session);
         Ok(())
+    }
+
+    /// Kill the multiplexer server the application owned, if this run is
+    /// responsible for one.
+    ///
+    /// Best effort by design: the server may already be gone, may never have
+    /// started, or tmux may be absent. None of those is a scenario failure, and
+    /// a teardown that could fail the run would turn a leak into a flake.
+    fn reap_app_socket(&mut self) {
+        let Some(socket) = self.app_socket.take() else {
+            return;
+        };
+        let _ = std::process::Command::new("tmux")
+            .arg("-S")
+            .arg(&socket)
+            .arg("kill-server")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
     }
 
     fn send_key(&mut self, key: &str, modifiers: &[Modifier]) -> Result<(), HarnessError> {
@@ -378,10 +408,12 @@ impl RunState<'_> {
     /// Finish: graceful stop then escalation, always reaping the group.
     fn finish(&mut self) -> Result<(), HarnessError> {
         let Some(mut session) = self.session.take() else {
+            self.reap_app_socket();
             return Ok(());
         };
         let exit = self.stop_session(&mut session)?;
         self.record_exit(exit);
+        self.reap_app_socket();
         Ok(())
     }
 


### PR DESCRIPTION
Fixes #586.

## Problem

The JSP preview scenarios pointed the application under test at fixed, shared socket paths:

```
/tmp/jefe-jsp-preview.sock
/tmp/jefe-jsp-preview-native.sock
```

Nothing could reap a server there. `TmuxDriver::kill_harness_server` (`tmux_driver.rs:468`) and the #375 `SignalCleanupGuard` both target the harness's private `-L jefe-harness-<pid>` socket. The PTY teardown kills the launched process group — which a tmux server leaves, because it **daemonizes**. So every run that did not exit cleanly leaked a server and every agent inside it.

Measured before the fix: **13 leaked processes, ~1.9 GB resident**, aged 45 minutes to over 5 hours, all reparented to init. Nine were real LLxprt fixture agents on a single socket, meaning nine separate runs had each leaked one.

The existing protections were not bypassed — the sessions were placed outside their scope.

## Change

The harness records the socket the application will own, taken from the resolved launch environment at launch time, and kills that server on both the finish and failure paths.

Both scenarios move to a per-run `${workspace}` socket, which additionally ends the collision between concurrent runs and the stale sockets a fixed path left behind.

## Containment decides what may be reaped

`JEFE_SOCKET_PATH` is scenario-supplied and could name **any** path on the machine — including the developer's real `jefe-<uid>.sock`. Reaping whatever it named would let a test kill live agents doing real work.

So a socket is reaped **only** when it lies inside the run's own workspace, which this run created and destroys:

- containment is decided on **canonicalized ancestors**, so a symlinked or `..`-laden path cannot claim it;
- a **relative** path is refused outright, because containment cannot be shown (jefe ignores a relative `JEFE_SOCKET_PATH` for the same reason);
- anything outside the workspace is left strictly alone.

`the_fixed_shared_tmp_socket_is_never_reaped` pins that the exact path this defect was reported against would *not* be reaped, which is precisely why scenarios must use a per-run path instead.

## A trap worth recording

The obvious spelling, `${workspace}/jefe.sock`, **does not work**.

On macOS the temp directory canonicalizes through `/private`, costing 57 bytes before the workspace name is added, and the workspace name carries a pid, a sequence and a nanosecond hex stamp:

| path | bytes |
|---|---|
| `${workspace}/jefe.sock` | **107** |
| `${workspace}/s` | **99** |
| kernel `sun_path` limit (macOS) | 104 |
| conservative bound already used by `runtime::socket` | 100 |

`jefe.sock` would simply fail to bind. `a_workspace_relative_socket_fits_the_unix_socket_path_limit` allocates a real workspace and asserts the resulting path fits, so a later rename of the workspace prefix fails *there* rather than silently breaking the preview scenarios at run time.

## Best effort by design

Reaping ignores its outcome: the server may already be gone, may never have started, or tmux may be absent. None of those is a scenario failure, and a teardown that could fail the run would convert a leak into a flake.

## Tests

Seven behavioral tests on the containment rule:

- `a_socket_inside_the_workspace_is_reaped`
- `a_socket_outside_the_workspace_is_never_reaped` — the property that protects real agents
- `the_fixed_shared_tmp_socket_is_never_reaped`
- `a_path_escaping_the_workspace_with_dotdot_is_not_reaped`
- `an_absent_or_empty_socket_variable_reaps_nothing`
- `a_relative_socket_path_is_not_reaped`
- `a_workspace_relative_socket_fits_the_unix_socket_path_limit`

## Verification

- `cargo test --workspace --all-features --locked`: **5391 passed, 0 failed**
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- No lint, complexity or coverage threshold changed; no suppression directive added.

## Not in this PR

The leaked `slow-tool` fixture observed alongside these came from a *different* harness workspace and is not explained by the socket issue — it suggests a fixture can outlive its run even on the harness socket. Recorded in #586 rather than folded in here.
