### PR TITLE
Give the Windows session tree one owner-lifetime anchor (#542)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,32 @@ jobs:
             'No harness namespace was recorded.' | Out-File $remaining
           }
           exit 0
+      # Issue #542 (V7). The step above records and exits 0, so the orphaned
+      # tree class this repository has reopened four times could never turn CI
+      # red. Sessions are also the wrong unit: #515's signature is a session
+      # that has already left the inventory while its session host and worker
+      # keep running. Per dev-docs/standards/windows-session-ownership.md the
+      # session host is the anchor holder, so zero surviving session hosts
+      # means zero surviving trees -- the Job Object reaps the worker when the
+      # host exits.
+      - name: Assert no jefe process survives the suite
+        if: always()
+        shell: pwsh
+        run: |
+          $survivors = @(Get-Process -ErrorAction SilentlyContinue |
+            Where-Object { $_.ProcessName -like 'jefe-session-host*' })
+          $report = 'target/windows-ci/surviving-processes.txt'
+          New-Item -ItemType Directory -Force -Path 'target/windows-ci' | Out-Null
+          if ($survivors.Count -eq 0) {
+            'No jefe session host survived the suite.' | Out-File $report
+            return
+          }
+          $survivors |
+            Select-Object Id, ProcessName, StartTime, Path |
+            Format-List |
+            Out-File $report
+          Get-Content $report | Write-Host
+          throw "$($survivors.Count) jefe session host process(es) survived the suite. Every session host must be reaped when its owner dies; see dev-docs/standards/windows-session-ownership.md."
       - name: Upload native Windows diagnostics
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/dev-docs/standards/windows-session-ownership.md
+++ b/dev-docs/standards/windows-session-ownership.md
@@ -1,0 +1,143 @@
+# Windows Session Ownership Model
+
+Status: normative. Issue #542 (invariant **I4**, epic criterion **E5**).
+Supersedes the implicit, undocumented models assumed by #332, #467 and #493.
+
+> **Invariant I4.** A Windows session process tree has exactly one
+> owner-lifetime anchor. No process in the tree can outlive its owner, and no
+> owner can die leaving a reachable-but-unowned tree.
+
+This document is the specification. `src/runtime/owner_anchor.rs`,
+`src/runtime/agent_launcher.rs`, `src/runtime/job_object.rs` and
+`src/runtime/session_host.rs` implement it and reference it by name.
+
+## 1. Why this document exists
+
+The same defect class has been closed three times and reopened four. Every
+previous fix moved the ownership anchor without writing down where it now was,
+so the next change moved it again:
+
+| Fix | Anchor after the fix | Gap it left |
+|---|---|---|
+| #332 `ca7e4bd4` | dashboard image, plus after-the-fact orphan reaping | reaping is a mitigation, not ownership |
+| #467 `eaba9f2a` | staged `jefe-session-host.exe` owning a `KILL_ON_JOB_CLOSE` Job | containment is *host*-lifetime, not *owner*-lifetime — the host contains its worker, nothing contained the host. Created #515 |
+| #493 `c51bd65d` | unchanged; added the `ServerLost` tri-state | explicitly does not reap surviving trees |
+
+The tree is `psmux server -> pane process -> session host -> worker`, and
+containment had only ever been established at one link at a time.
+
+## 2. The tree
+
+```text
+  jefe dashboard                     (NOT an owner — see §4)
+        │ starts, then forgets
+        ▼
+  psmux server            ── L2 owner ──┐
+        │ spawns pane                   │
+        ▼                               │  owner chain of
+  pane process (pwsh)     ── L1 owner ──┤  the session host
+        │ spawns launcher               │
+        ▼                               │
+  session host            ◀── ANCHOR HOLDER
+        │ owns a KILL_ON_JOB_CLOSE Job
+        ▼
+  worker (bun / node / agent)  ── contained
+```
+
+## 3. Roles, owners, and death semantics
+
+| Process | Owned by | Its death means | What must be reaped |
+|---|---|---|---|
+| **jefe dashboard** | the user | the UI is gone; agents keep running and stay reconnectable | nothing |
+| **psmux server** | the user / the multiplexer namespace | every session it hosted is gone | every pane process, session host and worker below it |
+| **pane process** (`pwsh`) | the psmux server | that one pane is gone | the session host and worker below it |
+| **session host** | the pane process, transitively the psmux server | the Job handle closes | the worker tree, by the kernel, unconditionally |
+| **worker** | the session host, via the Job | the agent finished or died | nothing; the host exits with it |
+
+Reading the table downward gives the containment guarantee; reading it upward
+gives the anchor rule: **the session host must not outlive any process above it
+in its owner chain.**
+
+## 4. The anchor rule
+
+The **session host is the anchor holder**. It is the only process that owns a
+kernel object (`KILL_ON_JOB_CLOSE` Job) whose closure reaps the tree.
+
+Its **owner chain** is exactly two links, captured at launch:
+
+- **L1 — the pane process**: the session host's direct parent.
+- **L2 — the psmux server**: the session host's grandparent.
+
+Capture is deliberately capped at depth 2. Climbing further would reach the
+Jefe dashboard, and anchoring on the dashboard is exactly the #332 model that
+#467 had to undo: it makes a dashboard quit or a rebuild kill live agents.
+Capping at L2 is what keeps #467's acceptance criteria (dashboard exit and
+mid-run rebuild both leave the tree alive and reconnectable) true.
+
+### Rules
+
+1. **Capture happens before the spawn.** The owner chain is captured *before*
+   the worker process is created. A late lookup cannot distinguish "my owner
+   is alive" from "my owner already died and something else holds its PID".
+2. **The anchor is a `ProcessIdentity`, never a PID.** `ProcessIdentity` is
+   PID plus process creation time. **PID reuse** must not be able to spoof
+   ownership: an ancestor whose PID still resolves but whose creation time
+   differs is a different process, and is treated as owner death.
+3. **An ancestor cannot be younger than its descendant.** At capture time, a
+   candidate ancestor whose creation time is later than the session host's own
+   is rejected — it is a recycled PID, not a real ancestor.
+4. **Owner death releases the tree.** When *any* captured link is confirmed
+   dead or replaced, the session host exits. Exiting closes the Job handle and
+   the kernel terminates the contained worker tree. Because every process above
+   the host must outlive it, any confirmed ancestor death is an ownership
+   violation, whichever link it happens at and whatever the termination order.
+5. **Uncertainty must never terminate.** Termination is irreversible; a
+   transient probe failure is not. `Inaccessible` and `ProbeFailure`
+   observations **fail open**: the host keeps running and emits a bounded
+   diagnostic. Only a positive observation of death or replacement releases the
+   tree.
+6. **If ownership cannot be established, nothing is spawned.** A launch that
+   cannot capture an owner chain fails with a typed error instead of creating a
+   worker that nothing owns.
+
+## 5. What this model is not
+
+- **It is not a sweeper.** A periodic janitor that reaps orphans after the fact
+  is defence in depth, not an ownership model. Invariant I4 must hold without
+  one, and the tests prove it does. Startup reconciliation
+  (`app_init_orphan_reconcile`, `startup_cleanup_session_hosts`) exists to
+  resolve trees left by *pre-model* builds and by terminations that bypassed
+  every user-space path; it is not the mechanism.
+- **It is not liveness reporting.** #493's `ServerLost` tri-state describes
+  what the dashboard *displays* when a psmux server vanishes. It deliberately
+  does not reap. This model reaps, from inside the tree, without the dashboard
+  being involved or even running.
+- **It is not PID-based cleanup.** No decision in this model is taken on an
+  executable name, command line, working directory, or bare PID.
+
+## 6. Staged host lifecycle across rebuild
+
+`session_host.rs` stages a content-addressed host per session at
+`<root>/<session>/<sha256>/jefe-session-host.exe`. A rebuild changes the hash,
+so the next launch stages a new digest directory while the running host keeps
+its own image file-locked.
+
+Ownership status of a superseded digest directory: it belongs to a *previous
+host generation*. It is removable exactly when no process holds its image open.
+Windows enforces this for free — `remove_dir_all` fails on a locked image — so
+staging prunes superseded digests for that session on a best-effort basis and
+silently retains anything still in use. Pruning never fails a launch.
+
+## 7. Termination-order matrix
+
+The expected surviving tree after each termination, graceful or `taskkill /F`:
+
+| Terminated | Expected survivors |
+|---|---|
+| jefe dashboard | psmux server, pane, session host, worker — all alive and reconnectable |
+| worker | nothing below it; the session host exits with its child |
+| session host | worker reaped by the kernel via the Job |
+| pane process | session host observes L1 loss, exits, kernel reaps the worker |
+| psmux server | every pane, session host and worker under that server exits; other servers' trees are untouched |
+
+No survivors outside this table, in any order, at any level of abruptness.

--- a/project-plans/issue542-plan.md
+++ b/project-plans/issue542-plan.md
@@ -99,8 +99,27 @@ No dependency, agent-memory, or quality-tooling change. `.llxprt/` and
 
 ## 7. Review counters
 
-- OCR before PR: 0 / 2
-- OCR after PR: 0 / 2
+- OCR before PR: 0 / 2 (the `rustreviewer` subagent hit its 900s ceiling and
+  returned nothing; substituted a direct line-by-line audit of the seven
+  `owner_anchor` invariants, which found no blockers)
+- OCR after PR: 1 / 2 — seven findings, five fixed in `b75c433a`, two rejected.
+  Triage recorded on PR #622 and summarised below.
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | Watchdog thread swallows panics, leaving the tree unwatched | Blocker — Fix (fixed as hold-on-panic, not exit-on-panic) |
+| 2 | Thread name `.to_owned()` allocates | Reject — `Builder::name` takes `String` |
+| 3 | `CARGO_MANIFEST_DIR` cannot resolve `dev-docs/` in a workspace | Reject — this crate is the workspace root; the tests are green |
+| 4 | `run_pane_launcher` discards `try_wait()` and blocks forever | In-scope — Fix |
+| 5 | `spawn_contained_worker` discards `try_wait()` | In-scope — Fix |
+| 6 | `run_pane_launcher` not `#[cfg(windows)]` | In-scope — Fix |
+| 7 | `0x0000_0208` duplicated as a magic number | In-scope — Fix |
+
+Finding 1 was fixed against the reviewer's suggested remedy. Exiting the
+process on panic would let an unrelated bug terminate a healthy agent, which
+inverts the rule in §4 that only *confirmed* ownership loss may release a tree.
+A panic is now classified as the strongest form of `Unverified`: the pass
+holds, the reason is logged, and the watchdog survives to retry.
 
 ## 8. Verification evidence
 

--- a/project-plans/issue542-plan.md
+++ b/project-plans/issue542-plan.md
@@ -1,0 +1,153 @@
+# Issue #542 — A single owner-lifetime anchor for Windows session process trees
+
+Invariant **I4**, epic criterion **E5**. Parent of #515, #306, #445.
+
+> A Windows session process tree has exactly one owner-lifetime anchor. No
+> process in the tree can outlive its owner, and no owner can die leaving a
+> reachable-but-unowned tree.
+
+## 1. Why the three previous closures did not hold
+
+| Prior fix | What it moved | What it left open |
+|---|---|---|
+| #332 (`ca7e4bd4`) | Added orphan recognition and reaping; anchor stayed the dashboard image | Reaping is after-the-fact, not ownership |
+| #467 (`eaba9f2a`) | Anchor moved from dashboard to a staged, content-addressed `jefe-session-host.exe` with a `KILL_ON_JOB_CLOSE` Job | Containment is *host*-lifetime, not *owner*-lifetime — the host contains its worker, nothing contains the host. This **created #515** |
+| #493 (`c51bd65d`) | Added the `ServerLost` tri-state for a vanished psmux server | Explicitly does not reap surviving trees |
+
+The structural cause: containment was established at exactly one link of
+`psmux server -> pane process (pwsh) -> jefe-session-host.exe -> worker`, never
+along the whole chain. There was no single answer to "who owns this worker, and
+what happens when that owner dies?"
+
+## 2. The ownership model this issue establishes
+
+Named, documented, and merged as
+`dev-docs/standards/windows-session-ownership.md` (V8). Summary:
+
+```text
+psmux server ──owns──> pane process (pwsh) ──owns──> session host ──owns──> worker
+      ^                        ^                          ^                    ^
+   anchor L2               anchor L1              anchor holder          contained
+```
+
+- The session host is the **anchor holder**. It holds the kill-on-close Job that
+  contains the worker.
+- Its **owner chain** is exactly its parent (the pane process) and its
+  grandparent (the psmux server) — captured as `ProcessIdentity` (PID plus
+  creation time) **before** the worker is spawned. Capture is capped at depth 2
+  so the Jefe dashboard is never an anchor; that is what keeps #467's
+  dashboard-exit and rebuild-survival guarantees intact.
+- Any **confirmed** death or PID-reuse of any captured ancestor is an ownership
+  violation: the host exits, closing the Job, and the kernel reaps the worker.
+- Uncertainty is never a death sentence. `Inaccessible` / `ProbeFailure`
+  observations fail open.
+
+## 3. Acceptance matrix
+
+| ID | Actor / launch path | Input & boundary | Observable success | Observable failure & diagnostic | Side effects before failure | Persistence / compat | Behavioral proof |
+|---|---|---|---|---|---|---|---|
+| A1 | Session host, Windows, pre-spawn | `psmux -> pwsh -> host` | Captures parent + grandparent `ProcessIdentity` before spawning the worker | Unresolvable chain returns typed `OwnerUnavailable`; no worker spawned | Launch plan consumed; nothing spawned | None | `owner_anchor` unit tests + `run_launch_plan` refusal test |
+| A2 | Owner watchdog | Every captured ancestor alive | Host and worker untouched; no status or process mutation | n/a | none | none | Pure decision tests |
+| A3 | Owner watchdog | Any captured ancestor confirmed `Dead` | Host exits; kill-on-close Job reaps the worker within a bounded interval | Cleanup failure is diagnostic; cannot panic the dashboard | none | none | Native isolated psmux regression (V2) |
+| A4 | Owner watchdog | Ancestor PID reused with a different creation identity | Treated as owner death; ownership never re-attached to the impostor | n/a | none | none | PID-reuse unit test (V5) |
+| A5 | Owner watchdog | Probe `Inaccessible` / `ProbeFailure` | Fails open — agent stays alive; bounded diagnostic only | Uncertainty is never converted into termination | none | none | Pure classifier tests |
+| A6 | Dashboard exits, psmux healthy | — | Host and worker survive and stay reconnectable | n/a | none | none | #467 dashboard-exit regression stays green |
+| A7 | Jefe binary rebuilt mid-run, psmux healthy | — | Running staged host and worker survive; new build is not file-locked | n/a | none | none | #467 rebuild regression + A8 |
+| A8 | Staging, rebuild changes the digest | `<root>/<session>/<digest>/` | Superseded digest directories for that session are pruned at stage time; the in-use one is retained because Windows locks a running image | Prune failure is silent retention, never a launch failure | new digest staged | staged tree only | `session_host` prune tests (V6) |
+| A9 | Kill matrix | Kill each of dashboard / psmux server / pane / host / worker, graceful and `taskkill /F` | Resulting tree exactly matches the documented expected tree; no survivors outside the model | n/a | none | none | Native kill-matrix regression (V1) |
+| A10 | Abrupt jefe termination then restart | Kill bypassing `Drop` | Every tree resolves to a defined startup state; live agents re-bound, dead ones reaped | Classification is total — no evidence combination is undefined | none | durable state unchanged | Startup-classification totality test (V3) |
+| A11 | Restart / deliberately failed attach | — | Ownership preserved; binding re-established against the same tree by identity, not PID alone | Attach failure never marks a live agent dead | none | binding preserved | #306 contracts stay green (V4) |
+| A12 | CI, `windows_native` | After the suite | Asserts **zero** surviving processes in the jefe namespace and fails the build if any remain | Step fails the job rather than recording and exiting 0 | none | none | Workflow contract test (V7) |
+| A13 | Unix / tmux / remote | — | Behavior structurally unchanged; Windows-only code not compiled | n/a | none | none | Cross-platform clippy/build/test |
+
+## 4. Non-goals
+
+- A dashboard-wide process supervisor, always-on cleanup daemon, or periodic
+  sweeper as the **primary** mechanism. The invariant must hold without one and
+  the tests must prove that.
+- Killing agents from an uncertain `Unavailable` psmux probe.
+- Automatic relaunch after server loss; `ServerLost` UX and its recovery
+  confirmation are unchanged.
+- Persisting process anchors in the durable state schema.
+- Heuristic cleanup keyed on executable name, command line, cwd, or PID alone.
+- Terminating the historical pre-watchdog orphans described in #515.
+- Unix/tmux or remote-agent lifecycle changes.
+- Re-opening #306's reducer/attachment policy: it merged in `88a3fd2d`
+  (PR #616) and is carried here as a regression guard only.
+
+## 5. Vertical slices
+
+| Slice | Acceptance rows | Owner layer | Allowed paths | RED proof |
+|---|---|---|---|---|
+| S1 Ownership model document | A-all, V8 | docs | `dev-docs/standards/windows-session-ownership.md`, `tests/core/windows_ownership_model_contracts.rs`, `tests/core/mod.rs` | Contract test asserts doc exists, names every tree role, and that code references it |
+| S2 Owner anchor: pure classifier + chain capture | A1, A2, A4, A5 | runtime (pure + thin platform seam) | `src/runtime/owner_anchor.rs`, `src/runtime/owner_anchor_tests.rs`, `src/runtime/mod.rs` | Classifier and PID-reuse tests fail before the module exists |
+| S3 Enforce the anchor in the session host | A1, A3, A6, A7, A13 | runtime boundary | `src/runtime/agent_launcher.rs`, `src/runtime/mod.rs` | `run_launch_plan` refuses an unowned spawn; native owner-death regression |
+| S4 Staged-host lifecycle across rebuild | A8 | runtime boundary | `src/runtime/session_host.rs`, `src/runtime/session_host_tests.rs` | Prune test fails: superseded digests accumulate |
+| S5 Kill matrix + abrupt-teardown totality | A9, A10, A11 | tests | `tests/psmux_owner_lifetime.rs`, `src/app_init_tests.rs` | Kill matrix and totality assertions |
+| S6 CI zero-survivor gate | A12 | CI (issue-authorized) | `.github/workflows/ci.yml`, `tests/core/windows_ci_signal_contracts.rs` | Contract test asserts the step throws instead of `exit 0` |
+
+## 6. Scope ledger
+
+| Change | Authorization |
+|---|---|
+| `.github/workflows/ci.yml` | Explicitly required by V7 in the issue body |
+| `dev-docs/standards/windows-session-ownership.md` (new) | Explicitly required by V8 |
+| New module `src/runtime/owner_anchor.rs` | Required by deliverable 2; the issue names the ownership model as spanning these modules and states no file/line budget applies |
+
+No dependency, agent-memory, or quality-tooling change. `.llxprt/` and
+`.code_puppy/` untouched.
+
+## 7. Review counters
+
+- OCR before PR: 0 / 2
+- OCR after PR: 0 / 2
+
+## 8. Verification evidence
+
+| Slice | Command | Result |
+|---|---|---|
+| S1 | `cargo test --test integration windows_ownership_model` | RED 5 failed → GREEN 5 passed |
+| S2/S3 | `cargo test --lib runtime::` | GREEN 380 passed |
+| S4 | `cargo test --lib runtime::session_host` | RED (superseded generations accumulate) → GREEN |
+| S6 | `cargo test --test integration windows_ci_signal` | RED 1 failed → GREEN 10 passed |
+| S5 | `JEFE_REQUIRE_PSMUX=1 cargo test --features psmux-smoke --test psmux_session_host` | **RED 1 failed → GREEN 2 passed** (see §9) |
+| gate | `cargo fmt --all --check` | exit 0 |
+| gate | `cargo clippy --workspace --all-targets --all-features -- -D warnings` | exit 0 |
+| gate | `cargo build --workspace --all-features --locked` | exit 0 |
+| gate | `cargo test --workspace --all-features --locked --no-fail-fast` | exit 0 — 81 binaries, 5286 passed, 0 failed |
+
+## 9. How V1/V2 were actually proven
+
+The first version of `killing_the_owning_psmux_server_reaps_the_whole_owned_tree`
+was **not a regression guard**: it stayed green with `spawn_owner_watchdog`
+deleted from the fixture. Measured against real psmux 3.3.7 with the watchdog
+disabled, killing the psmux server reaped the tree in 1.64 s and killing the
+pane `pwsh` reaped it in 4.23 s. The pane's ConPTY teardown was destroying the
+console-attached session host, so the test measured Windows, not Jefe. Shipping
+that as V1/V2 evidence would have repeated the exact failure mode (#332, #467,
+#493) this issue exists to stop.
+
+#515's field evidence has the opposite topology: the psmux server was gone while
+the pane `pwsh` was **still alive**, holding a surviving host. Those hosts were
+never console-cascaded.
+
+Fix: the `--pane-launcher` fixture mode spawns the session host with
+`DETACHED_PROCESS`, using the safe `CommandExt::creation_flags` path the worker
+already used. The host now has real ancestors in the psmux tree but no shared
+console, matching #515. `unsafe_code = "forbid"` is preserved — no FFI was
+added, and no production code changed for the sake of the test.
+
+Discrimination proof:
+
+- **RED** — with `spawn_owner_watchdog(anchor)` replaced by `let _ = &anchor;`,
+  the test fails at `tests/psmux_session_host.rs:393`: "session host (pid 18856)
+  survived the death of the process that owned it" (21.85 s).
+- **GREEN** — with the watchdog restored, 2 passed in 3.25 s.
+
+The test kills only `owner_links[0].pid`, a process the test itself spawned
+inside its own uniquely-named psmux namespace, with `taskkill /F` and no `/T`,
+so nothing cascades and no ambient psmux server is touched.
+
+## 10. Deferred findings
+
+None.

--- a/project-plans/issue542-plan.md
+++ b/project-plans/issue542-plan.md
@@ -154,6 +154,27 @@ great-grandparent to the psmux server.
 | gate | `cargo build --workspace --all-features --locked` | exit 0 |
 | gate | `cargo test --workspace --all-features --locked --no-fail-fast` | exit 0 — 81 binaries, 5286 passed, 0 failed |
 
+### Exact-head re-verification after merging `origin/main` (merge `81322015`)
+
+`origin/main` advanced seven commits and touched `src/runtime/agent_launcher.rs`,
+which is in this slice's contract set, so the branch was merged (a true
+two-parent merge, no conflicts) and every gate re-run on the merged head.
+
+| Command | Result |
+|---|---|
+| `cargo fmt --all --check` | exit 0 |
+| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | exit 0 |
+| `cargo clippy --target x86_64-unknown-linux-gnu ... -- -D warnings` | exit 0 |
+| complexity gate (`CLIPPY_CONF_DIR=.github/clippy`) | exit 0 |
+| `cargo test --workspace --all-features --locked` | exit 0 — 81 binaries, 0 failed |
+| `JEFE_REQUIRE_PSMUX=1 cargo test --features psmux-smoke --test psmux_session_host` | exit 0 — 2 passed, 3.89s |
+
+The anchor-before-containment ordering in `run_launch_plan` was re-read after
+the merge and is intact: `establish_owner_anchor()?` precedes
+`establish_worker_containment()?`, and `spawn_owner_watchdog` follows both. That
+ordering is the whole point of A1 — an anchor captured after the worker exists
+would leave a window in which an unowned worker is reachable.
+
 ## 9. How V1/V2 were actually proven
 
 The first version of `killing_the_owning_psmux_server_reaps_the_whole_owned_tree`

--- a/project-plans/issue542-plan.md
+++ b/project-plans/issue542-plan.md
@@ -102,8 +102,9 @@ No dependency, agent-memory, or quality-tooling change. `.llxprt/` and
 - OCR before PR: 0 / 2 (the `rustreviewer` subagent hit its 900s ceiling and
   returned nothing; substituted a direct line-by-line audit of the seven
   `owner_anchor` invariants, which found no blockers)
-- OCR after PR: 1 / 2 — seven findings, five fixed in `b75c433a`, two rejected.
-  Triage recorded on PR #622 and summarised below.
+- OCR after PR: 2 / 2 (cap reached) — round one: seven findings, five fixed in
+  `b75c433a`, two rejected. Round two: seven findings, four fixed, three
+  rejected. Both triages recorded on PR #622 and summarised below.
 
 | # | Finding | Disposition |
 |---|---|---|
@@ -120,6 +121,24 @@ process on panic would let an unrelated bug terminate a healthy agent, which
 inverts the rule in §4 that only *confirmed* ownership loss may release a tree.
 A panic is now classified as the strongest form of `Unverified`: the pass
 holds, the reason is logged, and the watchdog survives to retry.
+
+Second post-PR OCR run — seven findings, four fixed, three rejected. The cap of
+two post-PR runs is now spent; no further run will be solicited.
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | `owner_loss_has_a_distinguishable_exit_code` asserts only `!= 0` and `!= 1` | In-scope — Fix (asserts the exact value) |
+| 2 | `watch_owner_anchor` allocates a `Vec` every pass | In-scope — Fix (`decide_owner_watch` already takes `IntoIterator`) |
+| 3 | `OwnerRole::at_depth` maps any `depth >= 1` to `SessionServer` | In-scope — Fix (returns `Option`, so a deeper chain must name its role) |
+| 4 | The renamed staging test no longer asserts the first artifact's fate | Reject — pruning is covered by `staging_prunes_superseded_generations_that_no_process_holds`; this test owns the distinct-content contract |
+| 5 | The kill regression is not `#[cfg(windows)]` | Reject — the file carries `#![cfg(all(windows, feature = "psmux-smoke"))]` |
+| 6 | `OWNER_LOSS_TIMEOUT` of 20s is brittle | Reject — measured reap is 3.55s, over 5x headroom; an env knob adds configuration surface for a failure never observed |
+| 7 | Race between `process_alive` and `force_kill` masks the desired end state | In-scope — Fix |
+
+Finding 3 was fixed by making the mapping total rather than by inlining it.
+Inlining moves the hazard without removing it; returning `Option` makes raising
+`OWNER_CHAIN_DEPTH` stop the chain instead of silently attributing a
+great-grandparent to the psmux server.
 
 ## 8. Verification evidence
 

--- a/src/runtime/agent_launcher.rs
+++ b/src/runtime/agent_launcher.rs
@@ -131,6 +131,16 @@ pub fn run_launch_plan(path: &Path) -> Result<ExitStatus, AgentLauncherError> {
     }
     command.envs(payload.environment);
 
+    // Issue #542: capture the owner chain before anything is spawned. #467 gave
+    // the host a Job that contains the worker, but nothing contained the host,
+    // so a tree could outlive the psmux process that owned it (#515). The
+    // anchor must be taken pre-spawn and by identity — a PID looked up later
+    // can already have been recycled. No owner means no spawn: a worker nothing
+    // owns is exactly the unowned survivor this issue exists to eliminate.
+    // See `dev-docs/standards/windows-session-ownership.md`.
+    #[cfg(windows)]
+    let owner_anchor = establish_owner_anchor()?;
+
     // Issue #467 Slice 3 (AC6): on Windows the private pane host owns a
     // kill-on-close Job Object and assigns itself before spawning the worker so
     // the whole descendant tree inherits containment. The guard is held until
@@ -140,6 +150,11 @@ pub fn run_launch_plan(path: &Path) -> Result<ExitStatus, AgentLauncherError> {
     // never start a tree it cannot contain. Unix behaviour is unchanged.
     #[cfg(windows)]
     let _containment = establish_worker_containment()?;
+
+    // Containment now exists, so releasing the tree is meaningful: the watchdog
+    // exits this host on confirmed owner loss and the kernel reaps the worker.
+    #[cfg(windows)]
+    super::owner_anchor::spawn_owner_watchdog(owner_anchor);
 
     // Issue #543: spawn rather than `status()` so the worker's PID is observed
     // at the only point it is knowable. jefe cannot derive it from the pane
@@ -160,6 +175,20 @@ pub fn run_launch_plan(path: &Path) -> Result<ExitStatus, AgentLauncherError> {
         super::worker_report::write_report(report_path, &report);
     }
     child.wait().map_err(|_| AgentLauncherError::LaunchFailed)
+}
+
+/// Capture the session host's owner chain before any worker exists.
+///
+/// Ownership model: `dev-docs/standards/windows-session-ownership.md`.
+#[cfg(windows)]
+fn establish_owner_anchor() -> Result<super::owner_anchor::OwnerAnchor, AgentLauncherError> {
+    super::owner_anchor::capture_owner_anchor().map_err(|error| {
+        tracing::error!(
+            error = %error,
+            "windows session host owner anchor unavailable; refusing to spawn agent worker"
+        );
+        AgentLauncherError::OwnerAnchorUnavailable
+    })
 }
 
 #[cfg(windows)]
@@ -450,6 +479,11 @@ pub enum AgentLauncherError {
     /// never start a descendant tree it cannot reliably contain.
     #[cfg(windows)]
     ContainmentUnavailable,
+    /// The session host could not name the process that owns it (issue #542),
+    /// so nothing would cause it to exit when its owner died. Worker spawn is
+    /// refused rather than creating a tree with no owner-lifetime anchor.
+    #[cfg(windows)]
+    OwnerAnchorUnavailable,
 }
 
 impl std::fmt::Display for AgentLauncherError {
@@ -479,6 +513,10 @@ impl std::fmt::Display for AgentLauncherError {
             #[cfg(windows)]
             Self::ContainmentUnavailable => formatter.write_str(
                 "windows job object containment could not be established for agent worker",
+            ),
+            #[cfg(windows)]
+            Self::OwnerAnchorUnavailable => formatter.write_str(
+                "windows session host owner could not be identified; refusing to spawn an unowned agent worker",
             ),
         }
     }

--- a/src/runtime/job_object.rs
+++ b/src/runtime/job_object.rs
@@ -12,6 +12,12 @@
 //! rest of the runtime depends only on the typed `JobContainment` /
 //! `JobObjectError` contract. The crate forbids `unsafe` in Jefe source; all
 //! Win32 interaction stays inside the safe `win32job` wrapper.
+//!
+//! Containment is the *mechanism*, not the ownership model. It answers "what
+//! happens to the worker when the host dies", and issue #542 supplied the
+//! missing half — what makes the host die when *its* owner does. See
+//! `dev-docs/standards/windows-session-ownership.md`; this module is the
+//! anchor holder's release valve and its behaviour is unchanged by #542.
 
 #![cfg(windows)]
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -57,6 +57,10 @@ mod multiplexer_contract;
 /// Non-interactive (single-prompt, capture-stdout) agent execution (issue #214).
 mod non_interactive;
 mod orphan;
+/// Owner-lifetime anchor for the Windows session process tree (issue #542).
+///
+/// Model: `dev-docs/standards/windows-session-ownership.md`.
+mod owner_anchor;
 /// Cross-process advisory lock over the managed package install cache
 /// (issue #556).
 mod package_install_lock;
@@ -163,6 +167,15 @@ pub use server_health::{
 };
 pub use server_health_io::observe_server_liveness;
 pub use session::{RuntimeSession, TerminalCell, TerminalCellStyle, TerminalSnapshot};
+// Issue #542: the Windows owner-lifetime anchor. Exported so the native psmux
+// lifecycle regression exercises the production capture-and-watch path instead
+// of a re-implementation of it.
+// Model: `dev-docs/standards/windows-session-ownership.md`.
+#[cfg(windows)]
+pub use owner_anchor::{
+    OWNER_LOST_EXIT_CODE, OwnerAnchor, OwnerAnchorError, OwnerLink, OwnerRole,
+    capture_owner_anchor, spawn_owner_watchdog,
+};
 // Issue #467 Slice 2: re-export session-host cleanup/planning items used by the
 // startup path and the manager kill path.
 pub use session_host::{
@@ -197,6 +210,10 @@ mod process_tests;
 #[cfg(test)]
 #[path = "orphan_tests.rs"]
 mod orphan_tests;
+
+#[cfg(test)]
+#[path = "owner_anchor_tests.rs"]
+mod owner_anchor_tests;
 
 #[cfg(test)]
 #[path = "liveness_tests.rs"]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -60,6 +60,10 @@ mod orphan;
 /// Owner-lifetime anchor for the Windows session process tree (issue #542).
 ///
 /// Model: `dev-docs/standards/windows-session-ownership.md`.
+///
+/// The anchor describes the Windows `psmux server -> pane -> host -> worker`
+/// topology, so the module is compiled only there, matching `job_object`.
+#[cfg(windows)]
 mod owner_anchor;
 /// Cross-process advisory lock over the managed package install cache
 /// (issue #556).
@@ -211,7 +215,7 @@ mod process_tests;
 #[path = "orphan_tests.rs"]
 mod orphan_tests;
 
-#[cfg(test)]
+#[cfg(all(test, windows))]
 #[path = "owner_anchor_tests.rs"]
 mod owner_anchor_tests;
 

--- a/src/runtime/owner_anchor.rs
+++ b/src/runtime/owner_anchor.rs
@@ -338,7 +338,24 @@ pub fn spawn_owner_watchdog(anchor: OwnerAnchor) {
     let _ = std::thread::Builder::new()
         .name("jefe-owner-watchdog".to_owned())
         .spawn(move || {
-            let decision = watch_owner_anchor(&anchor, observe_owner_link, || {
+            // A panic inside a single observation must not kill the watchdog
+            // thread: a dead watchdog is a silently unanchored tree, which is
+            // the defect this mechanism exists to prevent. Treat it as what it
+            // is -- an unusable observation -- and hold, consistent with the
+            // fail-open rule applied to every other kind of uncertainty.
+            let observe = |link: OwnerLink| {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    observe_owner_link(link)
+                }))
+                .unwrap_or_else(|_| {
+                    tracing::warn!(
+                        role = %link.role,
+                        "owner observation panicked; holding the tree"
+                    );
+                    OwnerStatus::Unverified
+                })
+            };
+            let decision = watch_owner_anchor(&anchor, observe, || {
                 std::thread::sleep(OWNER_WATCH_INTERVAL);
                 true
             });

--- a/src/runtime/owner_anchor.rs
+++ b/src/runtime/owner_anchor.rs
@@ -344,16 +344,14 @@ pub fn spawn_owner_watchdog(anchor: OwnerAnchor) {
             // is -- an unusable observation -- and hold, consistent with the
             // fail-open rule applied to every other kind of uncertainty.
             let observe = |link: OwnerLink| {
-                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    observe_owner_link(link)
-                }))
-                .unwrap_or_else(|_| {
-                    tracing::warn!(
-                        role = %link.role,
-                        "owner observation panicked; holding the tree"
-                    );
-                    OwnerStatus::Unverified
-                })
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| observe_owner_link(link)))
+                    .unwrap_or_else(|_| {
+                        tracing::warn!(
+                            role = %link.role,
+                            "owner observation panicked; holding the tree"
+                        );
+                        OwnerStatus::Unverified
+                    })
             };
             let decision = watch_owner_anchor(&anchor, observe, || {
                 std::thread::sleep(OWNER_WATCH_INTERVAL);

--- a/src/runtime/owner_anchor.rs
+++ b/src/runtime/owner_anchor.rs
@@ -1,0 +1,353 @@
+//! Owner-lifetime anchor for the Windows session process tree (issue #542).
+//!
+//! Specification: `dev-docs/standards/windows-session-ownership.md`.
+//!
+//! The session host is the anchor holder: it owns the `KILL_ON_JOB_CLOSE` Job
+//! that contains the worker, so closing that handle reaps the tree. Nothing,
+//! however, contained the *host* — which is why `pwsh -> jefe-session-host.exe
+//! -> bun.exe` trees survived their owning psmux process (#515).
+//!
+//! This module supplies the missing link. Before the worker is spawned, the
+//! host captures the `ProcessIdentity` of its owner chain (pane process, then
+//! psmux server), and a watchdog releases the tree the moment any captured link
+//! is *confirmed* dead or replaced. Capture is capped at two levels so the Jefe
+//! dashboard is never an anchor; that cap is what preserves #467's guarantee
+//! that a dashboard quit or a mid-run rebuild leaves live agents alone.
+//!
+//! Every decision here is pure and platform-independent so it is exercised on
+//! all targets. Only [`capture_owner_anchor`] touches the operating system.
+
+use std::time::Duration;
+
+use crate::domain::ProcessIdentity;
+
+use super::process::ProcessLiveness;
+
+/// Exit status used when the host releases its tree because ownership was lost.
+///
+/// Distinct from success and from a generic failure so a native test or a CI
+/// log can tell "reaped by ownership loss" apart from "the agent exited" and
+/// "the host crashed".
+pub const OWNER_LOST_EXIT_CODE: i32 = 75;
+
+/// Interval between owner-chain observations.
+///
+/// Bounds how long a tree can outlive its owner. Each pass is at most two
+/// `OpenProcess`/`GetProcessTimes` probes, so a one-second period is
+/// negligible against the lifetime of an agent session.
+pub const OWNER_WATCH_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Levels of ancestry captured above the session host: the pane process and
+/// the psmux server. Deliberately not three — see the specification, §4.
+const OWNER_CHAIN_DEPTH: usize = 2;
+
+/// A process in the session host's owner chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OwnerRole {
+    /// L1: the session host's direct parent, the psmux pane process.
+    PaneProcess,
+    /// L2: the session host's grandparent, the psmux server that owns the pane.
+    SessionServer,
+}
+
+impl OwnerRole {
+    /// Human-readable role name for diagnostics.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::PaneProcess => "pane process",
+            Self::SessionServer => "psmux server",
+        }
+    }
+
+    const fn at_depth(depth: usize) -> Self {
+        if depth == 0 {
+            Self::PaneProcess
+        } else {
+            Self::SessionServer
+        }
+    }
+}
+
+impl std::fmt::Display for OwnerRole {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// One captured link of the owner chain: a role plus the exact process
+/// identity that held it at capture time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OwnerLink {
+    /// Which level of the chain this link occupies.
+    pub role: OwnerRole,
+    /// PID plus creation time. A PID alone is spoofable by reuse.
+    pub identity: ProcessIdentity,
+}
+
+/// The session host's complete owner chain, captured before the worker spawn.
+///
+/// Non-empty by construction: an empty chain is the absence of ownership, not a
+/// degraded form of it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnerAnchor {
+    links: Vec<OwnerLink>,
+}
+
+impl OwnerAnchor {
+    /// Build an anchor from a captured chain, rejecting an empty one.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OwnerAnchorError::NoAncestor`] when `links` is empty.
+    pub fn from_links(links: Vec<OwnerLink>) -> Result<Self, OwnerAnchorError> {
+        if links.is_empty() {
+            return Err(OwnerAnchorError::NoAncestor);
+        }
+        Ok(Self { links })
+    }
+
+    /// The captured chain, nearest ancestor first.
+    #[must_use]
+    pub fn links(&self) -> &[OwnerLink] {
+        &self.links
+    }
+}
+
+impl std::fmt::Display for OwnerAnchor {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (index, link) in self.links.iter().enumerate() {
+            if index > 0 {
+                formatter.write_str(", ")?;
+            }
+            write!(formatter, "{} pid {}", link.role, link.identity.pid)?;
+        }
+        Ok(())
+    }
+}
+
+/// Why an owner chain could not be established.
+///
+/// Every variant is fatal to the launch: rule 6 of the specification forbids
+/// spawning a worker that nothing owns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OwnerAnchorError {
+    /// No parent process could be resolved for the session host.
+    NoAncestor,
+    /// A parent PID was resolved, but its identity could not be captured or
+    /// could not be distinguished from a recycled PID.
+    AncestorUnobservable,
+    /// The session host could not observe its own identity, so the
+    /// ancestor-ordering guard cannot be applied.
+    SelfIdentityUnavailable,
+}
+
+impl std::fmt::Display for OwnerAnchorError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoAncestor => formatter.write_str(
+                "session host has no resolvable owning process; refusing to spawn an unowned worker",
+            ),
+            Self::AncestorUnobservable => formatter.write_str(
+                "session host owner identity could not be captured; refusing to spawn an unowned worker",
+            ),
+            Self::SelfIdentityUnavailable => formatter
+                .write_str("session host could not observe its own process identity"),
+        }
+    }
+}
+
+impl std::error::Error for OwnerAnchorError {}
+
+/// What one observation of one link says about ownership.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OwnerStatus {
+    /// The exact captured process is still running: ownership holds.
+    Held,
+    /// The captured process is confirmed gone or replaced: ownership is broken.
+    Lost,
+    /// The probe produced no usable evidence either way.
+    Unverified,
+}
+
+/// The action the session host must take after observing its whole chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OwnerWatchDecision {
+    /// Ownership still holds; change nothing.
+    Hold,
+    /// Ownership is broken at the named link; the host must exit so its Job
+    /// handle closes and the kernel reaps the contained worker tree.
+    ReleaseTree(OwnerRole),
+}
+
+/// Map a process-liveness observation onto ownership.
+///
+/// `Dead` and `ReusedPid` are the two ways a captured owner stops being the
+/// owner — a recycled PID resolves to a live process, so PID-only checks report
+/// "alive" forever. Everything else is an absence of evidence and must fail
+/// open: termination is irreversible, a failed probe is not.
+#[must_use]
+pub const fn classify_owner_link(liveness: ProcessLiveness) -> OwnerStatus {
+    match liveness {
+        ProcessLiveness::Alive => OwnerStatus::Held,
+        ProcessLiveness::Dead | ProcessLiveness::ReusedPid => OwnerStatus::Lost,
+        ProcessLiveness::Inaccessible
+        | ProcessLiveness::MalformedIdentity
+        | ProcessLiveness::ProbeFailure => OwnerStatus::Unverified,
+    }
+}
+
+/// Fold one pass over the owner chain into a decision.
+///
+/// A confirmed loss at *any* link releases the tree: every process above the
+/// session host must outlive it, so a break anywhere is an ownership violation
+/// whatever the termination order.
+#[must_use]
+pub fn decide_owner_watch(
+    statuses: impl IntoIterator<Item = (OwnerRole, OwnerStatus)>,
+) -> OwnerWatchDecision {
+    for (role, status) in statuses {
+        if status == OwnerStatus::Lost {
+            return OwnerWatchDecision::ReleaseTree(role);
+        }
+    }
+    OwnerWatchDecision::Hold
+}
+
+/// Reject a candidate ancestor that cannot have preceded its descendant.
+///
+/// A recycled PID sitting in the parent slot is the one case a snapshot cannot
+/// detect structurally, and creation-time ordering rules it out for free. An
+/// identity without a creation time can never be compared, so it can never be
+/// distinguished from an impostor and is not usable as an anchor.
+#[must_use]
+pub const fn is_plausible_ancestor(
+    descendant: ProcessIdentity,
+    candidate: ProcessIdentity,
+) -> bool {
+    match (descendant.started_at, candidate.started_at) {
+        (Some(descendant), Some(candidate)) => candidate <= descendant,
+        _ => false,
+    }
+}
+
+/// Observe the owner chain until ownership breaks or the caller stops ticking.
+///
+/// `observe` reports one link; `tick` waits for the next pass and returns
+/// `false` to end the watch. In production `tick` sleeps and always returns
+/// `true`, so the loop ends only by releasing the tree; the injection seam
+/// exists so the policy is testable without real processes or real time.
+pub fn watch_owner_anchor<Observe, Tick>(
+    anchor: &OwnerAnchor,
+    mut observe: Observe,
+    mut tick: Tick,
+) -> OwnerWatchDecision
+where
+    Observe: FnMut(OwnerLink) -> OwnerStatus,
+    Tick: FnMut() -> bool,
+{
+    loop {
+        let statuses: Vec<(OwnerRole, OwnerStatus)> = anchor
+            .links()
+            .iter()
+            .map(|link| (link.role, observe(*link)))
+            .collect();
+        if let OwnerWatchDecision::ReleaseTree(role) = decide_owner_watch(statuses) {
+            return OwnerWatchDecision::ReleaseTree(role);
+        }
+        if !tick() {
+            return OwnerWatchDecision::Hold;
+        }
+    }
+}
+
+/// Observe one captured link against the live operating system.
+#[must_use]
+pub fn observe_owner_link(link: OwnerLink) -> OwnerStatus {
+    classify_owner_link(super::process::process_liveness(Some(link.identity)))
+}
+
+/// Capture the session host's owner chain (Windows only).
+///
+/// Walks up to [`OWNER_CHAIN_DEPTH`] ancestors, capturing each as a full
+/// `ProcessIdentity` and rejecting any candidate that cannot have preceded this
+/// process. The nearest ancestor is mandatory — without it there is no owner
+/// and the caller must refuse to spawn. A missing second level degrades to a
+/// single-link anchor rather than failing the launch: the pane process is
+/// still a true owner, and killing psmux kills the pane.
+///
+/// # Errors
+///
+/// Returns [`OwnerAnchorError`] when this process's own identity is
+/// unobservable, when no parent can be resolved, or when the parent's identity
+/// cannot be trusted.
+#[cfg(windows)]
+pub fn capture_owner_anchor() -> Result<OwnerAnchor, OwnerAnchorError> {
+    capture_owner_anchor_from(std::process::id())
+}
+
+#[cfg(windows)]
+fn capture_owner_anchor_from(start_pid: u32) -> Result<OwnerAnchor, OwnerAnchorError> {
+    use super::process::{capture_process_identity, parent_process_id};
+
+    let start = capture_process_identity(start_pid)
+        .map_err(|_| OwnerAnchorError::SelfIdentityUnavailable)?;
+    let mut links = Vec::with_capacity(OWNER_CHAIN_DEPTH);
+    let mut current = start;
+    for depth in 0..OWNER_CHAIN_DEPTH {
+        let Some(parent_pid) = parent_process_id(current.pid).filter(|pid| *pid != 0) else {
+            break;
+        };
+        if parent_pid == current.pid {
+            break;
+        }
+        // A parent that exists but cannot be identified is not a usable anchor:
+        // without a creation time it is indistinguishable from a recycled PID,
+        // and an ordering violation means the real parent has already exited
+        // and something else now occupies its PID. For the mandatory nearest
+        // link that is a hard failure; beyond it the chain simply stops, which
+        // still leaves a true owner in hand.
+        let usable = capture_process_identity(parent_pid)
+            .ok()
+            .filter(|identity| is_plausible_ancestor(current, *identity));
+        let Some(identity) = usable else {
+            if depth == 0 {
+                return Err(OwnerAnchorError::AncestorUnobservable);
+            }
+            break;
+        };
+        links.push(OwnerLink {
+            role: OwnerRole::at_depth(depth),
+            identity,
+        });
+        current = identity;
+    }
+    OwnerAnchor::from_links(links)
+}
+
+/// Start the owner watchdog on a background thread (Windows only).
+///
+/// The returned handle is intentionally dropped by the caller: the watchdog
+/// must outlive every caller frame and is terminated only by process exit. On a
+/// confirmed ownership loss it exits the process, which closes the host's Job
+/// handle so the kernel terminates the contained worker tree.
+#[cfg(windows)]
+pub fn spawn_owner_watchdog(anchor: OwnerAnchor) {
+    // A watchdog that cannot start is not a reason to kill a healthy tree; the
+    // launch proceeds with startup reconciliation as the fallback.
+    let _ = std::thread::Builder::new()
+        .name("jefe-owner-watchdog".to_owned())
+        .spawn(move || {
+            let decision = watch_owner_anchor(&anchor, observe_owner_link, || {
+                std::thread::sleep(OWNER_WATCH_INTERVAL);
+                true
+            });
+            if let OwnerWatchDecision::ReleaseTree(role) = decision {
+                tracing::warn!(
+                    %role,
+                    "owning process exited; releasing the contained worker tree"
+                );
+                std::process::exit(OWNER_LOST_EXIT_CODE);
+            }
+        });
+}

--- a/src/runtime/owner_anchor.rs
+++ b/src/runtime/owner_anchor.rs
@@ -60,11 +60,18 @@ impl OwnerRole {
         }
     }
 
-    const fn at_depth(depth: usize) -> Self {
-        if depth == 0 {
-            Self::PaneProcess
-        } else {
-            Self::SessionServer
+    /// The role held at `depth` steps above the session host, if the model
+    /// names one.
+    ///
+    /// This returns `None` rather than a default beyond the deepest named role
+    /// so that raising [`OWNER_CHAIN_DEPTH`] cannot silently attribute a
+    /// great-grandparent to the psmux server. A new level requires naming the
+    /// role that occupies it.
+    const fn at_depth(depth: usize) -> Option<Self> {
+        match depth {
+            0 => Some(Self::PaneProcess),
+            1 => Some(Self::SessionServer),
+            _ => None,
         }
     }
 }
@@ -247,11 +254,10 @@ where
     Tick: FnMut() -> bool,
 {
     loop {
-        let statuses: Vec<(OwnerRole, OwnerStatus)> = anchor
+        let statuses = anchor
             .links()
             .iter()
-            .map(|link| (link.role, observe(*link)))
-            .collect();
+            .map(|link| (link.role, observe(*link)));
         if let OwnerWatchDecision::ReleaseTree(role) = decide_owner_watch(statuses) {
             return OwnerWatchDecision::ReleaseTree(role);
         }
@@ -316,10 +322,10 @@ fn capture_owner_anchor_from(start_pid: u32) -> Result<OwnerAnchor, OwnerAnchorE
             }
             break;
         };
-        links.push(OwnerLink {
-            role: OwnerRole::at_depth(depth),
-            identity,
-        });
+        let Some(role) = OwnerRole::at_depth(depth) else {
+            break;
+        };
+        links.push(OwnerLink { role, identity });
         current = identity;
     }
     OwnerAnchor::from_links(links)

--- a/src/runtime/owner_anchor_tests.rs
+++ b/src/runtime/owner_anchor_tests.rs
@@ -1,0 +1,386 @@
+//! Behavioral tests for the owner-lifetime anchor (issue #542).
+//!
+//! See `dev-docs/standards/windows-session-ownership.md`. Every test here maps
+//! to a rule in §4 of that document; the decision logic is pure so it is
+//! exercised on every platform, not only the one where the bug reproduces.
+
+use std::cell::RefCell;
+
+use super::owner_anchor::{
+    OWNER_LOST_EXIT_CODE, OwnerAnchor, OwnerAnchorError, OwnerLink, OwnerRole, OwnerStatus,
+    OwnerWatchDecision, classify_owner_link, decide_owner_watch, is_plausible_ancestor,
+    watch_owner_anchor,
+};
+use super::process::ProcessLiveness;
+use crate::domain::ProcessIdentity;
+
+fn identity(pid: u32, started_at: u64) -> ProcessIdentity {
+    ProcessIdentity {
+        pid,
+        started_at: Some(started_at),
+    }
+}
+
+fn pane(pid: u32, started_at: u64) -> OwnerLink {
+    OwnerLink {
+        role: OwnerRole::PaneProcess,
+        identity: identity(pid, started_at),
+    }
+}
+
+fn server(pid: u32, started_at: u64) -> OwnerLink {
+    OwnerLink {
+        role: OwnerRole::SessionServer,
+        identity: identity(pid, started_at),
+    }
+}
+
+fn anchor(links: Vec<OwnerLink>) -> OwnerAnchor {
+    OwnerAnchor::from_links(links)
+        .unwrap_or_else(|error| panic!("test anchor must have at least one link: {error:?}"))
+}
+
+// ── §4 rule 4: owner death releases the tree ────────────────────────────────
+
+/// A living owner chain is not an event. The host must not touch the worker,
+/// the Job, or any status while every captured link is alive.
+#[test]
+fn a_living_owner_chain_holds_the_tree() {
+    let decision = decide_owner_watch([
+        (OwnerRole::PaneProcess, OwnerStatus::Held),
+        (OwnerRole::SessionServer, OwnerStatus::Held),
+    ]);
+    assert_eq!(decision, OwnerWatchDecision::Hold);
+}
+
+/// #515's exact reproduction, as a decision: the psmux grandparent dies while
+/// the pane process is still alive. The old model saw a live parent and did
+/// nothing, which is how `pwsh -> jefe-session-host.exe -> bun.exe` survived.
+#[test]
+fn a_dead_session_server_releases_the_tree_even_while_the_pane_lives() {
+    let decision = decide_owner_watch([
+        (OwnerRole::PaneProcess, OwnerStatus::Held),
+        (OwnerRole::SessionServer, OwnerStatus::Lost),
+    ]);
+    assert_eq!(
+        decision,
+        OwnerWatchDecision::ReleaseTree(OwnerRole::SessionServer),
+        "a confirmed psmux server death is an ownership violation regardless \
+         of the pane process's state; this is issue #515"
+    );
+}
+
+/// The mirror case: the pane dies but the server survives. Ownership is a
+/// chain, so a break at any link releases the tree.
+#[test]
+fn a_dead_pane_process_releases_the_tree_even_while_the_server_lives() {
+    let decision = decide_owner_watch([
+        (OwnerRole::PaneProcess, OwnerStatus::Lost),
+        (OwnerRole::SessionServer, OwnerStatus::Held),
+    ]);
+    assert_eq!(
+        decision,
+        OwnerWatchDecision::ReleaseTree(OwnerRole::PaneProcess)
+    );
+}
+
+// ── §4 rule 2: PID reuse cannot spoof ownership (V5) ────────────────────────
+
+/// V5. A recycled PID resolves to a live process, so any PID-only check reports
+/// "owner alive" forever and the tree is never reaped. Identity comparison must
+/// classify it as owner death.
+#[test]
+fn a_reused_pid_is_owner_death_not_a_live_owner() {
+    assert_eq!(
+        classify_owner_link(ProcessLiveness::ReusedPid),
+        OwnerStatus::Lost,
+        "a PID that now belongs to a different process is not the owner; \
+         treating it as alive is how ownership gets silently transferred to an \
+         impostor"
+    );
+    assert_eq!(
+        decide_owner_watch([(OwnerRole::SessionServer, OwnerStatus::Lost)]),
+        OwnerWatchDecision::ReleaseTree(OwnerRole::SessionServer)
+    );
+}
+
+#[test]
+fn a_confirmed_exit_is_owner_death() {
+    assert_eq!(
+        classify_owner_link(ProcessLiveness::Dead),
+        OwnerStatus::Lost
+    );
+}
+
+#[test]
+fn a_live_matching_identity_holds_ownership() {
+    assert_eq!(
+        classify_owner_link(ProcessLiveness::Alive),
+        OwnerStatus::Held
+    );
+}
+
+// ── §4 rule 5: uncertainty must never terminate ─────────────────────────────
+
+/// Termination is irreversible and a probe failure is not. Every non-positive
+/// observation must fail open, or a transient `ACCESS_DENIED` under load
+/// becomes a killed agent with unsaved work.
+#[test]
+fn an_unverifiable_owner_never_terminates_the_tree() {
+    for liveness in [
+        ProcessLiveness::Inaccessible,
+        ProcessLiveness::ProbeFailure,
+        ProcessLiveness::MalformedIdentity,
+    ] {
+        assert_eq!(
+            classify_owner_link(liveness),
+            OwnerStatus::Unverified,
+            "{liveness:?} is an absence of evidence, not evidence of death"
+        );
+    }
+    assert_eq!(
+        decide_owner_watch([
+            (OwnerRole::PaneProcess, OwnerStatus::Unverified),
+            (OwnerRole::SessionServer, OwnerStatus::Unverified),
+        ]),
+        OwnerWatchDecision::Hold,
+        "a completely unverifiable chain must hold the tree, not reap it"
+    );
+}
+
+/// Evidence of death at one link is decisive even when the other link is
+/// merely unverifiable: one positive observation is enough.
+#[test]
+fn one_confirmed_loss_outweighs_an_unverifiable_link() {
+    assert_eq!(
+        decide_owner_watch([
+            (OwnerRole::PaneProcess, OwnerStatus::Unverified),
+            (OwnerRole::SessionServer, OwnerStatus::Lost),
+        ]),
+        OwnerWatchDecision::ReleaseTree(OwnerRole::SessionServer)
+    );
+}
+
+// ── The watch loop ──────────────────────────────────────────────────────────
+
+/// The watchdog must keep holding across an arbitrary number of live ticks and
+/// release on the first confirmed loss — not on the first tick, and not only
+/// after some bounded number of retries.
+#[test]
+fn the_watchdog_holds_until_a_link_is_confirmed_lost() {
+    let script = RefCell::new(vec![
+        OwnerStatus::Held,
+        OwnerStatus::Held,
+        OwnerStatus::Unverified,
+        OwnerStatus::Held,
+        OwnerStatus::Lost,
+    ]);
+    let ticks = RefCell::new(0usize);
+    let decision = watch_owner_anchor(
+        &anchor(vec![server(4242, 900)]),
+        |_| script.borrow_mut().remove(0),
+        || {
+            *ticks.borrow_mut() += 1;
+            true
+        },
+    );
+    assert_eq!(
+        decision,
+        OwnerWatchDecision::ReleaseTree(OwnerRole::SessionServer)
+    );
+    assert_eq!(
+        *ticks.borrow(),
+        4,
+        "the watchdog must survive live and unverifiable observations and act \
+         only on the confirmed loss"
+    );
+}
+
+/// Sustained uncertainty must never accumulate into a kill. A host whose owner
+/// is permanently unprobeable keeps its agent alive forever.
+#[test]
+fn sustained_uncertainty_never_accumulates_into_a_kill() {
+    let remaining = RefCell::new(500usize);
+    let decision = watch_owner_anchor(
+        &anchor(vec![pane(11, 100), server(7, 50)]),
+        |_| OwnerStatus::Unverified,
+        || {
+            let mut remaining = remaining.borrow_mut();
+            *remaining -= 1;
+            *remaining > 0
+        },
+    );
+    assert_eq!(
+        decision,
+        OwnerWatchDecision::Hold,
+        "500 consecutive failed probes is still not evidence of death"
+    );
+}
+
+/// The watchdog observes every link on each pass, so a loss at the second link
+/// is found in the same pass rather than one interval later.
+#[test]
+fn the_watchdog_observes_every_link_in_the_chain() {
+    let observed = RefCell::new(Vec::new());
+    let decision = watch_owner_anchor(
+        &anchor(vec![pane(11, 100), server(7, 50)]),
+        |link| {
+            observed.borrow_mut().push(link.role);
+            match link.role {
+                OwnerRole::PaneProcess => OwnerStatus::Held,
+                OwnerRole::SessionServer => OwnerStatus::Lost,
+            }
+        },
+        || true,
+    );
+    assert_eq!(
+        decision,
+        OwnerWatchDecision::ReleaseTree(OwnerRole::SessionServer)
+    );
+    assert_eq!(
+        *observed.borrow(),
+        vec![OwnerRole::PaneProcess, OwnerRole::SessionServer]
+    );
+}
+
+// ── §4 rule 3: an ancestor cannot be younger than its descendant ────────────
+
+/// A recycled PID that happens to sit in our parent slot is not an ancestor.
+/// Creation-time ordering is the cheap structural check that rejects it at
+/// capture time, before it can ever be trusted as an anchor.
+#[test]
+fn an_ancestor_younger_than_its_descendant_is_rejected() {
+    let host = identity(1000, 5_000);
+    assert!(
+        !is_plausible_ancestor(host, identity(900, 6_000)),
+        "a process created after the session host cannot have spawned its \
+         parent chain; this is a recycled PID"
+    );
+    assert!(is_plausible_ancestor(host, identity(900, 4_000)));
+    assert!(
+        is_plausible_ancestor(host, identity(900, 5_000)),
+        "clock granularity can make a real ancestor look simultaneous; only \
+         strictly-younger candidates are impostors"
+    );
+}
+
+/// An identity with no creation time can never be compared, so it can never be
+/// distinguished from a recycled PID. It is not usable as an anchor.
+#[test]
+fn an_ancestor_without_a_creation_time_is_not_an_anchor() {
+    let host = identity(1000, 5_000);
+    let timeless = ProcessIdentity {
+        pid: 900,
+        started_at: None,
+    };
+    assert!(!is_plausible_ancestor(host, timeless));
+    assert!(!is_plausible_ancestor(
+        ProcessIdentity {
+            pid: 1000,
+            started_at: None
+        },
+        identity(900, 4_000)
+    ));
+}
+
+// ── §4 rule 6: no anchor, no worker ─────────────────────────────────────────
+
+/// An empty chain is not a degraded anchor, it is the absence of one. The
+/// constructor must refuse it so no caller can spawn an unowned worker.
+#[test]
+fn an_anchor_cannot_be_constructed_without_a_link() {
+    assert_eq!(
+        OwnerAnchor::from_links(Vec::new()),
+        Err(OwnerAnchorError::NoAncestor)
+    );
+}
+
+#[test]
+fn an_anchor_preserves_its_chain_in_order() {
+    let anchor = anchor(vec![pane(11, 100), server(7, 50)]);
+    assert_eq!(anchor.links(), &[pane(11, 100), server(7, 50)]);
+}
+
+/// The exit code is the observable evidence in a native test and in CI logs
+/// that the tree was released by ownership loss rather than by the agent
+/// finishing or by an unrelated crash.
+#[test]
+fn owner_loss_has_a_distinguishable_exit_code() {
+    assert_ne!(OWNER_LOST_EXIT_CODE, 0);
+    assert_ne!(OWNER_LOST_EXIT_CODE, 1);
+}
+
+#[test]
+fn owner_roles_are_named_for_diagnostics() {
+    assert_eq!(OwnerRole::PaneProcess.as_str(), "pane process");
+    assert_eq!(OwnerRole::SessionServer.as_str(), "psmux server");
+}
+
+/// Rule 1 and rule 6 of the ownership model: the session host must be able to
+/// name a real owner from the live operating system, not merely accept one a
+/// test handed it. Walking up from this process must produce a chain that is
+/// non-empty, capped at the pane/server depth, ordered nearest-first, and made
+/// of identities that could actually have preceded their descendants.
+#[cfg(windows)]
+#[test]
+fn the_owner_chain_is_captured_from_the_live_process_tree() {
+    let anchor = super::owner_anchor::capture_owner_anchor()
+        .unwrap_or_else(|error| panic!("a test process always has a resolvable parent: {error:?}"));
+    let links = anchor.links();
+    assert!(
+        (1..=2).contains(&links.len()),
+        "the chain is capped at the pane process and the psmux server so the \
+         dashboard can never become an anchor, got {} links",
+        links.len()
+    );
+    assert_eq!(
+        links[0].role,
+        OwnerRole::PaneProcess,
+        "the nearest ancestor is the pane process"
+    );
+    if let Some(second) = links.get(1) {
+        assert_eq!(
+            second.role,
+            OwnerRole::SessionServer,
+            "the second ancestor is the session server"
+        );
+    }
+    let self_identity = super::process::capture_process_identity(std::process::id())
+        .unwrap_or_else(|error| panic!("this process can observe itself: {error:?}"));
+    let mut descendant = self_identity;
+    for link in links {
+        assert!(
+            is_plausible_ancestor(descendant, link.identity),
+            "captured {} pid {} cannot have preceded pid {}; a recycled PID \
+             must never be accepted as an owner",
+            link.role,
+            link.identity.pid,
+            descendant.pid
+        );
+        assert!(
+            link.identity.started_at.is_some(),
+            "an anchor identity without a creation time cannot be \
+             distinguished from a recycled PID"
+        );
+        descendant = link.identity;
+    }
+}
+
+/// A captured chain must report ownership as held while every member is
+/// genuinely running. This is the guard against a watchdog that reaps healthy
+/// trees: the ancestors of a live test process are, by construction, alive.
+#[cfg(windows)]
+#[test]
+fn a_freshly_captured_chain_reports_its_own_ancestors_as_alive() {
+    let anchor = super::owner_anchor::capture_owner_anchor()
+        .unwrap_or_else(|error| panic!("a test process always has a resolvable parent: {error:?}"));
+    for link in anchor.links() {
+        assert_eq!(
+            super::owner_anchor::observe_owner_link(*link),
+            OwnerStatus::Held,
+            "the live {} pid {} must not be read as lost",
+            link.role,
+            link.identity.pid
+        );
+    }
+}

--- a/src/runtime/owner_anchor_tests.rs
+++ b/src/runtime/owner_anchor_tests.rs
@@ -306,8 +306,7 @@ fn an_anchor_preserves_its_chain_in_order() {
 /// finishing or by an unrelated crash.
 #[test]
 fn owner_loss_has_a_distinguishable_exit_code() {
-    assert_ne!(OWNER_LOST_EXIT_CODE, 0);
-    assert_ne!(OWNER_LOST_EXIT_CODE, 1);
+    assert_eq!(OWNER_LOST_EXIT_CODE, 75);
 }
 
 #[test]

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -203,6 +203,35 @@ fn probe_process(pid: u32) -> ProcessObservation {
     }
 }
 
+/// Resolve the parent PID of `pid`, or `None` when it cannot be determined.
+///
+/// Used to walk the session host's owner chain before spawning a worker; see
+/// `dev-docs/standards/windows-session-ownership.md`. The returned PID is only
+/// a lookup key: the caller must capture a full `ProcessIdentity` and apply the
+/// ancestor-ordering guard before trusting it, because a parent slot can hold a
+/// recycled PID once the real parent has exited.
+#[cfg(windows)]
+#[must_use]
+pub(super) fn parent_process_id(pid: u32) -> Option<u32> {
+    use winsafe::co::TH32CS;
+    use winsafe::{HPROCESSLIST, PROCESSENTRY32};
+
+    if pid == 0 {
+        return None;
+    }
+    let mut snapshot = HPROCESSLIST::CreateToolhelp32Snapshot(TH32CS::SNAPPROCESS, None).ok()?;
+    for entry in snapshot.iter_processes() {
+        let entry: &PROCESSENTRY32 = match entry {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        if entry.th32ProcessID == pid {
+            return Some(entry.th32ParentProcessID);
+        }
+    }
+    None
+}
+
 #[cfg(unix)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum UnixProbeOutcome {

--- a/src/runtime/session_host.rs
+++ b/src/runtime/session_host.rs
@@ -9,6 +9,13 @@
 //! <root>/<sanitized-session>/<sha256>/jefe-session-host.exe
 //! ```
 //!
+//! Each digest directory is one *host generation*. A rebuild changes the hash
+//! and stages a new generation beside the running one, so
+//! `dev-docs/standards/windows-session-ownership.md` §6 defines when a
+//! superseded generation may be collected: exactly when no process holds its
+//! image. Staging prunes on that rule (issue #542, deliverable 6) and the
+//! startup sweep remains the backstop.
+//!
 //! Path planning is pure and deterministic; staging copies (never hardlinks)
 //! the source through a same-directory unique temp file and atomically renames
 //! it into place, reuses an existing digest artifact idempotently, and removes
@@ -203,6 +210,7 @@ fn stage_with_plan(
     reclaim_owned_temps(digest_directory, attempt_tag);
 
     if plan.staged_path().is_file() {
+        prune_superseded_generations(plan);
         return Ok(plan.staged_path().to_path_buf());
     }
 
@@ -217,6 +225,7 @@ fn stage_with_plan(
         // Treat that as success; all contenders wrote identical digest bytes.
         if plan.staged_path().is_file() {
             let _ = fs::remove_file(&temp_path);
+            prune_superseded_generations(plan);
             return Ok(plan.staged_path().to_path_buf());
         }
         // Best-effort cleanup of our temp file before surfacing the failure;
@@ -226,7 +235,47 @@ fn stage_with_plan(
             path: plan.staged_path().to_path_buf(),
         });
     }
+    prune_superseded_generations(plan);
     Ok(plan.staged_path().to_path_buf())
+}
+
+/// Collect host generations for this session that no process still holds.
+///
+/// Issue #542, deliverable 6. A rebuild changes the digest, so every rebuild
+/// during a long-lived session stages another host image, and nothing swept
+/// them until the next startup. Ownership answers what to do:
+/// `dev-docs/standards/windows-session-ownership.md` defines a superseded
+/// digest directory as belonging to a previous host generation, removable
+/// exactly when no process holds its image.
+///
+/// The operating system arbitrates that directly — Windows refuses to unlink a
+/// running image — so retention needs no liveness bookkeeping and cannot race
+/// against a host that is still using its binary. Every step is best effort: a
+/// generation that cannot be collected is simply left for the startup sweep,
+/// and pruning never fails a launch.
+fn prune_superseded_generations(plan: &SessionHostPlan) {
+    let current = plan.digest_directory();
+    let Some(session_directory) = current.parent() else {
+        return;
+    };
+    let Ok(entries) = fs::read_dir(session_directory) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let candidate = entry.path();
+        if candidate == current || !candidate.is_dir() {
+            continue;
+        }
+        // Unlink the image first and abandon the whole generation if that
+        // fails. `remove_dir_all` would delete the directory's other contents
+        // before discovering the lock, damaging a generation that is still in
+        // use; the image is the thing whose ownership is in question.
+        let image = candidate.join(SESSION_HOST_BINARY);
+        if image.exists() && fs::remove_file(&image).is_err() {
+            continue;
+        }
+        let _ = fs::remove_dir_all(&candidate);
+    }
 }
 
 fn reclaim_owned_temps(digest_directory: &Path, attempt_tag: &str) {

--- a/src/runtime/session_host_tests.rs
+++ b/src/runtime/session_host_tests.rs
@@ -178,7 +178,7 @@ fn staging_is_idempotent_and_reuses_existing_digest_artifact() {
 }
 
 #[test]
-fn staging_different_content_produces_distinct_artifacts_side_by_side() {
+fn staging_different_content_produces_distinct_artifacts() {
     let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
     let first_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src 1: {error}"));
     let second_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src 2: {error}"));
@@ -192,8 +192,96 @@ fn staging_different_content_produces_distinct_artifacts_side_by_side() {
         .unwrap_or_else(|error| panic!("second staging: {error}"));
 
     assert_ne!(first, second, "distinct digests stage separately");
-    assert!(first.exists(), "first artifact retained");
-    assert!(second.exists(), "second artifact retained");
+    assert!(
+        second.exists(),
+        "the current artifact is staged and retained"
+    );
+}
+
+/// Issue #542, deliverable 6: a rebuild changes the digest and stages a new
+/// directory. Nothing swept those between startups, so every rebuild during a
+/// long-lived session left another host image behind. A superseded generation
+/// that no process holds is unowned, and unowned artifacts are collected.
+#[test]
+fn staging_prunes_superseded_generations_that_no_process_holds() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+
+    let mut superseded = Vec::new();
+    for build in 1..=3_u8 {
+        let source = write_source(&source_dir, &[b'j', b'e', b'f', b'e', build]);
+        let staged = stage_session_host(root.path(), "jefe-agent-1", &source)
+            .unwrap_or_else(|error| panic!("staging build {build}: {error}"));
+        superseded.push(staged);
+    }
+    let current = superseded.pop().unwrap_or_else(|| panic!("staged nothing"));
+
+    assert!(current.exists(), "the current generation is retained");
+    for stale in &superseded {
+        assert!(
+            !stale.exists(),
+            "a superseded host generation that nothing holds must not \
+             accumulate across rebuilds: {} survived",
+            stale.display()
+        );
+    }
+    let session_directory = current
+        .parent()
+        .and_then(Path::parent)
+        .unwrap_or_else(|| panic!("staged path has a session directory"));
+    let generations = fs::read_dir(session_directory)
+        .unwrap_or_else(|error| panic!("read session dir: {error}"))
+        .count();
+    assert_eq!(
+        generations, 1,
+        "three rebuilds must leave exactly one live generation"
+    );
+}
+
+/// The counterpart guarantee, and the one #467 exists to protect: a rebuild may
+/// never orphan or disarm a live tree.
+///
+/// On Windows a running host's image is mapped as an image section and cannot
+/// be unlinked, which is what makes "no process holds it" decidable without
+/// liveness bookkeeping. Here that unlinkable image is modelled by a path
+/// `remove_file` must refuse, the same substitution
+/// `cleanup_session_directory_reports_retained_when_artifact_cannot_be_removed_as_directory`
+/// uses, so the retention rule is proven on every platform rather than only
+/// where a real image lock is reproducible.
+#[test]
+fn staging_retains_a_superseded_generation_whose_image_cannot_be_unlinked() {
+    let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+
+    let held_source = write_source(&source_dir, b"jefe-image-held");
+    let held = stage_session_host(root.path(), "jefe-agent-1", &held_source)
+        .unwrap_or_else(|error| panic!("staging held host: {error}"));
+    let held_generation = held
+        .parent()
+        .unwrap_or_else(|| panic!("staged path has a generation directory"))
+        .to_path_buf();
+    fs::remove_file(&held).unwrap_or_else(|error| panic!("replace image: {error}"));
+    fs::create_dir(&held).unwrap_or_else(|error| panic!("unlinkable image: {error}"));
+    fs::write(held.join("mapped"), b"in use")
+        .unwrap_or_else(|error| panic!("image contents: {error}"));
+    let companion = held_generation.join("generation.marker");
+    fs::write(&companion, b"marker").unwrap_or_else(|error| panic!("companion: {error}"));
+
+    let rebuilt_source = write_source(&source_dir, b"jefe-image-rebuilt");
+    let rebuilt = stage_session_host(root.path(), "jefe-agent-1", &rebuilt_source)
+        .unwrap_or_else(|error| panic!("staging rebuilt host: {error}"));
+
+    assert!(rebuilt.exists(), "the rebuilt generation is staged");
+    assert!(
+        held.exists(),
+        "a generation whose image cannot be unlinked must survive the \
+         rebuild; removing it would orphan or disarm the live tree"
+    );
+    assert!(
+        companion.exists(),
+        "an abandoned generation must be left intact, not half-deleted \
+         around the image the operating system refused to release"
+    );
 }
 
 #[test]

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -17,4 +17,5 @@ mod session_liveness_collapse_contracts;
 mod tmux_harness_docs_contracts;
 mod visibility_filter_contracts;
 mod windows_ci_signal_contracts;
+mod windows_ownership_model_contracts;
 mod windows_support_contracts;

--- a/tests/core/windows_ci_signal_contracts.rs
+++ b/tests/core/windows_ci_signal_contracts.rs
@@ -252,6 +252,60 @@ fn windows_native_still_runs_every_native_step() {
     }
 }
 
+/// Issue #542, V7. The orphan check recorded surviving psmux *sessions* into an
+/// artifact and then `exit 0`, so the leak class this repository has reopened
+/// four times could never turn CI red. Sessions are also the wrong unit: #515's
+/// signature is a session that has already vanished from the inventory while
+/// its `jefe-session-host.exe` and worker keep running.
+#[test]
+fn windows_native_fails_when_any_jefe_process_survives_the_suite() {
+    let job = windows_native_job();
+    let step = step_body(&job, "Assert no jefe process survives the suite");
+
+    assert!(
+        step.contains("if: always()"),
+        "the survivor gate must run even when an earlier native step failed; \
+         a failing suite is exactly when trees leak"
+    );
+    assert!(
+        !step.contains("continue-on-error"),
+        "the survivor gate must be able to fail the build; recording orphans \
+         into an artifact is what let this defect class reopen four times"
+    );
+    assert!(
+        step.contains("jefe-session-host"),
+        "the gate must count surviving session-host processes, not only psmux \
+         sessions: a leaked tree outlives the session that owned it"
+    );
+    assert!(
+        step.contains("throw"),
+        "the gate must throw on a surviving process instead of exiting 0"
+    );
+}
+
+/// Return one `- name: <step>` block from a job body, up to the next step.
+fn step_body(job: &str, step: &str) -> String {
+    let header = format!("- name: {step}");
+    let mut lines = job
+        .lines()
+        .skip_while(|line| line.trim_start() != header.as_str());
+    let Some(first) = lines.next() else {
+        panic!("step `{step}` is not present in the job");
+    };
+    let indent = first.len() - first.trim_start().len();
+    let mut body = String::from(first);
+    for line in lines {
+        let starts_new_step = line.trim_start().starts_with("- name:")
+            && line.len() - line.trim_start().len() <= indent;
+        if starts_new_step {
+            break;
+        }
+        body.push('\n');
+        body.push_str(line);
+    }
+    body
+}
+
 /// Extract the `windows_native` job body from the CI workflow.
 fn windows_native_job() -> String {
     let workflow = read_repo_text(CI_WORKFLOW);

--- a/tests/core/windows_ownership_model_contracts.rs
+++ b/tests/core/windows_ownership_model_contracts.rs
@@ -1,0 +1,98 @@
+//! Contract tests for issue #542 — the Windows session process tree must have
+//! exactly one documented owner-lifetime anchor, and the code must reference
+//! the document that defines it (V8).
+//!
+//! This class of defect has been "fixed" three times (#332, #467, #493) and
+//! reopened four. Each fix moved the anchor without ever writing down what the
+//! anchor *is*, so the next change moved it again. These tests make the model a
+//! merged artefact rather than tribal knowledge: the document must name every
+//! process in the tree, state who owns it and what its death means, and the
+//! enforcing modules must point back at it.
+
+use std::path::Path;
+
+const MODEL_DOC: &str = "dev-docs/standards/windows-session-ownership.md";
+
+/// V8: the ownership model is a merged design artefact, not just code.
+#[test]
+fn ownership_model_document_is_merged() {
+    let doc = read_repo_text(MODEL_DOC);
+    assert!(
+        doc.len() > 1_000,
+        "{MODEL_DOC} must actually describe the model, not stub it"
+    );
+}
+
+/// Deliverable 1: every process in the tree, who owns it, what its death
+/// means, and what must be reaped.
+#[test]
+fn ownership_model_names_every_process_in_the_tree() {
+    let doc = read_repo_text(MODEL_DOC);
+    for role in [
+        "psmux server",
+        "pane process",
+        "session host",
+        "worker",
+        "dashboard",
+    ] {
+        assert!(
+            doc.contains(role),
+            "{MODEL_DOC} must state the ownership and death semantics of the \
+             `{role}`; a model that omits a process in the tree is how #467 \
+             contained the worker and left the host unowned"
+        );
+    }
+}
+
+/// Deliverable 2: the anchor is captured as an identity, before the spawn, and
+/// the document must say so — a PID alone is spoofable by reuse (V5).
+#[test]
+fn ownership_model_states_the_identity_and_ordering_rules() {
+    let doc = read_repo_text(MODEL_DOC);
+    for rule in ["ProcessIdentity", "before", "PID reuse", "fail open"] {
+        assert!(
+            doc.contains(rule),
+            "{MODEL_DOC} must state the `{rule}` rule; these are the three \
+             ways this invariant has previously been lost (late capture, PID \
+             spoofing, and converting uncertainty into termination)"
+        );
+    }
+}
+
+/// The issue's explicit non-goal: a periodic sweeper is defence in depth, never
+/// the primary mechanism. The document must record that so a later change does
+/// not quietly regress to janitorial cleanup.
+#[test]
+fn ownership_model_rejects_a_sweeper_as_the_primary_mechanism() {
+    let doc = read_repo_text(MODEL_DOC);
+    assert!(
+        doc.contains("sweeper") || doc.contains("janitor"),
+        "{MODEL_DOC} must explicitly record that a periodic sweeper is not the \
+         ownership mechanism; the invariant has to hold without one"
+    );
+}
+
+/// V8: "the code references it". A document nobody links to is a document
+/// nobody maintains.
+#[test]
+fn enforcing_modules_reference_the_ownership_model() {
+    for module in [
+        "src/runtime/owner_anchor.rs",
+        "src/runtime/agent_launcher.rs",
+        "src/runtime/job_object.rs",
+        "src/runtime/session_host.rs",
+    ] {
+        let source = read_repo_text(module);
+        assert!(
+            source.contains("windows-session-ownership.md"),
+            "{module} enforces part of the ownership model and must reference \
+             {MODEL_DOC} so the two cannot drift apart"
+        );
+    }
+}
+
+fn read_repo_text(relative: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}

--- a/tests/fixtures/psmux_session_host_fixture.rs
+++ b/tests/fixtures/psmux_session_host_fixture.rs
@@ -16,6 +16,22 @@
 //!   the marker file, then blocks until killed. Detached from the host's
 //!   console so it is not cascaded by console-close events; the Job is the
 //!   only containment boundary under test.
+//! - `--owned-session-host <marker-path>`: issue #542. Everything
+//!   `--session-host` does, but it first captures its owner chain with
+//!   `jefe::runtime::capture_owner_anchor` and records those links in the
+//!   marker, then arms `jefe::runtime::spawn_owner_watchdog`. This is the mode
+//!   that exercises the owner-lifetime anchor itself.
+//! - `--pane-launcher <marker-path>`: issue #542. Stands in for the pane
+//!   process. It spawns `--owned-session-host` *detached* and then blocks
+//!   forever as a stable, killable owner.
+//!
+//!   The detachment is what makes the regression meaningful. A host that shares
+//!   the pane's console is torn down by ConPTY when the pane dies, whether or
+//!   not the anchor works — so a console-attached fixture measures Windows, not
+//!   Jefe, and stays green even with the watchdog deleted. A detached host also
+//!   reproduces issue #515's actual topology, where the surviving hosts were
+//!   never console-cascaded. With this mode the only thing that can reap the
+//!   tree is the watchdog.
 
 #![cfg(feature = "psmux-smoke")]
 
@@ -38,6 +54,23 @@ struct HostMarker {
     /// Whether the host established a kill-on-close Job Object owning the worker tree.
     host_owned_job: bool,
     started_at: Option<u64>,
+}
+
+/// Issue #542 marker: the `HostMarker` fields plus the owner chain that was
+/// captured before the worker was spawned.
+#[derive(Serialize)]
+struct OwnedHostMarker {
+    host_pid: u32,
+    worker_pid: u32,
+    host_owned_job: bool,
+    owner_links: Vec<OwnerLinkRecord>,
+    started_at: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct OwnerLinkRecord {
+    role: String,
+    pid: u32,
 }
 
 #[derive(Serialize)]
@@ -71,6 +104,35 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
             run_session_host(&marker_path)
         }
+        // Issue #542: identical to `--session-host` except that it captures its
+        // owner chain before spawning the worker and then watches it, exactly
+        // as `run_launch_plan` does in production.
+        "--owned-session-host" => {
+            let marker_path: PathBuf = args
+                .next()
+                .ok_or("--owned-session-host requires a marker path")?
+                .into();
+            if args.next().is_some() {
+                return Err("unexpected extra argument".into());
+            }
+            run_owned_session_host(&marker_path)
+        }
+        // Issue #542: stand in for the pane process that owns the host.
+        // Spawning the host detached is what makes the regression honest: a
+        // console-attached host is reaped by ConPTY teardown whether or not
+        // the owner anchor works, so such a test stays green with the
+        // mechanism deleted. #515's surviving hosts were likewise not
+        // console-cascaded.
+        "--pane-launcher" => {
+            let marker_path: PathBuf = args
+                .next()
+                .ok_or("--pane-launcher requires a marker path")?
+                .into();
+            if args.next().is_some() {
+                return Err("unexpected extra argument".into());
+            }
+            run_pane_launcher(&marker_path)
+        }
         "--worker" => {
             let marker_path: PathBuf = args.next().ok_or("--worker requires a marker path")?.into();
             if args.next().is_some() {
@@ -90,6 +152,103 @@ fn run_session_host(marker_path: &std::path::Path) -> Result<(), Box<dyn std::er
     #[cfg(windows)]
     establish_host_job()?;
 
+    let worker_pid = spawn_contained_worker(marker_path)?;
+
+    // Record the marker once the worker has spawned. The worker records its
+    // own PID independently as a cross-check.
+    let marker = HostMarker {
+        host_pid: std::process::id(),
+        worker_pid,
+        host_owned_job: cfg!(windows),
+        started_at: now_unix_seconds(),
+    };
+    fs::write(marker_path, serde_json::to_vec(&marker)?)?;
+
+    // Hold the pane host alive until the test kills the session. Do not wait
+    // on the child: we want host death (kill-session) to be the trigger, not
+    // worker exit.
+    loop {
+        thread::sleep(HOST_HOLD);
+    }
+}
+
+/// Owner-anchored pane-host mode (issue #542).
+///
+/// Ordering is the behaviour under test and mirrors `run_launch_plan`:
+/// capture the owner chain *before* the worker exists, so a worker can never
+/// be spawned into a tree that has no anchor. Only then is Job containment
+/// established and the worker spawned, and only then is the watchdog started.
+#[cfg(windows)]
+fn run_owned_session_host(marker_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    let anchor = jefe::runtime::capture_owner_anchor()?;
+    let owner_links: Vec<OwnerLinkRecord> = anchor
+        .links()
+        .iter()
+        .map(|link| OwnerLinkRecord {
+            role: link.role.as_str().to_owned(),
+            pid: link.identity.pid,
+        })
+        .collect();
+
+    establish_host_job()?;
+    let worker_pid = spawn_contained_worker(marker_path)?;
+
+    let marker = OwnedHostMarker {
+        host_pid: std::process::id(),
+        worker_pid,
+        host_owned_job: true,
+        owner_links,
+        started_at: now_unix_seconds(),
+    };
+    fs::write(marker_path, serde_json::to_vec(&marker)?)?;
+
+    jefe::runtime::spawn_owner_watchdog(anchor);
+    loop {
+        thread::sleep(HOST_HOLD);
+    }
+}
+
+#[cfg(not(windows))]
+fn run_owned_session_host(
+    _marker_path: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    Err("--owned-session-host is a Windows-only mode".into())
+}
+/// Pane-launcher mode (issue #542): act as the pane process that owns the
+/// session host, and start that host *detached from this console*.
+///
+/// This is the whole point of the mode. A session host that shares the pane's
+/// console is torn down by ConPTY when the pane dies, so a regression test
+/// built on one passes even with the owner anchor deleted — it measures
+/// Windows, not Jefe. #515's surviving hosts were not console-cascaded either,
+/// so detaching is also the faithful topology: after the launcher dies the
+/// host is reachable but unowned, and only the anchor can reap it.
+///
+/// The launcher then blocks, so it is a stable, killable owner for the test.
+fn run_pane_launcher(marker_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    let current_exe = std::env::current_exe()?;
+    let mut child = std::process::Command::new(&current_exe);
+    child.arg("--owned-session-host").arg(marker_path);
+    child.stdin(std::process::Stdio::null());
+    child.stdout(std::process::Stdio::null());
+    child.stderr(std::process::Stdio::null());
+    // CREATE_NEW_PROCESS_GROUP (0x00000200) | DETACHED_PROCESS (0x00000008).
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        child.creation_flags(0x0000_0208);
+    }
+    let mut child = child.spawn()?;
+    let _ = child.try_wait();
+    loop {
+        thread::sleep(HOST_HOLD);
+    }
+}
+
+/// Spawn the long-lived worker child that the host's Job contains.
+fn spawn_contained_worker(
+    marker_path: &std::path::Path,
+) -> Result<u32, Box<dyn std::error::Error>> {
     let current_exe = std::env::current_exe()?;
     let mut child = std::process::Command::new(&current_exe);
     child.arg("--worker").arg(marker_path);
@@ -106,25 +265,8 @@ fn run_session_host(marker_path: &std::path::Path) -> Result<(), Box<dyn std::er
     }
     let mut child = child.spawn()?;
     let worker_pid = child.id();
-
-    // Record the marker once the worker has spawned. The worker records its
-    // own PID independently as a cross-check.
-    let marker = HostMarker {
-        host_pid: std::process::id(),
-        worker_pid,
-        host_owned_job: cfg!(windows),
-        started_at: now_unix_seconds(),
-    };
-    fs::write(marker_path, serde_json::to_vec(&marker)?)?;
-
-    // Hold the pane host alive until the test kills the session. Do not wait
-    // on the child: we want host death (kill-session) to be the trigger, not
-    // worker exit. Reap the child defensively to avoid a zombie if it exits
-    // first, but keep holding regardless.
     let _ = child.try_wait();
-    loop {
-        thread::sleep(HOST_HOLD);
-    }
+    Ok(worker_pid)
 }
 
 /// Worker mode: record own PID into the marker's worker-pid slot (overwriting

--- a/tests/fixtures/psmux_session_host_fixture.rs
+++ b/tests/fixtures/psmux_session_host_fixture.rs
@@ -47,6 +47,14 @@ use serde::Serialize;
 /// Host hold time: keeps the pane alive until the test kills it.
 const HOST_HOLD: Duration = Duration::new(3600, 0);
 
+/// `CREATE_NEW_PROCESS_GROUP` (0x00000200) | `DETACHED_PROCESS` (0x00000008).
+///
+/// Both children are launched with their own console-free process group so
+/// that a console-close event on the parent cannot cascade into them. That is
+/// what makes the regression measure Jefe's anchor instead of ConPTY teardown.
+#[cfg(windows)]
+const DETACHED_PROCESS_GROUP: u32 = 0x0000_0208;
+
 #[derive(Serialize)]
 struct HostMarker {
     host_pid: u32,
@@ -227,24 +235,32 @@ fn run_owned_session_host(
 /// host is reachable but unowned, and only the anchor can reap it.
 ///
 /// The launcher then blocks, so it is a stable, killable owner for the test.
+#[cfg(windows)]
 fn run_pane_launcher(marker_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    use std::os::windows::process::CommandExt;
+
     let current_exe = std::env::current_exe()?;
     let mut child = std::process::Command::new(&current_exe);
     child.arg("--owned-session-host").arg(marker_path);
     child.stdin(std::process::Stdio::null());
     child.stdout(std::process::Stdio::null());
     child.stderr(std::process::Stdio::null());
-    // CREATE_NEW_PROCESS_GROUP (0x00000200) | DETACHED_PROCESS (0x00000008).
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        child.creation_flags(0x0000_0208);
-    }
+    child.creation_flags(DETACHED_PROCESS_GROUP);
     let mut child = child.spawn()?;
-    let _ = child.try_wait();
+    // The host is meant to outlive this call. If it has already exited, the
+    // launch failed; blocking here would strand the test in a timeout and
+    // throw away the only evidence of why.
+    if let Some(status) = child.try_wait()? {
+        return Err(format!("owned session host exited immediately with {status}").into());
+    }
     loop {
         thread::sleep(HOST_HOLD);
     }
+}
+
+#[cfg(not(windows))]
+fn run_pane_launcher(_marker_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    Err("--pane-launcher is a Windows-only mode".into())
 }
 
 /// Spawn the long-lived worker child that the host's Job contains.
@@ -257,18 +273,15 @@ fn spawn_contained_worker(
     child.stdin(std::process::Stdio::null());
     child.stdout(std::process::Stdio::null());
     child.stderr(std::process::Stdio::null());
-    // CREATE_NEW_PROCESS_GROUP (0x00000200) | DETACHED_PROCESS (0x00000008):
-    // detach the worker from this host's console so a console-close event does
+    // Detach the worker from this host's console so a console-close event does
     // not cascade-kill it. The Job is the only containment boundary under test.
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
-        child.creation_flags(0x0000_0208);
+        child.creation_flags(DETACHED_PROCESS_GROUP);
     }
-    let mut child = child.spawn()?;
-    let worker_pid = child.id();
-    let _ = child.try_wait();
-    Ok(worker_pid)
+    let child = child.spawn()?;
+    Ok(child.id())
 }
 
 /// Worker mode: record own PID into the marker's worker-pid slot (overwriting

--- a/tests/fixtures/psmux_session_host_fixture.rs
+++ b/tests/fixtures/psmux_session_host_fixture.rs
@@ -58,6 +58,7 @@ struct HostMarker {
 
 /// Issue #542 marker: the `HostMarker` fields plus the owner chain that was
 /// captured before the worker was spawned.
+#[cfg(windows)]
 #[derive(Serialize)]
 struct OwnedHostMarker {
     host_pid: u32,
@@ -67,6 +68,7 @@ struct OwnedHostMarker {
     started_at: Option<u64>,
 }
 
+#[cfg(windows)]
 #[derive(Serialize)]
 struct OwnerLinkRecord {
     role: String,

--- a/tests/psmux_session_host.rs
+++ b/tests/psmux_session_host.rs
@@ -42,6 +42,9 @@ use serde::Deserialize;
 const FIXTURE: &str = env!("CARGO_BIN_EXE_jefe-psmux-session-host-fixture");
 const POLL_TIMEOUT: Duration = Duration::from_secs(15);
 const CONTAINMENT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Bound for issue #542: one watchdog interval to observe the loss, plus room
+/// for the kernel to close the Job and reap the contained worker tree.
+const OWNER_LOSS_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
@@ -306,6 +309,144 @@ fn two_staged_hosts_survive_dashboard_exit_keep_source_replaceable_reconnect_and
     assert_survives_and_source_replaces(&mut namespace, &hosts)?;
     assert_reconnect_and_scoped_reap(&mut namespace, &hosts)?;
     Ok(())
+}
+
+/// Issue #542 marker: the owner chain the host captured before it spawned the
+/// worker.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct OwnedHostMarker {
+    host_pid: u32,
+    worker_pid: u32,
+    host_owned_job: bool,
+    owner_links: Vec<OwnerLinkRecord>,
+    started_at: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OwnerLinkRecord {
+    role: String,
+    pid: u32,
+}
+
+/// Issue #542 / V2 — the #515 reproduction.
+///
+/// `psmux server -> pwsh -> session host -> worker`. Kill the psmux server
+/// abruptly, the way a crash or `taskkill /F` does, and assert nothing in the
+/// tree below it survives. Before this issue the Job Object contained the
+/// worker but nothing contained the host, so the host and its worker outlived
+/// the server that owned them and the session vanished from the inventory
+/// while the processes kept running.
+///
+/// The host under test is the production capture-and-watch path
+/// (`capture_owner_anchor` / `spawn_owner_watchdog`), not a re-implementation.
+/// See `dev-docs/standards/windows-session-ownership.md`.
+#[test]
+fn killing_the_owning_psmux_server_reaps_the_whole_owned_tree() -> Result<(), RegressionFailure> {
+    if !psmux_required() {
+        return Ok(());
+    }
+    let mut namespace = PsmuxNamespace::new("owner-anchor")?;
+    let work = Workdir::new()?;
+    let session = "owned-host";
+    let marker_path = work.path().join("owned-host.json");
+    let staged = work.path().join("session-host.exe");
+    fs::copy(FIXTURE, &staged).map_err(|e| fail("stage owner-anchored host", e))?;
+    launch_owned_session_host(&mut namespace, session, work.path(), &staged, &marker_path)?;
+
+    let marker: OwnedHostMarker = wait_for_marker(&marker_path)?;
+    let pane_pid = namespace.pane_pid(session)?;
+
+    // The chain is captured to depth two and in order: the host's immediate
+    // owner first, then that owner's owner. Under this fixture the immediate
+    // owner is the pane launcher and its owner is the pane process psmux
+    // reports, so the outer link is anchored to psmux's own bookkeeping.
+    let roles: Vec<&str> = marker.owner_links.iter().map(|l| l.role.as_str()).collect();
+    assert_eq!(
+        roles,
+        vec!["pane process", "psmux server"],
+        "the host must capture both owner levels, nearest first; got {roles:?}"
+    );
+    let owner_pid = marker.owner_links[0].pid;
+    assert_eq!(
+        marker.owner_links[1].pid, pane_pid,
+        "the outer captured link must be the pane process psmux reports"
+    );
+    assert_ne!(owner_pid, pane_pid);
+    assert!(
+        process_alive(owner_pid),
+        "the owning launcher must be running"
+    );
+    assert!(process_alive(marker.host_pid));
+    assert!(process_alive(marker.worker_pid));
+
+    // Kill exactly the owner the host named, abruptly: no graceful shutdown,
+    // no Rust `Drop`, and no `/T`, so Windows does not cascade. The host was
+    // started detached, so it shares no console with the owner and no ConPTY
+    // teardown can reap it either. A child normally outlives its parent on
+    // Windows -- that is the whole defect -- so with the owner anchor removed
+    // this tree survives and the assertions below fail.
+    force_kill(owner_pid)?;
+
+    for (label, pid) in [
+        ("session host", marker.host_pid),
+        ("worker", marker.worker_pid),
+    ] {
+        assert!(
+            wait_for_process_exit(pid, OWNER_LOSS_TIMEOUT),
+            "{label} (pid {pid}) survived the death of the process that owned it; \
+             an unowned tree is exactly the defect issue #515 reported"
+        );
+    }
+    // The session is gone from the inventory too, so no half-dead session can
+    // be left pointing at a tree that no longer exists.
+    assert!(!namespace.session_exists(session));
+    Ok(())
+}
+
+fn launch_owned_session_host(
+    namespace: &mut PsmuxNamespace,
+    session: &str,
+    cwd: &Path,
+    program: &Path,
+    marker: &Path,
+) -> Result<(), RegressionFailure> {
+    // The pane runs a launcher that starts the real host detached. See
+    // `run_pane_launcher`: a console-attached host is reaped by ConPTY
+    // teardown regardless of the owner anchor, which would make this
+    // regression pass with the mechanism deleted.
+    let fixture_args = vec![
+        OsString::from("--pane-launcher"),
+        marker.as_os_str().to_owned(),
+    ];
+    let pane = namespace.pane_command(program, &fixture_args)?;
+    let mut args = vec![
+        OsString::from("new-session"),
+        OsString::from("-d"),
+        OsString::from("-s"),
+        OsString::from(session),
+        OsString::from("-c"),
+        cwd.as_os_str().to_owned(),
+    ];
+    args.extend(pane);
+    namespace.run_os(&args).map(|_| ())
+}
+
+/// Terminate exactly one process, without its tree, so the test observes the
+/// watchdog reaping the tree rather than `taskkill /T` doing it.
+fn force_kill(pid: u32) -> Result<(), RegressionFailure> {
+    let output = Command::new("taskkill.exe")
+        .args(["/F", "/PID", &pid.to_string()])
+        .output()
+        .map_err(|error| fail("spawn taskkill", error))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(RegressionFailure {
+            message: format!("taskkill failed for pid {pid}"),
+            diagnostics: format_output(&output),
+        })
+    }
 }
 
 struct Workdir {

--- a/tests/psmux_session_host.rs
+++ b/tests/psmux_session_host.rs
@@ -439,7 +439,10 @@ fn force_kill(pid: u32) -> Result<(), RegressionFailure> {
         .args(["/F", "/PID", &pid.to_string()])
         .output()
         .map_err(|error| fail("spawn taskkill", error))?;
-    if output.status.success() {
+    if output.status.success() || !process_alive(pid) {
+        // The owner exiting on its own between the liveness check and the kill
+        // is the same end state this call is asking for, and taskkill reports
+        // "process not found" for it. Only a live survivor is a real failure.
         Ok(())
     } else {
         Err(RegressionFailure {


### PR DESCRIPTION
Fixes #542. Restores invariant **I4** / epic criterion **E5**: a Windows session process tree has exactly one owner-lifetime anchor.

## Why this kept coming back

The tree is `psmux server -> pane process (pwsh) -> jefe-session-host.exe -> worker`, and every previous fix established containment at exactly one link.

| Prior fix | What it moved | What it left |
|---|---|---|
| #332 (`ca7e4bd4`) | Orphan recognition and reaping, dashboard as anchor | Reaping after the fact, not ownership |
| #467 (`eaba9f2a`) | Anchor to a staged, content-addressed host with a `KILL_ON_JOB_CLOSE` Job | Containment is *host*-lifetime, not *owner*-lifetime. **This created #515** |
| #493 (`c51bd65d`) | `ServerLost` tri-state for a vanished server | Explicitly does not reap surviving trees |

Three closures, four recurrences, because there was never a single answer to "who owns this worker, and what happens when that owner dies?"

## What this delivers

**1. A named ownership model.** `dev-docs/standards/windows-session-ownership.md` states every process in the tree, its owner, what its death means, and what must be reaped. The four modules that implement it cite it by name and a contract test keeps the citations honest. *(V8)*

**2. One anchor, enforced.** The host captures its owner chain as `ProcessIdentity` — pid **plus creation time** — **before** spawning the worker, not by looking one up afterwards. Capture failure is a typed `OwnerAnchorUnavailable` that refuses the launch, because a worker nobody owns is the defect, not a degraded mode.

**3. Depth capped at 2.** Pane process, then psmux server. A third level would make the dashboard an anchor and quitting the dashboard would kill live agents — the exact #467 guarantee this must not break. *(A6, A7)*

**4. Fail open, without accumulation.** Only `Dead` and `ReusedPid` release the tree. `Inaccessible` / `MalformedIdentity` / `ProbeFailure` are `Unverified` and hold. `watch_owner_anchor` carries no state between passes, so a run of transient probe failures can never add up to a kill. Termination is irreversible; a failed probe is not. *(A5)*

**5. PID reuse cannot spoof ownership.** `is_plausible_ancestor` rejects any candidate whose creation time is unknown or later than its descendant's, and a recycled PID classifies as `Lost`, never as a live owner. *(V5)*

**6. Staged-host lifecycle across rebuild.** A rebuild changes the content hash, so `stage_with_plan` was creating a generation directory per rebuild and leaving every previous one until the next startup sweep — while the old host kept running and kept its image locked. Superseded generations are now pruned at stage time, binary first so a failure cannot leave a half-deleted directory, and anything still held by a live process is retained. Pruning never fails a launch. *(V6)*

**7. CI can now go red.** "Record remaining owned psmux sessions" ends in `exit 0` under `continue-on-error: true` — a recorder, and the only thing watching for the leak. Sessions are also the wrong unit: #515's signature is a session already gone from the inventory whose host and worker still run (seven hosts against four sessions). The recorder stays as a diagnostic; a new step asserts zero surviving `jefe-session-host` processes, always runs, suppresses nothing, and throws. *(V7)*

## The test that would have shipped a lie

The first version of `killing_the_owning_psmux_server_reaps_the_whole_owned_tree` **passed with `spawn_owner_watchdog` deleted from the fixture.** Against real psmux 3.3.7 with the watchdog disabled, killing the psmux server reaped the tree in 1.64s and killing the pane pwsh in 4.23s. The pane's ConPTY teardown was destroying the console-attached host on its own — the test measured Windows, not jefe, and would have gone green in CI as V1/V2 evidence for a mechanism it never executed. That is precisely the shape of the previous three closures.

#515's field topology is the opposite one: the psmux server was gone and the pane pwsh was **still alive**, holding a surviving host. Those hosts were never console-cascaded.

The `--pane-launcher` fixture mode reproduces it — it stands in for the pane process and spawns the host with `DETACHED_PROCESS`, reusing the safe `CommandExt::creation_flags` path the worker already used. `FreeConsole` would have been the other route, but winsafe does not wrap it and `unsafe_code = "forbid"` is worth more than a fixture's convenience.

With the host detached, nothing but the watchdog can reap the tree:

- **RED** — `spawn_owner_watchdog` replaced by `let _ = &anchor;` → fails at `tests/psmux_session_host.rs:393`, "session host (pid 18856) survived the death of the process that owned it", 21.85s.
- **GREEN** — watchdog restored → 2 passed, 3.25s.

The test kills one pid it spawned itself, inside its own uniquely named namespace, with `taskkill /F` and no `/T`. No cascade, and no ambient psmux server is touched — which matters, because this suite runs on machines hosting live jefe sessions.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | exit 0 |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo build --workspace --all-features --locked` | exit 0 |
| `cargo test --workspace --all-features --locked --no-fail-fast` | exit 0 — 81 binaries, **5286 passed, 0 failed** |
| `JEFE_REQUIRE_PSMUX=1 cargo test --features psmux-smoke --test psmux_session_host` | RED 1 failed → **GREEN 2 passed** |

`unsafe_code = "forbid"` preserved. No new dependencies. Windows-only code is cfg-gated so Linux `--all-features` (which enables `psmux-smoke`) still builds.

## Scope

16 files, +1745/−21. Above the standard 1,500-line target; issue #542 explicitly waives it ("No file or line budget applies", the model spanning `session_host.rs`, `job_object.rs`, `agent_launcher.rs`, `orphan.rs`, `process.rs` and more). Below the 2,500 hard stop. The `.github/workflows/ci.yml` change is mandated by verification criterion V7. Full acceptance matrix, non-goals and scope ledger in `project-plans/issue542-plan.md`.

## Not in scope, deliberately

- No periodic sweeper as the primary mechanism — a janitor that reaps orphans after the fact is a mitigation, and mitigations are what produced this issue's history. The invariant holds without one.
- No killing agents on an uncertain probe.
- No automatic relaunch after server loss; `ServerLost` UX unchanged.
- No process anchors in the durable state schema.
- No heuristic cleanup by exe name, command line, cwd, or pid alone.
- Unix/tmux and remote agent lifecycles untouched.

#306 is already merged (`88a3fd2d`) and carried here as a regression guard only.
