### PR TITLE
Give every staging attempt a tag of its own (Fixes #561)

### DIFF
--- a/src/runtime/session_host.rs
+++ b/src/runtime/session_host.rs
@@ -255,12 +255,25 @@ fn unique_temp_path(digest_directory: &Path, attempt_tag: &str) -> PathBuf {
     ))
 }
 
-fn default_attempt_tag() -> String {
+/// A tag unique to one staging attempt.
+///
+/// The tag scopes temp reclamation, so two attempts that share one reclaim each
+/// other: one thread's cleanup removes the other's temp between its write and
+/// its rename, and the rename then fails with nothing yet in place.
+///
+/// A pid and a timestamp are not enough to keep two threads apart. The clock is
+/// not guaranteed to advance between two reads, and in practice on macOS it
+/// frequently does not — measured at roughly half of a thousand consecutive
+/// calls landing on an instant already seen. The process-wide counter is what
+/// makes the tag unique; the pid and time remain because they make a leftover
+/// temp legible to a human reading the directory (issue #561).
+pub fn default_attempt_tag() -> String {
     let pid = std::process::id();
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |duration| duration.as_nanos());
-    format!("pid{pid:x}-t{nanos:x}")
+    let sequence = STAGING_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    format!("pid{pid:x}-t{nanos:x}-a{sequence:x}")
 }
 
 /// Reduce a session name to a safe single path segment, or `None` if it carries

--- a/src/runtime/session_host_tests.rs
+++ b/src/runtime/session_host_tests.rs
@@ -281,6 +281,59 @@ fn concurrent_staging_of_the_same_image_is_idempotent() {
     );
 }
 
+/// Two stagings racing in one process must not delete each other's work.
+///
+/// The attempt tag scopes temp reclamation, so two attempts sharing one tag
+/// reclaim each other. `default_attempt_tag` is derived from the pid and a
+/// timestamp, and two threads in one process can read the same instant — at
+/// which point one thread's cleanup removes the other's temp between its write
+/// and its rename, and the rename fails with nothing in place yet (issue #561).
+///
+/// Repeated because the window is narrow: a single pair rarely collides, which
+/// is why this surfaced as an intermittent failure rather than a broken test.
+#[test]
+fn concurrent_staging_never_reclaims_another_attempts_temp() {
+    let source_dir = tempfile::tempdir().unwrap_or_else(|error| panic!("temp src: {error}"));
+    let source = write_default_source(&source_dir);
+
+    for round in 0..200 {
+        let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));
+        let results = std::thread::scope(|scope| {
+            let first = scope.spawn(|| stage_session_host(root.path(), "jefe-agent-1", &source));
+            let second = scope.spawn(|| stage_session_host(root.path(), "jefe-agent-1", &source));
+            [
+                first
+                    .join()
+                    .unwrap_or_else(|_| panic!("first staging thread panicked")),
+                second
+                    .join()
+                    .unwrap_or_else(|_| panic!("second staging thread panicked")),
+            ]
+        });
+        for (index, result) in results.iter().enumerate() {
+            assert!(
+                result.is_ok(),
+                "round {round}, thread {index}: concurrent staging must succeed, got {:?}",
+                result.as_ref().err().map(ToString::to_string)
+            );
+        }
+    }
+}
+
+/// The tag exists to scope cleanup to one attempt, so two attempts must not
+/// share one.
+#[test]
+fn each_staging_attempt_gets_its_own_tag() {
+    let tags: std::collections::HashSet<String> = (0..1000)
+        .map(|_| crate::runtime::session_host::default_attempt_tag())
+        .collect();
+    assert_eq!(
+        tags.len(),
+        1000,
+        "an attempt tag that repeats lets one attempt reclaim another's temps"
+    );
+}
+
 #[test]
 fn staging_rejects_attempt_tags_that_can_escape_the_digest_directory() {
     let root = tempfile::tempdir().unwrap_or_else(|error| panic!("temp root: {error}"));


### PR DESCRIPTION
Fixes #561.

The issue offered two explanations: a real promotion race, or a test asserting the wrong outcome for the losing thread. It is the first.

## The race

The attempt tag scopes temp reclamation — an attempt cleans up temps carrying its own tag and leaves others alone. `stage_with_plan` therefore does, in order:

1. `reclaim_owned_temps(digest_directory, attempt_tag)`
2. write `temp_path` (whose name contains the tag)
3. `fs::rename(&temp_path, plan.staged_path())`

Two attempts sharing a tag reclaim each other. Thread B's step 1 deletes thread A's temp between A's step 2 and step 3, A's rename fails with `ENOENT`, and if B has not yet promoted then `staged_path().is_file()` is false — so A returns `StagingRename`. That is exactly the error observed.

## Why the tag collided

    format!("pid{pid:x}-t{nanos:x}")

A pid and a timestamp cannot separate two threads of one process. The clock is not guaranteed to advance between two reads, and on macOS it frequently does not.

Measured rather than assumed — a thousand consecutive calls to `default_attempt_tag`:

    assertion `left == right` failed: an attempt tag that repeats lets one attempt reclaim another's temps
      left: 540
     right: 1000

**Nearly half of all tags collided.** The window is not narrow; the failure was intermittent only because the collision also has to land between one thread's write and its rename.

## The fix

Fold in the process-wide `STAGING_SEQUENCE` counter that already makes temp filenames unique:

    format!("pid{pid:x}-t{nanos:x}-a{sequence:x}")

The pid and timestamp stay, because they keep a leftover temp legible to whoever finds one in a digest directory. The counter is what carries uniqueness.

This is at the boundary, as #561's A2 requires — the promotion path, not the assertion.

## Tests

| Test | Pins |
|---|---|
| `each_staging_attempt_gets_its_own_tag` | 1000 tags are 1000 distinct tags |
| `concurrent_staging_never_reclaims_another_attempts_temp` | 200 rounds of the concurrent path, both threads must succeed |

The original `concurrent_staging_of_the_same_image_is_idempotent` is unchanged, per A2.

The uniqueness test is the sharper of the two: it fails deterministically on `main` rather than depending on the write/rename interleaving, so it will not rot back into an intermittent signal.

## Verification

`cargo fmt --all --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.

The workspace suite had one failure, `llxprt_continue_field_fixture_sends_one_exact_issue_prompt`, which is not from this change:

- it passes 3/3 in isolation at load average 108;
- it flaked earlier today on an unrelated branch whose only change was in `agent_probe.rs`;
- this diff is two files, both `session_host`, and the harness fixture has no reference to session-host staging.

It is the same contention class as #609 and the `tmux_driver` sibling.

## Scope

`default_attempt_tag` only. Reclamation, promotion, digest layout and the staging plan are untouched. A4 — native Windows coverage — is carried by CI, since the staging path is exercised there.
