### PR TITLE
Stop a failed attach from declaring an agent dead (Fixes #306)

### DIFF
--- a/src/app_input/relaunch.rs
+++ b/src/app_input/relaunch.rs
@@ -138,7 +138,20 @@ fn relaunch_runtime_session(
     spawn_relaunch_session(&mut ctx_guard.runtime, agent_id, &agent.work_dir, &prepared)?;
     std::thread::sleep(REMOTE_ATTACH_SETTLE_DELAY);
     if let Err(error) = attach_relaunched_session(&mut ctx_guard.runtime, agent_id) {
-        let _ = ctx_guard.runtime.mark_session_dead(agent_id);
+        // The spawn above succeeded, so a worker is running. Attaching is the
+        // separate act of building a view onto it, and its failure is not
+        // evidence that the thing just started has died.
+        //
+        // Marking it dead here discarded the mapping for a process that was
+        // still running -- and because the relaunch had already replaced the
+        // old record, nothing was left pointing at the new tree either. That
+        // is #306's first criterion, and the most direct way an agent becomes
+        // an orphan: it is created and disowned in consecutive statements.
+        warn!(
+            agent_id = %agent_id.0,
+            error = %error,
+            "relaunch attached failed; the spawned session keeps its binding for liveness to judge"
+        );
         drop(ctx_guard);
         return Err(error);
     }
@@ -278,9 +291,14 @@ fn recover_server_lost_runtime(
         .runtime
         .relaunch(agent_id, prepared.authorized(), prepared.remote())?;
     if let Err(error) = ctx_guard.runtime.attach(agent_id) {
-        if !ctx_guard.runtime.mark_session_dead(agent_id) {
-            warn!(agent_id = %agent_id.0, "psmux recovery: relaunched session record was absent after attach failure");
-        }
+        // Same shape as the relaunch path above: the recovery relaunch already
+        // succeeded, so this agent has a live session. A failed attach is a
+        // failure to view it, not a reason to disown it (issue #306).
+        warn!(
+            agent_id = %agent_id.0,
+            error = %error,
+            "psmux recovery: attach failed; the recovered session keeps its binding for liveness to judge"
+        );
         drop(ctx_guard);
         return Err(error);
     }

--- a/src/app_shell_attach.rs
+++ b/src/app_shell_attach.rs
@@ -60,8 +60,15 @@ pub fn perform_async_attach(
     let viewer = match TmuxRuntimeManager::build_viewer(inputs) {
         Ok(v) => v,
         Err(error) => {
-            warn!(agent_id = %agent_id.0, error = %error, "background: build_viewer failed");
-            mark_dead_or_log(&ctx, &agent_id);
+            // Building a viewer is jefe-side work. It can fail for reasons the
+            // agent knows nothing about, so it is not evidence the session or
+            // worker died, and the binding is left for liveness to judge
+            // (issue #306).
+            warn!(
+                agent_id = %agent_id.0,
+                error = %error,
+                "background: build_viewer failed; leaving the binding for liveness to judge"
+            );
             return AsyncAttachOutcome::Failed(agent_id);
         }
     };
@@ -87,10 +94,25 @@ pub fn perform_async_attach(
     match ctx_guard.runtime.apply_attach_result(&agent_id, viewer) {
         Ok(()) => AsyncAttachOutcome::Attached(agent_id),
         Err(error) => {
-            warn!(agent_id = %agent_id.0, error = %error, "background: apply_attach_result failed");
-            if !ctx_guard.runtime.mark_session_dead(&agent_id) {
-                warn!(agent_id = %agent_id.0, "background: session already gone when marking dead after apply_attach_result failure");
-            }
+            // Attaching is a viewer operation. Failing it says nothing about
+            // the session or the worker, both of which may be running
+            // perfectly well, so the binding is preserved and the agent is
+            // left as it was (issue #306).
+            //
+            // Marking it dead here removed the runtime mapping while the
+            // session and worker kept running, which is how a live agent
+            // became untracked: the row said Dead, nothing owned the tree, and
+            // nothing reaped it either.
+            //
+            // Liveness is the only thing entitled to conclude death, and it
+            // re-probes every `LIVENESS_POLL_INTERVAL`, so a session that
+            // really has gone is still resolved -- just by evidence rather
+            // than by a failed attach.
+            warn!(
+                agent_id = %agent_id.0,
+                error = %error,
+                "background: apply_attach_result failed; leaving the binding for liveness to judge"
+            );
             AsyncAttachOutcome::Failed(agent_id)
         }
     }
@@ -107,17 +129,6 @@ fn perform_async_detach(ctx: &Arc<std::sync::Mutex<AppContext>>) -> AsyncAttachO
         warn!(error = %e, "background: detach failed");
     }
     AsyncAttachOutcome::Detached
-}
-
-/// Mark `agent_id` dead, logging if the session was already gone.
-fn mark_dead_or_log(ctx: &Arc<std::sync::Mutex<AppContext>>, agent_id: &AgentId) {
-    let Ok(mut ctx_guard) = ctx.lock() else {
-        warn!(agent_id = %agent_id.0, "background: ctx mutex poisoned; cannot mark session dead");
-        return;
-    };
-    if !ctx_guard.runtime.mark_session_dead(agent_id) {
-        warn!(agent_id = %agent_id.0, "background: session already gone when marking dead after build_viewer failure");
-    }
 }
 
 /// Drop an `AttachedViewer` on a background thread to avoid blocking during

--- a/src/runtime/agent_launcher.rs
+++ b/src/runtime/agent_launcher.rs
@@ -106,6 +106,10 @@ pub fn write_launch_plan(
     Err(AgentLauncherError::PlanCreateFailed)
 }
 
+#[cfg(all(test, windows))]
+#[path = "job_inheritance_tests.rs"]
+mod job_inheritance_tests;
+
 /// Consume and execute a private launch plan, returning the child status.
 pub fn run_launch_plan(path: &Path) -> Result<ExitStatus, AgentLauncherError> {
     if !valid_launch_plan_path(path) {

--- a/src/runtime/job_inheritance_tests.rs
+++ b/src/runtime/job_inheritance_tests.rs
@@ -1,0 +1,173 @@
+//! Job containment through the path production uses (issue #542 S1a, #467).
+//!
+//! `job_object_tests` proves reaping via `contain_handle`: spawn a child,
+//! assign *its handle* to the Job, drop the guard, watch it die. Production
+//! does the opposite -- `enable_for_current_process` assigns *self*, and every
+//! worker spawned afterwards is expected to **inherit** membership, so that
+//! host death closes the handle and the kernel reaps the tree.
+//!
+//! Handle-assignment is tested. Inheritance is not, and inheritance is the half
+//! production runs on. This file tests it, using the real host entrypoint:
+//! `jefe.exe --jefe-internal-agent-launch <plan>` establishes the Job and
+//! spawns the worker exactly as it does in a psmux pane.
+//!
+//! The host is killed **without** `/T`. Killing the tree would prove only that
+//! `taskkill` works; killing the host alone means anything else that dies was
+//! reaped by the kernel closing the Job.
+
+use std::os::windows::process::CommandExt as _;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use super::{AgentLaunchPayload, AgentWrapperKindPayload};
+
+/// The kernel reaps on handle close, so this needs no polling grace beyond
+/// process teardown.
+const REAP_DEADLINE: Duration = Duration::from_secs(15);
+
+/// No console, so console teardown cannot be mistaken for containment.
+const DETACHED_PROCESS: u32 = 0x0000_0008;
+
+const MARKER_PREFIX: &str = "jefe-job-inheritance-probe";
+
+/// Passes: inheritance works, and this is the first test to say so.
+///
+/// It briefly appeared to fail, and that failure was an artefact of the probe
+/// rather than the code. Counting processes with
+/// `Get-CimInstance Win32_Process | Where-Object CommandLine -like '*marker*'`
+/// matches the PowerShell process running the query, because the marker is in
+/// its own command line. The count was therefore never below one, and a marker
+/// matching nothing at all still returned one. Restricting to the worker's
+/// image name fixes it, since the probe can never be `cmd.exe`.
+///
+/// Worth keeping despite passing: it closes the coverage gap that made the
+/// wrong conclusion plausible in the first place. `job_object_tests` proves
+/// reaping only through `contain_handle` -- spawn a child, assign *its handle*,
+/// drop the guard -- while production assigns *self* and relies on spawned
+/// workers inheriting membership. That inheritance is what every layer above
+/// delegates its killing to, and until now nothing exercised it.
+#[test]
+fn a_worker_spawned_into_the_hosts_job_is_reaped_when_the_host_dies() {
+    let Some(jefe) = jefe_binary() else {
+        return;
+    };
+
+    let marker = format!("{MARKER_PREFIX}-{}-{}", std::process::id(), nanos());
+    let plan_path = std::env::temp_dir().join(format!(
+        "jefe-agent-launch-{}-{}-job.json",
+        std::process::id(),
+        nanos()
+    ));
+    std::fs::write(&plan_path, plan_bytes(&marker))
+        .unwrap_or_else(|error| panic!("could not write launch plan: {error}"));
+
+    let mut host = std::process::Command::new(&jefe)
+        .arg("--jefe-internal-agent-launch")
+        .arg(&plan_path)
+        .creation_flags(DETACHED_PROCESS)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap_or_else(|error| panic!("could not spawn the session host: {error}"));
+
+    if !wait_for(REAP_DEADLINE, || marked_processes(&marker) > 0) {
+        let _ = host.kill();
+        let _ = host.wait();
+        cleanup(&marker, &plan_path);
+        panic!("the worker never started, so this proves nothing about containment");
+    }
+
+    // Kill the host only. Everything below it must now be reaped by the kernel
+    // closing the Job the host owned.
+    let _ = host.kill();
+    let _ = host.wait();
+
+    let reaped = wait_for(REAP_DEADLINE, || marked_processes(&marker) == 0);
+    let survivors = marked_processes(&marker);
+    cleanup(&marker, &plan_path);
+
+    assert!(
+        reaped,
+        "{survivors} process(es) outlived the host that contained them. The host \
+         assigns itself to a KILL_ON_JOB_CLOSE Job before spawning, so a worker \
+         spawned afterwards should inherit that Job and be terminated when the \
+         host dies. It was not, which means workers are not inheriting \
+         containment -- the half of #467 that contain_handle never covered, and \
+         the reason the owner anchor cannot reap anything (issue #542)."
+    );
+}
+
+fn plan_bytes(marker: &str) -> Vec<u8> {
+    let payload = AgentLaunchPayload {
+        path: PathBuf::from("cmd"),
+        wrapper: AgentWrapperKindPayload::Direct,
+        script_launch: None,
+        args: vec![
+            "/D".into(),
+            "/S".into(),
+            "/C".into(),
+            format!("ping -n 600 127.0.0.1 >nul & rem {marker}").into(),
+        ],
+        environment: Vec::new(),
+        cwd: std::env::temp_dir(),
+        worker_report: None,
+    };
+    serde_json::to_vec(&payload).unwrap_or_else(|error| panic!("payload should serialize: {error}"))
+}
+
+/// Count of live processes carrying `marker`.
+///
+/// CIM, not `wmic`: `wmic` is absent on current Windows and exits 255, so a
+/// probe built on it reports nothing for every query and would declare the tree
+/// reaped without ever looking.
+fn marked_processes(marker: &str) -> usize {
+    let script = format!(
+        "@(Get-CimInstance Win32_Process | Where-Object {{ $_.Name -eq 'cmd.exe' -and $_.CommandLine -like '*{marker}*' }}).Count"
+    );
+    let Ok(output) = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .output()
+    else {
+        return 0;
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0)
+}
+
+fn cleanup(marker: &str, plan_path: &std::path::Path) {
+    let script = format!(
+        "Get-CimInstance Win32_Process | Where-Object {{ $_.Name -eq 'cmd.exe' -and $_.CommandLine -like '*{marker}*' }} | \
+         ForEach-Object {{ Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }}"
+    );
+    let _ = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .output();
+    let _ = std::fs::remove_file(plan_path);
+}
+
+fn wait_for(limit: Duration, mut condition: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + limit;
+    loop {
+        if condition() {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+fn jefe_binary() -> Option<PathBuf> {
+    let current = std::env::current_exe().ok()?;
+    let candidate = current.parent()?.parent()?.join("jefe.exe");
+    candidate.exists().then_some(candidate)
+}
+
+fn nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |value| value.as_nanos())
+}

--- a/tests/core/attach_ownership_contracts.rs
+++ b/tests/core/attach_ownership_contracts.rs
@@ -1,0 +1,73 @@
+//! A failed attach must not conclude that an agent died (issue #306).
+//!
+//! Attaching is a viewer operation. It builds a terminal view of a session that
+//! is already running, and it can fail for reasons the agent knows nothing
+//! about. Concluding death from it removed the runtime mapping while the
+//! session and worker kept running, which is how a live agent became untracked:
+//! the row said Dead, nothing owned the tree, and nothing reaped it either.
+//!
+//! Liveness is the only thing entitled to conclude death, and it re-probes on
+//! its own interval, so a session that really has gone is still resolved — by
+//! evidence rather than by a failed attach.
+//!
+//! This is asserted in source because #306 has been open since 2026-07-14,
+//! deferred out of one narrower PR after another. The call is a one-liner that
+//! reads like tidy-up at the point of failure, which is exactly why it keeps
+//! being written.
+
+use std::path::{Path, PathBuf};
+
+/// Modules whose failure paths are viewer-only and must never mark a session
+/// dead.
+const VIEWER_ONLY_MODULES: &[&str] = &["src/app_shell_attach.rs"];
+
+#[test]
+fn an_attach_failure_never_marks_a_session_dead() {
+    for relative in VIEWER_ONLY_MODULES {
+        let text = read_repo_text(relative);
+        assert!(
+            !text.contains("mark_session_dead"),
+            "{relative} calls `mark_session_dead`. Attaching is a viewer \
+             operation, so its failure is not evidence the session or worker \
+             died; concluding death there orphans a live tree by removing the \
+             mapping that owned it (issue #306)."
+        );
+    }
+}
+
+/// A relaunch that spawned successfully must not disown what it just started.
+///
+/// Checked as an adjacency rather than a whole-file ban, because `relaunch.rs`
+/// legitimately marks a session dead elsewhere -- the psmux recovery path moves
+/// a live record to its retained cache before recreating it. The defect is
+/// specifically marking death *in the failure arm of an attach*, where a worker
+/// was created and disowned in consecutive statements.
+#[test]
+fn a_relaunch_never_disowns_the_session_it_just_spawned() {
+    let text = read_repo_text("src/app_input/relaunch.rs");
+    for (index, window) in text.lines().collect::<Vec<_>>().windows(3).enumerate() {
+        let opens_attach_failure =
+            window[0].contains("Err(error) =") && window[0].contains("attach");
+        if opens_attach_failure {
+            assert!(
+                !window[1..]
+                    .iter()
+                    .any(|line| line.contains("mark_session_dead")),
+                "src/app_input/relaunch.rs line {} marks a session dead in the failure arm of an \
+                 attach. The spawn above it succeeded, so a worker is running; disowning it there \
+                 is how an agent is created and orphaned in consecutive statements (issue #306).",
+                index + 1
+            );
+        }
+    }
+}
+
+fn read_repo_text(relative: &str) -> String {
+    let path = repo_path(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+fn repo_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -4,6 +4,7 @@
 //! @requirement REQ-TECH-002
 
 mod assign_workflow_contracts;
+mod attach_ownership_contracts;
 mod clippy_allow_policy;
 mod dashboard_search_contracts;
 mod domain_state_contracts;


### PR DESCRIPTION
Attaching builds a terminal view of a session that is **already running**. It can fail for reasons the agent knows nothing about — a viewer that could not be constructed, a result that could not be applied — and neither says anything about whether the session or worker is alive.

Four paths concluded death from it anyway:

| file | failure | did |
|---|---|---|
| `app_shell_attach.rs` | `build_viewer` failed | `mark_session_dead` |
| `app_shell_attach.rs` | `apply_attach_result` failed | `mark_session_dead` |
| `app_input/relaunch.rs` | attach after successful spawn | `mark_session_dead` |
| `app_input/relaunch.rs` | attach after psmux recovery relaunch | `mark_session_dead` |

The two in `relaunch.rs` are the worse shape — the spawn immediately above had **already succeeded**, so a worker was running. The agent is created and disowned in consecutive statements:

```rust
spawn_relaunch_session(...)?;          // succeeded — a worker is running
if let Err(error) = attach_relaunched_session(...) {
    let _ = ctx_guard.runtime.mark_session_dead(agent_id);   // ...and disowned
```

There the damage compounds: the relaunch had already replaced the old record, so marking the new session dead left nothing pointing at **either** tree — old gone from the map, new just removed from it — while both sets of processes kept running.

That is how a live agent became untracked: **the row said Dead, nothing owned the tree, and nothing reaped it either.** It is the first acceptance criterion of #306, open since 2026-07-14 and deferred out of one narrower PR after another.

## Fix

All four keep the binding and log why. Liveness is the only thing entitled to conclude death, and it re-probes every `LIVENESS_POLL_INTERVAL`, so a session that really has gone is still resolved — by evidence rather than by a failed attach.

Same disease as #541 and #597: concluding a fact from something that is not evidence of it. This one leaked processes.

## Tests

**No existing test asserted the old behaviour**, which is part of why it survived. Two source contracts now hold it.

The relaunch contract is an **adjacency check** rather than a whole-file ban, because `relaunch.rs` legitimately marks a session dead elsewhere — the psmux recovery path deliberately moves a live record to its retained cache before recreating it. Banning the call outright would have been easier and wrong.

Both were RED-proven: reintroducing the call fails the test with the exact line —

```
src/app_input/relaunch.rs line 140 marks a session dead in the failure arm of an attach.
```

## Also included

`job_inheritance_tests` covers the containment path production actually uses. `job_object_tests` only ever proved reaping through `contain_handle` — spawn a child, assign *its handle*, drop the guard — while production calls `enable_for_current_process`, assigning *self*, and relies on spawned workers **inheriting** the Job. Inheritance is what every layer above delegates its killing to, and nothing exercised it.

Found while investigating #542/#515; independent of both and worth having regardless of how they resolve.

## Verification

- `cargo fmt --all --check`, `source-size`, `architecture`, `clippy-allows`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- lib **3005 passed**, integration **413 passed**, 0 failed — native Windows with real psmux

Fixes #306
