### PR TITLE
Keep composer submit hints aligned with remaps (Fixes #189)

### DIFF
--- a/dev-docs/tmux-scenarios/pr-composer-submit-key.json
+++ b/dev-docs/tmux-scenarios/pr-composer-submit-key.json
@@ -1,10 +1,10 @@
 {
   "schema": 1,
-  "name": "issues-new-issue-typing",
+  "name": "pr-composer-submit-key",
   "platform": "macos",
   "terminal": {
     "cols": 120,
-    "rows": 40
+    "rows": 36
   },
   "workspace": {
     "mode": 448,
@@ -22,7 +22,7 @@
       {
         "path": "config/settings.toml",
         "content": {
-          "utf8": "settings_schema = 2\n[keymap.\"issues.new-form\"]\n\"issues.new-submit\" = [\"F8\"]\n"
+          "utf8": "settings_schema = 2\n[keymap.\"prs.inline\"]\n\"prs.inline-submit\" = [\"F9\"]\n"
         },
         "mode": 384
       }
@@ -48,36 +48,41 @@
     },
     {
       "op": "key",
-      "key": "i",
+      "key": "p",
       "modifiers": []
     },
     {
       "op": "wait",
       "source": "frame",
-      "literal": "No issues found",
+      "literal": "Add newest-first review sorting",
       "timeout_ms": 15000
     },
     {
       "op": "key",
-      "key": "n",
+      "key": "enter",
       "modifiers": []
     },
     {
       "op": "wait",
       "source": "frame",
-      "literal": "New Issue",
+      "literal": "Reviews",
       "timeout_ms": 15000
+    },
+    {
+      "op": "key",
+      "key": "c",
+      "modifiers": []
     },
     {
       "op": "wait",
       "source": "frame",
-      "literal": "F8 submit",
+      "literal": "F9 submit",
       "timeout_ms": 15000
     },
     {
       "op": "assert-frame",
       "contains": [
-        "F8 submit"
+        "F9 submit"
       ],
       "absent": [
         "Alt+Enter submit"
@@ -85,29 +90,7 @@
     },
     {
       "op": "text",
-      "text": "HelloTitle"
-    },
-    {
-      "op": "wait",
-      "source": "frame",
-      "literal": "HelloTitle",
-      "timeout_ms": 15000
-    },
-    {
-      "op": "assert-frame",
-      "contains": [
-        "HelloTitle"
-      ],
-      "absent": []
-    },
-    {
-      "op": "key",
-      "key": "tab",
-      "modifiers": []
-    },
-    {
-      "op": "text",
-      "text": "Body line one"
+      "text": "PR body line one"
     },
     {
       "op": "key",
@@ -116,31 +99,25 @@
     },
     {
       "op": "text",
-      "text": "Body line two"
+      "text": "PR body line two"
     },
     {
       "op": "wait",
       "source": "frame",
-      "literal": "Body line two",
+      "literal": "PR body line two",
       "timeout_ms": 15000
     },
     {
       "op": "assert-frame",
       "contains": [
-        "Body line one"
-      ],
-      "absent": []
-    },
-    {
-      "op": "assert-frame",
-      "contains": [
-        "Body line two"
+        "PR body line one",
+        "PR body line two"
       ],
       "absent": []
     },
     {
       "op": "key",
-      "key": "backspace",
+      "key": "escape",
       "modifiers": []
     },
     {
@@ -149,15 +126,11 @@
       "modifiers": []
     },
     {
-      "op": "wait",
-      "source": "frame",
-      "literal": "No issue selected",
-      "timeout_ms": 15000
-    },
-    {
       "op": "key",
       "key": "q",
-      "modifiers": ["control"]
+      "modifiers": [
+        "control"
+      ]
     },
     {
       "op": "finish"

--- a/project-plans/issue189-plan.md
+++ b/project-plans/issue189-plan.md
@@ -1,0 +1,93 @@
+# Issue #189 — Dedicated composer submit key with Enter reserved for newlines
+
+> Issues #265, #383, and #480 already established registry-owned
+> `Alt+Enter` / `Ctrl+Enter` submit actions and bare-Enter text behavior. Issue
+> #189 closes the remaining acceptance gap: the active composer must expose its
+> effective, user-remappable submit binding through the generated keybind footer,
+> without retaining a stale hardcoded default. The issue comment is interpreted
+> as requiring the same composer behavior on Pull Requests.
+
+## Acceptance matrix
+
+| # | Actor / launch path | Input / boundary | Target | Observable success | Observable failure / diagnostic | Side effects before failure | Persistence / compatibility | Proof |
+|---|---|---|---|---|---|---|---|---|
+| A1 | User opens New Issue from Issues mode | Bare Enter in Body; bare Enter in Title | Local TUI on supported terminals | Body Enter inserts a newline; Title Enter advances focus and never submits | None | Draft/focus mutation only; no GitHub mutation | Existing draft/form behavior remains compatible | Pure input tests plus New Issue TUI scenario with two visible body lines |
+| A2 | User composes an issue comment or reply | Bare Enter versus dedicated submit chord | Issues detail composer | Enter inserts a newline; default `Alt+Enter` or `Ctrl+Enter` resolves to `InlineSubmit` | Existing blank-draft validation remains visible | No GitHub mutation for blank/invalid draft | Existing `OpenNewIssueComposer` / `MutationSubmitted` flow is unchanged | Existing pure input and mutation tests plus focused production-route regression |
+| A3 | User composes a PR comment, reply, or review-thread comment | Bare Enter versus dedicated submit chord | Pull Requests detail/changes composer | Enter inserts a newline; default `Alt+Enter` or `Ctrl+Enter` resolves to `PrInlineSubmit` | Existing blank-draft validation remains visible | No GitHub mutation for blank/invalid draft | Existing PR mutation flow is unchanged | Existing pure input tests, focused production-route regression, and deterministic PR TUI scenario |
+| A4 | User overrides or unbinds a composer submit action in settings schema 2 | Override `issues.new-submit`, `issues.inline-submit`, or `prs.inline-submit` | Issues and Pull Requests composer contexts | Dispatch uses the effective chord; generated active-composer footer shows that effective chord, or `Unbound submit` when explicitly unbound | Invalid keymap continues to fail through existing settings diagnostics | No new side effects | Existing keymap format and action IDs remain authoritative | Pure projection tests for override/unbind, production registry-route tests, TUI scenarios with non-default submit chords |
+| A5 | User opens any accepted composer with default settings | Active composer footer and embedded content | Issues and Pull Requests | Footer includes discoverable `submit` text generated from the action snapshot; embedded composer content contains no stale hardcoded submit chord | None | Display only | Emoji-free existing theme behavior | Pure projection/component tests and TUI frame assertions |
+
+## Boundary decisions
+
+- New Issue Title is a single-line field: bare Enter advances to Body rather than inserting a title newline; it still never submits.
+- New Issue Body and all issue/PR comment bodies retain bare Enter as newline.
+- Both `Alt+Enter` and terminal-portable `Ctrl+Enter` remain compiled defaults; this issue does not choose a new chord.
+- Empty/blank submit behavior, mutation pending guards, retries, and GitHub diagnostics stay exactly as implemented.
+- The issue comment's word “merge” is read in context as composer parity on the PR screen. PR merge-chooser confirmation is not a composer action and is an explicit non-goal.
+
+## Non-goals
+
+- Changing PR merge-chooser bindings or merge behavior.
+- Changing mutation payloads, GitHub API calls, retry/pending semantics, or draft persistence.
+- Adding a new input, footer, keymap, or process subsystem.
+- Renaming public action IDs or changing settings schema.
+- Refactoring unrelated static shortcut text outside issue/PR composer surfaces.
+- Changing editor (as opposed to composer) behavior.
+- Adding dependencies, workflow/quality configuration, or `.llxprt/` changes.
+
+## Vertical slice — generated, remappable composer submit discovery
+
+- **Rows:** A1–A5.
+- **Owners / boundaries:** canonical action display inventory -> pure footer projection -> existing Issues/PR screen rendering; existing action registry -> existing input handlers. This is one bounded cutover across three ownership layers.
+- **Allowed paths:** the existing action display/projection and keybind-bar modules; Issues/PR screen and composer-content modules with their existing tests; focused action-routing tests; issue-scoped schema-1 TUI scenario/runner files; this plan.
+- **RED:** first make the New Issue scenario require a remapped submit hint while preserving two body lines; add a deterministic PR composer scenario requiring its own remapped submit hint and multiline text; add pure projection and production-route tests for effective composer chords. The current hardcoded `Alt+Enter` composer text must fail those remapped-hint assertions.
+- **GREEN:** select composer-specific groups from the existing footer mode mechanism, render effective snapshot chords, remove only the superseded hardcoded submit text on accepted composer surfaces, and preserve existing input/mutation routing.
+- **REFACTOR:** only remove duplication directly superseded by generated composer hints; do not clean adjacent shortcut text.
+- **Verification:** focused Rust tests, both issue-scoped TUI scenarios, `cargo xtask quick`, reviewers/OCR, then exact-head `cargo xtask ci`.
+- **Stop for approval:** a new subsystem or production module, a new public abstraction instead of extending the existing footer mode contract, mutation-flow changes, dependency/workflow/quality changes, or behavior outside A1–A5.
+
+## Expected paths / architectural layers
+
+- `src/domain/default_action_inventory_display.rs` — canonical composer footer groups referencing existing action IDs.
+- `src/action_projection.rs` — pure selection/projection of composer footer modes and effective bindings.
+- `src/ui/components/keybind_bar.rs` — pass the existing footer-mode selection into the pure projection.
+- `src/ui/screens/issues.rs`, `src/ui/screens/pull_requests.rs` — select an existing composer footer mode from current state.
+- `src/issue_detail_content.rs`, `src/pr_detail_content.rs`, `src/ui/components/pr_diff.rs` — remove only stale hardcoded submit chords superseded by the generated footer while retaining stable composer anchors.
+- Existing adjacent unit/component tests and `src/app_shell_key_routing_tests.rs` — behavioral dispatch/projection evidence.
+- `dev-docs/tmux-scenarios/issues-new-issue-typing.json` and an issue-scoped PR composer scenario/runner — real-TTY evidence for both screens.
+
+No new subsystem, production module, dependency, public action abstraction,
+workflow/quality-tool change, or unrelated refactor is authorized.
+
+## Scope ledger
+
+| Entry | Status | Reason |
+|---|---|---|
+| Composer-specific generated footer groups using existing action IDs | In scope | A4/A5 |
+| Effective override/unbind projection and dispatch evidence | In scope | A4 |
+| Remove hardcoded submit chords only from accepted composer surfaces | In scope | A5; prevents remap drift |
+| Issues multiline and dedicated-submit evidence | In scope | A1/A2 |
+| PR detail/changes composer parity | In scope | A3 and issue comment |
+| PR merge chooser changes | Rejected | Explicit non-goal |
+| Mutation/message-flow redesign | Rejected | Existing flow already satisfies A1–A3 |
+| Adjacent static shortcut cleanup | Rejected | Outside accepted composer surfaces |
+
+## Review and verification ledger
+
+- Local OCR: `1 / 2`
+- PR OCR: `0 / 2`
+- Rust reviewer / DeepThinker: cycle 1 complete
+- RED evidence: passed — the PR scenario, applied alone to unmodified HEAD `67511917`, failed with `HAR-E006: frame did not contain 'F9 submit' within 15000ms`; the baseline rendered its hardcoded default instead.
+- Focused verification: projection override/unbind tests and state-derived production-route override tests pass; strict Clippy and source-size policy pass; existing issue/PR submit and bare-Enter tests remain in the suite.
+- TUI verification: New Issue schema-1 scenario passes with `F8 submit` and two body lines; PR scenario passes with `F9 submit`, two body lines, bounded synchronization, and read-only `gh` audit.
+- Review triage: fixed the reviewer findings for focused projection-test extraction, effective-snapshot production-route proof, deterministic PR scenario synchronization, and retained runner diagnostics. Rejected a proposed `issues.new-rewrite` action because no such canonical action exists and adding one would expand submit scope. OCR medium findings for temporary shim-audit cleanup and fail-closed zero/one-argument handling were fixed and retested; OCR low findings were rejected as non-defects or redundant shared-path coverage.
+- Exact-head verification: passed with `cargo xtask ci` after `make ci-check` reported that this repository has no such Make target. The CI-equivalent command completed all format, policy, strict/complexity Clippy, coverage (67.98% lines), locked build, and locked workspace/all-feature tests successfully.
+- CI / native Windows: pending
+- Deferred findings: none
+
+## Completion contract
+
+Complete only when A1–A5 each have behavioral evidence, exact-head local gates
+and required CI pass, review findings are explicitly triaged within the review
+caps, the PR has correct ancestry and no conflicts, and every changed file maps
+to this ledger. Stop at that point without optional cleanup or hardening.

--- a/scripts/issue189-gh-shim.sh
+++ b/scripts/issue189-gh-shim.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Fail-closed read-only gh shim for issue #189 PR composer scenario.
+set -euo pipefail
+
+SHIM_OWNED_AUDIT=false
+if [[ -n "${GH_SHIM_AUDIT:-}" ]]; then
+    AUDIT_FILE="$GH_SHIM_AUDIT"
+else
+    AUDIT_FILE=$(mktemp "${TMPDIR:-/tmp}/jefe-issue189-gh-audit.XXXXXX.log") || {
+        echo "gh shim: failed to create a private audit file" >&2
+        exit 2
+    }
+    SHIM_OWNED_AUDIT=true
+fi
+if ! : 2>/dev/null >> "$AUDIT_FILE"; then
+    echo "gh shim: audit file is not writable: $AUDIT_FILE" >&2
+    exit 2
+fi
+
+cleanup_shim_audit() {
+    if [[ "$SHIM_OWNED_AUDIT" == true && -f "$AUDIT_FILE" ]]; then
+        rm -f "$AUDIT_FILE" 2>/dev/null || true
+    fi
+}
+trap cleanup_shim_audit EXIT
+
+audit_write() {
+    printf '%s\n' "$1" >> "$AUDIT_FILE"
+}
+
+audit_accept() {
+    local op="$1"; shift
+    audit_write "ACCEPTED $op -- gh $(printf '%q ' "$@")"
+}
+
+audit_reject() {
+    local reason="$1"; shift
+    audit_write "REJECTED $reason -- gh $(printf '%q ' "$@")"
+}
+
+if [[ "$*" == "auth status" ]]; then
+    audit_accept "auth-status" "$@"
+    exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
+    query_arg=""
+    search_query=""
+    for ((i = 3; i <= $#; i++)); do
+        if [[ "${!i}" == "-f" ]]; then
+            next=$((i + 1))
+            if (( next <= $# )); then
+                val="${!next}"
+                if [[ "$val" == query=* ]]; then
+                    query_arg="${val#query=}"
+                fi
+            fi
+        elif [[ "${!i}" == "-F" ]]; then
+            next=$((i + 1))
+            if (( next <= $# )); then
+                val="${!next}"
+                if [[ "$val" == searchQuery=* ]]; then
+                    search_query="${val#searchQuery=}"
+                fi
+            fi
+        fi
+    done
+
+    if [[ "$query_arg" == *"search(type: ISSUE"* && -n "$search_query" ]]; then
+        audit_accept "pr-search" "$@"
+        cat <<'JSON'
+{"data":{"search":{"nodes":[{"number":238,"title":"Add newest-first review sorting","state":"OPEN","mergedAt":null,"author":{"login":"contributor"},"updatedAt":"2026-07-03T12:00:00Z","headRefName":"feature-238","headRefOid":"abc238def","baseRefName":"main","isDraft":false,"reviewDecision":null,"statusCheckRollup":{"contexts":{"nodes":[]}},"assignees":{"nodes":[]},"labels":{"nodes":[]},"comments":{"totalCount":0},"body":"Test PR for review ordering"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}
+JSON
+        exit 0
+    fi
+
+    if [[ "$query_arg" == *"reviewThreads"* ]]; then
+        audit_accept "review-threads" "$@"
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
+        exit 0
+    fi
+
+    if [[ "$query_arg" == *"pullRequest(number:"* && "$query_arg" == *"comments(first:"* && "$query_arg" != *"reviewThreads"* ]]; then
+        audit_accept "pr-comments" "$@"
+        cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
+        exit 0
+    fi
+fi
+
+if [[ "${1:-} ${2:-}" == "pr view" ]]; then
+    has_number=0
+    has_json=0
+    for arg in "${@:3}"; do
+        [[ "$arg" == "238" ]] && has_number=1
+        [[ "$arg" == "--json" ]] && has_json=1
+    done
+    if (( has_number && has_json )); then
+        audit_accept "pr-view-detail" "$@"
+        cat <<'JSON'
+{"number":238,"title":"Add newest-first review sorting","state":"OPEN","mergedAt":null,"author":{"login":"contributor"},"createdAt":"2026-07-01T00:00:00Z","updatedAt":"2026-07-03T12:00:00Z","headRefName":"feature-238","headRefOid":"abc238def","baseRefName":"main","isDraft":false,"labels":[],"assignees":[],"milestone":null,"body":"Test PR for composer submit behavior","url":"https://github.com/owner/review-sort-fixture/pull/238","reviewDecision":null,"mergeable":null,"mergeStateStatus":null,"reviews":[]}
+JSON
+        exit 0
+    fi
+fi
+
+audit_reject "unexpected-argv" "$@"
+printf 'gh shim: REJECTED unexpected gh argv: ' >&2
+printf '%q ' "$@" >&2
+printf '\n' >&2
+exit 64

--- a/scripts/issue189-run-pr-scenario.sh
+++ b/scripts/issue189-run-pr-scenario.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Runner for issue #189 TUI scenario: pr-composer-submit-key.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+ARTIFACT_ROOT="$ROOT/target/tmux-harness"
+mkdir -p "$ARTIFACT_ROOT"
+ARTIFACT="$(mktemp -d "$ARTIFACT_ROOT/issue189-pr.XXXXXX")"
+CONFIG="$ARTIFACT/config"
+SHIM_BIN="$ARTIFACT/bin"
+REPO="$ARTIFACT/repo"
+AUDIT="$ARTIFACT/gh-audit.log"
+SESSION="jefe-issue189-pr-${ARTIFACT##*.}"
+RUN_SUCCEEDED=0
+
+cleanup() {
+  status=$?
+  trap - EXIT
+  if tmux has-session -t "$SESSION" 2>/dev/null; then
+    tmux kill-session -t "$SESSION" || echo "WARN: failed to stop tmux session $SESSION" >&2
+  fi
+  if (( RUN_SUCCEEDED )); then
+    rm -rf "$ARTIFACT"
+  else
+    echo "Diagnostics retained at $ARTIFACT" >&2
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+for command_name in cargo python3 tmux; do
+  command -v "$command_name" >/dev/null || { echo "FATAL: $command_name is required" >&2; exit 1; }
+done
+
+mkdir -p "$CONFIG" "$SHIM_BIN" "$REPO"
+cat > "$CONFIG/settings.toml" <<'EOF'
+settings_schema = 2
+[keymap."prs.inline"]
+"prs.inline-submit" = ["F9"]
+EOF
+python3 - "$REPO" "$CONFIG/state.json" <<'PY'
+import json
+import sys
+
+repo, output = sys.argv[1:]
+state = {
+    "schema_version": 1,
+    "repositories": [{
+        "id": "issue189-repo",
+        "name": "composer-submit-fixture",
+        "slug": "composer-submit-fixture",
+        "base_dir": repo,
+        "default_profile": "",
+        "default_code_puppy_model": "",
+        "github_repo": "owner/review-sort-fixture",
+        "remote": {"enabled": False, "host": "", "user": "", "port": None},
+        "issue_base_prompt": "",
+        "default_agent_kind": "llxprt",
+        "agent_ids": [],
+    }],
+    "agents": [],
+    "selected_repository_index": 0,
+    "selected_agent_index": None,
+    "hide_idle_repositories": False,
+    "last_selected_agent_by_repo": [],
+    "pane_focus": "",
+    "terminal_focused": False,
+    "user_preferences": {},
+}
+with open(output, "w", encoding="utf-8") as stream:
+    json.dump(state, stream)
+PY
+SHIM_SOURCE="$ROOT/scripts/issue189-gh-shim.sh"
+SCENARIO_JSON="$ROOT/dev-docs/tmux-scenarios/pr-composer-submit-key.json"
+[[ -s "$SHIM_SOURCE" ]] || { echo "FATAL: missing or empty gh shim: $SHIM_SOURCE" >&2; exit 1; }
+[[ -s "$SCENARIO_JSON" ]] || { echo "FATAL: missing or empty scenario JSON: $SCENARIO_JSON" >&2; exit 1; }
+cp "$SHIM_SOURCE" "$SHIM_BIN/gh"
+chmod +x "$SHIM_BIN/gh"
+
+(cd "$ROOT" && cargo build --locked --bin jefe --bin jefe-tmux-harness)
+
+JEFE_BIN="$ROOT/target/debug/jefe"
+HARNESS_BIN="$ROOT/target/debug/jefe-tmux-harness"
+[[ -x "$JEFE_BIN" ]] || { echo "FATAL: build did not produce $JEFE_BIN" >&2; exit 1; }
+[[ -x "$HARNESS_BIN" ]] || { echo "FATAL: build did not produce $HARNESS_BIN" >&2; exit 1; }
+
+env PATH="$SHIM_BIN:$PATH" GH_SHIM_AUDIT="$AUDIT" \
+  "$HARNESS_BIN" \
+  --scenario "$SCENARIO_JSON" \
+  --jefe-bin "$JEFE_BIN" \
+  --config "$CONFIG" --out-dir "$ARTIFACT" --session "$SESSION"
+
+[[ -s "$AUDIT" ]] || { echo "FATAL: gh shim was not invoked" >&2; exit 1; }
+if grep -q REJECTED "$AUDIT"; then cat "$AUDIT" >&2; exit 1; fi
+if grep -qE 'ACCEPTED (pr-merge|pr-close|pr-update|comment-create|pr-review|pr-ready|issue-create|issue-update|issue-close)' "$AUDIT"; then
+  echo "FATAL: unexpected write operation in gh audit:" >&2
+  cat "$AUDIT" >&2
+  exit 1
+fi
+for expected in "pr-search" "pr-view-detail" "review-threads"; do
+  grep -F -- "$expected" "$AUDIT" >/dev/null || { echo "FATAL: missing audit operation: $expected" >&2; cat "$AUDIT" >&2; exit 1; }
+done
+RUN_SUCCEEDED=1
+printf 'PASS: issue 189 PR composer submit-key scenario and read-only gh audit\n'

--- a/scripts/issue189-run-pr-scenario.sh
+++ b/scripts/issue189-run-pr-scenario.sh
@@ -92,8 +92,8 @@ env PATH="$SHIM_BIN:$PATH" GH_SHIM_AUDIT="$AUDIT" \
 
 [[ -s "$AUDIT" ]] || { echo "FATAL: gh shim was not invoked" >&2; exit 1; }
 if grep -q REJECTED "$AUDIT"; then cat "$AUDIT" >&2; exit 1; fi
-if grep -qE 'ACCEPTED (pr-merge|pr-close|pr-update|comment-create|pr-review|pr-ready|issue-create|issue-update|issue-close)' "$AUDIT"; then
-  echo "FATAL: unexpected write operation in gh audit:" >&2
+if grep '^ACCEPTED ' "$AUDIT" | grep -qvE '^ACCEPTED (auth-status|pr-search|review-threads|pr-comments|pr-view-detail) -- gh '; then
+  echo "FATAL: unexpected accepted operation in gh audit:" >&2
   cat "$AUDIT" >&2
   exit 1
 fi

--- a/scripts/issue189-run-pr-scenario.sh
+++ b/scripts/issue189-run-pr-scenario.sh
@@ -91,7 +91,7 @@ env PATH="$SHIM_BIN:$PATH" GH_SHIM_AUDIT="$AUDIT" \
   --config "$CONFIG" --out-dir "$ARTIFACT" --session "$SESSION"
 
 [[ -s "$AUDIT" ]] || { echo "FATAL: gh shim was not invoked" >&2; exit 1; }
-if grep -q REJECTED "$AUDIT"; then cat "$AUDIT" >&2; exit 1; fi
+if grep -q '^REJECTED ' "$AUDIT"; then cat "$AUDIT" >&2; exit 1; fi
 if grep '^ACCEPTED ' "$AUDIT" | grep -qvE '^ACCEPTED (auth-status|pr-search|review-threads|pr-comments|pr-view-detail) -- gh '; then
   echo "FATAL: unexpected accepted operation in gh audit:" >&2
   cat "$AUDIT" >&2

--- a/src/action_projection.rs
+++ b/src/action_projection.rs
@@ -70,6 +70,7 @@ pub struct FooterProjectionInput {
     pub shell_overlay_active: bool,
     pub shell_resume_available: bool,
     pub actions_focus: Option<ActionsFocus>,
+    pub mode_override: Option<FooterMode>,
 }
 
 // ── Availability lookup from snapshot ──────────────────────────────────────
@@ -316,12 +317,15 @@ fn sorted_help_lines() -> Vec<crate::domain::default_action_inventory::display::
 
 #[must_use]
 pub fn project_footer(snapshot: &ActionRegistrySnapshot, input: FooterProjectionInput) -> String {
+    let mode = input
+        .mode_override
+        .unwrap_or_else(|| footer_mode(input.screen));
     let hints = if input.shell_overlay_active {
         sorted_hints(SHELL_OVERLAY_HINTS)
     } else if input.terminal_focused {
         sorted_hints(TERMINAL_FOCUSED_HINTS)
     } else {
-        footer_hints(footer_mode(input.screen), input.actions_focus)
+        footer_hints(mode, input.actions_focus)
     };
     let mut parts = annotate_hints_with_status(
         snapshot,
@@ -329,7 +333,7 @@ pub fn project_footer(snapshot: &ActionRegistrySnapshot, input: FooterProjection
         input.shell_resume_available && !input.shell_overlay_active,
     );
     if !input.shell_overlay_active && !input.terminal_focused {
-        append_unlisted_unavailable_statuses(snapshot, input.screen, &mut parts);
+        append_unlisted_unavailable_statuses(snapshot, mode, &mut parts);
     }
     parts.join(" | ")
 }
@@ -403,10 +407,10 @@ fn render_footer_hint(
 
 fn append_unlisted_unavailable_statuses(
     snapshot: &ActionRegistrySnapshot,
-    screen: ScreenId,
+    mode: FooterMode,
     parts: &mut Vec<String>,
 ) {
-    let mode_contexts = footer_contexts(screen);
+    let mode_contexts = footer_contexts(mode);
     let rows = project_action_rows(snapshot);
     for row in rows.iter().filter(|row| {
         row.reason().is_some()
@@ -430,15 +434,18 @@ fn footer_hints_for_mode(mode: FooterMode) -> &'static [FooterDisplayHint] {
         .map_or(&[], |group| group.hints)
 }
 
-fn footer_contexts(mode: ScreenId) -> &'static [&'static str] {
+fn footer_contexts(mode: FooterMode) -> &'static [&'static str] {
     match mode {
-        ScreenId::Dashboard => &["dashboard"],
-        ScreenId::Repositories => &["split"],
-        ScreenId::Issues => &["issues.list", "issues.detail"],
-        ScreenId::PullRequests => &["prs.repo-list", "prs.list", "prs.detail"],
-        ScreenId::Actions => &["actions"],
-        ScreenId::Errors => &["errors"],
-        ScreenId::Terminals => &["terminal-manager"],
+        FooterMode::Dashboard => &["dashboard"],
+        FooterMode::Split => &["split"],
+        FooterMode::Issues => &["issues.list", "issues.detail"],
+        FooterMode::IssuesNewComposer => &["issues.new-form"],
+        FooterMode::IssuesInlineComposer => &["issues.inline"],
+        FooterMode::PullRequests => &["prs.repo-list", "prs.list", "prs.detail"],
+        FooterMode::PullRequestsInlineComposer => &["prs.inline"],
+        FooterMode::Actions => &["actions"],
+        FooterMode::Errors => &["errors"],
+        FooterMode::Terminals => &["terminal-manager"],
     }
 }
 
@@ -455,6 +462,10 @@ pub fn test_snapshot() -> ActionRegistrySnapshot {
     };
     composed.snapshot().clone()
 }
+
+#[cfg(test)]
+#[path = "action_projection_composer_tests.rs"]
+mod composer_tests;
 
 #[cfg(test)]
 mod tests {
@@ -530,6 +541,7 @@ mod tests {
             shell_overlay_active: false,
             shell_resume_available: false,
             actions_focus: None,
+            mode_override: None,
         }
     }
 
@@ -596,6 +608,7 @@ mod tests {
                     shell_overlay_active: false,
                     shell_resume_available: false,
                     actions_focus: Some(ActionsFocus::RunList),
+                    mode_override: None,
                 },
             ),
             "^/k/v/j select | g/G grab | m move | Esc back | ?/h/H/F1 help | Ctrl-q quit | qqq quit"
@@ -635,6 +648,7 @@ mod tests {
                 shell_overlay_active: false,
                 shell_resume_available: false,
                 actions_focus: None,
+                mode_override: None,
             },
         );
 

--- a/src/action_projection_composer_tests.rs
+++ b/src/action_projection_composer_tests.rs
@@ -1,0 +1,107 @@
+use std::collections::BTreeMap;
+
+use super::*;
+use crate::domain::default_action_inventory::display::FooterMode;
+use crate::state::ScreenId;
+
+struct ComposerFooterCase {
+    context: &'static str,
+    action: &'static str,
+    mode: FooterMode,
+    screen: ScreenId,
+    chord: &'static str,
+}
+
+fn snapshot_with_submit_override(
+    context: &str,
+    action: &str,
+    chords: &[&str],
+) -> ActionRegistrySnapshot {
+    let mut settings = crate::persistence::settings_document::PublishedSettings::default();
+    settings.keymap.insert(
+        context.to_owned(),
+        BTreeMap::from([(
+            action.to_owned(),
+            chords.iter().map(|chord| (*chord).to_owned()).collect(),
+        )]),
+    );
+    let composed = crate::persistence::keymap_edit::compose_published(&settings, "settings");
+    let Ok(composed) = composed else {
+        panic!("composer override fixture must compose: {composed:?}");
+    };
+    composed.snapshot().clone()
+}
+
+fn project_composer_footer(case: &ComposerFooterCase, chords: &[&str]) -> String {
+    let snapshot = snapshot_with_submit_override(case.context, case.action, chords);
+    project_footer(
+        &snapshot,
+        FooterProjectionInput {
+            screen: case.screen,
+            terminal_focused: false,
+            shell_overlay_active: false,
+            shell_resume_available: false,
+            actions_focus: None,
+            mode_override: Some(case.mode),
+        },
+    )
+}
+
+fn assert_effective_submit(case: ComposerFooterCase) {
+    let footer = project_composer_footer(&case, &[case.chord]);
+    assert!(
+        footer.contains(&format!("{} submit", case.chord)),
+        "composer footer did not project effective submit binding: {footer}"
+    );
+    assert!(
+        !footer.contains("Alt+Enter submit"),
+        "composer footer retained compiled submit binding: {footer}"
+    );
+}
+
+#[test]
+fn new_issue_footer_projects_effective_submit_binding() {
+    assert_effective_submit(ComposerFooterCase {
+        context: "issues.new-form",
+        action: "issues.new-submit",
+        mode: FooterMode::IssuesNewComposer,
+        screen: ScreenId::Issues,
+        chord: "F8",
+    });
+}
+
+#[test]
+fn issue_inline_footer_projects_effective_submit_binding() {
+    assert_effective_submit(ComposerFooterCase {
+        context: "issues.inline",
+        action: "issues.inline-submit",
+        mode: FooterMode::IssuesInlineComposer,
+        screen: ScreenId::Issues,
+        chord: "F9",
+    });
+}
+
+#[test]
+fn pr_inline_footer_projects_effective_submit_binding() {
+    assert_effective_submit(ComposerFooterCase {
+        context: "prs.inline",
+        action: "prs.inline-submit",
+        mode: FooterMode::PullRequestsInlineComposer,
+        screen: ScreenId::PullRequests,
+        chord: "F10",
+    });
+}
+
+#[test]
+fn unbound_composer_submit_is_discoverable() {
+    let case = ComposerFooterCase {
+        context: "issues.inline",
+        action: "issues.inline-submit",
+        mode: FooterMode::IssuesInlineComposer,
+        screen: ScreenId::Issues,
+        chord: "F9",
+    };
+    let footer = project_composer_footer(&case, &[]);
+
+    assert!(footer.contains("Unbound submit"), "footer: {footer}");
+}

--- a/src/app_shell_key_routing.rs
+++ b/src/app_shell_key_routing.rs
@@ -297,16 +297,19 @@ pub fn resolve_compiled_registry_key(
     state: &AppState,
     key_event: &KeyEvent,
 ) -> ResolvedRegistryKey {
-    let dir = std::env::temp_dir().join(format!("jefe_s3_route_{}", std::process::id()));
-    let result = jefe::startup::build_persistence(Some(&dir));
-    let Ok(startup) = result else {
-        panic!("compiled S3 snapshot should compose, got {result:?}");
-    };
+    let snapshot = state.action_registry_snapshot.clone().unwrap_or_else(|| {
+        let dir = std::env::temp_dir().join(format!("jefe_s3_route_{}", std::process::id()));
+        let result = jefe::startup::build_persistence(Some(&dir));
+        let Ok(startup) = result else {
+            panic!("compiled S3 snapshot should compose, got {result:?}");
+        };
+        startup.keymap_snapshot
+    });
     let context = derive_action_context(state, input_mode_for_state(state));
     let Ok(context) = context else {
         panic!("S3 context should derive, got {context:?}");
     };
-    let result = resolve_in_context(&startup.keymap_snapshot, context, key_event);
+    let result = resolve_in_context(&snapshot, context, key_event);
     let Ok(resolved) = result else {
         panic!("S3 key should resolve, got {result:?}");
     };

--- a/src/app_shell_key_routing_tests.rs
+++ b/src/app_shell_key_routing_tests.rs
@@ -3,8 +3,9 @@
 use iocraft::prelude::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use jefe::domain::action_registry::{HandlerKey, Resolution};
 use jefe::state::{
-    AppState, ConfirmFocus, ErrorsFocus, InlineState, IssueFocus, IssuePropertyEditorState,
-    IssuePropertyKind, IssuesState, ModalState, PaneFocus, ScreenId,
+    AppState, ComposerTarget, ConfirmFocus, ErrorsFocus, InlineState, IssueFocus,
+    IssuePropertyEditorState, IssuePropertyKind, IssuesState, ModalState, NewIssueFormState,
+    PaneFocus, PullRequestsState, ScreenId,
 };
 
 use super::resolve_compiled_registry_key;
@@ -26,6 +27,34 @@ fn assert_handler(state: &AppState, event: &KeyEvent, expected: HandlerKey) {
         "unexpected resolution: {:?}",
         resolved.resolution
     );
+}
+
+fn with_submit_override(mut state: AppState, context: &str, action: &str) -> AppState {
+    let dir = tempfile::tempdir();
+    let Ok(dir) = dir else {
+        panic!("composer route config directory must be created: {dir:?}");
+    };
+    let settings =
+        format!("settings_schema = 2\n[keymap.\"{context}\"]\n\"{action}\" = [\"F8\"]\n");
+    let result = std::fs::write(dir.path().join("settings.toml"), settings);
+    if let Err(error) = result {
+        panic!("composer route settings must be written: {error}");
+    }
+    let startup = jefe::startup::build_persistence(Some(dir.path()));
+    let Ok(startup) = startup else {
+        panic!("composer route fixture must compose: {startup:?}");
+    };
+    state.action_registry_snapshot = Some(startup.keymap_snapshot);
+    state
+}
+
+fn assert_replaced_submit_route(state: AppState, expected: HandlerKey) {
+    assert_handler(&state, &key(KeyCode::F(8)), expected);
+    let compiled = modified(KeyCode::Enter, KeyModifiers::ALT);
+    assert!(matches!(
+        resolve_compiled_registry_key(&state, &compiled).resolution,
+        Resolution::Unbound
+    ));
 }
 
 #[test]
@@ -197,6 +226,69 @@ fn full_s4_special_contexts_resolve_controls_and_leave_raw_text_unbound() {
     );
     let newline = resolve_compiled_registry_key(&state, &key(KeyCode::Enter));
     assert!(matches!(newline.resolution, Resolution::Unbound));
+}
+
+#[test]
+fn new_issue_submit_override_uses_state_derived_production_context() {
+    let state = AppState {
+        screen: ScreenId::Issues,
+        issues_state: IssuesState {
+            active: true,
+            issue_focus: IssueFocus::IssueDetail,
+            inline_state: InlineState::Composer {
+                target: ComposerTarget::NewIssue,
+                text: String::new(),
+                cursor: 0,
+            },
+            new_issue_form: Some(NewIssueFormState::default()),
+            ..IssuesState::default()
+        },
+        ..AppState::default()
+    };
+    let state = with_submit_override(state, "issues.new-form", "issues.new-submit");
+
+    assert_replaced_submit_route(state, HandlerKey::IssuesSubmitInline);
+}
+
+#[test]
+fn issue_inline_submit_override_uses_state_derived_production_context() {
+    let state = AppState {
+        screen: ScreenId::Issues,
+        issues_state: IssuesState {
+            active: true,
+            issue_focus: IssueFocus::IssueDetail,
+            inline_state: InlineState::Composer {
+                target: ComposerTarget::NewComment,
+                text: String::new(),
+                cursor: 0,
+            },
+            ..IssuesState::default()
+        },
+        ..AppState::default()
+    };
+    let state = with_submit_override(state, "issues.inline", "issues.inline-submit");
+
+    assert_replaced_submit_route(state, HandlerKey::IssuesSubmitInline);
+}
+
+#[test]
+fn pr_inline_submit_override_uses_state_derived_production_context() {
+    let state = AppState {
+        screen: ScreenId::PullRequests,
+        prs_state: PullRequestsState {
+            active: true,
+            inline_state: InlineState::Composer {
+                target: ComposerTarget::NewComment,
+                text: String::new(),
+                cursor: 0,
+            },
+            ..PullRequestsState::default()
+        },
+        ..AppState::default()
+    };
+    let state = with_submit_override(state, "prs.inline", "prs.inline-submit");
+
+    assert_replaced_submit_route(state, HandlerKey::PullRequestsSubmitInline);
 }
 
 #[test]

--- a/src/domain/default_action_inventory_display.rs
+++ b/src/domain/default_action_inventory_display.rs
@@ -375,7 +375,10 @@ pub enum FooterMode {
     Dashboard,
     Split,
     Issues,
+    IssuesNewComposer,
+    IssuesInlineComposer,
     PullRequests,
+    PullRequestsInlineComposer,
     Actions,
     Errors,
     Terminals,
@@ -570,6 +573,21 @@ pub const FOOTER_MODE_GROUPS: &[FooterModeGroup] = &[
         ],
     },
     FooterModeGroup {
+        mode: FooterMode::IssuesNewComposer,
+        hints: &[
+            hint("submit", &["issues.new-submit"], 1),
+            hint("cancel", &["issues.new-cancel"], 2),
+        ],
+    },
+    FooterModeGroup {
+        mode: FooterMode::IssuesInlineComposer,
+        hints: &[
+            hint("submit", &["issues.inline-submit"], 1),
+            hint("rewrite", &["issues.inline-rewrite"], 2),
+            hint("cancel", &["issues.inline-cancel"], 3),
+        ],
+    },
+    FooterModeGroup {
         mode: FooterMode::PullRequests,
         hints: &[
             hint(
@@ -613,6 +631,13 @@ pub const FOOTER_MODE_GROUPS: &[FooterModeGroup] = &[
             hint("list", &["prs.refocus-list"], 14),
             hint("exit", &["prs.exit"], 15),
             hint("back / exit", &["prs.back"], 16),
+        ],
+    },
+    FooterModeGroup {
+        mode: FooterMode::PullRequestsInlineComposer,
+        hints: &[
+            hint("submit", &["prs.inline-submit"], 1),
+            hint("cancel", &["prs.inline-cancel"], 2),
         ],
     },
     FooterModeGroup {

--- a/src/issue_detail_content.rs
+++ b/src/issue_detail_content.rs
@@ -8,7 +8,7 @@ use crate::domain::{IssueComment, IssueDetail};
 use crate::state::{ComposerTarget, DetailSubfocus, EditorTarget, InlineState};
 
 /// Stable anchor rendered where a reply TextBox is logically attached.
-pub(crate) const ISSUE_REPLY_ANCHOR: &str = "    [Reply]";
+pub(crate) const ISSUE_REPLY_ANCHOR: &str = "    [Composer input]";
 
 /// Scrollable issue-detail content and optional inline cursor position.
 pub struct DetailContent {
@@ -169,9 +169,7 @@ pub fn build_new_issue_content(_inline_state: &InlineState) -> DetailContent {
         .push("Title: first line | Body: remaining lines".to_string());
     builder.lines.push(String::new());
 
-    builder.lines.push(String::from(
-        "Alt+Enter submit | Ctrl+R rewrite | Esc cancel",
-    ));
+    builder.lines.push("[Composer input]".to_string());
     builder.finish()
 }
 
@@ -382,9 +380,7 @@ fn build_single_comment(
         && *comment_index == idx
     {
         builder.lines.push(ISSUE_REPLY_ANCHOR.to_string());
-        builder
-            .lines
-            .push("    Alt+Enter save | Esc cancel".to_string());
+        builder.lines.push(String::new());
     }
 
     builder.lines.push(String::new());
@@ -407,9 +403,7 @@ fn build_new_comment_section(
         ..
     } = inline_state
     {
-        builder
-            .lines
-            .push("  Alt+Enter submit | Esc cancel".to_string());
+        builder.lines.push("  [Composer input]".to_string());
     } else {
         builder.lines.push("  Press c to add a comment".to_string());
     }
@@ -637,7 +631,7 @@ mod tests {
         assert!(lines[range.0] == "> New Comment" || lines[range.0] == "  New Comment");
         assert!(
             lines[range.1].contains("Press c to add a comment")
-                || lines[range.1].contains("Alt+Enter submit"),
+                || lines[range.1].contains("[Composer input]"),
             "NewComment range must include the hint line"
         );
     }

--- a/src/pr_detail_content.rs
+++ b/src/pr_detail_content.rs
@@ -19,7 +19,7 @@ use crate::state::{ComposerTarget, InlineState, PrDetailSubfocus};
 /// @plan PLAN-20260624-PR-MODE.P14
 /// @requirement REQ-PR-009
 /// @pseudocode component-001 lines 169-176
-pub(crate) const PR_REPLY_ANCHOR: &str = "    [Reply]";
+pub(crate) const PR_REPLY_ANCHOR: &str = "    [Composer input]";
 
 /// Count the rendered scrollable lines for a PR detail.
 ///
@@ -659,9 +659,7 @@ fn build_single_comment(
         && *comment_index == idx
     {
         builder.lines.push(PR_REPLY_ANCHOR.to_string());
-        builder
-            .lines
-            .push("    Alt+Enter save | Esc cancel".to_string());
+        builder.lines.push(String::new());
     }
 
     builder.lines.push(String::new());
@@ -698,9 +696,7 @@ fn build_new_comment_section(
             // Stable anchor: the composer text/cursor is rendered by the
             // embedded TextBox component, NOT flattened here. Emit a hint so
             // the line count stays stable while typing.
-            builder
-                .lines
-                .push("  Alt+Enter submit | Esc cancel".to_string());
+            builder.lines.push("  [Composer input]".to_string());
         }
         _ => {
             builder.lines.push("  Press c to add a comment".to_string());

--- a/src/pr_detail_content_tests.rs
+++ b/src/pr_detail_content_tests.rs
@@ -195,11 +195,10 @@ fn new_comment_composer_not_flattened_into_document() {
         content.cursor.is_none(),
         "NewComment composer must NOT flatten a cursor into the read-only document"
     );
-    // The anchor/help line must still be present so the section is visible.
-    assert!(
-        content.text.contains("Alt+Enter submit | Esc cancel"),
-        "NewComment composer anchor/help line must be present"
-    );
+    // The neutral anchor must still be present so the section is visible,
+    // while shortcut ownership stays with the generated keybind footer.
+    assert!(content.text.contains("[Composer input]"));
+    assert!(!content.text.contains("Alt+Enter submit"));
     // The composer text must NOT be flattened into the document.
     assert!(
         !content.text.contains("abc"),
@@ -232,7 +231,8 @@ fn reply_composer_not_flattened_into_document() {
         "Reply composer cursor belongs to TextBox"
     );
     assert!(content.text.contains(PR_REPLY_ANCHOR));
-    assert!(content.text.contains("    Alt+Enter save | Esc cancel"));
+    assert!(content.text.contains("    [Composer input]"));
+    assert!(!content.text.contains("Alt+Enter save"));
     assert!(
         !content.text.contains("@pat hi"),
         "Reply composer text must NOT be flattened into the read-only document"
@@ -296,9 +296,10 @@ fn empty_new_comment_composer_emits_only_anchor_no_flattened_row() {
         "empty NewComment composer must NOT flatten a cursor into the document"
     );
     assert!(
-        content.text.contains("Alt+Enter submit | Esc cancel"),
-        "NewComment composer anchor/help line must be present"
+        content.text.contains("[Composer input]"),
+        "NewComment composer anchor line must be present"
     );
+    assert!(!content.text.contains("Alt+Enter submit"));
     // The composer gutter prefix must NOT appear in the document (no flattened row).
     assert!(
         !content.text.lines().any(|l| l == "  │ " || l == "  │"),
@@ -330,7 +331,7 @@ fn empty_reply_composer_emits_only_anchor_no_flattened_row() {
         "Reply composer cursor belongs to TextBox"
     );
     assert!(content.text.contains(PR_REPLY_ANCHOR));
-    assert!(content.text.contains("    Alt+Enter save | Esc cancel"));
+    assert!(!content.text.contains("Alt+Enter save"));
     assert!(
         !content.text.lines().any(|l| l == "    │ " || l == "    │"),
         "document must NOT contain a flattened reply composer prefix row"
@@ -873,7 +874,7 @@ fn pr_subfocus_line_range_new_comment_locates_label_and_hint() {
     // The hint line is the second line of the section.
     assert!(
         lines[range.1].contains("Press c to add a comment")
-            || lines[range.1].contains("Alt+Enter submit"),
+            || lines[range.1].contains("[Composer input]"),
         "NewComment range must include the hint line"
     );
 }

--- a/src/state/issues_tests_composer_focus.rs
+++ b/src/state/issues_tests_composer_focus.rs
@@ -176,8 +176,8 @@ fn wrapped_body_new_comment_open_reveals_tail_anchor_with_line_offset() {
     );
     let help_row = rows
         .iter()
-        .position(|row| row.text.contains("Alt+Enter submit"))
-        .unwrap_or_else(|| panic!("expected composer help row"));
+        .position(|row| row.text.contains("[Composer input]"))
+        .unwrap_or_else(|| panic!("expected composer anchor row"));
     let viewport = crate::layout::issue_detail_document_viewport_rows(20, true);
 
     assert!(state.issues_state.detail_scroll_offset > 0);

--- a/src/state/prs_tests_composer_focus.rs
+++ b/src/state/prs_tests_composer_focus.rs
@@ -516,8 +516,8 @@ fn wrapped_pr_body_new_comment_open_reveals_tail_anchor_with_line_offset() {
         crate::domain::document_wrap::line_first_row(&rows, state.prs_state.detail_scroll_offset);
     let help_row = rows
         .iter()
-        .position(|row| row.text.contains("Alt+Enter submit"))
-        .unwrap_or_else(|| panic!("expected composer help row"));
+        .position(|row| row.text.contains("[Composer input]"))
+        .unwrap_or_else(|| panic!("expected composer anchor row"));
     let viewport = crate::layout::pr_detail_document_viewport_rows(20, true);
 
     assert!(state.prs_state.detail_scroll_offset > 0);
@@ -749,7 +749,7 @@ fn test_open_reply_composer_reveals_target_reply_anchor() {
     let reply_line = content
         .text
         .lines()
-        .position(|line| line.contains("[Reply]"))
+        .position(|line| line == crate::pr_detail_content::PR_REPLY_ANCHOR)
         .unwrap_or_else(|| panic!("reply anchor should be rendered"));
     let offset = state.prs_state.detail_scroll_offset;
     let viewport =

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -436,7 +436,8 @@ mod tests {
 
         assert!(text.contains("New Issue"));
         assert!(text.contains("Title: first line | Body: remaining lines"));
-        assert!(text.contains("Alt+Enter submit | Ctrl+R rewrite | Esc cancel"));
+        assert!(text.contains("[Composer input]"));
+        assert!(!text.contains("Alt+Enter submit"));
         // The editor text is rendered by the embedded wrapping TextBox, so it
         // must NOT be flattened into the read-only document (issue #212).
         assert!(

--- a/src/ui/components/issue_detail_render_tests.rs
+++ b/src/ui/components/issue_detail_render_tests.rs
@@ -209,8 +209,8 @@ fn active_issue_new_comment_on_short_detail_starts_after_comments() {
         .unwrap_or_else(|| panic!("missing final comment line in: {rendered}"));
     let help_line = lines
         .iter()
-        .position(|line| line.contains("Alt+Enter submit | Esc cancel"))
-        .unwrap_or_else(|| panic!("missing composer help line in: {rendered}"));
+        .position(|line| line.contains("[Composer input]"))
+        .unwrap_or_else(|| panic!("missing composer anchor line in: {rendered}"));
     let draft_line = lines
         .iter()
         .position(|line| line.contains("short draft"))

--- a/src/ui/components/keybind_bar.rs
+++ b/src/ui/components/keybind_bar.rs
@@ -8,6 +8,7 @@ use iocraft::prelude::*;
 
 use crate::action_projection::{FooterProjectionInput, project_footer};
 use crate::domain::action_registry::ActionRegistrySnapshot;
+use crate::domain::default_action_inventory::display::FooterMode;
 use crate::state::{ActionsFocus, ScreenId};
 use crate::theme::{ResolvedColors, ThemeColors};
 
@@ -27,6 +28,7 @@ pub struct KeybindBarProps {
     /// Immutable action/binding/availability authority for this render.
     pub action_registry_snapshot: Option<ActionRegistrySnapshot>,
     pub actions_focus: Option<ActionsFocus>,
+    pub mode_override: Option<FooterMode>,
     /// Process-identity label (pid + commit) shown in the lower-right corner
     /// (issue #223).
     pub identity_label: String,
@@ -50,6 +52,7 @@ pub fn keybind_hints_for(
             shell_overlay_active: false,
             shell_resume_available: false,
             actions_focus,
+            mode_override: None,
         },
     )
 }
@@ -71,6 +74,7 @@ pub fn KeybindBar(props: &KeybindBarProps) -> impl Into<AnyElement<'static>> {
                     shell_overlay_active: props.shell_overlay_active,
                     shell_resume_available: props.shell_resume_available,
                     actions_focus: props.actions_focus,
+                    mode_override: props.mode_override,
                 },
             )
         });

--- a/src/ui/components/pr_diff.rs
+++ b/src/ui/components/pr_diff.rs
@@ -179,13 +179,13 @@ struct ChangesHintCtx {
 /// Build the contextual hint line for the Changes footer.
 ///
 /// Hints are contextual (issue #376 acceptance A11):
-/// - While composing: only the composer submit/cancel shortcuts.
+/// - While composing: a stable local status; the generated keybind bar owns shortcuts.
 /// - File-list focus: file-list navigation + view toggle.
 /// - Content focus with no selected file: a placeholder hint.
 /// - Blob failure (when full file is needed): retry hint.
 fn changes_hints(ctx: ChangesHintCtx) -> String {
     if ctx.composing {
-        return "Alt+Enter submit | Esc cancel".to_string();
+        return "Composer active".to_string();
     }
     let view_hint = match ctx.mode {
         PrDiffViewMode::DeltasOnly => "v full file",
@@ -290,7 +290,7 @@ mod tests {
             no_selected_file: false,
             blob: BlobHintState::Idle,
         });
-        assert_eq!(hint, "Alt+Enter submit | Esc cancel");
+        assert_eq!(hint, "Composer active");
     }
 
     #[test]

--- a/src/ui/components/pr_render_tests.rs
+++ b/src/ui/components/pr_render_tests.rs
@@ -619,11 +619,12 @@ fn test_pr_detail_composer_visible_within_viewport_when_active() {
         content.text.contains("New comment"),
         "the New comment section must render when the composer is active"
     );
-    // The anchor/help line must be present.
+    // The stable composer anchor must be present without shortcut authority.
     assert!(
-        content.text.contains("Alt+Enter submit | Esc cancel"),
-        "the composer anchor/help line must render when the composer is active"
+        content.text.contains("[Composer input]"),
+        "the composer anchor line must render when the composer is active"
     );
+    assert!(!content.text.contains("Alt+Enter submit"));
     // The document cursor must be None (composer not flattened).
     assert!(
         content.cursor.is_none(),

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -7,6 +7,7 @@
 
 use iocraft::prelude::*;
 
+use crate::domain::default_action_inventory::display::FooterMode;
 use crate::state::{AppState, IssueFocus, PaneFocus, ScreenId};
 use crate::theme::{ResolvedColors, ThemeColors};
 
@@ -91,6 +92,13 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
     let detail_subfocus = state.map_or_else(Default::default, |s| s.issues_state.detail_subfocus);
     let inline_state = state.map_or_else(Default::default, |s| s.issues_state.inline_state.clone());
     let new_issue_form = state.and_then(|s| s.issues_state.new_issue_form.clone());
+    let footer_mode = if new_issue_form.is_some() {
+        Some(FooterMode::IssuesNewComposer)
+    } else if matches!(inline_state, crate::state::InlineState::Composer { .. }) {
+        Some(FooterMode::IssuesInlineComposer)
+    } else {
+        None
+    };
     let comments_loading = state.is_some_and(|s| s.issues_state.loading.comments);
     let detail_scroll_offset = state.map_or(0, |s| s.issues_state.detail_scroll_offset);
     let detail_focused = issue_focus == IssueFocus::IssueDetail;
@@ -443,6 +451,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                 action_registry_snapshot: state.and_then(|state| state.action_registry_snapshot.clone()),
                 terminal_focused: false,
                 actions_focus: None,
+                mode_override: footer_mode,
                 identity_label: crate::process_identity_label(std::process::id(), crate::GIT_COMMIT),
                 colors: colors.clone(),
             )

--- a/src/ui/screens/pull_requests.rs
+++ b/src/ui/screens/pull_requests.rs
@@ -6,6 +6,7 @@
 
 use iocraft::prelude::*;
 
+use crate::domain::default_action_inventory::display::FooterMode;
 use crate::state::{AppState, PaneFocus, PrFocus, ScreenId};
 use crate::theme::{ResolvedColors, ThemeColors};
 
@@ -102,6 +103,8 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
     let pr_detail = state.and_then(|s| s.prs_state.pr_detail.clone());
     let detail_subfocus = state.map_or_else(Default::default, |s| s.prs_state.detail_subfocus);
     let inline_state = state.map_or_else(Default::default, |s| s.prs_state.inline_state.clone());
+    let footer_mode = matches!(inline_state, crate::state::InlineState::Composer { .. })
+        .then_some(FooterMode::PullRequestsInlineComposer);
     let comments_loading = state.is_some_and(|s| s.prs_state.loading.comments);
     let detail_loading = state.is_some_and(|s| s.prs_state.loading.detail);
     let detail_scroll_offset = state.map_or(0, |s| s.prs_state.detail_scroll_offset);
@@ -461,7 +464,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
             // active: Changes owns its own contextual footer hint, and the generic
             // PR bar advertises keys (merge/labels/assignees) that do not apply
             // (issue #376 acceptance A11).
-            #(if changes_active {
+            #(if changes_active && footer_mode.is_none() {
                 vec![element! {
                     Box(height: 1u32, width: 100pct, background_color: rc.bg) {}
                 }]
@@ -473,6 +476,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                 action_registry_snapshot: state.and_then(|state| state.action_registry_snapshot.clone()),
                             terminal_focused: state.is_some_and(|s| s.terminal_focused),
                             actions_focus: None,
+                            mode_override: footer_mode,
                             identity_label: crate::process_identity_label(std::process::id(), crate::GIT_COMMIT),
                             colors: colors.clone(),
                         )


### PR DESCRIPTION
## Summary

- adds composer-specific footer projections for New Issue, issue comments/replies, and pull-request comments/replies
- derives submit, cancel, and rewrite hints from effective action-registry bindings so remaps and explicit unbinds remain discoverable
- removes stale hardcoded composer shortcut text while preserving bare Enter multiline/form-navigation behavior
- adds production-route override coverage plus deterministic Issues and Pull Requests tmux scenarios

Fixes #189

## Pre-push checklist

- [x] Format — cargo xtask fmt
- [x] Clippy allow policy — cargo xtask check clippy-allows
- [x] Source file length — cargo xtask check source-size
- [x] Architecture boundary policy — cargo xtask check architecture
- [x] Lint — cargo xtask lint
- [x] Complexity — cargo xtask complexity
- [x] Coverage — cargo xtask coverage
- [x] Build — cargo xtask build
- [x] Tests — cargo xtask test
- [x] Aggregate — cargo xtask ci on exact rebased head

## Testing notes

- cargo test --lib action_projection::composer_tests
- cargo test --bin jefe app_shell_key_routing::tests
- strict all-target/all-feature Clippy
- New Issue schema-1 tmux scenario with F8 remap and two body lines
- Pull Request composer tmux scenario with F9 remap, two body lines, and read-only GitHub CLI audit
- cargo xtask ci after rebasing onto current origin/main

## Review notes

- Rust reviewer and DeepThinker cycle completed and findings triaged
- detached Open Code Review completed with all medium findings fixed and retested
- PR merge confirmation was intentionally not changed because it is not a composer action
