### PR TITLE
Stop refusing send-to-agent while the startup probe is still running (Fixes #633)

### DIFF
--- a/dev-docs/tmux-scenarios/send-to-agent-slow-probe.json
+++ b/dev-docs/tmux-scenarios/send-to-agent-slow-probe.json
@@ -1,0 +1,122 @@
+{
+  "schema": 1,
+  "name": "send-to-agent-slow-probe",
+  "platform": "macos",
+  "terminal": {
+    "cols": 160,
+    "rows": 40
+  },
+  "workspace": {
+    "mode": 448,
+    "dirs": [
+      {
+        "path": "config",
+        "mode": 448
+      },
+      {
+        "path": "work",
+        "mode": 448
+      },
+      {
+        "path": "bin",
+        "mode": 448
+      }
+    ],
+    "files": [
+      {
+        "path": "config/settings.toml",
+        "content": {
+          "utf8": "settings_schema = 2\n"
+        },
+        "mode": 384
+      },
+      {
+        "path": "bin/llxprt",
+        "content": {
+          "utf8": "#!/bin/sh\n# Issue #633: emulate the Windows npm shim, which spawns Node and takes\n# seconds to answer --version. The startup availability probe is therefore\n# still in flight when the user reaches the issue screen and presses Shift+S.\nsleep 9\nexec /bin/false\n"
+        },
+        "mode": 493
+      }
+    ],
+    "env": []
+  },
+  "steps": [
+    {
+      "op": "launch",
+      "argv": [
+        "jefe",
+        "--config",
+        "${workspace}/config"
+      ],
+      "env": [
+        {
+          "name": "PATH",
+          "value": "${workspace}/bin"
+        }
+      ],
+      "cwd": "work"
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "LLxprt Jefe",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "key",
+      "key": "i",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Issues",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "#230",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "key",
+      "key": "enter",
+      "modifiers": []
+    },
+    {
+      "op": "key",
+      "key": "s",
+      "modifiers": ["shift"]
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Send to Agent",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "assert-frame",
+      "contains": [
+        "Send to Agent"
+      ],
+      "absent": [
+        "No agents available"
+      ]
+    },
+    {
+      "op": "key",
+      "key": "escape",
+      "modifiers": []
+    },
+    {
+      "op": "key",
+      "key": "q",
+      "modifiers": ["control"]
+    },
+    {
+      "op": "finish"
+    }
+  ],
+  "secrets": []
+}

--- a/src/app_shell_key_routing.rs
+++ b/src/app_shell_key_routing.rs
@@ -220,7 +220,7 @@ fn route_app_owned(
 }
 
 fn record_unavailable(state: &mut AppState, reason: String) {
-    state.record_unavailable_action(&reason);
+    state.record_unavailable_action(reason);
 }
 
 fn rapid_quit_eligible(input_mode: InputMode) -> bool {

--- a/src/app_shell_key_routing.rs
+++ b/src/app_shell_key_routing.rs
@@ -220,7 +220,7 @@ fn route_app_owned(
 }
 
 fn record_unavailable(state: &mut AppState, reason: String) {
-    state.warning_message = Some(reason);
+    state.record_unavailable_action(&reason);
 }
 
 fn rapid_quit_eligible(input_mode: InputMode) -> bool {

--- a/src/state/action_availability.rs
+++ b/src/state/action_availability.rs
@@ -216,6 +216,75 @@ mod tests {
         assert_eq!(reason_for("prs.send-agent"), Some(NO_AGENTS_AVAILABLE));
     }
 
+    /// Issue #633: the send-agent action must not be projected `Unavailable`
+    /// merely because the async startup probe has not answered yet. The
+    /// projection is what short-circuits the key before the reducer runs, so a
+    /// pending verdict here is what makes `Shift+S` do nothing at all.
+    #[test]
+    fn send_agent_is_available_while_the_startup_probe_is_pending() {
+        let mut state = state_with_snapshot();
+        let type_id = crate::domain::shipped_agent_type(3);
+        let definition = crate::domain::agent_definition::AgentDefinition::shipped()
+            .into_iter()
+            .find(|definition| definition.id == type_id)
+            .unwrap_or_else(|| panic!("shipped_agent_type(3) must have a shipped definition"));
+
+        let mut repository = crate::domain::Repository::new(
+            crate::domain::RepositoryId("repo-1".to_string()),
+            type_id.clone(),
+            crate::domain::TypedMap::new(),
+            "Test Repo".to_string(),
+            "repo-1".to_string(),
+            std::path::PathBuf::from("/tmp/test"),
+        );
+        repository.github_repo = "owner/repo".to_string();
+        state.repositories.push(repository);
+        state.selected_repository_index = Some(0);
+
+        let mut agent = crate::domain::Agent::new(
+            crate::domain::AgentId("agent-1".to_string()),
+            crate::domain::RepositoryId("repo-1".to_string()),
+            type_id.clone(),
+            crate::domain::TypedMap::new(),
+            "My Agent".to_string(),
+            std::path::PathBuf::from("/tmp/a1"),
+        );
+        agent.type_id = type_id;
+        state.agents.push(agent);
+
+        // The probe was dispatched but has not answered: this is the state the
+        // app is in for the first seconds of every session on Windows.
+        state.agent_type_availability = vec![
+            crate::agent_status_view::AgentAvailabilityObservation::pending(
+                &definition,
+                true,
+                1,
+                crate::agent_candidate::CandidateResolution::NotFound(Vec::new()),
+            ),
+        ];
+        assert!(
+            state.available_agent_type_ids.is_empty(),
+            "fixture precondition: the compatible list is still unpopulated"
+        );
+
+        let actions = state
+            .action_registry_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.actions().to_vec())
+            .unwrap_or_default();
+        let entries = availability_entries(&state, &actions);
+        let send_agent = entries
+            .iter()
+            .find(|entry| entry.action().as_str() == "issues.send-agent")
+            .unwrap_or_else(|| panic!("issues.send-agent must be projected"));
+
+        assert!(
+            matches!(send_agent.availability(), Availability::Available),
+            "a pending probe must not refuse Shift+S, got {:?}",
+            send_agent.availability()
+        );
+    }
+
     #[test]
     fn stale_owner_generation_and_semantic_key_cannot_publish() {
         let initial = state_with_snapshot();

--- a/src/state/issues_tests_send_agent_probe.rs
+++ b/src/state/issues_tests_send_agent_probe.rs
@@ -215,3 +215,54 @@ fn unavailable_action_sets_the_issues_banner_notice() {
          the key press is not silently swallowed"
     );
 }
+
+#[test]
+fn unavailable_action_sets_the_pull_requests_banner_notice() {
+    let mut state = state_with_unprobed_agent();
+    state.screen = crate::workbench::ScreenId::PullRequests;
+
+    state.record_unavailable_action("No agents available");
+
+    assert_eq!(
+        state.prs_state.draft_notice.as_deref(),
+        Some("No agents available"),
+        "the PR screen owns its own notice band and must show the refusal there"
+    );
+    assert_eq!(
+        state.issues_state.draft_notice, None,
+        "a refusal on the PR screen must not leak into the Issues banner"
+    );
+}
+
+#[test]
+fn unavailable_action_on_other_screens_only_warns() {
+    // Screens without a notice band still surface the refusal in the status
+    // bar, and must not write a notice into a screen state they are not
+    // showing — a notice written there would appear later, out of context.
+    for screen in [
+        crate::workbench::ScreenId::Dashboard,
+        crate::workbench::ScreenId::Repositories,
+        crate::workbench::ScreenId::Actions,
+        crate::workbench::ScreenId::Errors,
+        crate::workbench::ScreenId::Terminals,
+    ] {
+        let mut state = state_with_unprobed_agent();
+        state.screen = screen;
+
+        state.record_unavailable_action("Nothing to do here");
+
+        assert_eq!(
+            state.warning_message.as_deref(),
+            Some("Nothing to do here"),
+            "{screen:?} must still surface the refusal in the status bar"
+        );
+        assert_eq!(
+            state.issues_state.draft_notice, None,
+            "{screen:?} must not write an Issues notice"
+        );
+        assert_eq!(
+            state.prs_state.draft_notice, None,
+            "{screen:?} must not write a PR notice"
+        );
+    }
+}

--- a/src/state/issues_tests_send_agent_probe.rs
+++ b/src/state/issues_tests_send_agent_probe.rs
@@ -90,6 +90,20 @@ fn not_found_observation() -> AgentAvailabilityObservation {
     AgentAvailabilityObservation::not_found(&definition_under_test(), true, 1)
 }
 
+/// An observation from a probe that answered successfully — the verdict
+/// production also records by adding the type to `available_agent_type_ids`.
+fn installed_compatible_observation() -> AgentAvailabilityObservation {
+    AgentAvailabilityObservation::new(
+        &definition_under_test(),
+        true,
+        Availability::InstalledCompatible {
+            identity: "0.10.0".to_string(),
+            capabilities: vec!["prompt-interactive".to_string()],
+            generation: 1,
+        },
+    )
+}
+
 // ── Selector: chooser eligibility must survive an unfinished probe ──────────
 
 #[test]
@@ -120,6 +134,30 @@ fn chooser_includes_agent_after_probe_error() {
         infos.len(),
         1,
         "a failed probe must not permanently disable send-to-agent for the session"
+    );
+}
+
+/// The widening must not cost the case it was built on top of: a probe that
+/// answered `InstalledCompatible` still makes the agent eligible. Guards
+/// against a future rewrite that folds success into the negative branch.
+#[test]
+fn chooser_includes_agent_after_a_successful_probe() {
+    let mut state = state_with_unprobed_agent();
+    state.agent_type_availability = vec![installed_compatible_observation()];
+    // Production records the positive verdict in both places.
+    state.available_agent_type_ids = vec![crate::domain::shipped_agent_type(3)];
+
+    let repo_id = state.selected_repository_id().cloned();
+    let infos = state.chooser_agents_for_repository(repo_id.as_ref());
+
+    assert_eq!(
+        infos.len(),
+        1,
+        "a successfully probed agent type must stay eligible"
+    );
+    assert!(
+        state.is_transient_available_for_repo(repo_id.as_ref()),
+        "a successfully probed default type must still allow a transient agent"
     );
 }
 

--- a/src/state/issues_tests_send_agent_probe.rs
+++ b/src/state/issues_tests_send_agent_probe.rs
@@ -1,0 +1,217 @@
+//! Issue #633: Send-to-Agent must not be refused while the startup agent
+//! availability probe is still in flight (or after it failed).
+//!
+//! `available_agent_type_ids` is populated only once the async startup probe
+//! reports `InstalledCompatible`. On Windows the `llxprt` npm shim takes
+//! seconds to answer, so for the first part of every session the list is
+//! empty — and it stays empty for the whole session when the probe times out.
+//! Gating the agent chooser on that list makes `Shift+S` silently refuse.
+//!
+//! This mirrors the launch-admission precedent from issues #587/#553/#575:
+//! a startup verdict cannot outlive the startup that produced it.
+
+use crate::agent_candidate::CandidateResolution;
+use crate::agent_status_view::AgentAvailabilityObservation;
+use crate::domain::agent_definition::{AgentDefinition, Availability, ProbeErrorCode};
+use crate::domain::{Agent, AgentId, Repository, RepositoryId};
+use crate::state::AppState;
+use crate::state::events::AppEvent;
+use crate::state::transition::TransitionExt;
+
+/// The shipped definition backing [`crate::domain::shipped_agent_type(3)`],
+/// which every fixture in this module uses as the agent type under test.
+fn definition_under_test() -> AgentDefinition {
+    let type_id = crate::domain::shipped_agent_type(3);
+    AgentDefinition::shipped()
+        .into_iter()
+        .find(|definition| definition.id == type_id)
+        .unwrap_or_else(|| panic!("shipped_agent_type(3) must have a shipped definition"))
+}
+
+/// A repository with one non-running agent of the type under test, in issues
+/// mode, with `available_agent_type_ids` deliberately EMPTY (the probe has not
+/// reported a compatible verdict yet).
+fn state_with_unprobed_agent() -> AppState {
+    let mut state = AppState::default();
+    let mut repository = Repository::new(
+        RepositoryId("repo-1".to_string()),
+        crate::domain::shipped_agent_type(3),
+        crate::domain::TypedMap::new(),
+        "Test Repo".to_string(),
+        "repo-1".to_string(),
+        std::path::PathBuf::from("/tmp/test"),
+    );
+    repository.github_repo = "owner/repo".to_string();
+    state.repositories.push(repository);
+    state.selected_repository_index = Some(0);
+
+    let mut agent = Agent::new(
+        AgentId("agent-1".to_string()),
+        RepositoryId("repo-1".to_string()),
+        crate::domain::shipped_agent_type(3),
+        crate::domain::TypedMap::new(),
+        "My Agent".to_string(),
+        std::path::PathBuf::from("/tmp/a1"),
+    );
+    agent.type_id = crate::domain::shipped_agent_type(3);
+    state.agents.push(agent);
+
+    state.apply(AppEvent::EnterIssuesMode).committed_pure()
+}
+
+/// An observation for a definition whose process probe has been dispatched but
+/// has not answered yet (`pending_generation` is set).
+fn pending_observation() -> AgentAvailabilityObservation {
+    AgentAvailabilityObservation::pending(
+        &definition_under_test(),
+        true,
+        1,
+        CandidateResolution::NotFound(Vec::new()),
+    )
+}
+
+/// An observation whose probe failed — e.g. the Windows npm shim exceeded the
+/// probe timeout. The executable was still resolved; only the interrogation
+/// failed.
+fn probe_error_observation() -> AgentAvailabilityObservation {
+    AgentAvailabilityObservation::new(
+        &definition_under_test(),
+        true,
+        Availability::ProbeError {
+            code: ProbeErrorCode::Agte201,
+            reason: "probe timed out".to_string(),
+            generation: 1,
+        },
+    )
+}
+
+/// An observation that definitively established the executable is absent.
+fn not_found_observation() -> AgentAvailabilityObservation {
+    AgentAvailabilityObservation::not_found(&definition_under_test(), true, 1)
+}
+
+// ── Selector: chooser eligibility must survive an unfinished probe ──────────
+
+#[test]
+fn chooser_includes_agent_while_startup_probe_is_pending() {
+    let mut state = state_with_unprobed_agent();
+    state.agent_type_availability = vec![pending_observation()];
+
+    let repo_id = state.selected_repository_id().cloned();
+    let infos = state.chooser_agents_for_repository(repo_id.as_ref());
+
+    assert_eq!(
+        infos.len(),
+        1,
+        "an agent whose type probe is still in flight must remain eligible; \
+         a pending verdict is not a negative verdict"
+    );
+}
+
+#[test]
+fn chooser_includes_agent_after_probe_error() {
+    let mut state = state_with_unprobed_agent();
+    state.agent_type_availability = vec![probe_error_observation()];
+
+    let repo_id = state.selected_repository_id().cloned();
+    let infos = state.chooser_agents_for_repository(repo_id.as_ref());
+
+    assert_eq!(
+        infos.len(),
+        1,
+        "a failed probe must not permanently disable send-to-agent for the session"
+    );
+}
+
+#[test]
+fn chooser_excludes_agent_when_probe_proved_not_found() {
+    let mut state = state_with_unprobed_agent();
+    state.agent_type_availability = vec![not_found_observation()];
+
+    let repo_id = state.selected_repository_id().cloned();
+    let infos = state.chooser_agents_for_repository(repo_id.as_ref());
+
+    assert!(
+        infos.is_empty(),
+        "a definitive NotFound verdict must still exclude the agent"
+    );
+}
+
+#[test]
+fn chooser_excludes_agent_with_no_observation_at_all() {
+    let state = state_with_unprobed_agent();
+
+    let repo_id = state.selected_repository_id().cloned();
+    let infos = state.chooser_agents_for_repository(repo_id.as_ref());
+
+    assert!(
+        infos.is_empty(),
+        "without any observation there is no evidence the type exists"
+    );
+}
+
+// ── Selector: transient availability must survive an unfinished probe ───────
+
+#[test]
+fn transient_available_while_startup_probe_is_pending() {
+    let mut state = state_with_unprobed_agent();
+    state.agent_type_availability = vec![pending_observation()];
+
+    let repo_id = state.selected_repository_id().cloned();
+    assert!(
+        state.is_transient_available_for_repo(repo_id.as_ref()),
+        "a pending probe must not hide the transient-agent chooser row"
+    );
+}
+
+#[test]
+fn transient_unavailable_when_probe_proved_not_found() {
+    let mut state = state_with_unprobed_agent();
+    state.agent_type_availability = vec![not_found_observation()];
+
+    let repo_id = state.selected_repository_id().cloned();
+    assert!(
+        !state.is_transient_available_for_repo(repo_id.as_ref()),
+        "a definitive NotFound verdict must still hide the transient row"
+    );
+}
+
+// ── Reducer: the chooser actually opens ────────────────────────────────────
+
+#[test]
+fn open_agent_chooser_opens_while_startup_probe_is_pending() {
+    let mut state = state_with_unprobed_agent();
+    state.agent_type_availability = vec![pending_observation()];
+
+    let state = state
+        .apply(AppEvent::OpenAgentChooser { metadata: vec![] })
+        .committed_pure();
+
+    assert!(
+        state.issues_state.agent_chooser.is_some(),
+        "Shift+S during the startup probe window must open the chooser, \
+         got notice {:?}",
+        state.issues_state.draft_notice
+    );
+}
+
+// ── Visibility: a refusal must reach the screen banner, not just the status bar ──
+
+#[test]
+fn unavailable_action_sets_the_issues_banner_notice() {
+    let state = state_with_unprobed_agent();
+    let mut state = state;
+    state.record_unavailable_action("No agents available");
+
+    assert_eq!(
+        state.warning_message.as_deref(),
+        Some("No agents available"),
+        "the status-bar warning must still be set"
+    );
+    assert_eq!(
+        state.issues_state.draft_notice.as_deref(),
+        Some("No agents available"),
+        "on the Issues screen the refusal must also surface in the banner so \
+         the key press is not silently swallowed"
+    );
+}

--- a/src/state/issues_tests_send_agent_probe.rs
+++ b/src/state/issues_tests_send_agent_probe.rs
@@ -201,7 +201,7 @@ fn open_agent_chooser_opens_while_startup_probe_is_pending() {
 fn unavailable_action_sets_the_issues_banner_notice() {
     let state = state_with_unprobed_agent();
     let mut state = state;
-    state.record_unavailable_action("No agents available");
+    state.record_unavailable_action("No agents available".to_string());
 
     assert_eq!(
         state.warning_message.as_deref(),
@@ -221,7 +221,7 @@ fn unavailable_action_sets_the_pull_requests_banner_notice() {
     let mut state = state_with_unprobed_agent();
     state.screen = crate::workbench::ScreenId::PullRequests;
 
-    state.record_unavailable_action("No agents available");
+    state.record_unavailable_action("No agents available".to_string());
 
     assert_eq!(
         state.prs_state.draft_notice.as_deref(),
@@ -249,7 +249,7 @@ fn unavailable_action_on_other_screens_only_warns() {
         let mut state = state_with_unprobed_agent();
         state.screen = screen;
 
-        state.record_unavailable_action("Nothing to do here");
+        state.record_unavailable_action("Nothing to do here".to_string());
 
         assert_eq!(
             state.warning_message.as_deref(),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -807,6 +807,27 @@ impl AppState {
             auth => self.apply_auth_message(auth),
         }
     }
+
+    /// Record that a key press resolved to an action the current state cannot
+    /// perform.
+    ///
+    /// The status-bar warning alone is easy to miss: on the Issues and Pull
+    /// Requests screens the eye is on the workspace banner, so a refused
+    /// `Shift+S` read as "the key did nothing" (issue #633). The same reason
+    /// is therefore mirrored into the owning screen's notice band, which is
+    /// where those screens already report `No agents available`.
+    pub fn record_unavailable_action(&mut self, reason: &str) {
+        self.warning_message = Some(reason.to_owned());
+        match self.screen {
+            ScreenId::Issues => self.issues_state.draft_notice = Some(reason.to_owned()),
+            ScreenId::PullRequests => self.prs_state.draft_notice = Some(reason.to_owned()),
+            ScreenId::Dashboard
+            | ScreenId::Repositories
+            | ScreenId::Actions
+            | ScreenId::Errors
+            | ScreenId::Terminals => {}
+        }
+    }
 }
 
 #[cfg(test)]
@@ -870,6 +891,9 @@ mod issues_tests_repo_nav;
 #[cfg(test)]
 #[path = "issues_tests_self_assignment.rs"]
 mod issues_tests_self_assignment;
+#[cfg(test)]
+#[path = "issues_tests_send_agent_probe.rs"]
+mod issues_tests_send_agent_probe;
 #[cfg(test)]
 #[path = "issues_tests_send_to_agent.rs"]
 mod issues_tests_send_to_agent;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -816,17 +816,17 @@ impl AppState {
     /// `Shift+S` read as "the key did nothing" (issue #633). The same reason
     /// is therefore mirrored into the owning screen's notice band, which is
     /// where those screens already report `No agents available`.
-    pub fn record_unavailable_action(&mut self, reason: &str) {
-        self.warning_message = Some(reason.to_owned());
+    pub fn record_unavailable_action(&mut self, reason: String) {
         match self.screen {
-            ScreenId::Issues => self.issues_state.draft_notice = Some(reason.to_owned()),
-            ScreenId::PullRequests => self.prs_state.draft_notice = Some(reason.to_owned()),
+            ScreenId::Issues => self.issues_state.draft_notice = Some(reason.clone()),
+            ScreenId::PullRequests => self.prs_state.draft_notice = Some(reason.clone()),
             ScreenId::Dashboard
             | ScreenId::Repositories
             | ScreenId::Actions
             | ScreenId::Errors
             | ScreenId::Terminals => {}
         }
+        self.warning_message = Some(reason);
     }
 }
 

--- a/src/state/selectors.rs
+++ b/src/state/selectors.rs
@@ -145,7 +145,42 @@ impl AppState {
         let remote = self
             .repository_by_id(&agent.repository_id)
             .is_some_and(|repository| repository.remote.enabled);
-        remote || self.available_agent_type_ids.contains(&agent.type_id)
+        remote || self.is_agent_type_selectable(&agent.type_id)
+    }
+
+    /// Whether an agent type may be offered as a send-to-agent target.
+    ///
+    /// `available_agent_type_ids` records types the startup probe positively
+    /// confirmed as `InstalledCompatible`. That list is empty until the async
+    /// probe answers — seconds on Windows, where the `llxprt` npm shim spawns
+    /// a Node process — and it stays empty for the rest of the session if the
+    /// probe times out, because nothing re-probes. Gating the chooser on it
+    /// alone made `Shift+S` silently refuse during that window (issue #633).
+    ///
+    /// So the gate is widened, not replaced: a positive verdict still counts,
+    /// and in addition a type whose probe is still in flight or whose probe
+    /// failed is treated as selectable, because neither outcome is evidence
+    /// the executable is absent. A definitive `NotFound` or an
+    /// `InstalledIncompatible` verdict still excludes the type.
+    ///
+    /// This mirrors launch admission (issues #587/#553/#575), which already
+    /// refuses to let a startup verdict outlive the startup that produced it.
+    #[must_use]
+    fn is_agent_type_selectable(&self, type_id: &AgentTypeId) -> bool {
+        if self.available_agent_type_ids.contains(type_id) {
+            return true;
+        }
+        self.agent_type_availability
+            .iter()
+            .find(|observation| observation.type_id() == type_id)
+            .is_some_and(|observation| {
+                observation.enabled()
+                    && (observation.pending_generation().is_some()
+                        || matches!(
+                            observation.availability(),
+                            crate::domain::agent_definition::Availability::ProbeError { .. }
+                        ))
+            })
     }
 
     #[must_use]
@@ -156,10 +191,7 @@ impl AppState {
         if repository.github_repo.trim().is_empty() {
             return false;
         }
-        repository.remote.enabled
-            || self
-                .available_agent_type_ids
-                .contains(&repository.default_type_id)
+        repository.remote.enabled || self.is_agent_type_selectable(&repository.default_type_id)
     }
 
     #[must_use]


### PR DESCRIPTION
Fixes #633.

## The symptom

On Windows, pressing `Shift+S` on the Issues screen did nothing. The send-to-agent chooser never appeared — no dialog, no error, apparently no reaction at all.

## Why it happened

The action-availability projection refuses `issues.send-agent` / `prs.send-agent` whenever no agent type is selectable:

```rust
// src/state/action_availability.rs
"issues.send-agent" | "prs.send-agent" if !agent_chooser_available(state) => Some(NO_AGENTS_AVAILABLE)
```

For a local repository, `agent_chooser_available` reduced entirely to `available_agent_type_ids.contains(type_id)`. That list is written once, in `observe_agent_types`, from `compatible_agent_type_ids(&startup.observations)` — which requires a positive `Availability::InstalledCompatible` verdict from the **async startup probe**.

Two consequences, both hit on this box:

1. The list is **empty for the first seconds of every session**. On Windows `llxprt` is an npm `.cmd` shim that spawns Node; `llxprt --version` measured ~3.5s here against a 10s probe budget. Any `Shift+S` in that window was refused.
2. If the probe times out or errors, the list stays **empty for the entire session**, because nothing re-probes. `Shift+S` then never works at all.

And because the refusal happens in the projection — *before* the reducer runs — the only feedback was `state.warning_message`, rendered as a small `WARN: No agents available` in the status bar. The Issues banner, which is where that screen already reports "No agents available", showed nothing. So the key looked dead rather than refused.

This also explains an inconsistency: `Ctrl-r` launch worked while `Shift+S` refused. Launch admission was already fixed for exactly this reason in #587/#553/#575 — "a startup verdict cannot outlive the startup that produced it" — but the chooser gate was never brought along.

## The change

**Widen the chooser gate rather than replace it** (`src/state/selectors.rs`). New `AppState::is_agent_type_selectable`:

- a positive `InstalledCompatible` verdict still counts, exactly as before;
- **additionally**, a type whose probe is still in flight, or whose probe errored, is selectable — neither outcome is evidence the executable is absent;
- a definitive `NotFound` or `InstalledIncompatible` verdict still excludes it.

Wired into `is_chooser_agent_available` and `is_transient_available_for_repo`, which are the two gates feeding `agent_chooser_available`. This is deliberately a union, not a swap: it cannot make a previously-working case stop working.

The permissiveness is safe because launch admission independently re-checks at execution time (`src/app_input/availability.rs`), so a chooser entry that turns out to be unlaunchable is refused there with a real reason instead of being silently absent from the list.

**Make refusals visible** (`src/state/mod.rs`, `src/app_shell_key_routing.rs`). New `AppState::record_unavailable_action` sets the status-bar warning as before and additionally mirrors the reason into the owning screen's notice band based on `self.screen`. A refused key press now says why, where the user is actually looking.

Creation-form gates (`modal_ops.rs`, `form_ops.rs`, the New Agent / New Repository type dropdowns) are **deliberately left strict**: offering an unverified runtime as a choice when authoring config is not the same as offering an already-configured agent as a send target.

## Tests

RED before GREEN. `src/state/issues_tests_send_agent_probe.rs` (10 behavioral tests) and one projection-level test in `src/state/action_availability.rs`:

- chooser includes the agent while the probe is pending, and after a probe error;
- chooser still excludes it on a definitive `NotFound`, and when no observation exists at all;
- transient-agent availability follows the same rule;
- `open_agent_chooser` actually opens while the probe is pending — this one failed pre-fix with `notice Some("No agents available")`, i.e. the exact reported symptom;
- `issues.send-agent` projects `Available` while pending, at the projection layer that does the short-circuiting;
- the notice reaches the Issues banner, the PR banner, and neither one on the five screens without a notice band.

Also adds the TUI scenario `dev-docs/tmux-scenarios/send-to-agent-slow-probe.json`, which installs a deliberately slow `llxprt` shim to hold the probe in flight, presses `Shift+S`, and asserts the chooser appears with no "No agents available".

## Verification

Run at this exact head: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo build --workspace --all-features --locked`, and `cargo test --workspace --all-features` — 81 suites, 0 failures.

## Review

Reviewed before opening. No blockers; the one in-scope finding (untested PR / no-op arms of `record_unavailable_action`) is fixed in the second commit. Two pre-existing problems the review surfaced were filed as follow-ups rather than expanding scope here:

- #635 — an `Err` probe-effect completion never closes the pending generation, which could leave a type pending forever.
- #636 — `RefocusPrList` never clears the PR notice, unlike `RefocusIssueList`; notice-clearing needs one lifecycle.
