### PR TITLE
Decide selector volatility by shape, not by a list of names (Fixes #601)

### DIFF
--- a/src/agent_candidate.rs
+++ b/src/agent_candidate.rs
@@ -176,6 +176,16 @@ fn is_resolvable_spec(value: &str) -> bool {
                     b'.' | b'-' | b'_' | b'^' | b'~' | b'>' | b'<' | b'=' | b'*' | b'+' | b'|'
                 )
         })
+        && pipes_are_doubled(value)
+}
+
+/// Whether every `|` in `value` belongs to a `||` pair.
+///
+/// npm's only use of the character is the range union `||`; a lone `|` is not
+/// syntax npm accepts, so a value carrying one cannot resolve and does not
+/// belong on the resolving path.
+fn pipes_are_doubled(value: &str) -> bool {
+    value.split("||").all(|segment| !segment.contains('|'))
 }
 
 /// Whether `value` is an exact semantic version, and therefore an immutable pin.

--- a/src/agent_candidate.rs
+++ b/src/agent_candidate.rs
@@ -90,17 +90,30 @@ impl VersionSelector {
         matches!(self, Self::Direct)
     }
 
-    /// Whether the selector resolves to a moving package-manager target whose
-    /// published version advances over time (a dist-tag or "latest" sentinel).
+    /// Whether the selector names a moving target whose published version
+    /// advances over time, rather than one immutable build.
     ///
-    /// `Latest` and `LatestNightly` are volatile: a fresh `npm install` may
-    /// resolve them to a newer build each time. `Direct` and `Explicit` are
-    /// not — an explicit version is an immutable pin. The managed install cache
-    /// uses this to re-resolve volatile selectors periodically (issue #554)
-    /// instead of caching the first resolution forever.
+    /// Decided by **shape**, not by a list of known names. A registry may
+    /// define any dist-tag it likes, so enumerating them cannot be exhaustive:
+    /// `glm52-vast`, `beta` and `next` move exactly as `latest` does, and a
+    /// range such as `^1.0.0` moves too. Only an exact version is a pin.
+    ///
+    /// This also fails in the safe direction. An unrecognized shape is
+    /// re-resolved, which costs a metadata query; treating it as a pin instead
+    /// would freeze the agent on whatever happened to be installed first, which
+    /// is the defect in issue #601. An exact version keeps the pinned path, so
+    /// pinned users never pay that query (issue #554).
     #[must_use]
-    pub const fn is_volatile(&self) -> bool {
-        matches!(self, Self::Latest | Self::LatestNightly)
+    pub fn is_volatile(&self) -> bool {
+        match self {
+            Self::Direct => false,
+            Self::Latest | Self::LatestNightly => true,
+            // A value that is not a usable npm spec at all can never be
+            // resolved, so asking the registry about it would spawn a process
+            // and wait, only to fail. Those keep the pinned path and fail at
+            // install exactly as they did before.
+            Self::Explicit(value) => is_resolvable_spec(value) && !is_exact_version(value),
+        }
     }
 
     /// Normalized persisted value; `None` means direct.
@@ -142,6 +155,79 @@ impl VersionSelector {
             }
         }
     }
+}
+
+/// Whether `value` could name something the registry can resolve.
+///
+/// npm dist-tags and ranges draw from a narrow character set. Anything with
+/// whitespace, a shell metacharacter, or other punctuation is not a spec npm
+/// would accept, so it cannot be a moving pointer and there is nothing to gain
+/// by querying it — only a process spawn and a wait before the same failure.
+///
+/// This keeps malformed and hostile values on the path they already took, which
+/// matters because it is the path their behaviour is pinned by tests.
+fn is_resolvable_spec(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 256
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'.' | b'-' | b'_' | b'^' | b'~' | b'>' | b'<' | b'=' | b'*' | b'+' | b'|'
+                )
+        })
+}
+
+/// Whether `value` is an exact semantic version, and therefore an immutable pin.
+///
+/// Accepts `MAJOR.MINOR.PATCH` with optional `-prerelease` and `+build`, which
+/// is the shape npm publishes and the shape `npm view <spec> version` returns.
+/// Everything else — a dist-tag, a range operator, a partial version, a
+/// `v`-prefixed string — is a pointer that can move.
+///
+/// Deliberately strict: a value this rejects is merely re-resolved, while a
+/// value it wrongly accepts is frozen forever (issue #601).
+fn is_exact_version(value: &str) -> bool {
+    // Split off build metadata, then prerelease, leaving the core triple.
+    let (without_build, build) = match value.split_once('+') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (value, None),
+    };
+    if build.is_some_and(|tail| !is_dot_separated_identifier(tail)) {
+        return false;
+    }
+    let (core, prerelease) = match without_build.split_once('-') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (without_build, None),
+    };
+    if prerelease.is_some_and(|tail| !is_dot_separated_identifier(tail)) {
+        return false;
+    }
+    let mut parts = core.split('.');
+    let triple = [parts.next(), parts.next(), parts.next()];
+    parts.next().is_none()
+        && triple
+            .iter()
+            .all(|part| part.is_some_and(is_numeric_identifier))
+}
+
+/// A non-empty run of ASCII digits with no leading zero beyond `0` itself.
+fn is_numeric_identifier(part: &str) -> bool {
+    !part.is_empty()
+        && part.bytes().all(|byte| byte.is_ascii_digit())
+        && (part == "0" || !part.starts_with('0'))
+}
+
+/// Dot-separated prerelease or build identifiers: alphanumerics and hyphens,
+/// each segment non-empty.
+fn is_dot_separated_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value.split('.').all(|segment| {
+            !segment.is_empty()
+                && segment
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        })
 }
 
 /// Version-selector construction error.

--- a/src/agent_candidate_tests.rs
+++ b/src/agent_candidate_tests.rs
@@ -442,6 +442,7 @@ fn moving_selectors_are_volatile_whatever_they_are_called() {
         "~0.11.0",
         ">=1.2.0",
         "1.x",
+        "^1.0.0||^2.0.0",
         "0.11",
         "v0.11.0", // npm accepts it, but it is not an exact version string
     ] {
@@ -474,6 +475,7 @@ fn unresolvable_selectors_do_not_become_volatile() {
         "../../etc/passwd",
         "tag/../escape",
         "$HOME",
+        "1.0.0|rm",
     ] {
         assert!(
             !VersionSelector::normalize(hostile)

--- a/src/agent_candidate_tests.rs
+++ b/src/agent_candidate_tests.rs
@@ -410,9 +410,11 @@ fn version_selector_blank_for_empty_string() {
 }
 
 #[test]
-fn version_selector_volatile_for_moving_sentinels_only() {
-    // Issue #554: only the moving dist-tag sentinels are volatile; an explicit
-    // version is an immutable pin even if its name contains "nightly".
+fn version_selector_volatile_unless_it_is_an_exact_version() {
+    // Volatility is decided by shape, not by a list of known names: a selector
+    // is a pin only when it is an exact version, because anything else is a
+    // pointer the registry may move (issue #601). An exact version is still a
+    // pin even when its prerelease says "nightly" (issue #554).
     assert!(VersionSelector::Latest.is_volatile());
     assert!(VersionSelector::LatestNightly.is_volatile());
     assert!(!VersionSelector::Direct.is_volatile());
@@ -422,6 +424,86 @@ fn version_selector_volatile_for_moving_sentinels_only() {
             .is_volatile(),
         "an explicit nightly version string is pinned, not volatile"
     );
+}
+
+/// Anything that is not an exact version is a pointer the registry can move.
+///
+/// A hard-coded list of sentinel names can never be exhaustive: a registry may
+/// define any dist-tag it likes. Deciding by shape covers custom tags and
+/// ranges alike, and it fails in the safe direction — an unrecognized shape is
+/// re-resolved rather than frozen (issue #601).
+#[test]
+fn moving_selectors_are_volatile_whatever_they_are_called() {
+    for moving in [
+        "glm52-vast", // a real custom dist-tag observed in a live cache
+        "beta",
+        "next",
+        "^1.0.0",
+        "~0.11.0",
+        ">=1.2.0",
+        "1.x",
+        "0.11",
+        "v0.11.0", // npm accepts it, but it is not an exact version string
+    ] {
+        assert!(
+            VersionSelector::normalize(moving)
+                .unwrap_or_else(|error| panic!("selector {moving:?}: {error}"))
+                .is_volatile(),
+            "{moving:?} is a moving pointer and must be re-resolved, not frozen at first install"
+        );
+    }
+}
+
+/// A value npm could never resolve must not become volatile.
+///
+/// Volatility decides whether jefe asks the registry about a selector. Asking
+/// about a value that is not a legal spec spawns a process and waits, only to
+/// fail the same way it would have anyway. Hostile input matters most here: it
+/// keeps shell-metacharacter selectors on the single argv-safe path whose
+/// behaviour is already pinned by the injection tests, instead of widening them
+/// to a second command (issue #601).
+#[test]
+fn unresolvable_selectors_do_not_become_volatile() {
+    // Whitespace is not represented here on purpose: normalization strips it
+    // before this decision is reached, so "0 9 0" arrives as "090", which is
+    // indistinguishable from a tag legitimately named "090".
+    for hostile in [
+        "1.0.0; rm -rf /",
+        "1.0;$(touch nope)",
+        "pkg@1.0.0",
+        "../../etc/passwd",
+        "tag/../escape",
+        "$HOME",
+    ] {
+        assert!(
+            !VersionSelector::normalize(hostile)
+                .unwrap_or_else(|error| panic!("selector {hostile:?}: {error}"))
+                .is_volatile(),
+            "{hostile:?} is not a resolvable spec and must not trigger a registry query"
+        );
+    }
+}
+
+/// An exact version must stay pinned, or every pinned user pays a registry
+/// query per launch for something that cannot move.
+#[test]
+fn exact_versions_remain_pinned() {
+    for exact in [
+        "0.11.0",
+        "1.2.3",
+        "10.20.30",
+        "0.11.0-nightly.260801.19ac22acc",
+        "1.0.0-rc.1",
+        "1.0.0+build.5",
+        "1.0.0-alpha.1+build.5",
+    ] {
+        assert!(
+            !VersionSelector::normalize(exact)
+                .unwrap_or_else(|error| panic!("selector {exact:?}: {error}"))
+                .is_volatile(),
+            "{exact:?} is an exact version and must remain an immutable pin"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #601.

## The defect

Only the two hard-coded sentinels ever advanced:

    matches!(self, Self::Latest | Self::LatestNightly)

Every other moving pointer was classified as an immutable pin, never re-resolved, and keyed in the cache on the literal string the user typed. A live cache shows the shape of it:

    ~/Library/Caches/jefe/package-versions/

    e54a2ebb…/package.json  { "@vybestack/llxprt-code": "glm52-vast" }   <- frozen since first install
    ee542e39…/package.json  { "@vybestack/llxprt-code": "nightly" }      <- advanced, being a sentinel

`glm52-vast` is a dist-tag. The registry re-points it exactly as it re-points `nightly`. jefe pinned it anyway, so that agent runs the build that happened to be current the day it was first launched, permanently.

The type already admitted this could happen. `VersionSelector::Explicit` is documented as holding an

> Explicit npm **tag/spec** or package version.

while `is_volatile` asserted the opposite about the same variant:

> `Direct` and `Explicit` are not — an explicit version is an immutable pin.

Two comments in the same file contradicting each other, and the code implemented the wrong one.

## The change

A registry can define any dist-tag it likes, so a list of names can never be exhaustive. Volatility is decided by **shape**: only an exact version is a pin, because only an exact version cannot move.

This fails in the safe direction. An unrecognized shape costs a metadata query; treating an unrecognized shape as a pin freezes the agent, which is the defect. Exact versions keep the pinned path, so pinned users never pay that query for something that cannot move.

## Volatility also gates whether we talk to the registry

That second role needed care, and it is where the first version of this change was wrong.

Classifying everything non-exact as volatile also sent values npm could never resolve to `npm view`. Two of those are the injection fixtures — `1.0.0; rm -rf /` and a backtick/`$()` payload — which exist to pin the behaviour of hostile input. Widening them to a second command spawns a process and waits, only to fail the same way, and it moves hostile input onto a path its tests were not written against.

So volatility now requires the value to be a spec npm could plausibly resolve. Anything carrying whitespace, a shell metacharacter or other punctuation keeps the pinned path and fails at install exactly as before, on the single argv-safe command whose behaviour is already pinned.

Worth stating plainly: this was caught because the change made a suite that had been passing start failing, and the mechanism turned out to be real rather than incidental.

## Tests

| Test | Pins |
|---|---|
| `moving_selectors_are_volatile_whatever_they_are_called` | custom tags (`glm52-vast`, `beta`, `next`) and ranges (`^1.0.0`, `1.x`, `0.11`) re-resolve |
| `exact_versions_remain_pinned` | exact versions including prerelease and build metadata stay pinned, with no registry query |
| `unresolvable_selectors_do_not_become_volatile` | hostile and malformed values never reach the registry |

`glm52-vast` is in the first list specifically because it is the real tag observed frozen in a live cache.

One expectation was corrected while writing these: `0 9 0` is **not** in the hostile list, because normalization strips whitespace before this decision is reached, so it arrives as `090` and is genuinely indistinguishable from a tag named `090`. The test comment records that rather than leaving it to be rediscovered.

## Verification

Full workspace suite clean at this head: **5397 passed, 0 failed**. `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` both clean.

Two flakes were seen during development and are **not** from this change: `jsp_host_socket::production_host_generates_unique_credentials_delivers_and_revokes` and `harness_v1_fixtures::llxprt_continue_field_fixture_sends_one_exact_issue_prompt`. Both are process/socket timing tests, each passed 3/3 in isolation, a different one failed on each run, and the machine was at load average 119. The final run above is clean.

## Scope

Only the classification changes. Resolution, install, caching and the directory layout are untouched — this makes moving selectors reach the machinery #584 and #588 already built. Because a tag that advances now installs to a new version-keyed directory, it inherits #588's property of not overwriting a tree live agents are running from.

Not addressed here: whether the version field should accept a range at all, and retention of superseded version directories.
