### PR TITLE
Judge a cached install by the version it holds (Fixes #610)

### DIFF
--- a/src/runtime/package_runtime.rs
+++ b/src/runtime/package_runtime.rs
@@ -399,15 +399,20 @@ fn bin_dir_of(install_dir: &Path) -> PathBuf {
 
 /// Contents of the install marker for a completed install.
 ///
-/// A volatile selector records the concrete version the tag resolved to on a
-/// fourth line, so a later preparation can tell "the tag still points here"
-/// from "the tag has moved" without consulting a clock (issue #584). A pinned
-/// selector keeps the three-line form: an explicit version never moves, so its
-/// cache entry is permanent.
+/// Always three lines — package, binary, and the identity version from
+/// [`marker_identity_version`] — whatever kind of selector asked for it. The
+/// selector no longer appears, because two selectors naming one version are the
+/// same install and must recognise each other's marker (issue #610).
+///
+/// Whether the tag has moved is no longer a question the marker answers: a
+/// different version is a different directory, so a moved tag simply looks
+/// elsewhere (issue #588). What used to be a fourth line recording the resolved
+/// version is now the third.
 ///
 /// `resolved` is `None` only when the registry could not be reached during an
-/// install, which leaves the marker in the three-line form and makes the next
-/// preparation re-resolve rather than trust an unverified tree.
+/// install. The third line then falls back to the declared selector, so the
+/// entry is not mistaken for a resolved one and the next preparation re-resolves
+/// rather than trusting an unverified tree (issue #584).
 fn marker_contents(selection: &PackageSelection, resolved: Option<&str>) -> String {
     format!(
         "{}\n{}\n{}\n",

--- a/src/runtime/package_runtime.rs
+++ b/src/runtime/package_runtime.rs
@@ -409,20 +409,33 @@ fn bin_dir_of(install_dir: &Path) -> PathBuf {
 /// install, which leaves the marker in the three-line form and makes the next
 /// preparation re-resolve rather than trust an unverified tree.
 fn marker_contents(selection: &PackageSelection, resolved: Option<&str>) -> String {
-    let effective = selection
-        .selector()
-        .effective(selection.runner())
-        .unwrap_or_default();
-    let base = format!(
+    format!(
         "{}\n{}\n{}\n",
         selection.package(),
         selection.binary(),
-        effective
-    );
-    if !selection.selector().is_volatile() {
-        return base;
-    }
-    resolved.map_or_else(|| base.clone(), |version| format!("{base}{version}\n"))
+        marker_identity_version(selection, resolved)
+    )
+}
+
+/// The third marker line: what this directory *holds*, not what was typed.
+///
+/// It must be the same value [`selection_digest`] keyed the directory on, or
+/// identity and location disagree. They did: the digest used the resolved
+/// version while the marker used the declared selector, so a tag resolving to
+/// 1.2.3 and an exact 1.2.3 shared one directory and each rejected the other's
+/// marker. The loser reinstalled and republished over a tree the winner could
+/// be executing from, which is precisely what keying on the version was meant
+/// to stop (issues #588, #571).
+fn marker_identity_version<'selection>(
+    selection: &'selection PackageSelection,
+    resolved: Option<&'selection str>,
+) -> &'selection str {
+    resolved.unwrap_or_else(|| {
+        selection
+            .selector()
+            .effective(selection.runner())
+            .unwrap_or_default()
+    })
 }
 
 /// Whether the cached install satisfies this selection.
@@ -432,11 +445,16 @@ fn marker_contents(selection: &PackageSelection, resolved: Option<&str>) -> Stri
 /// that version when the registry answered, and is `None` when it did not. A
 /// `None` therefore keeps the cached install rather than failing the launch —
 /// offline is a condition to ride out, not an error to raise (issue #584).
-fn cache_hit(install_dir: &Path, bin_dir: &Path, selection: &PackageSelection) -> bool {
+fn cache_hit(
+    install_dir: &Path,
+    bin_dir: &Path,
+    selection: &PackageSelection,
+    resolved: Option<&str>,
+) -> bool {
     let Ok(stored) = std::fs::read_to_string(install_dir.join(INSTALL_MARKER)) else {
         return false;
     };
-    if !marker_identity_matches(&stored, selection) {
+    if !marker_identity_matches(&stored, selection, resolved) {
         return false;
     }
     PathSnapshot::for_platform(
@@ -507,15 +525,16 @@ fn is_plausible_version(version: &str) -> bool {
 }
 
 /// Whether the stored marker's package/binary/effective lines match `selection`.
-fn marker_identity_matches(stored: &str, selection: &PackageSelection) -> bool {
-    let effective = selection
-        .selector()
-        .effective(selection.runner())
-        .unwrap_or_default();
+fn marker_identity_matches(
+    stored: &str,
+    selection: &PackageSelection,
+    resolved: Option<&str>,
+) -> bool {
+    let identity = marker_identity_version(selection, resolved);
     let mut lines = stored.split('\n');
     lines.next() == Some(selection.package())
         && lines.next() == Some(selection.binary())
-        && lines.next() == Some(effective)
+        && lines.next() == Some(identity)
 }
 fn prepare_managed_npm(
     candidate: &ResolvedCandidate,
@@ -587,7 +606,7 @@ fn prepare_managed_npm_with_lock_policy(
 
     // The directory is now the version, so a hit needs only identity and a
     // usable binary; there is no separate freshness question left to ask.
-    if !cache_hit(&install_dir, &bin_dir, selection) {
+    if !cache_hit(&install_dir, &bin_dir, selection, resolved_ref) {
         let staging = cache_root.join(format!("{STAGING_PREFIX}{digest}"));
         build_staged_install(candidate, selection, &staging, resolved_ref)?;
         promote_staged_install(&staging, &install_dir, &retired, &digest)?;

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -537,6 +537,55 @@ fn advancing_a_tag_leaves_the_previous_install_intact() {
     );
 }
 
+/// Two selectors naming the same version must share one install, not fight
+/// over it.
+///
+/// Since the cache is keyed on the resolved version (issue #588), a tag that
+/// resolves to 0.11.0 and an exact 0.11.0 address the *same* directory. If
+/// identity is judged by the selector the user typed rather than by the version
+/// that was installed, each rejects the other's marker, and the loser republishes
+/// over a tree the winner may be executing from — the exact destruction that
+/// version-keying was introduced to prevent (issue #571).
+#[cfg(unix)]
+#[test]
+fn a_tag_and_an_exact_pin_at_the_same_version_share_one_install() {
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let witness = witness_path(&bin);
+    counting_npm_stub(&bin, &witness);
+    publish_version(&witness, "0.11.0");
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+
+    let tagged = volatile_npm_candidate(&bin, "latest nightly");
+    let first = finalize_local_invocation_inner(&tagged, cache.path())
+        .unwrap_or_else(|error| panic!("tag install: {error}"));
+    let tagged_executable = first.executable().to_path_buf();
+    assert_eq!(
+        witness_lines(&witness).len(),
+        1,
+        "the tag must install once"
+    );
+
+    // The same version, named exactly. Nothing about the tree needs to change.
+    let pinned = volatile_npm_candidate(&bin, "0.11.0");
+    let second = finalize_local_invocation_inner(&pinned, cache.path())
+        .unwrap_or_else(|error| panic!("pinned install: {error}"));
+
+    assert_eq!(
+        tagged_executable,
+        second.executable(),
+        "the same version must resolve to the same install path"
+    );
+    assert_eq!(
+        witness_lines(&witness).len(),
+        1,
+        "naming the installed version exactly must be a cache hit, not a reinstall"
+    );
+    assert!(
+        tagged_executable.exists(),
+        "the tree the tagged agent is executing from must survive another selector          arriving at the same version"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn volatile_cache_hits_while_the_tag_has_not_moved() {


### PR DESCRIPTION
Fixes #610. Part of #571 — see the scope note I have posted there; most of what #571 describes is already delivered, and this closes one of the pieces that is not.

## The defect

The cache directory and the install marker disagreed about what identifies an install.

`selection_digest` keys the directory on the **resolved version** (`package_runtime.rs:341-350`). `marker_identity_matches` compared the **declared selector** (`package_runtime.rs:510-519`).

| selector | digest input | marker line 3 |
|---|---|---|
| `latest nightly` -> 0.11.0 | 0.11.0 | `latest nightly` |
| exact `0.11.0` | 0.11.0 | `0.11.0` |

Same directory. Different identity. So the cache-hit check fails, and promotion renames the published tree aside, renames staging into that same path, and deletes the retired tree — while an agent may be running out of it.

The comment sitting directly above that check already stated the invariant the code was violating:

> The directory is now the version, so a hit needs only identity and a usable binary; there is no separate freshness question left to ask.

Identity was not the version. It was the selector.

## Mine to own

This arrived with #588 (PR #600). Before that the digest keyed on the declared selector, so a tag and an exact pin lived in separate directories and could never meet. Keying on the version is right — it is what stops a tag advance from deleting a running agent's tree — but it made two selectors able to name one directory without teaching identity the same rule.

#601 then widened it: custom dist-tags and ranges became volatile, so `nightly`, `beta` or `^0.11.0` resolving to a version someone else pinned exactly now collide with it.

## The fix

The third marker line becomes the same expression the digest uses, `resolved.unwrap_or(declared)`. Any two selectors arriving at one version now recognise each other's install and share it.

The fourth line, which recorded the resolved version for volatile selectors, is removed: the third line carries it now, and nothing ever read past the third — it was write-only.

Net effect is a deletion rather than a new mechanism. There is no added branch, no new state, and one fewer line of marker to keep consistent.

## Tests

New: `a_tag_and_an_exact_pin_at_the_same_version_share_one_install`. Installs via a tag resolving to 0.11.0, then prepares an exact 0.11.0 against the same cache root.

Proven RED first — **2 installs where 1 is required**, with the second republishing the first's directory:

    assertion `left == right` failed: naming the installed version exactly must be a cache hit, not a reinstall
      left: 2
     right: 1

The three existing invariants still hold and were run alongside it: `advancing_a_tag_leaves_the_previous_install_intact`, `volatile_cache_hits_while_the_tag_has_not_moved`, `pinned_cache_remains_permanent_hit`.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo xtask complexity` all clean at this head. Workspace suite: 4978 passed, 1 failed — `production_host_generates_unique_credentials_delivers_and_revokes`, which is the contention flake filed as #609 and unrelated to this change.

## Scope

Only identity. Digest derivation, selector normalization, resolution, promotion and the lock are untouched.

Not addressed here, and still live in #571: the probe/launch double preparation, where two `npm view` calls in one launch can resolve different versions and compose probe availability from one with the executable and fingerprint of the other.
