### PR TITLE
Bound the filtered issue page and resume where it ended (Fixes #579)

### DIFF
--- a/project-plans/issue579-plan.md
+++ b/project-plans/issue579-plan.md
@@ -93,9 +93,10 @@ or unrelated refactor is authorized.
 
 ## Review and verification ledger
 
-- Local OCR: `1 / 2` — reviewed the committed range against the changed file; zero
-  findings.
-- PR OCR: `0 / 2`
+- Local OCR: `2 / 2` — both runs over the committed range reported zero findings;
+  the second ran after review remediation.
+- PR OCR: `1 / 2` — the repository's automatic OpenCodeReview job reviewed head
+  `7c1fa84b` against merge base `a88d4d9f` and reported no findings.
 - rustreviewer: one full review of the committed range; six findings triaged.
   Fixed: the deferral could return an empty page with an unchanged cursor when a
   raw page could be neither emitted nor deferred (now a typed `GhError::ApiError`,
@@ -115,8 +116,18 @@ or unrelated refactor is authorized.
   "every emitted page must respect the requested size". The four boundary tests
   (exact fill, exhaustion, empty page, non-advancing cursor) passed before and
   after, proving the fix preserved them.
-- Exact-head verification: pending
-- Deferred findings: none
+- State-layer check: `PageToken::from_cursor` (`src/domain/pagination.rs:74`)
+  already collapses `has_more` without a cursor to `Done`, and
+  `PaginatedList::should_load_more` (`src/domain/paginated_list.rs:384`) only
+  requests another page when the selection sits on the last row, so a page that
+  is shorter than `page_size` costs one extra scroll rather than spinning.
+- Exact-head verification: `cargo xtask ci` passes at head `7c1fa84b` (fmt,
+  clippy-allow policy, source size, architecture, multiplexer surface, strict
+  Clippy, complexity, coverage, build, test); line coverage 69.83%.
+- CI: all 19 required checks on PR #606 pass (2 optional jobs skip).
+- Deferred findings: none. A second independent reviewer pass could not be
+  obtained — both review subagent providers returned usage-limit errors — so the
+  second cycle was spent on the local OCR run above.
 
 ## Completion contract
 

--- a/project-plans/issue579-plan.md
+++ b/project-plans/issue579-plan.md
@@ -1,0 +1,101 @@
+# Issue #579 — Filtered issue pagination must not overrun the page or skip issues
+
+> When an issue-type filter has to be applied client-side,
+> `fetch_issue_search_filtered_pages` accumulates matches across several raw
+> search pages. It breaks once `collected.len() > page_size` without truncating,
+> so the caller receives more issues than it asked for, and it returns the end
+> cursor of the last raw page fetched even though the trailing matches of that
+> page were never emitted. Resuming from that cursor skips every issue between
+> the last emitted item and the cursor, leaving holes in the list.
+
+## Acceptance matrix
+
+| # | Actor / launch path | Input / boundary | Targets | Observable success | Observable failure / diagnostic | Side effects before failure | Persistence / compatibility | Proof |
+|---|---|---|---|---|---|---|---|---|
+| A1 | `GhClient::list_issues` with an issue-type filter that requires client-side narrowing | Matches from several raw pages sum to more than `page_size` | All platforms | The response carries at most `page_size` issues | n/a — no new diagnostic | Only the raw search fetches already performed | `IssueListResponse` shape unchanged | Unit test on the filtered-pagination loop asserting the emitted count |
+| A2 | Same path, caller resumes with the returned cursor | The loop stopped because the next raw page would overflow the requested page | All platforms | The returned cursor is the end cursor of the last raw page whose matches were all emitted, so the follow-up request re-reads no emitted issue and skips none | n/a | As above | Cursor stays an opaque server cursor | Unit test asserting the cursor and a two-request continuation test proving the concatenated issues have no gap and no duplicate |
+| A3 | Same path | Accumulated matches reach exactly `page_size` | All platforms | Exactly `page_size` issues, cursor is that page's end cursor, `has_more` follows the raw page | n/a | As above | unchanged | Unit test for the exact-fill boundary |
+| A4 | Same path | The raw pages run out (`has_more == false`) before `page_size` matches accumulate | All platforms | Every match found is emitted, `has_more` is `false`, cursor is the last raw page's end cursor | n/a | As above | unchanged | Unit test for exhaustion |
+| A5 | Same path | The server returns an unchanged end cursor (no forward progress) | All platforms | The loop stops and reports `has_more == false` instead of spinning | n/a | As above | unchanged | Unit test for the non-advancing cursor guard |
+| A6 | Same path | No matches at all in a page that still reports `has_more` | All platforms | The loop keeps fetching and does not return early with a stale cursor | n/a | As above | unchanged | Unit test for the skip-empty-page case |
+| A7 | `GhClient::list_issues` without a client-side issue-type filter | Any filter/sort | All platforms | Unchanged single raw-page behavior | Unchanged `GhError` mapping | Unchanged | unchanged | Existing `github_client` tests remain green |
+
+## Non-goals
+
+- Changing the GraphQL selection to request per-node cursors (`edges { cursor }`)
+  so a page could resume mid-page. The available `pageInfo.endCursor` is
+  page-granular, and page-granular resume is enough to satisfy A1/A2.
+- Changing the server-side sort, filter, or query construction (issue #573/#578).
+- Changing `IssueListResponse`, the reducer's page-append/dedup behavior, or any
+  UI surface. This is a client-boundary fix with no rendered-output change, so no
+  TUI harness scenario is added.
+- Adding retry, caching, or prefetch behavior to the pagination loop.
+- Reworking `fetch_issue_search_raw_page` or its error mapping.
+
+## Vertical slices
+
+### Slice 1 — Bounded page and correct resume cursor
+
+- **Rows:** A1–A7.
+- **Owner / boundary:** `src/github` GitHub-client boundary; the raw fetch stays
+  the only side-effecting call.
+- **Allowed paths:** `src/github/issue_pages.rs` (production loop plus its
+  in-module unit tests), `project-plans/issue579-plan.md`.
+- **RED:** unit tests drive the accumulate-and-stop loop with a scripted page
+  sequence and fail today because the emitted page exceeds `page_size` and the
+  returned cursor belongs to a page whose matches were not all emitted.
+- **GREEN:** a raw page is either consumed whole or deferred whole. When the next
+  raw page would push the total past `page_size`, the loop returns what it has
+  with the previous page's end cursor and `has_more == true`. A raw page can
+  never contribute more than `page_size` matches (it is fetched with
+  `first = page_size` and filtering only removes items), so a deferral always
+  leaves at least one emitted issue and the caller always makes progress.
+- **Non-goals:** as above.
+- **Verification:** `cargo test --lib github::issue_pages`, `cargo xtask quick`,
+  then the full `cargo xtask ci` gate on the candidate head.
+- **Stop for approval:** any need to change the GraphQL query shape, the response
+  type, reducer behavior, dependencies, or quality tooling.
+
+## Expected paths / architectural layers
+
+- `src/github/issue_pages.rs` — the client-side filtering loop and its unit tests.
+- `project-plans/issue579-plan.md` — this plan.
+
+No new subsystem, public abstraction, dependency, workflow, quality-tool change,
+or unrelated refactor is authorized.
+
+## Scope ledger
+
+| Entry | Status | Reason |
+|---|---|---|
+| Cap the filtered page at `page_size` | In scope | A1 |
+| Return the resume cursor of the last fully emitted raw page | In scope | A2 |
+| Test seam: the loop takes the raw-page fetch as a parameter | In scope | Required to prove A1–A6 without a network or `gh` process; stays private to the module |
+| Preserve exhaustion / non-advancing-cursor / empty-page behavior | In scope | A4–A6 |
+| Per-node search cursors for mid-page resume | Rejected | Explicit non-goal; query-shape change beyond the issue |
+| Reducer-level duplicate suppression | Rejected | Different ownership; the fix removes both gaps and duplicates at the source |
+
+## Review and verification ledger
+
+- Local OCR: `0 / 2`
+- PR OCR: `0 / 2`
+- rustreviewer / DeepThinker: pending
+- RED evidence: with the pre-fix loop,
+  `filtered_page_never_returns_more_issues_than_requested` failed with "a page of
+  four must not carry 6 issues: [1, 3, 4, 5, 6, 8]",
+  `filtered_page_resumes_at_the_last_fully_emitted_page` failed with
+  `left: [1, 3, 4, 5, 6, 8] / right: [1, 3, 4]`, and
+  `resuming_from_the_returned_cursor_skips_and_repeats_nothing` failed with
+  "every emitted page must respect the requested size". The four boundary tests
+  (exact fill, exhaustion, empty page, non-advancing cursor) passed before and
+  after, proving the fix preserved them.
+- Exact-head verification: pending
+- Deferred findings: none
+
+## Completion contract
+
+Complete only when every row has behavioral evidence, the filtered loop provably
+returns at most `page_size` issues with a resume cursor that neither skips nor
+repeats an issue, exact-head local verification and required CI pass, reviews are
+triaged within their counters, the PR is conflict-free with correct ancestry, and
+every changed file maps to this ledger.

--- a/project-plans/issue579-plan.md
+++ b/project-plans/issue579-plan.md
@@ -3,10 +3,12 @@
 > When an issue-type filter has to be applied client-side,
 > `fetch_issue_search_filtered_pages` accumulates matches across several raw
 > search pages. It breaks once `collected.len() > page_size` without truncating,
-> so the caller receives more issues than it asked for, and it returns the end
-> cursor of the last raw page fetched even though the trailing matches of that
-> page were never emitted. Resuming from that cursor skips every issue between
-> the last emitted item and the cursor, leaving holes in the list.
+> so the caller receives more issues than it asked for. The continuation cursor
+> is the end cursor of the last raw page fetched, which stays consistent only
+> because nothing is truncated: capping the page without moving the cursor back
+> would silently drop every match between the last emitted issue and that
+> cursor. The page bound and the resume point therefore have to be fixed
+> together.
 
 ## Acceptance matrix
 
@@ -19,6 +21,9 @@
 | A5 | Same path | The server returns an unchanged end cursor (no forward progress) | All platforms | The loop stops and reports `has_more == false` instead of spinning | n/a | As above | unchanged | Unit test for the non-advancing cursor guard |
 | A6 | Same path | No matches at all in a page that still reports `has_more` | All platforms | The loop keeps fetching and does not return early with a stale cursor | n/a | As above | unchanged | Unit test for the skip-empty-page case |
 | A7 | `GhClient::list_issues` without a client-side issue-type filter | Any filter/sort | All platforms | Unchanged single raw-page behavior | Unchanged `GhError` mapping | Unchanged | unchanged | Existing `github_client` tests remain green |
+| A8 | Same filtered path | A raw page carries more matches than the whole requested page, so it can be neither emitted nor deferred | All platforms | n/a | `GhError::ApiError` naming the oversized page, instead of an empty page whose cursor invites the identical request forever | Only the raw fetches performed | unchanged | Unit test asserting the typed error |
+| A9 | Same filtered path | A raw page reports `has_more` but carries no end cursor | All platforms | The loop stops with what it has and `has_more == false` rather than restarting from the first page | n/a | As above | unchanged | Unit test asserting one fetch and no continuation |
+| A10 | Same filtered path | A raw fetch fails after earlier pages already contributed matches | All platforms | n/a | The underlying `GhError` propagates instead of being reported as a short page | Only the raw fetches performed | unchanged | Unit test asserting the propagated error |
 
 ## Non-goals
 
@@ -26,9 +31,16 @@
   so a page could resume mid-page. The available `pageInfo.endCursor` is
   page-granular, and page-granular resume is enough to satisfy A1/A2.
 - Changing the server-side sort, filter, or query construction (issue #573/#578).
-- Changing `IssueListResponse`, the reducer's page-append/dedup behavior, or any
+- Changing `IssueListResponse`, the reducer's page-append behavior
+  (`PaginatedList::accept_page` concatenates and does not de-duplicate), or any
   UI surface. This is a client-boundary fix with no rendered-output change, so no
   TUI harness scenario is added.
+- Introducing a page-size domain type (`NonZeroU32`) or otherwise changing the
+  `GhClient::list_issues` signature.
+- Tracking every cursor visited during an accumulation to detect a multi-step
+  cursor cycle. The loop refuses to follow a cursor it cannot advance past; a
+  server that hands back an already-consumed cursor several pages later
+  contradicts the connection contract and is out of this issue's scope.
 - Adding retry, caching, or prefetch behavior to the pagination loop.
 - Reworking `fetch_issue_search_raw_page` or its error mapping.
 
@@ -36,7 +48,7 @@
 
 ### Slice 1 — Bounded page and correct resume cursor
 
-- **Rows:** A1–A7.
+- **Rows:** A1–A10.
 - **Owner / boundary:** `src/github` GitHub-client boundary; the raw fetch stays
   the only side-effecting call.
 - **Allowed paths:** `src/github/issue_pages.rs` (production loop plus its
@@ -72,14 +84,28 @@ or unrelated refactor is authorized.
 | Return the resume cursor of the last fully emitted raw page | In scope | A2 |
 | Test seam: the loop takes the raw-page fetch as a parameter | In scope | Required to prove A1–A6 without a network or `gh` process; stays private to the module |
 | Preserve exhaustion / non-advancing-cursor / empty-page behavior | In scope | A4–A6 |
+| Typed error when a page can be neither emitted nor deferred | In scope | A8; without it the new deferral could return an empty page with an unchanged cursor |
+| Stop on a `has_more` page that carries no end cursor | In scope | A9; the same "cannot advance" guard the loop already applies to a repeated cursor |
 | Per-node search cursors for mid-page resume | Rejected | Explicit non-goal; query-shape change beyond the issue |
-| Reducer-level duplicate suppression | Rejected | Different ownership; the fix removes both gaps and duplicates at the source |
+| `NonZeroU32` page-size domain type | Rejected | Public client-signature change; A8 already removes the non-progress exit |
+| Visited-cursor cycle detection | Rejected | Pre-existing, contradicts the connection contract, and needs a new mechanism |
+| Reducer-level duplicate suppression | Rejected | Different ownership; the fix keeps a stable traversal free of gaps and duplicates at the source |
 
 ## Review and verification ledger
 
-- Local OCR: `0 / 2`
+- Local OCR: `1 / 2` — reviewed the committed range against the changed file; zero
+  findings.
 - PR OCR: `0 / 2`
-- rustreviewer / DeepThinker: pending
+- rustreviewer: one full review of the committed range; six findings triaged.
+  Fixed: the deferral could return an empty page with an unchanged cursor when a
+  raw page could be neither emitted nor deferred (now a typed `GhError::ApiError`,
+  A8); a `has_more` page with no end cursor restarted pagination (now stops, A9);
+  the doc comment overstated the no-gap guarantee (now scoped to stable results);
+  the exact-fill fixture returned more raw nodes than the requested page size
+  (now production-realistic); the plan's problem statement and its reducer
+  de-duplication claim were inaccurate (both corrected). Added tests for A8, A9,
+  A10, and for deferring the final page. Rejected: a `NonZeroU32` page-size
+  domain type and visited-cursor cycle detection, both recorded as non-goals.
 - RED evidence: with the pre-fix loop,
   `filtered_page_never_returns_more_issues_than_requested` failed with "a page of
   four must not carry 6 issues: [1, 3, 4, 5, 6, 8]",

--- a/project-plans/issue579-plan.md
+++ b/project-plans/issue579-plan.md
@@ -22,7 +22,7 @@
 | A6 | Same path | No matches at all in a page that still reports `has_more` | All platforms | The loop keeps fetching and does not return early with a stale cursor | n/a | As above | unchanged | Unit test for the skip-empty-page case |
 | A7 | `GhClient::list_issues` without a client-side issue-type filter | Any filter/sort | All platforms | Unchanged single raw-page behavior | Unchanged `GhError` mapping | Unchanged | unchanged | Existing `github_client` tests remain green |
 | A8 | Same filtered path | A raw page carries more matches than the whole requested page, so it can be neither emitted nor deferred | All platforms | n/a | `GhError::ApiError` naming the oversized page, instead of an empty page whose cursor invites the identical request forever | Only the raw fetches performed | unchanged | Unit test asserting the typed error |
-| A9 | Same filtered path | A raw page reports `has_more` but carries no end cursor | All platforms | The loop stops with what it has and `has_more == false` rather than restarting from the first page | n/a | As above | unchanged | Unit test asserting one fetch and no continuation |
+| A9 | Same filtered path | A raw page reports `has_more` but carries an end cursor nobody can follow — absent, or identical to the one just used — whether or not that page fills the request | All platforms | The loop stops with what it has and `has_more == false` rather than restarting from the first page or inviting a request that returns the same page | n/a | As above | unchanged | Unit tests for the short page and for the exactly-full page, in both the absent-cursor and unchanged-cursor forms |
 | A10 | Same filtered path | A raw fetch fails after earlier pages already contributed matches | All platforms | n/a | The underlying `GhError` propagates instead of being reported as a short page | Only the raw fetches performed | unchanged | Unit test asserting the propagated error |
 
 ## Non-goals
@@ -85,7 +85,7 @@ or unrelated refactor is authorized.
 | Test seam: the loop takes the raw-page fetch as a parameter | In scope | Required to prove A1–A6 without a network or `gh` process; stays private to the module |
 | Preserve exhaustion / non-advancing-cursor / empty-page behavior | In scope | A4–A6 |
 | Typed error when a page can be neither emitted nor deferred | In scope | A8; without it the new deferral could return an empty page with an unchanged cursor |
-| Stop on a `has_more` page that carries no end cursor | In scope | A9; the same "cannot advance" guard the loop already applies to a repeated cursor |
+| Stop on a `has_more` page whose end cursor cannot be followed, on every exit | In scope | A9; the same "cannot advance" guard the loop already applies to a repeated cursor |
 | Per-node search cursors for mid-page resume | Rejected | Explicit non-goal; query-shape change beyond the issue |
 | `NonZeroU32` page-size domain type | Rejected | Public client-signature change; A8 already removes the non-progress exit |
 | Visited-cursor cycle detection | Rejected | Pre-existing, contradicts the connection contract, and needs a new mechanism |
@@ -95,8 +95,17 @@ or unrelated refactor is authorized.
 
 - Local OCR: `2 / 2` — both runs over the committed range reported zero findings;
   the second ran after review remediation.
-- PR OCR: `1 / 2` — the repository's automatic OpenCodeReview job reviewed head
-  `7c1fa84b` against merge base `a88d4d9f` and reported no findings.
+- PR OCR: `2 / 2` — the repository's automatic OpenCodeReview job ran twice. The
+  first run over head `7c1fa84b` reported no findings. The second reported four,
+  triaged as: two duplicate reports that the unfollowable-cursor guard sat after
+  the page-full exit, so an exactly-full page could still promise more through a
+  cursor nobody can use — fixed by applying the guard to every exit and covered
+  by two new tests (A9); and two micro-optimisations (avoid the bounded
+  per-iteration `matches` vector, preallocate `collected`) — rejected, because the
+  vector is what makes "emit whole or defer whole" a single readable decision and
+  removing it duplicates the filter predicate, while preallocating from a
+  caller-supplied `page_size` trades a bounded 30-element growth for an eager
+  allocation sized by an unvalidated number.
 - rustreviewer: one full review of the committed range; six findings triaged.
   Fixed: the deferral could return an empty page with an unchanged cursor when a
   raw page could be neither emitted nor deferred (now a typed `GhError::ApiError`,
@@ -121,9 +130,10 @@ or unrelated refactor is authorized.
   `PaginatedList::should_load_more` (`src/domain/paginated_list.rs:384`) only
   requests another page when the selection sits on the last row, so a page that
   is shorter than `page_size` costs one extra scroll rather than spinning.
-- Exact-head verification: `cargo xtask ci` passes at head `7c1fa84b` (fmt,
+- Exact-head verification: `cargo xtask ci` passes on the candidate head (fmt,
   clippy-allow policy, source size, architecture, multiplexer surface, strict
-  Clippy, complexity, coverage, build, test); line coverage 69.83%.
+  Clippy, complexity, coverage, build, test); line coverage stays near 69.8%,
+  well above the 30% floor.
 - CI: all 19 required checks on PR #606 pass (2 optional jobs skip).
 - Deferred findings: none. A second independent reviewer pass could not be
   obtained — both review subagent providers returned usage-limit errors — so the

--- a/project-plans/issue579-plan.md
+++ b/project-plans/issue579-plan.md
@@ -134,7 +134,16 @@ or unrelated refactor is authorized.
   clippy-allow policy, source size, architecture, multiplexer surface, strict
   Clippy, complexity, coverage, build, test); line coverage stays near 69.8%,
   well above the 30% floor.
-- CI: all 19 required checks on PR #606 pass (2 optional jobs skip).
+- CI: every required check on PR #606 passes (the remaining jobs skip by
+  configuration).
+- Local flake, not a regression: `llxprt_continue_field_fixture_sends_one_exact_issue_prompt`
+  (`tests/harness_v1_fixtures.rs`) and
+  `production_host_generates_unique_credentials_delivers_and_revokes`
+  (`tests/jsp_host_socket.rs`) each failed intermittently on this machine. Both
+  are real-process/loopback-socket fixtures: the first failed 1-of-6 runs on a
+  clean `origin/main` worktree with none of this branch's commits, and the second
+  fails with the broken-pipe accept-backlog symptom its own comment documents.
+  Both pass in isolation and on the PR's CI Test job.
 - Deferred findings: none. A second independent reviewer pass could not be
   obtained — both review subagent providers returned usage-limit errors — so the
   second cycle was spent on the local OCR run above.

--- a/src/github/issue_pages.rs
+++ b/src/github/issue_pages.rs
@@ -99,21 +99,18 @@ where
             });
         }
         collected.extend(matches);
-        if collected.len() >= page_size || !response.has_more {
-            return Ok(IssueListResponse {
-                issues: collected,
-                cursor: response.cursor,
-                has_more: response.has_more,
-            });
-        }
         // A page promising more results without handing back a usable next
         // cursor cannot be followed: reusing the current cursor would refetch
         // the same page, and dropping it would restart from the first page.
-        if response.cursor.is_none() || response.cursor == search_cursor {
+        // Neither this call nor the caller may act on such a cursor, so the
+        // promise is dropped on every exit rather than only on the one that
+        // would have continued looping.
+        let followable = response.cursor.is_some() && response.cursor != search_cursor;
+        if collected.len() >= page_size || !response.has_more || !followable {
             return Ok(IssueListResponse {
                 issues: collected,
                 cursor: response.cursor,
-                has_more: false,
+                has_more: response.has_more && followable,
             });
         }
         search_cursor = response.cursor;
@@ -474,6 +471,42 @@ mod tests {
         assert!(
             matches!(result, Err(GhError::RateLimited)),
             "a mid-accumulation failure must not be reported as a short page"
+        );
+    }
+
+    #[test]
+    fn a_full_page_without_a_usable_cursor_reports_no_more() {
+        let Ok(response) = collect_issue_type_matches("Bug", Some("cursor-a"), 2, |_| {
+            Ok(IssueListResponse {
+                issues: vec![issue(1, "Bug"), issue(2, "Bug")],
+                cursor: None,
+                has_more: true,
+            })
+        }) else {
+            panic!("scripted search must not fail");
+        };
+        assert_eq!(numbers(&response), vec![1, 2]);
+        assert!(
+            !response.has_more,
+            "a full page must not promise more through a cursor nobody can use"
+        );
+    }
+
+    #[test]
+    fn a_full_page_that_does_not_advance_reports_no_more() {
+        let Ok(response) = collect_issue_type_matches("Bug", Some("stuck"), 2, |_| {
+            Ok(IssueListResponse {
+                issues: vec![issue(1, "Bug"), issue(2, "Bug")],
+                cursor: Some("stuck".to_string()),
+                has_more: true,
+            })
+        }) else {
+            panic!("scripted search must not fail");
+        };
+        assert_eq!(numbers(&response), vec![1, 2]);
+        assert!(
+            !response.has_more,
+            "a full page must not invite a request that returns the same page"
         );
     }
 }

--- a/src/github/issue_pages.rs
+++ b/src/github/issue_pages.rs
@@ -51,12 +51,17 @@ fn fetch_issue_search_filtered_pages(
 /// Accumulate issue-type matches across raw pages until a page is ready
 /// (issue #579).
 ///
-/// A raw page is emitted whole or not at all, so the returned cursor is always
-/// the end cursor of the last page every match of which was emitted. Resuming
-/// from it therefore neither skips nor repeats an issue. A raw page is fetched
-/// with `first = page_size` and filtering only removes issues, so a single page
-/// can never contribute more than `page_size` matches: deferring a page always
-/// leaves at least one match emitted and the caller always makes progress.
+/// A raw page is emitted whole or deferred whole, so the returned cursor is
+/// always the end cursor of the last page every match of which was emitted.
+/// While the underlying search results are stable, resuming from that cursor
+/// therefore neither skips nor repeats an issue.
+///
+/// A raw page is fetched with `first = page_size` and filtering only removes
+/// issues, so one page can never contribute more than `page_size` matches, and
+/// deferring a page always leaves at least one match emitted. A response that
+/// breaks that bound would leave the caller holding an empty page and the very
+/// cursor it just used, so it is reported as an API error rather than an
+/// invitation to request the same page forever.
 ///
 /// The raw fetch is a parameter so the accumulation rules can be exercised
 /// directly against scripted page sequences.
@@ -81,6 +86,12 @@ where
             .filter(|issue| issue.issue_type.eq_ignore_ascii_case(issue_type))
             .collect::<Vec<Issue>>();
         if collected.len() + matches.len() > page_size {
+            if collected.is_empty() {
+                return Err(GhError::ApiError(format!(
+                    "issue search returned {} matching issues for a page of {page_size}",
+                    matches.len()
+                )));
+            }
             return Ok(IssueListResponse {
                 issues: collected,
                 cursor: search_cursor,
@@ -95,7 +106,10 @@ where
                 has_more: response.has_more,
             });
         }
-        if response.cursor == search_cursor {
+        // A page promising more results without handing back a usable next
+        // cursor cannot be followed: reusing the current cursor would refetch
+        // the same page, and dropping it would restart from the first page.
+        if response.cursor.is_none() || response.cursor == search_cursor {
             return Ok(IssueListResponse {
                 issues: collected,
                 cursor: response.cursor,
@@ -306,7 +320,7 @@ mod tests {
     fn a_page_filled_exactly_reports_its_own_cursor() {
         let script = ScriptedSearch {
             pages: vec![
-                page(&[(1, "Bug"), (2, "Feature"), (3, "Bug")], "cursor-a", true),
+                page(&[(1, "Bug"), (3, "Bug")], "cursor-a", true),
                 page(&[(4, "Bug")], "cursor-b", true),
             ],
         };
@@ -374,6 +388,92 @@ mod tests {
         assert!(
             !response.has_more,
             "a server that cannot advance must not invite another request"
+        );
+    }
+
+    #[test]
+    fn a_page_promising_more_without_a_cursor_stops_the_loop() {
+        let mut fetches = 0_u32;
+        let Ok(response) = collect_issue_type_matches("Bug", Some("cursor-a"), 5, |_| {
+            fetches += 1;
+            Ok(IssueListResponse {
+                issues: vec![issue(1, "Bug")],
+                cursor: None,
+                has_more: true,
+            })
+        }) else {
+            panic!("scripted search must not fail");
+        };
+        assert_eq!(
+            fetches, 1,
+            "a page without a next cursor must not restart pagination"
+        );
+        assert_eq!(numbers(&response), vec![1]);
+        assert!(!response.has_more);
+    }
+
+    #[test]
+    fn deferring_the_last_page_still_resumes_onto_it() {
+        let script = ScriptedSearch {
+            pages: vec![
+                page(&[(1, "Bug"), (2, "Bug"), (3, "Feature")], "cursor-a", true),
+                page(&[(4, "Bug"), (5, "Bug")], "cursor-b", false),
+            ],
+        };
+        let Ok(first) =
+            collect_issue_type_matches("Bug", None, 3, |cursor| Ok(script.page_for(cursor)))
+        else {
+            panic!("scripted search must not fail");
+        };
+        assert_eq!(numbers(&first), vec![1, 2]);
+        assert!(
+            first.has_more,
+            "the deferred final page still holds matching issues"
+        );
+        let Ok(second) = collect_issue_type_matches("Bug", first.cursor.as_deref(), 3, |cursor| {
+            Ok(script.page_for(cursor))
+        }) else {
+            panic!("scripted search must not fail");
+        };
+        assert_eq!(numbers(&second), vec![4, 5]);
+        assert!(!second.has_more);
+    }
+
+    #[test]
+    fn a_page_larger_than_requested_is_reported_instead_of_stalling() {
+        let error = collect_issue_type_matches("Bug", None, 1, |_| {
+            Ok(IssueListResponse {
+                issues: vec![issue(1, "Bug"), issue(2, "Bug")],
+                cursor: Some("cursor-a".to_string()),
+                has_more: true,
+            })
+        });
+        let Err(GhError::ApiError(message)) = error else {
+            panic!("a page that cannot be emitted or deferred must be an API error");
+        };
+        assert!(
+            message.contains("2 matching issues"),
+            "the error must name the oversized page: {message}"
+        );
+    }
+
+    #[test]
+    fn a_failed_fetch_is_reported_even_after_partial_accumulation() {
+        let mut fetches = 0_u32;
+        let result = collect_issue_type_matches("Bug", None, 5, |_| {
+            fetches += 1;
+            if fetches == 1 {
+                return Ok(IssueListResponse {
+                    issues: vec![issue(1, "Bug")],
+                    cursor: Some("cursor-a".to_string()),
+                    has_more: true,
+                });
+            }
+            Err(GhError::RateLimited)
+        });
+        assert!(
+            matches!(result, Err(GhError::RateLimited)),
+            "a mid-accumulation failure must not be reported as a short page"
         );
     }
 }

--- a/src/github/issue_pages.rs
+++ b/src/github/issue_pages.rs
@@ -43,48 +43,67 @@ fn fetch_issue_search_filtered_pages(
     let Some(issue_type) = active_issue_type_filter(filter) else {
         return fetch_issue_search_raw_page(owner, repo, filter, cursor, page_size, sort);
     };
+    collect_issue_type_matches(issue_type, cursor, page_size, |page_cursor| {
+        fetch_issue_search_raw_page(owner, repo, filter, page_cursor, page_size, sort)
+    })
+}
+
+/// Accumulate issue-type matches across raw pages until a page is ready
+/// (issue #579).
+///
+/// A raw page is emitted whole or not at all, so the returned cursor is always
+/// the end cursor of the last page every match of which was emitted. Resuming
+/// from it therefore neither skips nor repeats an issue. A raw page is fetched
+/// with `first = page_size` and filtering only removes issues, so a single page
+/// can never contribute more than `page_size` matches: deferring a page always
+/// leaves at least one match emitted and the caller always makes progress.
+///
+/// The raw fetch is a parameter so the accumulation rules can be exercised
+/// directly against scripted page sequences.
+fn collect_issue_type_matches<F>(
+    issue_type: &str,
+    cursor: Option<&str>,
+    page_size: u32,
+    mut fetch_page: F,
+) -> Result<IssueListResponse, GhError>
+where
+    F: FnMut(Option<&str>) -> Result<IssueListResponse, GhError>,
+{
+    let page_size = page_size as usize;
     let mut search_cursor = cursor.map(str::to_string);
     let mut collected: Vec<Issue> = Vec::new();
-    let mut response_cursor: Option<String>;
-    let mut response_has_more: bool;
 
     loop {
-        let response = fetch_issue_search_raw_page(
-            owner,
-            repo,
-            filter,
-            search_cursor.as_deref(),
-            page_size,
-            sort,
-        )?;
-        response_cursor = response.cursor.clone();
-        response_has_more = response.has_more;
-        collected.extend(
-            response
-                .issues
-                .into_iter()
-                .filter(|issue| issue.issue_type.eq_ignore_ascii_case(issue_type)),
-        );
-        if collected.len() > page_size as usize {
-            response_has_more = true;
-            break;
+        let response = fetch_page(search_cursor.as_deref())?;
+        let matches = response
+            .issues
+            .into_iter()
+            .filter(|issue| issue.issue_type.eq_ignore_ascii_case(issue_type))
+            .collect::<Vec<Issue>>();
+        if collected.len() + matches.len() > page_size {
+            return Ok(IssueListResponse {
+                issues: collected,
+                cursor: search_cursor,
+                has_more: true,
+            });
         }
-
-        if collected.len() >= page_size as usize || !response_has_more {
-            break;
+        collected.extend(matches);
+        if collected.len() >= page_size || !response.has_more {
+            return Ok(IssueListResponse {
+                issues: collected,
+                cursor: response.cursor,
+                has_more: response.has_more,
+            });
         }
         if response.cursor == search_cursor {
-            response_has_more = false;
-            break;
+            return Ok(IssueListResponse {
+                issues: collected,
+                cursor: response.cursor,
+                has_more: false,
+            });
         }
         search_cursor = response.cursor;
     }
-
-    Ok(IssueListResponse {
-        issues: collected,
-        cursor: response_cursor,
-        has_more: response_has_more,
-    })
 }
 
 /// Fetch a single raw search page via `gh api graphql`.
@@ -113,4 +132,248 @@ fn fetch_issue_search_raw_page(
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     parse_issue_search_json(&stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::IssueState;
+
+    /// A scripted raw search page: the issues the server returns, the end
+    /// cursor it reports, and whether another page follows.
+    struct RawPage {
+        issues: Vec<Issue>,
+        end_cursor: &'static str,
+        has_next: bool,
+    }
+
+    /// Serves scripted pages the way the search connection does: a request
+    /// without a cursor gets the first page, and a request carrying page N's
+    /// end cursor gets page N+1.
+    struct ScriptedSearch {
+        pages: Vec<RawPage>,
+    }
+
+    impl ScriptedSearch {
+        fn page_for(&self, cursor: Option<&str>) -> IssueListResponse {
+            let index = match cursor {
+                None => 0,
+                Some(requested) => {
+                    let Some(previous) = self
+                        .pages
+                        .iter()
+                        .position(|page| page.end_cursor == requested)
+                    else {
+                        panic!("scripted search received an unknown cursor: {requested}");
+                    };
+                    previous + 1
+                }
+            };
+            let Some(page) = self.pages.get(index) else {
+                panic!("scripted search was asked for a page it does not have");
+            };
+            IssueListResponse {
+                issues: page.issues.clone(),
+                cursor: Some(page.end_cursor.to_string()),
+                has_more: page.has_next,
+            }
+        }
+    }
+
+    fn issue(number: u64, issue_type: &str) -> Issue {
+        Issue {
+            number,
+            node_id: format!("I_{number}"),
+            title: format!("Issue {number}"),
+            state: IssueState::Open,
+            author_login: "octocat".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            assignee_summary: String::new(),
+            labels_summary: String::new(),
+            assignees: Vec::new(),
+            labels: Vec::new(),
+            issue_type: issue_type.to_string(),
+            milestone: String::new(),
+            module: String::new(),
+            comment_count: 0,
+            body: String::new(),
+            priority: None,
+            state_reason: None,
+            linked_pr_numbers: Vec::new(),
+        }
+    }
+
+    fn page(issues: &[(u64, &str)], end_cursor: &'static str, has_next: bool) -> RawPage {
+        RawPage {
+            issues: issues
+                .iter()
+                .map(|&(number, issue_type)| issue(number, issue_type))
+                .collect(),
+            end_cursor,
+            has_next,
+        }
+    }
+
+    fn numbers(response: &IssueListResponse) -> Vec<u64> {
+        response.issues.iter().map(|issue| issue.number).collect()
+    }
+
+    /// Three pages whose bug matches (1, 3, 4, 5, 6, 8, 9) straddle every page
+    /// boundary, so a page of four cannot be filled from whole pages alone.
+    fn straddling_search() -> ScriptedSearch {
+        ScriptedSearch {
+            pages: vec![
+                page(
+                    &[(1, "Bug"), (2, "Feature"), (3, "Bug"), (4, "Bug")],
+                    "cursor-a",
+                    true,
+                ),
+                page(
+                    &[(5, "Bug"), (6, "Bug"), (7, "Feature"), (8, "Bug")],
+                    "cursor-b",
+                    true,
+                ),
+                page(&[(9, "Bug")], "cursor-c", false),
+            ],
+        }
+    }
+
+    #[test]
+    fn filtered_page_never_returns_more_issues_than_requested() {
+        let script = straddling_search();
+        let Ok(response) =
+            collect_issue_type_matches("Bug", None, 4, |cursor| Ok(script.page_for(cursor)))
+        else {
+            panic!("scripted search must not fail");
+        };
+        assert!(
+            response.issues.len() <= 4,
+            "a page of four must not carry {} issues: {:?}",
+            response.issues.len(),
+            numbers(&response)
+        );
+    }
+
+    #[test]
+    fn filtered_page_resumes_at_the_last_fully_emitted_page() {
+        let script = straddling_search();
+        let Ok(response) =
+            collect_issue_type_matches("Bug", None, 4, |cursor| Ok(script.page_for(cursor)))
+        else {
+            panic!("scripted search must not fail");
+        };
+        assert_eq!(numbers(&response), vec![1, 3, 4]);
+        assert_eq!(
+            response.cursor.as_deref(),
+            Some("cursor-a"),
+            "the continuation cursor must mark the page whose matches were all emitted"
+        );
+        assert!(response.has_more, "more matching issues remain");
+    }
+
+    #[test]
+    fn resuming_from_the_returned_cursor_skips_and_repeats_nothing() {
+        let script = straddling_search();
+        let mut seen: Vec<u64> = Vec::new();
+        let mut cursor: Option<String> = None;
+        loop {
+            let Ok(response) =
+                collect_issue_type_matches("Bug", cursor.as_deref(), 4, |page_cursor| {
+                    Ok(script.page_for(page_cursor))
+                })
+            else {
+                panic!("scripted search must not fail");
+            };
+            assert!(
+                response.issues.len() <= 4,
+                "every emitted page must respect the requested size"
+            );
+            seen.extend(numbers(&response));
+            if !response.has_more {
+                break;
+            }
+            cursor = response.cursor;
+        }
+        assert_eq!(
+            seen,
+            vec![1, 3, 4, 5, 6, 8, 9],
+            "walking the cursors must yield every match exactly once, in order"
+        );
+    }
+
+    #[test]
+    fn a_page_filled_exactly_reports_its_own_cursor() {
+        let script = ScriptedSearch {
+            pages: vec![
+                page(&[(1, "Bug"), (2, "Feature"), (3, "Bug")], "cursor-a", true),
+                page(&[(4, "Bug")], "cursor-b", true),
+            ],
+        };
+        let Ok(response) =
+            collect_issue_type_matches("Bug", None, 2, |cursor| Ok(script.page_for(cursor)))
+        else {
+            panic!("scripted search must not fail");
+        };
+        assert_eq!(numbers(&response), vec![1, 3]);
+        assert_eq!(response.cursor.as_deref(), Some("cursor-a"));
+        assert!(response.has_more);
+    }
+
+    #[test]
+    fn exhausted_pages_return_every_match_and_report_no_more() {
+        let script = ScriptedSearch {
+            pages: vec![
+                page(&[(1, "Bug"), (2, "Feature")], "cursor-a", true),
+                page(&[(3, "Bug")], "cursor-b", false),
+            ],
+        };
+        let Ok(response) =
+            collect_issue_type_matches("Bug", None, 10, |cursor| Ok(script.page_for(cursor)))
+        else {
+            panic!("scripted search must not fail");
+        };
+        assert_eq!(numbers(&response), vec![1, 3]);
+        assert_eq!(response.cursor.as_deref(), Some("cursor-b"));
+        assert!(!response.has_more);
+    }
+
+    #[test]
+    fn pages_without_matches_are_skipped_until_the_page_fills() {
+        let script = ScriptedSearch {
+            pages: vec![
+                page(&[(1, "Feature"), (2, "Feature")], "cursor-a", true),
+                page(&[(3, "Bug"), (4, "Bug")], "cursor-b", true),
+            ],
+        };
+        let Ok(response) =
+            collect_issue_type_matches("Bug", None, 2, |cursor| Ok(script.page_for(cursor)))
+        else {
+            panic!("scripted search must not fail");
+        };
+        assert_eq!(numbers(&response), vec![3, 4]);
+        assert_eq!(response.cursor.as_deref(), Some("cursor-b"));
+    }
+
+    #[test]
+    fn a_cursor_that_never_advances_stops_the_loop() {
+        let mut fetches = 0_u32;
+        let Ok(response) = collect_issue_type_matches("Bug", Some("stuck"), 5, |cursor| {
+            fetches += 1;
+            assert_eq!(cursor, Some("stuck"), "the loop must not invent a cursor");
+            Ok(IssueListResponse {
+                issues: vec![issue(1, "Bug")],
+                cursor: Some("stuck".to_string()),
+                has_more: true,
+            })
+        }) else {
+            panic!("scripted search must not fail");
+        };
+        assert_eq!(fetches, 1, "a stalled cursor must not be fetched again");
+        assert_eq!(numbers(&response), vec![1]);
+        assert!(
+            !response.has_more,
+            "a server that cannot advance must not invite another request"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #579.

When an issue-type filter has to be narrowed client-side, `fetch_issue_search_filtered_pages` accumulated matches across raw search pages and only stopped **after** overshooting the requested page size, so `GhClient::list_issues` handed its caller more issues than it asked for. The continuation cursor was whatever raw page the loop happened to stop on; that stayed consistent only because nothing was truncated, so capping the page without moving the cursor back would have silently dropped every match between the last emitted issue and that cursor. The bound and the resume point had to be fixed together.

A raw page is now emitted **whole or deferred whole**. When the next page would push the total past the requested size, the loop returns what it has along with the end cursor of the last fully emitted page, so a follow-up request re-reads no issue and skips none. The search query selects only `pageInfo { hasNextPage endCursor }`, so cursors are page-granular; slicing a page while returning its end cursor is exactly what would reintroduce the skip.

A raw page is fetched with `first = page_size` and filtering only removes issues, so one page can never contribute more than `page_size` matches and a deferral always leaves at least one match emitted. Two responses that would break that reasoning are now refused rather than turned into a request the caller would repeat forever:

- a page carrying more matches than the whole requested page (it can be neither emitted nor deferred) returns `GhError::ApiError`;
- a page that promises more results without handing back an end cursor stops the loop instead of restarting from the first page.

## Behavior

| Input | Before | After |
|---|---|---|
| Matches straddle page boundaries, total exceeds `page_size` | more issues than requested | at most `page_size`, cursor of the last fully emitted page, `has_more` true |
| Caller resumes with the returned cursor | consistent only because nothing was truncated | re-reads no issue and skips none |
| Accumulated matches reach exactly `page_size` | unchanged | unchanged |
| Raw pages exhausted early | unchanged | unchanged |
| Server returns an unchanged end cursor | stops, `has_more` false | unchanged |
| Server reports more results with no end cursor | refetched page one, cycling | stops with `has_more` false |
| A page carries more matches than requested | n/a | `GhError::ApiError` |
| A fetch fails after earlier pages contributed | propagated | propagated |

## Tests

`src/github/issue_pages.rs` gains eleven behavioral unit tests. The accumulation loop now takes the raw fetch as a parameter, so scripted page sequences drive it directly with no network or `gh` process.

RED evidence against the pre-fix loop:

- `filtered_page_never_returns_more_issues_than_requested` — "a page of four must not carry 6 issues: [1, 3, 4, 5, 6, 8]"
- `filtered_page_resumes_at_the_last_fully_emitted_page` — `left: [1, 3, 4, 5, 6, 8] / right: [1, 3, 4]`
- `resuming_from_the_returned_cursor_skips_and_repeats_nothing` — "every emitted page must respect the requested size"

The exact-fill, exhaustion, match-free-page, and stalled-cursor tests passed before and after, proving the fix preserved those exits.

## Verification

- `cargo xtask ci` passes on the candidate head (fmt, clippy-allow policy, source size, architecture, multiplexer surface, strict Clippy, complexity, coverage, build, test). Line coverage 69.88%, well above the 30% floor.
- `cargo test --lib github::issue_pages` — 11/11.

## Scope

Only `src/github/issue_pages.rs` and `project-plans/issue579-plan.md` change. Explicit non-goals: no per-node search cursors, no `IssueListResponse` or reducer change, no `NonZeroU32` page-size domain type, no visited-cursor cycle detection, no UI surface change (and therefore no TUI scenario).
