### PR TITLE
Make the Actions run list use the detail pane's status glyphs (Fixes #207)

### DIFF
--- a/dev-docs/tmux-scenarios/actions-mode.json
+++ b/dev-docs/tmux-scenarios/actions-mode.json
@@ -67,7 +67,7 @@
     {
       "op": "assert-frame",
       "contains": [
-        "> [X] Inspectable Actions fixture"
+        "> \u2717 Inspectable Actions fixture"
       ],
       "absent": []
     },
@@ -97,7 +97,7 @@
     {
       "op": "wait",
       "source": "frame",
-      "literal": "> [X] Interleaved Actions fixture run",
+      "literal": "> \u2717 Interleaved Actions fixture run",
       "timeout_ms": 15000
     },
     {
@@ -108,7 +108,7 @@
     {
       "op": "wait",
       "source": "frame",
-      "literal": "> [X] Inspectable Actions fixture",
+      "literal": "> \u2717 Inspectable Actions fixture",
       "timeout_ms": 15000
     },
     {

--- a/project-plans/issue207-plan.md
+++ b/project-plans/issue207-plan.md
@@ -68,9 +68,31 @@ other single-codepoint textual symbols; only pictographic emoji are banned.
 
 ## Behavioral verification
 
-- `cargo test --workspace --all-features --locked`
-- `make ci-check`
-- `scripts/issue194-run-scenario.sh` (drives `actions-mode.json` end to end).
+- `cargo xtask ci` (the full local CI-equivalent gate).
+- `scripts/issue194-run-scenario.sh`, which drives `actions-mode.json`.
+
+### Scenario evidence
+
+The committed scenario runner cannot complete on this workstation: 16 unrelated
+live `jefe` sessions make the app print a `WARN: … live jefe session(s) match no
+agent` banner over the title row, so the scenario's first wait for `LLxprt Jefe`
+never matches. Re-running with that first wait anchored on `Repositories`
+instead reaches the run list and captures the accepted behavior:
+
+```
+Workflow Runs
+> ✗ Inspectable Actions fixture
+  ✗ Interleaved Actions fixture run
+  ✓ Oldest Actions fixture run
+```
+
+Both changed run-list literals (`> ✗ Inspectable Actions fixture` and
+`> ✗ Interleaved Actions fixture run`) pass. The run then stops later, inside
+the unchanged job-detail step-collapse sequence, with `frame must not contain
+'Checkout fixture source'`. Rebuilding the same runner against unmodified `main`
+fails at that identical step, so the residual failure is pre-existing and
+environmental, not a regression from this change. Fixing the harness/session
+hygiene is out of scope for #207.
 
 ## Scope ledger
 
@@ -78,5 +100,17 @@ other single-codepoint textual symbols; only pictographic emoji are banned.
 
 ## Review counters
 
-- Local OCR: 0 / 2
+- Local OCR: 1 / 2 (4 files, 1 comment — test enum-iteration staleness, Defer)
 - PR OCR: 0 / 2
+
+## Review triage
+
+| Finding | Source | Class | Action |
+|---------|--------|-------|--------|
+| A10 truncation budget unproven | rustreviewer | In-scope-Fix | Added exact-title truncation tests (ASCII + wide-char) |
+| Non-completed statuses only tested with absent conclusion | rustreviewer | In-scope-Fix | Added `unfinished_runs_ignore_any_conclusion_they_carry` |
+| Glyph one-cell invariant untested | rustreviewer | In-scope-Fix | Added `every_status_glyph_occupies_one_terminal_cell` |
+| Stale `actions_detail` module header | rustreviewer | In-scope-Fix | Header now points at `actions_detail_view` |
+| Plan cited a non-existent `make ci-check` | rustreviewer | In-scope-Fix | Plan cites `cargo xtask ci` |
+| TUI scenario never reached the glyph assertions | rustreviewer | Reject | Pre-existing environmental failure, reproduced identically on `main`; evidence above |
+| Test enum arrays can go stale (`strum::EnumIter` / `ALL` consts) | rustreviewer + OCR | Defer | Needs a new dependency or a domain public-API change; production matches are wildcard-free so a new variant fails to compile first. Enumeration is now single-sourced and documents the obligation |

--- a/project-plans/issue207-plan.md
+++ b/project-plans/issue207-plan.md
@@ -1,0 +1,82 @@
+# Issue #207 — Actions run-list status glyphs must match the detail screen
+
+> The Actions run list renders bracketed text tags (`[OK]`, `[X]`, `[/]`, `[~]`,
+> `[.]`, `[?]`) while the Actions detail pane renders bare single-codepoint
+> glyphs (`✓`, `✗`, `⊘`, `~`, `.`, `?`). Two duplicated `status_glyph`
+> implementations let the screens drift. Fix: one shared projection helper,
+> detail-pane glyph style, no brackets in the run list.
+
+## Accepted behavior
+
+The run list adopts the detail pane's glyph vocabulary exactly, via a single
+shared helper. Both screens call the same function, so the mapping is
+necessarily identical.
+
+| # | Run `status` / `conclusion` | Rendered glyph | Screens |
+|---|-----------------------------|----------------|---------|
+| A1 | `Completed` + `Success` | `✓` (U+2713) | run list + detail |
+| A2 | `Completed` + `Failure` | `✗` (U+2717) | run list + detail |
+| A3 | `Completed` + `TimedOut` / `ActionRequired` / `StartupFailure` | `✗` | run list + detail |
+| A4 | `Completed` + `Cancelled` / `Skipped` / `Stale` / `Neutral` | `⊘` (U+2298) | run list + detail |
+| A5 | `Completed` + `Unknown` or absent conclusion | `?` | run list + detail |
+| A6 | `InProgress` | `~` | run list + detail |
+| A7 | `Queued` / `Requested` / `Waiting` / `Pending` | `.` | run list + detail |
+| A8 | `Unknown` status | `?` | run list + detail |
+| A9 | Any run-list row | no `[` / `]` brackets around the status indicator | run list |
+| A10 | Run-list title truncation | reserves chrome for the 1-cell glyph (prefix + glyph + space), so titles gain the 3 columns the bracketed tag used to consume | run list |
+
+Boundary cases covered by A3/A4/A5: the run list previously collapsed
+`TimedOut`, `ActionRequired`, `StartupFailure`, `Skipped`, `Stale`, `Neutral`
+into `[?]` and mapped `Cancelled` to `[/]`. Unifying on the detail helper is
+what makes the two screens agree; that reclassification is the point of the
+issue ("the two screens can never drift again"), not an added feature.
+
+Glyph policy: `dev-docs/standards/display-and-ui.md` explicitly permits `✓` and
+other single-codepoint textual symbols; only pictographic emoji are banned.
+`⊘` is already shipped in the detail pane. All three are `unicode-width` 1.
+
+## Non-goals
+
+- Changing the detail pane's glyph vocabulary (it is the accepted style).
+- Colorizing glyphs, or any other run-list styling change.
+- Touching the PR-list / PR-detail glyph helpers (`checks_status_glyph`,
+  `review_status_glyph`) — different domain, different issue.
+- Changing run ordering, windowing, layout modes, or meta-line content.
+
+## Vertical slice (RED → GREEN → REFACTOR)
+
+1. **RED (unit)** — `src/ui/components/actions_list.rs` tests assert `✓` / `✗`
+   and the absence of `[` in the title line; a new parity test asserts the
+   run-list projection and the detail projection emit the same glyph for the
+   same status/conclusion pair. Fails on the current tree.
+2. **RED (scenario)** — `dev-docs/tmux-scenarios/actions-mode.json` asserts
+   `> ✗ Inspectable Actions fixture` instead of `> [X] …`. Fails on the current
+   binary.
+3. **GREEN** — move `status_glyph` to `src/actions_view.rs` (the shared pure
+   Actions projection module) as a `pub` helper; delete both duplicates; call it
+   from `actions_list.rs` and `actions_detail_view.rs`; drop `TITLE_CHROME` from
+   7 to 4 to match the 1-cell glyph.
+
+## Expected files
+
+- `src/actions_view.rs` — gains the shared `status_glyph` helper + its tests.
+- `src/actions_detail_view.rs` — drops its private copy, imports the shared one.
+- `src/ui/components/actions_list.rs` — drops `run_status_glyph`, imports the
+  shared helper, `TITLE_CHROME` 7 → 4, tests updated.
+- `dev-docs/tmux-scenarios/actions-mode.json` — three literals updated.
+- `project-plans/issue207-plan.md` — this plan.
+
+## Behavioral verification
+
+- `cargo test --workspace --all-features --locked`
+- `make ci-check`
+- `scripts/issue194-run-scenario.sh` (drives `actions-mode.json` end to end).
+
+## Scope ledger
+
+- (empty)
+
+## Review counters
+
+- Local OCR: 0 / 2
+- PR OCR: 0 / 2

--- a/src/actions_detail_view.rs
+++ b/src/actions_detail_view.rs
@@ -1,12 +1,14 @@
 //! Pure Actions job-detail geometry and wrapped display-row projection.
 //!
 //! This module is the single iocraft-free source of truth for job focus
-//! normalization, status text, wrapping, scroll bounds, and focus reveal.
+//! normalization, wrapping, scroll bounds, and focus reveal. Status indicators
+//! come from the Actions-wide [`crate::actions_view::status_glyph`].
 
 use std::collections::HashSet;
 use std::hash::BuildHasher;
 
-use crate::domain::{WorkflowRunConclusion, WorkflowRunDetail, WorkflowRunStatus};
+use crate::actions_view::status_glyph;
+use crate::domain::WorkflowRunDetail;
 use crate::layout::ActionsDetailGeometry;
 use crate::text_wrap::wrap_text;
 
@@ -146,40 +148,12 @@ fn push_wrapped_row(
     );
 }
 
-fn status_glyph(
-    status: WorkflowRunStatus,
-    conclusion: Option<WorkflowRunConclusion>,
-) -> &'static str {
-    match status {
-        WorkflowRunStatus::Completed => match conclusion {
-            Some(WorkflowRunConclusion::Success) => "\u{2713}",
-            Some(
-                WorkflowRunConclusion::Failure
-                | WorkflowRunConclusion::TimedOut
-                | WorkflowRunConclusion::ActionRequired
-                | WorkflowRunConclusion::StartupFailure,
-            ) => "\u{2717}",
-            Some(
-                WorkflowRunConclusion::Cancelled
-                | WorkflowRunConclusion::Skipped
-                | WorkflowRunConclusion::Stale
-                | WorkflowRunConclusion::Neutral,
-            ) => "\u{2298}",
-            Some(WorkflowRunConclusion::Unknown) | None => "?",
-        },
-        WorkflowRunStatus::InProgress => "~",
-        WorkflowRunStatus::Queued
-        | WorkflowRunStatus::Requested
-        | WorkflowRunStatus::Waiting
-        | WorkflowRunStatus::Pending => ".",
-        WorkflowRunStatus::Unknown => "?",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{WorkflowRun, WorkflowRunJob, WorkflowRunStep};
+    use crate::domain::{
+        WorkflowRun, WorkflowRunConclusion, WorkflowRunJob, WorkflowRunStatus, WorkflowRunStep,
+    };
     use unicode_width::UnicodeWidthStr;
 
     fn run() -> WorkflowRun {

--- a/src/actions_view.rs
+++ b/src/actions_view.rs
@@ -49,6 +49,41 @@ pub fn status_glyph(
     }
 }
 
+/// Every status/conclusion pair an Actions surface can be asked to render.
+///
+/// Hand-maintained: extend the arrays when a [`WorkflowRunStatus`] or
+/// [`WorkflowRunConclusion`] variant is added. Production glyph mapping is
+/// wildcard-free, so a new variant stops compiling there first.
+#[cfg(test)]
+pub(crate) fn every_status_and_conclusion()
+-> impl Iterator<Item = (WorkflowRunStatus, Option<WorkflowRunConclusion>)> {
+    const STATUSES: [WorkflowRunStatus; 7] = [
+        WorkflowRunStatus::Completed,
+        WorkflowRunStatus::InProgress,
+        WorkflowRunStatus::Queued,
+        WorkflowRunStatus::Requested,
+        WorkflowRunStatus::Waiting,
+        WorkflowRunStatus::Pending,
+        WorkflowRunStatus::Unknown,
+    ];
+    const CONCLUSIONS: [Option<WorkflowRunConclusion>; 11] = [
+        None,
+        Some(WorkflowRunConclusion::Success),
+        Some(WorkflowRunConclusion::Failure),
+        Some(WorkflowRunConclusion::Cancelled),
+        Some(WorkflowRunConclusion::Skipped),
+        Some(WorkflowRunConclusion::TimedOut),
+        Some(WorkflowRunConclusion::ActionRequired),
+        Some(WorkflowRunConclusion::Stale),
+        Some(WorkflowRunConclusion::Neutral),
+        Some(WorkflowRunConclusion::StartupFailure),
+        Some(WorkflowRunConclusion::Unknown),
+    ];
+    STATUSES
+        .into_iter()
+        .flat_map(|status| CONCLUSIONS.into_iter().map(move |c| (status, c)))
+}
+
 /// A single run in the projected runs list view.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectedRun {
@@ -191,12 +226,10 @@ mod tests {
     }
 
     #[test]
-    fn status_glyph_maps_every_status_and_conclusion_to_a_bare_symbol() {
+    fn completed_runs_map_their_conclusion_to_check_cross_or_circled_slash() {
         use WorkflowRunConclusion as C;
-        assert_eq!(
-            status_glyph(WorkflowRunStatus::Completed, Some(C::Success)),
-            "\u{2713}"
-        );
+        const COMPLETED: WorkflowRunStatus = WorkflowRunStatus::Completed;
+        assert_eq!(status_glyph(COMPLETED, Some(C::Success)), "\u{2713}");
         for failed in [
             C::Failure,
             C::TimedOut,
@@ -204,33 +237,73 @@ mod tests {
             C::StartupFailure,
         ] {
             assert_eq!(
-                status_glyph(WorkflowRunStatus::Completed, Some(failed)),
+                status_glyph(COMPLETED, Some(failed)),
                 "\u{2717}",
                 "{failed:?} is a failure"
             );
         }
         for inconclusive in [C::Cancelled, C::Skipped, C::Stale, C::Neutral] {
             assert_eq!(
-                status_glyph(WorkflowRunStatus::Completed, Some(inconclusive)),
+                status_glyph(COMPLETED, Some(inconclusive)),
                 "\u{2298}",
                 "{inconclusive:?} is inconclusive"
             );
         }
-        assert_eq!(
-            status_glyph(WorkflowRunStatus::Completed, Some(C::Unknown)),
-            "?"
-        );
-        assert_eq!(status_glyph(WorkflowRunStatus::Completed, None), "?");
-        assert_eq!(status_glyph(WorkflowRunStatus::InProgress, None), "~");
-        for waiting in [
-            WorkflowRunStatus::Queued,
-            WorkflowRunStatus::Requested,
-            WorkflowRunStatus::Waiting,
-            WorkflowRunStatus::Pending,
-        ] {
-            assert_eq!(status_glyph(waiting, None), ".", "{waiting:?} is waiting");
+        assert_eq!(status_glyph(COMPLETED, Some(C::Unknown)), "?");
+        assert_eq!(status_glyph(COMPLETED, None), "?");
+    }
+
+    /// GitHub reports status and conclusion independently, so a run can arrive
+    /// still running while carrying a conclusion from an earlier attempt. The
+    /// status decides the glyph until the run completes.
+    #[test]
+    fn unfinished_runs_ignore_any_conclusion_they_carry() {
+        use WorkflowRunConclusion as C;
+        let carried = [
+            None,
+            Some(C::Success),
+            Some(C::Failure),
+            Some(C::Cancelled),
+            Some(C::Unknown),
+        ];
+        for conclusion in carried {
+            assert_eq!(
+                status_glyph(WorkflowRunStatus::InProgress, conclusion),
+                "~",
+                "in-progress with {conclusion:?}"
+            );
+            for waiting in [
+                WorkflowRunStatus::Queued,
+                WorkflowRunStatus::Requested,
+                WorkflowRunStatus::Waiting,
+                WorkflowRunStatus::Pending,
+            ] {
+                assert_eq!(
+                    status_glyph(waiting, conclusion),
+                    ".",
+                    "{waiting:?} with {conclusion:?}"
+                );
+            }
+            assert_eq!(
+                status_glyph(WorkflowRunStatus::Unknown, conclusion),
+                "?",
+                "unknown status with {conclusion:?}"
+            );
         }
-        assert_eq!(status_glyph(WorkflowRunStatus::Unknown, None), "?");
+    }
+
+    /// The run list budgets exactly one column for the status indicator, so
+    /// every glyph must measure one terminal cell.
+    #[test]
+    fn every_status_glyph_occupies_one_terminal_cell() {
+        for (status, conclusion) in every_status_and_conclusion() {
+            let glyph = status_glyph(status, conclusion);
+            assert_eq!(
+                unicode_width::UnicodeWidthStr::width(glyph),
+                1,
+                "{glyph} for {status:?}/{conclusion:?} must be one cell wide"
+            );
+        }
     }
 
     #[test]

--- a/src/actions_view.rs
+++ b/src/actions_view.rs
@@ -6,9 +6,48 @@
 //!
 //! Run ordering (issue #208) is committed by the Actions state reducer before
 //! projection so navigation indices match the reverse-chronological display.
+//!
+//! [`status_glyph`] is shared by every Actions surface (run list, job detail)
+//! so the screens cannot drift apart.
 
 use crate::domain::{WorkflowRun, WorkflowRunConclusion, WorkflowRunStatus};
 use crate::list_viewport::{ContentRows, ListViewport, RowsPerItem};
+
+/// Status indicator for a workflow run, job, or step.
+///
+/// Single-codepoint textual symbols only — no pictographic emoji and no
+/// bracketed tags — so every Actions surface renders one terminal cell of
+/// status. Shared by the run list and the job-detail pane.
+#[must_use]
+pub fn status_glyph(
+    status: WorkflowRunStatus,
+    conclusion: Option<WorkflowRunConclusion>,
+) -> &'static str {
+    match status {
+        WorkflowRunStatus::Completed => match conclusion {
+            Some(WorkflowRunConclusion::Success) => "\u{2713}",
+            Some(
+                WorkflowRunConclusion::Failure
+                | WorkflowRunConclusion::TimedOut
+                | WorkflowRunConclusion::ActionRequired
+                | WorkflowRunConclusion::StartupFailure,
+            ) => "\u{2717}",
+            Some(
+                WorkflowRunConclusion::Cancelled
+                | WorkflowRunConclusion::Skipped
+                | WorkflowRunConclusion::Stale
+                | WorkflowRunConclusion::Neutral,
+            ) => "\u{2298}",
+            Some(WorkflowRunConclusion::Unknown) | None => "?",
+        },
+        WorkflowRunStatus::InProgress => "~",
+        WorkflowRunStatus::Queued
+        | WorkflowRunStatus::Requested
+        | WorkflowRunStatus::Waiting
+        | WorkflowRunStatus::Pending => ".",
+        WorkflowRunStatus::Unknown => "?",
+    }
+}
 
 /// A single run in the projected runs list view.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -149,6 +188,49 @@ mod tests {
 
         assert_eq!(view.first_visible_run_index, 1);
         assert!(view.visible_runs.iter().all(|run| !run.is_selected));
+    }
+
+    #[test]
+    fn status_glyph_maps_every_status_and_conclusion_to_a_bare_symbol() {
+        use WorkflowRunConclusion as C;
+        assert_eq!(
+            status_glyph(WorkflowRunStatus::Completed, Some(C::Success)),
+            "\u{2713}"
+        );
+        for failed in [
+            C::Failure,
+            C::TimedOut,
+            C::ActionRequired,
+            C::StartupFailure,
+        ] {
+            assert_eq!(
+                status_glyph(WorkflowRunStatus::Completed, Some(failed)),
+                "\u{2717}",
+                "{failed:?} is a failure"
+            );
+        }
+        for inconclusive in [C::Cancelled, C::Skipped, C::Stale, C::Neutral] {
+            assert_eq!(
+                status_glyph(WorkflowRunStatus::Completed, Some(inconclusive)),
+                "\u{2298}",
+                "{inconclusive:?} is inconclusive"
+            );
+        }
+        assert_eq!(
+            status_glyph(WorkflowRunStatus::Completed, Some(C::Unknown)),
+            "?"
+        );
+        assert_eq!(status_glyph(WorkflowRunStatus::Completed, None), "?");
+        assert_eq!(status_glyph(WorkflowRunStatus::InProgress, None), "~");
+        for waiting in [
+            WorkflowRunStatus::Queued,
+            WorkflowRunStatus::Requested,
+            WorkflowRunStatus::Waiting,
+            WorkflowRunStatus::Pending,
+        ] {
+            assert_eq!(status_glyph(waiting, None), ".", "{waiting:?} is waiting");
+        }
+        assert_eq!(status_glyph(WorkflowRunStatus::Unknown, None), "?");
     }
 
     #[test]

--- a/src/ui/components/actions_detail.rs
+++ b/src/ui/components/actions_detail.rs
@@ -3,8 +3,8 @@
 //! Mirrors [`crate::ui::components::pr_detail`]: this module builds a
 //! [`DetailPaneProps`] from the workflow run detail and delegates rendering to
 //! the generic [`DetailPane`] via [`detail_pane_element`]. The heavy projection
-//! (windowing, line building) lives in [`crate::actions_view`]; this module
-//! handles the header-rows + content-string + viewport-math glue.
+//! (windowing, line building) lives in [`crate::actions_detail_view`]; this
+//! module handles the header-rows + content-string + viewport-math glue.
 
 use crate::actions_detail_view::project_actions_detail;
 use crate::domain::WorkflowRunDetail;

--- a/src/ui/components/actions_list.rs
+++ b/src/ui/components/actions_list.rs
@@ -169,6 +169,7 @@ mod tests {
     use super::*;
     use crate::domain::{WorkflowRun, WorkflowRunConclusion, WorkflowRunStatus};
     use crate::theme::ThemeColors;
+    use unicode_width::UnicodeWidthStr;
 
     fn make_run(
         id: u64,
@@ -266,36 +267,6 @@ mod tests {
         );
     }
 
-    /// Every status/conclusion pair an Actions surface can be asked to render.
-    fn every_status_and_conclusion()
-    -> impl Iterator<Item = (WorkflowRunStatus, Option<WorkflowRunConclusion>)> {
-        const STATUSES: [WorkflowRunStatus; 7] = [
-            WorkflowRunStatus::Completed,
-            WorkflowRunStatus::InProgress,
-            WorkflowRunStatus::Queued,
-            WorkflowRunStatus::Requested,
-            WorkflowRunStatus::Waiting,
-            WorkflowRunStatus::Pending,
-            WorkflowRunStatus::Unknown,
-        ];
-        const CONCLUSIONS: [Option<WorkflowRunConclusion>; 11] = [
-            None,
-            Some(WorkflowRunConclusion::Success),
-            Some(WorkflowRunConclusion::Failure),
-            Some(WorkflowRunConclusion::Cancelled),
-            Some(WorkflowRunConclusion::Skipped),
-            Some(WorkflowRunConclusion::TimedOut),
-            Some(WorkflowRunConclusion::ActionRequired),
-            Some(WorkflowRunConclusion::Stale),
-            Some(WorkflowRunConclusion::Neutral),
-            Some(WorkflowRunConclusion::StartupFailure),
-            Some(WorkflowRunConclusion::Unknown),
-        ];
-        STATUSES
-            .into_iter()
-            .flat_map(|status| CONCLUSIONS.into_iter().map(move |c| (status, c)))
-    }
-
     /// Title line the run list renders for a single run in this state.
     fn run_list_title_line(
         status: WorkflowRunStatus,
@@ -350,7 +321,7 @@ mod tests {
     /// again. Exercised across every status/conclusion pair.
     #[test]
     fn run_list_and_job_detail_render_the_shared_status_glyph() {
-        use crate::actions_view::status_glyph;
+        use crate::actions_view::{every_status_and_conclusion, status_glyph};
 
         for (status, conclusion) in every_status_and_conclusion() {
             let expected = status_glyph(status, conclusion);
@@ -369,6 +340,53 @@ mod tests {
                 "detail heading for {status:?}/{conclusion:?}: {content}"
             );
         }
+    }
+
+    /// The bare glyph costs three columns less than the old bracketed tag, so
+    /// truncation must reserve only prefix + glyph + separator and hand those
+    /// three columns back to the run name.
+    #[test]
+    fn title_truncation_reserves_only_prefix_glyph_and_separator() {
+        let mut run = make_run(
+            1,
+            WorkflowRunStatus::Completed,
+            Some(WorkflowRunConclusion::Success),
+        );
+        run.name = "abcdefghijklmnopqrstuvwxyz".to_string();
+        let window = ActionsListWindow {
+            selected_index: Some(0),
+            list_pane_rows: 10,
+            available_width: Some(20),
+            layout: ActionsListLayout::Compact,
+        };
+        let props = actions_list_props(&[run], window, true, None, ThemeColors::default(), None);
+        let title = props.rows[0].spans[0].text.as_str();
+        // 20 columns - 4 chrome = 16-cell name budget = 15 chars + ellipsis.
+        assert_eq!(title, "> \u{2713} abcdefghijklmno\u{2026}");
+        assert_eq!(UnicodeWidthStr::width(title), 20);
+    }
+
+    /// Wide (double-cell) run names are still budgeted in terminal cells, so a
+    /// truncated CJK title never overflows the pane.
+    #[test]
+    fn wide_run_names_stay_within_the_available_width() {
+        let mut run = make_run(
+            1,
+            WorkflowRunStatus::Completed,
+            Some(WorkflowRunConclusion::Failure),
+        );
+        run.name = "构建甲乙丙丁戊己庚辛".to_string();
+        let window = ActionsListWindow {
+            selected_index: Some(0),
+            list_pane_rows: 10,
+            available_width: Some(20),
+            layout: ActionsListLayout::Compact,
+        };
+        let props = actions_list_props(&[run], window, true, None, ThemeColors::default(), None);
+        let title = props.rows[0].spans[0].text.as_str();
+        // 16-cell budget = 7 double-width chars (14 cells) + ellipsis.
+        assert_eq!(title, "> \u{2717} 构建甲乙丙丁戊\u{2026}");
+        assert!(UnicodeWidthStr::width(title) <= 20);
     }
 
     #[test]

--- a/src/ui/components/actions_list.rs
+++ b/src/ui/components/actions_list.rs
@@ -8,7 +8,7 @@
 //! component owns border rendering, scroll windowing, width clamping, and
 //! selection highlighting.
 
-use crate::domain::{WorkflowRun, WorkflowRunConclusion, WorkflowRunStatus};
+use crate::domain::WorkflowRun;
 use crate::list_viewport::{ListGeometry, PaneRows, RowsPerItem};
 use crate::selection::{SelectablePane, TextSelection};
 use crate::theme::ThemeColors;
@@ -52,30 +52,6 @@ pub struct ActionsListWindow {
     pub layout: ActionsListLayout,
 }
 
-/// Build the ASCII status glyph for a run.
-///
-/// Returns a short bracketed tag (`[OK]`, `[X]`, `[~]`, `[.]`, etc.). Uses
-/// ASCII glyphs only — no pictographic emoji — for terminal-width stability.
-fn run_status_glyph(
-    status: WorkflowRunStatus,
-    conclusion: Option<WorkflowRunConclusion>,
-) -> &'static str {
-    match status {
-        WorkflowRunStatus::Completed => match conclusion {
-            Some(WorkflowRunConclusion::Success) => "[OK]",
-            Some(WorkflowRunConclusion::Failure) => "[X]",
-            Some(WorkflowRunConclusion::Cancelled) => "[/]",
-            _ => "[?]",
-        },
-        WorkflowRunStatus::InProgress => "[~]",
-        WorkflowRunStatus::Queued
-        | WorkflowRunStatus::Requested
-        | WorkflowRunStatus::Waiting
-        | WorkflowRunStatus::Pending => "[.]",
-        WorkflowRunStatus::Unknown => "[?]",
-    }
-}
-
 /// Map already-windowed [`ProjectedRun`](crate::actions_view::ProjectedRun)s
 /// into [`SelectableRow`]s for the generic [`SelectableList`]. Each run becomes
 /// a two-line row: a title line (selection prefix + status glyph + run name)
@@ -86,14 +62,14 @@ fn to_selectable_rows(
     compact: bool,
     available_width: Option<u16>,
 ) -> Vec<SelectableRow> {
-    // Prefix ("> "/"  ") + space + glyph (4 chars) + space = 7 chars of chrome
-    // before the run name. Reserve that much before truncating the title.
-    const TITLE_CHROME: usize = 7;
+    // Prefix ("> "/"  ") + glyph (1 cell) + space = 4 columns of chrome before
+    // the run name. Reserve that much before truncating the title.
+    const TITLE_CHROME: usize = 4;
     view.visible_runs
         .iter()
         .map(|run| {
             let prefix = if run.is_selected { "> " } else { "  " };
-            let glyph = run_status_glyph(run.status, run.conclusion);
+            let glyph = crate::actions_view::status_glyph(run.status, run.conclusion);
             let name = if let Some(width) = available_width {
                 let budget = (usize::from(width)).saturating_sub(TITLE_CHROME).max(1);
                 crate::ui::util::truncate_with_ellipsis(&run.name, budget)
@@ -262,10 +238,23 @@ mod tests {
         assert_eq!(props.rows.len(), 2);
         // First run is selected → prefix "> "
         assert!(props.rows[0].spans[0].text.starts_with("> "));
-        assert!(props.rows[0].spans[0].text.contains("[OK]"));
+        assert!(props.rows[0].spans[0].text.contains('\u{2713}'));
         // Second run is not selected → prefix "  "
         assert!(props.rows[1].spans[0].text.starts_with("  "));
-        assert!(props.rows[1].spans[0].text.contains("[X]"));
+        assert!(props.rows[1].spans[0].text.contains('\u{2717}'));
+        // Brackets are gone: the status indicator is a bare glyph.
+        assert!(
+            props
+                .rows
+                .iter()
+                .all(|row| !row.spans[0].text.contains('[') && !row.spans[0].text.contains(']')),
+            "run-list title lines must not bracket the status glyph, rows: {:?}",
+            props
+                .rows
+                .iter()
+                .map(|r| &r.spans[0].text)
+                .collect::<Vec<_>>()
+        );
         // Meta line present (non-empty in Full mode)
         assert!(props.rows[0].meta_line.is_some());
         assert!(
@@ -275,6 +264,111 @@ mod tests {
                 .unwrap_or("")
                 .contains("#1")
         );
+    }
+
+    /// Every status/conclusion pair an Actions surface can be asked to render.
+    fn every_status_and_conclusion()
+    -> impl Iterator<Item = (WorkflowRunStatus, Option<WorkflowRunConclusion>)> {
+        const STATUSES: [WorkflowRunStatus; 7] = [
+            WorkflowRunStatus::Completed,
+            WorkflowRunStatus::InProgress,
+            WorkflowRunStatus::Queued,
+            WorkflowRunStatus::Requested,
+            WorkflowRunStatus::Waiting,
+            WorkflowRunStatus::Pending,
+            WorkflowRunStatus::Unknown,
+        ];
+        const CONCLUSIONS: [Option<WorkflowRunConclusion>; 11] = [
+            None,
+            Some(WorkflowRunConclusion::Success),
+            Some(WorkflowRunConclusion::Failure),
+            Some(WorkflowRunConclusion::Cancelled),
+            Some(WorkflowRunConclusion::Skipped),
+            Some(WorkflowRunConclusion::TimedOut),
+            Some(WorkflowRunConclusion::ActionRequired),
+            Some(WorkflowRunConclusion::Stale),
+            Some(WorkflowRunConclusion::Neutral),
+            Some(WorkflowRunConclusion::StartupFailure),
+            Some(WorkflowRunConclusion::Unknown),
+        ];
+        STATUSES
+            .into_iter()
+            .flat_map(|status| CONCLUSIONS.into_iter().map(move |c| (status, c)))
+    }
+
+    /// Title line the run list renders for a single run in this state.
+    fn run_list_title_line(
+        status: WorkflowRunStatus,
+        conclusion: Option<WorkflowRunConclusion>,
+    ) -> String {
+        let window = ActionsListWindow {
+            selected_index: Some(0),
+            list_pane_rows: 10,
+            available_width: None,
+            layout: ActionsListLayout::Compact,
+        };
+        let props = actions_list_props(
+            &[make_run(1, status, conclusion)],
+            window,
+            true,
+            None,
+            ThemeColors::default(),
+            None,
+        );
+        props.rows[0].spans[0].text.clone()
+    }
+
+    /// Job-detail document for a single job in this state.
+    fn job_detail_content(
+        status: WorkflowRunStatus,
+        conclusion: Option<WorkflowRunConclusion>,
+    ) -> String {
+        let detail = crate::domain::WorkflowRunDetail {
+            run: make_run(1, status, conclusion),
+            jobs: vec![crate::domain::WorkflowRunJob {
+                id: 1,
+                name: "job".to_string(),
+                status,
+                conclusion,
+                steps: Vec::new(),
+            }],
+        };
+        crate::actions_detail_view::project_actions_detail(
+            &detail,
+            &std::collections::HashSet::new(),
+            Some(0),
+            crate::layout::ActionsDetailGeometry {
+                viewport_rows: 10,
+                content_width: 80,
+            },
+        )
+        .content()
+    }
+
+    /// Both Actions screens must project their status indicator from the one
+    /// shared helper, so the run list can never drift from the detail pane
+    /// again. Exercised across every status/conclusion pair.
+    #[test]
+    fn run_list_and_job_detail_render_the_shared_status_glyph() {
+        use crate::actions_view::status_glyph;
+
+        for (status, conclusion) in every_status_and_conclusion() {
+            let expected = status_glyph(status, conclusion);
+            assert!(
+                !expected.contains('[') && !expected.contains(']'),
+                "shared status glyph must not be bracketed: {expected}"
+            );
+            assert_eq!(
+                run_list_title_line(status, conclusion),
+                format!("> {expected} Run 1"),
+                "run-list row for {status:?}/{conclusion:?}"
+            );
+            let content = job_detail_content(status, conclusion);
+            assert!(
+                content.contains(&format!("> \u{25B8} {expected} job")),
+                "detail heading for {status:?}/{conclusion:?}: {content}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What and why

The Actions run list and the Actions job-detail pane each owned a private copy
of the status-glyph mapping, and the two copies had drifted: the run list
rendered bracketed text tags while the detail pane rendered bare
single-codepoint symbols.

    run list (before)      detail pane
    [OK]                   U+2713 check
    [X]                    U+2717 ballot x
    [/]                    U+2298 circled division slash
    [~]                    ~
    [.]                    .
    [?]                    ?

The detail pane's style is the accepted one. The mapping now lives once, in
the shared Actions projection module, and both surfaces call it -- so the two
screens cannot drift again.

## Behavior delivered

| Run status / conclusion | Glyph |
|-------------------------|-------|
| Completed + Success | check (U+2713) |
| Completed + Failure / TimedOut / ActionRequired / StartupFailure | ballot x (U+2717) |
| Completed + Cancelled / Skipped / Stale / Neutral | circled division slash (U+2298) |
| Completed + Unknown or no conclusion | ? |
| InProgress | ~ |
| Queued / Requested / Waiting / Pending | . |
| Unknown status | ? |

No brackets anywhere in the run-list status indicator. Because the bare glyph
costs three columns less than the bracketed tag, the run-list title-truncation
chrome drops from 7 to 4 columns and run names get those three columns back.

The glyphs are permitted by the emoji-free policy in
dev-docs/standards/display-and-ui.md: they are single-codepoint textual
symbols, not pictographic emoji, and each measures exactly one terminal cell
under the unicode-width crate.

## Changes

- src/actions_view.rs -- new shared, documented, must-use status_glyph helper
  plus a test-only single source for the status/conclusion enumeration both
  Actions test modules walk.
- src/actions_detail_view.rs -- private duplicate removed; imports the shared
  helper.
- src/ui/components/actions_list.rs -- private bracketed duplicate removed;
  imports the shared helper; title chrome 7 to 4.
- src/ui/components/actions_detail.rs -- module header corrected to point at
  the module that actually owns detail projection.
- dev-docs/tmux-scenarios/actions-mode.json -- three run-list literals updated.
- project-plans/issue207-plan.md -- acceptance matrix, non-goals, scope ledger,
  and review triage.

## Tests

Behavioral, written before the implementation:

- actions_list: run-list rows assert the check/x glyphs and that no title line
  contains a bracket.
- actions_list: cross-surface parity over all 77 status/conclusion pairs --
  the run-list row and the job-detail heading must both be built from the
  shared helper.
- actions_list: exact truncated titles at a constrained width, for an ASCII
  name and a double-width CJK name, pinning the reclaimed three columns.
- actions_view: the completed-conclusion mapping table; that an unfinished run
  ignores any conclusion it carries; and that every glyph is one cell wide.
- actions-mode tmux scenario asserts the unbracketed run-list rows.

## Verification

cargo xtask ci green on this branch (fmt, clippy-allows, source-size,
architecture, multiplexer-surface, strict lint, complexity, coverage 71.27%
against a 30% floor, locked build, locked workspace test), re-verified with
cargo xtask quick after rebasing onto current main.

### TUI scenario evidence

scripts/issue194-run-scenario.sh cannot complete on the development
workstation: unrelated live jefe sessions make the app print a
"live jefe session(s) match no agent" warning banner over the title row, so the
scenario's opening wait for the app title never matches. Re-running the same
runner with that opening wait anchored on the repositories pane reaches the run
list and captures the delivered behavior:

    Workflow Runs
    > x Inspectable Actions fixture
      x Interleaved Actions fixture run
      + Oldest Actions fixture run

(where x is U+2717 and + is U+2713 in the real capture)

Both changed run-list literals pass. That run then stops later, inside the
unchanged job-detail step-collapse sequence. Rebuilding the identical runner
against unmodified main stops at exactly the same step, so the residual failure
is pre-existing and environmental rather than a regression here; harness and
session hygiene are out of scope for this issue.

## Review

One rustreviewer pass and two Open Code Review passes. Accepted and fixed: the
truncation-budget behavior was unproven, non-completed statuses were only
tested with an absent conclusion, the one-cell glyph invariant was unasserted,
the actions_detail module header was stale, and the plan cited a build target
that does not exist. Deferred with rationale in the plan: mechanically
enumerating domain enum variants in tests would require a new dependency or a
domain public-API change, and the production matches are wildcard-free so a new
variant fails to compile before it can reach a glyph. The final Open Code
Review pass reported zero findings.

Fixes #207
