### PR TITLE
Key the managed cache on the resolved version (Fixes #588)

### DIFF
--- a/src/runtime/package_runtime.rs
+++ b/src/runtime/package_runtime.rs
@@ -194,11 +194,20 @@ pub fn managed_package_cache_root() -> PathBuf {
         .join("package-versions")
 }
 
-/// Collision-resistant install location based on declared package, binary, and
-/// effective selector.
+/// Collision-resistant install location for one concrete installed version.
+///
+/// `resolved` is the version a moving dist-tag currently points at. Keying on
+/// it rather than on the tag is what makes a tag advance create a *new*
+/// directory instead of rewriting the one live agents are executing from
+/// (issue #588). A pinned selector is already a concrete version, so it passes
+/// `None` and keys on itself.
 #[must_use]
-pub fn managed_install_dir(cache_root: &Path, selection: &PackageSelection) -> PathBuf {
-    cache_root.join(selection_digest(selection).to_hex())
+pub fn managed_install_dir(
+    cache_root: &Path,
+    selection: &PackageSelection,
+    resolved: Option<&str>,
+) -> PathBuf {
+    cache_root.join(selection_digest(selection, resolved).to_hex())
 }
 
 /// Build the exact no-effect package invocation for a resolved candidate.
@@ -214,9 +223,14 @@ pub fn package_invocation(
     let Some(selection) = candidate.package() else {
         return Ok(None);
     };
+    // This predicts a path without installing, so it cannot resolve a moving tag
+    // itself. It uses the version the tag last resolved to when one is
+    // recorded, which is the directory a prepared install would occupy.
+    let remembered = remembered_version(cache_root, selection);
     let invocation = match (target, selection.runner()) {
         (PackageExecutionTarget::Local, PackageRunnerKind::Npm) => PackageInvocation {
-            executable: managed_bin_dir(cache_root, selection).join(selection.binary()),
+            executable: managed_bin_dir(cache_root, selection, remembered.as_deref())
+                .join(selection.binary()),
             wrapper_kind: AgentWrapperKind::Direct,
             prefix: Vec::new(),
             fingerprint: None,
@@ -317,19 +331,52 @@ fn uvx_prefix(selection: &PackageSelection) -> Result<Vec<OsString>, PackageRunt
     ])
 }
 
-fn selection_digest(selection: &PackageSelection) -> DefinitionSha256 {
+/// Digest identifying one immutable installed tree.
+///
+/// The third part is the concrete version when one is known, and the declared
+/// selector otherwise. For a pinned selector those are the same string, so its
+/// cache entry is unchanged. For a moving dist-tag they differ, which is the
+/// whole point: two nightlies get two directories, and installing the newer one
+/// cannot touch the tree an already-running agent is executing (issue #588).
+fn selection_digest(selection: &PackageSelection, resolved: Option<&str>) -> DefinitionSha256 {
+    let declared = selection
+        .selector()
+        .effective(selection.runner())
+        .unwrap_or_default();
     let mut bytes = Vec::new();
     append_digest_part(&mut bytes, selection.package().as_bytes());
     append_digest_part(&mut bytes, selection.binary().as_bytes());
-    append_digest_part(
-        &mut bytes,
-        selection
-            .selector()
-            .effective(selection.runner())
-            .unwrap_or_default()
-            .as_bytes(),
-    );
+    append_digest_part(&mut bytes, resolved.unwrap_or(declared).as_bytes());
     DefinitionSha256::digest(&bytes)
+}
+
+/// File recording the version a moving dist-tag last resolved to.
+///
+/// Keyed on the tag, so it survives the version changing. It exists for the
+/// offline path: without a registry answer the version-keyed directory cannot
+/// be derived, and a user with no network should still launch the build they
+/// already have (issue #588 change 4, issue #584 offline behavior).
+fn tag_pointer_path(cache_root: &Path, selection: &PackageSelection) -> PathBuf {
+    cache_root.join(format!(
+        "{}.version",
+        selection_digest(selection, None).to_hex()
+    ))
+}
+
+/// Version this tag last resolved to, if it has ever been installed here.
+fn remembered_version(cache_root: &Path, selection: &PackageSelection) -> Option<String> {
+    let stored = std::fs::read_to_string(tag_pointer_path(cache_root, selection)).ok()?;
+    let version = stored.trim().to_owned();
+    is_plausible_version(&version).then_some(version)
+}
+
+/// Record the version this tag now resolves to, so the offline path can find it.
+fn remember_version(cache_root: &Path, selection: &PackageSelection, version: &str) {
+    // Advisory only: losing this costs an offline launch, never a live agent.
+    let _ = std::fs::write(
+        tag_pointer_path(cache_root, selection),
+        format!("{version}\n"),
+    );
 }
 
 fn append_digest_part(bytes: &mut Vec<u8>, part: &[u8]) {
@@ -337,8 +384,12 @@ fn append_digest_part(bytes: &mut Vec<u8>, part: &[u8]) {
     bytes.extend_from_slice(part);
 }
 
-fn managed_bin_dir(cache_root: &Path, selection: &PackageSelection) -> PathBuf {
-    bin_dir_of(&managed_install_dir(cache_root, selection))
+fn managed_bin_dir(
+    cache_root: &Path,
+    selection: &PackageSelection,
+    resolved: Option<&str>,
+) -> PathBuf {
+    bin_dir_of(&managed_install_dir(cache_root, selection, resolved))
 }
 
 /// Executable directory inside a managed install tree, published or staged.
@@ -381,22 +432,11 @@ fn marker_contents(selection: &PackageSelection, resolved: Option<&str>) -> Stri
 /// that version when the registry answered, and is `None` when it did not. A
 /// `None` therefore keeps the cached install rather than failing the launch —
 /// offline is a condition to ride out, not an error to raise (issue #584).
-fn cache_hit(
-    install_dir: &Path,
-    bin_dir: &Path,
-    selection: &PackageSelection,
-    resolved: Option<&str>,
-) -> bool {
+fn cache_hit(install_dir: &Path, bin_dir: &Path, selection: &PackageSelection) -> bool {
     let Ok(stored) = std::fs::read_to_string(install_dir.join(INSTALL_MARKER)) else {
         return false;
     };
     if !marker_identity_matches(&stored, selection) {
-        return false;
-    }
-    if selection.selector().is_volatile()
-        && let Some(resolved) = resolved
-        && stored.split('\n').nth(3) != Some(resolved)
-    {
         return false;
     }
     PathSnapshot::for_platform(
@@ -496,7 +536,33 @@ fn prepare_managed_npm_with_lock_policy(
     cache_root: &Path,
     policy: LockPolicy,
 ) -> Result<PackageInvocation, PackageRuntimeError> {
-    let digest = selection_digest(selection).to_hex();
+    std::fs::create_dir_all(cache_root)
+        .map_err(|error| PackageRuntimeError::InstallDirectory(error.to_string()))?;
+
+    // Resolve before anything is keyed, because for a moving dist-tag the
+    // resolved version *is* the cache key. A pinned selector is already a
+    // concrete version and never reaches the registry.
+    //
+    // Resolving outside the lock is deliberate: it is a read-only metadata
+    // query, and the lock is keyed on the result.
+    let resolved = if selection.selector().is_volatile() {
+        resolve_volatile_version(candidate, selection).or_else(|| {
+            // Offline: fall back to the version this tag last resolved to, so
+            // the build the user already has still launches (issue #584).
+            let remembered = remembered_version(cache_root, selection);
+            tracing::warn!(
+                package = selection.package(),
+                recovered = remembered.is_some(),
+                "could not resolve dist-tag against the registry; using the last known version if present"
+            );
+            remembered
+        })
+    } else {
+        None
+    };
+    let resolved_ref = resolved.as_deref();
+
+    let digest = selection_digest(selection, resolved_ref).to_hex();
     // Ordering is always the intra-process digest guard, then the cross-process
     // lock. `digest_guard` outlives `_guard`, and `_guard` outlives `_lock`,
     // so both are released in the reverse order.
@@ -505,10 +571,8 @@ fn prepare_managed_npm_with_lock_policy(
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
-    std::fs::create_dir_all(cache_root)
-        .map_err(|error| PackageRuntimeError::InstallDirectory(error.to_string()))?;
-    let install_dir = managed_install_dir(cache_root, selection);
-    let bin_dir = managed_bin_dir(cache_root, selection);
+    let install_dir = managed_install_dir(cache_root, selection, resolved_ref);
+    let bin_dir = managed_bin_dir(cache_root, selection, resolved_ref);
     let retired = cache_root.join(format!("{RETIRED_PREFIX}{digest}"));
     // Held from before the cache-hit check through the fingerprint capture, so
     // no other process can rewrite the tree under a reader that has already
@@ -521,26 +585,15 @@ fn prepare_managed_npm_with_lock_policy(
         package_install_lock::acquire(&install_lock_path(cache_root, &digest), &digest, policy)?;
     reconcile_interrupted_promotion(&install_dir, &retired, selection, &digest)?;
 
-    // Resolve before consulting the cache: for a volatile selector the cached
-    // tree is only a hit when it holds the version the tag points at *now*. A
-    // pinned selector never moves, so it is never resolved and never reaches
-    // the registry.
-    let resolved = selection
-        .selector()
-        .is_volatile()
-        .then(|| resolve_volatile_version(candidate, selection))
-        .flatten();
-    if selection.selector().is_volatile() && resolved.is_none() {
-        tracing::warn!(
-            package = selection.package(),
-            "could not resolve dist-tag against the registry; using the cached install if present"
-        );
-    }
-
-    if !cache_hit(&install_dir, &bin_dir, selection, resolved.as_deref()) {
+    // The directory is now the version, so a hit needs only identity and a
+    // usable binary; there is no separate freshness question left to ask.
+    if !cache_hit(&install_dir, &bin_dir, selection) {
         let staging = cache_root.join(format!("{STAGING_PREFIX}{digest}"));
-        build_staged_install(candidate, selection, &staging, resolved.as_deref())?;
+        build_staged_install(candidate, selection, &staging, resolved_ref)?;
         promote_staged_install(&staging, &install_dir, &retired, &digest)?;
+    }
+    if let Some(version) = resolved_ref {
+        remember_version(cache_root, selection, version);
     }
 
     let snapshot = PathSnapshot::for_platform(

--- a/src/runtime/package_runtime_lock_tests.rs
+++ b/src/runtime/package_runtime_lock_tests.rs
@@ -44,13 +44,30 @@ const CHILD_TEST_PATH: &str = "runtime::package_runtime::tests::managed_install_
 
 use crate::runtime::commands::shell_escape_single;
 
+/// Version the observing stub reports for a volatile fixture unless a test
+/// moves the tag. The install directory is keyed on the resolved version
+/// (issue #588), so fixtures must derive paths from it.
+#[cfg(unix)]
+const SEEDED_VERSION: &str = "1.0.0";
+
+/// Resolved version a fixture's install will be keyed on: the seeded version
+/// for a moving dist-tag, and `None` for a pinned selector, which is already a
+/// concrete version and keys on itself.
+#[cfg(unix)]
+fn fixture_resolved(candidate: &ResolvedCandidate) -> Option<&'static str> {
+    candidate
+        .package()
+        .is_some_and(|selection| selection.selector().is_volatile())
+        .then_some(SEEDED_VERSION)
+}
+
 /// Published install directory for a resolved managed candidate.
 #[cfg(unix)]
 fn final_install_dir(candidate: &ResolvedCandidate, cache_root: &Path) -> PathBuf {
     let selection = candidate
         .package()
         .unwrap_or_else(|| panic!("candidate carries a package selection"));
-    super::managed_install_dir(cache_root, selection)
+    super::managed_install_dir(cache_root, selection, fixture_resolved(candidate))
 }
 
 /// Shell-safe single-quoted form of a path, so a stub script cannot be broken
@@ -161,7 +178,7 @@ fn observed_candidate(
     executable(bin, "npm", "#!/bin/sh\nexit 0\n");
     let probe = resolve_package(&definition, bin.path(), selector);
     let final_dir = final_install_dir(&probe, cache_root);
-    publish_observed_version(witness, "1.0.0");
+    publish_observed_version(witness, SEEDED_VERSION);
     observing_npm_stub(bin, witness, &final_dir, settle);
     (resolve_package(&definition, bin.path(), selector), final_dir)
 }
@@ -508,7 +525,7 @@ fn a_live_installer_blocks_preparation_with_a_typed_redacted_error() {
     let selection = candidate
         .package()
         .unwrap_or_else(|| panic!("candidate carries a package selection"));
-    let digest = super::selection_digest(selection).to_hex();
+    let digest = super::selection_digest(selection, fixture_resolved(&candidate)).to_hex();
     let final_dir = final_install_dir(&candidate, cache.path());
 
     let _held = crate::runtime::package_install_lock::acquire(
@@ -624,7 +641,7 @@ fn a_promotion_interrupted_after_retiring_restores_the_previous_install() {
     let selection = candidate
         .package()
         .unwrap_or_else(|| panic!("candidate carries a package selection"));
-    let digest = super::selection_digest(selection).to_hex();
+    let digest = super::selection_digest(selection, fixture_resolved(&candidate)).to_hex();
     let retired = cache.path().join(format!(".retired-{digest}"));
     // Reproduce the crash state exactly: published entry retired, nothing
     // published, staging never renamed into place.
@@ -739,6 +756,6 @@ fn retired_path(candidate: &ResolvedCandidate, cache_root: &Path) -> PathBuf {
         .unwrap_or_else(|| panic!("candidate carries a package selection"));
     cache_root.join(format!(
         ".retired-{}",
-        super::selection_digest(selection).to_hex()
+        super::selection_digest(selection, fixture_resolved(candidate)).to_hex()
     ))
 }

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -494,6 +494,49 @@ fn a_registry_version_answer_is_validated_before_it_is_trusted() {
     );
 }
 
+/// Advancing a dist-tag must not destroy the tree a live agent is executing.
+///
+/// The cache is keyed on the tag rather than the resolved version, so every
+/// nightly shares one directory and a refresh reinstalls into the directory
+/// running processes are executing out of, then deletes the tree they came
+/// from. On macOS that deletion makes the running executable's vnode nameless,
+/// so `proc_pidpath` fails, securityd can no longer reconstruct the process's
+/// code identity, and every Keychain operation degrades to a password prompt
+/// that "Always Allow" cannot satisfy (issue #588).
+///
+/// Keying on the resolved version makes an advance create a *new* directory and
+/// leaves the old one untouched, which is what keeps already-running agents
+/// intact.
+#[cfg(unix)]
+#[test]
+fn advancing_a_tag_leaves_the_previous_install_intact() {
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let witness = witness_path(&bin);
+    counting_npm_stub(&bin, &witness);
+    publish_version(&witness, "0.11.0-nightly.1");
+    let candidate = volatile_npm_candidate(&bin, "latest nightly");
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+
+    let first = finalize_local_invocation_inner(&candidate, cache.path())
+        .unwrap_or_else(|error| panic!("first install: {error}"));
+    let first_executable = first.executable().to_path_buf();
+
+    publish_version(&witness, "0.11.0-nightly.2");
+    let second = finalize_local_invocation_inner(&candidate, cache.path())
+        .unwrap_or_else(|error| panic!("advanced install: {error}"));
+
+    assert_ne!(
+        first_executable,
+        second.executable(),
+        "a new resolved version must install to its own path, not overwrite the old one"
+    );
+    assert!(
+        first_executable.exists(),
+        "the tree a live agent is executing from must survive the tag advancing; \
+         deleting it is what strands the process and triggers the Keychain storm"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn volatile_cache_hits_while_the_tag_has_not_moved() {
@@ -581,64 +624,34 @@ fn volatile_selector_uses_the_cached_install_when_the_registry_is_unreachable() 
 
 #[cfg(unix)]
 #[test]
-fn volatile_marker_without_a_resolved_version_re_installs() {
-    // AC3: a legacy/stuck marker (3 lines, no timestamp) for a volatile selector
-    // is treated as stale and re-installed, writing a marker that records the
-// version the dist-tag resolved to.
+fn a_marker_for_a_different_selection_forces_a_reinstall() {
+    // Identity still gates the cache: a directory whose marker describes a
+    // different package or binary is not this selection's install, whatever the
+    // path suggests. The resolved-version line is no longer consulted here,
+    // because the directory is now keyed on that version (issue #588).
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
     let witness = witness_path(&bin);
     counting_npm_stub(&bin, &witness);
+    publish_version(&witness, "0.11.0-nightly.1");
     let candidate = volatile_npm_candidate(&bin, "latest nightly");
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
 
     let first = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("first install: {error}"));
     let install_dir = install_dir_of(first.executable()).to_path_buf();
-    // Simulate a stuck/legacy cache: overwrite the marker with the old 3-line
-    // form (no resolved-version line) while keeping the binary present.
-    let selection = candidate
-        .package()
-        .unwrap_or_else(|| panic!("volatile candidate carries a package selection"));
-    let effective = selection
-        .selector()
-        .effective(selection.runner())
-        .unwrap_or_default();
-    let legacy_marker =
-        format!("{}
-{}
-{}
-", selection.package(), selection.binary(), effective);
-    std::fs::write(install_dir.join(".jefe-installed"), legacy_marker)
-        .unwrap_or_else(|error| panic!("write legacy marker: {error}"));
-    assert_eq!(
-        witness_lines(&witness).len(),
-        1,
-        "setup: one install recorded so far"
-    );
+    std::fs::write(
+        install_dir.join(".jefe-installed"),
+        "some-other-package\nsome-other-binary\nnightly\n",
+    )
+    .unwrap_or_else(|error| panic!("overwrite marker: {error}"));
 
-    // Any `now` should treat the timestamp-less marker as expired.
     finalize_local_invocation_inner(&candidate, cache.path())
-        .unwrap_or_else(|error| panic!("legacy re-resolve: {error}"));
+        .unwrap_or_else(|error| panic!("reinstall after identity mismatch: {error}"));
+
     assert_eq!(
         witness_lines(&witness).len(),
         2,
-        "a timestamp-less volatile marker must trigger a re-install (auto-heal)"
-    );
-    let refreshed = std::fs::read_to_string(install_dir.join(".jefe-installed"))
-        .unwrap_or_else(|error| panic!("read refreshed marker: {error}"));
-    let lines: Vec<&str> = refreshed.lines().collect();
-    assert!(
-        lines.len() >= 4,
-        "refreshed volatile marker must carry a resolved-version line: {refreshed:?}"
-    );
-    // The identity lines must be preserved across the refresh (no corruption).
-    assert_eq!(lines[0], selection.package(), "package line preserved");
-    assert_eq!(lines[1], selection.binary(), "binary line preserved");
-    assert_eq!(lines[2], effective, "effective-selector line preserved");
-    assert_eq!(
-        lines[3], "1.0.0",
-        "the 4th line must record the version the dist-tag resolved to, got {:?}",
-        lines[3]
+        "a marker describing a different selection must force a reinstall"
     );
 }
 
@@ -676,38 +689,45 @@ fn pinned_cache_remains_permanent_hit() {
 
 #[cfg(unix)]
 #[test]
-fn volatile_re_resolve_removes_stale_lockfile() {
-    // AC5 (#554): when a volatile cache expires, `npm install` must not observe a
-    // prior package-lock.json, so the dist-tag is re-resolved instead of reused,
-    // and the stale lockfile must not survive into the refreshed cache entry.
-    // Since #556 this is guaranteed structurally: the re-install is built in a
-    // fresh staging directory and promoted by rename, so nothing from the
-    // previous entry can leak into it.
+fn advancing_a_tag_never_writes_into_the_previous_version_directory() {
+    // A moving dist-tag used to be re-resolved by reinstalling over the same
+    // directory, which is why a stale package-lock.json there mattered. Keying
+    // the cache on the resolved version means an advance builds a *new*
+    // directory and the previous one is never opened again, so nothing a live
+    // agent is executing can be rewritten under it (issue #588).
     let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
     let witness = witness_path(&bin);
     counting_npm_stub(&bin, &witness);
+    publish_version(&witness, "0.11.0-nightly.1");
     let candidate = volatile_npm_candidate(&bin, "latest nightly");
     let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
 
     let first = finalize_local_invocation_inner(&candidate, cache.path())
         .unwrap_or_else(|error| panic!("first install: {error}"));
-    let install_dir = install_dir_of(first.executable()).to_path_buf();
-    // Plant a stale lockfile exactly where npm would leave it.
-    std::fs::write(install_dir.join("package-lock.json"), "stale-lockfile")
-        .unwrap_or_else(|error| panic!("plant stale lockfile: {error}"));
+    let first_dir = install_dir_of(first.executable()).to_path_buf();
+    // Anything at all in the previous directory: if the new install reached
+    // into it, this would be disturbed.
+    std::fs::write(first_dir.join("package-lock.json"), "in-use-by-a-live-agent")
+        .unwrap_or_else(|error| panic!("plant marker file: {error}"));
 
     publish_version(&witness, "0.11.0-nightly.2");
-    finalize_local_invocation_inner(&candidate, cache.path())
-        .unwrap_or_else(|error| panic!("re-resolve after tag moved: {error}"));
+    let second = finalize_local_invocation_inner(&candidate, cache.path())
+        .unwrap_or_else(|error| panic!("advanced install: {error}"));
+    let second_dir = install_dir_of(second.executable()).to_path_buf();
 
-    let lines = witness_lines(&witness);
-    assert_eq!(lines.len(), 2, "a moved dist-tag must re-run npm");
+    assert_ne!(first_dir, second_dir, "an advance must build a new directory");
     assert_eq!(
-        lines[1], "absent",
-        "npm must not see the stale package-lock.json when it re-resolves (got {lines:?})",
+        std::fs::read_to_string(first_dir.join("package-lock.json"))
+            .unwrap_or_else(|error| panic!("previous directory must be intact: {error}")),
+        "in-use-by-a-live-agent",
+        "the previous version directory must not be written to or rebuilt"
     );
-    assert!(
-        !install_dir.join("package-lock.json").exists(),
-        "the stale lockfile must remain absent after the re-resolve completes"
+    // The fresh install still starts from an empty staging directory, so npm
+    // never observes a prior lockfile.
+    let observations = witness_lines(&witness);
+    assert_eq!(observations.len(), 2, "the advance must install once more");
+    assert_eq!(
+        observations[1], "absent",
+        "the new install must not observe a package-lock.json (got {observations:?})"
     );
 }


### PR DESCRIPTION
Fixes #588.

## Problem

The cache directory was keyed on the **dist-tag**, so every nightly shared one directory:

```rust
fn selection_digest(selection: &PackageSelection) -> DefinitionSha256 {
    ...selection.selector().effective(...)   // the string "nightly"
```

Refreshing a tag therefore reinstalled **into the directory live agent processes were executing from**, and `promote_staged_install` then deleted the tree they came from.

On macOS that deletion is destructive in a way a rename is not. The running process survives, but its executable vnode becomes nameless, so `proc_pidpath` returns ENOENT and securityd can no longer reconstruct the process's code identity. It can then evaluate neither the Developer-ID requirement nor the team-ID partition entry on any Keychain item, and falls back to prompting for the login password on **every** protected operation, across every affected agent at once. "Always Allow" cannot help — the caller has no identity left to grant.

## Relationship to #584

#584 implemented this issue's **requested change 1**: resolve a moving tag to a concrete version at launch. That made `nightly` advance. It did **not** change what the advance *does*.

This PR is **requested change 2**, which the issue identifies as sufficient on its own to end the storm: key the cache on the resolved version, so an advance creates a *new* directory and the tree an already-running agent is executing is never opened again.

## Change

`selection_digest` now takes the resolved version and uses it in place of the declared selector. A pinned selector already *is* a concrete version, so its digest and cache entry are unchanged — no cache churn for pinned users.

Resolution moves ahead of the digest and both locks, because the resolved version is now the key the locks are taken on. It is a read-only metadata query, so performing it outside the lock is safe.

Because the directory *is* the version, `cache_hit` loses its freshness question and keeps only identity and a usable binary.

## Offline

The offline path needs a version it cannot ask for. A small pointer file records what a tag last resolved to, keyed on the tag so it survives the version changing. Without a registry answer, preparation falls back to that version's directory and the build the user already has still launches — preserving the behavior #584 introduced.

Losing that pointer costs an offline launch, never a live agent, so writing it is advisory.

## Tests

The headline test is behavioral and reproduces the exact reported harm:

`advancing_a_tag_leaves_the_previous_install_intact` — installs `nightly.1`, advances the tag to `nightly.2`, and asserts the second install lands on a different path **and that the first tree still exists**. Against `main` it fails with both paths equal, and the failing digest is `ee542e3993bd76eff…e924c5` — the same directory hash captured from the live machine in the issue evidence.

Two tests encoded the old model and are **replaced rather than repaired**:

- The legacy-marker auto-heal test: a version-keyed directory carries no staleness, so there is nothing to heal. Identity is still gated, and `a_marker_for_a_different_selection_forces_a_reinstall` keeps that pinned.
- The stale-lockfile test asked that a re-resolve rewrite the same directory cleanly — precisely what this change stops. `advancing_a_tag_never_writes_into_the_previous_version_directory` replaces it, asserting the previous directory is neither rewritten nor rebuilt, and that the fresh install still starts from empty staging.

## Verification

- `cargo test --workspace --all-features --locked`: **5394 passed, 0 failed**
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- No lint, complexity or coverage threshold changed; no suppression directive added.

## Deliberately not attempted

Requested changes 4–6 — a full tag-pointer scheme, reference-counted retention and garbage collection, and refusing a global upgrade while agents are live. Change 2 is the one the issue calls sufficient on its own, and the rest are separable. The pointer file added here is the minimum needed to keep offline launches working, not an implementation of change 4.

One consequence worth stating: existing cache entries for moving tags are keyed on the old scheme and will be reinstalled once, into their new version-keyed directories. That is self-healing and happens at most once per tag.
