### PR TITLE
Resolve a version in the cache, not wherever jefe was started (Fixes #623)

### DIFF
--- a/src/runtime/package_runtime.rs
+++ b/src/runtime/package_runtime.rs
@@ -482,6 +482,7 @@ fn cache_hit(
 fn resolve_volatile_version(
     candidate: &ResolvedCandidate,
     selection: &PackageSelection,
+    cache_root: &Path,
 ) -> Option<String> {
     let spec = selection
         .selector()
@@ -493,7 +494,11 @@ fn resolve_volatile_version(
     ];
     let mut command =
         command_for_path(candidate.executable(), candidate.wrapper_kind(), &arguments);
-    command.stdin(Stdio::null());
+    // Run where the work belongs. Without a directory of its own this inherits
+    // whatever jefe was started in — the user's project — and a package manager
+    // is entitled to read and write around its working directory. The install
+    // alongside this has always named its directory; the resolve did not.
+    command.current_dir(cache_root).stdin(Stdio::null());
     let output =
         run_command_capture_with_timeout(command, VERSION_RESOLVE_TIMEOUT, "jefe package resolve")
             .ok()?;
@@ -570,7 +575,7 @@ fn prepare_managed_npm_with_lock_policy(
     // Resolving outside the lock is deliberate: it is a read-only metadata
     // query, and the lock is keyed on the result.
     let resolved = if selection.selector().is_volatile() {
-        resolve_volatile_version(candidate, selection).or_else(|| {
+        resolve_volatile_version(candidate, selection, cache_root).or_else(|| {
             // Offline: fall back to the version this tag last resolved to, so
             // the build the user already has still launches (issue #584).
             let remembered = remembered_version(cache_root, selection);

--- a/src/runtime/package_runtime_tests.rs
+++ b/src/runtime/package_runtime_tests.rs
@@ -451,7 +451,7 @@ if [ \"$1\" = view ]; then
     echo \"unexpected npm view invocation: $*\" >&2
     exit 64
   fi
-  echo resolve >> \"$resolves\"
+  pwd >> \"$resolves\"
   if [ -f \"$versions\" ]; then cat \"$versions\"; exit 0; else exit 1; fi
 fi
 if [ -f package-lock.json ]; then echo present >> \"$witness\"; else echo absent >> \"$witness\"; fi
@@ -477,6 +477,14 @@ chmod 755 node_modules/.bin/llxprt
 #[cfg(unix)]
 fn resolve_path_for(witness: &Path) -> PathBuf {
     witness.with_file_name("resolve-witness.log")
+}
+
+/// Working directories the stub was run in, one per `npm view`.
+#[cfg(unix)]
+fn resolve_directories(witness: &Path) -> Vec<String> {
+    std::fs::read_to_string(resolve_path_for(witness))
+        .map(|contents| contents.lines().map(str::to_owned).collect())
+        .unwrap_or_default()
 }
 
 /// How many times the stub answered `npm view ... version`.
@@ -636,6 +644,43 @@ fn advancing_a_tag_leaves_the_previous_install_intact() {
         "the tree a live agent is executing from must survive the tag advancing; \
          deleting it is what strands the process and triggers the Keychain storm"
     );
+}
+
+/// Resolving a version must not run in whatever directory jefe was started in.
+///
+/// The resolve spawns a package manager, and a package manager is entitled to
+/// read and write around its working directory. With none of its own it
+/// inherits the user's project directory. The install beside it has always
+/// named its directory; the resolve did not, which let a test fixture create
+/// `node_modules/` in the repository it was run from.
+#[cfg(unix)]
+#[test]
+fn resolving_a_version_runs_in_the_cache_not_the_current_directory() {
+    let bin = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+    let witness = witness_path(&bin);
+    counting_npm_stub(&bin, &witness);
+    publish_version(&witness, "0.11.0");
+    let candidate = volatile_npm_candidate(&bin, "latest nightly");
+    let cache = tempfile::tempdir().unwrap_or_else(|error| panic!("cache: {error}"));
+
+    finalize_local_invocation_inner(&candidate, cache.path())
+        .unwrap_or_else(|error| panic!("install: {error}"));
+
+    let directories = resolve_directories(&witness);
+    assert!(
+        !directories.is_empty(),
+        "the volatile selector must have been resolved at least once"
+    );
+    let expected = std::fs::canonicalize(cache.path())
+        .unwrap_or_else(|error| panic!("canonicalize cache: {error}"));
+    for directory in directories {
+        let actual = std::fs::canonicalize(&directory)
+            .unwrap_or_else(|error| panic!("canonicalize {directory}: {error}"));
+        assert_eq!(
+            actual, expected,
+            "the resolve must run inside the managed cache, not wherever jefe happens to be"
+        );
+    }
 }
 
 /// Two selectors naming the same version must share one install, not fight

--- a/tests/issue382/package_selector.rs
+++ b/tests/issue382/package_selector.rs
@@ -39,8 +39,12 @@ fn write_fixtures(bin: &tempfile::TempDir) {
 
     for name in ["claude", "code-puppy", "codex", "llxprt", "npm", "uvx"] {
         let path = bin.path().join(name);
+        // The npm stub answers `view` from a fixed version and installs only on
+        // `install`. Answering every invocation as an install is what let a
+        // read-only metadata query build a tree, and it built it wherever the
+        // stub happened to run (issue #623).
         let script = if name == "npm" {
-            "#!/bin/sh\nmkdir -p node_modules/.bin\nprintf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/llxprt\nchmod 755 node_modules/.bin/llxprt\n"
+            "#!/bin/sh\ncase \"$1\" in\n  view) echo 1.0.0; exit 0 ;;\n  install) ;;\n  *) echo \"unexpected npm invocation: $*\" >&2; exit 64 ;;\nesac\nmkdir -p node_modules/.bin\nprintf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/llxprt\nchmod 755 node_modules/.bin/llxprt\n"
         } else {
             "#!/bin/sh\nexit 0\n"
         };


### PR DESCRIPTION
Fixes #623.

## Summary

Resolving a moving version selector spawns a package manager with no working directory of its own, so it inherits whatever directory jefe was started in — normally the user's project.

Found while cleaning an untracked `node_modules/` out of the repository that kept reappearing in `git status`.

## Cause

`resolve_volatile_version` sets stdin and nothing else (`src/runtime/package_runtime.rs:494-496`):

    let mut command = command_for_path(candidate.executable(), candidate.wrapper_kind(), &arguments);
    command.stdin(Stdio::null());

The install beside it does name its directory (`package_runtime.rs:855`):

    command.current_dir(install_dir).stdin(Stdio::null());

The resolve was added in #584 without the equivalent.

## Impact

Production is unharmed today: `npm view` is a read-only metadata query, so nothing is written into the inherited directory. The defect is that jefe does not control where the command runs, and a package manager is entitled to read and write around its working directory — config discovery, caches, lockfiles.

The test suite showed what that costs. The npm stub in `tests/issue382/package_selector.rs:42-43` ignores its arguments and unconditionally does:

    mkdir -p node_modules/.bin
    printf '#!/bin/sh\\nexit 0\\n' > node_modules/.bin/llxprt

Integration tests run with the package root as their working directory, so every `cargo test --workspace` created `node_modules/.bin/llxprt` **inside the repository**. Reproduced from a clean tree, and bisected to `issue382_behavior`.

## Fix

Run the resolve in the managed cache root — the thing it is resolving for, and already created before this point.

Two properties follow. A stub that ignores its arguments can no longer reach the repository, and the resolve stops depending on ambient state, so it behaves the same however jefe was launched.

## Acceptance criteria

| ID | Requirement |
|---|---|
| A1 | The resolve runs in a directory jefe chose, not an inherited one. |
| A2 | A full workspace test run leaves the working tree clean. |
| A3 | Resolution, offline fallback and cache-hit behavior are unchanged. |

## Verification

Full workspace suite after the fix: **5436 passed, 0 failed**, and the working tree is clean where it previously gained `node_modules/`.

## Note on the fixture

The stub answering every invocation as though it were `install` is its own small hazard — it is why a metadata query produced an install tree. Worth tightening to reject unexpected argv the way the `package_runtime` stubs do, but that is a separate change and not needed to stop the leak.
