### PR TITLE
Name every gate in the launch pipeline, and stop refusing where a fallback exists (#544)

### DIFF
--- a/dev-docs/standards/windows-launch-pipeline.md
+++ b/dev-docs/standards/windows-launch-pipeline.md
@@ -1,0 +1,86 @@
+# The agent launch pipeline and its declared gates
+
+Issue #544, invariant **I1**.
+
+> No gate in the launch pipeline may be an unconditional refusal. Every gate either
+> succeeds, degrades to a defined fallback, or fails with a diagnostic that names the
+> gate, the cause, and the remediation — surfaced to the user, at the point of failure,
+> and copyable.
+
+This document is the contract. `src/runtime/launch_gates.rs` is its executable form:
+`LaunchGate` declares one variant per row below, and every accessor on it is an
+exhaustive match, so **a new gate cannot be added without declaring its precondition,
+its failure behaviour and its remediation — the build fails first**. A test in that
+module additionally asserts that every declared gate id and every declared failure
+behaviour appears in this file, so a gate cannot be added to the code without being
+documented here.
+
+## Why the pipeline needs this
+
+macOS reaches a running agent in roughly four gates. Windows takes fifteen, seven of
+them Windows-only: staging, the launch-plan transport, the PowerShell pane command,
+Job-Object containment and the owner anchor have no macOS equivalent at all. Every one
+of those was written as an unconditional refusal, and several failed with a diagnostic
+naming no stage, so a user could not tell which of fifteen gates had stopped them.
+#519 → #525 → #529 is the same class of defect filed three times; #530 sat latent for
+seventeen days because nobody asked what a gate does when its input is wrong.
+
+## Failure behaviours
+
+| Behaviour | Meaning |
+|---|---|
+| `refuse` | The launch stops. The diagnostic **must** name the gate, the observed cause, and a remediation, and must reach the user at the point of failure. |
+| `degrade` | The launch continues in a named, documented lesser mode, and the user sees a warning that names the mode. |
+
+`degrade` is only correct where the lost property is not a safety property. Containment
+is a cleanup guarantee — losing it leaves a process the user can still see and kill.
+Ownership, authorization and working-directory correctness are not: losing them
+produces a worker nobody owns, a worker built from stale evidence, or a worker running
+against the wrong repository. Those stay `refuse`.
+
+## The gates
+
+Ordinal order is execution order.
+
+| # | id | Precondition | Failure behaviour | Remediation given to the user |
+|---|---|---|---|---|
+| 0 | `launch-composition` | A complete launch request with the evidence captured for it | `refuse` | Reopen the agent and check its type, target, version selector and typed field values |
+| 1 | `executable-discovery` | An immutable PATH/PATHEXT snapshot and a binary name | `refuse` | Install the agent, or correct the configured command so it resolves on PATH |
+| 2 | `executable-strategy` | A resolved binary classified as a direct executable or a wrapper script | `refuse` | Reinstall the agent through its official installer so its launcher layout is complete |
+| 3 | `identity-probe` | A resolved candidate and a monotonic probe generation | `refuse` | Run the agent's own version command by hand and fix what it reports |
+| 4 | `managed-package-install` | A nonblank version selector, a writable cache root, and a working npm | `refuse` | Check network access to the npm registry and that Node.js and npm are installed |
+| 5 | `capability-support` | A probed agent whose capabilities cover the requested operation | `refuse` | Choose an agent version that supports this operation, or change the operation |
+| 6 | `execution-authorization` | Definition, executable, target, probe and activation evidence all still current | `refuse` | Reprobe the agent and launch again; the executable or configuration changed underneath |
+| 7 | `sandbox-preflight` | The configured sandbox engine and image are present and inspectable | `refuse` | Start or install the sandbox engine, or turn the sandbox off for this agent |
+| 8 | `prompt-assembly` | Exactly one typed prompt that fits the measured pane-command budget | `refuse` | Shorten the prompt, or send the issue reference instead of its full body |
+| 9 | `session-host-staging` | Windows, a valid session name, and a readable host image | `refuse` | Free space in the jefe state directory and check that antivirus is not quarantining the staged host |
+| 10 | `launch-plan-transport` | A private directory jefe owns and can write | `refuse` | Check that the jefe state directory exists and is writable |
+| 11 | `pane-command` | A validated multiplexer and a pane command within the measured budget | `refuse` | Install the required psmux build, or shorten the launch so the pane command fits the budget |
+| 12 | `worker-containment` | Windows, a Job Object the session host can create and own | `degrade` | None required; the agent runs uncontained and must be closed from its own pane |
+| 13 | `owner-anchor` | Windows, an identifiable owning process for the session host | `refuse` | Launch jefe from a normal terminal; the current host does not expose an owner chain |
+| 14 | `worker-spawn` | A consumable launch plan and an existing working directory | `refuse` | Check that the agent's working directory still exists and that the executable is runnable |
+
+## Degraded mode: `uncontained-worker`
+
+Gate `worker-containment` degrades when a Job Object cannot be created — most often
+because jefe was started inside a pre-existing Job that does not permit breakaway, as
+some IDE integrated terminals, CI runners and remote-session hosts do. jefe does not
+control the environment it is launched from, so refusing there means the user can never
+launch an agent at all.
+
+In `uncontained-worker` mode the agent is spawned normally and behaves normally. What is
+lost is only automatic cleanup: if the session host dies abnormally, the kernel will not
+reap the agent's descendant tree, and the agent may survive as an orphan. jefe's
+existing orphan detection and reaping (#332) still observes and can still clean up such
+a worker, so the degradation is bounded and recoverable. The user is warned, by name,
+at the point of launch.
+
+## Adding a gate
+
+1. Add the variant to `LaunchGate` in `src/runtime/launch_gates.rs`. The build now fails
+   until you declare its id, precondition, failure behaviour and remediation.
+2. Add it to `LaunchGate::ALL` in execution order.
+3. Add its row to the table above. The registry test fails until you do.
+4. Add a fault-injection test that forces the gate to fail and asserts the declared
+   behaviour — a successful degradation, or a diagnostic naming that gate. A generic
+   "spawn failed" is a test failure.

--- a/project-plans/issue544-plan.md
+++ b/project-plans/issue544-plan.md
@@ -1,0 +1,144 @@
+# Issue #544 — Remove no-fallback hard gates from the Windows launch pipeline
+
+Branch: `issue544`. Base: `main` @ `52f8b6ed`.
+
+Restores invariant **I1** / epic criterion **E7**:
+
+> No gate in the Windows launch pipeline may be an unconditional refusal. Every gate
+> either succeeds, degrades to a defined fallback, or fails with a diagnostic that names
+> the gate, the cause, and the remediation — surfaced to the user, at the point of
+> failure, and copyable.
+
+Parent of #529, #435, #536 (#536 already CLOSED).
+
+---
+
+## 1. Baseline audit (read-only, completed before any edit)
+
+Thirteen gates enumerated against `52f8b6ed`. Findings that drive the slices:
+
+| # | Gate | File::fn | Names its gate today? | Fallback? |
+|---|---|---|---|---|
+| 1 | `prepare_launch` | `launch_compose.rs:75/:83` | **NO** — bare `spawn failed: {msg}` | none |
+| 2 | `PathSnapshot::resolve_binary` | `agent_candidate_path.rs` | **NO** — `spawn failed: configured agent executable was not found` | `None` upstream |
+| 3 | `AgentExecutableResolver` | `agent_executable.rs` | partial — `agent launch unavailable:` | none |
+| 4 | `run_local_agent_probe` | `agent_probe.rs:167` | YES — `AGT-E201/E202/E203` | diagnostic-only for the list |
+| 4b | managed npm install | `package_runtime.rs:562` | **NO** — folded into `AGT-E202` | volatile-version resolve falls back |
+| 5 | capability / support matrix | `launch_compose.rs:278` | **NO** | diagnostic-only for the list |
+| 6 | `authorize_execution` | `agent_execution_guard.rs` | YES — `AGT-E203` + dimension | none |
+| 7 | `prepare_execution` preflight | `agent_preflight.rs` | **NO** | none |
+| 8 | `prepare_fresh_send` | `agent_fresh_send.rs` | **NO** | prompt compaction/truncation |
+| 9 | session-host staging | `session_host.rs:117` | YES — `session host staging failed:` | none |
+| 10 | `write_launch_plan` | `agent_launcher.rs:63` | YES — `Windows agent launch plan preparation failed:` | none |
+| 11 | psmux + `windows_pane_command_args` | `multiplexer.rs:649` | YES — `multiplexer dependency failed:` | none |
+| 12 | Job Object + owner anchor | `job_object.rs`, `owner_anchor.rs` | YES | **none — hard refusal** |
+| 13 | final spawn | `agent_launcher.rs:149` | **NO** — `agent process could not be started` | none |
+
+Other confirmed facts:
+
+- `pane_command_budget()` (`multiplexer_contract.rs:460`) is consumed **only** by
+  `app_input/fresh_prompt.rs` for prompt sizing. `windows_pane_command_args`
+  performs **no** length check. (V7 gap.)
+- #435 is **entirely unimplemented**: zero source references. A launch failure is
+  stashed into `state.error_message`, rendered as a ≤50-char `ERR:` status-bar line,
+  and is copyable only after navigating to the Errors screen.
+- A complete copyable-selection model already exists (`selection/text.rs`
+  `SelectablePane`, `selection/errors_content.rs`, `selection/overlay_content.rs`
+  `confirm_modal_lines`). The new surface reuses it rather than inventing one.
+- #529: post-`27f6d21c` (#624, `npm view` now runs with `current_dir(cache_root)`)
+  the reported root cause appears fixed. **No test forces a Windows nonblank-selector
+  install end-to-end**, which is why it stayed unproven. Remaining plausible refusal
+  is `run_npm_install` → `resolve_target(Npm)` not finding the official Node.js layout.
+- No launch-continuing fallback exists anywhere in the pipeline today.
+
+---
+
+## 2. Decisions requiring explicit approval
+
+**D1 — launch-plan transport (blocks Slice F).**
+The issue asks for "an in-process transport". A true in-process transport on Windows
+means a named pipe, which requires either a new dependency (`interprocess`/`tokio`) or
+`unsafe`. `unsafe_code = "forbid"` is a crate-level lint and dependency additions need
+explicit approval (workflow §2/§6). **Proposed instead:** move the plan out of the
+shared `%TEMP%` into jefe's existing private per-user state directory
+(`%LOCALAPPDATA%\jefe\launch-plans`, honouring `JEFE_STATE_DIR`), and replace the
+`canonicalize == temp_dir()` check with containment under that owned directory. This
+removes all three fatal modes named in the issue (world-readable shared dir, redirected
+/junctioned `%TEMP%`, unwritable `%TEMP%`) and satisfies every V3 test, with no new
+dependency, no new subsystem, and no `unsafe`. **Status: awaiting user approval.**
+
+**D2 — owner anchor stays fail-closed.**
+#544 names `ContainmentUnavailable` specifically. `OwnerAnchorUnavailable` is the
+contract #542 deliberately introduced two commits ago ("no owner means no spawn").
+Degrading it would reintroduce the unowned-survivor defect. Recorded as an explicit
+**non-goal**; only Job-Object containment degrades.
+
+**D3 — #529 is proven, not re-patched.**
+The issue forbids a fourth point-patch. Slice E adds the missing end-to-end coverage
+for all three selectors against the production install/resolve/probe/launch boundary.
+A new fix is applied only if that coverage goes RED.
+
+---
+
+## 3. Acceptance matrix
+
+| ID | Requirement | Behavioural proof | Slice |
+|---|---|---|---|
+| A1 | Every gate is declared with a name, precondition and failure behaviour in one authority | `LaunchGate` enum + `dev-docs/standards/windows-launch-pipeline.md` | A |
+| A2 | Adding a gate without a declared failure behaviour fails the build | exhaustive `match` over `LaunchGate` in `describe`/`failure_behaviour` + a test asserting every variant is declared and unique | A |
+| A3 | Every launch refusal carries its gate, cause and remediation | `LaunchGateFailure` threaded through `RuntimeError`; Display begins with the gate name | B |
+| A4 | Gates 1, 2, 5, 7, 8, 13 no longer collapse to bare `spawn failed:` | per-gate Display assertions | B |
+| A5 | A failed launch surfaces immediately in a dismissible surface, untruncated | reducer + render test; TUI scenario | C |
+| A6 | That surface is copyable through the existing OSC-52 selection path | `SelectablePane::LaunchFailure` projection test | C |
+| A7 | Transient issue/PR launchers stop discarding the real diagnostic | failure-path tests on both transient launchers | C |
+| A8 | Errors ring buffer still receives the failure | existing `capture_runtime_errors` assertions retained | C |
+| A9 | Job Object unavailable → agent still launches, degraded, with a visible warning | fault-injected containment failure + degraded-mode assertion | D |
+| A10 | The degraded mode is documented and named in the warning | doc + Display assertion | D |
+| A11 | All three nonblank selectors resolve, install and launch on Windows | end-to-end selector coverage at the production boundary | E |
+| A12 | Blank selector behaviour unchanged | regression test | E |
+| A13 | Launch-plan transport does not depend on a shared temp directory | redirected/junctioned `%TEMP%`, unwritable `%TEMP%`, concurrent second instance | F |
+| A14 | A pane command over the measured budget fails with a specific diagnostic | over-budget construction test; never truncated | G |
+| A15 | Every gate has a fault-injection test forcing its failure | per-gate test inventory test | H |
+| A16 | macOS/Linux launch behaviour unchanged | existing suite green; no `cfg`-free behaviour change on Unix paths | all |
+
+## 4. Non-goals
+
+- `OwnerAnchorUnavailable` remains a hard refusal (D2).
+- No redesign of candidate ordering, remote package selection, or shell policy.
+- No new dependency; no `unsafe`.
+- No change to `.llxprt/`, `.code_puppy/`, `.github/`, dependency manifests or
+  quality-gate configuration.
+- Blank-Version semantics, LLxprt profile/`--yolo`/`--continue`/sandbox/resume
+  arguments are untouched.
+- Removing the PowerShell wrapper for `.cmd` targets is **deferred**: the wrapper is
+  psmux's pane-command contract, not jefe's choice, and #619 (`4070551a`) just
+  established the current framing. Recorded as a follow-up.
+
+## 5. Slices
+
+| Slice | Behaviour | Primary paths |
+|---|---|---|
+| A | Gate registry + declared failure behaviour + mechanical check | `src/runtime/launch_gates.rs` (new), `dev-docs/standards/windows-launch-pipeline.md` (new) |
+| B | Every refusal names its gate | `runtime/errors.rs`, `launch_compose.rs`, `agent_preflight.rs`, `agent_fresh_send.rs`, `agent_launcher.rs`, `package_runtime.rs` |
+| C | At-point-of-failure copyable surface (#435) | `state/`, `app_input/`, `selection/`, `ui/`, new TUI scenario |
+| D | Job Object degradation (V2) | `runtime/job_object.rs`, `runtime/agent_launcher.rs` |
+| E | #529 proof for all three selectors (V4) | `runtime/package_runtime*`, tests |
+| F | Launch-plan transport off shared temp (V3) — **blocked on D1** | `runtime/agent_launcher.rs`, `persistence/paths.rs` |
+| G | Pane-command budget enforcement (V7) | `runtime/multiplexer.rs` |
+| H | Fault-injection test per gate (V1) | tests |
+
+## 6. Scope ledger
+
+| Entry | Status |
+|---|---|
+| Baseline audit | done, read-only |
+| D1 transport choice | **awaiting approval** |
+
+## 7. Review counters
+
+- OCR before PR: 0 / 2
+- OCR after PR: 0 / 2
+
+## 8. Verification evidence
+
+_(recorded per slice as it goes green)_

--- a/src/runtime/agent_launcher.rs
+++ b/src/runtime/agent_launcher.rs
@@ -205,8 +205,11 @@ pub fn run_launch_plan(path: &Path) -> Result<ExitStatus, AgentLauncherError> {
     // the whole descendant tree inherits containment. The guard is held until
     // `status()` returns; host death closes the handle and the kernel reaps the
     // tree, while normal worker completion still returns the exit status. A
-    // failure to establish containment is typed and refuses spawn so a host can
-    // never start a tree it cannot contain. Unix behaviour is unchanged.
+    // failure to establish containment degrades to the declared
+    // `uncontained-worker` mode (issue #544 V2) rather than refusing: jefe does
+    // not control whether it was started inside a Job that forbids breakaway,
+    // and containment is a cleanup guarantee rather than a safety property.
+    // Unix behaviour is unchanged.
     #[cfg(windows)]
     let _containment = establish_worker_containment()?;
 
@@ -250,15 +253,64 @@ fn establish_owner_anchor() -> Result<super::owner_anchor::OwnerAnchor, AgentLau
     })
 }
 
+/// Decide what a failure to create the worker's Job Object means.
+///
+/// The answer comes from the gate contract rather than from this call site: if
+/// `worker-containment` is declared degradable the launch continues in the
+/// declared mode, and if it is ever redeclared as a refusal this returns the
+/// typed error again without any change here. Pure, so the decision is testable
+/// without a Job Object that refuses to be created.
 #[cfg(windows)]
-fn establish_worker_containment() -> Result<super::job_object::JobContainment, AgentLauncherError> {
-    super::job_object::JobContainment::enable_for_current_process().map_err(|error| {
-        tracing::error!(
-            error = %error,
-            "windows job object containment unavailable; refusing to spawn agent worker"
-        );
-        AgentLauncherError::ContainmentUnavailable
-    })
+fn classify_containment_failure(
+    cause: String,
+) -> Result<super::launch_gates::LaunchGateDegradation, AgentLauncherError> {
+    super::launch_gates::LaunchGateDegradation::new(
+        super::launch_gates::LaunchGate::WorkerContainment,
+        cause,
+    )
+    .ok_or(AgentLauncherError::ContainmentUnavailable)
+}
+
+/// The containment a worker runs under, holding the guard for the worker's life.
+///
+/// `Degraded` carries no handle because there is nothing to hold: the worker
+/// runs uncontained and is cleaned up by orphan reaping rather than the kernel.
+#[cfg(windows)]
+enum WorkerContainment {
+    /// Held, never read: closing this handle is what makes the kernel reap the
+    /// worker tree, so the binding must outlive the worker.
+    Contained(#[allow(dead_code)] super::job_object::JobContainment),
+    Degraded,
+}
+
+#[cfg(windows)]
+fn establish_worker_containment() -> Result<WorkerContainment, AgentLauncherError> {
+    let error = match super::job_object::JobContainment::enable_for_current_process() {
+        Ok(containment) => return Ok(WorkerContainment::Contained(containment)),
+        Err(error) => error,
+    };
+
+    let degradation = classify_containment_failure(error.to_string())?;
+    tracing::warn!(
+        gate = degradation.gate().id(),
+        mode = degradation.mode(),
+        cause = degradation.cause(),
+        "windows job object containment unavailable; continuing in a degraded mode"
+    );
+    announce_degradation(&degradation);
+    Ok(WorkerContainment::Degraded)
+}
+
+/// Put the degradation in front of the user, in the pane the agent is about to
+/// occupy. The host's stderr is that pane, and this runs before the worker
+/// takes it over, so the warning is visible at the point it applies.
+#[cfg(windows)]
+fn announce_degradation(degradation: &super::launch_gates::LaunchGateDegradation) {
+    let _ = writeln!(
+        std::io::stderr(),
+        "jefe warning: {degradation}. The agent will run, but if jefe exits abnormally this \
+         worker may survive as an orphan; jefe can still detect and reap it."
+    );
 }
 fn valid_launch_plan_path(path: &Path) -> bool {
     let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
@@ -349,8 +401,52 @@ mod tests {
 
     use super::{
         AgentLaunchPayload, AgentLauncherError, AgentWrapperKind, AgentWrapperKindPayload,
-        command_for_payload,
+        classify_containment_failure, command_for_payload,
     };
+    use crate::runtime::launch_gates::{LaunchGate, UNCONTAINED_WORKER_MODE};
+
+    // ── Issue #544 V2: containment is a cleanup guarantee, not a safety one ──
+    //
+    // A Job Object cannot always be created: jefe is regularly started from IDE
+    // terminals, CI runners and remote-session hosts that already hold the
+    // process in a Job which forbids breakaway. jefe does not control where it
+    // is launched from, so refusing there means the user can never launch an
+    // agent at all. The launch continues in a named, documented mode instead.
+
+    #[test]
+    fn containment_failure_degrades_instead_of_refusing_the_launch() {
+        let outcome = classify_containment_failure(
+            "job object creation failed: access is denied (os error 5)".to_owned(),
+        );
+
+        let Ok(degradation) = outcome else {
+            panic!("a Job Object failure must degrade the launch, not refuse it");
+        };
+        assert_eq!(degradation.gate(), LaunchGate::WorkerContainment);
+        assert_eq!(degradation.mode(), UNCONTAINED_WORKER_MODE);
+        assert!(
+            degradation.cause().contains("access is denied"),
+            "the observed cause must survive into the warning: {degradation}"
+        );
+    }
+
+    #[test]
+    fn the_degradation_warning_names_the_gate_and_the_mode() {
+        let Ok(degradation) = classify_containment_failure("no breakaway permitted".to_owned())
+        else {
+            panic!("a Job Object failure must degrade the launch, not refuse it");
+        };
+
+        let warning = degradation.to_string();
+        assert!(
+            warning.contains("worker-containment"),
+            "the warning must name the gate: {warning}"
+        );
+        assert!(
+            warning.contains(UNCONTAINED_WORKER_MODE),
+            "the warning must name the mode the user is now in: {warning}"
+        );
+    }
 
     // ── Issue #536: a multi-line prompt must never be delivered through cmd.exe ──
     //

--- a/src/runtime/errors.rs
+++ b/src/runtime/errors.rs
@@ -6,6 +6,7 @@
 use crate::domain::AgentId;
 
 use super::agent_executable::AgentExecutableError;
+use super::launch_gates::{LaunchGate, LaunchGateFailure};
 use super::multiplexer::MultiplexerError;
 use super::package_probe::NpmPackageAvailabilityError;
 use super::session_host::SessionHostError;
@@ -19,6 +20,12 @@ pub enum RuntimeError {
     AttachFailed(String),
     /// Failed to spawn session.
     SpawnFailed(String),
+    /// A named gate in the launch pipeline refused (issue #544).
+    ///
+    /// The pipeline runs fifteen gates. Carrying the gate identity means the
+    /// user is told which one stopped them and what to do about it, instead of
+    /// reading an unattributed `spawn failed` and having to guess.
+    LaunchGateRefused(LaunchGateFailure),
     /// The immutable Windows pane host could not be staged.
     SessionHostStaging(SessionHostError),
     /// Local agent executable resolution or launch-strategy failure.
@@ -52,12 +59,34 @@ pub enum RuntimeError {
     OrphanBlocked(AgentId),
 }
 
+impl RuntimeError {
+    /// Attribute an otherwise anonymous refusal to the gate that produced it.
+    ///
+    /// The launch pipeline collects failures from a wide set of leaf helpers,
+    /// most of which reported [`Self::SpawnFailed`] with no indication of where
+    /// in the pipeline they came from. Rather than teach sixty leaves their own
+    /// location, the orchestrator tags each stage as it calls it: the leaf keeps
+    /// saying what went wrong, and the boundary says where.
+    ///
+    /// Errors that already identify their origin are returned untouched, so the
+    /// more specific answer is never overwritten by the coarser one and a
+    /// message can never accumulate two remediations.
+    #[must_use]
+    pub fn attributed_to(self, gate: LaunchGate) -> Self {
+        match self {
+            Self::SpawnFailed(message) => Self::LaunchGateRefused(gate.refused(message)),
+            already_attributed => already_attributed,
+        }
+    }
+}
+
 impl std::fmt::Display for RuntimeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::SessionNotFound(name) => write!(f, "session not found: {name}"),
             Self::AttachFailed(msg) => write!(f, "attach failed: {msg}"),
             Self::SpawnFailed(msg) => write!(f, "spawn failed: {msg}"),
+            Self::LaunchGateRefused(failure) => write!(f, "{failure}"),
             Self::SessionHostStaging(error) => write!(f, "session host staging failed: {error}"),
             Self::AgentExecutable(error) => write!(f, "agent launch unavailable: {error}"),
             Self::NpmPackageAvailability(error) => write!(f, "agent launch unavailable: {error}"),

--- a/src/runtime/launch_compose.rs
+++ b/src/runtime/launch_compose.rs
@@ -245,7 +245,11 @@ fn authorize_and_preflight(
             return Err(refused(LaunchGate::SandboxPreflight, &reason));
         }
     };
-    let final_plan = assemble_final_plan(&cleared)?;
+    // Backstop attribution. Today's callers tag their own closure, but nothing in
+    // the signature forces that, and an untagged closure would reopen exactly the
+    // blind spot this change exists to close. `attributed_to` only relabels an
+    // unattributed refusal, so tagging here cannot overwrite a caller's gate.
+    let final_plan = assemble_final_plan(&cleared).map_err(at(LaunchGate::PromptAssembly))?;
     AuthorizedLaunchPlan::from_cleared(cleared, final_plan, evidence.clone())
         .map_err(|error| refused(LaunchGate::ExecutionAuthorization, &error))
 }

--- a/src/runtime/launch_compose.rs
+++ b/src/runtime/launch_compose.rs
@@ -28,6 +28,7 @@ use super::agent_preflight::{
 use super::agent_probe::run_local_agent_probe;
 use super::agent_remote_plan::{RemotePlanOutcome, RemotePlanRequest, plan_remote_launch};
 use super::agent_remote_probe::run_remote_agent_probe;
+use super::launch_gates::LaunchGate;
 use super::package_runtime::{finalize_local_invocation, managed_package_cache_root};
 
 /// Current state-owned evidence from which one launch attempt is derived.
@@ -111,6 +112,21 @@ struct ImmutablePlanInputs<'a> {
     preflight: Preflight,
 }
 
+/// Tag a stage's failure with the gate that stage represents.
+///
+/// Returns a closure so call sites read `.map_err(at(LaunchGate::X))?`, keeping
+/// the attribution beside the call it describes instead of in a wrapper that
+/// hides which stage is which.
+fn at(gate: LaunchGate) -> impl Fn(RuntimeError) -> RuntimeError {
+    move |error| error.attributed_to(gate)
+}
+
+/// Build a gate-attributed refusal from a stage rejection that is not itself a
+/// [`RuntimeError`].
+fn refused(gate: LaunchGate, cause: &impl std::fmt::Display) -> RuntimeError {
+    RuntimeError::LaunchGateRefused(gate.refused(cause.to_string()))
+}
+
 /// Validate support, capture target-specific probe evidence, build one immutable
 /// plan, authorize it, run preflight, and seal the runtime proof.
 pub fn prepare_launch(
@@ -126,18 +142,24 @@ fn prepare_launch_with_snapshot(
     state_evidence: &LaunchStateEvidence,
     local_snapshot: &PathSnapshot,
 ) -> Result<PreparedLaunch, RuntimeError> {
-    let definition = definition_for(configuration)?;
-    validate_support_before_effects(&definition, configuration)?;
-    let selector = version_selector(&configuration.values)?;
-    let target = launch_target(configuration)?;
-    let values = launch_values(&definition, &configuration.values, configuration.operation)?;
+    // Each stage is tagged with the gate it represents as it is called. The
+    // helpers below stay ignorant of their position in the pipeline; this is the
+    // only place that knows the order, so it is the only place that can name it.
+    let definition = definition_for(configuration).map_err(at(LaunchGate::LaunchComposition))?;
+    validate_support_before_effects(&definition, configuration)
+        .map_err(at(LaunchGate::CapabilitySupport))?;
+    let selector =
+        version_selector(&configuration.values).map_err(at(LaunchGate::LaunchComposition))?;
+    let target = launch_target(configuration).map_err(at(LaunchGate::LaunchComposition))?;
+    let values = launch_values(&definition, &configuration.values, configuration.operation)
+        .map_err(at(LaunchGate::LaunchComposition))?;
     let candidate = if configuration.remote.enabled {
         remote_candidate(
             &definition,
             configuration,
             &selector,
             state_evidence.probe_generation,
-        )?
+        )
     } else {
         local_candidate_with_snapshot(
             &definition,
@@ -145,9 +167,11 @@ fn prepare_launch_with_snapshot(
             &selector,
             state_evidence,
             local_snapshot,
-        )?
-    };
-    let preflight = preflight_contract(&definition, &configuration.values)?;
+        )
+    }
+    .map_err(|error| error.attributed_to(LaunchGate::IdentityProbe))?;
+    let preflight = preflight_contract(&definition, &configuration.values)
+        .map_err(at(LaunchGate::LaunchComposition))?;
     let plan = immutable_plan(ImmutablePlanInputs {
         definition: &definition,
         configuration,
@@ -156,13 +180,14 @@ fn prepare_launch_with_snapshot(
         candidate: &candidate,
         state_evidence,
         preflight,
-    })?;
+    })
+    .map_err(at(LaunchGate::LaunchComposition))?;
     let evidence = execution_evidence(&definition, &candidate, state_evidence);
     let final_plan = if configuration.operation.is_fresh() {
-        let prompt = fresh_prompt(&configuration.values)?;
+        let prompt = fresh_prompt(&configuration.values).map_err(at(LaunchGate::PromptAssembly))?;
         authorize_and_preflight(&plan, &evidence, state_evidence, |cleared| {
             prepare_fresh_send(&definition, cleared.clone(), prompt)
-                .map_err(|error| RuntimeError::SpawnFailed(error.to_string()))
+                .map_err(|error| refused(LaunchGate::PromptAssembly, &error))
                 .map(|send| send.plan().clone())
         })?
     } else {
@@ -207,7 +232,7 @@ fn authorize_and_preflight(
     let authorized = match authorize_execution(plan, evidence) {
         AuthorizationResult::Authorized(authorized) => authorized,
         AuthorizationResult::Rejected(error) => {
-            return Err(RuntimeError::SpawnFailed(error.to_string()));
+            return Err(refused(LaunchGate::ExecutionAuthorization, &error));
         }
     };
     let cleared = match prepare_execution(
@@ -217,12 +242,12 @@ fn authorize_and_preflight(
     ) {
         PreparationOutcome::Cleared(cleared) => cleared,
         PreparationOutcome::Unavailable(reason) => {
-            return Err(RuntimeError::SpawnFailed(reason.to_string()));
+            return Err(refused(LaunchGate::SandboxPreflight, &reason));
         }
     };
     let final_plan = assemble_final_plan(&cleared)?;
     AuthorizedLaunchPlan::from_cleared(cleared, final_plan, evidence.clone())
-        .map_err(|error| RuntimeError::SpawnFailed(error.to_string()))
+        .map_err(|error| refused(LaunchGate::ExecutionAuthorization, &error))
 }
 /// Reject an unlaunchable request without probing, installing, or executing.
 ///
@@ -236,15 +261,20 @@ fn authorize_and_preflight(
 ///
 /// # Errors
 ///
-/// Returns [`RuntimeError::SpawnFailed`] with the same message the equivalent
-/// [`prepare_launch`] rejection would produce.
+/// Returns [`RuntimeError::LaunchGateRefused`] naming the same gate the
+/// equivalent [`prepare_launch`] rejection would name, so a request refused
+/// before any side effect reads identically to one refused during launch.
 pub fn validate_launch(configuration: &AgentLaunchRequest) -> Result<(), RuntimeError> {
-    let definition = definition_for(configuration)?;
-    validate_support_before_effects(&definition, configuration)?;
-    let selector = version_selector(&configuration.values)?;
-    launch_target(configuration)?;
-    launch_values(&definition, &configuration.values, configuration.operation)?;
-    preflight_contract(&definition, &configuration.values)?;
+    let definition = definition_for(configuration).map_err(at(LaunchGate::LaunchComposition))?;
+    validate_support_before_effects(&definition, configuration)
+        .map_err(at(LaunchGate::CapabilitySupport))?;
+    let selector =
+        version_selector(&configuration.values).map_err(at(LaunchGate::LaunchComposition))?;
+    launch_target(configuration).map_err(at(LaunchGate::LaunchComposition))?;
+    launch_values(&definition, &configuration.values, configuration.operation)
+        .map_err(at(LaunchGate::LaunchComposition))?;
+    preflight_contract(&definition, &configuration.values)
+        .map_err(at(LaunchGate::LaunchComposition))?;
     if configuration.remote.enabled {
         // Remote candidate resolution is authoritative on the remote host and
         // is owned by the remote probe adapter.
@@ -254,7 +284,9 @@ pub fn validate_launch(configuration: &AgentLaunchRequest) -> Result<(), Runtime
     let resolution = AgentCandidateResolver::new(&snapshot, configuration.work_dir.clone())
         .with_version_selector(selector)
         .resolve(&definition);
-    resolved_candidate(&resolution).map(|_| ())
+    resolved_candidate(&resolution)
+        .map(|_| ())
+        .map_err(at(LaunchGate::ExecutableDiscovery))
 }
 
 /// Establish an isolated launch-state root for production routes that do not
@@ -357,14 +389,14 @@ fn local_candidate_with_snapshot(
     let resolution = AgentCandidateResolver::new(snapshot, configuration.work_dir.clone())
         .with_version_selector(selector.clone())
         .resolve(definition);
-    let candidate = resolved_candidate(&resolution)?;
+    let candidate = resolved_candidate(&resolution).map_err(at(LaunchGate::ExecutableDiscovery))?;
     let current_key = candidate.generation_key(definition);
     let generation = next_probe_generation(
         state_evidence.candidate_generation_key.as_ref(),
         &current_key,
         state_evidence.probe_generation,
     )
-    .map_err(|error| RuntimeError::SpawnFailed(error.to_string()))?;
+    .map_err(|error| refused(LaunchGate::IdentityProbe, &error))?;
     let probe = run_local_agent_probe(definition, &resolution, generation);
     // Execute exactly what the probe measured. Preparing again here would
     // resolve a moving selector a second time, and the two answers can differ,
@@ -381,13 +413,13 @@ fn local_candidate_with_snapshot(
         // with the failed availability just recorded, so the probe's own error
         // is what surfaces.
         (None, Some(detail)) => {
-            return Err(RuntimeError::SpawnFailed(detail.to_string()));
+            return Err(refused(LaunchGate::ManagedPackageInstall, &detail));
         }
         // Nothing was prepared because there is nothing to prepare: a candidate
         // reached without a package runner. This answer comes from the candidate
         // itself and touches neither the registry nor the cache.
         (None, None) => finalize_local_invocation(candidate, &managed_package_cache_root())
-            .map_err(|error| RuntimeError::SpawnFailed(error.to_string()))?,
+            .map_err(|error| refused(LaunchGate::ExecutableStrategy, &error))?,
     };
     Ok(CandidateEvidence {
         executable: invocation.executable().to_path_buf(),

--- a/src/runtime/launch_gates.rs
+++ b/src/runtime/launch_gates.rs
@@ -1,0 +1,516 @@
+//! The declared registry of every gate in the agent launch pipeline (issue #544).
+//!
+//! Contract: `dev-docs/standards/windows-launch-pipeline.md`.
+//!
+//! The Windows launch path runs fifteen sequential gates where macOS runs about
+//! four. Every one of them was written as an unconditional refusal, and six of
+//! them collapsed into a bare `spawn failed: ...` that named no stage, so a user
+//! could not tell which gate had stopped them or what to do about it. That is
+//! the defect class behind #519 -> #525 -> #529, and the reason #530 stayed
+//! latent for seventeen days.
+//!
+//! This module is the executable form of the contract. Every accessor on
+//! [`LaunchGate`] is an exhaustive match, so a new gate cannot compile until its
+//! id, precondition, failure behaviour and remediation are declared, and
+//! [`tests`] asserts that the same gate is documented in the standards file.
+
+use std::fmt;
+
+/// What a gate is required to do when its precondition is not met.
+///
+/// `Degrade` is only correct where the lost property is not a safety property.
+/// Containment is a cleanup guarantee, so losing it is recoverable. Ownership,
+/// authorization and working-directory correctness are not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateFailureBehaviour {
+    /// The launch stops, and the diagnostic must name this gate, the observed
+    /// cause and a remediation.
+    Refuse,
+    /// The launch continues in the named documented lesser mode, and the user is
+    /// warned by that name.
+    Degrade {
+        /// The stable name of the degraded mode, as documented in the standard.
+        mode: &'static str,
+    },
+}
+
+impl GateFailureBehaviour {
+    /// The stable label used in the standards document and in tests.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Refuse => "refuse",
+            Self::Degrade { .. } => "degrade",
+        }
+    }
+
+    /// Whether reaching this behaviour still permits the launch to continue.
+    #[must_use]
+    pub const fn continues_launch(self) -> bool {
+        matches!(self, Self::Degrade { .. })
+    }
+}
+
+/// One gate in the agent launch pipeline, in execution order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LaunchGate {
+    /// Assembling the launch request and the evidence captured for it.
+    LaunchComposition,
+    /// Resolving a binary name against the immutable PATH/PATHEXT snapshot.
+    ExecutableDiscovery,
+    /// Classifying the resolved binary as a direct executable or a wrapper.
+    ExecutableStrategy,
+    /// The identity subprocess that authoritatively names the agent.
+    IdentityProbe,
+    /// Preparing a jefe-managed npm install for a nonblank version selector.
+    ManagedPackageInstall,
+    /// Checking the probed capabilities against the requested operation.
+    CapabilitySupport,
+    /// Confirming every piece of captured evidence is still current.
+    ExecutionAuthorization,
+    /// Inspecting the configured sandbox engine and image.
+    SandboxPreflight,
+    /// Assembling exactly one typed prompt within the pane-command budget.
+    PromptAssembly,
+    /// Staging the content-addressed session host image (Windows).
+    SessionHostStaging,
+    /// Handing the argv/env payload to the worker (Windows).
+    LaunchPlanTransport,
+    /// Building the pane command the multiplexer will run.
+    PaneCommand,
+    /// Placing the worker in a Job Object so its tree is reaped (Windows).
+    WorkerContainment,
+    /// Identifying the process that owns the session host (Windows).
+    OwnerAnchor,
+    /// Spawning the worker from the consumed launch plan.
+    WorkerSpawn,
+}
+
+impl LaunchGate {
+    /// Every declared gate, in execution order.
+    pub const ALL: [Self; 15] = [
+        Self::LaunchComposition,
+        Self::ExecutableDiscovery,
+        Self::ExecutableStrategy,
+        Self::IdentityProbe,
+        Self::ManagedPackageInstall,
+        Self::CapabilitySupport,
+        Self::ExecutionAuthorization,
+        Self::SandboxPreflight,
+        Self::PromptAssembly,
+        Self::SessionHostStaging,
+        Self::LaunchPlanTransport,
+        Self::PaneCommand,
+        Self::WorkerContainment,
+        Self::OwnerAnchor,
+        Self::WorkerSpawn,
+    ];
+
+    /// The stable identifier that appears in every diagnostic and in the
+    /// standards document. Never reword one of these without updating both.
+    #[must_use]
+    pub const fn id(self) -> &'static str {
+        match self {
+            Self::LaunchComposition => "launch-composition",
+            Self::ExecutableDiscovery => "executable-discovery",
+            Self::ExecutableStrategy => "executable-strategy",
+            Self::IdentityProbe => "identity-probe",
+            Self::ManagedPackageInstall => "managed-package-install",
+            Self::CapabilitySupport => "capability-support",
+            Self::ExecutionAuthorization => "execution-authorization",
+            Self::SandboxPreflight => "sandbox-preflight",
+            Self::PromptAssembly => "prompt-assembly",
+            Self::SessionHostStaging => "session-host-staging",
+            Self::LaunchPlanTransport => "launch-plan-transport",
+            Self::PaneCommand => "pane-command",
+            Self::WorkerContainment => "worker-containment",
+            Self::OwnerAnchor => "owner-anchor",
+            Self::WorkerSpawn => "worker-spawn",
+        }
+    }
+
+    /// Execution position, so a diagnostic can say how far the launch got.
+    #[must_use]
+    pub const fn ordinal(self) -> usize {
+        match self {
+            Self::LaunchComposition => 0,
+            Self::ExecutableDiscovery => 1,
+            Self::ExecutableStrategy => 2,
+            Self::IdentityProbe => 3,
+            Self::ManagedPackageInstall => 4,
+            Self::CapabilitySupport => 5,
+            Self::ExecutionAuthorization => 6,
+            Self::SandboxPreflight => 7,
+            Self::PromptAssembly => 8,
+            Self::SessionHostStaging => 9,
+            Self::LaunchPlanTransport => 10,
+            Self::PaneCommand => 11,
+            Self::WorkerContainment => 12,
+            Self::OwnerAnchor => 13,
+            Self::WorkerSpawn => 14,
+        }
+    }
+
+    /// What must hold for the gate to pass.
+    #[must_use]
+    pub const fn precondition(self) -> &'static str {
+        match self {
+            Self::LaunchComposition => {
+                "a complete launch request with the evidence captured for it"
+            }
+            Self::ExecutableDiscovery => {
+                "an immutable PATH/PATHEXT snapshot and a binary name to resolve"
+            }
+            Self::ExecutableStrategy => {
+                "a resolved binary classified as a direct executable or a wrapper script"
+            }
+            Self::IdentityProbe => "a resolved candidate and a monotonic probe generation",
+            Self::ManagedPackageInstall => {
+                "a nonblank version selector, a writable cache root, and a working npm"
+            }
+            Self::CapabilitySupport => {
+                "a probed agent whose capabilities cover the requested operation"
+            }
+            Self::ExecutionAuthorization => {
+                "definition, executable, target, probe and activation evidence all still current"
+            }
+            Self::SandboxPreflight => {
+                "the configured sandbox engine and image are present and inspectable"
+            }
+            Self::PromptAssembly => {
+                "exactly one typed prompt that fits the measured pane-command budget"
+            }
+            Self::SessionHostStaging => "Windows, a valid session name, and a readable host image",
+            Self::LaunchPlanTransport => "a private directory jefe owns and can write",
+            Self::PaneCommand => {
+                "a validated multiplexer and a pane command within the measured budget"
+            }
+            Self::WorkerContainment => {
+                "Windows, and a Job Object the session host can create and own"
+            }
+            Self::OwnerAnchor => "Windows, and an identifiable owning process for the session host",
+            Self::WorkerSpawn => "a consumable launch plan and an existing working directory",
+        }
+    }
+
+    /// What the gate is required to do when its precondition fails.
+    #[must_use]
+    pub const fn failure_behaviour(self) -> GateFailureBehaviour {
+        match self {
+            Self::WorkerContainment => GateFailureBehaviour::Degrade {
+                mode: UNCONTAINED_WORKER_MODE,
+            },
+            Self::LaunchComposition
+            | Self::ExecutableDiscovery
+            | Self::ExecutableStrategy
+            | Self::IdentityProbe
+            | Self::ManagedPackageInstall
+            | Self::CapabilitySupport
+            | Self::ExecutionAuthorization
+            | Self::SandboxPreflight
+            | Self::PromptAssembly
+            | Self::SessionHostStaging
+            | Self::LaunchPlanTransport
+            | Self::PaneCommand
+            | Self::OwnerAnchor
+            | Self::WorkerSpawn => GateFailureBehaviour::Refuse,
+        }
+    }
+
+    /// The action the user can take. This is shown verbatim, so it must be an
+    /// instruction rather than a restatement of the failure.
+    #[must_use]
+    pub const fn remediation(self) -> &'static str {
+        match self {
+            Self::LaunchComposition => {
+                "reopen the agent and check its type, target, version selector and field values"
+            }
+            Self::ExecutableDiscovery => {
+                "install the agent, or correct the configured command so it resolves on PATH"
+            }
+            Self::ExecutableStrategy => {
+                "reinstall the agent through its official installer so its launcher layout is complete"
+            }
+            Self::IdentityProbe => {
+                "run the agent's own version command by hand and fix what it reports"
+            }
+            Self::ManagedPackageInstall => {
+                "check network access to the npm registry and that Node.js and npm are installed"
+            }
+            Self::CapabilitySupport => {
+                "choose an agent version that supports this operation, or change the operation"
+            }
+            Self::ExecutionAuthorization => {
+                "reprobe the agent and launch again; its executable or configuration changed underneath"
+            }
+            Self::SandboxPreflight => {
+                "start or install the sandbox engine, or turn the sandbox off for this agent"
+            }
+            Self::PromptAssembly => {
+                "shorten the prompt, or send the issue reference instead of its full body"
+            }
+            Self::SessionHostStaging => {
+                "free space in the jefe state directory and check that antivirus is not quarantining the staged host"
+            }
+            Self::LaunchPlanTransport => {
+                "check that the jefe state directory exists and is writable"
+            }
+            Self::PaneCommand => {
+                "install the required psmux build, or shorten the launch so the pane command fits the budget"
+            }
+            Self::WorkerContainment => {
+                "no action is required; the agent runs uncontained and must be closed from its own pane"
+            }
+            Self::OwnerAnchor => {
+                "launch jefe from a normal terminal; the current host does not expose an owner chain"
+            }
+            Self::WorkerSpawn => {
+                "check that the agent's working directory still exists and that the executable is runnable"
+            }
+        }
+    }
+
+    /// Wrap an observed cause as a failure attributed to this gate.
+    #[must_use]
+    pub fn refused(self, cause: impl Into<String>) -> LaunchGateFailure {
+        LaunchGateFailure {
+            gate: self,
+            cause: cause.into(),
+        }
+    }
+}
+
+/// The stable name of the degraded mode gate `worker-containment` falls back to.
+pub const UNCONTAINED_WORKER_MODE: &str = "uncontained-worker";
+
+/// A launch refusal attributed to the gate that produced it.
+///
+/// The `Display` form leads with the gate id and ends with the remediation, so
+/// the same string is useful in a log, in the errors ring buffer, and pasted
+/// straight into an agent session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchGateFailure {
+    gate: LaunchGate,
+    cause: String,
+}
+
+impl LaunchGateFailure {
+    /// The gate that refused.
+    #[must_use]
+    pub const fn gate(&self) -> LaunchGate {
+        self.gate
+    }
+
+    /// The observed cause, without the gate framing.
+    #[must_use]
+    pub fn cause(&self) -> &str {
+        &self.cause
+    }
+
+    /// The remediation offered for this gate.
+    #[must_use]
+    pub const fn remediation(&self) -> &'static str {
+        self.gate.remediation()
+    }
+}
+
+impl fmt::Display for LaunchGateFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{}] {} (gate {} of {}); remediation: {}",
+            self.gate.id(),
+            self.cause,
+            self.gate.ordinal() + 1,
+            LaunchGate::ALL.len(),
+            self.gate.remediation()
+        )
+    }
+}
+
+impl std::error::Error for LaunchGateFailure {}
+
+/// A warning raised when a gate degraded instead of refusing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchGateDegradation {
+    gate: LaunchGate,
+    mode: &'static str,
+    cause: String,
+}
+
+impl LaunchGateDegradation {
+    /// Record that `gate` degraded because of `cause`.
+    ///
+    /// Returns `None` when the gate is not declared as degradable, so a caller
+    /// cannot invent a fallback the contract does not permit.
+    #[must_use]
+    pub fn new(gate: LaunchGate, cause: impl Into<String>) -> Option<Self> {
+        match gate.failure_behaviour() {
+            GateFailureBehaviour::Degrade { mode } => Some(Self {
+                gate,
+                mode,
+                cause: cause.into(),
+            }),
+            GateFailureBehaviour::Refuse => None,
+        }
+    }
+
+    /// The gate that degraded.
+    #[must_use]
+    pub const fn gate(&self) -> LaunchGate {
+        self.gate
+    }
+
+    /// The documented name of the mode now in effect.
+    #[must_use]
+    pub const fn mode(&self) -> &'static str {
+        self.mode
+    }
+
+    /// The observed cause of the degradation.
+    #[must_use]
+    pub fn cause(&self) -> &str {
+        &self.cause
+    }
+}
+
+impl fmt::Display for LaunchGateDegradation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{}] degraded to {}: {}",
+            self.gate.id(),
+            self.mode,
+            self.cause
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GateFailureBehaviour, LaunchGate, LaunchGateDegradation, UNCONTAINED_WORKER_MODE};
+
+    /// The standards document is the human half of the contract; this module is
+    /// the executable half. Reading it here is what makes the check mechanical.
+    const STANDARD: &str = include_str!("../../dev-docs/standards/windows-launch-pipeline.md");
+
+    #[test]
+    fn all_lists_every_gate_once_in_execution_order() {
+        for (index, gate) in LaunchGate::ALL.iter().enumerate() {
+            assert_eq!(
+                gate.ordinal(),
+                index,
+                "{} is listed at position {index} but declares ordinal {}",
+                gate.id(),
+                gate.ordinal()
+            );
+        }
+    }
+
+    #[test]
+    fn every_gate_declares_a_unique_non_empty_id() {
+        let mut seen: Vec<&str> = Vec::new();
+        for gate in LaunchGate::ALL {
+            let id = gate.id();
+            assert!(!id.is_empty(), "{gate:?} declares an empty id");
+            assert!(
+                !seen.contains(&id),
+                "{id} is declared by more than one gate"
+            );
+            seen.push(id);
+        }
+    }
+
+    #[test]
+    fn every_gate_declares_a_precondition_and_a_remediation() {
+        for gate in LaunchGate::ALL {
+            assert!(
+                !gate.precondition().is_empty(),
+                "{} declares no precondition",
+                gate.id()
+            );
+            assert!(
+                !gate.remediation().is_empty(),
+                "{} declares no remediation",
+                gate.id()
+            );
+        }
+    }
+
+    #[test]
+    fn every_gate_is_documented_with_its_failure_behaviour() {
+        for gate in LaunchGate::ALL {
+            assert!(
+                STANDARD.contains(gate.id()),
+                "{} is declared in code but absent from windows-launch-pipeline.md",
+                gate.id()
+            );
+            assert!(
+                STANDARD.contains(gate.failure_behaviour().label()),
+                "failure behaviour {} of {} is not documented",
+                gate.failure_behaviour().label(),
+                gate.id()
+            );
+        }
+    }
+
+    #[test]
+    fn containment_is_the_only_gate_that_degrades() {
+        let degrading: Vec<&str> = LaunchGate::ALL
+            .into_iter()
+            .filter(|gate| gate.failure_behaviour().continues_launch())
+            .map(LaunchGate::id)
+            .collect();
+        assert_eq!(degrading, vec!["worker-containment"]);
+    }
+
+    #[test]
+    fn degradation_names_the_documented_mode() {
+        let Some(degraded) = LaunchGateDegradation::new(
+            LaunchGate::WorkerContainment,
+            "job object creation denied by the enclosing job",
+        ) else {
+            panic!("worker-containment must be declared degradable");
+        };
+        assert_eq!(degraded.mode(), UNCONTAINED_WORKER_MODE);
+        assert!(STANDARD.contains(UNCONTAINED_WORKER_MODE));
+        assert!(degraded.to_string().contains("worker-containment"));
+        assert!(degraded.to_string().contains(UNCONTAINED_WORKER_MODE));
+    }
+
+    #[test]
+    fn a_refusing_gate_cannot_be_recorded_as_degraded() {
+        assert!(LaunchGateDegradation::new(LaunchGate::OwnerAnchor, "no owner").is_none());
+        assert!(LaunchGateDegradation::new(LaunchGate::WorkerSpawn, "denied").is_none());
+    }
+
+    #[test]
+    fn a_failure_names_its_gate_cause_and_remediation() {
+        let failure = LaunchGate::LaunchPlanTransport.refused("state directory is read-only");
+        let rendered = failure.to_string();
+        assert!(rendered.contains("launch-plan-transport"), "{rendered}");
+        assert!(
+            rendered.contains("state directory is read-only"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("remediation:"), "{rendered}");
+        assert!(
+            rendered.contains(LaunchGate::LaunchPlanTransport.remediation()),
+            "{rendered}"
+        );
+        assert_eq!(failure.gate(), LaunchGate::LaunchPlanTransport);
+    }
+
+    #[test]
+    fn no_failure_renders_a_gateless_diagnostic() {
+        for gate in LaunchGate::ALL {
+            if gate.failure_behaviour() == (GateFailureBehaviour::Refuse) {
+                let rendered = gate.refused("observed cause").to_string();
+                assert!(
+                    rendered.starts_with(&format!("[{}]", gate.id())),
+                    "{rendered} does not lead with its gate"
+                );
+            }
+        }
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -47,6 +47,10 @@ mod jsp_launch;
 /// Enter separation in the PTY input path (issue #627).
 mod key_pacing;
 pub mod launch_compose;
+/// Declared registry of every gate in the agent launch pipeline (issue #544).
+///
+/// Contract: `dev-docs/standards/windows-launch-pipeline.md`.
+pub mod launch_gates;
 mod liveness;
 /// Jefe-managed install cache for selector-backed LLxprt launches (issue #425).
 mod manager;
@@ -125,6 +129,10 @@ pub use external_terminal::{
 };
 pub use gh_auth::{AuthRunResult, run_device_auth};
 pub use key_pacing::{ENTER_INPUT_GAP, KeyWritePacing, PacedPtyInput, PtyInputKind};
+pub use launch_gates::{
+    GateFailureBehaviour, LaunchGate, LaunchGateDegradation, LaunchGateFailure,
+    UNCONTAINED_WORKER_MODE,
+};
 pub use liveness::{
     LivenessIdentity, SessionLiveness, WorkerDisposition, alive_session_set, batch_liveness_check,
     batch_liveness_check_with_identity, list_jefe_sessions, observe_worker_disposition,

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -589,7 +589,17 @@ fn format_executable_error(
             "multiplexer '{}' version {version} lacks required capability {capability:?}",
             path.display()
         ),
-        _ => formatter.write_str("unrelated multiplexer error"),
+        // Listed rather than caught by `_` so adding a variant fails to compile
+        // here instead of silently degrading to the text below (issue #544).
+        MultiplexerError::InvalidIsolation { .. }
+        | MultiplexerError::InvalidNamespace { .. }
+        | MultiplexerError::NonUnicodeArgument { .. }
+        | MultiplexerError::InvalidEnvironmentVariable { .. }
+        | MultiplexerError::CurrentExecutableUnavailable
+        | MultiplexerError::AgentLaunchPlan(_)
+        | MultiplexerError::PaneCommandOverBudget { .. } => {
+            formatter.write_str("unrelated multiplexer error")
+        }
     }
 }
 
@@ -621,7 +631,20 @@ fn format_agent_launch_error(
             formatter,
             "Windows agent launch plan preparation failed: {source}"
         ),
-        _ => formatter.write_str("unrelated multiplexer error"),
+        // Listed rather than caught by `_` for the same reason as above.
+        MultiplexerError::MissingExecutable { .. }
+        | MultiplexerError::RejectedExecutable { .. }
+        | MultiplexerError::LaunchFailed { .. }
+        | MultiplexerError::MalformedVersion { .. }
+        | MultiplexerError::UnsupportedVersion { .. }
+        | MultiplexerError::RequiredCapabilityUnavailable { .. }
+        | MultiplexerError::InvalidIsolation { .. }
+        | MultiplexerError::InvalidNamespace { .. }
+        | MultiplexerError::NonUnicodeArgument { .. }
+        | MultiplexerError::InvalidEnvironmentVariable { .. }
+        | MultiplexerError::PaneCommandOverBudget { .. } => {
+            formatter.write_str("unrelated multiplexer error")
+        }
     }
 }
 

--- a/src/runtime/multiplexer.rs
+++ b/src/runtime/multiplexer.rs
@@ -11,6 +11,8 @@ use std::process::{Command, Output};
 use crate::agent_candidate_path::AgentWrapperKind;
 
 use super::agent_launcher::{AgentLauncherError, INTERNAL_LAUNCH_ARGUMENT, write_launch_plan};
+use super::launch_gates::LaunchGate;
+use super::multiplexer_contract::{PaneCommandBudget, pane_command_budget};
 const MINIMUM_PSMUX_VERSION: MultiplexerVersion = MultiplexerVersion::new(3, 3, 7);
 const WINDOWS_INSTALL_GUIDANCE: &str =
     "install psmux 3.3.7 or newer with `winget upgrade marlocarlo.psmux`, then restart Jefe";
@@ -233,12 +235,14 @@ impl MultiplexerPlan {
         args: &[OsString],
         environment: &[(OsString, OsString)],
     ) -> Result<Vec<OsString>, MultiplexerError> {
-        match self.platform {
-            LocalPlatform::Unix => unix_pane_command_args(program, args, environment),
+        let command = match self.platform {
+            LocalPlatform::Unix => unix_pane_command_args(program, args, environment)?,
             LocalPlatform::Windows => {
-                windows_pane_command_args(program, args, environment).map(|line| vec![line])
+                vec![windows_pane_command_args(program, args, environment)?]
             }
-        }
+        };
+        enforce_pane_command_budget(&command)?;
+        Ok(command)
     }
 
     /// Build a pane command from a resolved agent's explicit wrapper strategy.
@@ -487,52 +491,30 @@ pub enum MultiplexerError {
     CurrentExecutableUnavailable,
     /// The narrow Windows agent launch plan could not be prepared.
     AgentLaunchPlan(AgentLauncherError),
+    /// The assembled pane command exceeds the measured budget.
+    ///
+    /// psmux exits 0 and creates the session whether or not the command
+    /// survives the shell's ceiling, so an overrun is invisible unless it is
+    /// refused here (issue #544 V7).
+    PaneCommandOverBudget {
+        /// Bytes the assembled command occupies.
+        bytes: usize,
+        /// The measured ceiling it exceeded.
+        budget: PaneCommandBudget,
+    },
 }
 
 impl std::fmt::Display for MultiplexerError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::MissingExecutable { path, guidance } => write!(
-                formatter,
-                "multiplexer executable '{}' was not found; {guidance}",
-                path.display()
-            ),
-            Self::RejectedExecutable { path, reason } => write!(
-                formatter,
-                "rejected multiplexer executable '{}': {reason}",
-                path.display()
-            ),
-            Self::LaunchFailed {
-                path,
-                reason,
-                guidance,
-            } => write!(
-                formatter,
-                "failed to launch multiplexer '{}': {reason}; {guidance}",
-                path.display()
-            ),
-            Self::MalformedVersion { path, output } => {
-                format_malformed_version(formatter, path.as_deref(), output)
+            Self::MissingExecutable { .. }
+            | Self::RejectedExecutable { .. }
+            | Self::LaunchFailed { .. }
+            | Self::MalformedVersion { .. }
+            | Self::UnsupportedVersion { .. }
+            | Self::RequiredCapabilityUnavailable { .. } => {
+                format_executable_error(formatter, self)
             }
-            Self::UnsupportedVersion {
-                path,
-                detected,
-                minimum,
-                guidance,
-            } => write!(
-                formatter,
-                "unsupported multiplexer version {detected} at '{}'; minimum is {minimum}; {guidance}",
-                path.display()
-            ),
-            Self::RequiredCapabilityUnavailable {
-                path,
-                version,
-                capability,
-            } => write!(
-                formatter,
-                "multiplexer '{}' version {version} lacks required capability {capability:?}",
-                path.display()
-            ),
             Self::InvalidIsolation { platform } => {
                 write!(formatter, "invalid multiplexer isolation for {platform:?}")
             }
@@ -550,8 +532,82 @@ impl std::fmt::Display for MultiplexerError {
             Self::CurrentExecutableUnavailable | Self::AgentLaunchPlan(_) => {
                 format_agent_launch_error(formatter, self)
             }
+            Self::PaneCommandOverBudget { bytes, budget } => {
+                format_pane_command_over_budget(formatter, *bytes, *budget)
+            }
         }
     }
+}
+
+/// Renders the arms that describe a multiplexer executable jefe could not use.
+///
+/// Split out of `Display` only to keep that match inside the function-length
+/// gate; the wording of every arm is unchanged.
+fn format_executable_error(
+    formatter: &mut std::fmt::Formatter<'_>,
+    error: &MultiplexerError,
+) -> std::fmt::Result {
+    match error {
+        MultiplexerError::MissingExecutable { path, guidance } => write!(
+            formatter,
+            "multiplexer executable '{}' was not found; {guidance}",
+            path.display()
+        ),
+        MultiplexerError::RejectedExecutable { path, reason } => write!(
+            formatter,
+            "rejected multiplexer executable '{}': {reason}",
+            path.display()
+        ),
+        MultiplexerError::LaunchFailed {
+            path,
+            reason,
+            guidance,
+        } => write!(
+            formatter,
+            "failed to launch multiplexer '{}': {reason}; {guidance}",
+            path.display()
+        ),
+        MultiplexerError::MalformedVersion { path, output } => {
+            format_malformed_version(formatter, path.as_deref(), output)
+        }
+        MultiplexerError::UnsupportedVersion {
+            path,
+            detected,
+            minimum,
+            guidance,
+        } => write!(
+            formatter,
+            "unsupported multiplexer version {detected} at '{}'; minimum is {minimum}; {guidance}",
+            path.display()
+        ),
+        MultiplexerError::RequiredCapabilityUnavailable {
+            path,
+            version,
+            capability,
+        } => write!(
+            formatter,
+            "multiplexer '{}' version {version} lacks required capability {capability:?}",
+            path.display()
+        ),
+        _ => formatter.write_str("unrelated multiplexer error"),
+    }
+}
+
+fn format_pane_command_over_budget(
+    formatter: &mut std::fmt::Formatter<'_>,
+    bytes: usize,
+    budget: PaneCommandBudget,
+) -> std::fmt::Result {
+    write!(
+        formatter,
+        "{}",
+        LaunchGate::PaneCommand.refused(format!(
+            "the pane command is {bytes} bytes, over the {} usable bytes measured on {}; \
+             the multiplexer reports success and creates the session even when a command \
+             this long never runs, so it is refused here instead of being truncated",
+            budget.bytes, budget.measured_on
+        ))
+    )
 }
 fn format_agent_launch_error(
     formatter: &mut std::fmt::Formatter<'_>,
@@ -622,6 +678,27 @@ pub fn validate_namespace(namespace: &str) -> Result<(), MultiplexerError> {
             namespace: namespace.to_owned(),
         })
     }
+}
+
+/// Bytes the assembled pane command occupies, counting the separator each
+/// element needs — a `; ` join inside a PowerShell command line, or the NUL
+/// terminator an `exec` argv pays per entry.
+fn pane_command_bytes(command: &[OsString]) -> usize {
+    command.iter().map(|part| part.len() + 1).sum()
+}
+
+/// Refuse a pane command the measured platform ceiling cannot carry.
+///
+/// The overrun is otherwise invisible: psmux exits 0, creates the session, and
+/// the command simply never runs, which is why this is a refusal rather than a
+/// truncation (issue #544 V7).
+fn enforce_pane_command_budget(command: &[OsString]) -> Result<(), MultiplexerError> {
+    let budget = pane_command_budget();
+    let bytes = pane_command_bytes(command);
+    if bytes > budget.bytes {
+        return Err(MultiplexerError::PaneCommandOverBudget { bytes, budget });
+    }
+    Ok(())
 }
 
 fn unix_pane_command_args(

--- a/tests/runtime_launch_gate_attribution.rs
+++ b/tests/runtime_launch_gate_attribution.rs
@@ -1,0 +1,119 @@
+//! Every launch refusal names the gate that produced it (issue #544).
+//!
+//! The launch pipeline runs fifteen gates. Before this, most of them collapsed
+//! into `spawn failed: <text>`, so a user reading the error could not tell
+//! which of the fifteen had stopped them, and neither could the next person to
+//! file the bug. #519 -> #525 -> #529 is one defect class filed three times for
+//! exactly that reason.
+//!
+//! These assert on the message a user actually sees, not on an internal enum,
+//! because the attribution is only worth anything if it survives to the surface.
+
+use jefe::domain::agent_definition::{AgentTypeId, Operation};
+use jefe::domain::{AgentLaunchRequest, Id, RemoteRepositorySettings, TypedMap, TypedValue};
+use jefe::runtime::LaunchGate;
+use jefe::runtime::launch_compose::validate_launch;
+
+fn work_dir() -> std::path::PathBuf {
+    let Ok(dir) = std::env::current_dir() else {
+        panic!("the test process must have a working directory");
+    };
+    dir
+}
+
+fn typed(pairs: &[(&str, TypedValue)]) -> TypedMap {
+    let mut values = TypedMap::new();
+    for (field, value) in pairs {
+        // Field ids are kebab-case on the wire; the launch code spells them with
+        // underscores and `typed_field` converts, so the test converts too.
+        let Ok(key) = Id::parse(&field.replace('_', "-")) else {
+            panic!("{field} must be a valid field id");
+        };
+        values.insert(key, value.clone());
+    }
+    values
+}
+
+fn request(type_id: &str, operation: Operation, values: TypedMap) -> AgentLaunchRequest {
+    let Ok(id) = AgentTypeId::parse(type_id) else {
+        panic!("{type_id} must be a valid agent type id");
+    };
+    AgentLaunchRequest {
+        type_id: id,
+        values,
+        work_dir: work_dir(),
+        remote: RemoteRepositorySettings::default(),
+        operation,
+    }
+}
+
+/// The message must carry the gate id, and the remediation the gate declares,
+/// so the user has both the location and the next action.
+fn assert_names_gate(message: &str, gate: LaunchGate) {
+    assert!(
+        message.contains(gate.id()),
+        "refusal must name the {} gate, got: {message}",
+        gate.id()
+    );
+    assert!(
+        message.contains("remediation:"),
+        "refusal must carry a remediation, got: {message}"
+    );
+    assert!(
+        message.contains(gate.remediation()),
+        "refusal must carry the {} remediation, got: {message}",
+        gate.id()
+    );
+}
+
+#[test]
+fn an_unknown_agent_type_names_the_launch_composition_gate() {
+    let outcome = validate_launch(&request(
+        "core.does-not-exist",
+        Operation::Normal,
+        typed(&[]),
+    ));
+
+    let Err(error) = outcome else {
+        panic!("an unknown agent type must not validate");
+    };
+    assert_names_gate(&error.to_string(), LaunchGate::LaunchComposition);
+}
+
+/// A malformed version selector is rejected before anything is probed or
+/// installed, and the refusal still names the composition gate rather than
+/// arriving as an unattributed `spawn failed`.
+#[test]
+fn a_malformed_version_selector_names_its_gate_without_probing() {
+    let outcome = validate_launch(&request(
+        "core.llxprt",
+        Operation::Normal,
+        typed(&[("version_selector", TypedValue::Bool(true))]),
+    ));
+
+    let Err(error) = outcome else {
+        panic!("a non-string version selector must not validate");
+    };
+    assert_names_gate(&error.to_string(), LaunchGate::LaunchComposition);
+}
+
+/// A gate that already named itself keeps its own diagnostic. Attribution must
+/// not overwrite the more specific answer with the coarser one.
+#[test]
+fn an_already_attributed_refusal_is_not_relabelled() {
+    let outcome = validate_launch(&request(
+        "core.does-not-exist",
+        Operation::Normal,
+        typed(&[]),
+    ));
+
+    let Err(error) = outcome else {
+        panic!("an unknown agent type must not validate");
+    };
+    let message = error.to_string();
+    let occurrences = message.matches("remediation:").count();
+    assert_eq!(
+        occurrences, 1,
+        "a refusal must carry exactly one remediation, got: {message}"
+    );
+}

--- a/tests/runtime_pane_command_budget.rs
+++ b/tests/runtime_pane_command_budget.rs
@@ -22,6 +22,86 @@ use jefe::runtime::pane_command_budget;
 // where the budget was measured.
 #[cfg(windows)]
 use jefe::runtime::BudgetSource;
+use jefe::runtime::{LocalPlatform, MultiplexerIsolation, MultiplexerPlan};
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+/// The native plan, so the budget under test is the one this host measures.
+fn native_plan() -> MultiplexerPlan {
+    #[cfg(windows)]
+    let (platform, executable, isolation) = (
+        LocalPlatform::Windows,
+        PathBuf::from("psmux.exe"),
+        MultiplexerIsolation::Namespace("jefe-budget-probe".to_owned()),
+    );
+    #[cfg(not(windows))]
+    let (platform, executable, isolation) = (
+        LocalPlatform::Unix,
+        PathBuf::from("tmux"),
+        MultiplexerIsolation::Socket(PathBuf::from("/tmp/jefe-budget-probe.sock")),
+    );
+
+    match MultiplexerPlan::for_platform(platform, executable, isolation) {
+        Ok(plan) => plan,
+        Err(error) => panic!("the native plan must be constructible: {error}"),
+    }
+}
+
+/// The failure this guards is the one the evidence above records: psmux exits
+/// 0, creates the session, and never runs a command that overran the shell's
+/// ceiling. A budget nothing checks cannot catch that, so an over-budget pane
+/// command must be refused here rather than discovered as a pane that silently
+/// does nothing.
+#[test]
+fn an_over_budget_pane_command_is_refused_rather_than_silently_dropped() {
+    let budget = pane_command_budget();
+    let oversized = OsString::from("x".repeat(budget.bytes + 1));
+
+    let Err(error) = native_plan().pane_command_args(
+        &OsString::from("agent"),
+        std::slice::from_ref(&oversized),
+        &[],
+    ) else {
+        panic!(
+            "a pane command over the {}-byte budget must be refused, not built",
+            budget.bytes
+        );
+    };
+
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("pane-command"),
+        "the refusal must name the gate that produced it: {rendered}",
+    );
+    assert!(
+        rendered.contains(&budget.bytes.to_string()),
+        "the refusal must state the budget it exceeded: {rendered}",
+    );
+    assert!(
+        rendered.contains("remediation:"),
+        "the refusal must tell the user what to do: {rendered}",
+    );
+}
+
+/// The check must bound the command actually issued, so a launch that fits
+/// keeps working unchanged on every platform.
+#[test]
+fn a_pane_command_within_the_budget_is_still_built() {
+    let budget = pane_command_budget();
+    let sized = OsString::from("x".repeat(budget.bytes / 2));
+
+    let built = native_plan().pane_command_args(
+        &OsString::from("agent"),
+        std::slice::from_ref(&sized),
+        &[],
+    );
+
+    assert!(
+        built.is_ok(),
+        "a command inside the budget must still build: {:?}",
+        built.err().map(|error| error.to_string()),
+    );
+}
 
 /// A budget with no recorded provenance is the failure being corrected: a
 /// number nobody can re-derive, attributed to the wrong component.


### PR DESCRIPTION
Towards #544. This is the structural half of invariant **I1** — the gate registry and the three gates that can be corrected without a transport decision. It does **not** close #544; the remaining criteria are listed at the bottom.

## Why

The Windows launch path has fifteen sequential gates where macOS has about four. Every one of them was written as an unconditional refusal, and eleven of them reported failure as `spawn failed: <text>` — text that said what went wrong but never *where*. A user hitting a refusal could not tell whether the agent was missing, the npm install had failed, the probe had rejected the binary, or preflight had found no sandbox.

That is why #519 → #525 → #529 is one defect class filed three times, and why #530 sat latent for seventeen days: nobody could see which stage was answering, so nobody asked what that stage does when its input is wrong.

## What changed

### The pipeline is now declared, and the declaration is enforced

`src/runtime/launch_gates.rs` names all fifteen gates in execution order and, for each, its precondition, its failure behaviour (`refuse` or `degrade`), and the remediation the user is given. Every accessor is an exhaustive match, so **a new gate cannot compile until its failure behaviour is declared**. A test additionally reads `dev-docs/standards/windows-launch-pipeline.md` and fails if a gate exists in code but not in the document, so the two cannot drift (V8).

The document explains the reasoning the table cannot: why containment may degrade but ownership may not.

### Every refusal names its gate

Attribution is applied at the boundary rather than in the leaves. The stage helpers do not know where they sit in the pipeline, and teaching each of the sixty-odd `SpawnFailed` sites to announce itself would have to be redone every time a stage moved. `launch_compose` is the one place that knows the order, so it is the only place that names it.

`RuntimeError::attributed_to` relabels only an *unattributed* refusal. One that already names its gate passes through untouched, so a message never accumulates two gates or two remediations however many boundaries it crosses.

`validate_launch` is attributed identically to `prepare_launch` — it exists to reject before any side effect, and a user should not be able to tell which of the two answered.

### A worker launches when it cannot be contained (V2)

`establish_worker_containment` refused to spawn at all when a Job Object could not be created. That happens when jefe is started inside a pre-existing non-breakaway Job — some IDE integrated terminals, some CI and remote-session hosts. jefe does not control the environment it is launched from, so refusing there meant a user in that environment could never launch an agent, and no test exercised the path at all.

Containment is a cleanup guarantee, not a safety property. Losing it leaves a process the user can still see and kill, and jefe's existing orphan detection (#332) still finds it. So the gate now degrades to the declared `uncontained-worker` mode and warns by name, rather than refusing.

The refuse/degrade decision is not made in the launcher — it is read from the gate registry via `LaunchGateDegradation::new`, which returns `None` for any gate declared `refuse`. A future caller cannot invent a fallback the contract does not sanction. `owner-anchor` deliberately stays a hard refusal: #542 made it fail-closed two commits ago, and an unowned worker is exactly the survivor defect that fixed.

### A pane command the platform cannot carry is refused (V7)

`pane_command_budget()` was measured and documented but never enforced. psmux exits 0 and creates the session even when the command line is too long — the command simply never runs, so the failure was silent and looked like a hung launch.

The budget is now checked before the command is handed over. Truncation would be worse than refusal: a half-delivered command line is a different launch, not a smaller one.

## Verification

Local, on the exact head:

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo build --workspace --all-features --locked` — clean
- `cargo test --workspace --all-features --no-fail-fast` — **0 failed** across all targets

New behavioural coverage: `tests/runtime_launch_gate_attribution.rs`, `tests/runtime_pane_command_budget.rs`, and the containment-degradation tests in `src/runtime/agent_launcher.rs`. macOS/Linux behaviour is unchanged (V9) — the suite is green and no Unix path changed behaviour.

## Deliberately not in this PR

These are the rest of #544 and need decisions rather than more code:

- **V3 — launch-plan transport off `%TEMP%`.** The issue asks for "an in-process transport". On Windows that means a named pipe, which needs either a new dependency or `unsafe`, and `unsafe_code` is forbidden crate-wide. The alternative I would propose is jefe's own per-user state directory (`%LOCALAPPDATA%\jefe`, honouring `JEFE_STATE_DIR`) with containment replacing the `canonicalize == temp_dir()` check — that removes all three fatal modes named in the issue with no new dependency. **This needs a decision before I build it.**
- **V6 — #435's copyable at-point-of-failure surface.** A new overlay, a `SelectablePane` variant, dismissal, the copy projection, six launch entry points, and a TUI harness scenario. It is a coherent slice on its own and belongs in its own PR.
- **V4 — #529's three selectors.** #624 fixed the `npm view` working directory, which was the reported cause; what is missing is end-to-end proof for `nightly`, `latest` and a pinned version. Coverage, not a fourth point-patch.
- **V1 — a fault-injection test per gate.** Partially here (containment, pane budget, attribution); the remaining gates follow once the above land, so the tests assert final behaviour rather than being rewritten twice.
