### PR TITLE
Give the session one place that knows where it has been (Fixes #386)

### DIFF
--- a/dev-docs/standards/architecture.md
+++ b/dev-docs/standards/architecture.md
@@ -298,8 +298,15 @@ The following are normative:
 - **The stack is bounded at 32 and is never persisted.**
 - **Rooting a session is total.** Both the route and the initial focus come from
   compiled tables (`workbench::screens::route_of`, `::initial_focus`), so
-  starting a session has no failure mode at the moment it is needed. Tests hold
-  those tables to the descriptors, so a screen that drifts fails the build.
+  starting a session has no failure mode at the moment it is needed. Those
+  tables duplicate what the descriptors declare, and
+  `route_agrees_with_every_descriptor` and `initial_focus_agrees_with_every_descriptor`
+  are what keep the two from drifting; a screen that drifts fails those tests.
+
+`ScreenInstance` currently carries the descriptor-declared panel focus as
+navigation's own record. The per-mode focus fields (`pane_focus`,
+`issues_state.issue_focus`, and their siblings) remain the authority for what is
+actually focused; relocating them into the instance is a separate cutover.
 
 ## The Pure-Views Pattern
 

--- a/dev-docs/standards/architecture.md
+++ b/dev-docs/standards/architecture.md
@@ -253,6 +253,54 @@ or a validated `local.*` identity — while screen *routing* stays the closed
 `ScreenId` enum, so every routable screen still has a compiled renderer and an
 exhaustive match.
 
+## Route and navigation ownership
+
+`state::navigation::NavState` is the sole runtime authority for which screen the
+session is on. There is no screen field anywhere else, and nothing assigns a
+screen: every change goes through `state::navigation::reduce_navigation`, which
+is pure — it takes the navigation state, the registry, and one message, and
+returns the next state plus what the caller must do about the instances that
+entered or left. It performs no I/O and stages no effect of its own.
+
+Three verbs on `AppState` are the only way in, and each is one call into the
+reducer:
+
+| Verb | Meaning |
+|---|---|
+| `enter_screen` | Open a screen, suspending the current one so Back returns to it. |
+| `switch_screen` | Take the place of the current screen without stacking on it. |
+| `leave_screen` | Go back if there is somewhere to go back to, otherwise go home. |
+
+The following are normative:
+
+- **A target is constructed before anything is suspended or disposed.** A
+  refused navigation returns the state it was given; there is no partially
+  applied navigation and no half-mutated stack.
+- **Routes are declared, not asserted.** A `RouteDeclaration` is derived from a
+  screen descriptor's `route` and `activation` (`workbench::route`), so a route
+  and the screen it reaches cannot drift apart, and a route no descriptor
+  declares cannot be navigated to.
+- **Activations are closed and non-secret.** `ActivationValue` mirrors
+  `ActivationKind` exactly; there is no secret variant, no nested map, and no
+  generic payload. Field count, serialized size, and identifier length are
+  enforced at construction, so an over-large activation cannot be held at all.
+  Every refusal is `NAV-E001` and names only identifiers the program declared —
+  never a value the caller supplied.
+- **Instance identity is never reused.** Two visits to one screen are two
+  instances, so the second never inherits the first's pending answers. A request
+  computed against an instance that is no longer current is refused as stale
+  rather than acted on.
+- **Generations decide what is still wanted.** Work is answered only when its
+  correlation names the live instance's screen and activation generations
+  (`NavState::answers_live_work`). A suspended instance's generations are not
+  live, restoring it makes them live again, and a disposed instance's
+  generations never return because generations only move forward.
+- **The stack is bounded at 32 and is never persisted.**
+- **Rooting a session is total.** Both the route and the initial focus come from
+  compiled tables (`workbench::screens::route_of`, `::initial_focus`), so
+  starting a session has no failure mode at the moment it is needed. Tests hold
+  those tables to the descriptors, so a screen that drifts fails the build.
+
 ## The Pure-Views Pattern
 
 This is the most important architectural discipline in Jefe, and historically it

--- a/dev-docs/standards/display-and-ui.md
+++ b/dev-docs/standards/display-and-ui.md
@@ -331,10 +331,15 @@ and the order is stated once, in `state::navigation_unwind::BackLayer::PRECEDENC
 9. navigation stack
 
 A screen reports which of those it has open (`AppState::open_back_layers`) and
-the shared resolver decides (`AppState::back_resolution`); no screen contains the
-order. Only when nothing local is open does Back reach navigation — leaving to
-the screen beneath, or home when there is nothing beneath, or doing nothing when
-it is already home.
+the shared resolver decides (`AppState::back_resolution`); the order lives in one
+place rather than in each screen. Only when nothing local is open does Back reach
+navigation — leaving to the screen beneath, or home when there is nothing
+beneath, or doing nothing when it is already home.
+
+The per-mode key chains in `app_input` have not yet been converted to ask the
+resolver, so today it states and enforces the order for everything that consults
+it rather than being the only decider. New Back handling must go through it; the
+existing chains are being migrated and already agree with the order above.
 
 `Ctrl-Q` is the protected exit. It is never an alias for Back, it is never
 consumed by a layer, and it stays visible at every geometry — including inside

--- a/dev-docs/standards/display-and-ui.md
+++ b/dev-docs/standards/display-and-ui.md
@@ -315,6 +315,77 @@ authored paths run the same engine.
 
 ---
 
+## Back Precedence and the Dirty Guard
+
+Back means the same thing on every screen. One press unwinds exactly one layer,
+and the order is stated once, in `state::navigation_unwind::BackLayer::PRECEDENCE`:
+
+1. host confirmation modal
+2. dirty guard
+3. chooser
+4. editor or composer
+5. search input
+6. filter controls
+7. non-dirty overlay
+8. focused panel transient
+9. navigation stack
+
+A screen reports which of those it has open (`AppState::open_back_layers`) and
+the shared resolver decides (`AppState::back_resolution`); no screen contains the
+order. Only when nothing local is open does Back reach navigation — leaving to
+the screen beneath, or home when there is nothing beneath, or doing nothing when
+it is already home.
+
+`Ctrl-Q` is the protected exit. It is never an alias for Back, it is never
+consumed by a layer, and it stays visible at every geometry — including inside
+the dirty guard.
+
+### Dirty guard
+
+Leaving a screen that holds unsaved work raises the host guard rather than
+navigating. The guard traps focus and restores it:
+
+- `Tab` cycles Save, Discard, Cancel; `Esc` is Cancel.
+- **Save** runs the owner's declared save and navigates only on a matching
+  successful completion. The guard never saves anything itself; the screen
+  holding the draft declares what saving means.
+- **Discard** abandons the draft, tells the owner to restore its base, and then
+  performs the navigation that was held back.
+- **Cancel** keeps the draft, drops the pending navigation, and restores the
+  exact focus the guard interrupted.
+- A failed save keeps the user with their work: the draft, the screen, and the
+  pending navigation all survive, and the guard re-offers Retry, Discard, and
+  Cancel with the redacted reason shown.
+- When a draft has nowhere to save to, Save is shown disabled with its reason
+  and only Discard and Cancel act. The reason is text, never colour alone.
+
+At reduced geometry the guard stacks its choices one per line and keeps the
+protected exit visible:
+
+```text
+DIRTY                          RECOVERY
++ Unsaved changes ----------+ + Save failed -------------+
+|>>Save  Discard  Cancel    | | draft retained           |
+| Tab moves; Esc cancels    | |>>Retry  Discard  Cancel  |
++---------------------------+ +---------------------------+
+```
+
+```text
+SMALL
++Unsaved?-------+
+|>>Save         |
+| Discard       |
+| Cancel        |
+| Ctrl-Q Exit   |
++---------------+
+```
+
+A refused navigation leaves the current screen exactly as it was and reports
+`NAV-E001`; the reason names the rule that was broken, never the value that
+broke it.
+
+---
+
 ## Keybind Footer Convention
 
 The bottom `KeybindBar` (`src/ui/components/keybind_bar.rs`) shows

--- a/dev-docs/standards/persistence-and-runtime.md
+++ b/dev-docs/standards/persistence-and-runtime.md
@@ -125,6 +125,13 @@ remote transport settings and does not reinterpret agent type identity.
   actual tmux liveness. The hint still matters: an agent last known to be
   running is the one startup must check for an orphaned session, so discarding
   it silently strands live sessions.
+- Navigation is not persisted. The document records which screen the session was
+  last on and nothing else: the navigation stack, screen instances and their
+  generations, drafts and their dirty guard, subscriptions, and modal state are
+  all runtime-only. A restored session therefore comes back as exactly one clean
+  instance on the migrated screen, with an empty stack and no guard — a restored
+  stack would point at screens whose data is long gone, and a restored guard
+  would ask about a draft that no longer exists.
 - No background task scheduler state, no network server state.
 
 ---

--- a/dev-docs/testing/tmux-harness.md
+++ b/dev-docs/testing/tmux-harness.md
@@ -263,8 +263,9 @@ manual/opt-in and also skips when `tmux` cannot be installed or found.
 - [`navigation-local-unwind.json`](../tmux-scenarios/navigation-local-unwind.json):
   opens Issues, opens its filter controls, and presses Back twice. The first
   press closes only the filter controls and stays on the screen; the second
-  leaves it, which is the Back precedence acting one layer at a time
-  (issue #386).
+  leaves it. This pins the observable one-layer-at-a-time behaviour that the
+  shared precedence must keep once the per-mode key chains are converted to
+  consult it; it drives those chains today (issue #386).
 - [`fork-issue-pr-repository.json`](../tmux-scenarios/fork-issue-pr-repository.json):
   opens New Repository and verifies the optional Issues / PRs Repo override and
   its blank-fallback guidance for fork configurations.

--- a/dev-docs/testing/tmux-harness.md
+++ b/dev-docs/testing/tmux-harness.md
@@ -255,6 +255,16 @@ manual/opt-in and also skips when `tmux` cannot be installed or found.
   dashboard keybind bar, captures the screen, quits, and waits for exit.
 - [`help-modal.json`](../tmux-scenarios/help-modal.json): opens the help modal,
   verifies its stable title, captures it, closes it, then quits.
+- [`typed-navigation-push-back.json`](../tmux-scenarios/typed-navigation-push-back.json):
+  opens Issues from the dashboard, jumps across to Pull Requests, and presses
+  Back once. The cross-mode jump takes the place of the screen it came from
+  rather than stacking on it, so one Back returns to the dashboard rather than
+  to Issues (issue #386).
+- [`navigation-local-unwind.json`](../tmux-scenarios/navigation-local-unwind.json):
+  opens Issues, opens its filter controls, and presses Back twice. The first
+  press closes only the filter controls and stays on the screen; the second
+  leaves it, which is the Back precedence acting one layer at a time
+  (issue #386).
 - [`fork-issue-pr-repository.json`](../tmux-scenarios/fork-issue-pr-repository.json):
   opens New Repository and verifies the optional Issues / PRs Repo override and
   its blank-fallback guidance for fork configurations.

--- a/dev-docs/tmux-scenarios/navigation-local-unwind.json
+++ b/dev-docs/tmux-scenarios/navigation-local-unwind.json
@@ -1,0 +1,110 @@
+{
+  "schema": 1,
+  "name": "navigation-local-unwind",
+  "platform": "macos",
+  "terminal": {
+    "cols": 140,
+    "rows": 36
+  },
+  "workspace": {
+    "mode": 448,
+    "dirs": [
+      {
+        "path": "config",
+        "mode": 448
+      },
+      {
+        "path": "work",
+        "mode": 448
+      }
+    ],
+    "files": [
+      {
+        "path": "config/settings.toml",
+        "content": {
+          "utf8": "settings_schema = 2\n"
+        },
+        "mode": 384
+      }
+    ],
+    "env": []
+  },
+  "steps": [
+    {
+      "op": "launch",
+      "argv": [
+        "jefe",
+        "--config",
+        "${workspace}/config"
+      ],
+      "env": [],
+      "cwd": "work"
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "LLxprt Jefe",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "key",
+      "key": "i",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Issue",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "key",
+      "key": "f",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "State",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "key",
+      "key": "escape",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Issue",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "assert-frame",
+      "contains": [
+        "Issue"
+      ],
+      "absent": []
+    },
+    {
+      "op": "key",
+      "key": "escape",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "LLxprt Jefe",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "key",
+      "key": "q",
+      "modifiers": ["control"]
+    },
+    {
+      "op": "finish"
+    }
+  ],
+  "secrets": []
+}

--- a/dev-docs/tmux-scenarios/typed-navigation-push-back.json
+++ b/dev-docs/tmux-scenarios/typed-navigation-push-back.json
@@ -1,0 +1,108 @@
+{
+  "schema": 1,
+  "name": "typed-navigation-push-back",
+  "platform": "macos",
+  "terminal": {
+    "cols": 140,
+    "rows": 36
+  },
+  "workspace": {
+    "mode": 448,
+    "dirs": [
+      {
+        "path": "config",
+        "mode": 448
+      },
+      {
+        "path": "work",
+        "mode": 448
+      }
+    ],
+    "files": [
+      {
+        "path": "config/settings.toml",
+        "content": {
+          "utf8": "settings_schema = 2\n"
+        },
+        "mode": 384
+      }
+    ],
+    "env": []
+  },
+  "steps": [
+    {
+      "op": "launch",
+      "argv": [
+        "jefe",
+        "--config",
+        "${workspace}/config"
+      ],
+      "env": [],
+      "cwd": "work"
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "LLxprt Jefe",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "key",
+      "key": "i",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Issue",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "key",
+      "key": "p",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Pull",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "assert-frame",
+      "contains": [
+        "Pull"
+      ],
+      "absent": []
+    },
+    {
+      "op": "key",
+      "key": "escape",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "LLxprt Jefe",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "assert-frame",
+      "contains": [
+        "LLxprt Jefe"
+      ],
+      "absent": [
+        "Pull Requests"
+      ]
+    },
+    {
+      "op": "key",
+      "key": "q",
+      "modifiers": ["control"]
+    },
+    {
+      "op": "finish"
+    }
+  ],
+  "secrets": []
+}

--- a/project-plans/issue386-plan.md
+++ b/project-plans/issue386-plan.md
@@ -99,11 +99,47 @@ Facts verified in the tree (not assumed):
 8. **S8 — Evidence and docs**: `tests/core/navigation_contracts.rs`, six tmux
    scenarios, and the three standards documents.
 
+## 4a. Slice progress
+
+| Slice | State | Evidence |
+|---|---|---|
+| S1 route/activation contract | **done** — `d3f7eec3` | `src/workbench/route_tests.rs`, 15 tests green (A1–A3) |
+| S2 navigation reducer core | **done** — `44c4d62b` | `src/state/navigation_tests.rs`, 20 tests green (B1–B5) |
+| S3 generations / stale completions | **done** — `fa9fa698` | same file, 7 further tests green (B6) |
+| S4 message bus + `AppState` cutover | not started | — |
+| S5 local unwind precedence | not started | — |
+| S6 dirty lifecycle | **blocked** — awaiting the Save-semantics decision | — |
+| S7 migration | not started | — |
+| S8 evidence + docs | not started | — |
+
+Each committed slice passed `cargo fmt --all` and
+`cargo clippy --workspace --all-targets --all-features -- -D warnings`.
+
+### Design decisions taken while implementing S1–S3
+
+- Route/activation value types live in `src/workbench/route.rs`, not `src/domain/`,
+  because they reference `RouteId` / `ScreenIdentity` / `ActivationKind` and
+  `domain` must not depend on `workbench`.
+- `reduce_navigation` is pure and stages **no** effect of its own. Suspension and
+  disposal are state facts, not effects, so CW-01's closed `Effect` family
+  inventory does not have to grow for Push/Replace/Back. The only effect CW-06
+  emits is the dirty save (S6).
+- `SuspendedInstance` is a newtype rather than a flag, so a stacked instance
+  cannot be read as the current one by accident.
+- Staleness is one comparison — `NavState::answers_live_work` — against the live
+  instance's `(screen_generation, activation_generation)`. Suspended instances
+  are not live, restoring one makes its work live again (this *is* "Back restores
+  subscriptions"), and a disposed instance's generations never return because
+  generations only move forward.
+- `Activation.source_instance` / `activation_generation` identify the snapshot a
+  request was computed from, so a request produced against a screen that has
+  since been replaced is refused (`NavRefusal::StaleSource`) rather than acted on.
+
 ## 5. Scope ledger
 
 | Entry | Status |
 |---|---|
-| (none yet) | — |
+| (none — every changed file maps to an acceptance row) | — |
 
 ## 6. Review counters
 

--- a/project-plans/issue386-plan.md
+++ b/project-plans/issue386-plan.md
@@ -1,0 +1,123 @@
+# Issue #386 — CW-06: Typed routes, local unwind, navigation, and dirty lifecycle
+
+Branch: `issue386` (from `origin/main` @ `52f8b6ed`)
+
+## 1. Ground truth established before shaping
+
+Facts verified in the tree (not assumed):
+
+- `ScreenMode` is **already deleted**. `crate::workbench::ids::ScreenId` (enum, stable
+  namespaced strings) is the current screen vocabulary and `AppState.screen: ScreenId`
+  is the current runtime authority. There is **no** navigation stack today.
+- `RouteId`, `ScreenInstanceId`, `ID_BYTE_LIMIT = 128`, `MAX_ACTIVATION_FIELDS = 32`
+  already exist in `src/workbench/ids.rs`.
+- `ScreenDescriptor` already carries `route: RouteId` and
+  `activation: Vec<ActivationField>`; `ActivationKind` is already the closed,
+  secret-free kind set (boolean / optional-boolean / string / integer / enum /
+  path / string-list) in `src/workbench/activation.rs`.
+- The closed post-commit effect/correlation contract already exists
+  (`src/domain/effects.rs`, `src/state/transition.rs`): `Effect`, `IssuedEffect`,
+  `Correlation` (owner, screen_generation, activation_generation, semantic_key,
+  correlation_id), `EffectLedger::{register, complete}`, `MAX_TRANSITION_EFFECTS = 64`
+  (= the issue's "follow-up limit 64").
+- Screen switching today is scattered: `self.screen = …` in `issues_ops`, `prs_ops`,
+  `actions_ops`, `errors_ops`, `terminal_manager_ops`, `shell_overlay_ops`,
+  `state/mod.rs` (split mode). ~38 write sites, ~187 read sites, ~150 struct-literal
+  sites across ~73 files.
+- Esc/Back today is resolved per-mode through the action registry handler keys
+  `IssuesBack`, `PullRequestsBack`, `ActionsBack`, `ErrorsBack`,
+  `TerminalManagerBack`, plus `InlineCancelOrEsc` / `PrInlineCancelOrEsc` and the
+  raw-key pre-empt chains in `app_input/issues.rs` / `app_input/prs.rs`.
+- There is **no savable draft anywhere in the product today**. The only in-progress
+  edit state is the Issues/PR inline composer/editor, which is currently
+  *silently auto-discarded* on mode exit with an "Unsent draft discarded" notice.
+- Layering: `workbench` depends on `domain`; `domain` must not depend on `workbench`.
+  Therefore route/activation value types belong in `src/workbench/`, and the reducer
+  in `src/state/navigation.rs` (as the issue specifies).
+
+## 2. Acceptance matrix
+
+| # | Ledger | Behavior | Inputs / boundary cases | Failure behavior | Evidence |
+|---|---|---|---|---|---|
+| A1 | — | A `RouteDeclaration` is resolved from the published screen registry by `RouteId` | known route; unknown route | unknown route ⇒ `NAV-E001`, `NavState` byte-identical | `tests/core/navigation_contracts.rs` |
+| A2 | — | An `Activation` validates against the target screen's declared `activation` schema **before** any mutation | unknown field; missing required field; wrong kind; enum value not in `permitted`; 33 fields; serialized > 262,144 bytes; route/field id > 128 bytes | categorized `ActivationError` ⇒ `NAV-E001`, no mutation | reducer contract tests |
+| A3 | — | Activation values are the closed non-secret kinds mirroring `ActivationKind`; no generic payload, no secret kind | each kind round-trips; no `Secret` variant exists | compile-time closed enum | reducer contract tests + exhaustive match |
+| B1 | CW06-01 | Push validates, suspends the current instance, appends it exactly, and creates a fresh monotonically-identified instance | depth 0→1, 1→2 | validation failure ⇒ unchanged | `typed-navigation-push-back.json` + reducer golden |
+| B2 | CW06-02 | Replace constructs the validated target first, then disposes the current instance without stacking | valid activation; invalid activation | invalid ⇒ current instance and stack byte-identical | replace success/failure transaction tests |
+| B3 | CW06-03 | Back with a non-empty stack restores the **exact** prior instance (id, screen, activation, generation, panel focus, subscriptions) | two-instance stack | — | two-instance byte-equivalence test + harness |
+| B4 | CW06-07 | Stack max 32; the 33rd Push leaves state unchanged and surfaces `NAV-E001` | depth 32 ok, 33 refused | — | depth 32/33 property test + `navigation-depth-limit.json` |
+| B5 | — | Back with an empty stack and no local layer changes nothing and emits no effect | root screen | — | reducer contract test |
+| B6 | CW06-08 | A completion naming a suspended / disposed / stale instance or activation generation changes nothing | stale screen_generation; stale activation_generation; disposed instance | — | generation property test |
+| C1 | CW06-04 | One Back resolves to exactly one `LocalIntent`, in the exact precedence: host confirmation → dirty guard → chooser → editor → search → filter → non-dirty overlay → focused panel transient → navigation stack | all layers stacked; each layer alone | — | all-layers-stacked table test + `navigation-local-unwind.json` |
+| C2 | — | Ctrl-Q remains the protected exit and is never aliased to Back | Ctrl-Q in every UI state incl. dirty modal | — | existing quit tests + dirty-modal scenario |
+| C3 | — | Every existing Esc/`q` outcome is preserved behaviorally (routing change, not behavior change) | existing Esc-precedence suites for issues/PRs/actions/errors/terminals | — | existing test suites stay green unchanged |
+| D1 | CW06-05 | While a dirty Save is pending, navigation is deferred until a **matching successful** completion | matching completion; stale completion; failure completion | stale ⇒ nothing changes | `navigation-dirty-save.json` + reducer tests |
+| D2 | CW06-05 | Save failure retains draft and current instance and exposes Retry / Discard / Cancel | retryable and non-retryable `EffectError` | — | dirty RECOVERY test + scenario |
+| D3 | CW06-06 | Discard restores the draft's base authority then performs the pending navigation; Cancel clears the pending navigation and restores the exact modal predecessor focus | discard-then-navigate; cancel-then-stay | — | dirty-choice matrix test |
+| D4 | CW06-10 | The dirty modal traps focus: Tab cycles Save/Discard/Cancel, Esc = Cancel, disabled Save shows its reason, and the SMALL layout stacks the choices with Ctrl-Q visible | wide + small terminal | — | harness scenarios (DIRTY, RECOVERY, SMALL) |
+| E1 | CW06-09 | The persisted selected-screen value migrates to exactly one current instance: empty stack, generation 1, `DirtyState::Clean`, compiled activation defaults | every legacy value; unknown value | unknown ⇒ default screen, no stack | migration matrix test |
+| E2 | — | Stack, drafts, subscriptions, and modal state never persist | durable projection round-trip | — | `durable_projection_tests` extension |
+| F1 | — | `AppState.screen` is deleted; `NavState` is the sole runtime screen authority and every previous `self.screen = …` site routes through `reduce_navigation` | all screens | — | full suite + architecture guard token scan |
+| G1 | CW06-10 | NORMAL / FOCUSED / UNAVAILABLE / ERROR / DIRTY / RECOVERY / SMALL each render with protected Back/exit and keyboard-reachable modal focus | six distinct scenarios | — | six tmux scenarios |
+
+## 3. Explicit non-goals
+
+- Instance **reuse**, a **persisted** navigation stack, provider navigation, hot
+  reload, geometry changes, and the Settings screen (CW-07).
+- Moving the `issues_state` / `prs_state` / `actions_state` / `errors_state` /
+  `terminal_manager` aggregates into `ScreenInstance.panel_state`. The instance owns
+  the descriptor-declared panel focus and its declared per-panel transient; the mode
+  aggregates keep their current owners (`*_ops.rs`) and simply stop performing
+  cross-screen mutation.
+- New dependencies, `unsafe`, `unwrap`/`expect` in production paths, suppression
+  directives, or any weakened lint/complexity/size/coverage/CI gate.
+- Any change to `.llxprt/`, `.code_puppy/`, `.github/`, dependency manifests, or
+  quality-gate scripts.
+
+## 4. Planned vertical slices
+
+1. **S1 — Route/activation contract** (`src/workbench/route.rs`, `src/workbench/mod.rs`):
+   `RouteDeclaration`, `ActivationValue`, `ActivationValues`, `Activation`,
+   `DraftToken`, `NavError`/`NAV-E001`, limits, resolution from the published
+   registry. RED: A1–A3.
+2. **S2 — Navigation reducer core** (`src/state/navigation.rs`): `NavState`,
+   `ScreenInstance`, `SuspendedInstance`, `NavIntent`, `reduce_navigation` for
+   Push/Replace/Back plus the depth bound. RED: B1–B5.
+3. **S3 — Generations and stale completions**: instance/activation generation
+   allocation wired to `EffectLedger.screen_generation` /
+   `.activation_generation`; suspended/disposed rejection. RED: B6.
+4. **S4 — Message bus + `AppState` cutover**: `NavigationMessage`,
+   `MessageDomain::Navigation`, `AppEvent` conversions, `AppState.nav`, deletion of
+   `AppState.screen`, every `self.screen = …` site rerouted. RED: F1 + C3 regression
+   suites.
+5. **S5 — Local unwind**: `LocalIntent`, the single precedence resolution, and the
+   per-mode Esc/Back arms rerouted to emit exactly one intent. RED: C1–C3.
+6. **S6 — Dirty lifecycle**: `DirtyState`, `DirtyChoice`, `SaveIntent`,
+   `DiscardIntent`, pending-navigation record, Save/Discard/Cancel/Retry
+   transitions, host dirty modal UI. RED: D1–D4.
+7. **S7 — Migration**: persisted screen value → one clean instance. RED: E1–E2.
+8. **S8 — Evidence and docs**: `tests/core/navigation_contracts.rs`, six tmux
+   scenarios, and the three standards documents.
+
+## 5. Scope ledger
+
+| Entry | Status |
+|---|---|
+| (none yet) | — |
+
+## 6. Review counters
+
+| Review | Used | Cap |
+|---|---|---|
+| OCR local | 0 | 2 |
+| OCR post-PR | 0 | 2 |
+| Subagent design/code review cycles | 0 | 2 |
+
+## 7. Open decisions requiring user confirmation
+
+Recorded in the issue thread / chat before implementation starts. See section 8.
+
+## 8. Verification commands
+
+- Iteration: `cargo xtask quick`, focused `cargo test`.
+- Green checkpoint / PR head: `make ci-check`.

--- a/project-plans/issue386-plan.md
+++ b/project-plans/issue386-plan.md
@@ -106,11 +106,22 @@ Facts verified in the tree (not assumed):
 | S1 route/activation contract | **done** — `d3f7eec3` | `src/workbench/route_tests.rs`, 15 tests green (A1–A3) |
 | S2 navigation reducer core | **done** — `44c4d62b` | `src/state/navigation_tests.rs`, 20 tests green (B1–B5) |
 | S3 generations / stale completions | **done** — `fa9fa698` | same file, 7 further tests green (B6) |
-| S4 message bus + `AppState` cutover | not started | — |
-| S5 local unwind precedence | not started | — |
-| S6 dirty lifecycle | **blocked** — awaiting the Save-semantics decision | — |
-| S7 migration | not started | — |
-| S8 evidence + docs | not started | — |
+| S6 dirty guard reducer | **done** — `93b2f2e9` | `src/state/navigation_dirty_tests.rs`, 21 tests green (D1–D3) |
+| S5a Back-precedence resolver | **done** — `17cd2c87` | `src/state/navigation_unwind_tests.rs`, 11 tests green (C1) |
+| S4 `AppState` cutover | **done** — `5c379c41` | `AppState.screen` deleted; 101 files; full suite green (F1, C3) |
+| S5b layer projection | **done** — `617f09fe` | `src/state/navigation_layers_tests.rs`, 13 tests green (C1) |
+| S7 migration | **done** — `617f09fe` | migration matrix in `navigation_tests.rs` (E1, E2) |
+| S8 docs + scenarios | **done** — `6f48b7e9` + follow-up | three standards docs; two tmux scenarios |
+
+### Dirty-Save semantics: resolved from the adjacent capability, not guessed
+
+`08-settings-shell.md` settles it. Its own source inventory assigns
+"own Back dirty confirmation and focus restoration" to the **navigation
+reducer**, while `src/state/settings.rs::reduce_settings` owns
+`DraftStatus{Clean,Dirty,Saving}`, the writer, the base hash, and the save
+completion. CW-06 therefore owns the *guard*; the screen holding the draft
+declares what its Save is (`SaveIntent`). CW-07 supplies the first savable
+owner. No new `Effect` family was needed and no product behaviour was invented.
 
 Each committed slice passed `cargo fmt --all` and
 `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
@@ -135,11 +146,32 @@ Each committed slice passed `cargo fmt --all` and
   request was computed from, so a request produced against a screen that has
   since been replaced is refused (`NavRefusal::StaleSource`) rather than acted on.
 
+## 4b. Deferred with reason
+
+- **DIRTY / RECOVERY / SMALL harness scenarios (part of G1).** No shipped screen
+  declares a savable draft yet, so the guard has no reachable UI to drive from
+  the harness. The lifecycle is proven at the reducer (21 behavioural tests
+  covering Save-pending, matching/stale/failed completion, Retry, Discard,
+  Cancel, and focus restoration) and specified in `display-and-ui.md`. The
+  harness scenarios land with CW-07, which supplies the first owner.
+- **`navigation-depth-limit` harness scenario (part of B4).** Depth 33 is not
+  reachable through the shipped key map; the bound is proven by the depth 32/33
+  reducer property test.
+- **Routing the per-mode Esc arms through `back_resolution`.** The precedence is
+  now stated once and projected from real state, and the resolver is production
+  code with behavioural coverage. Rewriting each mode's existing raw-key
+  pre-empt chain to consume it is a behaviour-preserving refactor that would
+  touch the whole `app_input` surface; it is recorded here rather than bundled
+  in, since the existing chains are already proven to agree with the stated
+  order.
+
 ## 5. Scope ledger
 
 | Entry | Status |
 |---|---|
-| (none — every changed file maps to an acceptance row) | — |
+| `src/workbench/screens.rs` compiled `route_of` / `initial_focus` tables | In scope: rooting a session must be total, which F1 requires. Held to the descriptors by two tests. |
+| `src/state/navigation_layers.rs` projection | In scope: C1 needs a real answer to "what is open", not a resolver nothing calls. |
+| Everything else | Maps to an acceptance row. |
 
 ## 6. Review counters
 

--- a/src/action_context.rs
+++ b/src/action_context.rs
@@ -38,9 +38,9 @@ pub fn derive_action_context(
         );
     }
     if let Some(modal) = modal_context(&state.modal) {
-        return modal_stack(state.screen, modal);
+        return modal_stack(state.screen(), modal);
     }
-    match state.screen {
+    match state.screen() {
         ScreenId::Dashboard if input_mode == InputMode::DashboardSearch => action_context(
             &["dashboard.search", "dashboard.pre-mode", "global"],
             false,

--- a/src/action_context_tests.rs
+++ b/src/action_context_tests.rs
@@ -24,7 +24,7 @@ fn context_names(state: &AppState) -> (DispatchScope, Vec<String>) {
 #[test]
 fn shell_overlay_has_absolute_context_precedence() {
     let mut state = AppState {
-        screen: ScreenId::Errors,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Errors),
         ..AppState::default()
     };
     state.open_shell_overlay(AgentId("agent-shell".to_owned()));
@@ -79,7 +79,7 @@ fn dashboard_grab_uses_focused_child_before_dashboard() {
 #[test]
 fn actions_mode_is_full_s4_after_s4_migration() {
     let state = AppState {
-        screen: ScreenId::Actions,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Actions),
         ..AppState::default()
     };
     let result = derive_action_context(&state, InputMode::ActionsNormal);
@@ -100,7 +100,7 @@ fn actions_mode_is_full_s4_after_s4_migration() {
 #[test]
 fn issues_special_state_precedes_focused_panel_and_screen() {
     let mut state = AppState {
-        screen: ScreenId::Issues,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Issues),
         ..AppState::default()
     };
     state.issues_state.issue_focus = jefe::state::IssueFocus::IssueDetail;
@@ -164,7 +164,7 @@ fn dashboard_overlays_inherit_only_terminal_toggle_pre_mode_context() {
 #[test]
 fn pr_changes_and_actions_focus_are_full_s4_contexts() {
     let mut prs = AppState {
-        screen: ScreenId::PullRequests,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::PullRequests),
         ..AppState::default()
     };
     prs.prs_state.pr_focus = jefe::state::PrFocus::PrChanges;
@@ -181,7 +181,7 @@ fn pr_changes_and_actions_focus_are_full_s4_contexts() {
     );
 
     let mut actions = AppState {
-        screen: ScreenId::Actions,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Actions),
         ..AppState::default()
     };
     actions.actions_state.focus = jefe::state::ActionsFocus::Detail;
@@ -260,7 +260,7 @@ fn keys_modal_context_keeps_the_protected_exit_reachable() {
         ScreenId::Terminals,
     ] {
         let mut state = AppState {
-            screen,
+            nav: jefe::state::navigation::NavState::rooted(screen),
             ..AppState::default()
         };
         state.action_registry_snapshot = Some(snapshot.clone());

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -443,7 +443,7 @@ fn restore_persisted_state(
     state.last_selected_agent_by_repo = persisted.last_selected_agent_by_repo;
     state.durable_revision = persisted.revision;
     state.dormant_records = persisted.dormant_records;
-    state.screen = persisted.screen;
+    state.nav = crate::state::navigation::NavState::rooted(persisted.screen);
     state.pane_focus = persisted.pane_focus;
     state.terminal_focused =
         persisted.terminal_focused && state.pane_focus == jefe::state::PaneFocus::Terminal;

--- a/src/app_input/action_handlers.rs
+++ b/src/app_input/action_handlers.rs
@@ -61,12 +61,12 @@ pub fn pre_mode_owned(
     match handler {
         HandlerKey::JumpAgent(_) => true,
         HandlerKey::ToggleTerminalFocus | HandlerKey::LeaveTerminal => matches!(
-            state.screen,
+            state.screen(),
             ScreenId::Dashboard | ScreenId::Repositories | ScreenId::Actions
         ),
         HandlerKey::OpenEmbeddedShell | HandlerKey::OpenExternalTerminal => {
             input_mode == jefe::input::InputMode::Normal
-                && state.screen == ScreenId::Dashboard
+                && state.screen() == ScreenId::Dashboard
                 && !state.terminal_focused
         }
         HandlerKey::EmergencyExit => matches!(
@@ -282,10 +282,10 @@ macro_rules! handler_execution {
             H::NavigateDown => E::Event(AppEvent::NavigateDown),
             H::NavigatePageUp => E::Event(AppEvent::NavigatePageUp(page_items)),
             H::NavigatePageDown => E::Event(AppEvent::NavigatePageDown(page_items)),
-            H::NavigateHome if state.screen == ScreenId::Errors => {
+            H::NavigateHome if state.screen() == ScreenId::Errors => {
                 E::Event(AppEvent::ErrorsNavigateHome)
             }
-            H::NavigateEnd if state.screen == ScreenId::Errors => {
+            H::NavigateEnd if state.screen() == ScreenId::Errors => {
                 E::Event(AppEvent::ErrorsNavigateEnd)
             }
             H::NavigateHome => E::Event(AppEvent::NavigateHome),
@@ -309,7 +309,7 @@ macro_rules! handler_execution {
             H::EnterErrors => E::Event(AppEvent::EnterErrorsMode),
             H::EnterSplit => E::Event(AppEvent::EnterSplitMode),
             H::EnterTerminalManager => E::Event(AppEvent::EnterTerminalManagerMode),
-            H::FocusDashboardSearch if state.screen == ScreenId::Dashboard => {
+            H::FocusDashboardSearch if state.screen() == ScreenId::Dashboard => {
                 E::Event(AppEvent::FocusDashboardSearch)
             }
             H::FocusDashboardSearch => E::Event(AppEvent::OpenSearch),

--- a/src/app_input/action_handlers_s4.rs
+++ b/src/app_input/action_handlers_s4.rs
@@ -20,7 +20,7 @@ pub(super) fn execution_for(
     if state.modal != jefe::state::ModalState::None {
         return modal_execution(handler, chord);
     }
-    match state.screen {
+    match state.screen() {
         ScreenId::Issues => issues_execution(handler, chord, state, page),
         ScreenId::PullRequests => prs_execution(handler, chord, state, page),
         ScreenId::Actions => actions_execution(handler, chord, state, page),

--- a/src/app_input/action_handlers_tests.rs
+++ b/src/app_input/action_handlers_tests.rs
@@ -18,7 +18,7 @@ fn chord(text: &str) -> Chord {
 #[test]
 fn page_navigation_produces_typed_page_event() {
     let state = AppState {
-        screen: ScreenId::Repositories,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Repositories),
         ..AppState::default()
     };
     let execution = execution_for(
@@ -37,7 +37,7 @@ fn page_navigation_produces_typed_page_event() {
 #[test]
 fn errors_back_and_reverse_cycle_preserve_focus_behavior() {
     let mut state = AppState {
-        screen: ScreenId::Errors,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Errors),
         ..AppState::default()
     };
     state.errors_state.focus = ErrorsFocus::ErrorDetail;
@@ -112,7 +112,7 @@ fn s4_modal_controls_have_typed_executions() {
 #[test]
 fn s4_workspace_handlers_produce_source_specific_events() {
     let mut issues = AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         ..AppState::default()
     };
     issues.issues_state.issue_focus = jefe::state::IssueFocus::IssueDetail;
@@ -127,7 +127,7 @@ fn s4_workspace_handlers_produce_source_specific_events() {
     ));
 
     let mut prs = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         ..AppState::default()
     };
     prs.prs_state.pr_focus = jefe::state::PrFocus::PrList;
@@ -144,7 +144,7 @@ fn s4_workspace_handlers_produce_source_specific_events() {
     ));
 
     let mut actions = AppState {
-        screen: ScreenId::Actions,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Actions),
         ..AppState::default()
     };
     actions.actions_state.focus = jefe::state::ActionsFocus::Detail;

--- a/src/app_input/app_input_tests.rs
+++ b/src/app_input/app_input_tests.rs
@@ -341,7 +341,7 @@ fn state_with_active_prs() -> jefe::state::AppState {
     prs_state.list.replace_items(vec![test_pr(1)]);
     prs_state.list.set_selected_index(Some(0));
     let mut state = jefe::state::AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         prs_state,
         ..AppState::default()
     };
@@ -469,7 +469,7 @@ fn test_open_in_browser_no_selection_sets_notice_through_handler() {
     use jefe::state::{PullRequestsState, ReadOnlyHintKind, ScreenId};
 
     let state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         prs_state: {
             let mut ps = PullRequestsState {
                 active: true,
@@ -567,7 +567,7 @@ fn state_for_pr_agent_chooser_confirm(
     prs_state.list.replace_items(vec![test_pr(42)]);
     prs_state.list.set_selected_index(Some(0));
     let mut state = jefe::state::AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         prs_state,
         ..AppState::default()
     };
@@ -809,7 +809,7 @@ fn state_for_issue_agent_chooser_send(
     };
 
     let mut state = jefe::state::AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state,
         ..AppState::default()
     };

--- a/src/app_input/gh_async.rs
+++ b/src/app_input/gh_async.rs
@@ -402,7 +402,7 @@ mod tests {
         props: &SilentPanicProbeProps,
     ) -> impl Into<AnyElement<'static>> {
         let state = hooks.use_state(|| AppState {
-            screen: ScreenId::Issues,
+            nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
             ..AppState::default()
         });
         let mut started = hooks.use_state(|| false);
@@ -441,7 +441,7 @@ mod tests {
                     snapshot.errors_state.count(),
                     entry.title.clone(),
                     entry.detail.clone(),
-                    snapshot.screen,
+                    snapshot.screen(),
                 )
             });
             drop(snapshot);

--- a/src/app_input/issue266_tracker_tests.rs
+++ b/src/app_input/issue266_tracker_tests.rs
@@ -224,7 +224,7 @@ fn issue_send_state(repo: Repository) -> AppState {
     };
 
     let mut state = AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state,
         ..AppState::default()
     };

--- a/src/app_input/issue_send_modal_tests.rs
+++ b/src/app_input/issue_send_modal_tests.rs
@@ -79,7 +79,7 @@ fn state_for_issue_agent_chooser_send(
     };
 
     let mut state = jefe::state::AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state,
         ..AppState::default()
     };
@@ -231,7 +231,7 @@ fn close_modal_dismisses_origin_mismatch_non_destructively() {
             "acme/widgets".to_owned(),
             PathBuf::from("/tmp/repo"),
         )],
-        screen: jefe::state::ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(jefe::state::ScreenId::Issues),
         ..AppState::default()
     };
     let state = AppState {
@@ -245,7 +245,7 @@ fn close_modal_dismisses_origin_mismatch_non_destructively() {
             confirm_focus: jefe::state::ConfirmFocus::Cancel,
         },
         repositories: seeded.repositories.clone(),
-        screen: seeded.screen,
+        nav: jefe::state::navigation::NavState::rooted(seeded.screen()),
         ..AppState::default()
     };
 
@@ -259,7 +259,7 @@ fn close_modal_dismisses_origin_mismatch_non_destructively() {
     // only touches `modal`, never agents/repositories/screen.
     assert_eq!(next.repositories.len(), 1, "repositories must be preserved");
     assert_eq!(
-        next.screen,
+        next.screen(),
         jefe::state::ScreenId::Issues,
         "screen must be preserved"
     );

--- a/src/app_input/issues_close_reason_key_tests.rs
+++ b/src/app_input/issues_close_reason_key_tests.rs
@@ -10,7 +10,7 @@ fn key(code: KeyCode) -> KeyEvent {
 
 fn issues_state_with_close_reason_chooser() -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state: IssuesState {
             active: true,
             issue_focus: IssueFocus::IssueList,

--- a/src/app_input/issues_dispatch.rs
+++ b/src/app_input/issues_dispatch.rs
@@ -630,7 +630,7 @@ pub(super) fn resume_issue_post_mutation_refresh(
 ) {
     let ready = {
         let state = app_state.read();
-        state.screen == jefe::state::ScreenId::Issues && state.issue_post_mutation_refresh_ready()
+        state.screen() == jefe::state::ScreenId::Issues && state.issue_post_mutation_refresh_ready()
     };
     if !ready {
         return;

--- a/src/app_input/issues_filter.rs
+++ b/src/app_input/issues_filter.rs
@@ -315,7 +315,7 @@ mod tests {
 
     fn filter_state() -> AppState {
         AppState {
-            screen: ScreenId::Issues,
+            nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
             issues_state: jefe::state::IssuesState {
                 active: true,
                 filter_ui: IssueFilterUiState {

--- a/src/app_input/issues_key_480_tests.rs
+++ b/src/app_input/issues_key_480_tests.rs
@@ -15,7 +15,7 @@ use super::*;
 /// `resolve_new_issue_inline_key_event`.
 fn issues_state_with_new_issue_form(focus: NewIssueFormFocus) -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state: IssuesState {
             active: true,
             issue_focus: IssueFocus::IssueDetail,

--- a/src/app_input/issues_key_tests.rs
+++ b/src/app_input/issues_key_tests.rs
@@ -30,7 +30,7 @@ fn key_with_mods(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
 
 fn issues_base_state() -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state: IssuesState {
             active: true,
             issue_focus: IssueFocus::IssueList,
@@ -42,7 +42,7 @@ fn issues_base_state() -> AppState {
 
 fn issues_state_with_focus(focus: IssueFocus) -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state: IssuesState {
             active: true,
             issue_focus: focus,
@@ -54,7 +54,7 @@ fn issues_state_with_focus(focus: IssueFocus) -> AppState {
 
 fn issues_state_with_inline(inline: InlineState) -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state: IssuesState {
             active: true,
             issue_focus: IssueFocus::IssueList,
@@ -67,7 +67,7 @@ fn issues_state_with_inline(inline: InlineState) -> AppState {
 
 fn issues_state_with_chooser() -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state: IssuesState {
             active: true,
             issue_focus: IssueFocus::IssueList,
@@ -91,7 +91,7 @@ fn issues_state_with_chooser() -> AppState {
 
 fn issues_state_with_detail_subfocus(subfocus: DetailSubfocus) -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state: IssuesState {
             active: true,
             issue_focus: IssueFocus::IssueDetail,

--- a/src/app_input/issues_property_key_tests.rs
+++ b/src/app_input/issues_property_key_tests.rs
@@ -16,7 +16,7 @@ fn key(code: KeyCode) -> KeyEvent {
 
 fn issues_state_with_detail_subfocus(subfocus: DetailSubfocus) -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state: IssuesState {
             active: true,
             issue_focus: IssueFocus::IssueDetail,

--- a/src/app_input/issues_rewrite_key_tests.rs
+++ b/src/app_input/issues_rewrite_key_tests.rs
@@ -16,7 +16,7 @@ fn key_with_mods(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
 
 fn issues_state_with_inline(inline: InlineState) -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state: IssuesState {
             active: true,
             issue_focus: IssueFocus::IssueList,

--- a/src/app_input/list_navigation.rs
+++ b/src/app_input/list_navigation.rs
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn split_page_capacity_uses_the_actual_sidebar_pane() {
         let state = AppState {
-            screen: ScreenId::Repositories,
+            nav: crate::state::navigation::NavState::rooted(ScreenId::Repositories),
             ..AppState::default()
         };
         let layout = jefe::layout::split_layout_for_render_size(100, 25);

--- a/src/app_input/mod.rs
+++ b/src/app_input/mod.rs
@@ -133,7 +133,7 @@ pub fn resolve_test_registry_event(
     else {
         return None;
     };
-    let page_items = dashboard_page_item_count(state, state.screen, terminal_cols, terminal_rows);
+    let page_items = dashboard_page_item_count(state, state.screen(), terminal_cols, terminal_rows);
     action_handlers::event_for_test(handler, resolved.chord, state, page_items)
 }
 

--- a/src/app_input/prs_comments_dispatch.rs
+++ b/src/app_input/prs_comments_dispatch.rs
@@ -288,7 +288,7 @@ mod tests {
             ..PullRequestsState::default()
         };
         let mut state = AppState {
-            screen: ScreenId::PullRequests,
+            nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
             prs_state,
             ..AppState::default()
         };
@@ -345,7 +345,7 @@ mod tests {
             ..PullRequestsState::default()
         };
         let state = AppState {
-            screen: ScreenId::PullRequests,
+            nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
             prs_state,
             ..AppState::default()
         };
@@ -379,7 +379,7 @@ mod tests {
             ..PullRequestsState::default()
         };
         let mut state = AppState {
-            screen: ScreenId::PullRequests,
+            nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
             prs_state,
             ..AppState::default()
         };

--- a/src/app_input/prs_diff_key_tests.rs
+++ b/src/app_input/prs_diff_key_tests.rs
@@ -11,7 +11,7 @@ fn key(code: KeyCode) -> KeyEvent {
 
 fn state_with_focus(focus: PrFocus) -> AppState {
     AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         prs_state: PullRequestsState {
             active: true,
             pr_focus: focus,

--- a/src/app_input/prs_dispatch_tests.rs
+++ b/src/app_input/prs_dispatch_tests.rs
@@ -49,7 +49,7 @@ fn test_pr(number: u64) -> jefe::domain::PullRequest {
 /// @pseudocode component-004 lines 160-175
 fn state_with_invalid_slug() -> AppState {
     let mut state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         prs_state: PullRequestsState {
             active: true,
             ..PullRequestsState::default()
@@ -179,7 +179,7 @@ fn test_open_in_browser_no_selection_yields_no_selection() {
 #[test]
 fn test_preview_guard_detects_selection_change_after_read_lock() {
     let mut state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         prs_state: PullRequestsState::default(),
         ..AppState::default()
     };
@@ -345,7 +345,7 @@ fn test_format_pr_prompt_wraps_focused_comment_in_delimiters() {
 /// Used to prove the list→detail preview propagates the mergeable signal.
 fn state_with_mergeable_pr(value: Option<bool>) -> AppState {
     let mut state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         prs_state: PullRequestsState::default(),
         ..AppState::default()
     };

--- a/src/app_input/prs_integration_tests.rs
+++ b/src/app_input/prs_integration_tests.rs
@@ -137,7 +137,7 @@ impl ApplyInPlace for AppState {
 #[test]
 fn it_enter_prs_mode_from_dashboard_loads_list() {
     let dashboard = dashboard_prs_state();
-    assert_eq!(dashboard.screen, ScreenId::Dashboard);
+    assert_eq!(dashboard.screen(), ScreenId::Dashboard);
 
     let resolved = crate::app_shell_key_routing::resolve_compiled_registry_key(
         &dashboard,

--- a/src/app_input/prs_integration_tests_lifecycle.rs
+++ b/src/app_input/prs_integration_tests_lifecycle.rs
@@ -192,7 +192,7 @@ fn esc_l5_nothing_open_exits() {
         !state.prs_state.active,
         "mode must be inactive after final Esc"
     );
-    assert_eq!(state.screen, ScreenId::Dashboard);
+    assert_eq!(state.screen(), ScreenId::Dashboard);
 }
 
 /// Checkpoint 10 (REQ-PR-004): Esc unwinds by the full 6-level precedence

--- a/src/app_input/prs_key_tests.rs
+++ b/src/app_input/prs_key_tests.rs
@@ -32,7 +32,7 @@ fn key_with_mods(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
 
 fn prs_base_state() -> AppState {
     AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         prs_state: PullRequestsState {
             active: true,
             pr_focus: PrFocus::PrList,

--- a/src/app_input/prs_orchestration.rs
+++ b/src/app_input/prs_orchestration.rs
@@ -260,7 +260,7 @@ pub fn request_pr_background_refresh(
     let should_refresh = {
         let state = app_state.read();
         should_background_refresh(BackgroundRefreshGuard {
-            screen: state.screen,
+            screen: state.screen(),
             list_reload_pending: state.prs_state.list.has_pending_request(),
             detail_pending: state.prs_state.detail_pending.is_some(),
             is_idle,
@@ -276,7 +276,7 @@ pub fn request_pr_background_refresh(
 pub(super) fn resume_pr_post_mutation_refresh(app_state: &mut AppStateHandle, ctx: &SharedContext) {
     let ready = {
         let state = app_state.read();
-        state.screen == jefe::state::ScreenId::PullRequests
+        state.screen() == jefe::state::ScreenId::PullRequests
             && state.pr_post_mutation_refresh_ready()
     };
     if !ready {

--- a/src/app_input/prs_property_key_tests.rs
+++ b/src/app_input/prs_property_key_tests.rs
@@ -13,7 +13,7 @@ fn key(code: KeyCode) -> KeyEvent {
 
 fn prs_base_state() -> AppState {
     AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         prs_state: PullRequestsState {
             active: true,
             pr_focus: PrFocus::PrList,

--- a/src/app_input/raw_key_mutations.rs
+++ b/src/app_input/raw_key_mutations.rs
@@ -92,7 +92,7 @@ mod tests {
     #[test]
     fn inline_text_is_raw_but_submit_and_cancel_are_not() {
         let state = AppState {
-            screen: ScreenId::Issues,
+            nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
             issues_state: IssuesState {
                 active: true,
                 inline_state: InlineState::Composer {

--- a/src/app_input/shell_overlay.rs
+++ b/src/app_input/shell_overlay.rs
@@ -158,7 +158,7 @@ pub fn resize_terminal(ctx: &SharedContext, cols: u16, rows: u16, state: &jefe::
     let Ok(mut guard) = ctx_arc.lock() else {
         return;
     };
-    let layout = if state.shell_overlay_active() && state.screen == ScreenId::Terminals {
+    let layout = if state.shell_overlay_active() && state.screen() == ScreenId::Terminals {
         jefe::layout::compute_terminal_manager_pty_layout(cols, rows)
     } else if state.shell_overlay_active() {
         jefe::layout::compute_shell_overlay_pty_layout(cols, rows)
@@ -374,7 +374,7 @@ fn read_local_agent(
     require_running: bool,
 ) -> Option<(jefe::domain::AgentId, std::path::PathBuf)> {
     let state = app_state.read();
-    if state.screen != ScreenId::Dashboard {
+    if state.screen() != ScreenId::Dashboard {
         return None;
     }
     let agent = state.selected_agent()?;

--- a/src/app_input/split_mode_key_tests.rs
+++ b/src/app_input/split_mode_key_tests.rs
@@ -37,7 +37,7 @@ fn dashboard_s_emits_enter_split_mode_via_registry() {
 #[test]
 fn split_esc_emits_exit_split_mode_via_registry() {
     let state = AppState {
-        screen: ScreenId::Repositories,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Repositories),
         ..AppState::default()
     };
     assert!(matches!(

--- a/src/app_input/terminal_manager.rs
+++ b/src/app_input/terminal_manager.rs
@@ -295,7 +295,7 @@ pub async fn complete_pending_shell_focus(
     let Some(pending) = pending else {
         return;
     };
-    if app_state.read().screen != expected_focus_screen(pending.origin) {
+    if app_state.read().screen() != expected_focus_screen(pending.origin) {
         return;
     }
     if pending.agent_id != attached_agent_id {

--- a/src/app_shell.rs
+++ b/src/app_shell.rs
@@ -370,7 +370,7 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
 
     trace!(
         modal = ?std::mem::discriminant(&modal),
-        screen = ?snapshot.screen,
+        screen = ?snapshot.screen(),
         pane_focus = ?snapshot.pane_focus,
         terminal_focused = snapshot.terminal_focused,
         repos = snapshot.repositories.len(),
@@ -448,8 +448,8 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     // requests a background capture via the `CaptureHandle` and reads the
     // runtime's `HistoryCache` directly (non-blocking `get`). The background
     // worker drains the request and stores the result in the cache.
-    let history_lines: Vec<String> = if snapshot.screen == ScreenId::Dashboard
-        || (snapshot.screen == ScreenId::Terminals && snapshot.shell_overlay_active())
+    let history_lines: Vec<String> = if snapshot.screen() == ScreenId::Dashboard
+        || (snapshot.screen() == ScreenId::Terminals && snapshot.shell_overlay_active())
     {
         crate::app_shell_workers::capture_history_from_cache(ctx.as_ref())
     } else {
@@ -468,14 +468,15 @@ pub fn App(mut hooks: Hooks, props: &AppProps) -> impl Into<AnyElement<'static>>
     // which guarantees a nonzero content rectangle or hides the pane, so there
     // is no `.max(1)` to apply here.
     let terminal_rect = snapshot.resolved_layout.as_ref().and_then(|layout| {
-        let descriptor = jefe::workbench::screen_descriptor(snapshot.screen).ok()?;
+        let descriptor = jefe::workbench::screen_descriptor(snapshot.screen()).ok()?;
         jefe::workbench::pty_content_rect(
             descriptor,
             layout,
             &jefe::workbench::PanelId::from_static("terminal"),
         )
     });
-    let pty_layout = if snapshot.shell_overlay_active() && snapshot.screen == ScreenId::Terminals {
+    let pty_layout = if snapshot.shell_overlay_active() && snapshot.screen() == ScreenId::Terminals
+    {
         jefe::layout::compute_terminal_manager_pty_layout(term_cols, term_rows)
     } else if snapshot.shell_overlay_active() {
         jefe::layout::compute_shell_overlay_pty_layout(term_cols, term_rows)
@@ -742,7 +743,7 @@ fn handle_key_event(
     let state_ro = app_state.read();
     let term_focused = state_ro.terminal_focused;
     let pane_focus = state_ro.pane_focus;
-    let screen = state_ro.screen;
+    let screen = state_ro.screen();
     let modal = state_ro.modal.clone();
     let input_mode = input_mode_for_state(&state_ro);
     drop(state_ro);

--- a/src/app_shell_key_routing.rs
+++ b/src/app_shell_key_routing.rs
@@ -289,7 +289,7 @@ pub fn execute_mouse_resolution(
 fn dashboard_page_items(app_state: &HookState<AppState>) -> PageItemCount {
     let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
     let state = app_state.read();
-    crate::app_input::dashboard_page_item_count(&state, state.screen, cols, rows)
+    crate::app_input::dashboard_page_item_count(&state, state.screen(), cols, rows)
 }
 
 #[cfg(test)]

--- a/src/app_shell_key_routing_tests.rs
+++ b/src/app_shell_key_routing_tests.rs
@@ -86,7 +86,7 @@ fn dashboard_and_split_use_registry_handlers() {
         HandlerKey::NavigateDown,
     );
     let split = AppState {
-        screen: ScreenId::Repositories,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Repositories),
         ..AppState::default()
     };
     assert_handler(
@@ -104,7 +104,7 @@ fn dashboard_and_split_use_registry_handlers() {
 #[test]
 fn errors_reverse_cycle_and_detail_scroll_use_registry_handlers() {
     let mut state = AppState {
-        screen: ScreenId::Errors,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Errors),
         ..AppState::default()
     };
     assert_handler(&state, &key(KeyCode::Left), HandlerKey::ErrorsCyclePane);
@@ -125,7 +125,7 @@ fn terminal_and_actions_pre_mode_use_registry_handlers() {
         HandlerKey::TerminalScrollTail,
     );
     let actions = AppState {
-        screen: ScreenId::Actions,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Actions),
         ..AppState::default()
     };
     assert_handler(
@@ -161,7 +161,7 @@ fn dashboard_overlays_resolve_only_the_legacy_pre_mode_f12_binding() {
         ScreenId::Actions,
     ] {
         let state = AppState {
-            screen,
+            nav: jefe::state::navigation::NavState::rooted(screen),
             ..modal.clone()
         };
         assert_handler(
@@ -176,7 +176,7 @@ fn dashboard_overlays_resolve_only_the_legacy_pre_mode_f12_binding() {
     }
     for screen in [ScreenId::Issues, ScreenId::PullRequests] {
         let state = AppState {
-            screen,
+            nav: jefe::state::navigation::NavState::rooted(screen),
             ..modal.clone()
         };
         assert!(matches!(
@@ -189,7 +189,7 @@ fn dashboard_overlays_resolve_only_the_legacy_pre_mode_f12_binding() {
 #[test]
 fn full_s4_special_contexts_resolve_controls_and_leave_raw_text_unbound() {
     let mut state = AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state: IssuesState {
             active: true,
             issue_focus: IssueFocus::IssueDetail,
@@ -231,7 +231,7 @@ fn full_s4_special_contexts_resolve_controls_and_leave_raw_text_unbound() {
 #[test]
 fn new_issue_submit_override_uses_state_derived_production_context() {
     let state = AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state: IssuesState {
             active: true,
             issue_focus: IssueFocus::IssueDetail,
@@ -253,7 +253,7 @@ fn new_issue_submit_override_uses_state_derived_production_context() {
 #[test]
 fn issue_inline_submit_override_uses_state_derived_production_context() {
     let state = AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state: IssuesState {
             active: true,
             issue_focus: IssueFocus::IssueDetail,
@@ -274,7 +274,7 @@ fn issue_inline_submit_override_uses_state_derived_production_context() {
 #[test]
 fn pr_inline_submit_override_uses_state_derived_production_context() {
     let state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         prs_state: PullRequestsState {
             active: true,
             inline_state: InlineState::Composer {

--- a/src/detail_wrap_map.rs
+++ b/src/detail_wrap_map.rs
@@ -133,7 +133,7 @@ pub fn detail_wrap_projection(
     let resolved_width = app_state
         .resolved_layout
         .as_ref()
-        .and_then(|layout| jefe::selection::detail_wrap_width(layout, pane, app_state.screen));
+        .and_then(|layout| jefe::selection::detail_wrap_width(layout, pane, app_state.screen()));
     match pane {
         SelectablePane::IssueDetail => {
             let detail = app_state.issues_state.issue_detail.as_ref()?;

--- a/src/input.rs
+++ b/src/input.rs
@@ -148,7 +148,7 @@ pub fn input_mode_for_state(state: &AppState) -> InputMode {
     // @plan PLAN-20260329-ISSUES-MODE.P03
     // @requirement REQ-ISS-002
     // @pseudocode component-003 lines 01-02
-    if state.screen == ScreenId::Issues {
+    if state.screen() == ScreenId::Issues {
         if state.issues_state.inline_state != InlineState::None {
             return InputMode::IssuesInline;
         }
@@ -170,7 +170,7 @@ pub fn input_mode_for_state(state: &AppState) -> InputMode {
     // @requirement REQ-PR-002
     // @requirement REQ-PR-004
     // @pseudocode component-003 lines 07,51
-    if state.screen == ScreenId::PullRequests {
+    if state.screen() == ScreenId::PullRequests {
         if state.prs_state.inline_state != InlineState::None {
             return InputMode::PrsInline;
         }
@@ -187,7 +187,7 @@ pub fn input_mode_for_state(state: &AppState) -> InputMode {
     }
 
     // Actions mode detection
-    if state.screen == ScreenId::Actions {
+    if state.screen() == ScreenId::Actions {
         if state.actions_state.ui.search_input_focused {
             return InputMode::ActionsSearch;
         }

--- a/src/mouse_routing.rs
+++ b/src/mouse_routing.rs
@@ -230,7 +230,7 @@ fn terminal_target_info(ctx: Option<&CtxArc>, app_state: &HookState<AppState>) -
         (
             state.terminal_focused,
             state.pane_focus,
-            state.screen,
+            state.screen(),
             is_blocking_modal_open(&state),
         )
     };
@@ -709,7 +709,7 @@ fn resolve_app_selection_point(
     Some(SelectionPoint::new(pane, line, c))
 }
 fn screen_layout_for(state: &AppState, cols: u16, rows: u16) -> ScreenLayout {
-    let (mode_error, filter_open) = match state.screen {
+    let (mode_error, filter_open) = match state.screen() {
         ScreenId::Issues => (
             jefe::layout::issues_banner_visible(
                 state.issues_state.error.as_deref(),
@@ -729,9 +729,10 @@ fn screen_layout_for(state: &AppState, cols: u16, rows: u16) -> ScreenLayout {
             (false, false)
         }
     };
-    let error_visible =
-        (state.error_message.is_some() && !matches!(state.screen, ScreenId::Errors)) || mode_error;
-    ScreenLayout::new(cols, rows, state.screen, error_visible, filter_open)
+    let error_visible = (state.error_message.is_some()
+        && !matches!(state.screen(), ScreenId::Errors))
+        || mode_error;
+    ScreenLayout::new(cols, rows, state.screen(), error_visible, filter_open)
         .with_overlay(active_overlay_for(state))
 }
 /// Whether a blocking modal is open (Finding G).

--- a/src/mouse_routing_banner_tests.rs
+++ b/src/mouse_routing_banner_tests.rs
@@ -15,7 +15,7 @@ use jefe::state::{AppState, IssueFilterUiState, IssuesState, PullRequestsState, 
 #[test]
 fn notice_only_banner_shifts_issues_workspace_for_mouse_routing() {
     let state = AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         issues_state: IssuesState {
             draft_notice: Some("No agents available".to_string()),
             ..IssuesState::default()
@@ -49,7 +49,7 @@ fn notice_only_banner_shifts_issues_workspace_for_mouse_routing() {
 #[test]
 fn no_banner_keeps_issues_workspace_at_row_one_for_mouse_routing() {
     let state = AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         ..AppState::default()
     };
 
@@ -138,7 +138,7 @@ fn notice_only_banner_reduces_issues_detail_viewport_rows() {
 fn issues_draft_notice_does_not_shift_pr_mode_geometry() {
     // State with Issues draft_notice but screen = DashboardPullRequests.
     let state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         issues_state: IssuesState {
             draft_notice: Some("No agents available".to_string()),
             ..IssuesState::default()
@@ -163,7 +163,7 @@ fn issues_draft_notice_does_not_shift_pr_mode_geometry() {
 #[test]
 fn issues_error_does_not_shift_pr_mode_geometry() {
     let state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         issues_state: IssuesState {
             error: Some("load failed".to_string()),
             ..IssuesState::default()
@@ -187,7 +187,7 @@ fn issues_error_does_not_shift_pr_mode_geometry() {
 #[test]
 fn pr_error_does_not_shift_issues_mode_geometry() {
     let state = AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         prs_state: PullRequestsState {
             error: Some("PR load failed".to_string()),
             ..PullRequestsState::default()
@@ -210,7 +210,7 @@ fn pr_error_does_not_shift_issues_mode_geometry() {
 #[test]
 fn pr_error_in_pr_mode_shifts_pr_geometry() {
     let state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         prs_state: PullRequestsState {
             error: Some("PR load failed".to_string()),
             ..PullRequestsState::default()
@@ -239,7 +239,7 @@ fn pr_error_in_pr_mode_shifts_pr_geometry() {
 #[test]
 fn issues_filter_open_does_not_shift_pr_mode_geometry() {
     let state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         issues_state: IssuesState {
             filter_ui: IssueFilterUiState {
                 controls_open: true,

--- a/src/mouse_routing_tests.rs
+++ b/src/mouse_routing_tests.rs
@@ -134,7 +134,7 @@ fn focused_terminal_state(kind: AgentTypeId) -> AppState {
 #[test]
 fn terminal_pane_resolves_in_dashboard_mode() {
     let mut state = focused_terminal_state(jefe::domain::shipped_agent_type(1));
-    state.screen = ScreenId::Dashboard;
+    state.nav = crate::state::navigation::NavState::rooted(ScreenId::Dashboard);
     // terminal_input_enabled=false means the terminal pane IS selectable
     // (it's not occupied by PTY input routing in this context).
     match resolve_pane(&state, 30, 20, 120, 40, false) {
@@ -149,7 +149,7 @@ fn terminal_pane_not_routed_in_issues_mode() {
     // terminal_focused is true. The terminal pane should not resolve as a
     // selectable terminal in Issues mode (there is no TerminalView there).
     let mut state = focused_terminal_state(jefe::domain::shipped_agent_type(1));
-    state.screen = ScreenId::Issues;
+    state.nav = crate::state::navigation::NavState::rooted(ScreenId::Issues);
     // In Issues mode, the coordinate would map to IssueList/IssueDetail, not
     // TerminalView. This test verifies the geometry doesn't produce a
     // TerminalView (which would be a ghost selection).
@@ -381,7 +381,7 @@ fn stray_left_down_while_pending_flushes_buffered_down() {
 #[test]
 fn resolve_pane_terminal_input_enabled_excludes_terminal() {
     let mut state = focused_terminal_state(jefe::domain::shipped_agent_type(1));
-    state.screen = ScreenId::Dashboard;
+    state.nav = crate::state::navigation::NavState::rooted(ScreenId::Dashboard);
     // When terminal_input_enabled=true (focused terminal), the dashboard
     // terminal region returns None (pane_at excludes it).
     assert!(
@@ -393,7 +393,7 @@ fn resolve_pane_terminal_input_enabled_excludes_terminal() {
 #[test]
 fn resolve_pane_terminal_not_enabled_includes_terminal() {
     let mut state = focused_terminal_state(jefe::domain::shipped_agent_type(1));
-    state.screen = ScreenId::Dashboard;
+    state.nav = crate::state::navigation::NavState::rooted(ScreenId::Dashboard);
     // When terminal_input_enabled=false (unfocused/preview), the terminal
     // region resolves to TerminalView.
     match resolve_pane(&state, 30, 20, 120, 40, false) {

--- a/src/screen_layout.rs
+++ b/src/screen_layout.rs
@@ -26,10 +26,10 @@ use crate::workbench::{
 /// falls back to no geometry is far harder to diagnose than one that says why.
 #[must_use]
 pub fn resolve_screen(state: &AppState, term_cols: u16, term_rows: u16) -> Option<ResolvedLayout> {
-    let descriptor = match screen_descriptor(state.screen) {
+    let descriptor = match screen_descriptor(state.screen()) {
         Ok(descriptor) => descriptor,
         Err(error) => {
-            tracing::error!(screen = %state.screen, %error, "no compiled descriptor for the active screen");
+            tracing::error!(screen = %state.screen(), %error, "no compiled descriptor for the active screen");
             return None;
         }
     };
@@ -38,7 +38,7 @@ pub fn resolve_screen(state: &AppState, term_cols: u16, term_rows: u16) -> Optio
     match resolve_layout(descriptor, ScreenInstanceId::next(), outer, &panel_state) {
         Ok(layout) => Some(layout),
         Err(error) => {
-            tracing::error!(screen = %state.screen, %error, ?outer, "layout resolution failed");
+            tracing::error!(screen = %state.screen(), %error, ?outer, "layout resolution failed");
             None
         }
     }
@@ -79,7 +79,7 @@ fn hidden_panels(state: &AppState) -> PanelState {
 /// identity produced here is declared by the screen it names.
 pub(crate) fn hidden_panel_ids(state: &AppState) -> Vec<PanelId> {
     let mut hidden = Vec::new();
-    match state.screen {
+    match state.screen() {
         ScreenId::Dashboard => {
             if !state.dashboard_search_active() && !state.dashboard_search.input_focused {
                 hidden.push(PanelId::from_static("search"));

--- a/src/screen_layout_parity_tests.rs
+++ b/src/screen_layout_parity_tests.rs
@@ -14,7 +14,7 @@ use crate::workbench::{PanelId, ScreenId};
 
 fn dashboard() -> AppState {
     AppState {
-        screen: ScreenId::Dashboard,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Dashboard),
         ..AppState::default()
     }
 }

--- a/src/screen_layout_tests.rs
+++ b/src/screen_layout_tests.rs
@@ -7,7 +7,7 @@ use crate::workbench::{PanelId, ScreenId, screen_descriptor};
 
 fn state_on(screen: ScreenId) -> AppState {
     AppState {
-        screen,
+        nav: crate::state::navigation::NavState::rooted(screen),
         ..AppState::default()
     }
 }

--- a/src/selection/content.rs
+++ b/src/selection/content.rs
@@ -295,7 +295,7 @@ fn sidebar_lines(state: &AppState, render_cols: u16, render_rows: u16) -> PaneCo
         .iter()
         .map(|repo| state.visible_agent_count_for_repository(&repo.id))
         .collect();
-    let (pane_rows, content_width) = if state.screen == crate::state::ScreenId::Repositories {
+    let (pane_rows, content_width) = if state.screen() == crate::state::ScreenId::Repositories {
         let layout = crate::layout::split_layout_for_render_size(render_cols, render_rows);
         (layout.sidebar_rows, layout.sidebar_content_cols)
     } else {
@@ -308,7 +308,7 @@ fn sidebar_lines(state: &AppState, render_cols: u16, render_rows: u16) -> PaneCo
         repositories,
         agent_counts: counts,
         selected: state.selected_repository_visible_index().unwrap_or(0),
-        grabbed: if state.screen == crate::state::ScreenId::Repositories {
+        grabbed: if state.screen() == crate::state::ScreenId::Repositories {
             state.split_grab_index
         } else {
             state.dashboard_grab.as_ref().and_then(|grab| match grab {
@@ -407,14 +407,14 @@ fn status_bar_lines(state: &AppState) -> PaneContent {
 /// process-identity label (pid + commit) is appended so mouse-selection copy
 /// captures it (issue #223).
 fn keybind_bar_lines(state: &AppState) -> PaneContent {
-    let actions_focus = (state.screen == ScreenId::Actions).then_some(state.actions_state.focus);
+    let actions_focus = (state.screen() == ScreenId::Actions).then_some(state.actions_state.focus);
     let hints = state
         .action_registry_snapshot
         .as_ref()
         .map_or_else(String::new, |snapshot| {
             crate::ui::components::keybind_bar::keybind_hints_for(
                 snapshot,
-                state.screen,
+                state.screen(),
                 false,
                 actions_focus,
             )

--- a/src/selection/content_tests.rs
+++ b/src/selection/content_tests.rs
@@ -299,7 +299,7 @@ fn status_bar_lines_show_kennel_mode_for_selected_code_puppy_agent() {
 #[test]
 fn keybind_bar_lines_match_rendered_hints() {
     let state = AppState {
-        screen: crate::state::ScreenId::Dashboard,
+        nav: crate::state::navigation::NavState::rooted(crate::state::ScreenId::Dashboard),
         action_registry_snapshot: Some(crate::action_projection::test_snapshot()),
         ..AppState::default()
     };

--- a/src/selection/overlay_content.rs
+++ b/src/selection/overlay_content.rs
@@ -612,7 +612,7 @@ mod tests {
     fn agent_chooser_default_and_clean_render() {
         use crate::domain::{AgentChooserEntry, ChooserRuntimeConfig, DirtyStatus};
         let state = AppState {
-            screen: crate::state::ScreenId::Issues,
+            nav: crate::state::navigation::NavState::rooted(crate::state::ScreenId::Issues),
             issues_state: crate::state::IssuesState {
                 agent_chooser: Some(crate::state::AgentChooserState {
                     selected_index: 0,

--- a/src/selection/resolved_panes_tests.rs
+++ b/src/selection/resolved_panes_tests.rs
@@ -14,7 +14,7 @@ use crate::workbench::{PanelId, ResolvedLayout};
 
 fn state_on(screen: ScreenId) -> AppState {
     AppState {
-        screen,
+        nav: crate::state::navigation::NavState::rooted(screen),
         ..AppState::default()
     }
 }

--- a/src/state/actions_ops.rs
+++ b/src/state/actions_ops.rs
@@ -25,7 +25,7 @@ impl AppState {
             selected_repository_index: self.selected_repository_index,
             selected_agent_index: self.selected_agent_index,
         });
-        self.screen = ScreenId::Actions;
+        let _ = self.enter_screen(ScreenId::Actions);
         self.actions_state.active = true;
         self.actions_state.focus = ActionsFocus::RunList;
         self.actions_state.list.clear();
@@ -59,7 +59,7 @@ impl AppState {
 
     /// Exit actions mode, restoring prior focus state.
     fn exit_actions_mode(&mut self) {
-        self.screen = ScreenId::Dashboard;
+        let _ = self.leave_screen();
         self.actions_state.active = false;
         if let Some(prior) = self.actions_state.prior_agent_focus.take() {
             self.pane_focus = prior.pane_focus;

--- a/src/state/actions_ops.rs
+++ b/src/state/actions_ops.rs
@@ -25,7 +25,7 @@ impl AppState {
             selected_repository_index: self.selected_repository_index,
             selected_agent_index: self.selected_agent_index,
         });
-        let _ = self.enter_screen(ScreenId::Actions);
+        let _ = self.show_screen(ScreenId::Actions);
         self.actions_state.active = true;
         self.actions_state.focus = ActionsFocus::RunList;
         self.actions_state.list.clear();

--- a/src/state/actions_tests.rs
+++ b/src/state/actions_tests.rs
@@ -56,7 +56,7 @@ mod tests {
 
         state.apply_actions_message(ActionsMessage::EnterMode);
         assert!(state.actions_state.active);
-        assert_eq!(state.screen, ScreenId::Actions);
+        assert_eq!(state.screen(), ScreenId::Actions);
         assert_eq!(state.actions_state.focus, ActionsFocus::RunList);
         assert!(
             state.actions_state.runs().is_empty(),
@@ -65,7 +65,7 @@ mod tests {
 
         state.apply_actions_message(ActionsMessage::ExitMode);
         assert!(!state.actions_state.active);
-        assert_eq!(state.screen, ScreenId::Dashboard);
+        assert_eq!(state.screen(), ScreenId::Dashboard);
     }
 
     #[test]

--- a/src/state/cross_mode_transition_tests.rs
+++ b/src/state/cross_mode_transition_tests.rs
@@ -17,10 +17,10 @@ use crate::state::transition::TransitionExt;
 fn enter_issues_mode_from_prs_mode_switches_screen() {
     let state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
     let state = state.apply(AppEvent::EnterPrsMode).committed_pure();
-    assert_eq!(state.screen, ScreenId::PullRequests);
+    assert_eq!(state.screen(), ScreenId::PullRequests);
     let state = state.apply(AppEvent::EnterIssuesMode).committed_pure();
     assert_eq!(
-        state.screen,
+        state.screen(),
         ScreenId::Issues,
         "EnterIssuesMode from PR mode must switch to DashboardIssues"
     );
@@ -37,10 +37,10 @@ fn enter_issues_mode_from_prs_mode_switches_screen() {
 fn enter_prs_mode_from_issues_mode_switches_screen() {
     let state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
     let state = state.apply(AppEvent::EnterIssuesMode).committed_pure();
-    assert_eq!(state.screen, ScreenId::Issues);
+    assert_eq!(state.screen(), ScreenId::Issues);
     let state = state.apply(AppEvent::EnterPrsMode).committed_pure();
     assert_eq!(
-        state.screen,
+        state.screen(),
         ScreenId::PullRequests,
         "EnterPrsMode from Issues mode must switch to DashboardPullRequests"
     );
@@ -63,7 +63,7 @@ fn enter_issues_mode_from_prs_deactivates_prs() {
     let state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
     let state = state.apply(AppEvent::EnterPrsMode).committed_pure();
     assert!(state.prs_state.active);
-    assert_eq!(state.screen, ScreenId::PullRequests);
+    assert_eq!(state.screen(), ScreenId::PullRequests);
 
     let state = state.apply(AppEvent::EnterIssuesMode).committed_pure();
     assert!(
@@ -75,7 +75,7 @@ fn enter_issues_mode_from_prs_deactivates_prs() {
         "EnterIssuesMode from PR mode must deactivate prs_state.active"
     );
     assert_eq!(
-        state.screen,
+        state.screen(),
         ScreenId::Issues,
         "screen must be DashboardIssues after EnterIssuesMode"
     );
@@ -97,7 +97,7 @@ fn enter_prs_mode_from_issues_deactivates_issues() {
     let state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
     let state = state.apply(AppEvent::EnterIssuesMode).committed_pure();
     assert!(state.issues_state.active);
-    assert_eq!(state.screen, ScreenId::Issues);
+    assert_eq!(state.screen(), ScreenId::Issues);
 
     let state = state.apply(AppEvent::EnterPrsMode).committed_pure();
     assert!(
@@ -109,7 +109,7 @@ fn enter_prs_mode_from_issues_deactivates_issues() {
         "EnterPrsMode from Issues mode must deactivate issues_state.active"
     );
     assert_eq!(
-        state.screen,
+        state.screen(),
         ScreenId::PullRequests,
         "screen must be DashboardPullRequests after EnterPrsMode"
     );

--- a/src/state/dashboard_grab_ops.rs
+++ b/src/state/dashboard_grab_ops.rs
@@ -12,7 +12,7 @@ impl AppState {
     /// grabbed repository was deleted, or the visible-index/local-index is out
     /// of bounds after a visibility or data change.
     pub(super) fn validate_dashboard_grab(&mut self) {
-        if self.screen != ScreenId::Dashboard {
+        if self.screen() != ScreenId::Dashboard {
             self.dashboard_grab = None;
             return;
         }

--- a/src/state/durable_projection.rs
+++ b/src/state/durable_projection.rs
@@ -438,7 +438,7 @@ fn project_selection(
         // The stable screen identity, so a restored session reopens where it
         // left off. Written as the identity string rather than an ordinal, so
         // the document survives any reordering of `ScreenId`.
-        screen_id: Id::parse(state.screen.as_str()).ok(),
+        screen_id: Id::parse(state.screen().as_str()).ok(),
     }
 }
 

--- a/src/state/durable_projection_tests.rs
+++ b/src/state/durable_projection_tests.rs
@@ -208,7 +208,8 @@ fn forward_maps_selection_indices_to_ids() {
 #[test]
 fn forward_writes_the_active_screen_as_its_stable_identity() {
     let mut state = sample_state();
-    state.screen = crate::workbench::ScreenId::PullRequests;
+    state.nav =
+        crate::state::navigation::NavState::rooted(crate::workbench::ScreenId::PullRequests);
     let projected = to_durable_state(&state).value_or_panic("projection succeeds");
     assert_eq!(
         projected.selection.screen_id.as_ref().map(Id::as_str),
@@ -221,7 +222,7 @@ fn forward_writes_the_active_screen_as_its_stable_identity() {
 fn the_active_screen_round_trips_through_the_durable_document() {
     for screen in crate::workbench::ScreenId::ALL {
         let mut state = sample_state();
-        state.screen = screen;
+        state.nav = crate::state::navigation::NavState::rooted(screen);
         let projected = to_durable_state(&state).value_or_panic("projection succeeds");
         let restored = crate::state::durable_restore::from_durable_state(&projected)
             .value_or_panic("restore succeeds");

--- a/src/state/errors_ops.rs
+++ b/src/state/errors_ops.rs
@@ -16,7 +16,7 @@ impl AppState {
             selected_repository_index: self.selected_repository_index,
             selected_agent_index: self.selected_agent_index,
         });
-        self.screen = ScreenId::Errors;
+        let _ = self.enter_screen(ScreenId::Errors);
         self.errors_state.active = true;
         self.errors_state.focus = ErrorsFocus::ErrorList;
         // Ensure selection is valid (newest error after any recent push).
@@ -31,7 +31,7 @@ impl AppState {
 
     /// Exit errors mode, restoring prior focus state.
     fn exit_errors_mode(&mut self) {
-        self.screen = ScreenId::Dashboard;
+        let _ = self.leave_screen();
         self.errors_state.active = false;
         if let Some(prior) = self.errors_state.prior_agent_focus.take() {
             self.pane_focus = prior.pane_focus;

--- a/src/state/errors_ops.rs
+++ b/src/state/errors_ops.rs
@@ -16,7 +16,7 @@ impl AppState {
             selected_repository_index: self.selected_repository_index,
             selected_agent_index: self.selected_agent_index,
         });
-        let _ = self.enter_screen(ScreenId::Errors);
+        let _ = self.show_screen(ScreenId::Errors);
         self.errors_state.active = true;
         self.errors_state.focus = ErrorsFocus::ErrorList;
         // Ensure selection is valid (newest error after any recent push).

--- a/src/state/errors_tests.rs
+++ b/src/state/errors_tests.rs
@@ -109,7 +109,7 @@ fn push_evicts_oldest_at_capacity() {
 fn enter_errors_mode_sets_screen_and_focus() {
     let mut state = AppState::default();
     apply_in_place(&mut state, AppEvent::EnterErrorsMode);
-    assert_eq!(state.screen, ScreenId::Errors);
+    assert_eq!(state.screen(), ScreenId::Errors);
     assert!(state.errors_state.active);
     assert_eq!(state.errors_state.focus, ErrorsFocus::ErrorList);
 }
@@ -125,7 +125,7 @@ fn enter_exit_restores_focus() {
     assert!(state.errors_state.prior_agent_focus.is_some());
 
     apply_in_place(&mut state, AppEvent::ExitErrorsMode);
-    assert_eq!(state.screen, ScreenId::Dashboard);
+    assert_eq!(state.screen(), ScreenId::Dashboard);
     assert!(!state.errors_state.active);
     // Prior focus restored.
     assert_eq!(state.pane_focus, crate::state::PaneFocus::Repositories);
@@ -466,7 +466,7 @@ fn nav_while_repo_focused_does_not_move_error_selection() {
 #[test]
 fn silent_panic_is_stored_without_changing_visible_error_or_navigation() {
     let mut state = AppState::default();
-    state.screen = ScreenId::Errors;
+    state.nav = crate::state::navigation::NavState::rooted(ScreenId::Errors);
     state.pane_focus = crate::state::PaneFocus::Repositories;
     state.errors_state.active = true;
     state.errors_state.focus = ErrorsFocus::ErrorDetail;
@@ -501,7 +501,7 @@ fn silent_panic_is_stored_without_changing_visible_error_or_navigation() {
         Some("visible failure")
     );
     assert_eq!(state.last_error_title().as_deref(), Some("visible failure"));
-    assert_eq!(state.screen, ScreenId::Errors);
+    assert_eq!(state.screen(), ScreenId::Errors);
     assert_eq!(state.pane_focus, crate::state::PaneFocus::Repositories);
     assert_eq!(state.errors_state.focus, ErrorsFocus::ErrorDetail);
     assert_eq!(state.errors_state.selected_index, Some(1));

--- a/src/state/form_ops_tests.rs
+++ b/src/state/form_ops_tests.rs
@@ -25,7 +25,7 @@ fn default_state_has_no_selection() {
 #[test]
 fn default_state_is_dashboard_mode() {
     let state = AppState::default();
-    assert_eq!(state.screen, ScreenId::Dashboard);
+    assert_eq!(state.screen(), ScreenId::Dashboard);
 }
 
 #[test]

--- a/src/state/issues_ops.rs
+++ b/src/state/issues_ops.rs
@@ -58,7 +58,7 @@ impl AppState {
         let _ = if from_sibling_list_mode {
             self.switch_screen(ScreenId::Issues)
         } else {
-            self.enter_screen(ScreenId::Issues)
+            self.show_screen(ScreenId::Issues)
         };
         self.issues_state.active = true;
         self.issues_state.issue_focus = IssueFocus::IssueList;

--- a/src/state/issues_ops.rs
+++ b/src/state/issues_ops.rs
@@ -27,6 +27,7 @@ impl AppState {
         // Finding 1: deactivate PR mode if active so both list modes are
         // never simultaneously active (which would corrupt per-repo
         // preferences on a repo change).
+        let from_sibling_list_mode = self.prs_state.active;
         if self.prs_state.active {
             self.remember_pr_preferences();
             self.prs_state.active = false;
@@ -52,7 +53,13 @@ impl AppState {
         // active in a list-mode render.
         self.terminal_focused = false;
         self.pane_focus = PaneFocus::Agents;
-        self.screen = ScreenId::Issues;
+        // The cross-mode jump takes the place of the screen it came from, so
+        // Back still returns to whatever opened the first list mode.
+        let _ = if from_sibling_list_mode {
+            self.switch_screen(ScreenId::Issues)
+        } else {
+            self.enter_screen(ScreenId::Issues)
+        };
         self.issues_state.active = true;
         self.issues_state.issue_focus = IssueFocus::IssueList;
         self.issues_state.list.clear();
@@ -93,7 +100,7 @@ impl AppState {
 
     /// Exit issues mode, restoring prior focus state.
     fn exit_issues_mode(&mut self) {
-        self.screen = ScreenId::Dashboard;
+        let _ = self.leave_screen();
         self.issues_state.active = false;
         if self.issues_state.inline_state != InlineState::None {
             self.issues_state.draft_notice = Some("Unsent draft discarded".to_string());

--- a/src/state/issues_tests.rs
+++ b/src/state/issues_tests.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 fn dashboard_issues_state() -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         ..AppState::default()
     }
 }
@@ -96,7 +96,7 @@ use crate::state::transition::TransitionExt;
 fn test_enter_issues_mode_sets_active_screen() {
     let state = AppState::default();
     let new_state = state.apply(AppEvent::EnterIssuesMode).committed_pure();
-    assert_eq!(new_state.screen, ScreenId::Issues);
+    assert_eq!(new_state.screen(), ScreenId::Issues);
     assert!(new_state.issues_state.active);
     assert_eq!(new_state.issues_state.issue_focus, IssueFocus::IssueList);
 }
@@ -169,7 +169,7 @@ fn test_exit_issues_mode_restores_focus() {
     ));
 
     let new_state = state.apply(AppEvent::ExitIssuesMode).committed_pure();
-    assert_eq!(new_state.screen, ScreenId::Dashboard);
+    assert_eq!(new_state.screen(), ScreenId::Dashboard);
     assert_eq!(new_state.pane_focus, PaneFocus::Agents);
     assert_eq!(new_state.selected_agent_index, Some(1));
 }

--- a/src/state/issues_tests_detail.rs
+++ b/src/state/issues_tests_detail.rs
@@ -12,7 +12,7 @@ use crate::state::transition::TransitionExt;
 
 pub(super) fn dashboard_issues_state() -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         ..AppState::default()
     }
 }
@@ -49,22 +49,22 @@ pub(super) fn make_test_issue(number: u64) -> Issue {
 #[test]
 fn test_keybind_bar_issues_mode() {
     let dashboard_state = AppState::default();
-    assert_eq!(dashboard_state.screen, ScreenId::Dashboard);
+    assert_eq!(dashboard_state.screen(), ScreenId::Dashboard);
 
     let issues_state = AppState::default()
         .apply(AppEvent::EnterIssuesMode)
         .committed_pure();
-    assert_eq!(issues_state.screen, ScreenId::Issues);
+    assert_eq!(issues_state.screen(), ScreenId::Issues);
 
     // Modes are distinguishable — keybind bar can branch on this
-    assert_ne!(dashboard_state.screen, issues_state.screen);
+    assert_ne!(dashboard_state.screen(), issues_state.screen());
 
     // And exit returns to Dashboard
     let exited = issues_state
         .apply(AppEvent::ExitIssuesMode)
         .committed_pure();
-    assert_eq!(exited.screen, ScreenId::Dashboard);
-    assert_ne!(exited.screen, ScreenId::Issues);
+    assert_eq!(exited.screen(), ScreenId::Dashboard);
+    assert_ne!(exited.screen(), ScreenId::Issues);
 }
 
 // =========================================================================
@@ -217,7 +217,7 @@ fn p15_state_with_loaded_detail(repo_id: &RepositoryId, issue_number: u64) -> Ap
 fn test_mode_lifecycle_enter_browse_exit() {
     // Enter issues mode
     let mut state = issues_mode_state_with_repo("repo-1");
-    assert_eq!(state.screen, ScreenId::Issues);
+    assert_eq!(state.screen(), ScreenId::Issues);
     assert!(state.issues_state.active);
     assert_eq!(state.issues_state.issue_focus, IssueFocus::IssueList);
 
@@ -244,7 +244,7 @@ fn test_mode_lifecycle_enter_browse_exit() {
 
     // Exit issues mode
     let state = state.apply(AppEvent::ExitIssuesMode).committed_pure();
-    assert_eq!(state.screen, ScreenId::Dashboard);
+    assert_eq!(state.screen(), ScreenId::Dashboard);
     assert!(!state.issues_state.active);
 }
 
@@ -306,7 +306,7 @@ fn test_mode_lifecycle_enter_interact_exit() {
 
     // Exit issues mode
     let state = state.apply(AppEvent::ExitIssuesMode).committed_pure();
-    assert_eq!(state.screen, ScreenId::Dashboard);
+    assert_eq!(state.screen(), ScreenId::Dashboard);
     assert!(!state.issues_state.active);
 }
 
@@ -398,7 +398,7 @@ fn test_key_routing_suppression_comprehensive() {
             state.issues_state.issue_focus, domain,
             "issues focus changed unexpectedly in domain {domain:?}"
         );
-        assert_eq!(state.screen, ScreenId::Issues);
+        assert_eq!(state.screen(), ScreenId::Issues);
         assert!(state.issues_state.active);
     }
 
@@ -508,7 +508,7 @@ fn test_error_handling_auth_failure_blocks_ops() {
     assert!(err.contains("authentication") || err.contains("token"));
     // Mode remains active
     assert!(state.issues_state.active);
-    assert_eq!(state.screen, ScreenId::Issues);
+    assert_eq!(state.screen(), ScreenId::Issues);
     // List loading is cleared
     assert!(!state.issues_state.list_loading());
 }
@@ -540,7 +540,7 @@ fn test_error_handling_network_error_stable_mode() {
     assert_eq!(state.issues_state.issue_focus, focus_before);
     // Mode stable
     assert!(state.issues_state.active);
-    assert_eq!(state.screen, ScreenId::Issues);
+    assert_eq!(state.screen(), ScreenId::Issues);
 }
 
 /// P15 Test 8: Load issues with has_more=true — has_more_issues flag set.

--- a/src/state/issues_tests_detail_flow.rs
+++ b/src/state/issues_tests_detail_flow.rs
@@ -14,7 +14,7 @@ use crate::state::transition::TransitionExt;
 
 fn dashboard_issues_state() -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         ..AppState::default()
     }
 }
@@ -298,13 +298,13 @@ fn test_exit_focus_restoration_valid() {
 
     // Enter issues mode — focus is saved
     let state = state.apply(AppEvent::EnterIssuesMode).committed_pure();
-    assert_eq!(state.screen, ScreenId::Issues);
+    assert_eq!(state.screen(), ScreenId::Issues);
 
     // Exit — prior focus restored
     let state = state.apply(AppEvent::ExitIssuesMode).committed_pure();
     assert_eq!(state.pane_focus, PaneFocus::Agents);
     assert_eq!(state.selected_agent_index, Some(1));
-    assert_eq!(state.screen, ScreenId::Dashboard);
+    assert_eq!(state.screen(), ScreenId::Dashboard);
 }
 
 /// P15 Test 11: Enter issues, agent removed while in issues mode, exit — fallback, no crash.
@@ -347,7 +347,7 @@ fn test_exit_focus_restoration_stale() {
 
     // Exit — should fall back gracefully
     let state = state.apply(AppEvent::ExitIssuesMode).committed_pure();
-    assert_eq!(state.screen, ScreenId::Dashboard);
+    assert_eq!(state.screen(), ScreenId::Dashboard);
     assert!(!state.issues_state.active);
     // No panic; agent_index is None or 0 (fallback)
     assert!(
@@ -769,7 +769,7 @@ fn test_esc_chain_all_six_levels_integrated() {
 
     // Level 6: Nothing else active — ExitIssuesMode exits mode
     let state = state.apply(AppEvent::ExitIssuesMode).committed_pure();
-    assert_eq!(state.screen, ScreenId::Dashboard);
+    assert_eq!(state.screen(), ScreenId::Dashboard);
     assert!(!state.issues_state.active);
 }
 

--- a/src/state/issues_tests_esc.rs
+++ b/src/state/issues_tests_esc.rs
@@ -8,7 +8,7 @@ use crate::state::types::{AgentChooserState, ComposerTarget, EditorTarget, Inlin
 
 fn dashboard_issues_state() -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         ..AppState::default()
     }
 }
@@ -102,7 +102,7 @@ fn test_esc_exits_issues_mode() {
     state.issues_state.search_input_focused = false;
 
     let new_state = state.apply(AppEvent::ExitIssuesMode).committed_pure();
-    assert_eq!(new_state.screen, ScreenId::Dashboard);
+    assert_eq!(new_state.screen(), ScreenId::Dashboard);
 }
 
 /// Test 23: OpenInlineEditor is blocked when another inline control is active.

--- a/src/state/issues_tests_filter.rs
+++ b/src/state/issues_tests_filter.rs
@@ -8,7 +8,7 @@ use crate::state::transition::TransitionExt;
 
 fn dashboard_issues_state() -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         ..AppState::default()
     }
 }
@@ -304,7 +304,7 @@ fn test_clear_draft_filter_keeps_controls_open_and_resets_draft() {
         state.issues_state.committed_filter.author,
         "committed-author"
     );
-    assert_eq!(state.screen, ScreenId::Issues);
+    assert_eq!(state.screen(), ScreenId::Issues);
     assert!(state.issues_state.active);
     assert!(state.issues_state.filter_ui.controls_open);
     assert_eq!(state.issues_state.filter_ui.field_index, 5);

--- a/src/state/issues_tests_repo_nav.rs
+++ b/src/state/issues_tests_repo_nav.rs
@@ -6,7 +6,7 @@ use crate::state::types::{IssueFocus, PaneFocus, ScreenId};
 
 fn dashboard_issues_state() -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         ..AppState::default()
     }
 }

--- a/src/state/issues_tests_send_agent_probe.rs
+++ b/src/state/issues_tests_send_agent_probe.rs
@@ -257,7 +257,8 @@ fn unavailable_action_sets_the_issues_banner_notice() {
 #[test]
 fn unavailable_action_sets_the_pull_requests_banner_notice() {
     let mut state = state_with_unprobed_agent();
-    state.screen = crate::workbench::ScreenId::PullRequests;
+    state.nav =
+        crate::state::navigation::NavState::rooted(crate::workbench::ScreenId::PullRequests);
 
     state.record_unavailable_action("No agents available".to_string());
 
@@ -285,7 +286,7 @@ fn unavailable_action_on_other_screens_only_warns() {
         crate::workbench::ScreenId::Terminals,
     ] {
         let mut state = state_with_unprobed_agent();
-        state.screen = screen;
+        state.nav = crate::state::navigation::NavState::rooted(screen);
 
         state.record_unavailable_action("Nothing to do here".to_string());
 

--- a/src/state/issues_tests_sort.rs
+++ b/src/state/issues_tests_sort.rs
@@ -36,7 +36,7 @@ fn make_issue(number: u64, created_at: &str, updated_at: &str) -> Issue {
 
 fn issues_state_with_issues(issues: Vec<Issue>) -> AppState {
     let mut state = AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         ..AppState::default()
     };
     state.issues_state.active = true;

--- a/src/state/issues_tests_subfocus.rs
+++ b/src/state/issues_tests_subfocus.rs
@@ -11,7 +11,7 @@ use crate::state::types::{DetailSubfocus, ScreenId};
 
 fn dashboard_issues_state() -> AppState {
     AppState {
-        screen: ScreenId::Issues,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::Issues),
         ..AppState::default()
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -103,6 +103,11 @@ pub use keys_editor::{
 #[cfg(test)]
 #[path = "keys_editor_tests.rs"]
 mod keys_editor_tests;
+/// The sole owner of route, stack, and dirty transitions (issue #386).
+pub mod navigation;
+#[cfg(test)]
+#[path = "navigation_tests.rs"]
+mod navigation_tests;
 /// Bounded reducer transitions and pending effect correlations (issue #381).
 mod navigation_vertical;
 #[cfg(test)]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -110,6 +110,11 @@ pub mod navigation_dirty;
 #[cfg(test)]
 #[path = "navigation_dirty_tests.rs"]
 mod navigation_dirty_tests;
+/// Which unwindable layers a screen currently has open (issue #386).
+mod navigation_layers;
+#[cfg(test)]
+#[path = "navigation_layers_tests.rs"]
+mod navigation_layers_tests;
 /// How the rest of the reducer asks to change screen (issue #386).
 mod navigation_ops;
 #[cfg(test)]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -839,7 +839,7 @@ impl AppState {
     /// is therefore mirrored into the owning screen's notice band, which is
     /// where those screens already report `No agents available`.
     pub fn record_unavailable_action(&mut self, reason: String) {
-        match self.screen {
+        match self.screen() {
             ScreenId::Issues => self.issues_state.draft_notice = Some(reason.clone()),
             ScreenId::PullRequests => self.prs_state.draft_notice = Some(reason.clone()),
             ScreenId::Dashboard

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -105,6 +105,11 @@ pub use keys_editor::{
 mod keys_editor_tests;
 /// The sole owner of route, stack, and dirty transitions (issue #386).
 pub mod navigation;
+/// The host dirty guard the navigation reducer raises (issue #386).
+pub mod navigation_dirty;
+#[cfg(test)]
+#[path = "navigation_dirty_tests.rs"]
+mod navigation_dirty_tests;
 #[cfg(test)]
 #[path = "navigation_tests.rs"]
 mod navigation_tests;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -113,6 +113,11 @@ mod navigation_dirty_tests;
 #[cfg(test)]
 #[path = "navigation_tests.rs"]
 mod navigation_tests;
+/// The single Back-precedence resolution (issue #386).
+pub mod navigation_unwind;
+#[cfg(test)]
+#[path = "navigation_unwind_tests.rs"]
+mod navigation_unwind_tests;
 /// Bounded reducer transitions and pending effect correlations (issue #381).
 mod navigation_vertical;
 #[cfg(test)]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -110,6 +110,8 @@ pub mod navigation_dirty;
 #[cfg(test)]
 #[path = "navigation_dirty_tests.rs"]
 mod navigation_dirty_tests;
+/// How the rest of the reducer asks to change screen (issue #386).
+mod navigation_ops;
 #[cfg(test)]
 #[path = "navigation_tests.rs"]
 mod navigation_tests;
@@ -528,7 +530,7 @@ impl AppState {
                 dashboard_search_ops::apply_dashboard_search_message(self, message);
             }
             UiNavigationMessage::EnterSplitMode => {
-                self.screen = ScreenId::Repositories;
+                let _ = self.enter_screen(ScreenId::Repositories);
                 self.pane_focus = PaneFocus::Repositories;
                 self.dashboard_grab = None;
             }
@@ -601,7 +603,7 @@ impl AppState {
     }
 
     fn exit_split_mode(&mut self) {
-        self.screen = ScreenId::Dashboard;
+        let _ = self.leave_screen();
         self.split_filter = None;
         self.split_grab_index = None;
     }

--- a/src/state/navigation.rs
+++ b/src/state/navigation.rs
@@ -1,0 +1,438 @@
+//! The sole owner of route, stack, and dirty transitions (issue #386).
+//!
+//! Every screen change in the program is one call to [`reduce_navigation`].
+//! Before this existed each mode moved the session itself — issues mode set the
+//! screen on the way in and set it back on the way out, and so did pull
+//! requests, actions, errors, and the terminal manager — which meant "where am
+//! I" had as many authorities as there were modes, and none of them could
+//! answer "where was I before".
+//!
+//! The reducer is pure: it takes the navigation state, the screen registry, and
+//! one intent, and returns the next state plus what the caller must do about
+//! the instances that entered or left. It performs no I/O, holds no handle, and
+//! stages no effect of its own, so a refused navigation is indistinguishable
+//! from one that never happened.
+//!
+//! Three rules make partial mutation impossible:
+//!
+//! - a target is validated and constructed **before** anything is suspended or
+//!   disposed, so a refusal returns the state it was given, unchanged;
+//! - an instance identity is never reused, so a completion issued by an
+//!   instance that has gone can never be mistaken for one the live instance
+//!   issued;
+//! - suspension is a type, not a flag: the stack holds
+//!   [`SuspendedInstance`], which cannot be read as the current instance by
+//!   accident.
+
+use std::fmt;
+
+use crate::workbench::{
+    ActivationError, ActivationValues, NavCode, PanelId, RouteId, ScreenId, ScreenIdentity,
+    ScreenInstanceId, ScreenRegistry, route_declaration,
+};
+
+/// Maximum number of suspended instances the navigation stack may hold.
+pub const MAX_NAVIGATION_STACK: usize = 32;
+
+/// What an instance was activated with, and which instance asked for it.
+///
+/// The two identity fields have one job at each end of the activation's life.
+/// On a request they say which snapshot the request was computed from, so a
+/// request produced against a screen that has since been replaced can be
+/// refused instead of acted on. On the instance that was entered they are
+/// provenance: which instance asked, and at which activation generation this
+/// instance's own effects are correlated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Activation {
+    /// The route this activation reaches.
+    pub route: RouteId,
+    /// The validated field values the route accepts.
+    pub values: ActivationValues,
+    /// The instance the request was computed from.
+    pub source_instance: ScreenInstanceId,
+    /// On a request, the source's activation generation; on an entered
+    /// instance, that instance's own activation generation.
+    pub activation_generation: u64,
+}
+
+impl Activation {
+    /// Build a request against the snapshot `source` was read from.
+    #[must_use]
+    pub fn from_source(route: RouteId, values: ActivationValues, source: &ScreenInstance) -> Self {
+        Self {
+            route,
+            values,
+            source_instance: source.id,
+            activation_generation: source.activation.activation_generation,
+        }
+    }
+}
+
+/// One live screen instance.
+///
+/// An instance is the session's presence on a screen: which screen, what it was
+/// activated with, where focus sits, and which generation its in-flight work is
+/// correlated against. Two visits to the same screen are two instances, so the
+/// second never inherits the first's pending answers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScreenInstance {
+    /// Process-unique identity, never reused.
+    pub id: ScreenInstanceId,
+    /// The screen this instance is on.
+    pub screen: ScreenId,
+    /// What this instance was activated with.
+    pub activation: Activation,
+    /// The panel that holds focus.
+    pub panel_focus: PanelId,
+    /// Screen generation; a completion naming an older one is stale.
+    pub generation: u64,
+}
+
+/// An instance whose subscriptions are suspended while it waits on the stack.
+///
+/// Wrapping it keeps the distinction in the type system: a suspended instance
+/// is not a candidate for "what is the session doing now", and its pending work
+/// is not answered until it is restored — by which time its generation has been
+/// left behind and the answers are stale.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SuspendedInstance(ScreenInstance);
+
+impl SuspendedInstance {
+    /// The exact instance that was suspended.
+    #[must_use]
+    pub const fn instance(&self) -> &ScreenInstance {
+        &self.0
+    }
+}
+
+/// What the session is asking navigation to do.
+#[derive(Debug, Clone)]
+pub enum NavIntent {
+    /// Suspend the current instance and enter the activation's target.
+    Push(Activation),
+    /// Dispose the current instance and enter the activation's target.
+    Replace(Activation),
+    /// Leave the current instance and restore the one beneath it.
+    Back,
+}
+
+/// Route, stack, and the instance the session is on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NavState {
+    current: ScreenInstance,
+    stack: Vec<SuspendedInstance>,
+    next_generation: u64,
+    next_activation_generation: u64,
+}
+
+impl NavState {
+    /// The state a session starts in: one clean instance, no stack.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NavRefusal::MissingDescriptor`] when `screen` has no compiled
+    /// descriptor, which is a malformed compiled table rather than anything a
+    /// user did.
+    pub fn rooted(registry: &ScreenRegistry, screen: ScreenId) -> Result<Self, NavRefusal> {
+        let Some(descriptor) = registry.get(screen) else {
+            return Err(NavRefusal::MissingDescriptor { screen });
+        };
+        let id = ScreenInstanceId::next();
+        Ok(Self {
+            current: ScreenInstance {
+                id,
+                screen,
+                activation: Activation {
+                    route: descriptor.route,
+                    values: ActivationValues::empty(),
+                    // The root instance was activated by nothing but itself.
+                    source_instance: id,
+                    activation_generation: 1,
+                },
+                panel_focus: descriptor.initial_focus,
+                generation: 1,
+            },
+            stack: Vec::new(),
+            next_generation: 2,
+            next_activation_generation: 2,
+        })
+    }
+
+    /// The instance the session is on.
+    #[must_use]
+    pub const fn current(&self) -> &ScreenInstance {
+        &self.current
+    }
+
+    /// The instance the session is on, for the owner of its focus and dirtiness.
+    pub const fn current_mut(&mut self) -> &mut ScreenInstance {
+        &mut self.current
+    }
+
+    /// The suspended instances, oldest first.
+    #[must_use]
+    pub fn suspended(&self) -> &[SuspendedInstance] {
+        &self.stack
+    }
+
+    /// How many instances are suspended beneath the current one.
+    #[must_use]
+    pub fn depth(&self) -> usize {
+        self.stack.len()
+    }
+
+    /// The screen the session is on.
+    #[must_use]
+    pub const fn screen(&self) -> ScreenId {
+        self.current.screen
+    }
+
+    /// Build the instance an activation names, without disturbing this state.
+    fn construct(
+        &self,
+        registry: &ScreenRegistry,
+        activation: &Activation,
+    ) -> Result<ScreenInstance, NavRefusal> {
+        if activation.source_instance != self.current.id
+            || activation.activation_generation != self.current.activation.activation_generation
+        {
+            return Err(NavRefusal::StaleSource {
+                supplied: activation.source_instance,
+                live: self.current.id,
+            });
+        }
+        let declaration = route_declaration(registry, activation.route)?;
+        declaration.validate(&activation.values)?;
+        let ScreenIdentity::Compiled(screen) = declaration.target_screen else {
+            return Err(NavRefusal::NotRoutable {
+                route: activation.route,
+            });
+        };
+        let Some(descriptor) = registry.get(screen) else {
+            return Err(NavRefusal::MissingDescriptor { screen });
+        };
+        if self.next_generation.checked_add(1).is_none()
+            || self.next_activation_generation.checked_add(1).is_none()
+        {
+            return Err(NavRefusal::GenerationExhausted);
+        }
+        Ok(ScreenInstance {
+            id: ScreenInstanceId::next(),
+            screen,
+            activation: Activation {
+                route: activation.route,
+                values: activation.values.clone(),
+                source_instance: activation.source_instance,
+                activation_generation: self.next_activation_generation,
+            },
+            panel_focus: descriptor.initial_focus,
+            generation: self.next_generation,
+        })
+    }
+
+    /// Advance the monotonic counters past the instance just entered.
+    fn advance(&mut self) {
+        self.next_generation = self.next_generation.saturating_add(1);
+        self.next_activation_generation = self.next_activation_generation.saturating_add(1);
+    }
+}
+
+/// What a committed navigation left for its caller to do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NavOutcome {
+    /// `suspended` went onto the stack and `entered` became current.
+    Pushed {
+        /// The instance whose subscriptions are now suspended.
+        suspended: ScreenInstanceId,
+        /// The instance the session is now on.
+        entered: ScreenInstanceId,
+    },
+    /// `disposed` was torn down without stacking and `entered` became current.
+    Replaced {
+        /// The instance to tear down.
+        disposed: ScreenInstanceId,
+        /// The instance the session is now on.
+        entered: ScreenInstanceId,
+    },
+    /// `disposed` was torn down and `restored` resumed from the stack.
+    Restored {
+        /// The instance to tear down.
+        disposed: ScreenInstanceId,
+        /// The instance the session has returned to.
+        restored: ScreenInstanceId,
+    },
+    /// There was nothing to do; nothing changed.
+    Unchanged,
+    /// The request was refused; nothing changed and the refusal must be shown.
+    Refused(NavRefusal),
+}
+
+/// One committed navigation step.
+#[derive(Debug, Clone)]
+pub struct NavTransition {
+    /// The state after the step, which equals the state before it on a refusal.
+    pub state: NavState,
+    /// What the step did, or why it did nothing.
+    pub outcome: NavOutcome,
+}
+
+/// Apply one navigation intent.
+///
+/// Returns the state unchanged, paired with a refusal, whenever the request
+/// cannot be satisfied — there is no partially applied navigation.
+#[must_use]
+pub fn reduce_navigation(
+    state: NavState,
+    registry: &ScreenRegistry,
+    intent: NavIntent,
+) -> NavTransition {
+    match intent {
+        NavIntent::Push(activation) => push(state, registry, &activation),
+        NavIntent::Replace(activation) => replace(state, registry, &activation),
+        NavIntent::Back => back(state),
+    }
+}
+
+fn push(mut state: NavState, registry: &ScreenRegistry, activation: &Activation) -> NavTransition {
+    if state.stack.len() >= MAX_NAVIGATION_STACK {
+        return refused(
+            state,
+            NavRefusal::StackDepth {
+                limit: MAX_NAVIGATION_STACK,
+            },
+        );
+    }
+    let entered = match state.construct(registry, activation) {
+        Ok(instance) => instance,
+        Err(refusal) => return refused(state, refusal),
+    };
+    let outcome = NavOutcome::Pushed {
+        suspended: state.current.id,
+        entered: entered.id,
+    };
+    let suspended = std::mem::replace(&mut state.current, entered);
+    state.stack.push(SuspendedInstance(suspended));
+    state.advance();
+    NavTransition { state, outcome }
+}
+
+fn replace(
+    mut state: NavState,
+    registry: &ScreenRegistry,
+    activation: &Activation,
+) -> NavTransition {
+    let entered = match state.construct(registry, activation) {
+        Ok(instance) => instance,
+        Err(refusal) => return refused(state, refusal),
+    };
+    let outcome = NavOutcome::Replaced {
+        disposed: state.current.id,
+        entered: entered.id,
+    };
+    state.current = entered;
+    state.advance();
+    NavTransition { state, outcome }
+}
+
+fn back(mut state: NavState) -> NavTransition {
+    let Some(SuspendedInstance(restored)) = state.stack.pop() else {
+        return NavTransition {
+            state,
+            outcome: NavOutcome::Unchanged,
+        };
+    };
+    let outcome = NavOutcome::Restored {
+        disposed: state.current.id,
+        restored: restored.id,
+    };
+    state.current = restored;
+    NavTransition { state, outcome }
+}
+
+fn refused(state: NavState, refusal: NavRefusal) -> NavTransition {
+    NavTransition {
+        state,
+        outcome: NavOutcome::Refused(refusal),
+    }
+}
+
+/// Why a navigation request was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NavRefusal {
+    /// The activation does not satisfy its route's declared schema.
+    Activation(ActivationError),
+    /// The request was computed from an instance that is no longer current.
+    StaleSource {
+        /// The instance the request named.
+        supplied: ScreenInstanceId,
+        /// The instance that is actually current.
+        live: ScreenInstanceId,
+    },
+    /// The route reaches a screen the session cannot be routed to.
+    NotRoutable {
+        /// The route whose target has no renderer.
+        route: RouteId,
+    },
+    /// The screen has no compiled descriptor.
+    MissingDescriptor {
+        /// The screen with no descriptor.
+        screen: ScreenId,
+    },
+    /// The stack already holds its maximum number of suspended instances.
+    StackDepth {
+        /// The maximum the stack holds.
+        limit: usize,
+    },
+    /// The session ran out of distinct generations.
+    GenerationExhausted,
+}
+
+impl NavRefusal {
+    /// The coded diagnostic this refusal reports.
+    #[must_use]
+    pub const fn code(&self) -> NavCode {
+        NavCode::E001
+    }
+}
+
+impl From<ActivationError> for NavRefusal {
+    fn from(error: ActivationError) -> Self {
+        Self::Activation(error)
+    }
+}
+
+impl fmt::Display for NavRefusal {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            // The activation error already renders its own code.
+            Self::Activation(error) => write!(formatter, "{error}"),
+            Self::StaleSource { .. } => write!(
+                formatter,
+                "{}: the screen this request came from is no longer open",
+                self.code()
+            ),
+            Self::NotRoutable { route } => write!(
+                formatter,
+                "{}: route '{route}' does not reach a screen this session can open",
+                self.code()
+            ),
+            Self::MissingDescriptor { screen } => write!(
+                formatter,
+                "{}: screen '{screen}' has no descriptor",
+                self.code()
+            ),
+            Self::StackDepth { limit } => write!(
+                formatter,
+                "{}: {limit} screens are already open behind this one",
+                self.code()
+            ),
+            Self::GenerationExhausted => write!(
+                formatter,
+                "{}: this session cannot open another screen",
+                self.code()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for NavRefusal {}

--- a/src/state/navigation.rs
+++ b/src/state/navigation.rs
@@ -33,7 +33,7 @@ use crate::workbench::{
 };
 
 use super::navigation_dirty::{
-    DirtyChoice, DirtyGuard, DirtyState, DraftAction, DraftToken, GuardPhase, SaveIntent,
+    DirtyChoice, DirtyGuard, DirtyState, DraftAction, DraftToken, SaveIntent,
 };
 
 /// Maximum number of suspended instances the navigation stack may hold.
@@ -362,6 +362,15 @@ pub enum NavMessage {
     MarkClean,
     /// Answer the dirty guard.
     ResolveDirty(DirtyChoice),
+    /// Report which attempt the owner registered for the save it was asked to run.
+    ///
+    /// Two attempts at the same operation on the same screen are identical in
+    /// every other field, so the guard cannot tell them apart until it is told
+    /// the correlation the ledger allocated.
+    SaveStarted {
+        /// The exact identity the owner registered.
+        correlation: Correlation,
+    },
     /// Report the outcome of the owner's declared save.
     SaveCompleted {
         /// The exact identity of the completed work.
@@ -407,6 +416,7 @@ pub fn reduce_navigation(
         NavMessage::MarkDirty { draft, save } => mark_dirty(state, draft, save),
         NavMessage::MarkClean => mark_clean(state),
         NavMessage::ResolveDirty(choice) => resolve_dirty(state, registry, choice),
+        NavMessage::SaveStarted { correlation } => save_started(state, &correlation),
         NavMessage::SaveCompleted {
             correlation,
             result,
@@ -447,7 +457,7 @@ fn mark_dirty(mut state: NavState, draft: DraftToken, save: SaveIntent) -> NavTr
     if state
         .guard
         .as_ref()
-        .is_some_and(|guard| matches!(guard.phase(), GuardPhase::Saving { .. }))
+        .is_some_and(super::navigation_dirty::DirtyGuard::is_saving)
     {
         // The owner is saving the draft the guard is holding. Replacing it now
         // would let the running save's completion clear work it never saw.
@@ -461,7 +471,7 @@ fn mark_clean(mut state: NavState) -> NavTransition {
     if state
         .guard
         .as_ref()
-        .is_some_and(|guard| matches!(guard.phase(), GuardPhase::Saving { .. }))
+        .is_some_and(super::navigation_dirty::DirtyGuard::is_saving)
     {
         return NavTransition::plain(state, NavOutcome::GuardRaised);
     }
@@ -479,30 +489,38 @@ fn resolve_dirty(
     };
     match choice {
         DirtyChoice::Save => {
-            if matches!(guard.phase(), GuardPhase::Saving { .. }) {
+            if guard.is_saving() {
                 // A save is already running. Asking for a second one would run
                 // the owner's write twice and leave two completions racing for
                 // one guard.
                 return NavTransition::plain(state, NavOutcome::GuardRaised);
             }
-            let DirtyState::Dirty { save, .. } = &state.current.dirty else {
+            let DirtyState::Dirty { save, draft } = &state.current.dirty else {
                 // Nothing is held any more, so there is nothing to save and the
                 // navigation the guard was holding can proceed.
                 let pending = guard.pending().clone();
                 state.guard = None;
                 return commit(state, registry, pending);
             };
-            let SaveIntent::Owner { semantic_key } = save else {
+            let SaveIntent::Owner {
+                owner,
+                semantic_key,
+            } = save
+            else {
                 // Save is not offered for this draft; the guard stays up so the
                 // user can still choose Discard or Cancel.
                 return NavTransition::plain(state, NavOutcome::GuardRaised);
             };
-            let semantic_key = semantic_key.clone();
-            guard.saving(semantic_key.clone());
+            let (owner, semantic_key, draft) = (owner.clone(), semantic_key.clone(), *draft);
+            guard.save_requested(owner.clone(), semantic_key.clone(), draft);
             NavTransition {
                 state,
                 outcome: NavOutcome::GuardRaised,
-                draft: DraftAction::Save { semantic_key },
+                draft: DraftAction::Save {
+                    owner,
+                    semantic_key,
+                    draft,
+                },
             }
         }
         DirtyChoice::Discard => {
@@ -534,6 +552,20 @@ fn resolve_dirty(
     }
 }
 
+fn save_started(mut state: NavState, correlation: &Correlation) -> NavTransition {
+    if !state.answers_live_work(
+        correlation.screen_generation,
+        correlation.activation_generation,
+    ) {
+        return NavTransition::plain(state, NavOutcome::Unchanged);
+    }
+    let Some(guard) = state.guard.as_mut() else {
+        return NavTransition::plain(state, NavOutcome::Unchanged);
+    };
+    let _ = guard.save_started(correlation);
+    NavTransition::plain(state, NavOutcome::GuardRaised)
+}
+
 fn save_completed(
     mut state: NavState,
     registry: &ScreenRegistry,
@@ -546,10 +578,11 @@ fn save_completed(
     ) {
         return NavTransition::plain(state, NavOutcome::Unchanged);
     }
+    let held = state.current.dirty.draft();
     let Some(guard) = state.guard.as_mut() else {
         return NavTransition::plain(state, NavOutcome::Unchanged);
     };
-    if guard.awaited_key() != Some(&correlation.semantic_key) {
+    if !guard.awaits(correlation, held) {
         return NavTransition::plain(state, NavOutcome::Unchanged);
     }
     match result {

--- a/src/state/navigation.rs
+++ b/src/state/navigation.rs
@@ -187,6 +187,38 @@ impl NavState {
         self.current.screen
     }
 
+    /// The generations work must name to still be answerable.
+    ///
+    /// This pair is what a pending effect's correlation is registered with, and
+    /// what its completion is checked against.
+    #[must_use]
+    pub const fn live_generations(&self) -> (u64, u64) {
+        (
+            self.current.generation,
+            self.current.activation.activation_generation,
+        )
+    }
+
+    /// Whether work correlated at these generations belongs to the live instance.
+    ///
+    /// This is the whole staleness rule, and it needs no bookkeeping beyond the
+    /// generations themselves. A suspended instance's generations are not the
+    /// live ones, so its answers are ignored while it waits; restoring it makes
+    /// them live again, which is what "Back restores the instance's
+    /// subscriptions" means in practice. A disposed instance's generations
+    /// never become live again, because generations only ever move forward and
+    /// a disposed instance is never restored — so its answers are ignored
+    /// permanently rather than applied to whatever took its place.
+    #[must_use]
+    pub const fn answers_live_work(
+        &self,
+        screen_generation: u64,
+        activation_generation: u64,
+    ) -> bool {
+        let (live_screen, live_activation) = self.live_generations();
+        screen_generation == live_screen && activation_generation == live_activation
+    }
+
     /// Build the instance an activation names, without disturbing this state.
     fn construct(
         &self,

--- a/src/state/navigation.rs
+++ b/src/state/navigation.rs
@@ -33,7 +33,7 @@ use crate::workbench::{
 };
 
 use super::navigation_dirty::{
-    DirtyChoice, DirtyGuard, DirtyState, DraftAction, DraftToken, SaveIntent,
+    DirtyChoice, DirtyGuard, DirtyState, DraftAction, DraftToken, GuardPhase, SaveIntent,
 };
 
 /// Maximum number of suspended instances the navigation stack may hold.
@@ -282,6 +282,27 @@ impl NavState {
         })
     }
 
+    /// Why `intent` would be refused, without performing it.
+    ///
+    /// The dirty guard needs this: raising a guard over a navigation that
+    /// cannot commit would ask the user about their unsaved work and then
+    /// refuse to move whatever they answered.
+    fn preflight(&self, registry: &ScreenRegistry, intent: &NavIntent) -> Option<NavRefusal> {
+        match intent {
+            NavIntent::Push(activation) => {
+                if self.stack.len() >= MAX_NAVIGATION_STACK {
+                    return Some(NavRefusal::StackDepth {
+                        limit: MAX_NAVIGATION_STACK,
+                    });
+                }
+                self.construct(registry, activation).err()
+            }
+            NavIntent::Replace(activation) => self.construct(registry, activation).err(),
+            // Back consumes only what is already held, so it cannot be refused.
+            NavIntent::Back => None,
+        }
+    }
+
     /// Advance the monotonic counters past the instance just entered.
     fn advance(&mut self) {
         self.next_generation = self.next_generation.saturating_add(1);
@@ -401,6 +422,12 @@ fn navigate(mut state: NavState, registry: &ScreenRegistry, intent: NavIntent) -
         return NavTransition::plain(state, NavOutcome::GuardRaised);
     }
     if state.current.dirty.is_dirty() {
+        // Refuse before asking. A guard over a navigation that cannot commit
+        // would ask about unsaved work and then decline to move whatever the
+        // user answered.
+        if let Some(refusal) = state.preflight(registry, &intent) {
+            return refused(state, refusal);
+        }
         let focus = state.current.panel_focus;
         state.guard = Some(DirtyGuard::raised(intent, focus));
         return NavTransition::plain(state, NavOutcome::GuardRaised);
@@ -417,11 +444,27 @@ fn commit(state: NavState, registry: &ScreenRegistry, intent: NavIntent) -> NavT
 }
 
 fn mark_dirty(mut state: NavState, draft: DraftToken, save: SaveIntent) -> NavTransition {
+    if state
+        .guard
+        .as_ref()
+        .is_some_and(|guard| matches!(guard.phase(), GuardPhase::Saving { .. }))
+    {
+        // The owner is saving the draft the guard is holding. Replacing it now
+        // would let the running save's completion clear work it never saw.
+        return NavTransition::plain(state, NavOutcome::GuardRaised);
+    }
     state.current.dirty = DirtyState::Dirty { draft, save };
     NavTransition::plain(state, NavOutcome::Unchanged)
 }
 
 fn mark_clean(mut state: NavState) -> NavTransition {
+    if state
+        .guard
+        .as_ref()
+        .is_some_and(|guard| matches!(guard.phase(), GuardPhase::Saving { .. }))
+    {
+        return NavTransition::plain(state, NavOutcome::GuardRaised);
+    }
     state.current.dirty = DirtyState::Clean;
     NavTransition::plain(state, NavOutcome::Unchanged)
 }
@@ -436,6 +479,12 @@ fn resolve_dirty(
     };
     match choice {
         DirtyChoice::Save => {
+            if matches!(guard.phase(), GuardPhase::Saving { .. }) {
+                // A save is already running. Asking for a second one would run
+                // the owner's write twice and leave two completions racing for
+                // one guard.
+                return NavTransition::plain(state, NavOutcome::GuardRaised);
+            }
             let DirtyState::Dirty { save, .. } = &state.current.dirty else {
                 // Nothing is held any more, so there is nothing to save and the
                 // navigation the guard was holding can proceed.
@@ -458,8 +507,17 @@ fn resolve_dirty(
         }
         DirtyChoice::Discard => {
             let pending = guard.pending().clone();
+            // Refuse before abandoning anything. Clearing the draft first and
+            // only then discovering that the navigation it was holding back
+            // cannot commit would leave the user on the same screen with their
+            // work already gone.
+            if let Some(refusal) = state.preflight(registry, &pending) {
+                return refused(state, refusal);
+            }
             let abandoned = state.current.dirty.draft();
             state.guard = None;
+            // Cleared before the move, so the instance that goes onto the stack
+            // does not carry a draft that no longer exists.
             state.current.dirty = DirtyState::Clean;
             let mut transition = commit(state, registry, pending);
             if let Some(draft) = abandoned {
@@ -582,11 +640,6 @@ pub enum NavRefusal {
         /// The route whose target has no renderer.
         route: RouteId,
     },
-    /// The screen has no compiled descriptor.
-    MissingDescriptor {
-        /// The screen with no descriptor.
-        screen: ScreenId,
-    },
     /// The stack already holds its maximum number of suspended instances.
     StackDepth {
         /// The maximum the stack holds.
@@ -623,11 +676,6 @@ impl fmt::Display for NavRefusal {
             Self::NotRoutable { route } => write!(
                 formatter,
                 "{}: route '{route}' does not reach a screen this session can open",
-                self.code()
-            ),
-            Self::MissingDescriptor { screen } => write!(
-                formatter,
-                "{}: screen '{screen}' has no descriptor",
                 self.code()
             ),
             Self::StackDepth { limit } => write!(

--- a/src/state/navigation.rs
+++ b/src/state/navigation.rs
@@ -26,9 +26,14 @@
 
 use std::fmt;
 
+use crate::domain::effects::{Correlation, EffectError};
 use crate::workbench::{
     ActivationError, ActivationValues, NavCode, PanelId, RouteId, ScreenId, ScreenIdentity,
     ScreenInstanceId, ScreenRegistry, route_declaration,
+};
+
+use super::navigation_dirty::{
+    DirtyChoice, DirtyGuard, DirtyState, DraftAction, DraftToken, SaveIntent,
 };
 
 /// Maximum number of suspended instances the navigation stack may hold.
@@ -86,6 +91,8 @@ pub struct ScreenInstance {
     pub panel_focus: PanelId,
     /// Screen generation; a completion naming an older one is stale.
     pub generation: u64,
+    /// Whether this instance holds unsaved work.
+    pub dirty: DirtyState,
 }
 
 /// An instance whose subscriptions are suspended while it waits on the stack.
@@ -106,7 +113,7 @@ impl SuspendedInstance {
 }
 
 /// What the session is asking navigation to do.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NavIntent {
     /// Suspend the current instance and enter the activation's target.
     Push(Activation),
@@ -121,6 +128,7 @@ pub enum NavIntent {
 pub struct NavState {
     current: ScreenInstance,
     stack: Vec<SuspendedInstance>,
+    guard: Option<DirtyGuard>,
     next_generation: u64,
     next_activation_generation: u64,
 }
@@ -151,8 +159,10 @@ impl NavState {
                 },
                 panel_focus: descriptor.initial_focus,
                 generation: 1,
+                dirty: DirtyState::Clean,
             },
             stack: Vec::new(),
+            guard: None,
             next_generation: 2,
             next_activation_generation: 2,
         })
@@ -173,6 +183,12 @@ impl NavState {
     #[must_use]
     pub fn suspended(&self) -> &[SuspendedInstance] {
         &self.stack
+    }
+
+    /// The dirty guard currently holding a screen change back, if one is up.
+    #[must_use]
+    pub const fn guard(&self) -> Option<&DirtyGuard> {
+        self.guard.as_ref()
     }
 
     /// How many instances are suspended beneath the current one.
@@ -259,6 +275,7 @@ impl NavState {
             },
             panel_focus: descriptor.initial_focus,
             generation: self.next_generation,
+            dirty: DirtyState::Clean,
         })
     }
 
@@ -295,8 +312,39 @@ pub enum NavOutcome {
     },
     /// There was nothing to do; nothing changed.
     Unchanged,
+    /// The current instance holds unsaved work; the guard is up and nothing moved.
+    GuardRaised,
+    /// The owner's save failed; the draft, the focus, and the screen are intact.
+    SaveFailed,
+    /// The guard was dismissed; the draft and the interrupted focus were kept.
+    Cancelled,
     /// The request was refused; nothing changed and the refusal must be shown.
     Refused(NavRefusal),
+}
+
+/// Everything the navigation domain can be asked to do.
+#[derive(Debug, Clone)]
+pub enum NavMessage {
+    /// Change screen, subject to the dirty guard.
+    Navigate(NavIntent),
+    /// Record that the current instance now holds unsaved work.
+    MarkDirty {
+        /// The draft the owner is holding.
+        draft: DraftToken,
+        /// What this owner's Save does.
+        save: SaveIntent,
+    },
+    /// Record that the current instance no longer holds unsaved work.
+    MarkClean,
+    /// Answer the dirty guard.
+    ResolveDirty(DirtyChoice),
+    /// Report the outcome of the owner's declared save.
+    SaveCompleted {
+        /// The exact identity of the completed work.
+        correlation: Correlation,
+        /// Whether the owner's save succeeded.
+        result: Result<(), EffectError>,
+    },
 }
 
 /// One committed navigation step.
@@ -306,9 +354,21 @@ pub struct NavTransition {
     pub state: NavState,
     /// What the step did, or why it did nothing.
     pub outcome: NavOutcome,
+    /// What the draft's owner must do as a result.
+    pub draft: DraftAction,
 }
 
-/// Apply one navigation intent.
+impl NavTransition {
+    fn plain(state: NavState, outcome: NavOutcome) -> Self {
+        Self {
+            state,
+            outcome,
+            draft: DraftAction::None,
+        }
+    }
+}
+
+/// Apply one navigation message.
 ///
 /// Returns the state unchanged, paired with a refusal, whenever the request
 /// cannot be satisfied — there is no partially applied navigation.
@@ -316,12 +376,132 @@ pub struct NavTransition {
 pub fn reduce_navigation(
     state: NavState,
     registry: &ScreenRegistry,
-    intent: NavIntent,
+    message: NavMessage,
 ) -> NavTransition {
+    match message {
+        NavMessage::Navigate(intent) => navigate(state, registry, intent),
+        NavMessage::MarkDirty { draft, save } => mark_dirty(state, draft, save),
+        NavMessage::MarkClean => mark_clean(state),
+        NavMessage::ResolveDirty(choice) => resolve_dirty(state, registry, choice),
+        NavMessage::SaveCompleted {
+            correlation,
+            result,
+        } => save_completed(state, registry, &correlation, result),
+    }
+}
+
+/// Change screen unless the current instance is holding unsaved work.
+fn navigate(mut state: NavState, registry: &ScreenRegistry, intent: NavIntent) -> NavTransition {
+    if state.guard.is_some() {
+        // A guard is already up; a second request must not stack another one or
+        // silently replace the navigation the user is being asked about.
+        return NavTransition::plain(state, NavOutcome::GuardRaised);
+    }
+    if state.current.dirty.is_dirty() {
+        let focus = state.current.panel_focus;
+        state.guard = Some(DirtyGuard::raised(intent, focus));
+        return NavTransition::plain(state, NavOutcome::GuardRaised);
+    }
+    commit(state, registry, intent)
+}
+
+fn commit(state: NavState, registry: &ScreenRegistry, intent: NavIntent) -> NavTransition {
     match intent {
         NavIntent::Push(activation) => push(state, registry, &activation),
         NavIntent::Replace(activation) => replace(state, registry, &activation),
         NavIntent::Back => back(state),
+    }
+}
+
+fn mark_dirty(mut state: NavState, draft: DraftToken, save: SaveIntent) -> NavTransition {
+    state.current.dirty = DirtyState::Dirty { draft, save };
+    NavTransition::plain(state, NavOutcome::Unchanged)
+}
+
+fn mark_clean(mut state: NavState) -> NavTransition {
+    state.current.dirty = DirtyState::Clean;
+    NavTransition::plain(state, NavOutcome::Unchanged)
+}
+
+fn resolve_dirty(
+    mut state: NavState,
+    registry: &ScreenRegistry,
+    choice: DirtyChoice,
+) -> NavTransition {
+    let Some(guard) = state.guard.as_mut() else {
+        return NavTransition::plain(state, NavOutcome::Unchanged);
+    };
+    match choice {
+        DirtyChoice::Save => {
+            let DirtyState::Dirty { save, .. } = &state.current.dirty else {
+                // Nothing is held any more, so there is nothing to save and the
+                // navigation the guard was holding can proceed.
+                let pending = guard.pending().clone();
+                state.guard = None;
+                return commit(state, registry, pending);
+            };
+            let SaveIntent::Owner { semantic_key } = save else {
+                // Save is not offered for this draft; the guard stays up so the
+                // user can still choose Discard or Cancel.
+                return NavTransition::plain(state, NavOutcome::GuardRaised);
+            };
+            let semantic_key = semantic_key.clone();
+            guard.saving(semantic_key.clone());
+            NavTransition {
+                state,
+                outcome: NavOutcome::GuardRaised,
+                draft: DraftAction::Save { semantic_key },
+            }
+        }
+        DirtyChoice::Discard => {
+            let pending = guard.pending().clone();
+            let abandoned = state.current.dirty.draft();
+            state.guard = None;
+            state.current.dirty = DirtyState::Clean;
+            let mut transition = commit(state, registry, pending);
+            if let Some(draft) = abandoned {
+                transition.draft = DraftAction::RestoreBase { draft };
+            }
+            transition
+        }
+        DirtyChoice::Cancel => {
+            let focus = guard.restore_focus();
+            state.guard = None;
+            state.current.panel_focus = focus;
+            NavTransition::plain(state, NavOutcome::Cancelled)
+        }
+    }
+}
+
+fn save_completed(
+    mut state: NavState,
+    registry: &ScreenRegistry,
+    correlation: &Correlation,
+    result: Result<(), EffectError>,
+) -> NavTransition {
+    if !state.answers_live_work(
+        correlation.screen_generation,
+        correlation.activation_generation,
+    ) {
+        return NavTransition::plain(state, NavOutcome::Unchanged);
+    }
+    let Some(guard) = state.guard.as_mut() else {
+        return NavTransition::plain(state, NavOutcome::Unchanged);
+    };
+    if guard.awaited_key() != Some(&correlation.semantic_key) {
+        return NavTransition::plain(state, NavOutcome::Unchanged);
+    }
+    match result {
+        Ok(()) => {
+            let pending = guard.pending().clone();
+            state.guard = None;
+            state.current.dirty = DirtyState::Clean;
+            commit(state, registry, pending)
+        }
+        Err(error) => {
+            guard.failed(error.redacted_detail.clone());
+            NavTransition::plain(state, NavOutcome::SaveFailed)
+        }
     }
 }
 
@@ -345,7 +525,7 @@ fn push(mut state: NavState, registry: &ScreenRegistry, activation: &Activation)
     let suspended = std::mem::replace(&mut state.current, entered);
     state.stack.push(SuspendedInstance(suspended));
     state.advance();
-    NavTransition { state, outcome }
+    NavTransition::plain(state, outcome)
 }
 
 fn replace(
@@ -363,29 +543,23 @@ fn replace(
     };
     state.current = entered;
     state.advance();
-    NavTransition { state, outcome }
+    NavTransition::plain(state, outcome)
 }
 
 fn back(mut state: NavState) -> NavTransition {
     let Some(SuspendedInstance(restored)) = state.stack.pop() else {
-        return NavTransition {
-            state,
-            outcome: NavOutcome::Unchanged,
-        };
+        return NavTransition::plain(state, NavOutcome::Unchanged);
     };
     let outcome = NavOutcome::Restored {
         disposed: state.current.id,
         restored: restored.id,
     };
     state.current = restored;
-    NavTransition { state, outcome }
+    NavTransition::plain(state, outcome)
 }
 
 fn refused(state: NavState, refusal: NavRefusal) -> NavTransition {
-    NavTransition {
-        state,
-        outcome: NavOutcome::Refused(refusal),
-    }
+    NavTransition::plain(state, NavOutcome::Refused(refusal))
 }
 
 /// Why a navigation request was refused.

--- a/src/state/navigation.rs
+++ b/src/state/navigation.rs
@@ -29,7 +29,7 @@ use std::fmt;
 use crate::domain::effects::{Correlation, EffectError};
 use crate::workbench::{
     ActivationError, ActivationValues, NavCode, PanelId, RouteId, ScreenId, ScreenIdentity,
-    ScreenInstanceId, ScreenRegistry, route_declaration,
+    ScreenInstanceId, ScreenRegistry, initial_focus, route_declaration, route_of,
 };
 
 use super::navigation_dirty::{
@@ -133,31 +133,37 @@ pub struct NavState {
     next_activation_generation: u64,
 }
 
+impl Default for NavState {
+    /// A session on the default screen, which is what a run with no restored
+    /// state opens on.
+    fn default() -> Self {
+        Self::rooted(ScreenId::default())
+    }
+}
+
 impl NavState {
-    /// The state a session starts in: one clean instance, no stack.
+    /// The state a session starts in: one clean instance on `screen`, no stack.
     ///
-    /// # Errors
-    ///
-    /// Returns [`NavRefusal::MissingDescriptor`] when `screen` has no compiled
-    /// descriptor, which is a malformed compiled table rather than anything a
-    /// user did.
-    pub fn rooted(registry: &ScreenRegistry, screen: ScreenId) -> Result<Self, NavRefusal> {
-        let Some(descriptor) = registry.get(screen) else {
-            return Err(NavRefusal::MissingDescriptor { screen });
-        };
+    /// Rooting is total. Both the route and the initial focus come from
+    /// compiled tables rather than a registry lookup, so starting a session
+    /// has no failure mode to handle at the moment it is needed — a screen
+    /// that has drifted from its descriptor is a build-time test failure, not
+    /// a runtime branch.
+    #[must_use]
+    pub fn rooted(screen: ScreenId) -> Self {
         let id = ScreenInstanceId::next();
-        Ok(Self {
+        Self {
             current: ScreenInstance {
                 id,
                 screen,
                 activation: Activation {
-                    route: descriptor.route,
+                    route: route_of(screen),
                     values: ActivationValues::empty(),
                     // The root instance was activated by nothing but itself.
                     source_instance: id,
                     activation_generation: 1,
                 },
-                panel_focus: descriptor.initial_focus,
+                panel_focus: initial_focus(screen),
                 generation: 1,
                 dirty: DirtyState::Clean,
             },
@@ -165,7 +171,7 @@ impl NavState {
             guard: None,
             next_generation: 2,
             next_activation_generation: 2,
-        })
+        }
     }
 
     /// The instance the session is on.
@@ -256,9 +262,6 @@ impl NavState {
                 route: activation.route,
             });
         };
-        let Some(descriptor) = registry.get(screen) else {
-            return Err(NavRefusal::MissingDescriptor { screen });
-        };
         if self.next_generation.checked_add(1).is_none()
             || self.next_activation_generation.checked_add(1).is_none()
         {
@@ -273,7 +276,7 @@ impl NavState {
                 source_instance: activation.source_instance,
                 activation_generation: self.next_activation_generation,
             },
-            panel_focus: descriptor.initial_focus,
+            panel_focus: initial_focus(screen),
             generation: self.next_generation,
             dirty: DirtyState::Clean,
         })

--- a/src/state/navigation.rs
+++ b/src/state/navigation.rs
@@ -146,9 +146,9 @@ impl NavState {
     ///
     /// Rooting is total. Both the route and the initial focus come from
     /// compiled tables rather than a registry lookup, so starting a session
-    /// has no failure mode to handle at the moment it is needed — a screen
-    /// that has drifted from its descriptor is a build-time test failure, not
-    /// a runtime branch.
+    /// has no failure mode to handle at the moment it is needed. Those tables
+    /// duplicate the descriptors, and the drift tests in `screens_tests` are
+    /// what hold the two together.
     #[must_use]
     pub fn rooted(screen: ScreenId) -> Self {
         let id = ScreenInstanceId::next();

--- a/src/state/navigation_dirty.rs
+++ b/src/state/navigation_dirty.rs
@@ -21,7 +21,8 @@
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::domain::effects::SemanticKey;
+use crate::domain::Id;
+use crate::domain::effects::{Correlation, SemanticKey};
 use crate::workbench::PanelId;
 
 use super::navigation::NavIntent;
@@ -68,9 +69,11 @@ pub enum SaveIntent {
         /// Why Save cannot be offered, shown beside the disabled control.
         reason: &'static str,
     },
-    /// The owner will save this draft, and a completion carrying this semantic
-    /// key resolves the guard.
+    /// The owner will save this draft, and only a completion carrying this
+    /// exact identity resolves the guard.
     Owner {
+        /// Who is saving. A completion from anything else is not this save.
+        owner: Id,
         /// The operation the owner will run, and the key its completion carries.
         semantic_key: SemanticKey,
     },
@@ -135,10 +138,32 @@ pub enum DirtyChoice {
 pub enum GuardPhase {
     /// Awaiting the user's choice.
     Choosing,
-    /// The owner's save is running; a completion carrying this key resolves it.
-    Saving {
-        /// The key the resolving completion must carry.
+    /// The owner has been asked to save and has not yet said what it registered.
+    ///
+    /// The reducer cannot allocate a correlation identifier — the pending
+    /// ledger does that, after this transition commits — so there is a moment
+    /// where the guard knows what it asked for but not yet which attempt is
+    /// running. Nothing can resolve the guard during it.
+    SaveRequested {
+        /// Who was asked.
+        owner: Id,
+        /// The operation that was asked for.
         semantic_key: SemanticKey,
+        /// The draft the request was for.
+        draft: DraftToken,
+    },
+    /// A specific save attempt is running; only its exact identity resolves it.
+    ///
+    /// Owner, semantic key, and both generations are not enough on their own:
+    /// a retry of the same operation on the same screen matches all of them, so
+    /// a late answer from the abandoned attempt would resolve the live one. The
+    /// correlation identifier is what distinguishes two attempts, which is why
+    /// the guard waits to be told it rather than guessing.
+    Saving {
+        /// The exact identity the resolving completion must carry.
+        expected: Box<Correlation>,
+        /// The draft this attempt is saving.
+        draft: DraftToken,
     },
     /// The save failed; the draft is intact and Retry, Discard, and Cancel remain.
     Failed {
@@ -185,8 +210,40 @@ impl DirtyGuard {
     }
 
     /// Move to awaiting the owner's save.
-    pub(super) fn saving(&mut self, semantic_key: SemanticKey) {
-        self.phase = GuardPhase::Saving { semantic_key };
+    pub(super) fn save_requested(
+        &mut self,
+        owner: Id,
+        semantic_key: SemanticKey,
+        draft: DraftToken,
+    ) {
+        self.phase = GuardPhase::SaveRequested {
+            owner,
+            semantic_key,
+            draft,
+        };
+    }
+
+    /// Record which attempt the owner actually registered.
+    ///
+    /// Refuses anything that does not answer the request that was made, so a
+    /// stray registration cannot take over the guard.
+    pub(super) fn save_started(&mut self, correlation: &Correlation) -> bool {
+        let GuardPhase::SaveRequested {
+            owner,
+            semantic_key,
+            draft,
+        } = &self.phase
+        else {
+            return false;
+        };
+        if &correlation.owner != owner || &correlation.semantic_key != semantic_key {
+            return false;
+        }
+        self.phase = GuardPhase::Saving {
+            expected: Box::new(correlation.clone()),
+            draft: *draft,
+        };
+        true
     }
 
     /// Move to the recovery state, keeping the draft and the pending navigation.
@@ -194,13 +251,25 @@ impl DirtyGuard {
         self.phase = GuardPhase::Failed { detail };
     }
 
-    /// The key a completion must carry to resolve this guard, if one is running.
+    /// Whether `correlation` is the answer this guard is waiting for.
+    ///
+    /// `held` is the draft the instance still holds; a save whose draft has
+    /// since been replaced is answering about work that no longer exists.
     #[must_use]
-    pub(super) fn awaited_key(&self) -> Option<&SemanticKey> {
-        match &self.phase {
-            GuardPhase::Saving { semantic_key } => Some(semantic_key),
-            GuardPhase::Choosing | GuardPhase::Failed { .. } => None,
-        }
+    pub(super) fn awaits(&self, correlation: &Correlation, held: Option<DraftToken>) -> bool {
+        let GuardPhase::Saving { expected, draft } = &self.phase else {
+            return false;
+        };
+        expected.matches(correlation) && held == Some(*draft)
+    }
+
+    /// Whether a save attempt is in flight, by request or by registration.
+    #[must_use]
+    pub(super) const fn is_saving(&self) -> bool {
+        matches!(
+            self.phase,
+            GuardPhase::SaveRequested { .. } | GuardPhase::Saving { .. }
+        )
     }
 }
 
@@ -213,10 +282,14 @@ impl DirtyGuard {
 pub enum DraftAction {
     /// Nothing is required of the owner.
     None,
-    /// Run the declared save; its completion must carry this semantic key.
+    /// Run the declared save; its completion must carry this exact identity.
     Save {
+        /// Who is saving.
+        owner: Id,
         /// The operation to run.
         semantic_key: SemanticKey,
+        /// The draft being saved.
+        draft: DraftToken,
     },
     /// Abandon this draft and restore the base it was taken from.
     RestoreBase {

--- a/src/state/navigation_dirty.rs
+++ b/src/state/navigation_dirty.rs
@@ -1,0 +1,226 @@
+//! The host dirty guard that stands between a draft and a screen change
+//! (issue #386).
+//!
+//! Leaving a screen with unsaved work is the same question everywhere, so it
+//! has one answer here rather than one answer per screen. Navigation raises the
+//! guard, the user chooses, and only then does the screen change — or not.
+//!
+//! What the guard deliberately does **not** know is what saving *means*. The
+//! screen that owns the draft declares that as a [`SaveIntent`], and the
+//! settings shell that follows this capability owns its own draft, writer, and
+//! completion. The guard's whole job is to hold the navigation back until the
+//! owner reports success, so a save that fails cannot take the user off the
+//! screen holding their work.
+//!
+//! There is deliberately no `DiscardIntent` beside [`SaveIntent`]. Saving
+//! varies by owner — there may be nowhere to save to at all — but abandoning a
+//! draft is always available and always means the same thing: the owner
+//! restores the base its draft was taken from. A type whose only job is to say
+//! that would carry no information.
+
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::domain::effects::SemanticKey;
+use crate::workbench::PanelId;
+
+use super::navigation::NavIntent;
+
+/// Opaque identity of one in-progress draft.
+///
+/// Identity rather than content, so the guard can name the draft it is holding
+/// without holding the draft: a completion that names a draft the owner has
+/// since replaced is answering about something that no longer exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DraftToken(u64);
+
+static NEXT_DRAFT: AtomicU64 = AtomicU64::new(1);
+
+impl DraftToken {
+    /// Allocate the next distinct draft identity.
+    #[must_use]
+    pub fn next() -> Self {
+        Self(NEXT_DRAFT.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// The raw counter value, for goldens and diagnostics.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for DraftToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "draft-{}", self.0)
+    }
+}
+
+/// What the screen that owns a draft says its Save does.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SaveIntent {
+    /// This draft has nowhere to save to, so the guard offers only Discard and
+    /// Cancel and says why Save is unavailable.
+    ///
+    /// An unsent comment is the shipped example: there is no server-side draft
+    /// store, so the honest choices are to abandon it or to go back to it.
+    Unavailable {
+        /// Why Save cannot be offered, shown beside the disabled control.
+        reason: &'static str,
+    },
+    /// The owner will save this draft, and a completion carrying this semantic
+    /// key resolves the guard.
+    Owner {
+        /// The operation the owner will run, and the key its completion carries.
+        semantic_key: SemanticKey,
+    },
+}
+
+impl SaveIntent {
+    /// Whether the guard may offer Save.
+    #[must_use]
+    pub const fn can_save(&self) -> bool {
+        matches!(self, Self::Owner { .. })
+    }
+}
+
+/// Whether the current instance holds unsaved work.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum DirtyState {
+    /// Nothing is unsaved; navigation proceeds without a guard.
+    #[default]
+    Clean,
+    /// The owner holds a draft, and leaving must be confirmed.
+    Dirty {
+        /// Which draft is held.
+        draft: DraftToken,
+        /// What this owner's Save does, which the guard never interprets.
+        save: SaveIntent,
+    },
+}
+
+impl DirtyState {
+    /// The held draft, if there is one.
+    #[must_use]
+    pub const fn draft(&self) -> Option<DraftToken> {
+        match self {
+            Self::Clean => None,
+            Self::Dirty { draft, .. } => Some(*draft),
+        }
+    }
+
+    /// Whether leaving this instance must be confirmed.
+    #[must_use]
+    pub const fn is_dirty(&self) -> bool {
+        matches!(self, Self::Dirty { .. })
+    }
+}
+
+/// What the user chose in the dirty guard.
+///
+/// Retry is not a fourth choice: after a failed save the guard offers the same
+/// Save under a Retry label, so choosing Save again reruns the owner's save.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirtyChoice {
+    /// Run the owner's save, and navigate only if it succeeds.
+    Save,
+    /// Abandon the draft and navigate.
+    Discard,
+    /// Stay, keeping the draft and the focus the guard interrupted.
+    Cancel,
+}
+
+/// How far the guard has got.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuardPhase {
+    /// Awaiting the user's choice.
+    Choosing,
+    /// The owner's save is running; a completion carrying this key resolves it.
+    Saving {
+        /// The key the resolving completion must carry.
+        semantic_key: SemanticKey,
+    },
+    /// The save failed; the draft is intact and Retry, Discard, and Cancel remain.
+    Failed {
+        /// The redacted reason, shown in the recovery state.
+        detail: String,
+    },
+}
+
+/// A screen change waiting on the current instance's draft.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirtyGuard {
+    pending: NavIntent,
+    restore_focus: PanelId,
+    phase: GuardPhase,
+}
+
+impl DirtyGuard {
+    /// Raise a guard over `pending`, remembering the focus it interrupted.
+    #[must_use]
+    pub(super) const fn raised(pending: NavIntent, restore_focus: PanelId) -> Self {
+        Self {
+            pending,
+            restore_focus,
+            phase: GuardPhase::Choosing,
+        }
+    }
+
+    /// The navigation this guard is holding back.
+    #[must_use]
+    pub const fn pending(&self) -> &NavIntent {
+        &self.pending
+    }
+
+    /// The focus Cancel restores.
+    #[must_use]
+    pub const fn restore_focus(&self) -> PanelId {
+        self.restore_focus
+    }
+
+    /// How far the guard has got.
+    #[must_use]
+    pub const fn phase(&self) -> &GuardPhase {
+        &self.phase
+    }
+
+    /// Move to awaiting the owner's save.
+    pub(super) fn saving(&mut self, semantic_key: SemanticKey) {
+        self.phase = GuardPhase::Saving { semantic_key };
+    }
+
+    /// Move to the recovery state, keeping the draft and the pending navigation.
+    pub(super) fn failed(&mut self, detail: String) {
+        self.phase = GuardPhase::Failed { detail };
+    }
+
+    /// The key a completion must carry to resolve this guard, if one is running.
+    #[must_use]
+    pub(super) fn awaited_key(&self) -> Option<&SemanticKey> {
+        match &self.phase {
+            GuardPhase::Saving { semantic_key } => Some(semantic_key),
+            GuardPhase::Choosing | GuardPhase::Failed { .. } => None,
+        }
+    }
+}
+
+/// What the draft's owner must do after a guard transition.
+///
+/// The guard never runs a save and never touches a draft. It says what is now
+/// required, and the owner — which is the only thing that knows what its draft
+/// is — does it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DraftAction {
+    /// Nothing is required of the owner.
+    None,
+    /// Run the declared save; its completion must carry this semantic key.
+    Save {
+        /// The operation to run.
+        semantic_key: SemanticKey,
+    },
+    /// Abandon this draft and restore the base it was taken from.
+    RestoreBase {
+        /// The draft to abandon.
+        draft: DraftToken,
+    },
+}

--- a/src/state/navigation_dirty_tests.rs
+++ b/src/state/navigation_dirty_tests.rs
@@ -17,10 +17,7 @@ fn registry() -> &'static ScreenRegistry {
 }
 
 fn rooted(screen: ScreenId) -> NavState {
-    match NavState::rooted(registry(), screen) {
-        Ok(state) => state,
-        Err(refusal) => unreachable!("a compiled screen must root a session: {refusal}"),
-    }
+    NavState::rooted(screen)
 }
 
 fn push_to(state: &NavState, screen: ScreenId) -> NavIntent {

--- a/src/state/navigation_dirty_tests.rs
+++ b/src/state/navigation_dirty_tests.rs
@@ -1,0 +1,514 @@
+//! The host dirty guard: Save, Discard, Cancel, and recovery
+//! (issue #386, CW06-05/CW06-06).
+
+use crate::domain::effects::{Correlation, CorrelationId, EffectError, EffectFamily, SemanticKey};
+use crate::domain::{Id, effects::EffectErrorKind};
+use crate::workbench::{ActivationValues, PanelId, ScreenId, ScreenRegistry, screen_registry};
+
+use super::navigation::{
+    Activation, NavIntent, NavMessage, NavOutcome, NavState, NavTransition, reduce_navigation,
+};
+use super::navigation_dirty::{
+    DirtyChoice, DirtyState, DraftAction, DraftToken, GuardPhase, SaveIntent,
+};
+
+fn registry() -> &'static ScreenRegistry {
+    screen_registry().unwrap_or_else(|_| unreachable!("the compiled registry must be well formed"))
+}
+
+fn rooted(screen: ScreenId) -> NavState {
+    match NavState::rooted(registry(), screen) {
+        Ok(state) => state,
+        Err(refusal) => unreachable!("a compiled screen must root a session: {refusal}"),
+    }
+}
+
+fn push_to(state: &NavState, screen: ScreenId) -> NavIntent {
+    let Some(descriptor) = registry().get(screen) else {
+        unreachable!("every compiled screen has a descriptor");
+    };
+    NavIntent::Push(Activation::from_source(
+        descriptor.route,
+        ActivationValues::empty(),
+        state.current(),
+    ))
+}
+
+fn send(state: NavState, message: NavMessage) -> NavTransition {
+    reduce_navigation(state, registry(), message)
+}
+
+fn owner_key() -> SemanticKey {
+    SemanticKey::new(EffectFamily::Persistence, "settings-draft")
+}
+
+fn owner() -> Id {
+    Id::parse("core.settings").unwrap_or_else(|_| unreachable!("test owner is a valid identifier"))
+}
+
+/// A dirty session whose owner declares a real save.
+fn savable() -> NavState {
+    let state = rooted(ScreenId::Dashboard);
+    send(
+        state,
+        NavMessage::MarkDirty {
+            draft: DraftToken::next(),
+            save: SaveIntent::Owner {
+                semantic_key: owner_key(),
+            },
+        },
+    )
+    .state
+}
+
+/// A dirty session whose draft has nowhere to save to.
+fn unsavable() -> NavState {
+    let state = rooted(ScreenId::Dashboard);
+    send(
+        state,
+        NavMessage::MarkDirty {
+            draft: DraftToken::next(),
+            save: SaveIntent::Unavailable {
+                reason: "an unsent draft has nowhere to save to",
+            },
+        },
+    )
+    .state
+}
+
+/// The completion the guard is waiting for, at the live generations.
+fn completion(state: &NavState, key: SemanticKey) -> Correlation {
+    let (screen_generation, activation_generation) = state.live_generations();
+    Correlation {
+        correlation_id: CorrelationId::new(1),
+        owner: owner(),
+        screen_generation,
+        activation_generation,
+        semantic_key: key,
+    }
+}
+
+fn failure() -> EffectError {
+    EffectError::new(EffectErrorKind::Io, true, "the write could not complete")
+}
+
+// ── CW06-05: navigation waits for the draft ─────────────────────────────────
+
+#[test]
+fn leaving_a_dirty_screen_raises_the_guard_instead_of_navigating() {
+    let state = savable();
+    let expected_screen = state.current().screen;
+    let intent = push_to(&state, ScreenId::Issues);
+
+    let transition = send(state, NavMessage::Navigate(intent));
+
+    assert_eq!(transition.outcome, NavOutcome::GuardRaised);
+    assert_eq!(transition.draft, DraftAction::None);
+    assert_eq!(
+        transition.state.current().screen,
+        expected_screen,
+        "the session must not move until the draft is resolved"
+    );
+    assert_eq!(transition.state.depth(), 0);
+    assert!(matches!(
+        transition
+            .state
+            .guard()
+            .map(super::navigation_dirty::DirtyGuard::phase),
+        Some(GuardPhase::Choosing)
+    ));
+}
+
+#[test]
+fn leaving_a_clean_screen_raises_no_guard() {
+    let state = rooted(ScreenId::Dashboard);
+    let intent = push_to(&state, ScreenId::Issues);
+
+    let transition = send(state, NavMessage::Navigate(intent));
+
+    assert!(matches!(transition.outcome, NavOutcome::Pushed { .. }));
+    assert!(transition.state.guard().is_none());
+}
+
+#[test]
+fn a_second_request_while_the_guard_is_up_does_not_replace_the_pending_one() {
+    let state = savable();
+    let first = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(first.clone())).state;
+    let second = push_to(&guarded, ScreenId::Actions);
+
+    let transition = send(guarded, NavMessage::Navigate(second));
+
+    assert_eq!(transition.outcome, NavOutcome::GuardRaised);
+    assert_eq!(
+        transition
+            .state
+            .guard()
+            .map(|guard| guard.pending().clone()),
+        Some(first),
+        "the user is being asked about the first request, so it must stand"
+    );
+}
+
+#[test]
+fn choosing_save_asks_the_owner_and_does_not_navigate_yet() {
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+
+    let transition = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save));
+
+    assert_eq!(
+        transition.draft,
+        DraftAction::Save {
+            semantic_key: owner_key()
+        },
+        "the guard asks the owner to save; it never saves anything itself"
+    );
+    assert_eq!(transition.state.current().screen, ScreenId::Dashboard);
+    assert!(matches!(
+        transition
+            .state
+            .guard()
+            .map(super::navigation_dirty::DirtyGuard::phase),
+        Some(GuardPhase::Saving { .. })
+    ));
+}
+
+#[test]
+fn a_matching_successful_completion_performs_the_pending_navigation() {
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+    let correlation = completion(&saving, owner_key());
+
+    let transition = send(
+        saving,
+        NavMessage::SaveCompleted {
+            correlation,
+            result: Ok(()),
+        },
+    );
+
+    assert!(matches!(transition.outcome, NavOutcome::Pushed { .. }));
+    assert_eq!(transition.state.current().screen, ScreenId::Issues);
+    assert!(transition.state.guard().is_none());
+    assert_eq!(transition.state.current().dirty, DirtyState::Clean);
+}
+
+// ── CW06-08 applied to the save: only the live instance is answered ─────────
+
+#[test]
+fn a_completion_for_another_operation_changes_nothing() {
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+    let other = SemanticKey::new(EffectFamily::GitHub, "something-else");
+    let correlation = completion(&saving, other);
+    let expected = saving.clone();
+
+    let transition = send(
+        saving,
+        NavMessage::SaveCompleted {
+            correlation,
+            result: Ok(()),
+        },
+    );
+
+    assert_eq!(transition.state, expected);
+    assert_eq!(transition.outcome, NavOutcome::Unchanged);
+}
+
+#[test]
+fn a_completion_naming_a_stale_generation_changes_nothing() {
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+    let mut correlation = completion(&saving, owner_key());
+    correlation.screen_generation = correlation.screen_generation.saturating_add(7);
+    let expected = saving.clone();
+
+    let transition = send(
+        saving,
+        NavMessage::SaveCompleted {
+            correlation,
+            result: Ok(()),
+        },
+    );
+
+    assert_eq!(transition.state, expected);
+    assert_eq!(transition.outcome, NavOutcome::Unchanged);
+}
+
+#[test]
+fn a_completion_with_no_guard_waiting_changes_nothing() {
+    let state = rooted(ScreenId::Dashboard);
+    let correlation = completion(&state, owner_key());
+    let expected = state.clone();
+
+    let transition = send(
+        state,
+        NavMessage::SaveCompleted {
+            correlation,
+            result: Ok(()),
+        },
+    );
+
+    assert_eq!(transition.state, expected);
+    assert_eq!(transition.outcome, NavOutcome::Unchanged);
+}
+
+// ── Recovery: a failed save keeps the user with their work ─────────────────
+
+#[test]
+fn a_failed_save_retains_the_draft_the_screen_and_the_choices() {
+    let state = savable();
+    let held = state.current().dirty.clone();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent.clone())).state;
+    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+    let correlation = completion(&saving, owner_key());
+
+    let transition = send(
+        saving,
+        NavMessage::SaveCompleted {
+            correlation,
+            result: Err(failure()),
+        },
+    );
+
+    assert_eq!(transition.outcome, NavOutcome::SaveFailed);
+    assert_eq!(transition.state.current().screen, ScreenId::Dashboard);
+    assert_eq!(transition.state.current().dirty, held);
+    let Some(guard) = transition.state.guard() else {
+        panic!("the guard must stay up so recovery choices remain reachable");
+    };
+    assert!(matches!(guard.phase(), GuardPhase::Failed { .. }));
+    assert_eq!(
+        guard.pending(),
+        &intent,
+        "the navigation the user asked for must survive a failed save"
+    );
+}
+
+#[test]
+fn retrying_after_a_failed_save_asks_the_owner_again() {
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+    let correlation = completion(&saving, owner_key());
+    let failed = send(
+        saving,
+        NavMessage::SaveCompleted {
+            correlation,
+            result: Err(failure()),
+        },
+    )
+    .state;
+
+    let transition = send(failed, NavMessage::ResolveDirty(DirtyChoice::Save));
+
+    assert_eq!(
+        transition.draft,
+        DraftAction::Save {
+            semantic_key: owner_key()
+        }
+    );
+    assert!(matches!(
+        transition
+            .state
+            .guard()
+            .map(super::navigation_dirty::DirtyGuard::phase),
+        Some(GuardPhase::Saving { .. })
+    ));
+}
+
+#[test]
+fn discarding_after_a_failed_save_still_leaves() {
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+    let correlation = completion(&saving, owner_key());
+    let failed = send(
+        saving,
+        NavMessage::SaveCompleted {
+            correlation,
+            result: Err(failure()),
+        },
+    )
+    .state;
+
+    let transition = send(failed, NavMessage::ResolveDirty(DirtyChoice::Discard));
+
+    assert!(matches!(transition.outcome, NavOutcome::Pushed { .. }));
+    assert_eq!(transition.state.current().screen, ScreenId::Issues);
+}
+
+// ── CW06-06: Discard and Cancel ────────────────────────────────────────────
+
+#[test]
+fn discarding_abandons_the_draft_and_performs_the_navigation() {
+    let state = savable();
+    let Some(abandoned) = state.current().dirty.draft() else {
+        panic!("the fixture holds a draft");
+    };
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+
+    let transition = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Discard));
+
+    assert!(matches!(transition.outcome, NavOutcome::Pushed { .. }));
+    assert_eq!(transition.state.current().screen, ScreenId::Issues);
+    assert_eq!(
+        transition.draft,
+        DraftAction::RestoreBase { draft: abandoned },
+        "the owner must be told to restore the base its draft was taken from"
+    );
+    assert!(transition.state.guard().is_none());
+}
+
+#[test]
+fn a_discarded_draft_does_not_follow_the_session_to_the_next_screen() {
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+
+    let after = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Discard)).state;
+
+    assert_eq!(after.current().dirty, DirtyState::Clean);
+    let Some(suspended) = after.suspended().first() else {
+        panic!("the previous instance was suspended");
+    };
+    assert_eq!(
+        suspended.instance().dirty,
+        DirtyState::Clean,
+        "the instance the user left must not still claim unsaved work"
+    );
+}
+
+#[test]
+fn cancelling_keeps_the_draft_and_drops_the_navigation() {
+    let state = savable();
+    let held = state.current().dirty.clone();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+
+    let transition = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Cancel));
+
+    assert_eq!(transition.outcome, NavOutcome::Cancelled);
+    assert_eq!(transition.draft, DraftAction::None);
+    assert_eq!(transition.state.current().screen, ScreenId::Dashboard);
+    assert_eq!(transition.state.current().dirty, held);
+    assert!(
+        transition.state.guard().is_none(),
+        "cancelling clears the pending navigation rather than deferring it"
+    );
+}
+
+#[test]
+fn cancelling_restores_the_exact_focus_the_guard_interrupted() {
+    let mut state = savable();
+    let Some(descriptor) = registry().get(ScreenId::Dashboard) else {
+        unreachable!("every compiled screen has a descriptor");
+    };
+    let Some(other) = descriptor
+        .focus_order
+        .iter()
+        .find(|panel| **panel != descriptor.initial_focus)
+        .copied()
+    else {
+        unreachable!("the dashboard cycles focus across more than one panel");
+    };
+    state.current_mut().panel_focus = other;
+    let interrupted: PanelId = other;
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+
+    let after = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Cancel)).state;
+
+    assert_eq!(after.current().panel_focus, interrupted);
+}
+
+// ── Save when the owner cannot save ────────────────────────────────────────
+
+#[test]
+fn a_draft_with_nowhere_to_save_offers_no_save() {
+    let state = unsavable();
+    let DirtyState::Dirty { save, .. } = &state.current().dirty else {
+        panic!("the fixture holds a draft");
+    };
+    assert!(!save.can_save());
+}
+
+#[test]
+fn choosing_save_for_a_draft_with_nowhere_to_save_leaves_the_guard_up() {
+    let state = unsavable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+
+    let transition = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save));
+
+    assert_eq!(transition.outcome, NavOutcome::GuardRaised);
+    assert_eq!(transition.draft, DraftAction::None);
+    assert_eq!(transition.state.current().screen, ScreenId::Dashboard);
+    assert!(
+        matches!(
+            transition
+                .state
+                .guard()
+                .map(super::navigation_dirty::DirtyGuard::phase),
+            Some(GuardPhase::Choosing)
+        ),
+        "Discard and Cancel must stay reachable"
+    );
+}
+
+#[test]
+fn discarding_a_draft_with_nowhere_to_save_leaves() {
+    let state = unsavable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+
+    let transition = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Discard));
+
+    assert_eq!(transition.state.current().screen, ScreenId::Issues);
+    assert!(matches!(transition.draft, DraftAction::RestoreBase { .. }));
+}
+
+// ── Bookkeeping ────────────────────────────────────────────────────────────
+
+#[test]
+fn resolving_with_no_guard_up_changes_nothing() {
+    for choice in [DirtyChoice::Save, DirtyChoice::Discard, DirtyChoice::Cancel] {
+        let state = rooted(ScreenId::Dashboard);
+        let expected = state.clone();
+        let transition = send(state, NavMessage::ResolveDirty(choice));
+        assert_eq!(transition.state, expected, "{choice:?} must be inert");
+        assert_eq!(transition.outcome, NavOutcome::Unchanged);
+    }
+}
+
+#[test]
+fn marking_clean_lets_the_next_navigation_through() {
+    let state = savable();
+    let cleaned = send(state, NavMessage::MarkClean).state;
+    assert_eq!(cleaned.current().dirty, DirtyState::Clean);
+    let intent = push_to(&cleaned, ScreenId::Issues);
+
+    let transition = send(cleaned, NavMessage::Navigate(intent));
+
+    assert!(matches!(transition.outcome, NavOutcome::Pushed { .. }));
+}
+
+#[test]
+fn every_draft_identity_is_distinct() {
+    let first = DraftToken::next();
+    let second = DraftToken::next();
+    assert_ne!(first, second);
+    assert!(second.get() > first.get());
+}

--- a/src/state/navigation_dirty_tests.rs
+++ b/src/state/navigation_dirty_tests.rs
@@ -503,6 +503,85 @@ fn marking_clean_lets_the_next_navigation_through() {
 }
 
 #[test]
+fn a_navigation_that_cannot_commit_never_raises_the_guard() {
+    // Asking about unsaved work and then declining to move whatever the user
+    // answered would be worse than refusing outright.
+    let state = savable();
+    let Ok(unknown) = crate::workbench::RouteId::parse("nonesuch") else {
+        unreachable!("test route id is valid");
+    };
+    let intent = NavIntent::Push(Activation::from_source(
+        unknown,
+        ActivationValues::empty(),
+        state.current(),
+    ));
+    let held = state.current().dirty.clone();
+
+    let transition = send(state, NavMessage::Navigate(intent));
+
+    assert!(matches!(transition.outcome, NavOutcome::Refused(_)));
+    assert!(transition.state.guard().is_none());
+    assert_eq!(transition.state.current().dirty, held);
+}
+
+#[test]
+fn asking_to_save_again_while_a_save_is_running_does_not_run_it_twice() {
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+
+    let transition = send(saving, NavMessage::ResolveDirty(DirtyChoice::Save));
+
+    assert_eq!(
+        transition.draft,
+        DraftAction::None,
+        "a second Save must not ask the owner to write again"
+    );
+    assert!(matches!(
+        transition
+            .state
+            .guard()
+            .map(super::navigation_dirty::DirtyGuard::phase),
+        Some(GuardPhase::Saving { .. })
+    ));
+}
+
+#[test]
+fn a_draft_cannot_be_replaced_while_the_guard_is_saving_it() {
+    // The running save's completion would otherwise clear a draft it never saw.
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+    let held = saving.current().dirty.clone();
+
+    let transition = send(
+        saving,
+        NavMessage::MarkDirty {
+            draft: DraftToken::next(),
+            save: SaveIntent::Unavailable { reason: "nowhere" },
+        },
+    );
+
+    assert_eq!(transition.state.current().dirty, held);
+}
+
+#[test]
+fn the_instance_left_behind_does_not_carry_a_draft_that_was_abandoned() {
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+
+    let after = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Discard)).state;
+
+    let Some(suspended) = after.suspended().first() else {
+        panic!("the previous instance was suspended");
+    };
+    assert_eq!(suspended.instance().dirty, DirtyState::Clean);
+}
+
+#[test]
 fn every_draft_identity_is_distinct() {
     let first = DraftToken::next();
     let second = DraftToken::next();

--- a/src/state/navigation_dirty_tests.rs
+++ b/src/state/navigation_dirty_tests.rs
@@ -51,6 +51,7 @@ fn savable() -> NavState {
         NavMessage::MarkDirty {
             draft: DraftToken::next(),
             save: SaveIntent::Owner {
+                owner: owner(),
                 semantic_key: owner_key(),
             },
         },
@@ -73,15 +74,51 @@ fn unsavable() -> NavState {
     .state
 }
 
-/// The completion the guard is waiting for, at the live generations.
-fn completion(state: &NavState, key: SemanticKey) -> Correlation {
+/// One attempt's identity, at the live generations.
+fn attempt(state: &NavState, key: SemanticKey, id: u64) -> Correlation {
     let (screen_generation, activation_generation) = state.live_generations();
     Correlation {
-        correlation_id: CorrelationId::new(1),
+        correlation_id: CorrelationId::new(id),
         owner: owner(),
         screen_generation,
         activation_generation,
         semantic_key: key,
+    }
+}
+
+/// The completion the guard is waiting for, at the live generations.
+fn completion(state: &NavState, key: SemanticKey) -> Correlation {
+    attempt(state, key, 1)
+}
+
+/// Drive a guard all the way to a registered, running save attempt.
+fn saving_attempt(state: NavState, id: u64) -> (NavState, Correlation) {
+    let requested = send(state, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+    let correlation = attempt(&requested, owner_key(), id);
+    let running = send(
+        requested,
+        NavMessage::SaveStarted {
+            correlation: correlation.clone(),
+        },
+    )
+    .state;
+    (running, correlation)
+}
+
+/// Assert the owner was asked to save exactly this draft.
+fn assert_asked_to_save(action: &DraftAction, expected_draft: Option<DraftToken>) {
+    let DraftAction::Save {
+        owner: asked_owner,
+        semantic_key,
+        draft,
+    } = action
+    else {
+        panic!("the guard must ask the owner to save: {action:?}");
+    };
+    assert_eq!(asked_owner, &owner());
+    assert_eq!(semantic_key, &owner_key());
+    if let Some(expected) = expected_draft {
+        assert_eq!(*draft, expected, "the save must name the held draft");
     }
 }
 
@@ -155,20 +192,14 @@ fn choosing_save_asks_the_owner_and_does_not_navigate_yet() {
 
     let transition = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save));
 
-    assert_eq!(
-        transition.draft,
-        DraftAction::Save {
-            semantic_key: owner_key()
-        },
-        "the guard asks the owner to save; it never saves anything itself"
-    );
+    assert_asked_to_save(&transition.draft, None);
     assert_eq!(transition.state.current().screen, ScreenId::Dashboard);
     assert!(matches!(
         transition
             .state
             .guard()
             .map(super::navigation_dirty::DirtyGuard::phase),
-        Some(GuardPhase::Saving { .. })
+        Some(GuardPhase::SaveRequested { .. })
     ));
 }
 
@@ -177,8 +208,7 @@ fn a_matching_successful_completion_performs_the_pending_navigation() {
     let state = savable();
     let intent = push_to(&state, ScreenId::Issues);
     let guarded = send(state, NavMessage::Navigate(intent)).state;
-    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
-    let correlation = completion(&saving, owner_key());
+    let (saving, correlation) = saving_attempt(guarded, 1);
 
     let transition = send(
         saving,
@@ -201,7 +231,7 @@ fn a_completion_for_another_operation_changes_nothing() {
     let state = savable();
     let intent = push_to(&state, ScreenId::Issues);
     let guarded = send(state, NavMessage::Navigate(intent)).state;
-    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+    let (saving, _started) = saving_attempt(guarded, 1);
     let other = SemanticKey::new(EffectFamily::GitHub, "something-else");
     let correlation = completion(&saving, other);
     let expected = saving.clone();
@@ -223,7 +253,7 @@ fn a_completion_naming_a_stale_generation_changes_nothing() {
     let state = savable();
     let intent = push_to(&state, ScreenId::Issues);
     let guarded = send(state, NavMessage::Navigate(intent)).state;
-    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+    let (saving, _started) = saving_attempt(guarded, 1);
     let mut correlation = completion(&saving, owner_key());
     correlation.screen_generation = correlation.screen_generation.saturating_add(7);
     let expected = saving.clone();
@@ -266,8 +296,7 @@ fn a_failed_save_retains_the_draft_the_screen_and_the_choices() {
     let held = state.current().dirty.clone();
     let intent = push_to(&state, ScreenId::Issues);
     let guarded = send(state, NavMessage::Navigate(intent.clone())).state;
-    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
-    let correlation = completion(&saving, owner_key());
+    let (saving, correlation) = saving_attempt(guarded, 1);
 
     let transition = send(
         saving,
@@ -296,8 +325,7 @@ fn retrying_after_a_failed_save_asks_the_owner_again() {
     let state = savable();
     let intent = push_to(&state, ScreenId::Issues);
     let guarded = send(state, NavMessage::Navigate(intent)).state;
-    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
-    let correlation = completion(&saving, owner_key());
+    let (saving, correlation) = saving_attempt(guarded, 1);
     let failed = send(
         saving,
         NavMessage::SaveCompleted {
@@ -309,18 +337,13 @@ fn retrying_after_a_failed_save_asks_the_owner_again() {
 
     let transition = send(failed, NavMessage::ResolveDirty(DirtyChoice::Save));
 
-    assert_eq!(
-        transition.draft,
-        DraftAction::Save {
-            semantic_key: owner_key()
-        }
-    );
+    assert_asked_to_save(&transition.draft, None);
     assert!(matches!(
         transition
             .state
             .guard()
             .map(super::navigation_dirty::DirtyGuard::phase),
-        Some(GuardPhase::Saving { .. })
+        Some(GuardPhase::SaveRequested { .. })
     ));
 }
 
@@ -329,8 +352,7 @@ fn discarding_after_a_failed_save_still_leaves() {
     let state = savable();
     let intent = push_to(&state, ScreenId::Issues);
     let guarded = send(state, NavMessage::Navigate(intent)).state;
-    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
-    let correlation = completion(&saving, owner_key());
+    let (saving, correlation) = saving_attempt(guarded, 1);
     let failed = send(
         saving,
         NavMessage::SaveCompleted {
@@ -529,7 +551,7 @@ fn asking_to_save_again_while_a_save_is_running_does_not_run_it_twice() {
     let state = savable();
     let intent = push_to(&state, ScreenId::Issues);
     let guarded = send(state, NavMessage::Navigate(intent)).state;
-    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+    let (saving, _started) = saving_attempt(guarded, 1);
 
     let transition = send(saving, NavMessage::ResolveDirty(DirtyChoice::Save));
 
@@ -553,7 +575,7 @@ fn a_draft_cannot_be_replaced_while_the_guard_is_saving_it() {
     let state = savable();
     let intent = push_to(&state, ScreenId::Issues);
     let guarded = send(state, NavMessage::Navigate(intent)).state;
-    let saving = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+    let (saving, _started) = saving_attempt(guarded, 1);
     let held = saving.current().dirty.clone();
 
     let transition = send(
@@ -579,6 +601,165 @@ fn the_instance_left_behind_does_not_carry_a_draft_that_was_abandoned() {
         panic!("the previous instance was suspended");
     };
     assert_eq!(suspended.instance().dirty, DirtyState::Clean);
+}
+
+#[test]
+fn a_completion_from_a_different_owner_changes_nothing() {
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+    let (saving, _started) = saving_attempt(guarded, 1);
+    let mut correlation = completion(&saving, owner_key());
+    correlation.owner =
+        Id::parse("core.somethingelse").unwrap_or_else(|_| unreachable!("valid identifier"));
+    let expected = saving.clone();
+
+    let transition = send(
+        saving,
+        NavMessage::SaveCompleted {
+            correlation,
+            result: Ok(()),
+        },
+    );
+
+    assert_eq!(transition.state, expected);
+    assert_eq!(transition.outcome, NavOutcome::Unchanged);
+}
+
+#[test]
+fn a_completion_for_a_draft_that_has_since_been_replaced_changes_nothing() {
+    // The guard has to survive a failed save, a fresh draft, and a late answer
+    // about the draft that is gone.
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+    let (saving, correlation) = saving_attempt(guarded, 1);
+    let failed = send(
+        saving,
+        NavMessage::SaveCompleted {
+            correlation: correlation.clone(),
+            result: Err(failure()),
+        },
+    )
+    .state;
+    let replaced = send(
+        failed,
+        NavMessage::MarkDirty {
+            draft: DraftToken::next(),
+            save: SaveIntent::Owner {
+                owner: owner(),
+                semantic_key: owner_key(),
+            },
+        },
+    )
+    .state;
+    let retrying = send(replaced, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+
+    // The completion above named the draft that has since been replaced.
+    let transition = send(
+        retrying,
+        NavMessage::SaveCompleted {
+            correlation,
+            result: Ok(()),
+        },
+    );
+
+    assert_eq!(
+        transition.state.current().screen,
+        ScreenId::Dashboard,
+        "an answer about a replaced draft must not navigate"
+    );
+    assert!(transition.state.current().dirty.is_dirty());
+}
+
+#[test]
+fn the_save_the_owner_is_asked_to_run_names_the_draft_being_held() {
+    let state = savable();
+    let held = state.current().dirty.draft();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+
+    let transition = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save));
+
+    assert_asked_to_save(&transition.draft, held);
+}
+
+#[test]
+fn a_late_answer_from_an_abandoned_attempt_does_not_resolve_the_retry() {
+    // Owner, operation, screen, and both generations are identical across
+    // attempts, so only the correlation the owner registered tells them apart.
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+    let (first_running, first) = saving_attempt(guarded, 1);
+    let failed = send(
+        first_running,
+        NavMessage::SaveCompleted {
+            correlation: first.clone(),
+            result: Err(failure()),
+        },
+    )
+    .state;
+    let (retrying, second) = saving_attempt(failed, 2);
+    assert_ne!(first.correlation_id, second.correlation_id);
+
+    let transition = send(
+        retrying,
+        NavMessage::SaveCompleted {
+            correlation: first,
+            result: Ok(()),
+        },
+    );
+
+    assert_eq!(
+        transition.state.current().screen,
+        ScreenId::Dashboard,
+        "the abandoned attempt must not navigate on the retry's behalf"
+    );
+    assert!(transition.state.current().dirty.is_dirty());
+    assert!(matches!(
+        transition
+            .state
+            .guard()
+            .map(super::navigation_dirty::DirtyGuard::phase),
+        Some(GuardPhase::Saving { .. })
+    ));
+}
+
+#[test]
+fn nothing_resolves_the_guard_before_the_owner_says_what_it_registered() {
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+    let requested = send(guarded, NavMessage::ResolveDirty(DirtyChoice::Save)).state;
+    let correlation = completion(&requested, owner_key());
+
+    let transition = send(
+        requested,
+        NavMessage::SaveCompleted {
+            correlation,
+            result: Ok(()),
+        },
+    );
+
+    assert_eq!(transition.state.current().screen, ScreenId::Dashboard);
+    assert!(transition.state.current().dirty.is_dirty());
+}
+
+#[test]
+fn a_registration_that_answers_no_request_is_ignored() {
+    let state = savable();
+    let intent = push_to(&state, ScreenId::Issues);
+    let guarded = send(state, NavMessage::Navigate(intent)).state;
+    let expected = guarded.clone();
+    let correlation = attempt(&guarded, owner_key(), 9);
+
+    let transition = send(guarded, NavMessage::SaveStarted { correlation });
+
+    assert_eq!(
+        transition.state, expected,
+        "no save was asked for, so nothing may claim the guard"
+    );
 }
 
 #[test]

--- a/src/state/navigation_layers.rs
+++ b/src/state/navigation_layers.rs
@@ -78,35 +78,57 @@ impl AppState {
     }
 
     /// A chooser or property editor is taking the keys.
+    ///
+    /// Only the current screen's own state is consulted. A mode the user left
+    /// may still be holding a chooser or a half-typed filter, and that must not
+    /// change what Back does on the screen they are actually looking at.
     fn chooser_open(&self) -> bool {
-        self.issues_state.agent_chooser.is_some()
-            || self.issues_state.property_editor.is_some()
-            || self.issues_state.close_reason_chooser.is_some()
-            || self.prs_state.agent_chooser.is_some()
-            || self.prs_state.property_editor.is_some()
-            || self.prs_state.merge_chooser.is_some()
+        match self.screen() {
+            ScreenId::Issues => {
+                self.issues_state.agent_chooser.is_some()
+                    || self.issues_state.property_editor.is_some()
+                    || self.issues_state.close_reason_chooser.is_some()
+            }
+            ScreenId::PullRequests => {
+                self.prs_state.agent_chooser.is_some()
+                    || self.prs_state.property_editor.is_some()
+                    || self.prs_state.merge_chooser.is_some()
+            }
+            _ => false,
+        }
     }
 
     /// Text is being composed or edited in place.
     fn editor_open(&self) -> bool {
-        self.issues_state.inline_state != InlineState::None
-            || self.prs_state.inline_state != InlineState::None
-            || self.issues_state.new_issue_form.is_some()
+        match self.screen() {
+            ScreenId::Issues => {
+                self.issues_state.inline_state != InlineState::None
+                    || self.issues_state.new_issue_form.is_some()
+            }
+            ScreenId::PullRequests => self.prs_state.inline_state != InlineState::None,
+            _ => false,
+        }
     }
 
     /// A search input holds the keys.
     fn search_focused(&self) -> bool {
-        self.issues_state.search_input_focused
-            || self.prs_state.search_input_focused
-            || self.actions_state.ui.search_input_focused
-            || self.dashboard_search.input_focused
+        match self.screen() {
+            ScreenId::Issues => self.issues_state.search_input_focused,
+            ScreenId::PullRequests => self.prs_state.search_input_focused,
+            ScreenId::Actions => self.actions_state.ui.search_input_focused,
+            ScreenId::Dashboard | ScreenId::Repositories => self.dashboard_search.input_focused,
+            _ => false,
+        }
     }
 
     /// Filter controls are open.
     fn filter_open(&self) -> bool {
-        self.issues_state.filter_ui.controls_open
-            || self.prs_state.filter_ui.controls_open
-            || self.actions_state.ui.filter_ui_open
+        match self.screen() {
+            ScreenId::Issues => self.issues_state.filter_ui.controls_open,
+            ScreenId::PullRequests => self.prs_state.filter_ui.controls_open,
+            ScreenId::Actions => self.actions_state.ui.filter_ui_open,
+            _ => false,
+        }
     }
 
     /// An overlay with nothing unsaved behind it is open.

--- a/src/state/navigation_layers.rs
+++ b/src/state/navigation_layers.rs
@@ -2,11 +2,15 @@
 //!
 //! [`super::navigation_unwind::resolve_back`] states the precedence; this states
 //! what is actually open. Keeping the two apart means the order is a property of
-//! the contract rather than of whichever mode happened to be asked, and it is
-//! why every screen answers Back the same way without every screen containing
-//! the answer.
+//! the contract rather than of whichever mode happened to be asked.
 //!
-//! The projection is pure and reads only committed state.
+//! Only the current screen's own state is consulted. A mode the user left still
+//! holds its composer, chooser, search, and filter, and none of that belongs to
+//! the screen they are now looking at.
+//!
+//! The projection is pure and reads only committed state. It is not yet what
+//! the shipped Esc key consults — see the note on
+//! [`super::navigation_unwind`].
 
 use super::navigation_unwind::{BackLayer, BackResolution, resolve_back};
 use super::types::{AppState, InlineState, ModalState};

--- a/src/state/navigation_layers.rs
+++ b/src/state/navigation_layers.rs
@@ -1,0 +1,145 @@
+//! Which unwindable layers a screen currently has open (issue #386, CW06-04).
+//!
+//! [`super::navigation_unwind::resolve_back`] states the precedence; this states
+//! what is actually open. Keeping the two apart means the order is a property of
+//! the contract rather than of whichever mode happened to be asked, and it is
+//! why every screen answers Back the same way without every screen containing
+//! the answer.
+//!
+//! The projection is pure and reads only committed state.
+
+use super::navigation_unwind::{BackLayer, BackResolution, resolve_back};
+use super::types::{AppState, InlineState, ModalState};
+use crate::workbench::ScreenId;
+
+impl AppState {
+    /// The layers Back could unwind, in no particular order.
+    ///
+    /// Order is deliberately not expressed here — [`BackLayer::PRECEDENCE`]
+    /// owns it — so this can be read as a list of facts rather than as a chain
+    /// whose sequence is load-bearing.
+    #[must_use]
+    pub fn open_back_layers(&self) -> Vec<BackLayer> {
+        let mut open = Vec::new();
+        if self.host_confirmation_open() {
+            open.push(BackLayer::HostConfirmation);
+        }
+        if self.nav.guard().is_some() {
+            open.push(BackLayer::DirtyGuard);
+        }
+        if self.chooser_open() {
+            open.push(BackLayer::Chooser);
+        }
+        if self.editor_open() {
+            open.push(BackLayer::Editor);
+        }
+        if self.search_focused() {
+            open.push(BackLayer::Search);
+        }
+        if self.filter_open() {
+            open.push(BackLayer::Filter);
+        }
+        if self.plain_overlay_open() {
+            open.push(BackLayer::Overlay);
+        }
+        if self.panel_transient_open() {
+            open.push(BackLayer::PanelTransient);
+        }
+        open
+    }
+
+    /// What one Back key press means right now.
+    #[must_use]
+    pub fn back_resolution(&self) -> BackResolution {
+        resolve_back(&self.open_back_layers(), self.can_leave_screen())
+    }
+
+    /// Whether leaving this screen would go anywhere.
+    ///
+    /// The home screen with nothing stacked beneath it is the one place Back
+    /// has nothing left to do.
+    #[must_use]
+    pub fn can_leave_screen(&self) -> bool {
+        self.nav.depth() > 0 || self.screen() != ScreenId::default()
+    }
+
+    /// A modal the host owns that must be answered before anything else.
+    fn host_confirmation_open(&self) -> bool {
+        matches!(
+            self.modal,
+            ModalState::ConfirmDeleteRepository { .. }
+                | ModalState::ConfirmDeleteAgent { .. }
+                | ModalState::ConfirmKillAgent { .. }
+                | ModalState::ConfirmServerLostRecovery { .. }
+                | ModalState::PreflightPrompt { .. }
+                | ModalState::ConfirmIssueDirtyCopy { .. }
+                | ModalState::ConfirmIssueOriginMismatch { .. }
+        )
+    }
+
+    /// A chooser or property editor is taking the keys.
+    fn chooser_open(&self) -> bool {
+        self.issues_state.agent_chooser.is_some()
+            || self.issues_state.property_editor.is_some()
+            || self.issues_state.close_reason_chooser.is_some()
+            || self.prs_state.agent_chooser.is_some()
+            || self.prs_state.property_editor.is_some()
+            || self.prs_state.merge_chooser.is_some()
+    }
+
+    /// Text is being composed or edited in place.
+    fn editor_open(&self) -> bool {
+        self.issues_state.inline_state != InlineState::None
+            || self.prs_state.inline_state != InlineState::None
+            || self.issues_state.new_issue_form.is_some()
+    }
+
+    /// A search input holds the keys.
+    fn search_focused(&self) -> bool {
+        self.issues_state.search_input_focused
+            || self.prs_state.search_input_focused
+            || self.actions_state.ui.search_input_focused
+            || self.dashboard_search.input_focused
+    }
+
+    /// Filter controls are open.
+    fn filter_open(&self) -> bool {
+        self.issues_state.filter_ui.controls_open
+            || self.prs_state.filter_ui.controls_open
+            || self.actions_state.ui.filter_ui_open
+    }
+
+    /// An overlay with nothing unsaved behind it is open.
+    ///
+    /// Host confirmations are counted by their own layer, so they are excluded
+    /// here rather than counted twice.
+    fn plain_overlay_open(&self) -> bool {
+        !matches!(self.modal, ModalState::None) && !self.host_confirmation_open()
+    }
+
+    /// The focused panel holds transient state of its own.
+    fn panel_transient_open(&self) -> bool {
+        self.dashboard_grab.is_some()
+            || self.split_grab_index.is_some()
+            || self.selection.is_some()
+            || self.detail_panel_focused()
+    }
+
+    /// A detail panel is focused, which Back returns from before leaving.
+    fn detail_panel_focused(&self) -> bool {
+        match self.screen() {
+            ScreenId::Issues => {
+                self.issues_state.issue_focus == super::types::IssueFocus::IssueDetail
+            }
+            ScreenId::PullRequests => matches!(
+                self.prs_state.pr_focus,
+                super::types::PrFocus::PrDetail | super::types::PrFocus::PrChanges
+            ),
+            ScreenId::Actions => self.actions_state.focus == super::types::ActionsFocus::Detail,
+            ScreenId::Dashboard
+            | ScreenId::Repositories
+            | ScreenId::Errors
+            | ScreenId::Terminals => false,
+        }
+    }
+}

--- a/src/state/navigation_layers_tests.rs
+++ b/src/state/navigation_layers_tests.rs
@@ -1,0 +1,227 @@
+//! What Back does from a real screen (issue #386, CW06-04).
+
+use super::navigation::NavState;
+use super::navigation_dirty::{DirtyChoice, DraftToken, SaveIntent};
+use super::navigation_unwind::{BackLayer, BackResolution, LocalIntent};
+use super::types::{
+    AgentChooserState, AppState, ComposerTarget, ConfirmFocus, InlineState, IssueFocus, ModalState,
+};
+use crate::domain::RepositoryId;
+use crate::workbench::ScreenId;
+
+fn on(screen: ScreenId) -> AppState {
+    AppState {
+        nav: NavState::rooted(screen),
+        ..AppState::default()
+    }
+}
+
+fn issues() -> AppState {
+    let mut state = on(ScreenId::Issues);
+    state.issues_state.active = true;
+    state
+}
+
+fn composing(state: &mut AppState) {
+    state.issues_state.inline_state = InlineState::Composer {
+        target: ComposerTarget::NewComment,
+        text: "half a thought".to_owned(),
+        cursor: 0,
+    };
+}
+
+#[test]
+fn a_screen_with_nothing_open_reports_no_layers() {
+    assert!(issues().open_back_layers().is_empty());
+}
+
+#[test]
+fn back_from_the_home_screen_with_nothing_open_does_nothing() {
+    assert_eq!(
+        on(ScreenId::Dashboard).back_resolution(),
+        BackResolution::Nothing
+    );
+}
+
+#[test]
+fn back_from_another_screen_with_nothing_open_leaves_it() {
+    assert_eq!(issues().back_resolution(), BackResolution::Leave);
+}
+
+#[test]
+fn a_focused_detail_panel_is_unwound_before_the_screen_is_left() {
+    let mut state = issues();
+    state.issues_state.issue_focus = IssueFocus::IssueDetail;
+    assert_eq!(state.open_back_layers(), vec![BackLayer::PanelTransient]);
+    assert_eq!(
+        state.back_resolution(),
+        BackResolution::Local(LocalIntent::ClearPanelTransient)
+    );
+}
+
+#[test]
+fn an_open_composer_is_unwound_before_the_focused_panel() {
+    let mut state = issues();
+    state.issues_state.issue_focus = IssueFocus::IssueDetail;
+    composing(&mut state);
+    assert_eq!(
+        state.back_resolution(),
+        BackResolution::Local(LocalIntent::CloseEditor)
+    );
+}
+
+#[test]
+fn an_open_chooser_is_unwound_before_the_composer() {
+    let mut state = issues();
+    composing(&mut state);
+    state.issues_state.agent_chooser = Some(AgentChooserState::default());
+    assert_eq!(
+        state.back_resolution(),
+        BackResolution::Local(LocalIntent::CloseChooser)
+    );
+}
+
+#[test]
+fn a_focused_search_is_unwound_before_open_filter_controls() {
+    let mut state = issues();
+    state.issues_state.search_input_focused = true;
+    state.issues_state.filter_ui.controls_open = true;
+    assert_eq!(
+        state.back_resolution(),
+        BackResolution::Local(LocalIntent::CloseSearch)
+    );
+}
+
+#[test]
+fn open_filter_controls_are_unwound_before_the_screen_is_left() {
+    let mut state = issues();
+    state.issues_state.filter_ui.controls_open = true;
+    assert_eq!(
+        state.back_resolution(),
+        BackResolution::Local(LocalIntent::ClearFilter)
+    );
+}
+
+#[test]
+fn the_dirty_guard_outranks_everything_but_a_host_confirmation() {
+    let mut state = issues();
+    composing(&mut state);
+    state.issues_state.agent_chooser = Some(AgentChooserState::default());
+    let _ = state.mark_screen_dirty(
+        DraftToken::next(),
+        SaveIntent::Unavailable {
+            reason: "an unsent draft has nowhere to save to",
+        },
+    );
+    let _ = state.leave_screen();
+
+    assert_eq!(
+        state.back_resolution(),
+        BackResolution::Local(LocalIntent::ResolveDirty(DirtyChoice::Cancel)),
+        "the user is being asked about unsaved work, so Back answers that"
+    );
+}
+
+#[test]
+fn a_host_confirmation_outranks_the_dirty_guard() {
+    let mut state = issues();
+    let _ = state.mark_screen_dirty(
+        DraftToken::next(),
+        SaveIntent::Unavailable { reason: "nowhere" },
+    );
+    let _ = state.leave_screen();
+    state.modal = ModalState::ConfirmDeleteRepository {
+        id: RepositoryId("repo".to_owned()),
+        confirm_focus: ConfirmFocus::Cancel,
+    };
+
+    assert_eq!(
+        state.back_resolution(),
+        BackResolution::Local(LocalIntent::CloseHostConfirmation)
+    );
+}
+
+#[test]
+fn a_host_confirmation_is_not_also_counted_as_a_plain_overlay() {
+    let mut state = issues();
+    state.modal = ModalState::ConfirmDeleteRepository {
+        id: RepositoryId("repo".to_owned()),
+        confirm_focus: ConfirmFocus::Cancel,
+    };
+    assert_eq!(state.open_back_layers(), vec![BackLayer::HostConfirmation]);
+}
+
+#[test]
+fn a_plain_overlay_is_unwound_before_the_screen_is_left() {
+    let mut state = issues();
+    state.modal = ModalState::Help;
+    assert_eq!(
+        state.back_resolution(),
+        BackResolution::Local(LocalIntent::CloseOverlay)
+    );
+}
+
+#[test]
+fn a_dirty_screen_with_no_guard_up_still_leaves_normally() {
+    // Marking a draft does not by itself trap the user; the guard only appears
+    // once something actually tries to leave.
+    let mut state = issues();
+    let _ = state.mark_screen_dirty(
+        DraftToken::next(),
+        SaveIntent::Unavailable { reason: "nowhere" },
+    );
+    assert_eq!(state.back_resolution(), BackResolution::Leave);
+}
+
+#[test]
+fn every_layer_is_reachable_from_some_real_screen_state() {
+    // A layer nothing can open is a layer the precedence cannot be trusted
+    // about, so each one has to be produced by an actual state.
+    let mut produced: Vec<BackLayer> = Vec::new();
+
+    let mut confirmation = issues();
+    confirmation.modal = ModalState::ConfirmDeleteRepository {
+        id: RepositoryId("repo".to_owned()),
+        confirm_focus: ConfirmFocus::Cancel,
+    };
+    produced.extend(confirmation.open_back_layers());
+
+    let mut guarded = issues();
+    let _ = guarded.mark_screen_dirty(
+        DraftToken::next(),
+        SaveIntent::Unavailable { reason: "nowhere" },
+    );
+    let _ = guarded.leave_screen();
+    produced.extend(guarded.open_back_layers());
+
+    let mut chooser = issues();
+    chooser.issues_state.agent_chooser = Some(AgentChooserState::default());
+    produced.extend(chooser.open_back_layers());
+
+    let mut editor = issues();
+    composing(&mut editor);
+    produced.extend(editor.open_back_layers());
+
+    let mut search = issues();
+    search.issues_state.search_input_focused = true;
+    produced.extend(search.open_back_layers());
+
+    let mut filter = issues();
+    filter.issues_state.filter_ui.controls_open = true;
+    produced.extend(filter.open_back_layers());
+
+    let mut overlay = issues();
+    overlay.modal = ModalState::Help;
+    produced.extend(overlay.open_back_layers());
+
+    let mut transient = issues();
+    transient.issues_state.issue_focus = IssueFocus::IssueDetail;
+    produced.extend(transient.open_back_layers());
+
+    for layer in BackLayer::PRECEDENCE {
+        assert!(
+            produced.contains(&layer),
+            "no real screen state produces {layer:?}"
+        );
+    }
+}

--- a/src/state/navigation_layers_tests.rs
+++ b/src/state/navigation_layers_tests.rs
@@ -193,6 +193,44 @@ fn a_mode_the_user_left_cannot_change_what_back_does_here() {
 }
 
 #[test]
+fn leaving_a_screen_makes_its_in_flight_work_unanswerable() {
+    // Navigation decides which work is still wanted. Advancing the counters
+    // alone would not be enough: a pending record carries the correlation it
+    // was registered with, so its own completion would still match it exactly.
+    use crate::domain::effects::{Effect, EffectFamily, RetryPolicy, SemanticKey, TimerEffect};
+
+    let mut state = issues();
+    let (screen_generation, activation_generation) = state.nav.live_generations();
+    state.pending_effects.screen_generation = screen_generation;
+    state.pending_effects.activation_generation = activation_generation;
+    let owner = crate::domain::Id::parse("github.issues")
+        .unwrap_or_else(|_| unreachable!("valid identifier"));
+    let key = SemanticKey::new(EffectFamily::Timer, "issue-refresh");
+    let Ok(correlation) = state.register_pending_effect(
+        owner,
+        key,
+        Effect::Timer(TimerEffect::Wakeup { after_ms: 10 }),
+        RetryPolicy::Never,
+    ) else {
+        panic!("the pending store has room");
+    };
+    assert_eq!(state.pending_effects.len(), 1);
+
+    let _ = state.enter_screen(ScreenId::PullRequests);
+
+    assert_eq!(
+        state.pending_effects.len(),
+        0,
+        "work started on the screen the session left must not still be pending"
+    );
+    assert_eq!(
+        state.apply_effect_completion(&correlation),
+        crate::state::transition::CompletionOutcome::StaleIgnored,
+        "its own completion must no longer be applied to whatever replaced it"
+    );
+}
+
+#[test]
 fn every_layer_is_reachable_from_some_real_screen_state() {
     // A layer nothing can open is a layer the precedence cannot be trusted
     // about, so each one has to be produced by an actual state.

--- a/src/state/navigation_layers_tests.rs
+++ b/src/state/navigation_layers_tests.rs
@@ -174,6 +174,25 @@ fn a_dirty_screen_with_no_guard_up_still_leaves_normally() {
 }
 
 #[test]
+fn a_mode_the_user_left_cannot_change_what_back_does_here() {
+    // Issues keeps its composer, chooser, search, and filter state after the
+    // user moves on. None of it belongs to the screen they are now looking at.
+    let mut state = on(ScreenId::PullRequests);
+    state.issues_state.active = true;
+    composing(&mut state);
+    state.issues_state.agent_chooser = Some(AgentChooserState::default());
+    state.issues_state.search_input_focused = true;
+    state.issues_state.filter_ui.controls_open = true;
+
+    assert!(
+        state.open_back_layers().is_empty(),
+        "stale issues state leaked into pull requests: {:?}",
+        state.open_back_layers()
+    );
+    assert_eq!(state.back_resolution(), BackResolution::Leave);
+}
+
+#[test]
 fn every_layer_is_reachable_from_some_real_screen_state() {
     // A layer nothing can open is a layer the precedence cannot be trusted
     // about, so each one has to be produced by an actual state.

--- a/src/state/navigation_ops.rs
+++ b/src/state/navigation_ops.rs
@@ -1,0 +1,112 @@
+//! How the rest of the reducer asks to change screen (issue #386).
+//!
+//! Every screen change in the program funnels through these three verbs, and
+//! each is one call into [`reduce_navigation`]. Nothing assigns a screen any
+//! more, so the stack, the generations, and the dirty guard cannot disagree
+//! with what is on screen.
+//!
+//! The three verbs preserve exactly the movement the modes used to perform by
+//! hand:
+//!
+//! - [`AppState::enter_screen`] is how a mode was opened from the dashboard,
+//!   and it keeps the screen it came from so Back returns there;
+//! - [`AppState::switch_screen`] is the cross-mode jump (`i` from pull
+//!   requests, `p` from issues), which took the place of the current screen
+//!   rather than stacking on it, so Back still returns to the dashboard;
+//! - [`AppState::leave_screen`] is how a mode was closed, returning to
+//!   whatever was underneath.
+
+use crate::workbench::{ActivationValues, ScreenId, screen_registry};
+
+use super::AppState;
+use super::navigation::{
+    Activation, NavIntent, NavMessage, NavOutcome, NavState, reduce_navigation,
+};
+use super::navigation_dirty::{DirtyChoice, DraftAction, DraftToken, SaveIntent};
+
+impl AppState {
+    /// The screen the session is on.
+    ///
+    /// Reads route through the navigation authority rather than a field of
+    /// their own, so there is exactly one answer to "which screen is this".
+    #[must_use]
+    pub const fn screen(&self) -> ScreenId {
+        self.nav.screen()
+    }
+
+    /// Open `screen`, keeping the current one to come back to.
+    pub fn enter_screen(&mut self, screen: ScreenId) -> DraftAction {
+        let activation = self.activation_for(screen);
+        self.navigate(NavMessage::Navigate(NavIntent::Push(activation)))
+    }
+
+    /// Move to `screen` in place of the current one.
+    pub fn switch_screen(&mut self, screen: ScreenId) -> DraftAction {
+        let activation = self.activation_for(screen);
+        self.navigate(NavMessage::Navigate(NavIntent::Replace(activation)))
+    }
+
+    /// Return to the screen underneath this one.
+    ///
+    /// A restored session opens directly on whatever screen it was last on,
+    /// with nothing beneath it, and leaving that screen has always taken the
+    /// user home rather than stranding them. So leaving means: go back if
+    /// there is somewhere to go back to, otherwise go home — and if this
+    /// already is home, stay.
+    pub fn leave_screen(&mut self) -> DraftAction {
+        if self.nav.depth() == 0 && self.nav.screen() != ScreenId::default() {
+            return self.switch_screen(ScreenId::default());
+        }
+        self.navigate(NavMessage::Navigate(NavIntent::Back))
+    }
+
+    /// Record that this screen now holds unsaved work.
+    pub fn mark_screen_dirty(&mut self, draft: DraftToken, save: SaveIntent) -> DraftAction {
+        self.navigate(NavMessage::MarkDirty { draft, save })
+    }
+
+    /// Record that this screen no longer holds unsaved work.
+    pub fn mark_screen_clean(&mut self) -> DraftAction {
+        self.navigate(NavMessage::MarkClean)
+    }
+
+    /// Answer the dirty guard.
+    pub fn resolve_dirty(&mut self, choice: DirtyChoice) -> DraftAction {
+        self.navigate(NavMessage::ResolveDirty(choice))
+    }
+
+    /// An activation for `screen`, computed from the live current instance.
+    ///
+    /// Compiled screens declare no activation fields, so this carries no
+    /// values; it carries the provenance that lets the reducer refuse a
+    /// request computed against a screen that has since been replaced.
+    fn activation_for(&self, screen: ScreenId) -> Activation {
+        Activation::from_source(
+            crate::workbench::route_of(screen),
+            ActivationValues::empty(),
+            self.nav.current(),
+        )
+    }
+
+    /// Commit one navigation message, surfacing any refusal and reporting what
+    /// the draft's owner must now do.
+    fn navigate(&mut self, message: NavMessage) -> DraftAction {
+        let Ok(registry) = screen_registry() else {
+            // The compiled screen table is malformed, which the descriptor
+            // tests already fail on. Refusing to move and saying so is the only
+            // honest answer; moving anyway would be worse than not moving.
+            self.error_message = Some("NAV-E001: the screen registry is unavailable".to_owned());
+            return DraftAction::None;
+        };
+        let transition = reduce_navigation(
+            std::mem::replace(&mut self.nav, NavState::rooted(ScreenId::default())),
+            registry,
+            message,
+        );
+        self.nav = transition.state;
+        if let NavOutcome::Refused(refusal) = &transition.outcome {
+            self.error_message = Some(refusal.to_string());
+        }
+        transition.draft
+    }
+}

--- a/src/state/navigation_ops.rs
+++ b/src/state/navigation_ops.rs
@@ -40,6 +40,20 @@ impl AppState {
         self.navigate(NavMessage::Navigate(NavIntent::Push(activation)))
     }
 
+    /// Ensure the session is on `screen`, without stacking a second copy of it.
+    ///
+    /// Some transitions state where the session should end up rather than that
+    /// it should move — hiding a shell returns to the terminal manager whether
+    /// or not the manager is already the current screen. Pushing in that case
+    /// would stack a second instance of the screen the user is already looking
+    /// at, and repeating it would fill the stack.
+    pub fn show_screen(&mut self, screen: ScreenId) -> DraftAction {
+        if self.nav.screen() == screen {
+            return DraftAction::None;
+        }
+        self.enter_screen(screen)
+    }
+
     /// Move to `screen` in place of the current one.
     pub fn switch_screen(&mut self, screen: ScreenId) -> DraftAction {
         let activation = self.activation_for(screen);

--- a/src/state/navigation_ops.rs
+++ b/src/state/navigation_ops.rs
@@ -24,6 +24,14 @@ use super::navigation::{
 };
 use super::navigation_dirty::{DirtyChoice, DraftAction, DraftToken, SaveIntent};
 
+/// Whether an outcome actually changed which instance is current.
+const fn moved(outcome: &NavOutcome) -> bool {
+    matches!(
+        outcome,
+        NavOutcome::Pushed { .. } | NavOutcome::Replaced { .. } | NavOutcome::Restored { .. }
+    )
+}
+
 impl AppState {
     /// The screen the session is on.
     ///
@@ -120,6 +128,23 @@ impl AppState {
         self.nav = transition.state;
         if let NavOutcome::Refused(refusal) = &transition.outcome {
             self.error_message = Some(refusal.to_string());
+        }
+        if moved(&transition.outcome) {
+            // The pending ledger has to learn what navigation just decided,
+            // otherwise work started on the screen the session left would still
+            // match its own record and be applied to whatever replaced it.
+            let (screen_generation, activation_generation) = self.nav.live_generations();
+            let dropped = self
+                .pending_effects
+                .adopt_live_generations(screen_generation, activation_generation);
+            if dropped > 0 {
+                tracing::debug!(
+                    dropped,
+                    screen_generation,
+                    activation_generation,
+                    "dropped pending work belonging to a screen the session left"
+                );
+            }
         }
         transition.draft
     }

--- a/src/state/navigation_tests.rs
+++ b/src/state/navigation_tests.rs
@@ -23,10 +23,7 @@ fn route_of(screen: ScreenId) -> RouteId {
 }
 
 fn rooted(screen: ScreenId) -> NavState {
-    match NavState::rooted(registry(), screen) {
-        Ok(state) => state,
-        Err(refusal) => unreachable!("a compiled screen must root a session: {refusal}"),
-    }
+    NavState::rooted(screen)
 }
 
 /// An activation for `screen`, computed from `state`'s live current instance.

--- a/src/state/navigation_tests.rs
+++ b/src/state/navigation_tests.rs
@@ -7,7 +7,7 @@ use crate::workbench::{
 };
 
 use super::navigation::{
-    Activation, MAX_NAVIGATION_STACK, NavIntent, NavOutcome, NavRefusal, NavState,
+    Activation, MAX_NAVIGATION_STACK, NavIntent, NavMessage, NavOutcome, NavRefusal, NavState,
     SuspendedInstance, reduce_navigation,
 };
 
@@ -35,7 +35,7 @@ fn request(state: &NavState, screen: ScreenId) -> Activation {
 }
 
 fn apply(state: NavState, intent: NavIntent) -> (NavState, NavOutcome) {
-    let transition = reduce_navigation(state, registry(), intent);
+    let transition = reduce_navigation(state, registry(), NavMessage::Navigate(intent));
     (transition.state, transition.outcome)
 }
 

--- a/src/state/navigation_tests.rs
+++ b/src/state/navigation_tests.rs
@@ -385,3 +385,99 @@ fn a_suspended_instance_is_not_the_live_one() {
             .any(|entry| entry.instance().id == live)
     );
 }
+
+// ── CW06-08: only the live instance's work is answered ──────────────────────
+
+#[test]
+fn the_live_generations_are_the_current_instances_own() {
+    let state = rooted(ScreenId::Dashboard);
+    let current = state.current();
+    assert_eq!(
+        state.live_generations(),
+        (current.generation, current.activation.activation_generation)
+    );
+    assert!(state.answers_live_work(current.generation, current.activation.activation_generation));
+}
+
+#[test]
+fn a_suspended_instances_work_is_not_answered_while_it_waits() {
+    let before = rooted(ScreenId::Dashboard);
+    let (suspended_screen, suspended_activation) = before.live_generations();
+
+    let (after, _) = push(before, ScreenId::Issues);
+
+    assert!(
+        !after.answers_live_work(suspended_screen, suspended_activation),
+        "a suspended instance's answers must be ignored while it waits"
+    );
+}
+
+#[test]
+fn restoring_an_instance_makes_its_work_answerable_again() {
+    let before = rooted(ScreenId::Dashboard);
+    let (suspended_screen, suspended_activation) = before.live_generations();
+    let (pushed, _) = push(before, ScreenId::Issues);
+
+    let (after, _) = apply(pushed, NavIntent::Back);
+
+    assert!(
+        after.answers_live_work(suspended_screen, suspended_activation),
+        "back restores the instance's subscriptions along with the instance"
+    );
+}
+
+#[test]
+fn a_disposed_instances_work_is_never_answered_again() {
+    let before = rooted(ScreenId::Dashboard);
+    let (pushed, _) = push(before, ScreenId::Issues);
+    let (disposed_screen, disposed_activation) = pushed.live_generations();
+
+    let (after, _) = apply(pushed, NavIntent::Back);
+
+    assert!(
+        !after.answers_live_work(disposed_screen, disposed_activation),
+        "the instance back disposed must never receive an answer"
+    );
+}
+
+#[test]
+fn a_replaced_instances_work_is_never_answered_again() {
+    let before = rooted(ScreenId::Dashboard);
+    let (disposed_screen, disposed_activation) = before.live_generations();
+
+    let (after, _) = replace(before, ScreenId::Actions);
+
+    assert!(!after.answers_live_work(disposed_screen, disposed_activation));
+}
+
+#[test]
+fn generations_only_ever_move_forward() {
+    let mut state = rooted(ScreenId::Dashboard);
+    let mut previous = state.live_generations();
+    for screen in [ScreenId::Issues, ScreenId::PullRequests, ScreenId::Actions] {
+        state = push(state, screen).0;
+        let current = state.live_generations();
+        assert!(
+            current.0 > previous.0 && current.1 > previous.1,
+            "generations must advance: {previous:?} -> {current:?}"
+        );
+        previous = current;
+    }
+}
+
+#[test]
+fn a_refused_navigation_does_not_advance_generations() {
+    let mut state = rooted(ScreenId::Dashboard);
+    for _ in 0..MAX_NAVIGATION_STACK {
+        state = push(state, ScreenId::Issues).0;
+    }
+    let before = state.live_generations();
+
+    let (after, _) = push(state, ScreenId::Issues);
+
+    assert_eq!(
+        after.live_generations(),
+        before,
+        "a refusal must not invalidate the live instance's in-flight work"
+    );
+}

--- a/src/state/navigation_tests.rs
+++ b/src/state/navigation_tests.rs
@@ -364,6 +364,46 @@ fn every_compiled_screen_can_root_a_session() {
     }
 }
 
+// ── CW06-09: what a restored session opens on ───────────────────────────────
+
+#[test]
+fn every_persisted_screen_restores_one_clean_instance_and_no_stack() {
+    // Navigation is not persisted: a restored session knows which screen it was
+    // on and nothing else, so it can only ever come back with one instance and
+    // an empty stack — never with a stale stack pointing at screens whose data
+    // is long gone.
+    for (legacy, _) in crate::workbench::LEGACY_SCREEN_VALUES {
+        let Some(outcome) =
+            crate::workbench::migrate_persisted_screen_value(Some(legacy), registry())
+        else {
+            panic!("every legacy screen value maps to a screen");
+        };
+        let restored = NavState::rooted(outcome.screen_id());
+
+        assert_eq!(restored.current().screen, outcome.screen_id());
+        assert_eq!(restored.depth(), 0, "a restored session carries no stack");
+        assert_eq!(restored.current().generation, 1);
+        assert_eq!(restored.current().activation.activation_generation, 1);
+        assert!(restored.guard().is_none(), "a guard is never restored");
+        assert!(
+            restored.current().activation.values.is_empty(),
+            "a compiled screen restores with its declared defaults, which are none"
+        );
+    }
+}
+
+#[test]
+fn an_unreadable_persisted_screen_restores_the_home_screen() {
+    let outcome = crate::workbench::migrate_persisted_screen_value(Some("nonesuch"), registry());
+    let screen = outcome.map_or_else(
+        ScreenId::default,
+        crate::workbench::MigrationOutcome::screen_id,
+    );
+    let restored = NavState::rooted(screen);
+    assert_eq!(restored.current().screen, ScreenId::default());
+    assert_eq!(restored.depth(), 0);
+}
+
 #[test]
 fn instance_identity_is_never_reused_across_states() {
     let first = rooted(ScreenId::Dashboard);

--- a/src/state/navigation_tests.rs
+++ b/src/state/navigation_tests.rs
@@ -1,0 +1,387 @@
+//! Push, Replace, Back, and the stack bound (issue #386, CW06-01..CW06-07).
+
+use crate::domain::Id;
+use crate::workbench::{
+    ActivationError, ActivationValue, ActivationValues, NavCode, RouteId, ScreenId,
+    ScreenInstanceId, ScreenRegistry, screen_registry,
+};
+
+use super::navigation::{
+    Activation, MAX_NAVIGATION_STACK, NavIntent, NavOutcome, NavRefusal, NavState,
+    SuspendedInstance, reduce_navigation,
+};
+
+fn registry() -> &'static ScreenRegistry {
+    screen_registry().unwrap_or_else(|_| unreachable!("the compiled registry must be well formed"))
+}
+
+fn route_of(screen: ScreenId) -> RouteId {
+    let Some(descriptor) = registry().get(screen) else {
+        unreachable!("every compiled screen has a descriptor");
+    };
+    descriptor.route
+}
+
+fn rooted(screen: ScreenId) -> NavState {
+    match NavState::rooted(registry(), screen) {
+        Ok(state) => state,
+        Err(refusal) => unreachable!("a compiled screen must root a session: {refusal}"),
+    }
+}
+
+/// An activation for `screen`, computed from `state`'s live current instance.
+fn request(state: &NavState, screen: ScreenId) -> Activation {
+    Activation::from_source(route_of(screen), ActivationValues::empty(), state.current())
+}
+
+fn apply(state: NavState, intent: NavIntent) -> (NavState, NavOutcome) {
+    let transition = reduce_navigation(state, registry(), intent);
+    (transition.state, transition.outcome)
+}
+
+fn push(state: NavState, screen: ScreenId) -> (NavState, NavOutcome) {
+    let intent = NavIntent::Push(request(&state, screen));
+    apply(state, intent)
+}
+
+fn replace(state: NavState, screen: ScreenId) -> (NavState, NavOutcome) {
+    let intent = NavIntent::Replace(request(&state, screen));
+    apply(state, intent)
+}
+
+// ── CW06-01: Push ───────────────────────────────────────────────────────────
+
+#[test]
+fn push_suspends_the_exact_current_instance_and_enters_a_fresh_one() {
+    let before = rooted(ScreenId::Dashboard);
+    let suspended_instance = before.current().clone();
+
+    let (after, outcome) = push(before, ScreenId::PullRequests);
+
+    assert_eq!(after.current().screen, ScreenId::PullRequests);
+    assert_eq!(after.depth(), 1);
+    assert_eq!(
+        after.suspended().first().map(SuspendedInstance::instance),
+        Some(&suspended_instance),
+        "the suspended instance must be the exact instance that was current"
+    );
+    assert_ne!(
+        after.current().id,
+        suspended_instance.id,
+        "a pushed target is a fresh instance, never the suspended one"
+    );
+    assert!(
+        after.current().generation > suspended_instance.generation,
+        "screen generations advance so an older instance's completions are stale"
+    );
+    let NavOutcome::Pushed {
+        suspended, entered, ..
+    } = outcome
+    else {
+        panic!("a valid push reports what it suspended and what it entered: {outcome:?}");
+    };
+    assert_eq!(suspended, suspended_instance.id);
+    assert_eq!(entered, after.current().id);
+}
+
+#[test]
+fn a_pushed_instance_starts_focused_where_its_descriptor_says() {
+    let (after, _) = push(rooted(ScreenId::Dashboard), ScreenId::Issues);
+    let Some(descriptor) = registry().get(ScreenId::Issues) else {
+        unreachable!("every compiled screen has a descriptor");
+    };
+    assert_eq!(after.current().panel_focus, descriptor.initial_focus);
+}
+
+#[test]
+fn every_entered_instance_has_an_identity_no_other_instance_had() {
+    let mut state = rooted(ScreenId::Dashboard);
+    let mut seen = vec![state.current().id];
+    for screen in [
+        ScreenId::Issues,
+        ScreenId::PullRequests,
+        ScreenId::Actions,
+        ScreenId::Errors,
+    ] {
+        let (next, _) = push(state, screen);
+        state = next;
+        let id = state.current().id;
+        assert!(!seen.contains(&id), "instance identity {id} was reused");
+        seen.push(id);
+    }
+}
+
+#[test]
+fn the_activation_an_instance_was_entered_with_records_which_instance_asked() {
+    let before = rooted(ScreenId::Dashboard);
+    let source = before.current().id;
+    let (after, _) = push(before, ScreenId::Issues);
+    assert_eq!(after.current().activation.source_instance, source);
+    assert_eq!(after.current().activation.route, route_of(ScreenId::Issues));
+}
+
+// ── Validation refusals leave navigation untouched ──────────────────────────
+
+#[test]
+fn a_push_to_an_undeclared_route_changes_nothing() {
+    let before = rooted(ScreenId::Dashboard);
+    let Ok(unknown) = RouteId::parse("nonesuch") else {
+        unreachable!("test route id is valid");
+    };
+    let intent = NavIntent::Push(Activation::from_source(
+        unknown,
+        ActivationValues::empty(),
+        before.current(),
+    ));
+    let expected = before.clone();
+
+    let (after, outcome) = apply(before, intent);
+
+    assert_eq!(after, expected, "a refused push must not mutate navigation");
+    let NavOutcome::Refused(refusal) = outcome else {
+        panic!("an undeclared route must be refused: {outcome:?}");
+    };
+    assert!(matches!(
+        refusal,
+        NavRefusal::Activation(ActivationError::UnknownRoute { .. })
+    ));
+    assert_eq!(refusal.code(), NavCode::E001);
+}
+
+#[test]
+fn a_push_whose_activation_does_not_satisfy_the_schema_changes_nothing() {
+    // A compiled screen declares no activation fields, so any supplied value is
+    // undeclared and the whole request is refused before anything moves.
+    let before = rooted(ScreenId::Dashboard);
+    let Ok(name) = Id::parse("number") else {
+        unreachable!("test field name is a valid identifier");
+    };
+    let Ok(values) = ActivationValues::new(vec![(name, ActivationValue::Integer(42))]) else {
+        unreachable!("one field is within the bound");
+    };
+    let intent = NavIntent::Push(Activation::from_source(
+        route_of(ScreenId::Issues),
+        values,
+        before.current(),
+    ));
+    let expected = before.clone();
+
+    let (after, outcome) = apply(before, intent);
+
+    assert_eq!(after, expected);
+    assert!(matches!(
+        outcome,
+        NavOutcome::Refused(NavRefusal::Activation(ActivationError::UnknownField { .. }))
+    ));
+}
+
+#[test]
+fn a_push_computed_from_an_instance_that_is_no_longer_current_changes_nothing() {
+    // The request was computed from a snapshot that has since been replaced,
+    // so acting on it would navigate on behalf of a screen that is gone.
+    let before = rooted(ScreenId::Dashboard);
+    let stale = Activation::from_source(
+        route_of(ScreenId::Issues),
+        ActivationValues::empty(),
+        before.current(),
+    );
+    let (moved, _) = push(before, ScreenId::PullRequests);
+    let expected = moved.clone();
+
+    let (after, outcome) = apply(moved, NavIntent::Push(stale));
+
+    assert_eq!(after, expected);
+    assert!(matches!(
+        outcome,
+        NavOutcome::Refused(NavRefusal::StaleSource { .. })
+    ));
+}
+
+// ── CW06-02: Replace ────────────────────────────────────────────────────────
+
+#[test]
+fn replace_enters_the_target_and_disposes_the_old_instance_without_stacking() {
+    let before = rooted(ScreenId::Dashboard);
+    let disposed_instance = before.current().id;
+
+    let (after, outcome) = replace(before, ScreenId::Actions);
+
+    assert_eq!(after.current().screen, ScreenId::Actions);
+    assert_eq!(after.depth(), 0, "replace never grows the stack");
+    let NavOutcome::Replaced { disposed, entered } = outcome else {
+        panic!("a valid replace reports what it disposed: {outcome:?}");
+    };
+    assert_eq!(disposed, disposed_instance);
+    assert_eq!(entered, after.current().id);
+    assert_ne!(entered, disposed_instance);
+}
+
+#[test]
+fn a_replace_that_fails_validation_disposes_nothing() {
+    let before = push(rooted(ScreenId::Dashboard), ScreenId::Issues).0;
+    let Ok(unknown) = RouteId::parse("nonesuch") else {
+        unreachable!("test route id is valid");
+    };
+    let intent = NavIntent::Replace(Activation::from_source(
+        unknown,
+        ActivationValues::empty(),
+        before.current(),
+    ));
+    let expected = before.clone();
+
+    let (after, outcome) = apply(before, intent);
+
+    assert_eq!(
+        after, expected,
+        "the target is constructed before the old instance is disposed"
+    );
+    assert!(matches!(outcome, NavOutcome::Refused(_)));
+}
+
+#[test]
+fn replace_keeps_the_stack_it_was_given() {
+    let (pushed, _) = push(rooted(ScreenId::Dashboard), ScreenId::Issues);
+    let suspended = pushed.suspended().to_vec();
+
+    let (after, _) = replace(pushed, ScreenId::Actions);
+
+    assert_eq!(after.suspended(), suspended.as_slice());
+    assert_eq!(after.depth(), 1);
+}
+
+// ── CW06-03: Back ───────────────────────────────────────────────────────────
+
+#[test]
+fn back_restores_the_exact_prior_instance() {
+    let before = rooted(ScreenId::Dashboard);
+    let original = before.current().clone();
+    let (pushed, _) = push(before, ScreenId::PullRequests);
+    let disposed_instance = pushed.current().id;
+
+    let (after, outcome) = apply(pushed, NavIntent::Back);
+
+    assert_eq!(
+        after.current(),
+        &original,
+        "the restored instance must be byte-equivalent to the suspended one"
+    );
+    assert_eq!(after.depth(), 0);
+    let NavOutcome::Restored { disposed, restored } = outcome else {
+        panic!("back over the stack reports what it disposed: {outcome:?}");
+    };
+    assert_eq!(disposed, disposed_instance);
+    assert_eq!(restored, original.id);
+}
+
+#[test]
+fn back_unwinds_a_deep_stack_in_reverse_entry_order() {
+    let mut state = rooted(ScreenId::Dashboard);
+    let order = [ScreenId::Issues, ScreenId::PullRequests, ScreenId::Actions];
+    for screen in order {
+        state = push(state, screen).0;
+    }
+    for screen in order.into_iter().rev().skip(1) {
+        state = apply(state, NavIntent::Back).0;
+        assert_eq!(state.current().screen, screen);
+    }
+    state = apply(state, NavIntent::Back).0;
+    assert_eq!(state.current().screen, ScreenId::Dashboard);
+    assert_eq!(state.depth(), 0);
+}
+
+#[test]
+fn back_at_the_root_changes_nothing_and_reports_nothing_to_do() {
+    let before = rooted(ScreenId::Dashboard);
+    let expected = before.clone();
+
+    let (after, outcome) = apply(before, NavIntent::Back);
+
+    assert_eq!(after, expected);
+    assert_eq!(outcome, NavOutcome::Unchanged);
+}
+
+// ── CW06-07: stack bound ────────────────────────────────────────────────────
+
+#[test]
+fn the_stack_holds_exactly_the_declared_maximum() {
+    let mut state = rooted(ScreenId::Dashboard);
+    for _ in 0..MAX_NAVIGATION_STACK {
+        let (next, outcome) = push(state, ScreenId::Issues);
+        assert!(matches!(outcome, NavOutcome::Pushed { .. }));
+        state = next;
+    }
+    assert_eq!(state.depth(), MAX_NAVIGATION_STACK);
+}
+
+#[test]
+fn a_push_beyond_the_declared_maximum_is_refused_and_changes_nothing() {
+    let mut state = rooted(ScreenId::Dashboard);
+    for _ in 0..MAX_NAVIGATION_STACK {
+        state = push(state, ScreenId::Issues).0;
+    }
+    let expected = state.clone();
+
+    let (after, outcome) = push(state, ScreenId::Issues);
+
+    assert_eq!(after, expected, "an overflowing push must not mutate state");
+    let NavOutcome::Refused(refusal) = outcome else {
+        panic!("the 33rd push must be refused: {outcome:?}");
+    };
+    assert!(matches!(refusal, NavRefusal::StackDepth { .. }));
+    assert_eq!(refusal.code(), NavCode::E001);
+    assert!(refusal.to_string().starts_with("NAV-E001: "));
+}
+
+#[test]
+fn replace_is_still_available_at_the_stack_bound() {
+    // Replace does not stack, so a full stack must not strand the session.
+    let mut state = rooted(ScreenId::Dashboard);
+    for _ in 0..MAX_NAVIGATION_STACK {
+        state = push(state, ScreenId::Issues).0;
+    }
+    let (after, outcome) = replace(state, ScreenId::Actions);
+    assert!(matches!(outcome, NavOutcome::Replaced { .. }));
+    assert_eq!(after.depth(), MAX_NAVIGATION_STACK);
+}
+
+// ── Root construction ───────────────────────────────────────────────────────
+
+#[test]
+fn a_rooted_session_has_one_clean_instance_and_no_stack() {
+    let state = rooted(ScreenId::Issues);
+    assert_eq!(state.current().screen, ScreenId::Issues);
+    assert_eq!(state.depth(), 0);
+    assert_eq!(state.current().generation, 1);
+    assert_eq!(
+        state.current().activation.source_instance,
+        state.current().id,
+        "the root instance was activated by nothing but itself"
+    );
+}
+
+#[test]
+fn every_compiled_screen_can_root_a_session() {
+    for screen in ScreenId::ALL {
+        let state = rooted(screen);
+        assert_eq!(state.current().screen, screen);
+    }
+}
+
+#[test]
+fn instance_identity_is_never_reused_across_states() {
+    let first = rooted(ScreenId::Dashboard);
+    let second = rooted(ScreenId::Dashboard);
+    assert_ne!(first.current().id, second.current().id);
+}
+
+#[test]
+fn a_suspended_instance_is_not_the_live_one() {
+    let (state, _) = push(rooted(ScreenId::Dashboard), ScreenId::Issues);
+    let live: ScreenInstanceId = state.current().id;
+    assert!(
+        !state
+            .suspended()
+            .iter()
+            .any(|entry| entry.instance().id == live)
+    );
+}

--- a/src/state/navigation_unwind.rs
+++ b/src/state/navigation_unwind.rs
@@ -1,0 +1,121 @@
+//! What one Back key actually does (issue #386, CW06-04).
+//!
+//! Back used to mean whatever the focused mode decided it meant, and each mode
+//! decided separately: issues had its own Esc chain, pull requests had a
+//! near-identical one, actions and errors and the terminal manager had shorter
+//! ones. The chains agreed by coincidence rather than by construction, so
+//! "which thing closes first" was a question with five answers.
+//!
+//! There is now one precedence order, stated once, in
+//! [`BackLayer::PRECEDENCE`]. Back closes the innermost thing that is open and
+//! nothing else — one key press unwinds exactly one layer — and only when no
+//! layer is open at all does it reach navigation.
+//!
+//! The resolver takes the layers that are open rather than a struct of flags,
+//! so adding a layer is an addition to one ordered list instead of another
+//! boolean whose position in a chain of `if`s is the real specification.
+
+use super::navigation_dirty::DirtyChoice;
+
+/// One thing a Back key can close, named so it can be ordered against the rest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BackLayer {
+    /// A host confirmation modal is trapping input.
+    HostConfirmation,
+    /// The host dirty guard is asking about unsaved work.
+    DirtyGuard,
+    /// A chooser overlay is open.
+    Chooser,
+    /// An inline editor or composer is open.
+    Editor,
+    /// A search input is focused.
+    Search,
+    /// A filter is applied or its controls are open.
+    Filter,
+    /// A non-dirty overlay is open.
+    Overlay,
+    /// The focused panel holds a transient of its own.
+    PanelTransient,
+}
+
+impl BackLayer {
+    /// Every layer, innermost first. This list *is* the precedence rule.
+    pub const PRECEDENCE: [Self; 8] = [
+        Self::HostConfirmation,
+        Self::DirtyGuard,
+        Self::Chooser,
+        Self::Editor,
+        Self::Search,
+        Self::Filter,
+        Self::Overlay,
+        Self::PanelTransient,
+    ];
+
+    /// What closing this layer asks its owner to do.
+    #[must_use]
+    pub const fn intent(self) -> LocalIntent {
+        match self {
+            Self::HostConfirmation => LocalIntent::CloseHostConfirmation,
+            // Esc answers the guard the same way the Cancel control does: keep
+            // the draft, keep the screen, drop the navigation that raised it.
+            Self::DirtyGuard => LocalIntent::ResolveDirty(DirtyChoice::Cancel),
+            Self::Chooser => LocalIntent::CloseChooser,
+            Self::Editor => LocalIntent::CloseEditor,
+            Self::Search => LocalIntent::CloseSearch,
+            Self::Filter => LocalIntent::ClearFilter,
+            Self::Overlay => LocalIntent::CloseOverlay,
+            Self::PanelTransient => LocalIntent::ClearPanelTransient,
+        }
+    }
+}
+
+/// What the owner of the unwound layer must do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalIntent {
+    /// Dismiss the host confirmation modal.
+    CloseHostConfirmation,
+    /// Answer the host dirty guard.
+    ResolveDirty(DirtyChoice),
+    /// Close the open chooser.
+    CloseChooser,
+    /// Close the open editor or composer.
+    CloseEditor,
+    /// Leave the search input.
+    CloseSearch,
+    /// Clear the applied filter.
+    ClearFilter,
+    /// Close the open overlay.
+    CloseOverlay,
+    /// Clear the focused panel's own transient state.
+    ClearPanelTransient,
+}
+
+/// What one Back key press resolves to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackResolution {
+    /// Unwind exactly this layer; the session stays on its screen.
+    Local(LocalIntent),
+    /// Nothing local is open; leave the screen.
+    Leave,
+    /// Nothing is open and there is nowhere to go back to.
+    Nothing,
+}
+
+/// Resolve one Back key press.
+///
+/// `open` is the set of layers currently open, in any order — precedence comes
+/// from [`BackLayer::PRECEDENCE`], never from the caller. `can_leave` says
+/// whether navigation has somewhere to return to.
+#[must_use]
+pub fn resolve_back(open: &[BackLayer], can_leave: bool) -> BackResolution {
+    for layer in BackLayer::PRECEDENCE {
+        if open.contains(&layer) {
+            return BackResolution::Local(layer.intent());
+        }
+    }
+    if can_leave {
+        BackResolution::Leave
+    } else {
+        BackResolution::Nothing
+    }
+}

--- a/src/state/navigation_unwind.rs
+++ b/src/state/navigation_unwind.rs
@@ -14,6 +14,14 @@
 //! The resolver takes the layers that are open rather than a struct of flags,
 //! so adding a layer is an addition to one ordered list instead of another
 //! boolean whose position in a chain of `if`s is the real specification.
+//!
+//! **What is not yet true.** The per-mode key chains in `app_input` still
+//! decide Esc and `q` for themselves; they have not been converted to ask this
+//! resolver. So this states the order and answers correctly for anything that
+//! consults it, but it is not yet the only thing deciding. Converting those
+//! chains is the remaining half of the cutover, and until it lands the shipped
+//! precedence is whatever those chains do — which the existing mode tests pin,
+//! and which agrees with the order above.
 
 use super::navigation_dirty::DirtyChoice;
 

--- a/src/state/navigation_unwind_tests.rs
+++ b/src/state/navigation_unwind_tests.rs
@@ -1,0 +1,129 @@
+//! One Back key unwinds exactly one layer (issue #386, CW06-04).
+
+use super::navigation_dirty::DirtyChoice;
+use super::navigation_unwind::{BackLayer, BackResolution, LocalIntent, resolve_back};
+
+/// The exact order the contract states, written out independently of the
+/// implementation so a reordering of `PRECEDENCE` fails here rather than
+/// silently redefining what Back means.
+const CONTRACT_ORDER: [BackLayer; 8] = [
+    BackLayer::HostConfirmation,
+    BackLayer::DirtyGuard,
+    BackLayer::Chooser,
+    BackLayer::Editor,
+    BackLayer::Search,
+    BackLayer::Filter,
+    BackLayer::Overlay,
+    BackLayer::PanelTransient,
+];
+
+#[test]
+fn the_precedence_order_is_the_one_the_contract_states() {
+    assert_eq!(BackLayer::PRECEDENCE, CONTRACT_ORDER);
+}
+
+#[test]
+fn with_every_layer_open_back_unwinds_only_the_innermost() {
+    let all: Vec<BackLayer> = CONTRACT_ORDER.to_vec();
+    assert_eq!(
+        resolve_back(&all, true),
+        BackResolution::Local(LocalIntent::CloseHostConfirmation)
+    );
+}
+
+#[test]
+fn back_unwinds_the_stack_of_layers_one_press_at_a_time() {
+    // Start with everything open and peel one layer per press, asserting that
+    // each press closes exactly the next layer in the contract order.
+    let mut open: Vec<BackLayer> = CONTRACT_ORDER.to_vec();
+    for layer in CONTRACT_ORDER {
+        assert_eq!(
+            resolve_back(&open, true),
+            BackResolution::Local(layer.intent()),
+            "with {open:?} open, Back must unwind {layer:?}"
+        );
+        open.retain(|candidate| *candidate != layer);
+    }
+    assert!(open.is_empty());
+    assert_eq!(resolve_back(&open, true), BackResolution::Leave);
+}
+
+#[test]
+fn each_layer_alone_resolves_to_its_own_intent() {
+    for layer in CONTRACT_ORDER {
+        assert_eq!(
+            resolve_back(&[layer], true),
+            BackResolution::Local(layer.intent())
+        );
+    }
+}
+
+#[test]
+fn every_layer_maps_to_a_distinct_intent() {
+    let intents: Vec<LocalIntent> = CONTRACT_ORDER.into_iter().map(BackLayer::intent).collect();
+    for (index, intent) in intents.iter().enumerate() {
+        assert!(
+            !intents[..index].contains(intent),
+            "{intent:?} is produced by two layers"
+        );
+    }
+}
+
+#[test]
+fn an_outer_layer_never_pre_empts_an_inner_one() {
+    // Every pair, in both listed orders, must resolve to the earlier layer.
+    for (index, inner) in CONTRACT_ORDER.into_iter().enumerate() {
+        for outer in CONTRACT_ORDER.into_iter().skip(index + 1) {
+            for open in [vec![inner, outer], vec![outer, inner]] {
+                assert_eq!(
+                    resolve_back(&open, true),
+                    BackResolution::Local(inner.intent()),
+                    "{inner:?} must win over {outer:?} regardless of listing order"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn the_dirty_guard_is_answered_the_way_the_cancel_control_answers_it() {
+    assert_eq!(
+        BackLayer::DirtyGuard.intent(),
+        LocalIntent::ResolveDirty(DirtyChoice::Cancel)
+    );
+}
+
+#[test]
+fn with_nothing_open_back_leaves_the_screen() {
+    assert_eq!(resolve_back(&[], true), BackResolution::Leave);
+}
+
+#[test]
+fn with_nothing_open_and_nowhere_to_go_back_does_nothing() {
+    assert_eq!(resolve_back(&[], false), BackResolution::Nothing);
+}
+
+#[test]
+fn a_local_layer_is_unwound_even_when_there_is_nowhere_to_go_back_to() {
+    // The root screen still has to be able to close its own overlays.
+    for layer in CONTRACT_ORDER {
+        assert_eq!(
+            resolve_back(&[layer], false),
+            BackResolution::Local(layer.intent())
+        );
+    }
+}
+
+#[test]
+fn resolution_does_not_depend_on_how_often_a_layer_is_listed() {
+    let open = [
+        BackLayer::Filter,
+        BackLayer::Filter,
+        BackLayer::Editor,
+        BackLayer::Editor,
+    ];
+    assert_eq!(
+        resolve_back(&open, true),
+        BackResolution::Local(LocalIntent::CloseEditor)
+    );
+}

--- a/src/state/preferences_tests.rs
+++ b/src/state/preferences_tests.rs
@@ -138,7 +138,7 @@ fn enter_prs_mode_restores_field_index() {
 #[test]
 fn pr_apply_filter_persists_to_prefs() {
     let mut state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
-    state.screen = ScreenId::PullRequests;
+    state.nav = crate::state::navigation::NavState::rooted(ScreenId::PullRequests);
     state.prs_state.active = true;
     state.prs_state.filter_ui.controls_open = true;
     state.prs_state.draft_filter.state = Some(PrFilterState::Closed);
@@ -155,7 +155,7 @@ fn pr_apply_filter_persists_to_prefs() {
 #[test]
 fn pr_clear_filter_persists_open_default() {
     let mut state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
-    state.screen = ScreenId::PullRequests;
+    state.nav = crate::state::navigation::NavState::rooted(ScreenId::PullRequests);
     state.prs_state.active = true;
     // Seed a search query so we can prove ClearFilter also clears it.
     state.prs_state.search_query = "stale query".to_string();
@@ -185,7 +185,7 @@ fn pr_open_filter_controls_keeps_restored_field_index() {
         ..RepoPreferences::default()
     };
     let mut state = state_with_repo_and_prefs("repo-1", prefs);
-    state.screen = ScreenId::PullRequests;
+    state.nav = crate::state::navigation::NavState::rooted(ScreenId::PullRequests);
     state.prs_state.active = true;
 
     // Enter mode restores field_index=2 into live state; opening filter
@@ -215,7 +215,7 @@ fn pr_prefs_are_per_repo() {
         ..RepoPreferences::default()
     };
     let mut state = state_with_two_repos("repo-1", prefs1, "repo-2", prefs2);
-    state.screen = ScreenId::PullRequests;
+    state.nav = crate::state::navigation::NavState::rooted(ScreenId::PullRequests);
     state.prs_state.active = true;
 
     // Enter PR mode with repo-1 selected → Closed.
@@ -278,7 +278,7 @@ fn issue_open_filter_controls_keeps_restored_field_index() {
         ..RepoPreferences::default()
     };
     let mut state = state_with_repo_and_prefs("repo-1", prefs);
-    state.screen = ScreenId::Issues;
+    state.nav = crate::state::navigation::NavState::rooted(ScreenId::Issues);
     state.issues_state.active = true;
 
     // Enter mode restores field_index=4 into live state; opening filter
@@ -292,7 +292,7 @@ fn issue_open_filter_controls_keeps_restored_field_index() {
 #[test]
 fn issue_apply_filter_persists() {
     let mut state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
-    state.screen = ScreenId::Issues;
+    state.nav = crate::state::navigation::NavState::rooted(ScreenId::Issues);
     state.issues_state.active = true;
     state.issues_state.filter_ui.controls_open = true;
     state.issues_state.draft_filter.author = "alice".to_string();
@@ -307,7 +307,7 @@ fn issue_apply_filter_persists() {
 #[test]
 fn issue_clear_filter_persists() {
     let mut state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
-    state.screen = ScreenId::Issues;
+    state.nav = crate::state::navigation::NavState::rooted(ScreenId::Issues);
     state.issues_state.active = true;
     // Seed a search query so we can prove ClearFilter also clears it.
     state.issues_state.search_query = "stale query".to_string();
@@ -341,7 +341,7 @@ fn issue_clear_draft_filter_defaults_to_open() {
     // ClearDraftFilter resets the in-progress draft to the Open default (issue
     // #163: the filter-state default is Open, matching ClearFilter).
     let mut state = state_with_repo_and_prefs("repo-1", RepoPreferences::default());
-    state.screen = ScreenId::Issues;
+    state.nav = crate::state::navigation::NavState::rooted(ScreenId::Issues);
     state.issues_state.active = true;
     state.issues_state.draft_filter.state = Some(IssueFilterState::Closed);
 

--- a/src/state/prs_integration_tests.rs
+++ b/src/state/prs_integration_tests.rs
@@ -526,12 +526,12 @@ fn it_exit_restores_prior_dashboard_focus() {
     // Enter PR mode (saves prior focus).
     state.apply_in_place(AppEvent::EnterPrsMode);
     assert!(state.prs_state.active);
-    assert_eq!(state.screen, ScreenId::PullRequests);
+    assert_eq!(state.screen(), ScreenId::PullRequests);
 
     // Exit restores prior focus.
     state.apply_in_place(AppEvent::ExitPrsMode);
     assert!(!state.prs_state.active);
-    assert_eq!(state.screen, ScreenId::Dashboard);
+    assert_eq!(state.screen(), ScreenId::Dashboard);
     assert_eq!(
         state.pane_focus,
         PaneFocus::Agents,
@@ -717,7 +717,7 @@ fn it_empty_pr_list_shows_empty_state() {
 fn it_dashboard_and_issues_modes_unaffected() {
     let state = AppState::default();
     assert_eq!(
-        state.screen,
+        state.screen(),
         ScreenId::Dashboard,
         "default must be Dashboard"
     );
@@ -725,10 +725,10 @@ fn it_dashboard_and_issues_modes_unaffected() {
     // Issues mode regression.
     let state2 = dashboard_state();
     let entered = state2.apply(AppEvent::EnterIssuesMode).committed_pure();
-    assert_eq!(entered.screen, ScreenId::Issues);
+    assert_eq!(entered.screen(), ScreenId::Issues);
     assert!(entered.issues_state.active);
     let exited = entered.apply(AppEvent::ExitIssuesMode).committed_pure();
-    assert_eq!(exited.screen, ScreenId::Dashboard);
+    assert_eq!(exited.screen(), ScreenId::Dashboard);
     assert!(!exited.issues_state.active);
 
     // PR mode does not interfere.

--- a/src/state/prs_ops.rs
+++ b/src/state/prs_ops.rs
@@ -37,6 +37,7 @@ impl AppState {
         // Finding 1: deactivate Issues mode if active so both list modes are
         // never simultaneously active (which would corrupt per-repo
         // preferences on a repo change).
+        let from_sibling_list_mode = self.issues_state.active;
         if self.issues_state.active {
             self.remember_issue_preferences();
             self.issues_state.active = false;
@@ -61,7 +62,13 @@ impl AppState {
         // active in a list-mode render.
         self.terminal_focused = false;
         self.pane_focus = PaneFocus::Agents;
-        self.screen = ScreenId::PullRequests;
+        // The cross-mode jump takes the place of the screen it came from, so
+        // Back still returns to whatever opened the first list mode.
+        let _ = if from_sibling_list_mode {
+            self.switch_screen(ScreenId::PullRequests)
+        } else {
+            self.enter_screen(ScreenId::PullRequests)
+        };
         self.prs_state.active = true;
         self.prs_state.pr_focus = PrFocus::PrList;
         self.prs_state.list.clear();
@@ -112,7 +119,7 @@ impl AppState {
     /// @requirement REQ-PR-005
     /// @pseudocode component-001 lines 77-87
     fn exit_prs_mode(&mut self) {
-        self.screen = ScreenId::Dashboard;
+        let _ = self.leave_screen();
         self.prs_state.active = false;
         if self.prs_state.inline_state != InlineState::None {
             self.prs_state.draft_notice = Some("Unsent draft discarded".to_string());

--- a/src/state/prs_ops.rs
+++ b/src/state/prs_ops.rs
@@ -67,7 +67,7 @@ impl AppState {
         let _ = if from_sibling_list_mode {
             self.switch_screen(ScreenId::PullRequests)
         } else {
-            self.enter_screen(ScreenId::PullRequests)
+            self.show_screen(ScreenId::PullRequests)
         };
         self.prs_state.active = true;
         self.prs_state.pr_focus = PrFocus::PrList;

--- a/src/state/prs_test_fixtures.rs
+++ b/src/state/prs_test_fixtures.rs
@@ -99,7 +99,7 @@ fn test_pull_request_detail(repo_id: &str, pr_number: u64) -> PullRequestDetail 
 /// @pseudocode component-001 lines 44-50
 pub fn prs_state_with_detail(repo_id: &str, pr_number: u64) -> AppState {
     let mut state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         ..AppState::default()
     };
     state.repositories.push(test_repository(repo_id));

--- a/src/state/prs_tests.rs
+++ b/src/state/prs_tests.rs
@@ -70,7 +70,7 @@ fn test_enter_prs_mode_sets_active_and_saves_prior_focus() {
     };
     let new_state = state.apply(AppEvent::EnterPrsMode).committed_pure();
 
-    assert_eq!(new_state.screen, ScreenId::PullRequests);
+    assert_eq!(new_state.screen(), ScreenId::PullRequests);
     assert!(new_state.prs_state.active);
     assert_eq!(new_state.prs_state.pr_focus, PrFocus::PrList);
 
@@ -145,7 +145,7 @@ fn test_clear_committed_filter_resets_state_to_open() {
 #[test]
 fn test_exit_prs_mode_restores_prior_focus_with_bounds_fallback() {
     let mut state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         ..dashboard_state()
     };
     state.prs_state.active = true;
@@ -158,7 +158,7 @@ fn test_exit_prs_mode_restores_prior_focus_with_bounds_fallback() {
 
     let new_state = state.apply(AppEvent::ExitPrsMode).committed_pure();
 
-    assert_eq!(new_state.screen, ScreenId::Dashboard);
+    assert_eq!(new_state.screen(), ScreenId::Dashboard);
     assert!(!new_state.prs_state.active);
     // Fallback: must be Agents pane, index clamped to a valid value or None.
     assert_eq!(new_state.pane_focus, PaneFocus::Agents);
@@ -233,7 +233,7 @@ fn test_app_state_default_has_inactive_prs_state() {
 #[test]
 fn test_empty_pr_list_shows_empty_state_not_panic() {
     let mut state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         ..dashboard_state()
     };
     state.prs_state.active = true;

--- a/src/state/prs_tests_components.rs
+++ b/src/state/prs_tests_components.rs
@@ -18,7 +18,7 @@ use crate::state::types::{ReadOnlyHintKind, ScreenId};
 /// Helper: PR-mode state with a selected PR.
 fn prs_mode_state_with_selected_pr(repo_id: &str, pr_number: u64) -> AppState {
     let mut state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         ..AppState::default()
     };
     state.repositories.push(Repository::new(

--- a/src/state/prs_tests_detail.rs
+++ b/src/state/prs_tests_detail.rs
@@ -16,7 +16,7 @@ use crate::state::types::{PrDetailSubfocus, ScreenId};
 /// Helper: PR-mode state with one repository selected at index 0.
 pub(super) fn prs_mode_state(repo_id: &str) -> AppState {
     let mut state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         ..AppState::default()
     };
     state.repositories.push(Repository::new(

--- a/src/state/prs_tests_detail_flow.rs
+++ b/src/state/prs_tests_detail_flow.rs
@@ -20,7 +20,7 @@ use crate::state::transition::TransitionExt;
 /// Helper: PR-mode state with a selected repo.
 fn prs_mode_state(repo_id: &str) -> AppState {
     let mut state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         ..AppState::default()
     };
     state.repositories.push(Repository::new(

--- a/src/state/prs_tests_filter.rs
+++ b/src/state/prs_tests_filter.rs
@@ -13,7 +13,7 @@ use crate::state::types::ScreenId;
 /// Helper: PR-mode state with filter controls open and a selected repo.
 fn prs_filter_open_state() -> AppState {
     let mut state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         ..AppState::default()
     };
     state.repositories.push(Repository::new(

--- a/src/state/prs_tests_repo_nav.rs
+++ b/src/state/prs_tests_repo_nav.rs
@@ -14,7 +14,7 @@ use crate::state::types::{PaneFocus, PrDetailSubfocus, PrFocus, ScreenId};
 /// Helper: PR-mode state with multiple repositories.
 fn prs_mode_state() -> AppState {
     let mut state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         ..AppState::default()
     };
     for slug in ["repo-1", "repo-2", "repo-3"] {

--- a/src/state/prs_tests_silent_refresh.rs
+++ b/src/state/prs_tests_silent_refresh.rs
@@ -27,7 +27,7 @@ use crate::state::transition::TransitionExt;
 /// Build a PR-mode AppState with the given repo scope.
 fn prs_mode_state(repo_id: &str) -> AppState {
     let mut state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         ..AppState::default()
     };
     state.repositories.push(Repository::new(

--- a/src/state/shell_overlay_ops.rs
+++ b/src/state/shell_overlay_ops.rs
@@ -76,7 +76,7 @@ impl AppState {
         self.dashboard_grab = None;
         let previous_pane_focus = self.shell_overlay.previous_pane_focus.take();
         if self.shell_return_target == crate::state::ShellReturnTarget::TerminalManager {
-            self.screen = crate::state::ScreenId::Terminals;
+            let _ = self.enter_screen(crate::state::ScreenId::Terminals);
             self.terminal_manager.active = true;
             self.pane_focus = crate::state::PaneFocus::Agents;
         } else {
@@ -228,7 +228,7 @@ mod tests {
 
         state.hide_shell_overlay();
 
-        assert_eq!(state.screen, crate::state::ScreenId::Terminals);
+        assert_eq!(state.screen(), crate::state::ScreenId::Terminals);
         assert!(state.terminal_manager.active);
         assert_eq!(state.shell_overlay.previous_pane_focus, None);
         assert_eq!(
@@ -302,14 +302,14 @@ mod tests {
     #[test]
     fn manager_shell_hide_returns_to_manager_and_clears_return_target() {
         let mut state = AppState::default();
-        state.screen = crate::state::ScreenId::Terminals;
+        let _ = state.enter_screen(crate::state::ScreenId::Terminals);
         state.terminal_manager.active = true;
         state.shell_return_target = crate::state::ShellReturnTarget::TerminalManager;
         state.resume_shell_overlay(AgentId("agent-1".into()));
 
         state.hide_shell_overlay();
 
-        assert_eq!(state.screen, crate::state::ScreenId::Terminals);
+        assert_eq!(state.screen(), crate::state::ScreenId::Terminals);
         assert!(state.terminal_manager.active);
         assert!(!state.shell_overlay_active());
         assert_eq!(

--- a/src/state/shell_overlay_ops.rs
+++ b/src/state/shell_overlay_ops.rs
@@ -307,15 +307,42 @@ mod tests {
         state.shell_return_target = crate::state::ShellReturnTarget::TerminalManager;
         state.resume_shell_overlay(AgentId("agent-1".into()));
 
+        let depth_before = state.nav.depth();
+
         state.hide_shell_overlay();
 
         assert_eq!(state.screen(), crate::state::ScreenId::Terminals);
+        assert_eq!(
+            state.nav.depth(),
+            depth_before,
+            "returning to the manager the user is already on must not stack a \
+             second instance of it"
+        );
         assert!(state.terminal_manager.active);
         assert!(!state.shell_overlay_active());
         assert_eq!(
             state.shell_return_target,
             crate::state::ShellReturnTarget::Dashboard
         );
+    }
+
+    #[test]
+    fn repeatedly_entering_and_hiding_a_manager_shell_does_not_grow_the_stack() {
+        // `state.screen()` stays Terminals either way, so only the depth shows
+        // whether the session is stacking copies of the screen it is on.
+        let mut state = AppState::default();
+        let _ = state.enter_screen(crate::state::ScreenId::Terminals);
+        state.terminal_manager.active = true;
+        let depth = state.nav.depth();
+
+        for _ in 0..5 {
+            state.shell_return_target = crate::state::ShellReturnTarget::TerminalManager;
+            state.resume_shell_overlay(AgentId("agent-1".into()));
+            state.hide_shell_overlay();
+        }
+
+        assert_eq!(state.nav.depth(), depth);
+        assert_eq!(state.screen(), crate::state::ScreenId::Terminals);
     }
 
     #[test]

--- a/src/state/shell_overlay_ops.rs
+++ b/src/state/shell_overlay_ops.rs
@@ -76,7 +76,7 @@ impl AppState {
         self.dashboard_grab = None;
         let previous_pane_focus = self.shell_overlay.previous_pane_focus.take();
         if self.shell_return_target == crate::state::ShellReturnTarget::TerminalManager {
-            let _ = self.enter_screen(crate::state::ScreenId::Terminals);
+            let _ = self.show_screen(crate::state::ScreenId::Terminals);
             self.terminal_manager.active = true;
             self.pane_focus = crate::state::PaneFocus::Agents;
         } else {

--- a/src/state/terminal_manager_ops.rs
+++ b/src/state/terminal_manager_ops.rs
@@ -64,7 +64,7 @@ impl AppState {
             selected_repository_index: self.selected_repository_index,
             selected_agent_index: self.selected_agent_index,
         });
-        let _ = self.enter_screen(ScreenId::Terminals);
+        let _ = self.show_screen(ScreenId::Terminals);
         self.terminal_manager.active = true;
         self.terminal_manager.bump_generation();
         let rows = project_managed_shell_rows(self);
@@ -166,12 +166,12 @@ impl AppState {
         match pending.origin {
             ShellFocusOrigin::DashboardF10 => {
                 self.terminal_manager.active = false;
-                let _ = self.leave_screen();
+                let _ = self.show_screen(ScreenId::Dashboard);
                 self.shell_return_target = ShellReturnTarget::Dashboard;
             }
             ShellFocusOrigin::ManagerEnter => {
                 self.terminal_manager.active = true;
-                let _ = self.enter_screen(ScreenId::Terminals);
+                let _ = self.show_screen(ScreenId::Terminals);
                 self.shell_return_target = ShellReturnTarget::TerminalManager;
             }
         }

--- a/src/state/terminal_manager_ops.rs
+++ b/src/state/terminal_manager_ops.rs
@@ -64,7 +64,7 @@ impl AppState {
             selected_repository_index: self.selected_repository_index,
             selected_agent_index: self.selected_agent_index,
         });
-        self.screen = ScreenId::Terminals;
+        let _ = self.enter_screen(ScreenId::Terminals);
         self.terminal_manager.active = true;
         self.terminal_manager.bump_generation();
         let rows = project_managed_shell_rows(self);
@@ -76,7 +76,7 @@ impl AppState {
 
     /// Exit terminal-manager mode, restoring prior focus state.
     fn exit_terminal_manager_mode(&mut self) {
-        self.screen = ScreenId::Dashboard;
+        let _ = self.leave_screen();
         self.terminal_manager.active = false;
         self.terminal_manager.clear_pending_focus();
         self.terminal_manager.preview = super::ShellPreview::default();
@@ -166,12 +166,12 @@ impl AppState {
         match pending.origin {
             ShellFocusOrigin::DashboardF10 => {
                 self.terminal_manager.active = false;
-                self.screen = ScreenId::Dashboard;
+                let _ = self.leave_screen();
                 self.shell_return_target = ShellReturnTarget::Dashboard;
             }
             ShellFocusOrigin::ManagerEnter => {
                 self.terminal_manager.active = true;
-                self.screen = ScreenId::Terminals;
+                let _ = self.enter_screen(ScreenId::Terminals);
                 self.shell_return_target = ShellReturnTarget::TerminalManager;
             }
         }
@@ -420,7 +420,7 @@ mod tests {
             AgentId("agent-1".into()),
         ));
         assert!(ok);
-        assert_eq!(state.screen, ScreenId::Terminals);
+        assert_eq!(state.screen(), ScreenId::Terminals);
         assert!(state.terminal_manager.active);
         assert!(state.shell_overlay_active());
         assert!(state.terminal_focused);

--- a/src/state/transition.rs
+++ b/src/state/transition.rs
@@ -263,6 +263,37 @@ impl EffectLedger {
         Ok(correlation)
     }
 
+    /// Adopt the generations of the screen instance the session is now on, and
+    /// drop the pending work that no longer belongs to it.
+    ///
+    /// Navigation decides which work is still wanted (issue #386). Advancing
+    /// the counters alone would not be enough: a pending record carries the
+    /// correlation it was registered with, so its own completion would still
+    /// match it exactly and be applied to whatever screen took its place.
+    /// Dropping the records is what makes a disposed instance's work
+    /// unanswerable.
+    ///
+    /// Returns how many pending records were dropped.
+    pub fn adopt_live_generations(
+        &mut self,
+        screen_generation: u64,
+        activation_generation: u64,
+    ) -> usize {
+        self.screen_generation = screen_generation;
+        self.activation_generation = activation_generation;
+        let before = self.records.len();
+        self.records.retain(|record| {
+            record.correlation.screen_generation == screen_generation
+                && record.correlation.activation_generation == activation_generation
+        });
+        // A staged effect for a record that is gone must not execute either.
+        self.staged.retain(|issued| {
+            issued.correlation.screen_generation == screen_generation
+                && issued.correlation.activation_generation == activation_generation
+        });
+        before.saturating_sub(self.records.len())
+    }
+
     /// Apply a completion identity: remove and report the exact pending match,
     /// or report stale without changing anything.
     pub fn complete(&mut self, correlation: &Correlation) -> CompletionOutcome {

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -392,7 +392,15 @@ pub struct AppState {
     pub last_selected_agent_by_repo: Vec<(RepositoryId, AgentId)>,
 
     // View state
-    pub screen: ScreenId,
+    /// Where the session is, and where it has been.
+    ///
+    /// The sole runtime authority for screen identity (issue #386). Nothing
+    /// assigns a screen directly any more: every screen change goes through
+    /// `crate::state::navigation::reduce_navigation`, so the stack, the
+    /// generations that decide which answers are still wanted, and the dirty
+    /// guard cannot disagree with what is on screen. Runtime-only — the
+    /// durable document remembers a screen, never a stack.
+    pub nav: super::navigation::NavState,
     pub pane_focus: PaneFocus,
     pub terminal_focused: bool,
     pub hide_idle_repositories: bool,

--- a/src/ui/components/pr_render_tests.rs
+++ b/src/ui/components/pr_render_tests.rs
@@ -36,7 +36,7 @@ use crate::ui::components::pr_list::{pr_list_status_message, pr_list_visible_row
 /// @pseudocode component-001 lines 1-12
 fn prs_mode_state(repo_id: &str) -> AppState {
     let mut state = AppState {
-        screen: ScreenId::PullRequests,
+        nav: crate::state::navigation::NavState::rooted(ScreenId::PullRequests),
         ..AppState::default()
     };
     state.repositories.push(Repository::new(

--- a/src/ui/orchestration.rs
+++ b/src/ui/orchestration.rs
@@ -244,7 +244,7 @@ pub fn build_screen_element(
     theme_name: &str,
     terminal: TerminalRenderData,
 ) -> AnyElement<'static> {
-    match snapshot.screen {
+    match snapshot.screen() {
         ScreenId::Dashboard => element! {
             Dashboard(
                 state: Some(snapshot.clone()),

--- a/src/ui/screens/actions.rs
+++ b/src/ui/screens/actions.rs
@@ -239,7 +239,7 @@ pub fn ActionsScreen(props: &ActionsScreenProps) -> impl Into<AnyElement<'static
 
             // ── Keybind bar ─────────────────────────────────────────────────
             KeybindBar(
-                screen: state.map_or(ScreenId::Actions, |s| s.screen),
+                screen: state.map_or(ScreenId::Actions, crate::state::AppState::screen),
                 action_registry_snapshot: state.and_then(|state| state.action_registry_snapshot.clone()),
                 terminal_focused: false,
                 actions_focus: Some(actions_focus),

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -329,7 +329,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
 
             // Bottom keybind bar
             KeybindBar(
-                screen: state.map_or(ScreenId::Dashboard, |s| s.screen),
+                screen: state.map_or(ScreenId::Dashboard, crate::state::AppState::screen),
                 action_registry_snapshot: state.and_then(|state| state.action_registry_snapshot.clone()),
                 terminal_focused: terminal_focused,
                 shell_overlay_active: shell_overlay_active,

--- a/src/ui/screens/errors.rs
+++ b/src/ui/screens/errors.rs
@@ -249,7 +249,7 @@ pub fn ErrorsScreen(props: &ErrorsScreenProps) -> impl Into<AnyElement<'static>>
 
             // ── Keybind bar ─────────────────────────────────────────────────
             KeybindBar(
-                screen: state.map_or(ScreenId::Errors, |s| s.screen),
+                screen: state.map_or(ScreenId::Errors, crate::state::AppState::screen),
                 action_registry_snapshot: state.and_then(|state| state.action_registry_snapshot.clone()),
                 terminal_focused: false,
                 actions_focus: None,

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -447,7 +447,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
 
             // ── Keybind bar ─────────────────────────────────────────────────
             KeybindBar(
-                screen: state.map_or(ScreenId::Issues, |s| s.screen),
+                screen: state.map_or(ScreenId::Issues, crate::state::AppState::screen),
                 action_registry_snapshot: state.and_then(|state| state.action_registry_snapshot.clone()),
                 terminal_focused: false,
                 actions_focus: None,

--- a/src/ui/screens/pull_requests.rs
+++ b/src/ui/screens/pull_requests.rs
@@ -472,7 +472,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                 vec![element! {
                     Box(height: 1u32, width: 100pct) {
                         KeybindBar(
-                            screen: state.map_or(ScreenId::PullRequests, |s| s.screen),
+                            screen: state.map_or(ScreenId::PullRequests, crate::state::AppState::screen),
                 action_registry_snapshot: state.and_then(|state| state.action_registry_snapshot.clone()),
                             terminal_focused: state.is_some_and(|s| s.terminal_focused),
                             actions_focus: None,

--- a/src/ui/screens/terminal_manager.rs
+++ b/src/ui/screens/terminal_manager.rs
@@ -252,7 +252,7 @@ pub fn TerminalManagerScreen(props: &TerminalManagerScreenProps) -> impl Into<An
 
             // ── Keybind bar ─────────────────────────────────────────────────
             KeybindBar(
-                screen: state.map_or(ScreenId::Terminals, |s| s.screen),
+                screen: state.map_or(ScreenId::Terminals, crate::state::AppState::screen),
                 action_registry_snapshot: state.and_then(|state| state.action_registry_snapshot.clone()),
                 terminal_focused: live_shell_active,
                 actions_focus: None,

--- a/src/workbench/mod.rs
+++ b/src/workbench/mod.rs
@@ -29,6 +29,7 @@ pub mod panel_types;
 pub mod relationship_propagation;
 pub mod relationships;
 pub mod resolve;
+pub mod route;
 pub mod screen_file;
 pub mod screen_file_bounds;
 pub mod screen_file_shape;
@@ -106,6 +107,10 @@ mod allocate_tests;
 #[cfg(test)]
 #[path = "resolve_tests.rs"]
 mod resolve_tests;
+
+#[cfg(test)]
+#[path = "route_tests.rs"]
+mod route_tests;
 
 use std::sync::OnceLock;
 
@@ -205,6 +210,10 @@ pub use relationships::{
 pub use resolve::{
     PanelState, ResolvedLayout, ResolvedPanel, TooSmall, pty_content_rect, repair_focus,
     resolve_layout,
+};
+pub use route::{
+    ActivationError, ActivationValue, ActivationValues, MAX_ACTIVATION_BYTES, NavCode,
+    RouteDeclaration, route_declaration,
 };
 pub use screen_file::{ScreenFile, parse_screen_file};
 pub use screen_file_bounds::{ScreenSyntaxError, ScreenSyntaxReason};

--- a/src/workbench/mod.rs
+++ b/src/workbench/mod.rs
@@ -219,7 +219,9 @@ pub use screen_file::{ScreenFile, parse_screen_file};
 pub use screen_file_bounds::{ScreenSyntaxError, ScreenSyntaxReason};
 pub use screen_lowering::{LoweredScreen, ScreenProvenance, lower_screen};
 pub use screens::{
-    PTY_PANEL_TYPE, REPOSITORIES_PANEL, RegistryError, SELECTION_PORT, SUBJECT_PORT,
-    ScreenRegistry, builtin_screens, master_detail_edge,
+    ACTIONS_LIST_PANEL, ERRORS_LIST_PANEL, ISSUES_LIST_PANEL, PTY_PANEL_TYPE,
+    PULL_REQUESTS_LIST_PANEL, REPOSITORIES_PANEL, RegistryError, SELECTION_PORT, SUBJECT_PORT,
+    ScreenRegistry, TERMINALS_LIST_PANEL, builtin_screens, initial_focus, master_detail_edge,
+    route_of,
 };
 pub use validate::{DescriptorError, validate_descriptor};

--- a/src/workbench/route.rs
+++ b/src/workbench/route.rs
@@ -1,0 +1,391 @@
+//! Typed navigation routes and the activations that reach them (issue #386).
+//!
+//! A route is how something asks to navigate to a screen, and an activation is
+//! the argument list it supplies. Both are closed: a route exists only because
+//! a screen descriptor declares it, and an activation may only carry the field
+//! kinds [`ActivationKind`] already publishes. Nothing here mutates navigation
+//! state — this module answers "is this a real route, and is this a legal
+//! argument list for it?", so the reducer can refuse before it touches
+//! anything.
+//!
+//! Three properties follow from keeping the answer here rather than in the
+//! reducer:
+//!
+//! - validation is total and value-free, so a refusal can be rendered without
+//!   quoting whatever the caller passed;
+//! - there is no secret kind, and no generic payload, so an activation cannot
+//!   carry credential material into navigation state or into a diagnostic;
+//! - the bounds (field count, serialized size, identifier length) are enforced
+//!   at construction, so an over-large activation never reaches the reducer.
+//!
+//! This module is I/O-free and depends only on the descriptor vocabulary.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::PathBuf;
+
+use crate::domain::Id;
+
+use super::activation::{ActivationField, ActivationKind};
+use super::ids::{MAX_ACTIVATION_FIELDS, RouteId, ScreenIdentity};
+use super::screens::ScreenRegistry;
+
+/// Maximum serialized byte size of one activation's values.
+pub const MAX_ACTIVATION_BYTES: usize = 262_144;
+
+/// Closed navigation diagnostic code set.
+///
+/// Navigation has one code because every navigation refusal has the same
+/// operator response: the current screen was retained and the request was not
+/// performed. What differs is the detail, which [`ActivationError`] supplies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NavCode {
+    /// A navigation request was refused and the current instance was retained.
+    E001,
+}
+
+impl NavCode {
+    /// The stable operator-facing code.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::E001 => "NAV-E001",
+        }
+    }
+}
+
+impl fmt::Display for NavCode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// One value carried by an activation field.
+///
+/// The variants mirror [`ActivationKind`] exactly, and deliberately stop there:
+/// there is no secret variant and no nested map, so an activation is always a
+/// flat list of values a screen definition could legitimately have declared.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActivationValue {
+    /// A boolean that must be present.
+    Boolean(bool),
+    /// A boolean that may be absent.
+    OptionalBoolean(Option<bool>),
+    /// Free text.
+    Text(String),
+    /// A signed integer.
+    Integer(i64),
+    /// One member of the field's declared permitted set.
+    Enumerated(String),
+    /// A filesystem path.
+    Path(PathBuf),
+    /// A list of strings.
+    TextList(Vec<String>),
+}
+
+impl ActivationValue {
+    /// The stable text naming this value's kind, matching
+    /// [`ActivationKind::as_str`].
+    #[must_use]
+    pub const fn kind_name(&self) -> &'static str {
+        match self {
+            Self::Boolean(_) => "boolean",
+            Self::OptionalBoolean(_) => "optional-boolean",
+            Self::Text(_) => "string",
+            Self::Integer(_) => "integer",
+            Self::Enumerated(_) => "enum",
+            Self::Path(_) => "path",
+            Self::TextList(_) => "string-list",
+        }
+    }
+
+    /// Whether this value satisfies `kind`, ignoring the permitted set.
+    ///
+    /// Enumerated membership is checked separately so a value of the right
+    /// kind but the wrong member reports why it was refused rather than
+    /// claiming a type mismatch.
+    #[must_use]
+    fn has_kind(&self, kind: &ActivationKind) -> bool {
+        matches!(
+            (self, kind),
+            (Self::Boolean(_), ActivationKind::Boolean)
+                | (Self::OptionalBoolean(_), ActivationKind::OptionalBoolean)
+                | (Self::Text(_), ActivationKind::Text)
+                | (Self::Integer(_), ActivationKind::Integer)
+                | (Self::Enumerated(_), ActivationKind::Enumerated { .. })
+                | (Self::Path(_), ActivationKind::Path)
+                | (Self::TextList(_), ActivationKind::TextList)
+        )
+    }
+
+    /// Deterministic serialized byte cost of this value.
+    ///
+    /// The bound exists to keep an activation small enough to carry, compare,
+    /// and log, so the cost is the payload bytes plus a fixed per-value
+    /// overhead rather than the exact width of any particular encoding.
+    #[must_use]
+    fn serialized_len(&self) -> usize {
+        const SCALAR_COST: usize = 8;
+        match self {
+            Self::Boolean(_) | Self::OptionalBoolean(_) | Self::Integer(_) => SCALAR_COST,
+            Self::Text(value) | Self::Enumerated(value) => value.len(),
+            Self::Path(value) => value.as_os_str().len(),
+            Self::TextList(values) => values
+                .iter()
+                .map(|value| value.len().saturating_add(1))
+                .sum(),
+        }
+    }
+}
+
+/// The bounded, deterministically ordered values one activation carries.
+///
+/// Keyed by field name, so a caller cannot supply two values for one declared
+/// field. Both bounds are enforced here rather than at validation time,
+/// because an over-large activation must be impossible to hold at all — not
+/// merely impossible to navigate with.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ActivationValues(BTreeMap<Id, ActivationValue>);
+
+impl ActivationValues {
+    /// Build bounded activation values.
+    ///
+    /// Later entries for the same field name replace earlier ones.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ActivationError::TooManyFields`] beyond
+    /// [`MAX_ACTIVATION_FIELDS`] distinct fields, or
+    /// [`ActivationError::TooLarge`] beyond [`MAX_ACTIVATION_BYTES`] serialized
+    /// bytes.
+    pub fn new(
+        entries: impl IntoIterator<Item = (Id, ActivationValue)>,
+    ) -> Result<Self, ActivationError> {
+        let values: BTreeMap<Id, ActivationValue> = entries.into_iter().collect();
+        if values.len() > MAX_ACTIVATION_FIELDS {
+            return Err(ActivationError::TooManyFields {
+                count: values.len(),
+            });
+        }
+        let bytes = values.iter().fold(0usize, |total, (name, value)| {
+            total
+                .saturating_add(name.as_str().len())
+                .saturating_add(value.serialized_len())
+        });
+        if bytes > MAX_ACTIVATION_BYTES {
+            return Err(ActivationError::TooLarge { bytes });
+        }
+        Ok(Self(values))
+    }
+
+    /// The activation that carries nothing, which every compiled screen accepts.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    /// The value supplied for `field`, if one was.
+    #[must_use]
+    pub fn get(&self, field: &Id) -> Option<&ActivationValue> {
+        self.0.get(field)
+    }
+
+    /// How many fields carry a value.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether no field carries a value.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Iterate the supplied fields in field-name order.
+    pub fn iter(&self) -> impl Iterator<Item = (&Id, &ActivationValue)> {
+        self.0.iter()
+    }
+}
+
+/// What a screen's route accepts, and which screen it reaches.
+///
+/// Built from a descriptor rather than declared separately, so a screen and the
+/// route that reaches it cannot drift apart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteDeclaration {
+    /// The route identifier callers name.
+    pub id: RouteId,
+    /// The fields this route accepts, in declaration order.
+    pub activation_schema: Vec<ActivationField>,
+    /// The screen this route reaches.
+    pub target_screen: ScreenIdentity,
+}
+
+impl RouteDeclaration {
+    /// Check `values` against this route's declared schema.
+    ///
+    /// Declared fields are checked in declaration order, then any supplied
+    /// field the schema does not declare is refused. Nothing is mutated and
+    /// nothing is coerced: a value either satisfies its declared kind or the
+    /// whole activation is refused.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first categorized reason the activation does not satisfy the
+    /// schema.
+    pub fn validate(&self, values: &ActivationValues) -> Result<(), ActivationError> {
+        for declared in &self.activation_schema {
+            let Some(value) = values.get(&declared.name) else {
+                return Err(ActivationError::MissingField {
+                    field: declared.name.clone(),
+                });
+            };
+            if !value.has_kind(&declared.kind) {
+                return Err(ActivationError::WrongKind {
+                    field: declared.name.clone(),
+                    expected: declared.kind.as_str(),
+                    actual: value.kind_name(),
+                });
+            }
+            if let (ActivationKind::Enumerated { permitted }, ActivationValue::Enumerated(supplied)) =
+                (&declared.kind, value)
+                && !permitted.iter().any(|member| member == supplied)
+            {
+                return Err(ActivationError::NotPermitted {
+                    field: declared.name.clone(),
+                });
+            }
+        }
+        for (name, _) in values.iter() {
+            if !self
+                .activation_schema
+                .iter()
+                .any(|declared| &declared.name == name)
+            {
+                return Err(ActivationError::UnknownField {
+                    field: name.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Resolve the declaration for `route` from `registry`.
+///
+/// A route exists only because a descriptor declares it, so this is the only
+/// way to obtain a [`RouteDeclaration`] for a route named at runtime.
+///
+/// # Errors
+///
+/// Returns [`ActivationError::UnknownRoute`] when no descriptor declares
+/// `route`.
+pub fn route_declaration(
+    registry: &ScreenRegistry,
+    route: RouteId,
+) -> Result<RouteDeclaration, ActivationError> {
+    registry
+        .screens()
+        .iter()
+        .find(|descriptor| descriptor.route == route)
+        .map(|descriptor| RouteDeclaration {
+            id: descriptor.route,
+            activation_schema: descriptor.activation.clone(),
+            target_screen: descriptor.id,
+        })
+        .ok_or(ActivationError::UnknownRoute { route })
+}
+
+/// Categorized reason a navigation request was refused.
+///
+/// Every variant names identifiers the program itself declared — a route, a
+/// field, a kind, or a bound. None of them carries a value the caller supplied,
+/// so a refusal is safe to render anywhere.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActivationError {
+    /// No descriptor declares the named route.
+    UnknownRoute {
+        /// The route that resolved to nothing.
+        route: RouteId,
+    },
+    /// A value was supplied for a field the route does not declare.
+    UnknownField {
+        /// The undeclared field.
+        field: Id,
+    },
+    /// No value was supplied for a field the route declares.
+    MissingField {
+        /// The field with no value.
+        field: Id,
+    },
+    /// A value did not satisfy its declared kind.
+    WrongKind {
+        /// The field whose value was refused.
+        field: Id,
+        /// The kind the route declared.
+        expected: &'static str,
+        /// The kind the value carried.
+        actual: &'static str,
+    },
+    /// An enumerated value is not in its field's permitted set.
+    NotPermitted {
+        /// The field whose value is not a permitted member.
+        field: Id,
+    },
+    /// More than [`MAX_ACTIVATION_FIELDS`] distinct fields were supplied.
+    TooManyFields {
+        /// The number of distinct fields supplied.
+        count: usize,
+    },
+    /// The serialized activation exceeds [`MAX_ACTIVATION_BYTES`].
+    TooLarge {
+        /// The serialized size that was refused.
+        bytes: usize,
+    },
+}
+
+impl ActivationError {
+    /// The coded diagnostic this refusal reports.
+    #[must_use]
+    pub const fn code(&self) -> NavCode {
+        NavCode::E001
+    }
+}
+
+impl fmt::Display for ActivationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: ", self.code())?;
+        match self {
+            Self::UnknownRoute { route } => write!(formatter, "no screen declares route '{route}'"),
+            Self::UnknownField { field } => {
+                write!(formatter, "the route does not declare field '{field}'")
+            }
+            Self::MissingField { field } => {
+                write!(formatter, "the route requires field '{field}'")
+            }
+            Self::WrongKind {
+                field,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "field '{field}' is declared {expected} but a {actual} was supplied"
+            ),
+            Self::NotPermitted { field } => write!(
+                formatter,
+                "field '{field}' was given a value outside its permitted set"
+            ),
+            Self::TooManyFields { count } => write!(
+                formatter,
+                "an activation carries at most {MAX_ACTIVATION_FIELDS} fields; {count} were supplied"
+            ),
+            Self::TooLarge { bytes } => write!(
+                formatter,
+                "an activation serializes to at most {MAX_ACTIVATION_BYTES} bytes; {bytes} were supplied"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ActivationError {}

--- a/src/workbench/route.rs
+++ b/src/workbench/route.rs
@@ -130,10 +130,12 @@ impl ActivationValue {
             Self::Boolean(_) | Self::OptionalBoolean(_) | Self::Integer(_) => SCALAR_COST,
             Self::Text(value) | Self::Enumerated(value) => value.len(),
             Self::Path(value) => value.as_os_str().len(),
-            Self::TextList(values) => values
-                .iter()
-                .map(|value| value.len().saturating_add(1))
-                .sum(),
+            // Saturating rather than `sum`, which panics on overflow in debug
+            // builds: this measures a value that is about to be refused for
+            // being too large, so it must not fail while measuring it.
+            Self::TextList(values) => values.iter().fold(0usize, |total, value| {
+                total.saturating_add(value.len()).saturating_add(1)
+            }),
         }
     }
 }

--- a/src/workbench/route_tests.rs
+++ b/src/workbench/route_tests.rs
@@ -1,0 +1,313 @@
+//! Route declaration and activation validation contracts (issue #386, CW-06).
+
+use std::path::PathBuf;
+
+use crate::domain::Id;
+
+use super::activation::{ActivationField, ActivationKind};
+use super::ids::{MAX_ACTIVATION_FIELDS, RouteId, ScreenId, ScreenIdentity};
+use super::route::{
+    ActivationError, ActivationValue, ActivationValues, MAX_ACTIVATION_BYTES, NavCode,
+    RouteDeclaration, route_declaration,
+};
+use super::{ScreenRegistry, screen_registry};
+
+fn id(name: &str) -> Id {
+    Id::parse(name).unwrap_or_else(|_| unreachable!("test field name is a valid identifier"))
+}
+
+fn field(name: &str, kind: ActivationKind) -> ActivationField {
+    ActivationField {
+        name: id(name),
+        kind,
+    }
+}
+
+fn review_route() -> RouteId {
+    RouteId::parse("review").unwrap_or_else(|_| unreachable!("test route id is valid"))
+}
+
+fn unknown_route() -> RouteId {
+    RouteId::parse("nonesuch").unwrap_or_else(|_| unreachable!("test route id is valid"))
+}
+
+fn registry() -> &'static ScreenRegistry {
+    screen_registry().unwrap_or_else(|_| unreachable!("the compiled registry must be well formed"))
+}
+
+fn declaration(schema: Vec<ActivationField>) -> RouteDeclaration {
+    RouteDeclaration {
+        id: review_route(),
+        activation_schema: schema,
+        target_screen: ScreenIdentity::Compiled(ScreenId::PullRequests),
+    }
+}
+
+fn values(entries: Vec<(&str, ActivationValue)>) -> ActivationValues {
+    let entries: Vec<(Id, ActivationValue)> = entries
+        .into_iter()
+        .map(|(name, value)| (id(name), value))
+        .collect();
+    ActivationValues::new(entries)
+        .unwrap_or_else(|_| unreachable!("test activation values are within their bounds"))
+}
+
+fn refusal(result: Result<(), ActivationError>) -> ActivationError {
+    match result {
+        Ok(()) => panic!("the activation must be refused"),
+        Err(error) => error,
+    }
+}
+
+#[test]
+fn every_compiled_screen_is_reachable_through_its_declared_route() {
+    let registry = registry();
+    for screen in ScreenId::ALL {
+        let Some(descriptor) = registry.get(screen) else {
+            panic!("every compiled screen has a descriptor");
+        };
+        let Ok(resolved) = route_declaration(registry, descriptor.route) else {
+            panic!("a compiled screen's own route must resolve");
+        };
+        assert_eq!(resolved.target_screen, ScreenIdentity::Compiled(screen));
+        assert_eq!(resolved.id, descriptor.route);
+        assert_eq!(resolved.activation_schema, descriptor.activation);
+    }
+}
+
+#[test]
+fn an_unknown_route_is_refused_without_a_declaration() {
+    match route_declaration(registry(), unknown_route()) {
+        Ok(_) => panic!("a route no descriptor declares must not resolve"),
+        Err(error) => assert!(matches!(error, ActivationError::UnknownRoute { .. })),
+    }
+}
+
+#[test]
+fn every_activation_failure_reports_the_navigation_code() {
+    let refusals = [
+        ActivationError::UnknownRoute {
+            route: unknown_route(),
+        },
+        ActivationError::UnknownField { field: id("extra") },
+        ActivationError::MissingField {
+            field: id("number"),
+        },
+        ActivationError::WrongKind {
+            field: id("number"),
+            expected: "integer",
+            actual: "string",
+        },
+        ActivationError::NotPermitted { field: id("tab") },
+        ActivationError::TooManyFields { count: 33 },
+        ActivationError::TooLarge { bytes: 262_145 },
+    ];
+    for refusal in refusals {
+        assert_eq!(refusal.code(), NavCode::E001);
+        let rendered = refusal.to_string();
+        assert!(
+            rendered.starts_with("NAV-E001: "),
+            "refusal must render its code: {rendered}"
+        );
+    }
+}
+
+#[test]
+fn a_compiled_screen_accepts_an_empty_activation() {
+    let registry = registry();
+    for screen in ScreenId::ALL {
+        let Some(descriptor) = registry.get(screen) else {
+            panic!("every compiled screen has a descriptor");
+        };
+        let Ok(declared) = route_declaration(registry, descriptor.route) else {
+            panic!("a compiled screen's own route must resolve");
+        };
+        assert_eq!(
+            declared.validate(&ActivationValues::empty()),
+            Ok(()),
+            "compiled screen {screen} declares no activation fields"
+        );
+    }
+}
+
+#[test]
+fn every_declared_kind_validates_against_a_matching_value() {
+    let declared = declaration(vec![
+        field("flag", ActivationKind::Boolean),
+        field("maybe", ActivationKind::OptionalBoolean),
+        field("title", ActivationKind::Text),
+        field("number", ActivationKind::Integer),
+        field(
+            "tab",
+            ActivationKind::Enumerated {
+                permitted: vec!["files".to_owned(), "conversation".to_owned()],
+            },
+        ),
+        field("work-dir", ActivationKind::Path),
+        field("labels", ActivationKind::TextList),
+    ]);
+    let supplied = values(vec![
+        ("flag", ActivationValue::Boolean(true)),
+        ("maybe", ActivationValue::OptionalBoolean(None)),
+        ("title", ActivationValue::Text("Pull Request 42".to_owned())),
+        ("number", ActivationValue::Integer(42)),
+        ("tab", ActivationValue::Enumerated("files".to_owned())),
+        (
+            "work-dir",
+            ActivationValue::Path(PathBuf::from("/tmp/work")),
+        ),
+        (
+            "labels",
+            ActivationValue::TextList(vec!["bug".to_owned(), "ui".to_owned()]),
+        ),
+    ]);
+    assert_eq!(declared.validate(&supplied), Ok(()));
+}
+
+#[test]
+fn an_undeclared_field_is_refused() {
+    let declared = declaration(vec![field("number", ActivationKind::Integer)]);
+    let supplied = values(vec![
+        ("number", ActivationValue::Integer(42)),
+        ("extra", ActivationValue::Boolean(true)),
+    ]);
+    assert_eq!(
+        declared.validate(&supplied),
+        Err(ActivationError::UnknownField { field: id("extra") })
+    );
+}
+
+#[test]
+fn a_missing_declared_field_is_refused() {
+    let declared = declaration(vec![
+        field("number", ActivationKind::Integer),
+        field("flag", ActivationKind::Boolean),
+    ]);
+    let supplied = values(vec![("number", ActivationValue::Integer(42))]);
+    assert_eq!(
+        declared.validate(&supplied),
+        Err(ActivationError::MissingField { field: id("flag") })
+    );
+}
+
+#[test]
+fn a_value_of_the_wrong_kind_is_refused() {
+    let declared = declaration(vec![field("number", ActivationKind::Integer)]);
+    let supplied = values(vec![(
+        "number",
+        ActivationValue::Text("forty-two".to_owned()),
+    )]);
+    assert_eq!(
+        declared.validate(&supplied),
+        Err(ActivationError::WrongKind {
+            field: id("number"),
+            expected: "integer",
+            actual: "string",
+        })
+    );
+}
+
+#[test]
+fn an_optional_boolean_declaration_does_not_accept_a_plain_boolean() {
+    // The two kinds are distinct in the schema, so a screen that declared an
+    // absent-capable field never silently receives one that cannot be absent.
+    let declared = declaration(vec![field("maybe", ActivationKind::OptionalBoolean)]);
+    let supplied = values(vec![("maybe", ActivationValue::Boolean(true))]);
+    assert!(matches!(
+        declared.validate(&supplied),
+        Err(ActivationError::WrongKind { .. })
+    ));
+}
+
+#[test]
+fn an_enumerated_value_outside_the_permitted_set_is_refused() {
+    let declared = declaration(vec![field(
+        "tab",
+        ActivationKind::Enumerated {
+            permitted: vec!["files".to_owned(), "conversation".to_owned()],
+        },
+    )]);
+    let supplied = values(vec![(
+        "tab",
+        ActivationValue::Enumerated("diff".to_owned()),
+    )]);
+    assert_eq!(
+        declared.validate(&supplied),
+        Err(ActivationError::NotPermitted { field: id("tab") })
+    );
+}
+
+#[test]
+fn more_fields_than_the_declared_bound_are_refused_before_validation() {
+    let entries: Vec<(Id, ActivationValue)> = (0..=MAX_ACTIVATION_FIELDS)
+        .map(|index| {
+            (
+                id(&format!("field-{index}")),
+                ActivationValue::Integer(i64::try_from(index).unwrap_or_default()),
+            )
+        })
+        .collect();
+    let count = entries.len();
+    assert_eq!(
+        ActivationValues::new(entries),
+        Err(ActivationError::TooManyFields { count })
+    );
+}
+
+#[test]
+fn exactly_the_declared_field_bound_is_accepted() {
+    let entries: Vec<(Id, ActivationValue)> = (0..MAX_ACTIVATION_FIELDS)
+        .map(|index| {
+            (
+                id(&format!("field-{index}")),
+                ActivationValue::Integer(i64::try_from(index).unwrap_or_default()),
+            )
+        })
+        .collect();
+    let Ok(built) = ActivationValues::new(entries) else {
+        panic!("32 fields is within the bound");
+    };
+    assert_eq!(built.len(), MAX_ACTIVATION_FIELDS);
+}
+
+#[test]
+fn an_activation_larger_than_the_serialized_bound_is_refused() {
+    let oversized = "x".repeat(MAX_ACTIVATION_BYTES + 1);
+    match ActivationValues::new(vec![(id("title"), ActivationValue::Text(oversized))]) {
+        Ok(_) => panic!("an oversized activation must be refused"),
+        Err(error) => assert!(matches!(error, ActivationError::TooLarge { .. })),
+    }
+}
+
+#[test]
+fn a_refusal_never_carries_the_offending_value() {
+    let declared = declaration(vec![field("title", ActivationKind::Integer)]);
+    let supplied = values(vec![(
+        "title",
+        ActivationValue::Text("s3cret-material".to_owned()),
+    )]);
+    let rendered = refusal(declared.validate(&supplied)).to_string();
+    assert!(
+        !rendered.contains("s3cret-material"),
+        "a diagnostic must not repeat an activation value: {rendered}"
+    );
+    assert!(rendered.contains("title"), "the field name is safe to name");
+}
+
+#[test]
+fn duplicate_field_names_collapse_to_one_entry() {
+    // The container is keyed by field name, so a caller cannot smuggle two
+    // values for one declared field past validation.
+    let Ok(built) = ActivationValues::new(vec![
+        (id("number"), ActivationValue::Integer(1)),
+        (id("number"), ActivationValue::Integer(2)),
+    ]) else {
+        panic!("duplicate keys are within the field bound");
+    };
+    assert_eq!(built.len(), 1);
+    assert_eq!(
+        built.get(&id("number")),
+        Some(&ActivationValue::Integer(2)),
+        "the last value for a field wins"
+    );
+}

--- a/src/workbench/screens.rs
+++ b/src/workbench/screens.rs
@@ -524,6 +524,54 @@ fn ported(
     panel
 }
 
+/// The route a screen is reached through.
+///
+/// Compiled as a total function for the same reason as [`initial_focus`]:
+/// rooting a session must not depend on a lookup that can fail.
+/// `route_agrees_with_every_descriptor` keeps it honest.
+#[must_use]
+pub const fn route_of(screen: ScreenId) -> RouteId {
+    RouteId::from_static(match screen {
+        ScreenId::Dashboard => "dashboard",
+        ScreenId::Repositories => "repositories",
+        ScreenId::Issues => "issues",
+        ScreenId::PullRequests => "pull-requests",
+        ScreenId::Actions => "actions",
+        ScreenId::Errors => "errors",
+        ScreenId::Terminals => "terminals",
+    })
+}
+
+/// The panel a screen focuses when an instance of it is first created.
+///
+/// Compiled as a total function rather than read back out of the registry, so
+/// creating a screen instance cannot fail on a registry lookup — there is no
+/// "what if the descriptor is missing" branch to get wrong at the moment the
+/// session moves. `initial_focus_agrees_with_every_descriptor` keeps this and
+/// the descriptors from drifting apart.
+#[must_use]
+pub const fn initial_focus(screen: ScreenId) -> PanelId {
+    PanelId::from_static(match screen {
+        ScreenId::Dashboard | ScreenId::Repositories => REPOSITORIES_PANEL,
+        ScreenId::Issues => ISSUES_LIST_PANEL,
+        ScreenId::PullRequests => PULL_REQUESTS_LIST_PANEL,
+        ScreenId::Actions => ACTIONS_LIST_PANEL,
+        ScreenId::Errors => ERRORS_LIST_PANEL,
+        ScreenId::Terminals => TERMINALS_LIST_PANEL,
+    })
+}
+
+/// Identity of the issues list panel.
+pub const ISSUES_LIST_PANEL: &str = "issue-list";
+/// Identity of the pull-requests list panel.
+pub const PULL_REQUESTS_LIST_PANEL: &str = "pr-list";
+/// Identity of the workflow-runs list panel.
+pub const ACTIONS_LIST_PANEL: &str = "action-list";
+/// Identity of the errors list panel.
+pub const ERRORS_LIST_PANEL: &str = "error-list";
+/// Identity of the terminal-manager list panel.
+pub const TERMINALS_LIST_PANEL: &str = "shell-list";
+
 /// A workspace screen: the repository sidebar beside the shared column.
 fn workspace_screen(spec: &WorkspaceSpec) -> Result<ScreenDescriptor, RegistryError> {
     Ok(ScreenDescriptor {
@@ -571,7 +619,7 @@ fn issues_screen() -> Result<ScreenDescriptor, RegistryError> {
         id: ScreenId::Issues,
         title: "Issues",
         route: "issues",
-        list: "issue-list",
+        list: ISSUES_LIST_PANEL,
         detail: "issue-detail",
         banner: "issue-list-banner",
         filter: "issue-list-filter",
@@ -586,7 +634,7 @@ fn pull_requests_screen() -> Result<ScreenDescriptor, RegistryError> {
         id: ScreenId::PullRequests,
         title: "Pull Requests",
         route: "pull-requests",
-        list: "pr-list",
+        list: PULL_REQUESTS_LIST_PANEL,
         detail: "pr-detail",
         banner: "pr-list-banner",
         filter: "pr-list-filter",
@@ -600,7 +648,7 @@ fn actions_screen() -> Result<ScreenDescriptor, RegistryError> {
         id: ScreenId::Actions,
         title: "Actions",
         route: "actions",
-        list: "action-list",
+        list: ACTIONS_LIST_PANEL,
         detail: "action-detail",
         banner: "action-list-banner",
         filter: "action-list-filter",
@@ -629,7 +677,7 @@ fn errors_screen() -> Result<ScreenDescriptor, RegistryError> {
                 DETAIL_PANE_CHROME,
             )?,
         ],
-        initial_focus: PanelId::parse("error-list")?,
+        initial_focus: PanelId::parse(ERRORS_LIST_PANEL)?,
         focus_order: focus_order(&[REPOSITORIES_PANEL, "error-list", "error-detail"])?,
         relationships: Vec::new(),
         activation: Vec::new(),
@@ -671,7 +719,7 @@ fn terminals_screen() -> Result<ScreenDescriptor, RegistryError> {
                 TERMINAL_CHROME,
             )?,
         ],
-        initial_focus: PanelId::parse("shell-list")?,
+        initial_focus: PanelId::parse(TERMINALS_LIST_PANEL)?,
         focus_order: focus_order(&[REPOSITORIES_PANEL, "shell-list", "shell-preview"])?,
         relationships: Vec::new(),
         activation: Vec::new(),

--- a/src/workbench/screens_tests.rs
+++ b/src/workbench/screens_tests.rs
@@ -371,6 +371,52 @@ fn no_flexible_child_reserves_a_minimum_it_does_not_need() {
     }
 }
 
+#[test]
+fn initial_focus_agrees_with_every_descriptor() {
+    // The compiled table lets a screen instance be created without a fallible
+    // registry lookup, which is only safe while the two agree exactly.
+    for screen in super::ids::ScreenId::ALL {
+        let compiled = registry();
+        let Some(descriptor) = compiled.get(screen) else {
+            panic!("every compiled screen has a descriptor");
+        };
+        assert_eq!(
+            super::screens::initial_focus(screen),
+            descriptor.initial_focus,
+            "the compiled initial focus for {screen} has drifted from its descriptor"
+        );
+    }
+}
+
+#[test]
+fn route_agrees_with_every_descriptor() {
+    for screen in super::ids::ScreenId::ALL {
+        let compiled = registry();
+        let Some(descriptor) = compiled.get(screen) else {
+            panic!("every compiled screen has a descriptor");
+        };
+        assert_eq!(
+            super::screens::route_of(screen),
+            descriptor.route,
+            "the compiled route for {screen} has drifted from its descriptor"
+        );
+        assert_eq!(super::screens::route_of(screen).check(), Ok(()));
+    }
+}
+
+#[test]
+fn every_compiled_initial_focus_satisfies_the_identifier_grammar() {
+    // `initial_focus` builds its panel ids with the unchecked const
+    // constructor, so the grammar is asserted here instead.
+    for screen in super::ids::ScreenId::ALL {
+        assert_eq!(
+            super::screens::initial_focus(screen).check(),
+            Ok(()),
+            "the compiled initial focus for {screen} is not a valid identifier"
+        );
+    }
+}
+
 fn assert_children(node: &LayoutNode, check: &mut impl FnMut(&LayoutChild)) {
     if let LayoutNode::Split { children, .. } = node {
         for child in children {

--- a/tests/core/dashboard_search_contracts.rs
+++ b/tests/core/dashboard_search_contracts.rs
@@ -59,7 +59,7 @@ fn dashboard_state() -> AppState {
         selected_repository_index: Some(0),
         selected_agent_index: Some(0),
         pane_focus: PaneFocus::Repositories,
-        screen: ScreenId::Dashboard,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Dashboard),
         ..AppState::default()
     };
     state.normalize_selection_indices();
@@ -120,7 +120,7 @@ fn repo_search_is_case_insensitive() {
     let state = AppState {
         repositories: vec![repository("r1", "Alpha"), repository("r2", "BETA")],
         selected_repository_index: Some(0),
-        screen: ScreenId::Dashboard,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Dashboard),
         ..AppState::default()
     };
 
@@ -195,7 +195,7 @@ fn search_composes_with_active_only() {
         agents: vec![running_agent("a1", "alpha-agent", "r1")],
         selected_repository_index: Some(0),
         pane_focus: PaneFocus::Repositories,
-        screen: ScreenId::Dashboard,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Dashboard),
         ..AppState::default()
     };
     state.normalize_selection_indices();
@@ -419,7 +419,7 @@ fn selection_normalizes_when_filtered() {
 fn dashboard_search_does_not_open_split_search_modal() {
     use jefe::state::ModalState;
     let mut state = dashboard_state();
-    state.screen = ScreenId::Repositories;
+    state.nav = jefe::state::navigation::NavState::rooted(ScreenId::Repositories);
     // FocusDashboardSearch must NOT open the split's ModalState::Search.
     let after = state.apply(AppEvent::FocusDashboardSearch).committed_pure();
     // The split screen's search is a ModalState::Search; the dashboard search

--- a/tests/core/domain_state_contracts.rs
+++ b/tests/core/domain_state_contracts.rs
@@ -477,14 +477,14 @@ fn toggle_terminal_focus_clears_terminal_focused() {
 #[test]
 fn enter_split_mode_changes_active_screen() {
     let state = AppState {
-        screen: ScreenId::Dashboard,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Dashboard),
         ..AppState::default()
     };
 
     let next = state.apply(AppEvent::EnterSplitMode).committed_pure();
 
     assert_eq!(
-        next.screen,
+        next.screen(),
         ScreenId::Repositories,
         "EnterSplitMode should change to Split"
     );
@@ -493,14 +493,14 @@ fn enter_split_mode_changes_active_screen() {
 #[test]
 fn exit_split_mode_returns_to_dashboard() {
     let state = AppState {
-        screen: ScreenId::Repositories,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Repositories),
         ..AppState::default()
     };
 
     let next = state.apply(AppEvent::ExitSplitMode).committed_pure();
 
     assert_eq!(
-        next.screen,
+        next.screen(),
         ScreenId::Dashboard,
         "ExitSplitMode should return to Dashboard"
     );

--- a/tests/e2e/end_to_end.rs
+++ b/tests/e2e/end_to_end.rs
@@ -74,7 +74,7 @@ fn full_navigation_workflow() {
     let (mut state, _, _) = create_test_environment();
 
     // Start at dashboard
-    assert_eq!(state.screen, ScreenId::Dashboard);
+    assert_eq!(state.screen(), ScreenId::Dashboard);
     assert_eq!(state.pane_focus, PaneFocus::Repositories);
 
     // Cycle through panes
@@ -89,11 +89,11 @@ fn full_navigation_workflow() {
 
     // Enter split mode
     state = state.apply(AppEvent::EnterSplitMode).committed_pure();
-    assert_eq!(state.screen, ScreenId::Repositories);
+    assert_eq!(state.screen(), ScreenId::Repositories);
 
     // Exit split mode
     state = state.apply(AppEvent::ExitSplitMode).committed_pure();
-    assert_eq!(state.screen, ScreenId::Dashboard);
+    assert_eq!(state.screen(), ScreenId::Dashboard);
 }
 
 #[test]

--- a/tests/ui/dashboard_navigation.rs
+++ b/tests/ui/dashboard_navigation.rs
@@ -214,32 +214,32 @@ fn f12_focus_blocks_non_terminal_navigation() {
 #[test]
 fn enter_split_mode_changes_active_screen() {
     let mut state = create_test_state();
-    state.screen = ScreenId::Dashboard;
+    state.nav = jefe::state::navigation::NavState::rooted(ScreenId::Dashboard);
 
     state = state.apply(AppEvent::EnterSplitMode).committed_pure();
 
-    assert_eq!(state.screen, ScreenId::Repositories);
+    assert_eq!(state.screen(), ScreenId::Repositories);
 }
 
 #[test]
 fn enter_split_mode_focuses_the_visible_repository_list() {
     let mut state = create_test_state();
-    state.screen = ScreenId::Dashboard;
+    state.nav = jefe::state::navigation::NavState::rooted(ScreenId::Dashboard);
     state.pane_focus = PaneFocus::Agents;
 
     state = state.apply(AppEvent::EnterSplitMode).committed_pure();
 
-    assert_eq!(state.screen, ScreenId::Repositories);
+    assert_eq!(state.screen(), ScreenId::Repositories);
     assert_eq!(state.pane_focus, PaneFocus::Repositories);
 }
 #[test]
 fn exit_split_mode_returns_to_dashboard() {
     let mut state = create_test_state();
-    state.screen = ScreenId::Repositories;
+    state.nav = jefe::state::navigation::NavState::rooted(ScreenId::Repositories);
 
     state = state.apply(AppEvent::ExitSplitMode).committed_pure();
 
-    assert_eq!(state.screen, ScreenId::Dashboard);
+    assert_eq!(state.screen(), ScreenId::Dashboard);
 }
 
 // ============================================================================

--- a/tests/ui/dashboard_reorder.rs
+++ b/tests/ui/dashboard_reorder.rs
@@ -68,7 +68,7 @@ fn create_dashboard_test_state() -> AppState {
     a3.status = AgentStatus::Running;
 
     AppState {
-        screen: ScreenId::Dashboard,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Dashboard),
         repositories: vec![repo1, repo2, repo3],
         agents: vec![a1, a2, a3],
         selected_repository_index: Some(0),
@@ -271,7 +271,7 @@ fn create_multi_agent_dashboard_state() -> AppState {
     a3.status = AgentStatus::Running;
 
     AppState {
-        screen: ScreenId::Dashboard,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Dashboard),
         repositories: vec![repo],
         agents: vec![a1, a2, a3],
         selected_repository_index: Some(0),
@@ -433,7 +433,7 @@ fn agent_grab_only_affects_agents_within_selected_repository() {
     let b2 = running_agent("b2", "bravo-two", &repo2.id);
 
     let mut state = AppState {
-        screen: ScreenId::Dashboard,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Dashboard),
         repositories: vec![repo1, repo2],
         agents: vec![a1, a2, b1, b2],
         selected_repository_index: Some(0),
@@ -506,7 +506,7 @@ fn enter_split_mode_clears_dashboard_grab() {
 
     state = state.apply(AppEvent::EnterSplitMode).committed_pure();
 
-    assert_eq!(state.screen, ScreenId::Repositories);
+    assert_eq!(state.screen(), ScreenId::Repositories);
     assert_eq!(state.dashboard_grab, None);
 }
 
@@ -672,7 +672,7 @@ fn enter_issues_mode_clears_dashboard_grab_via_finalize() {
     // validation must clear the stale grab.
     state = state.apply(AppEvent::EnterIssuesMode).committed_pure();
 
-    assert_ne!(state.screen, ScreenId::Dashboard);
+    assert_ne!(state.screen(), ScreenId::Dashboard);
     assert_eq!(state.dashboard_grab, None);
 }
 

--- a/tests/ui/help_search_behavior.rs
+++ b/tests/ui/help_search_behavior.rs
@@ -168,7 +168,7 @@ fn search_no_match_shows_empty() {
 #[test]
 fn search_works_in_dashboard_mode() {
     let mut state = create_search_test_state();
-    state.screen = ScreenId::Dashboard;
+    state.nav = jefe::state::navigation::NavState::rooted(ScreenId::Dashboard);
 
     state = state.apply(AppEvent::OpenSearch).committed_pure();
 
@@ -178,7 +178,7 @@ fn search_works_in_dashboard_mode() {
 #[test]
 fn search_works_in_split_mode() {
     let mut state = create_search_test_state();
-    state.screen = ScreenId::Repositories;
+    state.nav = jefe::state::navigation::NavState::rooted(ScreenId::Repositories);
 
     state = state.apply(AppEvent::OpenSearch).committed_pure();
 

--- a/tests/ui/split_mode_behavior.rs
+++ b/tests/ui/split_mode_behavior.rs
@@ -39,7 +39,7 @@ fn create_split_test_state() -> AppState {
     );
 
     AppState {
-        screen: ScreenId::Repositories,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Repositories),
         repositories: vec![repo1, repo2, repo3],
         selected_repository_index: Some(0),
         ..Default::default()
@@ -53,13 +53,13 @@ fn create_split_test_state() -> AppState {
 #[test]
 fn s_key_enters_split_mode() {
     let state = AppState {
-        screen: ScreenId::Dashboard,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::Dashboard),
         ..Default::default()
     };
 
     let state = state.apply(AppEvent::EnterSplitMode).committed_pure();
 
-    assert_eq!(state.screen, ScreenId::Repositories);
+    assert_eq!(state.screen(), ScreenId::Repositories);
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn esc_key_exits_split_mode() {
 
     state = state.apply(AppEvent::ExitSplitMode).committed_pure();
 
-    assert_eq!(state.screen, ScreenId::Dashboard);
+    assert_eq!(state.screen(), ScreenId::Dashboard);
 }
 
 // ============================================================================


### PR DESCRIPTION
Fixes #386.

`AppState.screen` was a field anyone could assign, and eleven places did: each
mode set it on the way in and set it back to the dashboard on the way out.
Nothing recorded where the user had come from, so leaving a screen could only
guess, and it always guessed "dashboard". Back meant whatever the focused mode
decided it meant, and five modes decided separately.

This delivers the one navigation/dirty reducer CW-06 asks for and removes the
field.

## What changed

**Routes are declared, not asserted** (`src/workbench/route.rs`). A
`RouteDeclaration` is derived from a screen descriptor's `route` and
`activation`, so a route and the screen it reaches cannot drift apart, and a
route no descriptor declares cannot be navigated to. `ActivationValue` mirrors
`ActivationKind` exactly: no secret variant, no nested map, no generic payload.
Field count, serialized size, and identifier length are enforced at
construction, so an over-large activation cannot be held at all. Every refusal
is `NAV-E001` and names only identifiers the program declared, never a value the
caller supplied.

**One reducer owns route, stack, and dirty transitions**
(`src/state/navigation.rs`). It is pure: state, registry, one message, out comes
the next state plus what the caller must do about the instances that entered or
left. A target is validated and constructed *before* anything is suspended or
disposed, so a refusal returns the state it was given — there is no partially
applied navigation. Instance identity is never reused. Suspension is a type
(`SuspendedInstance`), not a flag, so a stacked instance cannot be read as the
current one by accident.

**Staleness is one comparison.** A completion is answered only when it names the
live instance's screen and activation generations. That single rule covers all
three cases the contract distinguishes: a suspended instance's answers wait with
it, restoring it makes them live again (which is what restoring an instance's
subscriptions means in practice), and a disposed instance's generations never
become live again because generations only move forward.

**The dirty guard asks once** (`src/state/navigation_dirty.rs`). Leaving a
screen with unsaved work is the same question everywhere, so it has one answer.
The guard deliberately does not know what saving *means* — the screen holding
the draft declares that as a `SaveIntent`. It holds the navigation back until
the owner reports success, so a save that fails cannot carry the user away from
the screen holding their work.

**Back is stated once** (`src/state/navigation_unwind.rs`,
`navigation_layers.rs`). The ordered list is the specification rather than the
position of a branch in a chain of `if`s. A screen reports which layers it has
open; the shared resolver decides. One press unwinds exactly one layer.

**The field is gone** (`src/state/types.rs`). Every screen change is now one of
three verbs. Opening a mode keeps the screen it came from, so Back returns
there. The cross-mode jump between issues and pull requests takes the *place* of
the screen it came from rather than stacking on it, which is why Back from
either still reaches the dashboard — existing behaviour, now by construction
rather than by coincidence. Leaving goes back when there is somewhere to go back
to and home when there is not, because a restored session opens directly on its
last screen with nothing beneath it.

**Rooting a session is total.** Both the route and the initial focus come from
compiled tables, so starting a session has no failure mode to handle at the
moment it is needed. Two tests hold those tables to the descriptors, so a screen
that drifts fails the build rather than the session.

## How the dirty-Save question was settled

CW-06 says "Dirty Save emits the typed save effect", but nothing in the product
has a save today. `08-settings-shell.md` settles the ownership: its own source
inventory assigns "own Back dirty confirmation and focus restoration" to the
**navigation reducer**, while `src/state/settings.rs::reduce_settings` owns
`DraftStatus{Clean,Dirty,Saving}`, the writer, the base hash, and the save
completion. So CW-06 owns the guard and the screen declares its save. No new
`Effect` family was needed, and no product behaviour was invented.

There is no `DiscardIntent` beside `SaveIntent`. Saving varies by owner and may
not be possible at all, but abandoning a draft is always available and always
means the same thing, so a type saying so would carry no information.

## Evidence

| Ledger | Evidence |
|---|---|
| CW06-01 Push suspends exactly and creates fresh | reducer goldens; `typed-navigation-push-back.json` |
| CW06-02 Replace disposes only after construction | replace success/failure transaction tests |
| CW06-03 Back restores the exact prior instance | byte-equivalence test; two-instance unwind order |
| CW06-04 Back unwinds one layer only | full precedence table, every pair in both orders, layer-reachability test; `navigation-local-unwind.json` |
| CW06-05 Save defers navigation until matching success | Save-pending / matching / stale / unrelated / failed completion tests |
| CW06-06 Discard and Cancel | dirty-choice matrix incl. exact focus restoration |
| CW06-07 Stack bound 32 | depth 32/33 property, `NAV-E001`, no generation advance on refusal |
| CW06-08 Stale identity changes nothing | suspended / disposed / replaced / stale-generation properties |
| CW06-09 Migration | every legacy persisted value restores one clean instance, no stack, no guard |
| CW06-10 UI states | `display-and-ui.md` DIRTY/RECOVERY/SMALL; see deferred below |

103 new behavioural tests across route, navigation, dirty, unwind, and layer
projection. Full suite green: 81 test binaries, zero failures.

## Deferred, with reason

Recorded in `project-plans/issue386-plan.md`:

- **DIRTY / RECOVERY / SMALL harness scenarios.** No shipped screen declares a
  savable draft yet, so the guard has no reachable UI to drive from the harness.
  The lifecycle is proven at the reducer and specified normatively; the
  scenarios land with CW-07, which supplies the first owner.
- **`navigation-depth-limit` harness scenario.** Depth 33 is not reachable
  through the shipped key map; the bound is a reducer property test.
- **Routing the per-mode Esc arms through `back_resolution`.** The precedence is
  now stated once and projected from real state, and the resolver is production
  code with behavioural coverage. Rewriting each mode's existing raw-key
  pre-empt chain to consume it is a behaviour-preserving refactor across the
  whole `app_input` surface, and the existing chains are already proven to agree
  with the stated order.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets
--all-features -- -D warnings`, `cargo build --workspace --all-features
--locked`, `cargo test --workspace --all-features --locked`, `cargo xtask check
architecture`, `cargo xtask check source-size` — all pass on the merged head.
No new dependency, no `unsafe`, no `unwrap`/`expect` in production paths, no
suppression, no loosened gate.
