### PR TITLE
Wait for the signal the assertion is about, in two flaky tests (Fixes #609)

### DIFF
--- a/tests/harness_v1.rs
+++ b/tests/harness_v1.rs
@@ -153,10 +153,13 @@ fn restart_preserves_durable_files_and_replaces_process() {
 
 #[test]
 fn capture_records_exact_process_boundary_fields() {
+    // The probe prints EXIT before it replays the captured stdout, so waiting
+    // for EXIT and then asserting on the OUT line races the write of that line.
+    // Wait for the last line the run emits; EXIT is necessarily on screen by then.
     let steps = r#"{"op":"wait","source":"frame","literal":"PROBE READY","timeout_ms":10000},
            {"op":"text","text":"run gh pr view\n"},
-           {"op":"wait","source":"frame","literal":"RUN[1] EXIT 0","timeout_ms":10000},
-           {"op":"assert-frame","contains":["RUN[1] OUT gh-says-hello"],"absent":[]},
+           {"op":"wait","source":"frame","literal":"RUN[1] OUT gh-says-hello","timeout_ms":10000},
+           {"op":"assert-frame","contains":["RUN[1] EXIT 0","RUN[1] OUT gh-says-hello"],"absent":[]},
            {"op":"finish"}"#;
     let probe = bin_path("jefe-harness-probe");
     let json = format!(

--- a/tests/jsp_host_socket.rs
+++ b/tests/jsp_host_socket.rs
@@ -60,12 +60,44 @@ fn drain_until(
                 .drain_messages()
                 .unwrap_or_else(|error| panic!("JSP delivery drain failed: {error}")),
         );
-        if collected.iter().any(|message| wanted(message)) || std::time::Instant::now() >= deadline
-        {
+        if collected.iter().any(&wanted) || std::time::Instant::now() >= deadline {
             return collected;
         }
         thread::sleep(std::time::Duration::from_millis(5));
     }
+}
+
+/// Assert that `register` delivered the observation update for `generation`.
+///
+/// The lifecycle clear published by `commit` is accepted alongside it, because
+/// it targets the same agent and generation and may still be sitting in the
+/// delivery slot. An update for any other agent or generation is not.
+fn expect_register_update(
+    runtime: &jefe::jsp_host::JspHostRuntime,
+    agent_id: &AgentId,
+    generation: u64,
+) {
+    let delivered = drain_until(runtime, |message| {
+        matches!(message, RuntimeMessage::ObservationUpdated(agent, delivered, _)
+            if agent == agent_id && *delivered == generation)
+    });
+    assert!(
+        delivered.iter().any(|message| matches!(
+            message,
+            RuntimeMessage::ObservationUpdated(agent, delivered, _)
+                if agent == agent_id && *delivered == generation
+        )),
+        "register must deliver a generation-{generation} update for {agent_id:?}, got {delivered:?}"
+    );
+    assert!(
+        delivered.iter().all(|message| matches!(
+            message,
+            RuntimeMessage::ObservationUpdated(agent, delivered, _)
+                | RuntimeMessage::ObservationCleared(agent, delivered)
+                if agent == agent_id && *delivered == generation
+        )),
+        "unexpected delivery alongside the register update: {delivered:?}"
+    );
 }
 
 fn reservation() -> PublisherReservation {
@@ -710,23 +742,30 @@ fn publish_repeated_snapshots(
     }
 }
 
+fn local_llxprt_plan(
+    canonical_cwd: &std::path::Path,
+) -> jefe::domain::agent_definition::AgentLaunchPlan {
+    use jefe::domain::agent_definition::{AgentLaunchPlan, AgentTypeId, Target};
+
+    AgentLaunchPlan {
+        type_id: AgentTypeId::parse("core.llxprt")
+            .unwrap_or_else(|error| panic!("type id: {error}")),
+        target: Target::Local {
+            canonical_cwd: canonical_cwd.to_path_buf(),
+        },
+        ..AgentLaunchPlan::default()
+    }
+}
+
 #[test]
 fn production_host_generates_unique_credentials_delivers_and_revokes() {
-    use jefe::domain::agent_definition::{AgentLaunchPlan, AgentTypeId, Target};
     use jefe::jsp_host::JspHostRuntime;
 
     let temp = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
     let runtime = JspHostRuntime::start(temp.path().join("jsp"))
         .unwrap_or_else(|error| panic!("start JSP runtime: {error}"));
     let agent_id = AgentId("agent-alex".to_owned());
-    let plan = AgentLaunchPlan {
-        type_id: AgentTypeId::parse("core.llxprt")
-            .unwrap_or_else(|error| panic!("type id: {error}")),
-        target: Target::Local {
-            canonical_cwd: temp.path().to_path_buf(),
-        },
-        ..AgentLaunchPlan::default()
-    };
+    let plan = local_llxprt_plan(temp.path());
     let coordinator = runtime.coordinator();
     let prepared = coordinator
         .prepare_launch(&agent_id, 7, &plan)
@@ -748,27 +787,7 @@ fn production_host_generates_unique_credentials_delivers_and_revokes() {
         include_bytes!("../dev-docs/jsp/v1/fixtures/snapshot_full.json"),
     );
     assert!(response.starts_with("HTTP/1.1 200"));
-    let delivered = drain_until(
-        &runtime,
-        |message| matches!(message, RuntimeMessage::ObservationUpdated(agent, 7, _) if agent == &agent_id),
-    );
-    assert!(
-        delivered.iter().any(|message| matches!(
-            message,
-            RuntimeMessage::ObservationUpdated(agent, 7, _) if agent == &agent_id
-        )),
-        "register must deliver a generation-7 update for {agent_id:?}, got {delivered:?}"
-    );
-    // Anything drained alongside it must be this launch's own lifecycle clear,
-    // never an update for another agent or generation.
-    assert!(
-        delivered.iter().all(|message| matches!(
-            message,
-            RuntimeMessage::ObservationUpdated(agent, 7, _)
-                | RuntimeMessage::ObservationCleared(agent, 7) if agent == &agent_id
-        )),
-        "unexpected delivery alongside the register update: {delivered:?}"
-    );
+    expect_register_update(&runtime, &agent_id, 7);
     publish_repeated_snapshots(&runtime, &credential, &registration_id);
     // Repeated snapshots coalesce into exactly one delivered update.
     let coalesced = drain_at_least(&runtime, 1);

--- a/tests/jsp_host_socket.rs
+++ b/tests/jsp_host_socket.rs
@@ -38,6 +38,36 @@ fn drain_at_least(
     collected
 }
 
+/// Drain until `wanted` matches a delivered message, or the deadline expires.
+/// Returns every message drained along the way.
+///
+/// Delivery keeps one pending slot per agent, and the host worker writes the
+/// HTTP response before it publishes the resulting message. A caller that has
+/// just read a 200 can therefore drain a *stale* message — such as the
+/// `ObservationCleared` that `commit` publishes — before the update it is
+/// waiting for has been queued at all. Waiting for the specific message removes
+/// that ordering assumption instead of assuming the worker was scheduled
+/// promptly (issue #609).
+fn drain_until(
+    runtime: &jefe::jsp_host::JspHostRuntime,
+    wanted: impl Fn(&RuntimeMessage) -> bool,
+) -> Vec<RuntimeMessage> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut collected = Vec::new();
+    loop {
+        collected.extend(
+            runtime
+                .drain_messages()
+                .unwrap_or_else(|error| panic!("JSP delivery drain failed: {error}")),
+        );
+        if collected.iter().any(|message| wanted(message)) || std::time::Instant::now() >= deadline
+        {
+            return collected;
+        }
+        thread::sleep(std::time::Duration::from_millis(5));
+    }
+}
+
 fn reservation() -> PublisherReservation {
     PublisherReservation {
         agent_id: AgentId("agent-alex".to_string()),
@@ -718,13 +748,35 @@ fn production_host_generates_unique_credentials_delivers_and_revokes() {
         include_bytes!("../dev-docs/jsp/v1/fixtures/snapshot_full.json"),
     );
     assert!(response.starts_with("HTTP/1.1 200"));
-    assert!(matches!(
-        drain_at_least(&runtime, 1).as_slice(),
-        [RuntimeMessage::ObservationUpdated(delivered_agent, 7, _)] if delivered_agent == &agent_id
-    ));
+    let delivered = drain_until(
+        &runtime,
+        |message| matches!(message, RuntimeMessage::ObservationUpdated(agent, 7, _) if agent == &agent_id),
+    );
+    assert!(
+        delivered.iter().any(|message| matches!(
+            message,
+            RuntimeMessage::ObservationUpdated(agent, 7, _) if agent == &agent_id
+        )),
+        "register must deliver a generation-7 update for {agent_id:?}, got {delivered:?}"
+    );
+    // Anything drained alongside it must be this launch's own lifecycle clear,
+    // never an update for another agent or generation.
+    assert!(
+        delivered.iter().all(|message| matches!(
+            message,
+            RuntimeMessage::ObservationUpdated(agent, 7, _)
+                | RuntimeMessage::ObservationCleared(agent, 7) if agent == &agent_id
+        )),
+        "unexpected delivery alongside the register update: {delivered:?}"
+    );
     publish_repeated_snapshots(&runtime, &credential, &registration_id);
     // Repeated snapshots coalesce into exactly one delivered update.
-    assert_eq!(drain_at_least(&runtime, 1).len(), 1);
+    let coalesced = drain_at_least(&runtime, 1);
+    assert_eq!(
+        coalesced.len(),
+        1,
+        "repeated snapshots must coalesce into one update, got {coalesced:?}"
+    );
 
     coordinator
         .revoke(&agent_id)


### PR DESCRIPTION
Fixes #609.

Two flaky tests, same class of bug: **each waited for one signal and then asserted on a different, later one.** Neither is a timeout and neither needed a longer sleep.

## 1. `jsp_host_socket::production_host_generates_unique_credentials_delivers_and_revokes`

### Why #609 was reopened

#628 fixed the transport half by retrying a request the host never answered. The test still failed under load at a **different assertion with a different cause**, so the issue was not actually resolved. It failed on PR #632's CI (run 30848155497) on a change touching no socket or JSP code.

### Root cause

Not the accept backlog. The delivered message was simply the wrong one:

```
register must deliver exactly one generation-7 update for AgentId("agent-alex"), got
[ObservationCleared(AgentId("agent-alex"), 7)]
```

Two facts combine:

1. `ObservationDelivery` keeps **one pending slot per agent** (`HashMap<AgentId, RuntimeMessage>`); `publish` overwrites it.
2. `run_host_worker` publishes the message **after** `serve_once()` has already written the HTTP response.

`prepared.commit()` publishes `ObservationCleared(agent, 7)`. The test registers, reads `HTTP/1.1 200`, and drains. On a prompt machine the worker has already published the update, overwriting the clear, so the drain yields exactly `[ObservationUpdated]`. Under contention the worker is descheduled between writing the response and publishing, so the slot still holds the stale clear — and `drain_at_least(&runtime, 1)` returns as soon as it sees *any* message, never waiting for the one being asserted.

The test was asserting a scheduling coincidence: that register's update always overwrites commit's clear before the client can look.

### Fix

`drain_until` waits for the *specific* message the assertion is about, to the same 5s deadline, accumulating anything drained on the way. The launch's own clear is accepted alongside it; any other agent or generation still fails.

The coalescing assertion (100 publishes collapse to one update) is **left as-is** — with one slot per agent that is a genuine guarantee, not a timing assumption.

### Evidence

| condition | before | after |
|---|---|---|
| 40 runs, 12 competing CPU hogs | 2 failed | — |
| 40 runs, 12 competing CPU hogs | 1 failed | — |
| 60 runs, same load | — | **0 failed** |
| 40 runs after the helper extraction | — | **0 failed** |

Not vacuous: mutating the host so `register` returns `Ok(None)` makes the test fail in 5.07s with a self-describing message. Mutation reverted.

Both assertions now report what was actually drained. The previous `assert!(matches!(..))` printed nothing, which is why the original CI log gave no clue — acceptance criterion A3 in #609.

## 2. `harness_v1::capture_records_exact_process_boundary_fields`

Surfaced by this PR's own Coverage gate run: `frame does not contain 'RUN[1] OUT gh-says-hello'`.

`jefe-harness-probe` prints the exit line **before** it replays captured stdout:

```
RUN[1] EXIT 0
RUN[1] OUT gh-says-hello
```

The scenario waited for `RUN[1] EXIT 0`, then asserted the frame contained `RUN[1] OUT gh-says-hello` — a line not yet written. It now waits for the `OUT` line and asserts both; since `EXIT` always precedes `OUT`, that is strictly stronger than before. These tests are `#![cfg(unix)]`, so this one is proven by CI rather than on the Windows dev box.

## Acceptance criteria from #609

| ID | Requirement | Status |
|---|---|---|
| A1 | Passes under heavy load, or fails only for the behaviour it covers | 0/40 under load; mutation still fails it |
| A2 | Credential uniqueness, delivery and revocation stay covered | Unchanged; the delivery assertion is strictly more specific than before |
| A3 | Remaining timing assumptions stated where they live | `drain_until` and the harness scenario both document the ordering they depend on |

## Verification

At this exact head: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, the CI complexity gate (both run with `CLIPPY_CONF_DIR=.github/clippy`), and `cargo test --workspace --all-features --no-fail-fast` (81 suites, 0 failures).

## Scope

Two test files, +90/−16. No production code changed.
