### PR TITLE
Stop cmd.exe from eating everything after the prompt's first line

### DIFF
--- a/project-plans/issue536-plan.md
+++ b/project-plans/issue536-plan.md
@@ -124,11 +124,18 @@ workflow, quality-tool change, or unrelated refactor is authorized.
   failed once on scrollback delivery and passed on immediate re-run. It exercises psmux/ConPTY
   input delivery (issues #438, #546) and touches no launcher code.
 - Local OCR: `0 / 2`
-- PR OCR: `0 / 2`
-- RED evidence: pending
-- Fast verification: pending
-- Exact-head verification: pending
-- Native Windows CI: pending
+- PR OCR: `1 / 2` — automatic run on head `8f06292a` (merge base `fc2d4f19`),
+  open-code-review v1.7.9, phase `review`, exit `0`, coverage
+  `complete_best_effort`: **no findings**.
+- RED evidence: recorded above.
+- Fast verification: recorded above.
+- Exact-head verification: PR #619, head `8f06292a`. Format, Lint (clippy),
+  Clippy allow policy, Complexity, Source file length, Architecture boundary
+  policy, Uncertain-observation coercion policy, Coverage gate, Build and
+  Mergeability gate all green.
+- Native Windows CI: green — `Native Windows (MSVC + psmux)`, `Windows Clippy
+  (cfg(windows) lint gap)` and `Windows coverage floors` all pass on head
+  `8f06292a`, which is the platform the defect reproduces on.
 - Deferred findings: see scope ledger
 
 ## Completion contract

--- a/project-plans/issue536-plan.md
+++ b/project-plans/issue536-plan.md
@@ -1,0 +1,141 @@
+# Issue #536 — Windows send-to-agent delivers only the first line of the prompt
+
+> On Windows the agent's argv is delivered through `cmd.exe /D /S /C <wrapper.cmd> …`
+> whenever the resolved executable is a `.cmd`/`.bat` wrapper. `cmd.exe` terminates
+> its command line at the first `0x0A`, so a multi-line issue prompt is silently cut
+> down to `Read and work on the following GitHub issue.` and the issue number, body,
+> comments and delivery-workflow appendix never reach the agent. The cmd.exe bypass
+> that already exists for this exact reason (`CanonicalScriptLaunchPlan`, issue #258)
+> is never populated on the production launch path.
+
+## Root cause (reproduced)
+
+1. `PathSnapshot::resolve_binary` (the generic resolver used by `AgentCandidateResolver`)
+   classifies `llxprt.cmd` as `AgentWrapperKind::CommandScript` and carries no
+   canonical script-launch plan. The product-specific `AgentExecutableResolver`,
+   which *does* compute one, is no longer on the agent-candidate path.
+2. `write_launch_plan` hard-codes `script_launch: None`, so the `Some` branch of
+   `base_command_for_payload` — which spawns `runtime + entrypoint + args` with no
+   `cmd.exe` — is unreachable in production.
+3. `base_command_for_payload` therefore runs `cmd.exe /D /S /C <wrapper> <argv>` and
+   the prompt is truncated at its first newline.
+
+`5c1d5fc9` did not introduce the truncation; it made Windows launches succeed where
+the `--help` probe previously failed them, which is what exposed the pre-existing defect.
+
+## Acceptance matrix
+
+| # | Actor / launch path | Input / boundary | Targets | Observable success | Observable failure / diagnostic | Side effects before failure | Persistence / compatibility | Proof |
+|---|---|---|---|---|---|---|---|---|
+| A1 | Windows pane launch of a `CommandScript` wrapper carrying the official native-launcher marker and a complete bundled layout | Multi-line prompt argv | Windows local | Worker is spawned as `runtime entrypoint <argv>` with the argv byte-identical to the requested one; no `cmd.exe` in the process chain | n/a | Plan file written and consumed exactly once | Plan JSON keeps its existing shape; `script_launch` is populated instead of `null` | Launcher behavior test asserting program + full multi-line argv |
+| A2 | Windows pane launch of a `CommandScript` wrapper with **no** canonical layout | Argv containing `\n` or `\r` | Windows local | none | Typed `CommandScriptArgumentUnsupported`, surfaced through `MultiplexerError::AgentLaunchPlan` → `SendToAgentFailed` | No plan file is left behind; no agent process is started | No partial/truncated launch is ever performed | Behavior test asserting the typed error and that no truncated command is built |
+| A3 | Windows pane launch of a `CommandScript` wrapper with no canonical layout | Newline-free argv (`--version`, normal-mode prompts) | Windows local | Existing `cmd.exe /D /S /C` behavior is unchanged, including verbatim-prefix stripping (#525) | Existing diagnostics | Unchanged | Unchanged | Existing `canonical_command_script_payload_uses_launch_safe_path` test stays green |
+| A4 | Windows pane launch of a `Direct` or `PowerShellScript` executable | Any argv, including multi-line | Windows local | Existing direct/PowerShell spawn is unchanged and already newline-safe | Existing diagnostics | Unchanged | Unchanged | Direct-wrapper multi-line argv test |
+| A5 | Unix pane launch | Any argv, including multi-line | Unix local | Unchanged `execve` argv delivery | Unchanged | Unchanged | Unchanged | Existing Unix pane-command tests stay green |
+| A6 | Issue send prompt construction | Issue with number, title, body, comments | All | The composed prompt still contains the issue number, body and delivery-workflow appendix at the point it enters the launch plan | n/a | none | Unchanged | Prompt-composition test proving the content reaching `write_launch_plan` is complete |
+
+## Non-goals
+
+- Changing prompt composition, compaction thresholds, or the pane-command byte budget.
+- Re-plumbing `ResolvedCandidate` / `PackageInvocation` / `CandidateEvidence` /
+  `AgentLaunchPlan` / `AgentPaneLaunch` to carry a script-launch plan end to end.
+- Changing the capability-probe path (`command_for_path`), whose argv is short and
+  newline-free, or reverting anything from `5c1d5fc9`.
+- Changing remote/SSH launch composition or its quoting.
+- Changing candidate resolution order, fingerprinting, or the execution guard.
+- Adding a general shell-escaping or argv-encoding subsystem.
+
+## Vertical slices
+
+### Slice 1 — Derive the cmd.exe bypass at the launch-plan boundary
+
+- **Rows:** A1, A3, A4, A5.
+- **Owner / boundary:** the Windows private pane launcher and the platform-owned
+  executable resolver that already owns canonical-layout knowledge.
+- **Allowed paths:** `src/runtime/agent_executable.rs`, `src/runtime/agent_launcher.rs`,
+  their existing test modules, and a bounded issue behavior test.
+- **RED:** a launcher test spawning a marked wrapper fixture with a multi-line argv
+  must show the argument arriving truncated at the first newline.
+- **GREEN:** `write_launch_plan` asks the resolver for the wrapper's canonical
+  runtime + entrypoint and stores it in the payload's existing `script_launch` field.
+  The derivation is pure and reuses the audited `#258`/`#432` layout logic, including
+  verbatim-prefix stripping.
+- **Non-goals:** no changes to candidate resolution, probing, or plan transport shape.
+- **Verification:** focused launcher tests plus `make quick-check`.
+- **Stop for approval:** any need to widen `AgentPaneLaunch`/`AgentLaunchPlan`, change
+  the probe path, or introduce a new subsystem.
+
+### Slice 2 — Never deliver a silently truncated argv
+
+- **Rows:** A2, A6.
+- **Owner / boundary:** the same launch-plan boundary.
+- **Allowed paths:** `src/runtime/agent_launcher.rs` and its tests, plus the bounded
+  issue behavior test.
+- **RED:** an unmarked `.cmd` wrapper with a multi-line argv currently produces a
+  truncating `cmd.exe` command instead of an error.
+- **GREEN:** that combination returns a typed `CommandScriptArgumentUnsupported`
+  naming the gate, leaves no plan file behind, and starts no process.
+- **Non-goals:** no fallback that partially delivers the prompt.
+- **Verification:** focused tests, `make quick-check`, then the full gate.
+- **Stop for approval:** any request to soften the guard into best-effort truncation.
+
+## Expected paths / architectural layers
+
+- `src/runtime/agent_executable.rs` — expose the existing canonical-layout derivation
+  for an already-resolved wrapper path.
+- `src/runtime/agent_launcher.rs` — populate `script_launch`, add the typed
+  no-silent-truncation gate, its `Display` text, and the Windows behavior tests that
+  carry a multi-line prompt across the real launch-plan boundary.
+- A6 is already covered by `src/app_input/fresh_prompt.rs::prompt_content_is_inlined_as_one_typed_value`,
+  which proves the composed prompt reaching the launch signature contains the issue body verbatim.
+
+No new subsystem, public abstraction beyond one pure resolver function, dependency,
+workflow, quality-tool change, or unrelated refactor is authorized.
+
+## Scope ledger
+
+| Entry | Status | Reason |
+|---|---|---|
+| Canonical runtime/entrypoint derivation for a resolved wrapper path | In scope | A1 |
+| Populating the existing `script_launch` payload field | In scope | A1 |
+| Typed refusal for newline argv with no canonical layout | In scope | A2 |
+| Preserving `cmd.exe` behavior for newline-free argv | In scope | A3 |
+| Direct/PowerShell/Unix regression protection | In scope | A4/A5 |
+| Prompt-content completeness evidence | In scope | A6 |
+| End-to-end `script_launch` plumbing through candidate/plan structs | Deferred | Same observable behavior at far higher blast radius; follow-up if probe parity is later required |
+| Probe-path (`command_for_path`) cmd.exe removal | Deferred | Probe argv is short and newline-free; not part of this defect |
+| Remote/SSH argv quoting | Rejected | Different target and ownership |
+
+## Review and verification ledger
+
+- RED evidence: `marked_wrapper_delivers_multiline_prompt_without_cmd_exe` and
+  `unmarked_command_script_refuses_a_newline_argument_instead_of_truncating` both failed
+  before implementation (`AgentLauncherError::CommandScriptArgumentUnsupported` did not
+  exist, and every written plan carried `script_launch: None`, so the marked wrapper was
+  still routed through `cmd.exe`).
+- Empirical repro: spawning `%COMSPEC% /D /S /C wrapper.cmd "<multi-line prompt>"` on this
+  machine returned `ARG1=[Read and work on the following GitHub issue.]`, reproducing the
+  reported symptom exactly. The reporting machine's `llxprt.cmd` carries the native-launcher
+  marker and the complete bun/entrypoint layout, so the bypass is applicable there.
+- Local verification: `cargo fmt --all` clean; `cargo clippy --workspace --all-targets
+  --all-features -- -D warnings` clean; `cargo test --workspace --all-features
+  --no-fail-fast` reports zero failures attributable to this change.
+- Known-flaky exclusion: `psmux_attach::native_psmux_attachment_preserves_terminal_contract_and_session`
+  failed once on scrollback delivery and passed on immediate re-run. It exercises psmux/ConPTY
+  input delivery (issues #438, #546) and touches no launcher code.
+- Local OCR: `0 / 2`
+- PR OCR: `0 / 2`
+- RED evidence: pending
+- Fast verification: pending
+- Exact-head verification: pending
+- Native Windows CI: pending
+- Deferred findings: see scope ledger
+
+## Completion contract
+
+Complete only when a multi-line issue prompt provably reaches the spawned Windows
+worker byte-intact, no configuration can silently deliver a truncated prompt,
+newline-free and non-`CommandScript` launches are unchanged, exact-head local
+verification and required CI (including native Windows) pass, reviews are triaged
+within their counters, the PR is conflict-free, and every changed file maps to
+this ledger.

--- a/project-plans/issue536-plan.md
+++ b/project-plans/issue536-plan.md
@@ -136,6 +136,20 @@ workflow, quality-tool change, or unrelated refactor is authorized.
 - Native Windows CI: green — `Native Windows (MSVC + psmux)`, `Windows Clippy
   (cfg(windows) lint gap)` and `Windows coverage floors` all pass on head
   `8f06292a`, which is the platform the defect reproduces on.
+- CodeRabbit: no findings.
+- LLxprt PR Review triage:
+  - "Referenced plan file `project-plans/issue536-plan.md` is missing" — **Reject**.
+    The file is added by this PR; `git diff --stat fc2d4f19..b4fa9227` lists it at
+    148 added lines. The run that raised this was triggered by a description edit
+    and evaluated the body without the diff.
+  - "Claims a broader cmd.exe metacharacter-injection mitigation not present in the
+    diff" — **In-scope-Fix**, applied to the description rather than the code. The
+    original wording overstated the result: the marked path is no longer exposed
+    because it stops invoking `cmd.exe` at all, but the newline-free `CommandScript`
+    path is intentionally byte-identical and its quoting is unchanged. General
+    metacharacter quoting is out of scope for this defect.
+  - "PR description missing template sections" — **In-scope-Fix**, applied; the body
+    now carries Summary, Pre-push checklist, Testing notes and Reviewers / Assignees.
 - Deferred findings: see scope ledger
 
 ## Completion contract

--- a/src/runtime/agent_executable.rs
+++ b/src/runtime/agent_executable.rs
@@ -368,6 +368,35 @@ fn official_llxprt_outcome(directory: &Path, wrapper_path: &Path) -> CanonicalSc
     }
 }
 
+/// Derive the canonical runtime + entrypoint for an already-resolved Windows
+/// `CommandScript` wrapper, so the agent can be launched without `cmd.exe`.
+///
+/// `cmd.exe` terminates its command line at the first `0x0A` and offers no
+/// escape for it, so any wrapper reached through `cmd.exe /D /S /C` silently
+/// loses every line of a multi-line prompt after the first (issue #536). The
+/// same `#258` contract that this module already applies during resolution is
+/// therefore also needed at the launch-plan boundary, where the generic
+/// candidate resolver only carries `(path, wrapper_kind)`.
+///
+/// Only the marked official layout is recognized. An unmarked wrapper gets
+/// `None` rather than a guessed runtime: inferring a neighbouring `node.exe` +
+/// `npm-cli.js` for an arbitrary agent wrapper would launch npm instead of the
+/// agent. The caller decides what to do with `None`.
+pub(super) fn canonical_script_launch_for_marked_wrapper(
+    wrapper_path: &Path,
+) -> Option<CanonicalScriptLaunchPlan> {
+    if !wrapper_carries_native_launcher_marker(wrapper_path) {
+        return None;
+    }
+    // Canonical fingerprints store verbatim (long-path prefixed) paths. Those
+    // are passed to the kernel unnormalized, so `/` is not a separator in them
+    // and the relative layout joins below would not resolve. Strip the prefix
+    // before joining; `canonical_script_launch_plan` re-canonicalizes.
+    let launchable = strip_verbatim_prefix(wrapper_path);
+    let directory = launchable.parent()?;
+    canonical_script_launch_plan(directory, LLXPRT_BUN_REL, LLXPRT_ENTRYPOINT_REL)
+}
+
 fn canonical_script_launch_plan(
     directory: &Path,
     runtime_rel: &str,

--- a/src/runtime/agent_launcher.rs
+++ b/src/runtime/agent_launcher.rs
@@ -68,10 +68,17 @@ pub fn write_launch_plan(
     cwd: &Path,
     worker_report: Option<&Path>,
 ) -> Result<PathBuf, AgentLauncherError> {
+    let script_launch = script_launch_for(executable, wrapper);
+    if script_launch.is_none()
+        && wrapper == AgentWrapperKind::CommandScript
+        && args.iter().any(argument_defeats_cmd_exe)
+    {
+        return Err(AgentLauncherError::CommandScriptArgumentUnsupported);
+    }
     let payload = AgentLaunchPayload {
         path: executable.to_path_buf(),
         wrapper: wrapper.into(),
-        script_launch: None,
+        script_launch,
         args: args.to_vec(),
         environment: environment.to_vec(),
         cwd: cwd.to_path_buf(),
@@ -104,6 +111,34 @@ pub fn write_launch_plan(
         }
     }
     Err(AgentLauncherError::PlanCreateFailed)
+}
+
+/// Resolve the wrapper's own runtime + entrypoint so the agent is spawned
+/// directly instead of through `cmd.exe` (issue #536). Non-`CommandScript`
+/// executables already receive their argv verbatim and need no plan.
+fn script_launch_for(executable: &Path, wrapper: AgentWrapperKind) -> Option<ScriptLaunchPayload> {
+    if wrapper != AgentWrapperKind::CommandScript {
+        return None;
+    }
+    super::agent_executable::canonical_script_launch_for_marked_wrapper(executable).map(|plan| {
+        ScriptLaunchPayload {
+            runtime: plan.runtime().to_path_buf(),
+            entrypoint: plan.entrypoint().to_path_buf(),
+        }
+    })
+}
+
+/// Whether an argument cannot survive a `cmd.exe` command line.
+///
+/// `cmd.exe` ends its command line at the first `0x0A`; a bare `0x0D` is
+/// likewise not carried through intact. Neither can be quoted or escaped, so an
+/// argument containing either must never be handed to `cmd.exe` — silently
+/// delivering only its first line is exactly the issue #536 defect.
+fn argument_defeats_cmd_exe(argument: &OsString) -> bool {
+    // Lossy decoding is sound for this check: replacement characters only ever
+    // stand in for unpaired surrogates, and can neither create nor hide a CR/LF.
+    let text = argument.to_string_lossy();
+    text.contains('\n') || text.contains('\r')
 }
 
 #[cfg(all(test, windows))]
@@ -260,8 +295,177 @@ mod tests {
     use std::path::PathBuf;
 
     use super::{
-        AgentLaunchPayload, AgentLauncherError, AgentWrapperKindPayload, command_for_payload,
+        AgentLaunchPayload, AgentLauncherError, AgentWrapperKind, AgentWrapperKindPayload,
+        command_for_payload,
     };
+
+    // ── Issue #536: a multi-line prompt must never be delivered through cmd.exe ──
+    //
+    // `cmd.exe` terminates its command line at the first 0x0A, so an issue prompt
+    // passed through `cmd.exe /D /S /C wrapper.cmd <prompt>` arrives cut down to its
+    // first line. There is no escape for this, so the wrapper's own canonical
+    // runtime + entrypoint must be launched directly instead.
+
+    const NATIVE_LAUNCHER_MARKER: &str = "LLXPRT_NATIVE_LAUNCHER owned by @vybestack/llxprt-code";
+    const MULTILINE_PROMPT: &str = "Read and work on the following GitHub issue.\n\n\
+                                    Issue #536: the body must survive.\n\nWorkflow appendix.";
+
+    /// Build a marked official-LLxprt wrapper beside a complete bundled layout.
+    fn marked_official_wrapper(root: &std::path::Path) -> PathBuf {
+        let bun_dir = root.join("node_modules/@vybestack/llxprt-code/node_modules/bun/bin");
+        std::fs::create_dir_all(&bun_dir)
+            .unwrap_or_else(|error| panic!("could not create bun fixture: {error}"));
+        std::fs::write(bun_dir.join("bun.exe"), b"fixture")
+            .unwrap_or_else(|error| panic!("could not write bun fixture: {error}"));
+        std::fs::write(
+            root.join("node_modules/@vybestack/llxprt-code/index.ts"),
+            b"fixture",
+        )
+        .unwrap_or_else(|error| panic!("could not write entrypoint fixture: {error}"));
+        let wrapper = root.join("llxprt.cmd");
+        std::fs::write(
+            &wrapper,
+            format!("@echo off\r\nREM {NATIVE_LAUNCHER_MARKER}\r\n").as_bytes(),
+        )
+        .unwrap_or_else(|error| panic!("could not write wrapper fixture: {error}"));
+        wrapper
+    }
+
+    /// Round-trip a written plan back into its payload the way the pane host does.
+    fn payload_from_written_plan(plan_path: &std::path::Path) -> AgentLaunchPayload {
+        let bytes = std::fs::read(plan_path)
+            .unwrap_or_else(|error| panic!("could not read written plan: {error}"));
+        let payload = serde_json::from_slice(&bytes)
+            .unwrap_or_else(|error| panic!("could not decode written plan: {error}"));
+        let _ = std::fs::remove_file(plan_path);
+        payload
+    }
+
+    #[test]
+    fn marked_wrapper_delivers_multiline_prompt_without_cmd_exe() {
+        let dir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("could not create launcher fixture: {error}"));
+        let wrapper = marked_official_wrapper(dir.path());
+        let plan_path = super::write_launch_plan(
+            &wrapper,
+            AgentWrapperKind::CommandScript,
+            &[OsString::from("-i"), OsString::from(MULTILINE_PROMPT)],
+            &[],
+            dir.path(),
+            None,
+        )
+        .unwrap_or_else(|error| panic!("marked wrapper must produce a launch plan: {error}"));
+
+        let payload = payload_from_written_plan(&plan_path);
+        let command = command_for_payload(&payload);
+        let program = PathBuf::from(command.get_program());
+        assert_eq!(
+            program.file_name().and_then(|name| name.to_str()),
+            Some("bun.exe"),
+            "a marked wrapper must be launched through its own runtime, not cmd.exe, got {program:?}"
+        );
+
+        let args = command
+            .get_args()
+            .map(std::ffi::OsStr::to_os_string)
+            .collect::<Vec<_>>();
+        let entrypoint = PathBuf::from(&args[0]);
+        assert_eq!(
+            entrypoint.file_name().and_then(|name| name.to_str()),
+            Some("index.ts"),
+            "the canonical entrypoint must precede the agent argv"
+        );
+        assert_eq!(
+            args[2],
+            OsString::from(MULTILINE_PROMPT),
+            "the full multi-line prompt must reach the agent byte-intact (issue #536)"
+        );
+    }
+
+    #[test]
+    fn unmarked_command_script_refuses_a_newline_argument_instead_of_truncating() {
+        let dir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("could not create launcher fixture: {error}"));
+        let wrapper = dir.path().join("agent.cmd");
+        std::fs::write(&wrapper, b"@echo off\r\nexit /b 0\r\n")
+            .unwrap_or_else(|error| panic!("could not write launcher fixture: {error}"));
+
+        let result = super::write_launch_plan(
+            &wrapper,
+            AgentWrapperKind::CommandScript,
+            &[OsString::from(MULTILINE_PROMPT)],
+            &[],
+            dir.path(),
+            None,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(AgentLauncherError::CommandScriptArgumentUnsupported)
+            ),
+            "a wrapper that can only be reached through cmd.exe must refuse a newline \
+             argument rather than silently deliver its first line, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn direct_executable_still_carries_a_multiline_argument() {
+        let dir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("could not create launcher fixture: {error}"));
+        let executable = dir.path().join("agent.exe");
+        std::fs::write(&executable, b"fixture")
+            .unwrap_or_else(|error| panic!("could not write launcher fixture: {error}"));
+
+        let plan_path = super::write_launch_plan(
+            &executable,
+            AgentWrapperKind::Direct,
+            &[OsString::from(MULTILINE_PROMPT)],
+            &[],
+            dir.path(),
+            None,
+        )
+        .unwrap_or_else(|error| panic!("a direct executable must launch: {error}"));
+
+        let payload = payload_from_written_plan(&plan_path);
+        let command = command_for_payload(&payload);
+        let args = command
+            .get_args()
+            .map(std::ffi::OsStr::to_os_string)
+            .collect::<Vec<_>>();
+        assert_eq!(args, vec![OsString::from(MULTILINE_PROMPT)]);
+    }
+
+    #[test]
+    fn newline_free_command_script_argv_keeps_the_existing_cmd_exe_contract() {
+        let dir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("could not create launcher fixture: {error}"));
+        let wrapper = dir.path().join("agent.cmd");
+        std::fs::write(&wrapper, b"@echo off\r\nexit /b 0\r\n")
+            .unwrap_or_else(|error| panic!("could not write launcher fixture: {error}"));
+
+        let plan_path = super::write_launch_plan(
+            &wrapper,
+            AgentWrapperKind::CommandScript,
+            &[OsString::from("--version")],
+            &[],
+            dir.path(),
+            None,
+        )
+        .unwrap_or_else(|error| panic!("a newline-free wrapper launch must succeed: {error}"));
+
+        let payload = payload_from_written_plan(&plan_path);
+        assert!(
+            payload.script_launch.is_none(),
+            "an unmarked wrapper must not invent a runtime"
+        );
+        let command = command_for_payload(&payload);
+        let args = command
+            .get_args()
+            .map(std::ffi::OsStr::to_os_string)
+            .collect::<Vec<_>>();
+        assert_eq!(args[0], OsString::from("/D"));
+        assert_eq!(args[3], wrapper.as_os_str());
+    }
 
     #[test]
     fn canonical_command_script_payload_uses_launch_safe_path() {
@@ -445,6 +649,11 @@ pub enum AgentLauncherError {
     /// (issue #530). The worker is refused spawn so the agent never silently
     /// starts in the wrong directory.
     InvalidWorkingDirectory,
+    /// The resolved executable is a `.cmd`/`.bat` wrapper with no canonical
+    /// runtime of its own, and an argument contains a line break (issue #536).
+    /// `cmd.exe` would truncate the command line at that break, so the launch is
+    /// refused rather than delivering a silently shortened prompt.
+    CommandScriptArgumentUnsupported,
     /// Windows Job Object containment could not be established before spawning
     /// the worker (issue #467 Slice 3). Worker spawn is refused so a host can
     /// never start a descendant tree it cannot reliably contain.
@@ -476,6 +685,10 @@ impl std::fmt::Display for AgentLauncherError {
             Self::InvalidWorkingDirectory => {
                 formatter.write_str("agent working directory does not exist or is not a directory")
             }
+            Self::CommandScriptArgumentUnsupported => formatter.write_str(
+                "agent wrapper can only be launched through cmd.exe, which cannot carry a \
+                 multi-line argument; install the agent so it exposes a native launcher",
+            ),
             #[cfg(windows)]
             Self::ContainmentUnavailable => formatter.write_str(
                 "windows job object containment could not be established for agent worker",


### PR DESCRIPTION
## Summary

Fixes #536.

Sending an issue to an agent on Windows delivered exactly this to the agent:

```
Read and work on the following GitHub issue.
```

No issue number, no title, no body, no comments, no delivery-workflow appendix. The agent had nothing to work on.

### Why

The prompt was intact right up to the last hop — `format_issue_prompt`, `fresh_prompt_instruction`, `prepare_fresh_send` and the launch-plan JSON all carry it losslessly. The loss happened when the pane host spawned the agent.

`llxprt` on Windows resolves to the npm shim `llxprt.cmd`, classified `AgentWrapperKind::CommandScript`, which `base_command_for_payload` ran as `cmd.exe /D /S /C llxprt.cmd -i "<prompt>"`. **`cmd.exe` terminates its command line at the first `0x0A`, and there is no escape for it.** Reproduced directly:

```powershell
& $env:COMSPEC /D /S /C wrapper.cmd "Read and work on the following GitHub issue.`n`nbody"
# wrapper observed: ARG1=[Read and work on the following GitHub issue.]
```

The codebase already solved this once for #258: `CanonicalScriptLaunchPlan`, documented as *"bypassing `cmd.exe` so the full argument vector survives intact"*. It was unreachable for two independent reasons:

1. **Never computed.** Agent candidates now resolve through the generic `AgentCandidateResolver` → `PathSnapshot::resolve_binary` (#382 CW-02 S2), which returns only `(path, wrapper_kind)` and has no canonical-layout logic. The product-specific `AgentExecutableResolver` that does compute the plan is no longer on this path.
2. **Never deliverable.** `AgentLaunchPayload` has a `script_launch` field whose `Some` branch spawns `runtime + entrypoint + args` with no `cmd.exe` — but `write_launch_plan` hard-coded `script_launch: None`.

`5c1d5fc9` ("Skip `--help` capability probe for trusted agents"), named in the issue as the regression point, touches neither prompt construction nor argv delivery. It made Windows launches *succeed* where the `--help` probe previously failed them outright, which is what made the pre-existing truncation observable — consistent with the reported bisect.

### The fix

Derive the canonical plan at the launch-plan boundary, where the wrapper path is known:

- `canonical_script_launch_for_marked_wrapper` returns the wrapper's own runtime + entrypoint **only** when the wrapper carries the native-launcher marker.
- `write_launch_plan` populates `script_launch` from it, making the existing bypass live.
- An unmarked `CommandScript` handed an argument containing CR/LF now returns a typed `CommandScriptArgumentUnsupported` error naming the cause.

Two deliberate non-fallbacks:

- **No runtime guessing.** Inferring a neighbouring `node.exe` + `npm-cli.js` for an arbitrary unmarked wrapper would launch npm instead of the agent.
- **No silent truncation.** Shipping a first-line-only prompt is the defect itself, so the unmarked case fails loudly rather than quietly.

Newline-free argv keeps the existing `cmd.exe` contract byte for byte, `Direct`/`PowerShellScript` wrappers are untouched, and Unix is unaffected.

### Scope

3 files, including `project-plans/issue536-plan.md`, which this PR adds. Deliberately narrow: threading `script_launch` end-to-end through `ResolvedCandidate` → `PackageInvocation` → `CandidateEvidence` → `AgentLaunchPlan` → `AgentPaneLaunch` would have touched ~20 files and ~35 test struct literals for the same observable behavior. That plumbing is recorded as deferred in the plan's scope ledger.

Not claimed and not implemented: general `cmd.exe` metacharacter quoting. The marked-wrapper path stops going through `cmd.exe` at all, so it is incidentally no longer exposed to `&`, `|`, `^`, `%`, `<`, `>` in the prompt body; the newline-free `CommandScript` path is intentionally left byte-identical, so its existing quoting behavior is unchanged either way. Hardening that path is a separate concern from this defect.

**Known caveat, recorded in the plan:** the execution guard fingerprints `plan.executable` (the `.cmd`) while we now execute `bun.exe` + `index.ts`. This is the same substitution `AgentExecutableResolver` already performed, and the marked wrapper itself declares that layout.

## Pre-push checklist

Run locally on the exact head before pushing:

- [x] **Format** — `cargo fmt --all --check` clean
- [x] **Lint** — `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] **Build** — `cargo build --workspace --all-features` clean
- [x] **Tests** — `cargo test --workspace --all-features --no-fail-fast`, zero failures attributable to this change
- [x] **Clippy allow policy** — no `#[allow(clippy::...)]` added
- [x] **Source file length** — verified by CI on this head
- [x] **Architecture boundary policy** — verified by CI on this head
- [x] **Complexity** — verified by CI on this head
- [x] **Coverage** — verified by CI on this head (Coverage gate and Windows coverage floors)

Optional TUI smoke is not applicable: this change alters process-spawn argv construction, not TUI rendering or input handling.

## Testing notes

RED first — `marked_wrapper_delivers_multiline_prompt_without_cmd_exe` and `unmarked_command_script_refuses_a_newline_argument_instead_of_truncating` both failed before the change (the error variant did not exist and every written plan carried `script_launch: None`).

| Row | Behavior | Test |
|---|---|---|
| A1 | Marked layout + multi-line prompt → full argv via runtime+entrypoint, no `cmd.exe` | `marked_wrapper_delivers_multiline_prompt_without_cmd_exe` |
| A2 | Unmarked `CommandScript` + newline argv → typed error, never truncation | `unmarked_command_script_refuses_a_newline_argument_instead_of_truncating` |
| A3 | Newline-free argv → existing `cmd.exe` contract unchanged | `newline_free_command_script_argv_keeps_the_existing_cmd_exe_contract` |
| A4 | `Direct` wrappers unchanged | `direct_executable_still_carries_a_multiline_argument` |
| A6 | Composed prompt contains the issue body verbatim | `fresh_prompt::prompt_content_is_inlined_as_one_typed_value` |

Tests round-trip a real written plan back through `serde` and `command_for_payload`, so they exercise the actual launch boundary rather than asserting on an in-memory struct.

Targeted run: `cargo test --lib runtime::agent_launcher` → 11 passed, 0 failed.

`psmux_attach::native_psmux_attachment_preserves_terminal_contract_and_session` failed once locally on scrollback delivery and passed on immediate re-run — known ConPTY flake (#438, #546), no launcher code involved. It passes in CI on this head.

The `Native Windows (MSVC + psmux)` job is the one that matters here, since the defect reproduces only on Windows; it is green.

## Reviewers / Assignees

@acoliver
