### PR TITLE
Give the probe retry tests a budget that clears spawn latency

### DIFF
--- a/src/runtime/agent_probe.rs
+++ b/src/runtime/agent_probe.rs
@@ -696,7 +696,7 @@ mod tests {
             }
         };
 
-        let outcome = super::run_probe_with_loader_retry(&build, Duration::from_millis(300));
+        let outcome = super::run_probe_with_loader_retry(&build, RETRY_TEST_BUDGET);
 
         assert!(
             outcome.is_ok(),
@@ -723,7 +723,7 @@ mod tests {
             sleeping_command()
         };
 
-        let outcome = super::run_probe_with_loader_retry(&build, Duration::from_millis(300));
+        let outcome = super::run_probe_with_loader_retry(&build, RETRY_TEST_BUDGET);
 
         assert!(
             outcome.is_err(),
@@ -736,15 +736,27 @@ mod tests {
         );
     }
 
-    /// A command that outlives a short budget on every platform.
+    /// Budget for the retry tests.
+    ///
+    /// Must clear the cost of *spawning* a process, not just running one. At
+    /// 300ms these tests passed alone and failed 3 runs in 4 under the full
+    /// parallel suite, because the second attempt's `cmd` spawn could itself
+    /// exceed the budget on a loaded machine -- so the retry that was supposed
+    /// to succeed timed out too, and the test blamed the code. The budget only
+    /// has to be shorter than [`sleeping_command`] for these tests to mean what
+    /// they say, so it is set well clear of spawn latency instead.
+    const RETRY_TEST_BUDGET: Duration = Duration::from_secs(2);
+
+    /// A command that outlives [`RETRY_TEST_BUDGET`] on every platform, by
+    /// enough that load cannot make the two overlap.
     fn sleeping_command() -> std::process::Command {
         if cfg!(windows) {
             let mut command = std::process::Command::new("cmd");
-            command.args(["/D", "/S", "/C", "ping -n 4 127.0.0.1"]);
+            command.args(["/D", "/S", "/C", "ping -n 12 127.0.0.1"]);
             command
         } else {
             let mut command = std::process::Command::new("sh");
-            command.args(["-c", "sleep 3"]);
+            command.args(["-c", "sleep 11"]);
             command
         }
     }


### PR DESCRIPTION
The retry tests I added in #605 pass in isolation and **fail 3 runs in 4** under the full parallel suite.

| | result |
|---|---|
| isolated | 6/6 pass |
| full parallel suite (before) | **3/4 FAIL** |
| full parallel suite (after) | **4/4 pass** |

## Cause

The budget was 300ms. That has to cover not just *running* the second attempt but *spawning* it. On a loaded machine the retry's own `cmd` spawn exceeded 300ms, so the attempt that was supposed to succeed timed out — and the test failed on the exact path it exists to protect.

A flaky test here is worse than no test, because the failure is indistinguishable from the bug returning. Epic #539 already records this pattern: a mouse/Page-key test "fixed" twice and then failing three more times on main.

## Fix

The budget only has to be shorter than the deliberately-slow command for these tests to mean what they say. So it moves to 2s — well clear of spawn latency — and the slow command grows to stay comfortably beyond it. Named `RETRY_TEST_BUDGET` with the reasoning recorded, so the next person does not quietly shrink it back.

No production code changes.

## Verification

- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- 4 consecutive full-suite runs: **3004 passed, 0 failed** each
