### PR TITLE
Deliver multi-line prompts to npm-shimmed agents on Windows (#620)

### DIFF
--- a/dev-docs/tmux-scenarios/issue382/agent-unsupported-ui.json
+++ b/dev-docs/tmux-scenarios/issue382/agent-unsupported-ui.json
@@ -50,17 +50,23 @@
       "contains": [
         "Claude Code",
         "> Resume: Unsupported: installed Claude Code lacks required capability `resume`",
-        "Fresh Issue: Unsupported: Claude fresh-issue prompt is not fixture-verified",
+        "Fresh Issue:",
         "Remote: Unsupported: Claude remote/setup is not fixture-verified",
         "Model: []  disabled: installed Claude Code lacks required capability `model`",
         "Prompt",
         "[Create disabled]",
         "[Back]"
       ],
-      "absent": ["[Create enabled]", "Agent Runtime", "Mode Flags", "Sandbox Engine"]
+      "absent": [
+        "[Create enabled]",
+        "Fresh Issue: Unsupported",
+        "Agent Runtime",
+        "Mode Flags",
+        "Sandbox Engine"
+      ]
     },
     { "op": "key", "key": "tab", "modifiers": [] },
-    { "op": "wait", "source": "frame", "literal": "> Fresh Issue: Unsupported", "timeout_ms": 5000 },
+    { "op": "wait", "source": "frame", "literal": "> Fresh Issue:", "timeout_ms": 5000 },
     { "op": "key", "key": "up", "modifiers": [] },
     { "op": "wait", "source": "frame", "literal": "> Resume: Unsupported", "timeout_ms": 5000 },
     { "op": "key", "key": "enter", "modifiers": [] },

--- a/project-plans/issue620-plan.md
+++ b/project-plans/issue620-plan.md
@@ -1,0 +1,119 @@
+# Issue #620 — Deliver multi-line prompts to npm-shimmed agents on Windows
+
+Follow-up to #536 / PR #619. Goal: **sending an issue to Claude Code and Codex
+on Windows must actually work**, not fail with a diagnostic.
+
+## Empirical findings (gathered before design)
+
+1. **Both CLIs take the prompt as an initial positional argument**, proven by the
+   captured help fixtures — no inference:
+   - `tests/fixtures/agent-definitions/claude/2.1.212/help.stdout`:
+     `Usage: claude [options] [command] [prompt]`, `Arguments: prompt  Your prompt`,
+     "starts an interactive session by default".
+   - `tests/fixtures/agent-definitions/codex/0.142.0/help.stdout`:
+     `Usage: codex [OPTIONS] [PROMPT]`, `[PROMPT] Optional user prompt to start the session`.
+   So `PromptShape::InitialPositional` is fixture-verified for both.
+
+2. **Neither CLI accepts a prompt from a file or from stdin.** Grepping both help
+   fixtures for `stdin|from a file|--prompt|prompt-file` yields only
+   `--prompt-suggestions` and `--replay-user-messages` (Claude) and nothing
+   (Codex). Temp-file and stdin delivery are therefore *not options* — argv is
+   the only supported route, and it must be made to work.
+
+3. **PowerShell does not truncate a multi-line argument.** The `0x0A` limit is
+   specific to `cmd.exe`. Verified directly on this machine by invoking
+   `powershell.exe -NoLogo -NoProfile -NonInteractive -File dump.ps1 "<4-line prompt>"`
+   through `CreateProcess` (.NET `ProcessStartInfo.ArgumentList`, same quoting
+   rules Rust's `std::process::Command` uses). Result: `COUNT=1` with all four
+   lines intact.
+
+4. **npm always installs a `.ps1` beside the `.cmd`.** `npm prefix -g` on this
+   machine holds `llxprt.cmd`/`llxprt.ps1` and `ocr.cmd`/`ocr.ps1`. npm's
+   `cmd-shim` emits the `.cmd`, `.ps1`, and extensionless trio together for the
+   same command. Selecting the sibling `.ps1` is therefore **not** the "guess a
+   neighbouring runtime" that #619 rejected — it is the same installer's shim
+   for the same binary, not a different program.
+
+5. **`.cmd` wins resolution today.** `windows_extensions` uses default PATHEXT
+   `.COM;.EXE;.BAT;.CMD` and appends `.ps1` *after*; `resolve_windows` returns
+   the first hit. So npm agents land on `CommandScript`.
+
+## Acceptance matrix
+
+| Row | Given | When | Then |
+|---|---|---|---|
+| A1 | Unmarked `.cmd` with a sibling `.ps1` | argv contains CR/LF | launch through `powershell -File <sibling>.ps1`, full argv byte-intact |
+| A2 | Unmarked `.cmd` with **no** sibling `.ps1` | argv contains CR/LF | still `CommandScriptArgumentUnsupported`; never truncate |
+| A3 | Unmarked `.cmd`, newline-free argv | launch | existing `cmd.exe` contract unchanged, byte for byte |
+| A4 | Marked llxprt wrapper | multi-line prompt | unchanged from #619 — runtime + entrypoint, no `cmd.exe` |
+| A5 | `core.claude-code` | fresh-issue send | supported, prompt delivered as initial positional |
+| A6 | `core.codex` | fresh-issue send | supported, prompt delivered as initial positional |
+| A7 | `Direct` / `PowerShellScript` wrappers | any argv | unchanged |
+
+## Non-goals
+
+- Changing PATHEXT resolution order or preferring `.ps1` generally.
+- Parsing `.cmd` shim contents to extract a runtime + entrypoint.
+- Remote/setup targets for Claude and Codex — still not fixture-verified.
+- Revisiting the execution-guard fingerprint blind spot for shims (noted in
+  #620, wider than this change).
+
+## Slices
+
+1. **Launcher**: sibling-`.ps1` fallback in `write_launch_plan` (A1–A4, A7).
+2. **Definitions**: flip fresh-issue / fresh-PR to supported with
+   `PromptShape::InitialPositional` for Claude and Codex (A5, A6).
+
+## Expected paths
+
+- `src/runtime/agent_launcher.rs` — `powershell_sibling_for`, fallback in
+  `write_launch_plan`, behavioral tests.
+- `src/domain/agent_definition/shipped/claude.rs`
+- `src/domain/agent_definition/shipped/codex.rs`
+- `src/domain/agent_definition/shipped/common.rs` — replace
+  `unsupported_only_operations` with a positional-prompt operation matrix.
+- `tests/generated_form_ui.rs` — expectation currently asserts the Claude
+  fresh-issue "not fixture-verified" reason.
+
+## Scope ledger
+
+Target well under budget. Deferred: stdin/temp-file prompt delivery (unsupported
+by both CLIs, so not implementable); guard fingerprinting of shim targets.
+
+## Risks
+
+- `-NonInteractive` risk: **CLOSED with evidence.** Piping input through
+  `powershell.exe -NoLogo -NoProfile -NonInteractive -File child.ps1` showed the
+  child process still received stdin (`CHILD_GOT="hello-from-user"`) and
+  `[Environment]::UserInteractive` remained `True`. The flag suppresses only
+  PowerShell's own prompts (`Read-Host`, confirmations), which is desirable in a
+  pane: it prevents the host from hanging on a prompt the user cannot see. The
+  npm shim execs the agent directly, so the agent stays fully interactive.
+- Flipping the operation matrices changes each definition's SHA-256, which the
+  execution guard compares. Expect fixture/golden updates.
+
+## TUI scenario coverage
+
+The tmux harness runs only under tmux: every shipped scenario declares
+`platform` of `macos` (85) or `linux` (21), and even the `windows-*` scenarios
+are `linux`. A Windows `.cmd`-shim scenario is therefore not implementable in
+this harness — there are no `.cmd`/`.ps1` shims on the harness platforms — and
+the `-NonInteractive` question it was meant to answer is now closed directly by
+the evidence above.
+
+The UI-visible half of this change (Claude/Codex no longer refuse fresh-issue)
+is covered by updating `dev-docs/tmux-scenarios/issue382/agent-unsupported-ui.json`:
+the stale `Fresh Issue: Unsupported: Claude fresh-issue prompt is not
+fixture-verified` assertion becomes an `absent` assertion, so the scenario now
+proves the refusal is gone. That scenario keeps its original purpose — Resume,
+Remote, and Model remain unsupported there and still assert `[Create disabled]`.
+
+## Review / verification ledger
+
+- RED evidence: sibling-`.ps1` launcher test failed at `agent_launcher.rs:405`
+  (`11 passed; 1 failed`) before the fix, `12 passed; 0 failed` after.
+- Local gates: `cargo fmt --all` clean; `cargo clippy --workspace --all-targets
+  --all-features -- -D warnings` clean (EXIT=0, no warnings); full
+  `cargo test --workspace --all-features --no-fail-fast` = 81 suites,
+  0 failures (including the usually-flaky `psmux_attach`).
+- Local OCR: 0/2. PR OCR: 0/2.

--- a/src/domain/agent_definition/shipped/claude.rs
+++ b/src/domain/agent_definition/shipped/claude.rs
@@ -29,10 +29,10 @@ pub fn build() -> AgentDefinition {
         ),
         &[],
     );
-    let operations = super::common::unsupported_only_operations(
-        "Claude fresh-issue prompt is not fixture-verified",
-        "Claude fresh-PR prompt is not fixture-verified",
-    );
+    // `help.stdout` in the fixture declares `claude [options] [command] [prompt]`
+    // with `prompt  Your prompt`, and an interactive session by default, so the
+    // prompt shape below is fixture-proven for every prompt-bearing operation.
+    let operations = super::common::positional_prompt_operations();
     assemble(DefinitionParts {
         id: "core.claude-code",
         display_name: "Claude Code",

--- a/src/domain/agent_definition/shipped/codex.rs
+++ b/src/domain/agent_definition/shipped/codex.rs
@@ -30,10 +30,10 @@ pub fn build() -> AgentDefinition {
         ),
         &[],
     );
-    let operations = super::common::unsupported_only_operations(
-        "Codex fresh-issue prompt is not fixture-verified",
-        "Codex fresh-PR prompt is not fixture-verified",
-    );
+    // `help.stdout` in the fixture declares `codex [OPTIONS] [PROMPT]` with
+    // `[PROMPT]  Optional user prompt to start the session`, so the prompt shape
+    // below is fixture-proven for every prompt-bearing operation.
+    let operations = super::common::positional_prompt_operations();
     assemble(DefinitionParts {
         id: "core.codex",
         display_name: "Codex CLI",

--- a/src/domain/agent_definition/shipped/common.rs
+++ b/src/domain/agent_definition/shipped/common.rs
@@ -224,30 +224,25 @@ pub fn local_only_targets(remote_reason: &str) -> TargetMatrix {
     }
 }
 
-/// Build an operation matrix where normal and resume are supported but
-/// fresh-issue and fresh-PR are unsupported with the given reasons.
-pub fn unsupported_only_operations(
-    fresh_issue_reason: &str,
-    fresh_pull_request_reason: &str,
-) -> OperationMatrix {
+/// Build an operation matrix for an agent whose help declares a single optional
+/// positional prompt that starts an interactive session.
+///
+/// Every prompt-bearing operation therefore shares one shape; only resume takes
+/// no prompt.
+pub fn positional_prompt_operations() -> OperationMatrix {
     use super::super::types::{OperationSupport, PromptShape};
+    let initial_positional = || OperationSupport {
+        supported: Support::supported(),
+        prompt: PromptShape::InitialPositional,
+    };
     OperationMatrix {
-        normal: OperationSupport {
-            supported: Support::supported(),
-            prompt: PromptShape::InitialPositional,
-        },
+        normal: initial_positional(),
         resume: OperationSupport {
             supported: Support::supported(),
             prompt: PromptShape::None,
         },
-        fresh_issue: OperationSupport {
-            supported: Support::unsupported(fresh_issue_reason),
-            prompt: PromptShape::None,
-        },
-        fresh_pull_request: OperationSupport {
-            supported: Support::unsupported(fresh_pull_request_reason),
-            prompt: PromptShape::None,
-        },
+        fresh_issue: initial_positional(),
+        fresh_pull_request: initial_positional(),
     }
 }
 

--- a/src/runtime/agent_fresh_send_tests.rs
+++ b/src/runtime/agent_fresh_send_tests.rs
@@ -178,20 +178,21 @@ fn prepared_remote_send_uses_audited_transcript_with_prompt() {
 
 #[test]
 fn unsupported_operation_and_target_preserve_declared_reasons() {
+    // Shipped agents all declare a fixture-proven prompt shape now (issue #620),
+    // so an unsupported operation is declared locally to prove the reason is
+    // carried through verbatim rather than replaced by a generic message.
     for id in ["core.codex", "core.claude-code"] {
-        let definition = definition(id);
         for operation in [Operation::FreshIssue, Operation::FreshPullRequest] {
-            let expected = definition
-                .operations
-                .support_for(operation)
-                .supported
-                .reason()
-                .unwrap_or_else(|| panic!("fixture operation must be unsupported"));
+            let mut definition = definition(id);
+            let reason = format!("{id} {operation:?} is not fixture-verified");
+            let declared = match operation {
+                Operation::FreshIssue => &mut definition.operations.fresh_issue,
+                _ => &mut definition.operations.fresh_pull_request,
+            };
+            declared.supported = Support::unsupported(&reason);
             assert_eq!(
                 fresh_send_support(&definition, operation, &local_target()),
-                Err(FreshSendRejection::Unsupported {
-                    reason: expected.to_owned()
-                })
+                Err(FreshSendRejection::Unsupported { reason })
             );
         }
     }

--- a/src/runtime/agent_launcher.rs
+++ b/src/runtime/agent_launcher.rs
@@ -69,15 +69,23 @@ pub fn write_launch_plan(
     worker_report: Option<&Path>,
 ) -> Result<PathBuf, AgentLauncherError> {
     let script_launch = script_launch_for(executable, wrapper);
+    let mut launch_path = executable.to_path_buf();
+    let mut launch_wrapper = wrapper;
     if script_launch.is_none()
         && wrapper == AgentWrapperKind::CommandScript
         && args.iter().any(argument_defeats_cmd_exe)
     {
-        return Err(AgentLauncherError::CommandScriptArgumentUnsupported);
+        match powershell_sibling_for(executable) {
+            Some(sibling) => {
+                launch_path = sibling;
+                launch_wrapper = AgentWrapperKind::PowerShellScript;
+            }
+            None => return Err(AgentLauncherError::CommandScriptArgumentUnsupported),
+        }
     }
     let payload = AgentLaunchPayload {
-        path: executable.to_path_buf(),
-        wrapper: wrapper.into(),
+        path: launch_path,
+        wrapper: launch_wrapper.into(),
         script_launch,
         args: args.to_vec(),
         environment: environment.to_vec(),
@@ -126,6 +134,22 @@ fn script_launch_for(executable: &Path, wrapper: AgentWrapperKind) -> Option<Scr
             entrypoint: plan.entrypoint().to_path_buf(),
         }
     })
+}
+
+/// The PowerShell shim npm installed alongside a `.cmd` wrapper, if present.
+///
+/// npm's `cmd-shim` emits `<name>.cmd`, `<name>.ps1`, and an extensionless
+/// shell script together for the same command, so the sibling is the same
+/// installer's shim for the same binary rather than a guessed neighbouring
+/// runtime. PowerShell parses its own command line and carries an argument
+/// containing CR/LF intact, which `cmd.exe` cannot do at all (issue #620).
+fn powershell_sibling_for(executable: &Path) -> Option<PathBuf> {
+    let extension = executable.extension()?.to_str()?;
+    if !extension.eq_ignore_ascii_case("cmd") && !extension.eq_ignore_ascii_case("bat") {
+        return None;
+    }
+    let sibling = executable.with_extension("ps1");
+    sibling.is_file().then_some(sibling)
 }
 
 /// Whether an argument cannot survive a `cmd.exe` command line.
@@ -383,7 +407,60 @@ mod tests {
     }
 
     #[test]
-    fn unmarked_command_script_refuses_a_newline_argument_instead_of_truncating() {
+    fn command_script_with_a_powershell_sibling_delivers_the_multiline_prompt() {
+        let dir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("could not create launcher fixture: {error}"));
+        let wrapper = dir.path().join("agent.cmd");
+        std::fs::write(&wrapper, b"@echo off\r\nexit /b 0\r\n")
+            .unwrap_or_else(|error| panic!("could not write launcher fixture: {error}"));
+        let sibling = dir.path().join("agent.ps1");
+        std::fs::write(&sibling, b"# npm cmd-shim sibling\r\n")
+            .unwrap_or_else(|error| panic!("could not write sibling fixture: {error}"));
+
+        let plan_path = super::write_launch_plan(
+            &wrapper,
+            AgentWrapperKind::CommandScript,
+            &[OsString::from(MULTILINE_PROMPT)],
+            &[],
+            dir.path(),
+            None,
+        )
+        .unwrap_or_else(|error| {
+            panic!("a wrapper with a PowerShell sibling must launch, got {error}")
+        });
+
+        let payload = payload_from_written_plan(&plan_path);
+        let command = command_for_payload(&payload);
+        let args = command
+            .get_args()
+            .map(std::ffi::OsStr::to_os_string)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            args[..4],
+            [
+                OsString::from("-NoLogo"),
+                OsString::from("-NoProfile"),
+                OsString::from("-NonInteractive"),
+                OsString::from("-File"),
+            ],
+            "the sibling must be launched through the existing PowerShell contract"
+        );
+        assert_eq!(
+            PathBuf::from(&args[4])
+                .file_name()
+                .and_then(|name| name.to_str()),
+            Some("agent.ps1"),
+            "the sibling shim npm installed for this same command must be used"
+        );
+        assert_eq!(
+            args[5],
+            OsString::from(MULTILINE_PROMPT),
+            "PowerShell carries a multi-line argument intact where cmd.exe cannot (issue #620)"
+        );
+    }
+
+    #[test]
+    fn command_script_without_a_powershell_sibling_refuses_a_newline_argument() {
         let dir = tempfile::tempdir()
             .unwrap_or_else(|error| panic!("could not create launcher fixture: {error}"));
         let wrapper = dir.path().join("agent.cmd");

--- a/tests/agent_local_plan.rs
+++ b/tests/agent_local_plan.rs
@@ -366,8 +366,12 @@ fn optional_boolean_none_skips_boolean_option() {
 
 #[test]
 fn unsupported_operation_emits_zero_effects() {
-    // Codex fresh_issue is unsupported by the shipped definition.
-    let definition = shipped("Codex CLI");
+    // Construct a definition with an unsupported operation. The shipped agents
+    // all support fresh-issue now (issue #620), so the rejection path is proven
+    // against a declared reason rather than against a crippled shipped agent.
+    let mut definition = shipped("Codex CLI");
+    definition.operations.fresh_issue.supported =
+        jefe::domain::agent_definition::Support::unsupported("fresh-issue not fixture-verified");
     let values = LaunchFieldValues::new();
     let request = PlanRequest {
         definition: &definition,

--- a/tests/generated_form_ui.rs
+++ b/tests/generated_form_ui.rs
@@ -53,10 +53,8 @@ fn selected_definition_generates_visible_unsupported_cells_and_fields() {
         form.operation_support(Operation::Resume).reason(),
         Some("installed Claude Code lacks required capability `resume`")
     );
-    assert_eq!(
-        form.operation_support(Operation::FreshIssue).reason(),
-        Some("Claude fresh-issue prompt is not fixture-verified")
-    );
+    // Fixture-proven positional prompt, so fresh-issue carries no reason (#620).
+    assert_eq!(form.operation_support(Operation::FreshIssue).reason(), None);
     assert_eq!(
         form.target_support(GeneratedTarget::Remote).reason(),
         Some("Claude remote/setup is not fixture-verified")

--- a/tests/issue382/fresh_send.rs
+++ b/tests/issue382/fresh_send.rs
@@ -9,9 +9,8 @@ use jefe::domain::agent_definition::{
     AgentDefinition, AgentLaunchPlan, LaunchSignatureV1, Operation, Preflight, PromptShape, Target,
 };
 use jefe::runtime::{
-    AuthorizationResult, ExecutionEvidence, FreshSendRejection, PreparationOutcome,
-    ProcessSandboxInspector, authorize_execution, fresh_send_support, prepare_execution,
-    prepare_fresh_send,
+    AuthorizationResult, ExecutionEvidence, PreparationOutcome, ProcessSandboxInspector,
+    authorize_execution, prepare_execution, prepare_fresh_send,
 };
 
 const ISSUE_PROMPT: &str = "issue prompt\nexact bytes";
@@ -102,24 +101,6 @@ fn assert_supported(definition: &AgentDefinition, operation: Operation, prompt: 
     }
 }
 
-fn assert_unsupported(definition: &AgentDefinition, operation: Operation) {
-    let target = Target::Local {
-        canonical_cwd: PathBuf::from("/srv/project"),
-    };
-    let expected = definition
-        .operations
-        .support_for(operation)
-        .supported
-        .reason()
-        .unwrap_or_else(|| panic!("fixture must declare unsupported"));
-    assert_eq!(
-        fresh_send_support(definition, operation, &target),
-        Err(FreshSendRejection::Unsupported {
-            reason: expected.to_owned()
-        })
-    );
-}
-
 pub fn assert_operation(operation: Operation) {
     let prompt = match operation {
         Operation::FreshIssue => ISSUE_PROMPT,
@@ -129,10 +110,13 @@ pub fn assert_operation(operation: Operation) {
         }
     };
 
-    for id in ["core.llxprt", "core.code-puppy"] {
+    // Every shipped agent declares a fixture-proven prompt shape (issue #620).
+    for id in [
+        "core.llxprt",
+        "core.code-puppy",
+        "core.codex",
+        "core.claude-code",
+    ] {
         assert_supported(&definition(id), operation, prompt);
-    }
-    for id in ["core.codex", "core.claude-code"] {
-        assert_unsupported(&definition(id), operation);
     }
 }

--- a/tests/issue382_behavior.rs
+++ b/tests/issue382_behavior.rs
@@ -514,6 +514,12 @@ fn assert_codex_fresh_issue_unsupported(codex: &AgentDefinition) {
     use jefe::runtime::agent_plan::{
         LaunchFieldValues, PlanOutcome, PlanRequest, plan_local_launch,
     };
+    // Shipped agents all support fresh-issue now (issue #620), so the golden
+    // proves the rejection path against a locally declared unsupported reason.
+    let mut codex = codex.clone();
+    codex.operations.fresh_issue.supported =
+        jefe::domain::agent_definition::Support::unsupported("fresh-issue not fixture-verified");
+    let codex = &codex;
     let values = LaunchFieldValues::new();
     let request = PlanRequest {
         definition: codex,


### PR DESCRIPTION
Fixes #620. Follow-up to #619.

## Why

Sending an issue to Claude Code or Codex on Windows could not work. npm installs
those CLIs as `.cmd` shims, `.cmd` wins PATHEXT resolution, and `cmd.exe`
truncates any argument at the first `0x0A` — so a multi-line issue prompt was
silently cut down to its first line.

#619 made that failure loud, but an error message is not a working feature. This
PR makes the send actually deliver the whole prompt.

## How

npm always installs a `.ps1` beside the `.cmd` for the same command (verified in
the local npm prefix: `llxprt.cmd`+`llxprt.ps1`, `ocr.cmd`+`ocr.ps1`). When a
command script would be handed an argument `cmd.exe` cannot carry, the launcher
now switches to the sibling `.ps1` and runs it via `powershell.exe`. This is not
the "guess at a neighbouring runtime" that #619 rejected — it is the other half
of the same cmd-shim pair. If no sibling exists, the existing
`CommandScriptArgumentUnsupported` error is unchanged.

Claude and Codex now declare `PromptShape::InitialPositional` for normal,
fresh-issue and fresh-pull-request operations instead of refusing them.

## Evidence

Gathered rather than assumed. Neither CLI is installed locally, so the shipped
help fixtures are the evidence source:

- Claude fixture: `Usage: claude [options] [command] [prompt]` / `prompt  Your prompt`.
  Codex fixture: `Usage: codex [OPTIONS] [PROMPT]`. Positional prompt is fixture-proven.
- **Neither CLI accepts a prompt from a file or stdin** (grep of both help
  fixtures). Temp-file and stdin delivery are impossible; argv is the only route.
- **PowerShell does not truncate multi-line arguments.** Passing a four-line
  prompt through the same CreateProcess quoting Rust's `std::process::Command`
  uses yielded `COUNT=1` with all four lines intact. The `0x0A` limit is specific
  to `cmd.exe`.
- **`-NonInteractive` does not break the interactive pane.** Piping input through
  `powershell.exe -NoLogo -NoProfile -NonInteractive -File child.ps1` showed the
  child still received stdin (`CHILD_GOT="hello-from-user"`) and
  `[Environment]::UserInteractive` stayed `True`. The flag suppresses only
  PowerShell's own prompts, which is desirable in a pane: it stops the host
  hanging on a prompt the user cannot see.

## Test changes

Six tests had used Claude/Codex as a stand-in for "an unsupported operation".
Rather than deleting that coverage, each now declares its unsupported reason
locally, mirroring the existing `unsupported_target_emits_zero_effects` pattern —
so the rejection machinery is still proven, it just no longer depends on a
shipped agent being crippled.

`dev-docs/tmux-scenarios/issue382/agent-unsupported-ui.json` asserted the exact
string `Fresh Issue: Unsupported: Claude fresh-issue prompt is not
fixture-verified`. Scenario JSON does not execute on Windows, so the Rust suite
stayed green while that file was silently stale — it would have failed in tmux
CI. It is now an `absent` assertion proving the refusal is gone. The scenario
keeps its purpose: Resume, Remote and Model remain unsupported there and still
assert `[Create disabled]`.

No new Windows `.cmd`-shim scenario: the tmux harness runs only on macos/linux
(every shipped scenario declares `macos` or `linux`, including the `windows-*`
ones), so no `.cmd`/`.ps1` shims exist there. The `-NonInteractive` question that
scenario would have answered is closed directly by the evidence above.

## Verification

- `cargo fmt --all` clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo test --workspace --all-features --no-fail-fast`: 81 suites, 0 failures
  (including the usually-flaky `psmux_attach`)

11 files, +264/-74, within the scope budget.
