### PR TITLE
Reach the PR screen through nav, not the field it lost (Fixes #650)

### DIFF
--- a/src/app_input/prs_lifecycle_key_tests.rs
+++ b/src/app_input/prs_lifecycle_key_tests.rs
@@ -21,7 +21,7 @@ fn key(code: KeyCode) -> KeyEvent {
 
 fn prs_list_state() -> AppState {
     AppState {
-        screen: ScreenId::PullRequests,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::PullRequests),
         prs_state: PullRequestsState {
             active: true,
             pr_focus: PrFocus::PrList,


### PR DESCRIPTION
Fixes #650.

`main` at `6b6d9289` does not compile. This restores it.

## What broke

```
src\app_input\prs_lifecycle_key_tests.rs:24:9: error[E0560]:
struct `jefe::state::AppState` has no field named `screen`
```

Two PRs that were each green on their own base, and that merged without a
textual conflict, are incompatible with each other:

- **#643** (`ffe1307b`) added `src/app_input/prs_lifecycle_key_tests.rs`, which
  builds `AppState { screen: ScreenId::PullRequests, .. }`.
- **#644** (`6b6d9289`) replaced that field with a `screen()` accessor over
  `NavState`, rewriting every `screen:` literal that existed on its base.

The file did not exist when #644 branched, so it was never there to be
rewritten, and #643 had no way to know the field was going away.

## The change

One line, matching how #644 migrated the other literals:

```rust
-        screen: ScreenId::PullRequests,
+        nav: jefe::state::navigation::NavState::rooted(ScreenId::PullRequests),
```

The test's subject — key routing on the PR screen — is untouched. Only the way
it states which screen it is on moves to the accessor's backing field.

## Verification

Run on this exact head:

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | exit 0 |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo build --all-targets` | exit 0 |
| `cargo test --workspace --all-features` | exit 0 — **81 suites, 0 failed** |

I also confirmed the break is real and pre-existing by building a clean worktree
checked out at `6b6d9289` with no other branch involved; it fails identically.

## Why CI missed it

`cargo build --workspace` still succeeded, because the offending literal lives in
a test module — only `--all-targets` broke. Combined with required checks running
against each PR head rather than the merge result, neither PR could have shown
red. A merge-queue or merge-result build would catch this class; worth
considering separately, as noted in #650.
