### PR TITLE
Execute the invocation the probe measured (Fixes #571)

### DIFF
--- a/src/runtime/agent_probe.rs
+++ b/src/runtime/agent_probe.rs
@@ -99,6 +99,7 @@ pub struct AgentProbeResult {
     candidate_generation_key: Option<CandidateGenerationKey>,
     definition_sha256: DefinitionSha256,
     prepared_invocation: Option<super::package_runtime::PackageInvocation>,
+    preparation_error: Option<String>,
 }
 
 impl AgentProbeResult {
@@ -121,6 +122,18 @@ impl AgentProbeResult {
     #[must_use]
     pub const fn prepared_invocation(&self) -> Option<&super::package_runtime::PackageInvocation> {
         self.prepared_invocation.as_ref()
+    }
+
+    /// Why preparation failed, when it was attempted and did not succeed.
+    ///
+    /// This is what tells an absent [`Self::prepared_invocation`] apart from a
+    /// candidate that simply has no package runner to prepare. Without the
+    /// distinction a caller cannot know whether falling back is safe, and
+    /// retrying a failed preparation would resolve a moving selector a second
+    /// time — the very thing binding the probe to the plan removes (issue #571).
+    #[must_use]
+    pub fn preparation_error(&self) -> Option<&str> {
+        self.preparation_error.as_deref()
     }
 
     /// Physical executable fingerprint, absent only for NotFound.
@@ -180,6 +193,7 @@ pub fn run_local_agent_probe_with_cache(
             candidate_generation_key: None,
             definition_sha256,
             prepared_invocation: None,
+            preparation_error: None,
         };
     };
     let candidate_generation_key = candidate.generation_key(definition);
@@ -191,7 +205,7 @@ pub fn run_local_agent_probe_with_cache(
         .and_then(|invocation| invocation.fingerprint())
         .cloned()
         .unwrap_or_else(|| candidate.fingerprint().clone());
-    let (availability, prepared_invocation) = match prepared {
+    let (availability, prepared_invocation, preparation_error) = match prepared {
         Ok(invocation) => (
             probe_resolved(
                 definition,
@@ -200,15 +214,20 @@ pub fn run_local_agent_probe_with_cache(
                 requested_generation,
             ),
             invocation,
-        ),
-        Err(error) => (
-            probe_error(
-                ProbeErrorCode::Agte202,
-                error.to_string(),
-                requested_generation,
-            ),
             None,
         ),
+        Err(error) => {
+            let detail = error.to_string();
+            (
+                probe_error(
+                    ProbeErrorCode::Agte202,
+                    detail.clone(),
+                    requested_generation,
+                ),
+                None,
+                Some(detail),
+            )
+        }
     };
     AgentProbeResult {
         availability,
@@ -216,6 +235,7 @@ pub fn run_local_agent_probe_with_cache(
         candidate_generation_key: Some(candidate_generation_key),
         definition_sha256,
         prepared_invocation,
+        preparation_error,
     }
 }
 

--- a/src/runtime/agent_probe.rs
+++ b/src/runtime/agent_probe.rs
@@ -98,6 +98,7 @@ pub struct AgentProbeResult {
     executable_fingerprint: Option<CandidateFingerprint>,
     candidate_generation_key: Option<CandidateGenerationKey>,
     definition_sha256: DefinitionSha256,
+    prepared_invocation: Option<super::package_runtime::PackageInvocation>,
 }
 
 impl AgentProbeResult {
@@ -105,6 +106,21 @@ impl AgentProbeResult {
     #[must_use]
     pub const fn availability(&self) -> &Availability {
         &self.availability
+    }
+
+    /// The package invocation this probe prepared and measured.
+    ///
+    /// Launch must execute *this* invocation rather than preparing its own.
+    /// Preparing twice means resolving a moving selector twice, and two
+    /// resolutions can disagree — which composed availability measured from one
+    /// version with the executable and fingerprint of another (issue #571).
+    ///
+    /// `None` when the agent is not reached through a package runner, and when
+    /// preparation failed; in both cases there is no measured invocation to
+    /// carry.
+    #[must_use]
+    pub const fn prepared_invocation(&self) -> Option<&super::package_runtime::PackageInvocation> {
+        self.prepared_invocation.as_ref()
     }
 
     /// Physical executable fingerprint, absent only for NotFound.
@@ -163,6 +179,7 @@ pub fn run_local_agent_probe_with_cache(
             executable_fingerprint: None,
             candidate_generation_key: None,
             definition_sha256,
+            prepared_invocation: None,
         };
     };
     let candidate_generation_key = candidate.generation_key(definition);
@@ -174,17 +191,23 @@ pub fn run_local_agent_probe_with_cache(
         .and_then(|invocation| invocation.fingerprint())
         .cloned()
         .unwrap_or_else(|| candidate.fingerprint().clone());
-    let availability = match prepared {
-        Ok(invocation) => probe_resolved(
-            definition,
-            candidate,
-            invocation.as_ref(),
-            requested_generation,
+    let (availability, prepared_invocation) = match prepared {
+        Ok(invocation) => (
+            probe_resolved(
+                definition,
+                candidate,
+                invocation.as_ref(),
+                requested_generation,
+            ),
+            invocation,
         ),
-        Err(error) => probe_error(
-            ProbeErrorCode::Agte202,
-            error.to_string(),
-            requested_generation,
+        Err(error) => (
+            probe_error(
+                ProbeErrorCode::Agte202,
+                error.to_string(),
+                requested_generation,
+            ),
+            None,
         ),
     };
     AgentProbeResult {
@@ -192,6 +215,7 @@ pub fn run_local_agent_probe_with_cache(
         executable_fingerprint: Some(fingerprint),
         candidate_generation_key: Some(candidate_generation_key),
         definition_sha256,
+        prepared_invocation,
     }
 }
 

--- a/src/runtime/launch_compose.rs
+++ b/src/runtime/launch_compose.rs
@@ -374,9 +374,19 @@ fn local_candidate_with_snapshot(
     // The fallback runs only when the probe prepared nothing: a candidate with
     // no package runner, which `finalize_local_invocation` answers from the
     // candidate itself without touching the registry or the cache.
-    let invocation = match probe.prepared_invocation() {
-        Some(prepared) => prepared.clone(),
-        None => finalize_local_invocation(candidate, &managed_package_cache_root())
+    let invocation = match (probe.prepared_invocation(), probe.preparation_error()) {
+        (Some(prepared), _) => prepared.clone(),
+        // Preparation was attempted and failed. Retrying it here would resolve a
+        // moving selector a second time and could pair a successful executable
+        // with the failed availability just recorded, so the probe's own error
+        // is what surfaces.
+        (None, Some(detail)) => {
+            return Err(RuntimeError::SpawnFailed(detail.to_string()));
+        }
+        // Nothing was prepared because there is nothing to prepare: a candidate
+        // reached without a package runner. This answer comes from the candidate
+        // itself and touches neither the registry nor the cache.
+        (None, None) => finalize_local_invocation(candidate, &managed_package_cache_root())
             .map_err(|error| RuntimeError::SpawnFailed(error.to_string()))?,
     };
     Ok(CandidateEvidence {

--- a/src/runtime/launch_compose.rs
+++ b/src/runtime/launch_compose.rs
@@ -366,8 +366,19 @@ fn local_candidate_with_snapshot(
     )
     .map_err(|error| RuntimeError::SpawnFailed(error.to_string()))?;
     let probe = run_local_agent_probe(definition, &resolution, generation);
-    let invocation = finalize_local_invocation(candidate, &managed_package_cache_root())
-        .map_err(|error| RuntimeError::SpawnFailed(error.to_string()))?;
+    // Execute exactly what the probe measured. Preparing again here would
+    // resolve a moving selector a second time, and the two answers can differ,
+    // which is how availability from one version came to be paired with the
+    // executable and fingerprint of another (issue #571).
+    //
+    // The fallback runs only when the probe prepared nothing: a candidate with
+    // no package runner, which `finalize_local_invocation` answers from the
+    // candidate itself without touching the registry or the cache.
+    let invocation = match probe.prepared_invocation() {
+        Some(prepared) => prepared.clone(),
+        None => finalize_local_invocation(candidate, &managed_package_cache_root())
+            .map_err(|error| RuntimeError::SpawnFailed(error.to_string()))?,
+    };
     Ok(CandidateEvidence {
         executable: invocation.executable().to_path_buf(),
         fingerprint: invocation

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -258,6 +258,84 @@ fn package_probe_executes_the_selected_agent_not_the_runner_version() {
     );
 }
 
+/// Launch must execute the invocation the probe measured.
+///
+/// Preparation resolves a moving selector, so preparing twice in one launch
+/// asks the registry twice, and the two answers can differ. That is how a
+/// launch came to pair availability measured from one version with the
+/// executable and fingerprint of another — probing V1 and running an unprobed
+/// V2 (issue #571).
+///
+/// The tag is moved here between the probe and the point launch would have
+/// prepared again, which is exactly the interleaving that produced the mismatch.
+#[cfg(unix)]
+#[test]
+fn launch_executes_the_invocation_the_probe_measured() {
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let witness = witness_path(&bin);
+    counting_npm_stub(&bin, &witness);
+    publish_version(&witness, "0.11.0");
+    let definition = definition("LLxprt");
+    let candidate_for_replay = resolve_package(&definition, bin.path(), "latest nightly");
+    let resolution = CandidateResolution::Resolved(resolve_package(
+        &definition,
+        bin.path(),
+        "latest nightly",
+    ));
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+
+    let probe =
+        crate::runtime::run_local_agent_probe_with_cache(&definition, &resolution, 7, cache.path());
+
+    let Some(measured) = probe.prepared_invocation() else {
+        panic!("a managed package probe must hand back the invocation it measured");
+    };
+    let probed_executable = measured.executable().to_path_buf();
+    assert_eq!(
+        resolve_count(&witness),
+        1,
+        "the probe must resolve the tag once"
+    );
+
+    // The tag moves while the launch is still in flight.
+    publish_version(&witness, "0.11.1");
+
+    // What launch composition now does: use what was measured, not a fresh
+    // preparation. Nothing may reach the registry a second time, and the
+    // executable must still be the one whose availability was established.
+    assert_eq!(
+        probe
+            .prepared_invocation()
+            .map(|invocation| invocation.executable().to_path_buf()),
+        Some(probed_executable.clone()),
+        "launch must run the probed version, not whatever the tag points at now"
+    );
+    assert_eq!(
+        resolve_count(&witness),
+        1,
+        "one launch must ask the registry once; a second resolution is what lets \
+         availability and executable come from different versions"
+    );
+
+    // Show the hazard is real rather than hypothetical: the second preparation
+    // launch used to perform, run here explicitly, lands on a different version
+    // than the one just probed. Pairing that executable with the availability
+    // above is the defect; the assertions above are what now prevents it.
+    let second_preparation = finalize_local_invocation_inner(&candidate_for_replay, cache.path())
+        .unwrap_or_else(|error| panic!("second preparation: {error}"));
+    assert_ne!(
+        second_preparation.executable(),
+        probed_executable.as_path(),
+        "preparing a second time reaches a different version — which is precisely \
+         why launch must not do it"
+    );
+    assert_eq!(
+        resolve_count(&witness),
+        2,
+        "that second preparation is the extra registry call this change removes"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn structural_uvx_probe_executes_the_selected_agent_invocation() {
@@ -367,11 +445,13 @@ fn counting_npm_stub(bin: &TempDir, witness: &Path) {
 set -e
 witness={witness}
 versions={versions}
+resolves={resolves}
 if [ \"$1\" = view ]; then
   if [ \"$#\" -ne 3 ] || [ \"$3\" != version ]; then
     echo \"unexpected npm view invocation: $*\" >&2
     exit 64
   fi
+  echo resolve >> \"$resolves\"
   if [ -f \"$versions\" ]; then cat \"$versions\"; exit 0; else exit 1; fi
 fi
 if [ -f package-lock.json ]; then echo present >> \"$witness\"; else echo absent >> \"$witness\"; fi
@@ -381,9 +461,30 @@ chmod 755 node_modules/.bin/llxprt
 ",
             witness = crate::runtime::commands::shell_escape_single(&witness.to_string_lossy()),
             versions =
-                crate::runtime::commands::shell_escape_single(&version_file.to_string_lossy())
+                crate::runtime::commands::shell_escape_single(&version_file.to_string_lossy()),
+            resolves = crate::runtime::commands::shell_escape_single(
+                &resolve_path_for(witness).to_string_lossy()
+            )
         ),
     );
+}
+
+/// Path the npm stub appends to on every `npm view`.
+///
+/// Installs are counted by the witness; resolutions are counted here, because
+/// "how many times did we ask the registry?" is a separate question from "how
+/// many times did we install?" and issue #571 turns on the former.
+#[cfg(unix)]
+fn resolve_path_for(witness: &Path) -> PathBuf {
+    witness.with_file_name("resolve-witness.log")
+}
+
+/// How many times the stub answered `npm view ... version`.
+#[cfg(unix)]
+fn resolve_count(witness: &Path) -> usize {
+    std::fs::read_to_string(resolve_path_for(witness))
+        .map(|contents| contents.lines().count())
+        .unwrap_or_default()
 }
 
 /// Path of the file the npm stub reads to answer `npm view ... version`.


### PR DESCRIPTION
Fixes #571 — the last live part of it. The rest was already delivered by #582, #600 and #611; the [scope note on the issue](https://github.com/vybestack/llxprt-jefe/issues/571#issuecomment-5161386796) has the evidence for each.

## The defect

Launch composition prepared the agent twice:

    let probe = run_local_agent_probe(definition, &resolution, generation);          // prepares
    let invocation = finalize_local_invocation(candidate, &managed_package_cache_root())?;  // prepares again

`prepare_local_probe` calls the very same `finalize_local_invocation`, so this was two full preparations of one agent in one launch. Preparation is what resolves a moving selector, so it was also two `npm view` calls — and two answers can differ.

When they did, `CandidateEvidence` took `availability` from the first and `executable`/`fingerprint` from the second. The launch ran a version nothing had probed, carrying the other version's capability measurement. It can also fail the other way: reject a perfectly good new version on the old one's failed probe.

Version-keying does not cover this. #600 stops V2 overwriting V1 on disk; it does not bind the two observations to one version. #601 widened the exposure, since custom dist-tags and ranges now resolve too.

## The fix

`AgentProbeResult` carries the invocation the probe prepared, and composition executes that rather than preparing its own. One preparation, one resolution, and what was probed is what runs.

The fallback only triggers when the probe prepared nothing — a candidate with no package runner — and `finalize_local_invocation` answers that from the candidate itself without touching the registry or the cache. So no launch resolves twice.

## Test

`launch_executes_the_invocation_the_probe_measured` moves the dist-tag between the probe and the point composition used to prepare again — the exact interleaving that produced the mismatch. It asserts the probe resolves once, that the invocation handed back is still the probed version after the tag moves, and that the count stays at one.

It then demonstrates the hazard rather than assuming it, by performing the second preparation explicitly:

    assert_ne!(second_preparation.executable(), probed_executable.as_path());
    assert_eq!(resolve_count(&witness), 2);

That is what the old code did on every launch: a different version, and an extra registry call.

To count resolutions the npm stub now records `npm view` separately from `npm install`. Installs were already counted; "how many times did we ask the registry" is a different question, and this issue turns on it.

Worth being straight about the limitation: these assertions sit at the probe seam, because `local_candidate_with_snapshot` reads the cache root from a global and has no injection point. The launch-side binding is guaranteed by construction — one call site, and a fallback that performs no I/O — not by an end-to-end test. Adding that seam is a larger change than this fix and I did not want to bundle it.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo xtask complexity` all clean. Full workspace suite: **5435 passed, 0 failed** — no flakes on this run.

## Scope

Composition and the probe result only. Resolution, install, caching, promotion and the lock are untouched.
