### PR TITLE
Stop answering a three-valued question with a bool (Fixes #597)

### DIFF
--- a/src/runtime/launch_compose_tests.rs
+++ b/src/runtime/launch_compose_tests.rs
@@ -407,5 +407,5 @@ fn post_evidence_replacement_is_rejected_before_stub_session_effects() {
         panic!("fingerprint mismatch must be a spawn failure");
     };
     assert!(reason.contains("AGT-E203"), "{reason}");
-    assert!(!manager.session_exists(&agent_id));
+    assert!(!manager.has_session_record(&agent_id));
 }

--- a/src/runtime/liveness.rs
+++ b/src/runtime/liveness.rs
@@ -9,11 +9,9 @@ use std::hash::BuildHasher;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 
+use crate::domain::AgentId;
 use crate::domain::liveness_observation::{Observed, ProbeBoundary};
-use crate::domain::{AgentId, RemoteRepositorySettings};
-use crate::runtime::commands::{
-    remote_tmux_command, run_remote_ssh, shell_escape_single, tmux_command,
-};
+use crate::runtime::commands::tmux_command;
 use crate::runtime::manager::LivenessCheck;
 
 /// Timeout for local tmux subprocess invocations in the batch liveness path.
@@ -90,48 +88,6 @@ pub(super) fn parse_dead_pane_flags(output: &str) -> SessionLiveness {
     } else {
         SessionLiveness::Unavailable
     }
-}
-
-/// Check if a tmux session exists and has at least one non-dead pane.
-///
-/// @pseudocode component-002 lines 33-35
-#[must_use]
-pub fn check_session_alive(session_name: &str) -> bool {
-    session_liveness(session_name) == SessionLiveness::Alive
-}
-
-/// Check if a remote tmux session exists and has at least one non-dead pane.
-#[must_use]
-pub fn check_remote_session_alive(remote: &RemoteRepositorySettings, session_name: &str) -> bool {
-    let command = remote_tmux_command(
-        remote,
-        &format!(
-            "tmux has-session -t {} && tmux list-panes -t {} -F '#{{pane_dead}}'",
-            shell_escape_single(session_name),
-            shell_escape_single(session_name)
-        ),
-    );
-
-    let output = run_remote_ssh(remote, &command);
-    let Ok(out) = output else {
-        return false;
-    };
-    if !out.status.success() {
-        return false;
-    }
-
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    for line in stdout.lines() {
-        let dead_flag = line.trim();
-        if dead_flag.is_empty() {
-            continue;
-        }
-        if dead_flag == "0" || dead_flag.eq_ignore_ascii_case("false") {
-            return true;
-        }
-    }
-
-    false
 }
 
 /// Parse raw `tmux list-sessions -F '#{session_name}'` output into a set of

--- a/src/runtime/liveness_tests.rs
+++ b/src/runtime/liveness_tests.rs
@@ -398,10 +398,20 @@ fn batch_command_count_constant_with_agent_count() {
 // --- existing tests ---
 
 #[test]
-fn check_nonexistent_session_returns_false() {
-    // This session should not exist
-    let alive = check_session_alive("jefe-nonexistent-test-session-12345");
-    assert!(!alive);
+fn a_session_that_does_not_exist_is_never_reported_alive() {
+    // Deliberately not asserting through a `bool` helper. The point of #597 is
+    // that `Missing` and `Unavailable` are different answers, so this names the
+    // acceptable ones instead of folding them into one negative: which of the
+    // two arrives depends on whether a multiplexer is installed here, and that
+    // difference is exactly what a `bool` would destroy.
+    let liveness = session_liveness("jefe-nonexistent-test-session-12345");
+    assert!(
+        matches!(
+            liveness,
+            SessionLiveness::Missing | SessionLiveness::Unavailable
+        ),
+        "a session that was never created must never be reported Alive, got {liveness:?}"
+    );
 }
 
 // --- run_child_with_timeout (issue #287 review: kill path must be verified) ---

--- a/src/runtime/manager.rs
+++ b/src/runtime/manager.rs
@@ -165,14 +165,6 @@ pub trait RuntimeManager: Send {
         remote: Option<&RemoteRepositorySettings>,
     ) -> Result<(), RuntimeError>;
 
-    /// Check if a session is alive.
-    ///
-    /// @pseudocode component-002 lines 33-35
-    fn is_alive(&self, agent_id: &AgentId) -> bool;
-
-    /// Check whether a tmux session exists for the given agent.
-    fn session_exists(&self, agent_id: &AgentId) -> bool;
-
     /// Get terminal snapshot for the currently attached session.
     fn snapshot(&self) -> Option<TerminalSnapshot>;
 
@@ -855,29 +847,6 @@ impl RuntimeManager for TmuxRuntimeManager {
         }
         let result = self.spawn_session_fresh(agent_id, launch, remote);
         complete_relaunch_attempt(&mut self.dead_plans, agent_id, result)
-    }
-
-    fn is_alive(&self, agent_id: &AgentId) -> bool {
-        if let Some(session) = self.sessions.get(agent_id) {
-            if let Some(remote) = session.remote.as_ref() {
-                liveness::check_remote_session_alive(remote, &session.session_name)
-            } else {
-                liveness::check_session_alive(&session.session_name)
-            }
-        } else {
-            false
-        }
-    }
-
-    fn session_exists(&self, agent_id: &AgentId) -> bool {
-        if let Some(session) = self.sessions.get(agent_id)
-            && let Some(remote) = session.remote.as_ref()
-        {
-            return commands::remote_session_exists(remote, &session.session_name).unwrap_or(false);
-        }
-
-        let session_name = RuntimeSession::session_name_for(agent_id);
-        liveness::check_session_alive(&session_name)
     }
 
     fn snapshot(&self) -> Option<TerminalSnapshot> {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -114,9 +114,9 @@ pub use external_terminal::{
 pub use gh_auth::{AuthRunResult, run_device_auth};
 pub use liveness::{
     LivenessIdentity, SessionLiveness, WorkerDisposition, alive_session_set, batch_liveness_check,
-    batch_liveness_check_with_identity, check_remote_session_alive, check_session_alive,
-    list_jefe_sessions, observe_worker_disposition, parse_alive_sessions, parse_pane_alive,
-    reconcile_dead_agents, reconcile_dead_agents_with_identity, session_liveness,
+    batch_liveness_check_with_identity, list_jefe_sessions, observe_worker_disposition,
+    parse_alive_sessions, parse_pane_alive, reconcile_dead_agents,
+    reconcile_dead_agents_with_identity, session_liveness,
 };
 pub use manager::{
     AttachInputs, HISTORY_LINE_CAP, LivenessCheck, RuntimeManager, TmuxRuntimeManager,
@@ -302,7 +302,7 @@ mod tests {
         if let Err(error) = mgr.spawn_session(&agent_id, &plan, None) {
             panic!("spawn should succeed: {error}");
         }
-        assert!(mgr.is_alive(&agent_id));
+        assert!(mgr.has_session_record(&agent_id));
 
         if let Err(error) = mgr.attach(&agent_id) {
             panic!("attach should succeed: {error}");
@@ -322,7 +322,7 @@ mod tests {
         if let Err(error) = mgr.kill(&agent_id) {
             panic!("kill should succeed: {error}");
         }
-        assert!(!mgr.is_alive(&agent_id));
+        assert!(!mgr.has_session_record(&agent_id));
     }
 
     #[test]
@@ -353,7 +353,7 @@ mod tests {
         if let Err(error) = mgr.spawn_session_fresh(&agent_id, &plan, None) {
             panic!("fresh spawn should succeed: {error}");
         }
-        assert!(mgr.is_alive(&agent_id));
+        assert!(mgr.has_session_record(&agent_id));
 
         let duplicate = mgr.spawn_session_fresh(&agent_id, &plan, None);
         assert!(duplicate.is_err());

--- a/src/runtime/stub_manager.rs
+++ b/src/runtime/stub_manager.rs
@@ -40,6 +40,19 @@ impl StubRuntimeManager {
         }
     }
 
+    /// Whether this stub is still holding a session record for `agent_id`.
+    ///
+    /// Named for what it actually answers. The trait used to carry
+    /// `is_alive`/`session_exists` returning `bool`, which read as liveness
+    /// predicates while really reporting the stub's own bookkeeping -- and a
+    /// real implementation cannot answer liveness in two values, because
+    /// "the session is gone" and "the multiplexer could not be asked" are
+    /// different facts (issue #597).
+    #[must_use]
+    pub fn has_session_record(&self, agent_id: &AgentId) -> bool {
+        self.sessions.iter().any(|s| &s.agent_id == agent_id)
+    }
+
     /// Construct a deterministic manager whose attach boundary returns `error`.
     #[must_use]
     pub fn with_attach_failure(error: RuntimeError) -> Self {
@@ -140,14 +153,6 @@ impl RuntimeManager for StubRuntimeManager {
             return Err(RuntimeError::NotRunning(agent_id.clone()));
         }
         self.spawn_session(agent_id, launch, remote)
-    }
-
-    fn is_alive(&self, agent_id: &AgentId) -> bool {
-        self.sessions.iter().any(|s| &s.agent_id == agent_id)
-    }
-
-    fn session_exists(&self, agent_id: &AgentId) -> bool {
-        self.sessions.iter().any(|s| &s.agent_id == agent_id)
     }
 
     fn snapshot(&self) -> Option<TerminalSnapshot> {

--- a/src/services/runtime_effect_adapter_tests.rs
+++ b/src/services/runtime_effect_adapter_tests.rs
@@ -87,7 +87,7 @@ fn kill_session_effect_kills_the_runtime_session_and_reports_killed() {
         other => panic!("expected Killed response, got {other:?}"),
     }
     assert!(
-        !manager.session_exists(&agent_id),
+        !manager.has_session_record(&agent_id),
         "session must be removed by the kill effect"
     );
 }

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -12,6 +12,7 @@ mod ocr_workflow_contracts;
 mod persistence_theme_contracts;
 mod pr_review_workflow_contracts;
 mod release_workflow_contracts;
+mod session_liveness_collapse_contracts;
 mod tmux_harness_docs_contracts;
 mod visibility_filter_contracts;
 mod windows_ci_signal_contracts;

--- a/tests/core/session_liveness_collapse_contracts.rs
+++ b/tests/core/session_liveness_collapse_contracts.rs
@@ -1,0 +1,92 @@
+//! Session liveness must not be collapsed into a bare `bool` (issue #597).
+//!
+//! `SessionLiveness` separates `Missing` -- the session is gone -- from
+//! `Unavailable` -- the multiplexer could not be asked. A helper returning
+//! `bool` erases that distinction, and the resulting `false` reads as "not
+//! alive" at every call site.
+//!
+//! #541 removed nine such collapses from the paths that decide agent death.
+//! The helpers covered here were left behind because only tests called them,
+//! which is precisely what makes them dangerous: `is_alive` reads like a total
+//! predicate, so
+//!
+//! ```ignore
+//! if !runtime.is_alive(&agent_id) { /* mark dead */ }
+//! ```
+//!
+//! reintroduces the bug while looking obviously correct. The
+//! `xtask check observation-coercion` policy cannot see this shape, because it
+//! matches an uncertain accessor spent through an `Option` combinator and
+//! these helpers return a bare `bool` with no accessor to match.
+//!
+//! So the deletion is asserted here, in source, rather than trusted to stay
+//! deleted.
+
+use std::path::{Path, PathBuf};
+
+/// Helpers deleted by #597, each of which answered a three-valued question
+/// with two values.
+const DELETED_COLLAPSING_HELPERS: &[(&str, &str)] = &[
+    ("src/runtime/liveness.rs", "fn check_session_alive"),
+    ("src/runtime/liveness.rs", "fn check_remote_session_alive"),
+    ("src/runtime/manager.rs", "fn is_alive"),
+    ("src/runtime/manager.rs", "fn session_exists"),
+];
+
+#[test]
+fn no_helper_answers_session_liveness_with_a_bare_bool() {
+    for (relative, signature) in DELETED_COLLAPSING_HELPERS {
+        let text = read_repo_text(relative);
+        assert!(
+            !text.contains(signature),
+            "{relative} still declares `{signature}`. A session-liveness answer of `false` \
+             cannot distinguish a session that is gone from one that could not be asked \
+             about, which is the collapse issue #541 exists to remove (issue #597)."
+        );
+    }
+}
+
+/// The runtime manager trait must not offer a boolean liveness predicate.
+///
+/// Checked separately from the inherent methods above: a trait method is the
+/// more dangerous of the two, because every implementor inherits the shape and
+/// every caller programs against it.
+#[test]
+fn the_runtime_manager_trait_exposes_no_boolean_liveness_predicate() {
+    let text = read_repo_text("src/runtime/manager.rs");
+    for forbidden in [
+        "fn is_alive(&self, agent_id: &AgentId) -> bool",
+        "fn session_exists(&self, agent_id: &AgentId) -> bool",
+    ] {
+        assert!(
+            !text.contains(forbidden),
+            "RuntimeManager still declares `{forbidden}`. Implementors and callers would \
+             inherit a total predicate over a question that has three answers (issue #597)."
+        );
+    }
+}
+
+/// Nothing may re-export the deleted helpers.
+///
+/// A re-export outlives its definition in review: the name stays reachable and
+/// the next caller finds it by autocomplete rather than by reading the module.
+#[test]
+fn the_runtime_module_re_exports_no_collapsing_liveness_helper() {
+    let text = read_repo_text("src/runtime/mod.rs");
+    for forbidden in ["check_session_alive", "check_remote_session_alive"] {
+        assert!(
+            !text.contains(forbidden),
+            "src/runtime/mod.rs still re-exports `{forbidden}` (issue #597)."
+        );
+    }
+}
+
+fn read_repo_text(relative: &str) -> String {
+    let path = repo_path(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+fn repo_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}

--- a/tests/runtime/runtime_lifecycle.rs
+++ b/tests/runtime/runtime_lifecycle.rs
@@ -54,7 +54,7 @@ fn spawn_creates_session_for_agent() {
         .test_unwrap("spawn should succeed");
 
     assert!(
-        mgr.is_alive(&agent.id),
+        mgr.has_session_record(&agent.id),
         "session should be alive after spawn"
     );
 }
@@ -88,8 +88,8 @@ fn spawn_allows_multiple_different_agents() {
     mgr.spawn_session(&agent2.id, &sig2, None)
         .test_unwrap("second spawn should succeed");
 
-    assert!(mgr.is_alive(&agent1.id));
-    assert!(mgr.is_alive(&agent2.id));
+    assert!(mgr.has_session_record(&agent1.id));
+    assert!(mgr.has_session_record(&agent2.id));
 }
 
 // =============================================================================
@@ -145,7 +145,7 @@ fn attach_switches_from_previous_session() {
     );
 
     // Verify agent1 session is still alive but not attached
-    assert!(mgr.is_alive(&agent1.id));
+    assert!(mgr.has_session_record(&agent1.id));
     let session1 = mgr.get_session(&agent1.id).test_unwrap("session 1 exists");
     assert!(!session1.attached, "agent 1 should be detached");
 }
@@ -179,8 +179,14 @@ fn repeated_attach_switching_ends_on_last_selected_agent() {
     let session2 = mgr.get_session(&agent2.id).test_unwrap("session b exists");
     assert!(!session1.attached, "agent a should be detached at the end");
     assert!(session2.attached, "agent b should be attached at the end");
-    assert!(mgr.is_alive(&agent1.id), "agent a should remain alive");
-    assert!(mgr.is_alive(&agent2.id), "agent b should remain alive");
+    assert!(
+        mgr.has_session_record(&agent1.id),
+        "agent a should remain alive"
+    );
+    assert!(
+        mgr.has_session_record(&agent2.id),
+        "agent b should remain alive"
+    );
 }
 
 #[test]
@@ -234,11 +240,11 @@ fn kill_removes_session() {
 
     mgr.spawn_session(&agent.id, &sig, None)
         .test_unwrap("spawn");
-    assert!(mgr.is_alive(&agent.id));
+    assert!(mgr.has_session_record(&agent.id));
 
     mgr.kill(&agent.id).test_unwrap("kill should succeed");
     assert!(
-        !mgr.is_alive(&agent.id),
+        !mgr.has_session_record(&agent.id),
         "session should not be alive after kill"
     );
 }
@@ -288,8 +294,11 @@ fn kill_one_session_preserves_others() {
 
     mgr.kill(&agent1.id).test_unwrap("kill 1");
 
-    assert!(!mgr.is_alive(&agent1.id));
-    assert!(mgr.is_alive(&agent2.id), "agent 2 should still be alive");
+    assert!(!mgr.has_session_record(&agent1.id));
+    assert!(
+        mgr.has_session_record(&agent2.id),
+        "agent 2 should still be alive"
+    );
 }
 
 // =============================================================================
@@ -343,7 +352,7 @@ fn relaunch_dead_session_requires_signature() {
 fn is_alive_returns_false_for_unknown_agent() {
     let mgr = StubRuntimeManager::default();
     let agent_id = AgentId("unknown".into());
-    assert!(!mgr.is_alive(&agent_id));
+    assert!(!mgr.has_session_record(&agent_id));
 }
 
 #[test]
@@ -354,7 +363,7 @@ fn is_alive_returns_true_for_spawned_agent() {
 
     mgr.spawn_session(&agent.id, &sig, None)
         .test_unwrap("spawn");
-    assert!(mgr.is_alive(&agent.id));
+    assert!(mgr.has_session_record(&agent.id));
 }
 
 #[test]
@@ -366,5 +375,5 @@ fn is_alive_returns_false_after_kill() {
     mgr.spawn_session(&agent.id, &sig, None)
         .test_unwrap("spawn");
     mgr.kill(&agent.id).test_unwrap("kill");
-    assert!(!mgr.is_alive(&agent.id));
+    assert!(!mgr.has_session_record(&agent.id));
 }


### PR DESCRIPTION
Fixes #597

## The collapse

`SessionLiveness` separates two different facts:

```rust
Missing,     // the session is absent, or all its panes exited
Unavailable, // the multiplexer could not be started or queried
```

Four helpers erased that distinction by returning `bool`, so after each one "the session is gone" and "I could not ask" were the same `false`.

## Why delete rather than re-type

The caller audit in the issue holds, and I re-verified it:

- `check_session_alive` / `check_remote_session_alive` were reached **only** through `RuntimeManager::is_alive` and `RuntimeManager::session_exists`.
- Both of those were called **only from tests**.
- The `is_alive` calls in `attach.rs`, `async_attach.rs`, `pty.rs` and `manager.rs:735` are the **viewer** method of the same name, unrelated and untouched.
- `commands::remote_session_exists` returns `Result<bool>` and is still used by `manager_liveness`; it does not collapse, and is untouched. The collapse was the `.unwrap_or(false)` at the deleted call site.

Nothing in production decided agent death from these, which is exactly why #541 left them alone rather than expanding scope — and exactly what made them worth removing now. `is_alive` reads like a total predicate, so:

```rust
if !runtime.is_alive(&agent_id) { /* mark dead */ }
```

reintroduces the bug #541 exists to remove while looking obviously correct, with no reviewer likely to object. #541 found nine of these, every one in code that read reasonably when written. A collapsing helper left beside a correct one is how the main dead-agent path stayed broken after its first fix.

## What replaced them

The stub's two implementations were byte-identical bookkeeping — `self.sessions.iter().any(...)`, i.e. "is there a session record". Tests that used them now call `StubRuntimeManager::has_session_record`, which says what it does and cannot be mistaken for a liveness answer.

The one real test of the deleted helper was rewritten to name the acceptable answers rather than fold them:

```rust
assert!(matches!(liveness, SessionLiveness::Missing | SessionLiveness::Unavailable), ...)
```

Which of the two arrives depends on whether a multiplexer is installed — and that difference is precisely what a `bool` destroyed.

## Held in place by contracts, not by hope

`xtask check observation-coercion` (added in #541) **cannot** police this shape: it matches an uncertain accessor spent through an `Option` combinator, and a bare `bool` offers no accessor to match. So `tests/core/session_liveness_collapse_contracts.rs` asserts in source that the helpers stay deleted, that the trait exposes no boolean liveness predicate, and that nothing re-exports them — a re-export outlives its definition in review, because the name stays reachable by autocomplete.

Proven RED first: all three contracts failed with the specific names before the deletion.

## Verification

Native Windows, against a locally built psmux:

- `cargo fmt --all --check`, `xtask check source-size|architecture|clippy-allows`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- lib: **2998 passed, 0 failed**
- integration: **414 passed, 0 failed**

Net **-110 lines** of production surface.
