### PR TITLE
Retry a request the host never answered (Fixes #609)

### DIFF
--- a/tests/jsp_host_socket.rs
+++ b/tests/jsp_host_socket.rs
@@ -67,22 +67,56 @@ fn request_with_registration(
             "header values must not contain CR or LF"
         );
     }
-    let mut stream =
-        TcpStream::connect(addr).unwrap_or_else(|error| panic!("connect loopback host: {error}"));
+    // The host worker is single-threaded, so a burst can fill the accept
+    // backlog. The kernel then refuses or resets a connection that never
+    // reached the application, which is a property of the queue rather than of
+    // what is being tested (issue #609).
+    //
+    // Only a transport failure is retried. A response that arrives is returned
+    // whatever its status, so a genuine 401 or 500 still fails the caller's
+    // assertion rather than being retried away.
+    for attempt in 1..=TRANSPORT_ATTEMPTS {
+        match attempt_request(addr, route, token, registration_id, body) {
+            Ok(response) => return response,
+            Err(error) if attempt == TRANSPORT_ATTEMPTS => {
+                panic!("host unreachable after {TRANSPORT_ATTEMPTS} attempts: {error}")
+            }
+            Err(_) => thread::sleep(std::time::Duration::from_millis(10 * u64::from(attempt))),
+        }
+    }
+    unreachable!("the loop returns or panics on its final attempt")
+}
+
+/// Attempts allowed before a transport failure is treated as a real failure.
+const TRANSPORT_ATTEMPTS: u32 = 5;
+
+/// One request attempt. `Err` means the exchange did not complete, so nothing
+/// can be concluded about the host from it.
+fn attempt_request(
+    addr: SocketAddr,
+    route: &str,
+    token: &str,
+    registration_id: &str,
+    body: &[u8],
+) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect(addr)?;
     write!(
         stream,
         "POST {route} HTTP/1.1\r\nHost: {addr}\r\nAuthorization: Bearer {token}\r\nJsp-Registration-Id: {registration_id}\r\nContent-Length: {}\r\n\r\n",
         body.len()
-    )
-    .unwrap_or_else(|error| panic!("write request: {error}"));
-    stream
-        .write_all(body)
-        .unwrap_or_else(|error| panic!("write body: {error}"));
+    )?;
+    stream.write_all(body)?;
     let mut response = String::new();
-    stream
-        .read_to_string(&mut response)
-        .unwrap_or_else(|error| panic!("read response: {error}"));
-    response
+    stream.read_to_string(&mut response)?;
+    if response.is_empty() {
+        // The peer closed before writing a status line, so the request was
+        // dropped rather than answered.
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "host closed the connection without a response",
+        ));
+    }
+    Ok(response)
 }
 
 #[test]


### PR DESCRIPTION
Fixes #609.

## The failure

`production_host_generates_unique_credentials_delivers_and_revokes` publishes 100 snapshots in a loop against a single-threaded host worker. Under contention the accept backlog fills, and the kernel refuses or resets connections that never reach the application.

Two shapes were observed, both transport-level:

    tests/jsp_host_socket.rs:686  assertion failed: response.starts_with("HTTP/1.1 200")   // empty read
    tests/jsp_host_socket.rs:84   panicked inside read_to_string                            // reset

Neither says anything about credential delivery or revocation, which is what the test exists to check.

The helper already carried a comment naming this hazard and mitigated it with a fixed `thread::sleep` of 1 ms per iteration. That is a timing assumption, and it holds only while the scheduler returns to the worker promptly. Under enough load it does not.

## The fix

A transport failure is retried with a short backoff, up to five attempts.

The distinction that matters: **the retry covers the connection, never the answer.** A response that arrives is returned whatever its status, so a genuine 401 or 500 still fails the caller's assertion rather than being retried away. An empty read is treated as a transport failure rather than a response, because the peer closed before writing a status line.

## Measurement

Eight concurrent runs of the affected test, which is the contention the failure needs:

| | failures |
|---|---|
| `main` | **3 / 8** |
| this branch | **0 / 8** |

The three failures on `main` were the two shapes above, which is what the change targets.

Full workspace suite on this branch: **5635 passed, 0 failed**, exit 0. `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` both clean.

## Scope

The test helper only. No production code, and nothing about what the test asserts: credential uniqueness, delivery and revocation are all still checked exactly as before.

The 1 ms courtesy sleep stays. It reduces pressure on the backlog rather than guaranteeing anything, and the retry is now what carries the guarantee.

## Why this is worth doing

This is not only a local-machine problem. CI runners are contended, and this class already cost a Coverage-gate rerun on an unrelated PR through its sibling `pane_status_reads_dead_after_process_exit_when_tmux_available`. A test that fails for reasons unrelated to its subject trains people to re-run rather than read failures.
