### PR TITLE
Reap the orphan the anchors were meant to identify (Fixes #642)

### DIFF
--- a/project-plans/issue642-plan.md
+++ b/project-plans/issue642-plan.md
@@ -81,7 +81,7 @@ anchors alone would therefore still leak on the `restore_runtime_sessions` route
 | Default-on logging | deferred, follow-up |
 | Staging-dir pruning per build hash | deferred, follow-up |
 | `recover_server_lost_agents` revisiting Dead+unbound | deferred, follow-up |
-| A `Held` orphan is never revisited, so its tree is never reaped (review finding 7) | deferred, follow-up |
+| A `Held` orphan is never revisited, so its tree is never reaped (review finding 7) | deferred, filed as #651 |
 
 No changes to `.llxprt/`, `.code_puppy/`, `.github/`, dependency manifests, or
 quality-gate configuration are planned.
@@ -161,4 +161,16 @@ head.
 
 ## 8. Deferred findings
 
-Recorded in the scope ledger above; follow-up issues to be filed rather than folded in.
+Recorded in the scope ledger above; follow-up issues filed rather than folded in.
+
+- #651 — a `Held` orphan is never revisited, so its tree is never reaped. The
+  probe-`Unavailable` route never reaches `Orphaned`, so the reap this issue
+  built is unreachable from it.
+
+## 9. Blocked on
+
+`main` at `6b6d9289` does not compile: `#643` added an `AppState { screen: .. }`
+literal and `#644` removed that field, a semantic conflict that is clean in each
+PR and broken only in the merge. Filed as #650. This branch rebases onto that
+head without textual conflict and is otherwise ready, but its CI cannot go green
+until #650 lands.

--- a/project-plans/issue642-plan.md
+++ b/project-plans/issue642-plan.md
@@ -167,10 +167,12 @@ Recorded in the scope ledger above; follow-up issues filed rather than folded in
   probe-`Unavailable` route never reaches `Orphaned`, so the reap this issue
   built is unreachable from it.
 
-## 9. Blocked on
+## 9. Base
 
-`main` at `6b6d9289` does not compile: `#643` added an `AppState { screen: .. }`
-literal and `#644` removed that field, a semantic conflict that is clean in each
-PR and broken only in the merge. Filed as #650. This branch rebases onto that
-head without textual conflict and is otherwise ready, but its CI cannot go green
-until #650 lands.
+`main` at `6b6d9289` did not compile: `#643` added an `AppState { screen: .. }`
+literal and `#644` removed that field, a semantic conflict clean in each PR and
+broken only in the merge. Filed as #650 and fixed by #653, which is green.
+
+This branch is stacked on `issue650` so its CI runs against a base that builds;
+GitHub retargets it to `main` when #653 merges. Verified on the restacked head:
+fmt 0, clippy 0, `cargo test --workspace --all-features` 81 suites 0 failures.

--- a/project-plans/issue642-plan.md
+++ b/project-plans/issue642-plan.md
@@ -91,7 +91,11 @@ quality-gate configuration are planned.
 | Phase | Cap | Used |
 |---|---|---|
 | Local OCR before PR | 2 | 1 |
-| OCR after PR opened | 2 | 0 |
+| OCR after PR opened | 2 | 1 |
+
+Post-PR OCR ran as the `OpenCodeReview` check on #654 and passed with no
+findings. CodeRabbit also passed. No review threads were opened, so there is
+nothing to triage.
 
 ### Local review 1 — triage
 
@@ -156,8 +160,24 @@ bury adjacent in one place rather than spread through the restore entry point.
 | Clippy | `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0 |
 | Tests | `cargo test --workspace --all-features` — 81 suites, 0 failures |
 
-Required CI, including native Windows and coverage, is watched on the exact PR
-head.
+### Required CI on the PR head (#654)
+
+Run [30925250524](https://github.com/vybestack/llxprt-jefe/actions/runs/30925250524),
+every job green:
+
+| Job | Result |
+|---|---|
+| Native Windows (MSVC + psmux) | ✓ 7m7s |
+| Native Windows completion gate | ✓ |
+| Test | ✓ 3m22s |
+| Build | ✓ |
+| Coverage gate | ✓ 4m17s |
+| Windows coverage floors | ✓ 4m21s |
+| Windows Clippy (cfg(windows) lint gap) | ✓ 2m57s |
+| Lint (clippy), Clippy allow policy | ✓ |
+| Format (rustfmt) | ✓ |
+| Complexity, source length, architecture boundary, uncertain-observation | ✓ |
+| Mergeability gate, OpenCodeReview, CodeRabbit | ✓ |
 
 ## 8. Deferred findings
 
@@ -173,6 +193,13 @@ Recorded in the scope ledger above; follow-up issues filed rather than folded in
 literal and `#644` removed that field, a semantic conflict clean in each PR and
 broken only in the merge. Filed as #650 and fixed by #653, which is green.
 
-This branch is stacked on `issue650` so its CI runs against a base that builds;
-GitHub retargets it to `main` when #653 merges. Verified on the restacked head:
-fmt 0, clippy 0, `cargo test --workspace --all-features` 81 suites 0 failures.
+PR #654 targets `main` and carries the fix commit `4633594c`, so the merge result
+builds even while `main` alone does not. Once #653 merges, that commit drops out
+on the next rebase, leaving the five #642 commits.
+
+Stacking on `issue650` was tried first and abandoned: `ci.yml` is
+`pull_request: branches: [main]`, so a PR based on anything else runs only
+CodeRabbit, OCR and the mergeability gate — not the suite that matters.
+
+Verified locally on the same head: fmt 0, clippy 0,
+`cargo test --workspace --all-features` 81 suites 0 failures.

--- a/project-plans/issue642-plan.md
+++ b/project-plans/issue642-plan.md
@@ -112,6 +112,20 @@ quality-gate configuration are planned.
 | Clippy | `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0 |
 | Regression | `cargo test --workspace --all-features` on the candidate head |
 
+### Slice 2 — AC4/AC6 consumer coverage
+
+A re-read of the matrix against the landed tests found AC4 and AC6 had no
+proving test of their own: slice 1 proved the anchors survive the round trip and
+slice 2 proved the routing, but nothing pinned the consumer in between — that a
+restored, non-empty anchor set gets past `orphan_evidence`'s
+`identities.is_empty()` short-circuit, which is the exact blind spot the issue
+describes.
+
+| Step | Evidence |
+|---|---|
+| Coverage | `restored_anchors_are_answered_by_observation_not_by_the_empty_short_circuit` (AC4), `a_remote_agent_never_reaps_even_with_restored_anchors` (AC6) |
+| GREEN | `cargo test --bin jefe orphan` — 8 passed, 0 failed |
+
 REFACTOR note: extracting the classification loop into
 `classify_agents_for_restore` was required by the repo's 60-line function gate,
 which fired once the orphan arm was added. The extraction keeps the reap and the

--- a/project-plans/issue642-plan.md
+++ b/project-plans/issue642-plan.md
@@ -1,0 +1,103 @@
+# Issue #642 — Orphan reaping never runs after a restart
+
+<https://github.com/vybestack/llxprt-jefe/issues/642>
+
+`RuntimeBinding.worker_identities` is never written to the durable document and is
+hardcoded to `Vec::new()` on restore, so `orphan_evidence` always returns `NoOrphan`
+after a restart. Startup then takes the plain `Stopped` path and `reap_orphaned_agent`
+is never called, leaking a `jefe-session-host.exe` + `psmux server` pair (and ~26 MB of
+staged binary) for every dead-pane agent.
+
+A second defect found while shaping this plan: `app_init::restore_one_agent` maps
+`StartupClassification::Orphaned` to `RestoreOneOutcome::Dead` **without reaping**,
+unlike `reconcile_running_agents`, which does reap before Dead-marking. Persisting the
+anchors alone would therefore still leak on the `restore_runtime_sessions` route.
+
+## 1. Acceptance matrix
+
+| # | Actor / launch path | Input & boundary cases | Target | Observable success | Observable failure & diagnostic | Side effects before failure | Persistence / compatibility | Proving test |
+|---|---|---|---|---|---|---|---|---|
+| AC1 | `state::durable_projection` (save) | Agent whose `RuntimeBinding.worker_identities` is non-empty; also the empty case | local | Schema-2 `RuntimeRecord` carries `worker_identities` in recorded order | Projection is pure and total; no failure mode introduced | none | Field omitted entirely when empty (`skip_serializing_if`), so existing documents and goldens are byte-identical | behavioral projection test |
+| AC2 | `state::durable_restore::restore_agent` | `RuntimeRecord` **with** anchors; **without** the key (pre-#642 document); `session_id: None` | local | `RuntimeBinding.worker_identities` equals the recorded anchors | Missing key restores to empty rather than erroring | none | `#[serde(default)]`; `deny_unknown_fields` preserved | behavioral restore test |
+| AC3 | Save → load round trip | Agent with anchors, saved then restored | local | Anchors survive the round trip unchanged | — | none | Revision semantics unchanged | round-trip test |
+| AC4 | Startup classification after restart | Restored agent, session present, pane dead, validated descendants alive | local | `orphan_evidence` yields `DeadPaneWithOrphans` and `classify_startup` yields `Orphaned` (not `Stopped`) | Anchors that no longer match are `Dead`, so a stale record does not fabricate an orphan | none | n/a | behavioral test over restored binding |
+| AC5 | `app_init::restore_one_agent` | `StartupClassification::Orphaned` | local | The orphan tree is reaped **before** the agent is Dead-marked and its binding cleared | Reap failures are logged and swallowed; startup is never aborted | reap is the intended effect | binding still present at reap time | behavioral test |
+| AC6 | Remote repositories | Agent on a remote repository | remote | `orphan_evidence` still short-circuits to `NoOrphan`; no local reap is attempted | — | none | unchanged | existing + new assertion |
+
+## 2. Non-goals
+
+- Re-deriving descendants by walking the live process tree (the issue's alternative
+  suggestion). Persisting the anchors is the accepted approach; the tree walk is not
+  implemented here.
+- Enabling `JEFE_LOG_FILE` by default. Tracked separately.
+- Pruning superseded build-hash staging directories under
+  `%LOCALAPPDATA%\jefe\session-hosts\`. Tracked separately.
+- Changing `recover_server_lost_agents` so it revisits Dead+unbound agents.
+- Making `worker_identity_from_pane` return a worker on Windows (the `BindingEvidence::Legacy`
+  aggravating factor).
+- Any change to reap mechanics inside `jefe::runtime::reap_orphan_session`.
+
+## 3. Vertical slices
+
+### Slice 1 — persist and restore the descendant anchors (AC1, AC2, AC3, AC6)
+
+- Owner: durable state contract + projection/restore.
+- Allowed paths: `src/domain/state_contract.rs`, `src/state/durable_projection.rs`,
+  `src/state/durable_restore.rs`, and their existing test modules.
+- RED: projection/restore/round-trip tests asserting anchors persist; a pre-#642
+  document without the key still loads.
+- GREEN: add the field, write it, restore it.
+- Non-goals: no classification or reap changes.
+- Stop if: the schema change appears to require a migration or a schema version bump.
+
+### Slice 2 — reap on the restore route (AC4, AC5)
+
+- Owner: `app_init` startup reconciliation.
+- Allowed paths: `src/app_init.rs`, `src/app_init_orphan_reconcile.rs`,
+  `src/app_init_tests.rs`.
+- RED: a test proving `Orphaned` on the `restore_one_agent` route reaps before the
+  binding is cleared.
+- GREEN: split `Orphaned` out of the combined Dead arm and reap first.
+- Non-goals: no new process-management subsystem; reuse `reap_orphaned_agent`.
+- Stop if: reaping here needs new cancellation/timeout machinery.
+
+## 4. Expected files by layer
+
+| Layer | Files |
+|---|---|
+| Durable contract | `src/domain/state_contract.rs` |
+| Pure projection | `src/state/durable_projection.rs`, `src/state/durable_restore.rs` |
+| Startup boundary | `src/app_init.rs`, `src/app_init_orphan_reconcile.rs` |
+| Tests | `src/state/durable_projection_tests.rs`, `src/app_init_tests.rs` |
+| Plan | `project-plans/issue642-plan.md` |
+
+## 5. Scope ledger
+
+| Entry | Status |
+|---|---|
+| Persist `worker_identities` on `RuntimeRecord` | in scope (AC1) |
+| Restore anchors instead of `Vec::new()` | in scope (AC2) |
+| Reap on the `restore_one_agent` route | in scope (AC5) — discovered while shaping, same defect, recorded here |
+| Default-on logging | deferred, follow-up |
+| Staging-dir pruning per build hash | deferred, follow-up |
+| `recover_server_lost_agents` revisiting Dead+unbound | deferred, follow-up |
+
+No changes to `.llxprt/`, `.code_puppy/`, `.github/`, dependency manifests, or
+quality-gate configuration are planned.
+
+## 6. Review counters
+
+| Phase | Cap | Used |
+|---|---|---|
+| Local OCR before PR | 2 | 0 |
+| OCR after PR opened | 2 | 0 |
+
+## 7. Verification evidence
+
+To be recorded on the candidate head: `make ci-check` (fmt, clippy `-D warnings`,
+build, test, coverage `--fail-under-lines 30`) plus required CI including native
+Windows.
+
+## 8. Deferred findings
+
+Recorded in the scope ledger above; follow-up issues to be filed rather than folded in.

--- a/project-plans/issue642-plan.md
+++ b/project-plans/issue642-plan.md
@@ -81,6 +81,7 @@ anchors alone would therefore still leak on the `restore_runtime_sessions` route
 | Default-on logging | deferred, follow-up |
 | Staging-dir pruning per build hash | deferred, follow-up |
 | `recover_server_lost_agents` revisiting Dead+unbound | deferred, follow-up |
+| A `Held` orphan is never revisited, so its tree is never reaped (review finding 7) | deferred, follow-up |
 
 No changes to `.llxprt/`, `.code_puppy/`, `.github/`, dependency manifests, or
 quality-gate configuration are planned.
@@ -89,8 +90,22 @@ quality-gate configuration are planned.
 
 | Phase | Cap | Used |
 |---|---|---|
-| Local OCR before PR | 2 | 0 |
+| Local OCR before PR | 2 | 1 |
 | OCR after PR opened | 2 | 0 |
+
+### Local review 1 — triage
+
+Non-blocking; no Critical or High findings. Seven Low findings, dispositioned:
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | Comment on the `reattempt_held_agents` orphan arm promises a reap that route can never reach (that route only visits binding-less agents) | In-scope-Fix — comment corrected to state the arm is unreachable today and why it is kept |
+| 2 | AC5's reap-before-bury ordering had no behavioral test; only the mapping was pinned | In-scope-Fix — `record_restore_outcome` now takes the reap as a parameter so the ordering is observable; `an_orphan_is_reaped_while_it_still_carries_its_anchors` added and mutation-checked (dropping the reap makes it fail with `left: None`) |
+| 3 | `u32::MAX` PID assumption undocumented | In-scope-Fix — comment citing the per-platform PID ceilings. Reviewer independently verified the assumption holds on Linux, macOS and Windows |
+| 4 | AC2's compat test bypassed `StateDocument::parse`, the boundary a real state.json actually crosses | In-scope-Fix — the keyless document now goes through the strict parser |
+| 5 | The extraction left `restore_runtime_sessions` undocumented and stacked two doc blocks on the private helper | In-scope-Fix — doc comment moved back to the public entry point |
+| 6 | The orphan arm is duplicated across the two restore loops | Reject — the loops differ in Held handling and signature; unifying them would mean passing an extra parameter to suppress a warning path, for no behavioral gain |
+| 7 | An orphan whose session probe answers `Unavailable` is classified `Held`, keeps its binding, and is never revisited, so its tree is never reaped | Defer — pre-existing #541 hold semantics interacting with #332, not a regression from this work. Added to the scope ledger as a follow-up |
 
 ## 7. Verification evidence
 
@@ -130,6 +145,16 @@ REFACTOR note: extracting the classification loop into
 `classify_agents_for_restore` was required by the repo's 60-line function gate,
 which fired once the orphan arm was added. The extraction keeps the reap and the
 bury adjacent in one place rather than spread through the restore entry point.
+
+### Slice 4 — review fixes
+
+| Step | Evidence |
+|---|---|
+| Mutation check | Dropping `reap(agent);` from the orphan arm fails `an_orphan_is_reaped_while_it_still_carries_its_anchors` at `app_init_tests.rs:844` — `left: None`, right holds the anchor |
+| Strict-parse compat | `a_document_without_descendant_anchors_restores_an_empty_set` passes through `StateDocument::parse` |
+| Format | `cargo fmt --all --check` — exit 0 |
+| Clippy | `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0 |
+| Tests | `cargo test --workspace --all-features` — 81 suites, 0 failures |
 
 Required CI, including native Windows and coverage, is watched on the exact PR
 head.

--- a/project-plans/issue642-plan.md
+++ b/project-plans/issue642-plan.md
@@ -94,9 +94,31 @@ quality-gate configuration are planned.
 
 ## 7. Verification evidence
 
-To be recorded on the candidate head: `make ci-check` (fmt, clippy `-D warnings`,
-build, test, coverage `--fail-under-lines 30`) plus required CI including native
-Windows.
+### Slice 1 — persist the anchors (commit `717dc020`)
+
+| Step | Evidence |
+|---|---|
+| RED | `descendant_anchors_survive_the_durable_round_trip` failed: `left: []`, right held the two expected anchors |
+| GREEN | `cargo test --lib descendant` — 8 passed, 0 failed |
+| Regression | `cargo test --workspace --all-features` — 81 suites, 0 failures (lib: 3249 passed) |
+| Format | `cargo fmt --all --check` — exit 0 |
+
+### Slice 2 — reap before the binding is cleared
+
+| Step | Evidence |
+|---|---|
+| RED | `an_orphan_does_not_take_the_same_restore_route_as_a_plain_dead_agent` failed at `app_init_tests.rs:795` — "Orphaned must stay distinguishable from Dead, or the reap is skipped" |
+| GREEN | `cargo test --bin jefe` — 839 passed, 0 failed |
+| Clippy | `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0 |
+| Regression | `cargo test --workspace --all-features` on the candidate head |
+
+REFACTOR note: extracting the classification loop into
+`classify_agents_for_restore` was required by the repo's 60-line function gate,
+which fired once the orphan arm was added. The extraction keeps the reap and the
+bury adjacent in one place rather than spread through the restore entry point.
+
+Required CI, including native Windows and coverage, is watched on the exact PR
+head.
 
 ## 8. Deferred findings
 

--- a/project-plans/issue642-plan.md
+++ b/project-plans/issue642-plan.md
@@ -189,17 +189,24 @@ Recorded in the scope ledger above; follow-up issues filed rather than folded in
 
 ## 9. Base
 
-`main` at `6b6d9289` did not compile: `#643` added an `AppState { screen: .. }`
-literal and `#644` removed that field, a semantic conflict clean in each PR and
-broken only in the merge. Filed as #650 and fixed by #653, which is green.
+PR #654 sits directly on `main`. Its seven commits are all #642 work; nothing
+else rides along.
 
-PR #654 targets `main` and carries the fix commit `4633594c`, so the merge result
-builds even while `main` alone does not. Once #653 merges, that commit drops out
-on the next rebase, leaving the five #642 commits.
+For a while it did not. `main` at `6b6d9289` did not compile — `#643` added an
+`AppState { screen: .. }` literal and `#644` removed that field, a semantic
+conflict clean in each PR and broken only in the merge. That was filed as #650
+and carried here as a fix commit so this branch had a base that built.
 
-Stacking on `issue650` was tried first and abandoned: `ci.yml` is
-`pull_request: branches: [main]`, so a PR based on anything else runs only
-CodeRabbit, OCR and the mergeability gate — not the suite that matters.
+`#640` then landed the same one-line change on `main`, which resolved #650 and
+made the carried commit redundant — the two versions of that line collided, and
+that collision was the conflict. The fix commit has been dropped and #653 and
+#650 are closed. Current `main` (`b1c965bb`) builds: `cargo check --all-targets`
+exits 0.
 
-Verified locally on the same head: fmt 0, clippy 0,
+Verified on the rebased head: fmt 0, clippy 0,
 `cargo test --workspace --all-features` 81 suites 0 failures.
+
+The gap that produced #650 outlived it. `#643` and `#644` were each green
+against their own base, and the break existed only in their combination.
+Required checks that evaluate PR heads cannot see that class of failure; a merge
+queue or a required merge-result build would. Out of scope here, unfiled.

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -124,7 +124,10 @@ pub fn reattempt_held_agents(app_state: &mut HookState<AppState>, ctx: &SharedCo
                 binding,
             }),
             RestoreOneOutcome::Dead => newly_dead.push(agent.id.clone()),
-            // Reap while the binding still carries the anchors, then bury.
+            // Unreachable today: this route only visits agents with no runtime
+            // binding, and an orphan is recognised from anchors that live on
+            // that binding. Kept reaping-first anyway so the arm stays correct
+            // if the readoption filter ever widens.
             RestoreOneOutcome::Orphaned => {
                 orphan_reconcile::reap_orphaned_agent(&agent);
                 newly_dead.push(agent.id.clone());
@@ -750,6 +753,70 @@ fn restore_one_agent(
     }
 }
 
+/// The three sets a restore pass sorts agents into.
+#[derive(Default)]
+struct RestoreOutcomeSets {
+    revived: Vec<RevivedAgent>,
+    newly_dead: Vec<AgentId>,
+    held: Vec<(AgentId, String)>,
+}
+
+/// Record one agent's restore outcome, reaping an orphan's descendant tree
+/// before that agent joins the newly-dead set.
+///
+/// The reap is injected rather than called directly so the ordering this
+/// function exists to guarantee is observable: burying an agent clears its
+/// runtime binding, and that binding holds the only anchors the reap can match
+/// against, so the reap has to see the agent while it is still bound
+/// (issue #642).
+fn record_restore_outcome(
+    agent: &Agent,
+    outcome: RestoreOneOutcome,
+    sets: &mut RestoreOutcomeSets,
+    reap: &mut dyn FnMut(&Agent),
+) {
+    match outcome {
+        RestoreOneOutcome::Revived(binding) => sets.revived.push(RevivedAgent {
+            agent_id: agent.id.clone(),
+            binding,
+        }),
+        RestoreOneOutcome::Dead => sets.newly_dead.push(agent.id.clone()),
+        RestoreOneOutcome::Orphaned => {
+            reap(agent);
+            sets.newly_dead.push(agent.id.clone());
+        }
+        RestoreOneOutcome::Skip => {}
+        // Left exactly as persisted, including its binding.
+        RestoreOneOutcome::Held(reason) => {
+            warn!(
+                agent_id = %agent.id.0,
+                %reason,
+                "startup held this agent: its state was not determined and was left untouched"
+            );
+            sets.held.push((agent.id.clone(), reason.to_string()));
+        }
+    }
+}
+
+/// Classify every persisted agent into the revived, newly-dead and held sets.
+fn classify_agents_for_restore(
+    agents: Vec<Agent>,
+    repositories: &[jefe::domain::Repository],
+    runtime: &mut TmuxRuntimeManager,
+    runtime_warning: Option<&String>,
+) -> (Vec<RevivedAgent>, Vec<AgentId>, Vec<(AgentId, String)>) {
+    let mut sets = RestoreOutcomeSets::default();
+
+    for agent in agents {
+        let outcome = restore_one_agent(&agent, repositories, runtime, runtime_warning);
+        record_restore_outcome(&agent, outcome, &mut sets, &mut |orphan| {
+            orphan_reconcile::reap_orphaned_agent(orphan);
+        });
+    }
+
+    (sets.revived, sets.newly_dead, sets.held)
+}
+
 /// Restore the runtime session map from persisted agent statuses exactly once.
 ///
 /// Running agents prefer reattach to existing live tmux sessions by stable ID;
@@ -758,51 +825,6 @@ fn restore_one_agent(
 /// Local agents whose tmux session is gone but whose persisted worker PID is
 /// still alive are left Running with their binding preserved (PID-liveness
 /// fallback), rather than being marked Dead or revived.
-/// Classify every persisted agent into the revived, newly-dead and held sets.
-///
-/// An orphan's descendant tree is reaped here, while the agent still holds the
-/// binding whose anchors identify that tree, because the caller clears the
-/// binding when it buries the agent (issue #642).
-fn classify_agents_for_restore(
-    agents: Vec<Agent>,
-    repositories: &[jefe::domain::Repository],
-    runtime: &mut TmuxRuntimeManager,
-    runtime_warning: Option<&String>,
-) -> (Vec<RevivedAgent>, Vec<AgentId>, Vec<(AgentId, String)>) {
-    let mut revived_running = Vec::new();
-    let mut newly_dead = Vec::new();
-    let mut held: Vec<(AgentId, String)> = Vec::new();
-
-    for agent in agents {
-        match restore_one_agent(&agent, repositories, runtime, runtime_warning) {
-            RestoreOneOutcome::Revived(binding) => {
-                revived_running.push(RevivedAgent {
-                    agent_id: agent.id.clone(),
-                    binding,
-                });
-            }
-            RestoreOneOutcome::Dead => newly_dead.push(agent.id.clone()),
-            // Reap while the binding still carries the anchors, then bury.
-            RestoreOneOutcome::Orphaned => {
-                orphan_reconcile::reap_orphaned_agent(&agent);
-                newly_dead.push(agent.id.clone());
-            }
-            RestoreOneOutcome::Skip => {}
-            // Left exactly as persisted, including its binding.
-            RestoreOneOutcome::Held(reason) => {
-                warn!(
-                    agent_id = %agent.id.0,
-                    %reason,
-                    "startup held this agent: its state was not determined and was left untouched"
-                );
-                held.push((agent.id.clone(), reason.to_string()));
-            }
-        }
-    }
-
-    (revived_running, newly_dead, held)
-}
-
 pub fn restore_runtime_sessions(app_state: &mut HookState<AppState>, ctx: &SharedContext) {
     let Some(ctx_arc) = ctx else {
         return;

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -124,6 +124,11 @@ pub fn reattempt_held_agents(app_state: &mut HookState<AppState>, ctx: &SharedCo
                 binding,
             }),
             RestoreOneOutcome::Dead => newly_dead.push(agent.id.clone()),
+            // Reap while the binding still carries the anchors, then bury.
+            RestoreOneOutcome::Orphaned => {
+                orphan_reconcile::reap_orphaned_agent(&agent);
+                newly_dead.push(agent.id.clone());
+            }
             // Still unanswered, or not ours to answer. Left as persisted.
             RestoreOneOutcome::Skip | RestoreOneOutcome::Held(_) => {}
         }
@@ -652,6 +657,11 @@ enum RestoreOneOutcome {
     Revived(Box<jefe::domain::RuntimeBinding>),
     /// Agent should be marked Dead (binding cleared).
     Dead,
+    /// Agent's pane is gone but its validated worker descendants are still
+    /// running, so the caller must reap that tree before the agent is marked
+    /// Dead and its binding — which holds the only anchors the reap can use —
+    /// is cleared (issue #642).
+    Orphaned,
     /// Agent should be left as-is (non-running, or local orphan kept Running).
     Skip,
     /// A startup probe did not answer, so the agent keeps everything it was
@@ -665,6 +675,19 @@ enum RestoreOneOutcome {
 struct RevivedAgent {
     agent_id: AgentId,
     binding: Box<jefe::domain::RuntimeBinding>,
+}
+
+/// Map a terminal (non-reviving) startup classification to its restore outcome.
+///
+/// Kept separate from [`restore_one_agent`] so the mapping can be pinned
+/// directly: the caller of a terminal outcome clears the runtime binding, and
+/// an orphan's reap needs that binding's descendant anchors, so the two cannot
+/// share one route (issue #642).
+fn terminal_restore_outcome(classification: StartupClassification) -> RestoreOneOutcome {
+    match classification {
+        StartupClassification::Orphaned => RestoreOneOutcome::Orphaned,
+        _ => RestoreOneOutcome::Dead,
+    }
 }
 
 /// Process one agent during restore: decide Dead / Skip / Revive and, when
@@ -697,10 +720,10 @@ fn restore_one_agent(
     let signature = launch_signature_for_agent(agent, &repository);
 
     match classify_agent_startup(agent, &signature, runtime) {
-        StartupClassification::Stopped
+        terminal @ (StartupClassification::Stopped
         | StartupClassification::Stale
         | StartupClassification::Inconsistent
-        | StartupClassification::Orphaned => RestoreOneOutcome::Dead,
+        | StartupClassification::Orphaned) => terminal_restore_outcome(terminal),
         StartupClassification::Recoverable => RestoreOneOutcome::Skip,
         StartupClassification::Held => RestoreOneOutcome::Held(Uncertainty::new(
             ProbeBoundary::SessionExists,
@@ -735,6 +758,51 @@ fn restore_one_agent(
 /// Local agents whose tmux session is gone but whose persisted worker PID is
 /// still alive are left Running with their binding preserved (PID-liveness
 /// fallback), rather than being marked Dead or revived.
+/// Classify every persisted agent into the revived, newly-dead and held sets.
+///
+/// An orphan's descendant tree is reaped here, while the agent still holds the
+/// binding whose anchors identify that tree, because the caller clears the
+/// binding when it buries the agent (issue #642).
+fn classify_agents_for_restore(
+    agents: Vec<Agent>,
+    repositories: &[jefe::domain::Repository],
+    runtime: &mut TmuxRuntimeManager,
+    runtime_warning: Option<&String>,
+) -> (Vec<RevivedAgent>, Vec<AgentId>, Vec<(AgentId, String)>) {
+    let mut revived_running = Vec::new();
+    let mut newly_dead = Vec::new();
+    let mut held: Vec<(AgentId, String)> = Vec::new();
+
+    for agent in agents {
+        match restore_one_agent(&agent, repositories, runtime, runtime_warning) {
+            RestoreOneOutcome::Revived(binding) => {
+                revived_running.push(RevivedAgent {
+                    agent_id: agent.id.clone(),
+                    binding,
+                });
+            }
+            RestoreOneOutcome::Dead => newly_dead.push(agent.id.clone()),
+            // Reap while the binding still carries the anchors, then bury.
+            RestoreOneOutcome::Orphaned => {
+                orphan_reconcile::reap_orphaned_agent(&agent);
+                newly_dead.push(agent.id.clone());
+            }
+            RestoreOneOutcome::Skip => {}
+            // Left exactly as persisted, including its binding.
+            RestoreOneOutcome::Held(reason) => {
+                warn!(
+                    agent_id = %agent.id.0,
+                    %reason,
+                    "startup held this agent: its state was not determined and was left untouched"
+                );
+                held.push((agent.id.clone(), reason.to_string()));
+            }
+        }
+    }
+
+    (revived_running, newly_dead, held)
+}
+
 pub fn restore_runtime_sessions(app_state: &mut HookState<AppState>, ctx: &SharedContext) {
     let Some(ctx_arc) = ctx else {
         return;
@@ -749,37 +817,13 @@ pub fn restore_runtime_sessions(app_state: &mut HookState<AppState>, ctx: &Share
         return;
     };
 
-    let mut revived_running = Vec::new();
-    let mut newly_dead = Vec::new();
-    let mut held: Vec<(AgentId, String)> = Vec::new();
     let runtime_warning: Option<String> = None;
-
-    for agent in agents {
-        match restore_one_agent(
-            &agent,
-            &repositories,
-            &mut ctx_guard.runtime,
-            runtime_warning.as_ref(),
-        ) {
-            RestoreOneOutcome::Revived(binding) => {
-                revived_running.push(RevivedAgent {
-                    agent_id: agent.id.clone(),
-                    binding,
-                });
-            }
-            RestoreOneOutcome::Dead => newly_dead.push(agent.id.clone()),
-            RestoreOneOutcome::Skip => {}
-            // Left exactly as persisted, including its binding.
-            RestoreOneOutcome::Held(reason) => {
-                warn!(
-                    agent_id = %agent.id.0,
-                    %reason,
-                    "startup held this agent: its state was not determined and was left untouched"
-                );
-                held.push((agent.id.clone(), reason.to_string()));
-            }
-        }
-    }
+    let (revived_running, newly_dead, held) = classify_agents_for_restore(
+        agents,
+        &repositories,
+        &mut ctx_guard.runtime,
+        runtime_warning.as_ref(),
+    );
 
     drop(ctx_guard);
 

--- a/src/app_init_orphan_reconcile.rs
+++ b/src/app_init_orphan_reconcile.rs
@@ -132,6 +132,9 @@ mod tests {
     fn restored_anchors_are_answered_by_observation_not_by_the_empty_short_circuit() {
         use jefe::runtime::OrphanClassification as Oc;
 
+        // u32::MAX is unallocatable on every supported platform (Linux caps
+        // pid_max at 2^22, macOS at 99998, Windows PIDs are multiples of 4), so
+        // the probe verdict here is fixed rather than racing the process table.
         let stale = vec![jefe::domain::WorkerProcessIdentity::new(u32::MAX, 1)];
 
         assert_eq!(

--- a/src/app_init_orphan_reconcile.rs
+++ b/src/app_init_orphan_reconcile.rs
@@ -115,6 +115,49 @@ mod tests {
         );
     }
 
+    /// Issue #642 AC4: the anchor set a restart hands to `orphan_evidence` is
+    /// what decides whether the reaper ever looks at the process table.
+    ///
+    /// An empty set — what every restore produced before the anchors were
+    /// persisted — short-circuits to `NoOrphan` *before* any descendant is
+    /// observed, which is the blind spot that leaked a process tree per
+    /// restart. A restored, non-empty set must get past that short-circuit and
+    /// be answered by observation instead.
+    ///
+    /// The anchors here name a PID that cannot exist, so observation is
+    /// deterministic and also pins the other half of AC4: a record whose
+    /// descendants are gone answers `DeadPaneNoWorker` rather than fabricating
+    /// an orphan out of a stale anchor.
+    #[test]
+    fn restored_anchors_are_answered_by_observation_not_by_the_empty_short_circuit() {
+        use jefe::runtime::OrphanClassification as Oc;
+
+        let stale = vec![jefe::domain::WorkerProcessIdentity::new(u32::MAX, 1)];
+
+        assert_eq!(
+            super::orphan_evidence(SessionEvidence::Missing, false, Some(&stale)),
+            Oc::DeadPaneNoWorker,
+            "restored anchors must be observed, and one that no longer matches is not an orphan"
+        );
+        assert_eq!(
+            super::orphan_evidence(SessionEvidence::Missing, false, Some(&Vec::new())),
+            Oc::NoOrphan,
+            "an empty anchor set is the pre-#642 blind spot: no observation happens at all"
+        );
+    }
+
+    /// Issue #642 AC6: a remote repository has no local process table to
+    /// observe, so restored anchors must not send it down the reaping path.
+    #[test]
+    fn a_remote_agent_never_reaps_even_with_restored_anchors() {
+        let stale = vec![jefe::domain::WorkerProcessIdentity::new(u32::MAX, 1)];
+        assert_eq!(
+            super::orphan_evidence(SessionEvidence::Missing, true, Some(&stale)),
+            jefe::runtime::OrphanClassification::NoOrphan,
+            "remote agents short-circuit before any local observation"
+        );
+    }
+
     #[test]
     fn dead_pane_without_orphans_is_not_orphaned() {
         // A dead pane with no surviving orphans must not take the Orphaned path.

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -783,3 +783,40 @@ fn an_agent_whose_repository_is_missing_is_held_not_buried() {
         "a repository we cannot find says nothing about whether the process is alive"
     );
 }
+
+/// An orphan is a dead pane whose validated worker descendants are still
+/// running, so it is the one terminal classification that has work to do
+/// before the agent is written off. The plain Dead route clears the runtime
+/// binding, and `reap_orphaned_agent` returns immediately without one, so
+/// folding Orphaned into Dead destroys the anchors the reap depends on and the
+/// leftover process tree survives every restart (issue #642).
+#[test]
+fn an_orphan_does_not_take_the_same_restore_route_as_a_plain_dead_agent() {
+    assert!(
+        !matches!(
+            terminal_restore_outcome(StartupClassification::Orphaned),
+            RestoreOneOutcome::Dead
+        ),
+        "Orphaned must stay distinguishable from Dead, or the reap is skipped"
+    );
+}
+
+/// The three classifications that carry no surviving descendants are genuinely
+/// finished and must keep taking the binding-clearing Dead route, so splitting
+/// the orphan out does not quietly strand ordinary dead agents.
+#[test]
+fn terminal_classifications_without_orphans_still_mark_the_agent_dead() {
+    for classification in [
+        StartupClassification::Stopped,
+        StartupClassification::Stale,
+        StartupClassification::Inconsistent,
+    ] {
+        assert!(
+            matches!(
+                terminal_restore_outcome(classification),
+                RestoreOneOutcome::Dead
+            ),
+            "{classification:?} has nothing left to reap and must still be marked Dead"
+        );
+    }
+}

--- a/src/app_init_tests.rs
+++ b/src/app_init_tests.rs
@@ -801,6 +801,58 @@ fn an_orphan_does_not_take_the_same_restore_route_as_a_plain_dead_agent() {
     );
 }
 
+/// Issue #642 AC5: the reap must see the orphan while it is still bound.
+///
+/// Burying an agent clears its runtime binding, and that binding holds the only
+/// anchors `reap_orphan_session` can match a surviving process against. So it is
+/// not enough that a reap happens somewhere on the orphan route — it has to
+/// happen while the anchors are still reachable, and the agent must still end up
+/// buried afterwards.
+#[test]
+fn an_orphan_is_reaped_while_it_still_carries_its_anchors() {
+    let (mut agent, repo) = code_puppy_agent_and_repository();
+    agent.status = AgentStatus::Running;
+    let request = AgentLaunchRequest::for_agent(&agent, &repo);
+    let launched_with = jefe::runtime::launch_compose::launch_signature_from_request(&request)
+        .unwrap_or_else(|error| panic!("fixture signature must compose: {error}"));
+    let anchors = vec![jefe::domain::WorkerProcessIdentity::new(4310, 111)];
+    agent.runtime_binding = Some(jefe::domain::RuntimeBinding {
+        session_name: RuntimeSession::session_name_for(&agent.id),
+        launch_signature: launched_with,
+        attached: false,
+        last_seen: None,
+        pane_identity: None,
+        worker_identity: None,
+        lifecycle_generation: 0,
+        worker_identities: anchors.clone(),
+    });
+
+    let mut sets = RestoreOutcomeSets::default();
+    let mut anchors_visible_to_the_reap = None;
+    record_restore_outcome(
+        &agent,
+        RestoreOneOutcome::Orphaned,
+        &mut sets,
+        &mut |orphan| {
+            anchors_visible_to_the_reap = orphan
+                .runtime_binding
+                .as_ref()
+                .map(|binding| binding.worker_identities.clone());
+        },
+    );
+
+    assert_eq!(
+        anchors_visible_to_the_reap,
+        Some(anchors),
+        "the reap must run before the bury, while the binding still names the tree to kill"
+    );
+    assert_eq!(
+        sets.newly_dead,
+        vec![agent.id.clone()],
+        "reaping the tree does not excuse the agent from being buried"
+    );
+}
+
 /// The three classifications that carry no surviving descendants are genuinely
 /// finished and must keep taking the binding-clearing Dead route, so splitting
 /// the orphan out does not quietly strand ordinary dead agents.

--- a/src/domain/state_contract.rs
+++ b/src/domain/state_contract.rs
@@ -192,6 +192,16 @@ pub struct RuntimeRecord {
     /// that inferred one from the other would reintroduce the conflation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worker_identity: Option<WorkerProcessIdentity>,
+    /// Validated worker descendants observed for this session (issue #642).
+    ///
+    /// These are the anchors the orphan reaper matches against. They must be
+    /// durable: after a restart the reaper has no other way to tell a
+    /// dead-launcher orphan tree from an ordinary stopped agent, and an empty
+    /// set makes `orphan_evidence` return `NoOrphan` before it observes
+    /// anything. Omitted when empty so documents written before #642 stay
+    /// byte-identical.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub worker_identities: Vec<WorkerProcessIdentity>,
 }
 
 /// Last persisted runtime observation.

--- a/src/domain/tests.rs
+++ b/src/domain/tests.rs
@@ -610,6 +610,7 @@ fn runtime_record_roundtrips_pane_and_worker_identities_separately() {
         last_known: crate::domain::state_contract::LastKnownRuntime::Running,
         pane_identity: Some(PaneProcessIdentity::new(1111, 7)),
         worker_identity: Some(WorkerProcessIdentity::new(2222, 9)),
+        worker_identities: Vec::new(),
     };
 
     let encoded = serde_json::to_string(&record)

--- a/src/persistence/migration.rs
+++ b/src/persistence/migration.rs
@@ -526,6 +526,9 @@ fn migrate_agent_record(
             // here; reconciliation re-observes them (issue #543).
             pane_identity: None,
             worker_identity: None,
+            // Schema-1 recorded no descendants either, so a migrated document
+            // starts with no orphan anchors (issue #642).
+            worker_identities: Vec::new(),
         },
     })
 }

--- a/src/state/durable_projection.rs
+++ b/src/state/durable_projection.rs
@@ -385,6 +385,13 @@ fn agent_record(
                 .runtime_binding
                 .as_ref()
                 .and_then(|binding| binding.worker_identity),
+            // The orphan reaper has no way to rediscover these after a
+            // restart, so they have to be durable (issue #642).
+            worker_identities: agent
+                .runtime_binding
+                .as_ref()
+                .map(|binding| binding.worker_identities.clone())
+                .unwrap_or_default(),
         },
     })
 }

--- a/src/state/durable_projection_tests.rs
+++ b/src/state/durable_projection_tests.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use crate::domain::{
     Agent, AgentId, AgentStatus, DormantRecord, Id, LastKnownRuntime, LaunchSignatureV1,
     PaneProcessIdentity, RemoteRepositorySettings, Repository, RepositoryId, RepositoryLocation,
-    RuntimeBinding, UserPreferences,
+    RuntimeBinding, UserPreferences, WorkerProcessIdentity,
 };
 use crate::persistence::state_v2::StateDocument;
 use crate::state::durable_projection::{current_launch_signature, to_durable_state};
@@ -732,5 +732,76 @@ fn forward_drops_a_remembered_agent_owned_by_another_repository() {
         durable.last_selected_agent_by_repo.is_empty(),
         "a cross-repository remembered selection must not be persisted, got: {:?}",
         durable.last_selected_agent_by_repo
+    );
+}
+
+/// Issue #642 AC1/AC2/AC3: the descendant anchors the orphan reaper matches
+/// against must survive a restart.
+///
+/// Before this fix the projection dropped `worker_identities` and the restore
+/// hardcoded `Vec::new()`, so `orphan_evidence` saw an empty anchor set on
+/// every startup, returned `NoOrphan`, and the reap never ran — leaking a
+/// session-host and a psmux server per restart.
+///
+/// The round trip goes through the real serialized document so the assertion
+/// covers the serde wiring, not just the in-memory structs.
+#[test]
+fn descendant_anchors_survive_the_durable_round_trip() {
+    let mut state = sample_state();
+    let anchors = vec![
+        WorkerProcessIdentity::new(4310, 111),
+        WorkerProcessIdentity::new(4311, 222),
+    ];
+    state.agents[0]
+        .runtime_binding
+        .as_mut()
+        .value_or_panic("the running agent has a binding")
+        .worker_identities
+        .clone_from(&anchors);
+
+    let projected = to_durable_state(&state).value_or_panic("projection succeeds");
+    assert_eq!(
+        projected.agents[0].runtime.worker_identities, anchors,
+        "the durable record must carry the descendant anchors in recorded order"
+    );
+
+    let encoded = serde_json::to_string(&projected).value_or_panic("serialize candidate");
+    let reparsed: crate::domain::StateV2 =
+        serde_json::from_str(&encoded).value_or_panic("deserialize candidate");
+
+    let restored = from_durable_state(&reparsed).value_or_panic("restore succeeds");
+    let binding = restored.agents[0]
+        .runtime_binding
+        .as_ref()
+        .value_or_panic("the restored running agent keeps its binding");
+    assert_eq!(
+        binding.worker_identities, anchors,
+        "the anchors must survive the round trip so orphan reaping works after a restart"
+    );
+}
+
+/// Issue #642 AC2: a document written before the anchors were persisted has no
+/// `worker_identities` key at all. It must still load, and an empty anchor set
+/// must stay out of the document so existing files and goldens are unchanged.
+#[test]
+fn a_document_without_descendant_anchors_restores_an_empty_set() {
+    let state = sample_state();
+    let projected = to_durable_state(&state).value_or_panic("projection succeeds");
+    let encoded = serde_json::to_vec_pretty(&projected).value_or_panic("serialize candidate");
+    let text = String::from_utf8(encoded).value_or_panic("candidate is utf-8");
+
+    assert!(
+        !text.contains("worker_identities"),
+        "an empty anchor set must be omitted so pre-#642 documents stay byte-identical"
+    );
+
+    let restored = from_durable_state(&projected).value_or_panic("restore succeeds");
+    let binding = restored.agents[0]
+        .runtime_binding
+        .as_ref()
+        .value_or_panic("the restored running agent keeps its binding");
+    assert!(
+        binding.worker_identities.is_empty(),
+        "a document without anchors must restore an empty set, not fail"
     );
 }

--- a/src/state/durable_projection_tests.rs
+++ b/src/state/durable_projection_tests.rs
@@ -783,19 +783,27 @@ fn descendant_anchors_survive_the_durable_round_trip() {
 /// Issue #642 AC2: a document written before the anchors were persisted has no
 /// `worker_identities` key at all. It must still load, and an empty anchor set
 /// must stay out of the document so existing files and goldens are unchanged.
+///
+/// The load goes through `StateDocument::parse` rather than straight into
+/// `from_durable_state`, because that is the boundary a real state.json crosses
+/// on startup — the one that also rejects duplicate keys and unknown fields. A
+/// keyless document has to survive the strict parser, not just serde defaults.
 #[test]
 fn a_document_without_descendant_anchors_restores_an_empty_set() {
     let state = sample_state();
     let projected = to_durable_state(&state).value_or_panic("projection succeeds");
     let encoded = serde_json::to_vec_pretty(&projected).value_or_panic("serialize candidate");
-    let text = String::from_utf8(encoded).value_or_panic("candidate is utf-8");
+    let text = String::from_utf8(encoded.clone()).value_or_panic("candidate is utf-8");
 
     assert!(
         !text.contains("worker_identities"),
         "an empty anchor set must be omitted so pre-#642 documents stay byte-identical"
     );
 
-    let restored = from_durable_state(&projected).value_or_panic("restore succeeds");
+    let parsed = StateDocument::parse(&encoded).unwrap_or_else(|diagnostics| {
+        panic!("a pre-#642 document must still parse: {diagnostics:?}")
+    });
+    let restored = from_durable_state(parsed.state()).value_or_panic("restore succeeds");
     let binding = restored.agents[0]
         .runtime_binding
         .as_ref()

--- a/src/state/durable_restore.rs
+++ b/src/state/durable_restore.rs
@@ -267,9 +267,10 @@ fn restore_agent(record: &AgentRecord, repository: &Repository) -> Projected<Age
             // re-observes liveness; these are anchors, not proof of life.
             pane_identity: record.runtime.pane_identity,
             worker_identity: record.runtime.worker_identity,
-            // The durable document records no descendant anchors (issue #332);
-            // startup reconciliation re-observes them.
-            worker_identities: Vec::new(),
+            // Restored from the document because nothing re-observes them: a
+            // restart is exactly when the reaper needs the anchors to tell a
+            // dead-launcher orphan tree from a stopped agent (issue #642).
+            worker_identities: record.runtime.worker_identities.clone(),
             lifecycle_generation: record.runtime.invocation_generation,
         });
     agent.persisted_launch_signature = Some(record.launch_signature.clone());


### PR DESCRIPTION
Fixes #642.

Not stacked. This sits directly on `main`; every commit here is #642 work.

It was briefly stacked. `main` did not compile (#650), so this branch carried a
one-line fix to have a base that built. #640 then landed the same change on
`main`, which resolved #650 and made the carried commit redundant — the two
versions of that line collided, which is what showed up as a conflict. The
carried commit has been dropped and both #653 and #650 are closed.

## The defect

`RuntimeBinding.worker_identities` was never written to the durable document and
was hardcoded to `Vec::new()` on restore. `orphan_evidence` short-circuits on
`identities.is_empty()`, so after a restart it always returned `NoOrphan`.
Startup then took the plain `Stopped` path and `reap_orphaned_agent` was never
called — leaking a `jefe-session-host.exe` + `psmux server` pair, and ~26 MB of
staged binary, for every dead-pane agent.

**A second defect, found while shaping the plan:** `restore_one_agent` mapped
`StartupClassification::Orphaned` to `RestoreOneOutcome::Dead` *without reaping*,
unlike `reconcile_running_agents`, which reaps before Dead-marking. Persisting
the anchors alone would still have leaked on the `restore_runtime_sessions`
route. Recorded in the scope ledger as in-scope, same defect.

## What changed

**Slice 1 — persist and restore the anchors** (AC1–AC3, AC6)
`worker_identities` is written to the schema-2 `RuntimeRecord` and restored from
it. The field is `skip_serializing_if` empty and `#[serde(default)]`, so existing
documents are byte-identical and a pre-#642 document still loads under
`deny_unknown_fields`. No migration, no schema bump.

**Slice 2 — reap on the restore route** (AC4, AC5)
`Orphaned` is split out of the combined Dead arm and reaps *before* the binding
is cleared, because the binding holds the only anchors identifying the tree.

## On the ordering test

The first version of the AC5 test only pinned the classification mapping — it
could prove an orphan is not a plain `Dead` agent, but nothing failed if the reap
moved *after* the bury, which is the property that actually matters.

`record_restore_outcome` now takes the reap as a parameter, so a test can observe
what the agent looked like at the moment it ran. Mutation-checked: deleting
`reap(agent);` fails `an_orphan_is_reaped_while_it_still_carries_its_anchors`
with `left: None` against the expected anchor.

## Review

One local OpenCodeReview run before opening (cap 2). Non-blocking; no Critical or
High. Seven Low findings triaged — 4 fixed, 1 rejected, 1 deferred, 1 doc-only.
Post-PR OCR and CodeRabbit both passed with no threads.

The rejected one proposed unifying the duplicated orphan arm across the two
restore loops; they differ in `Held` handling and signature, so unifying means
passing a parameter purely to suppress a warning path, for no behavioral gain.

The deferred one is filed as **#651**: an orphan whose probe answers
`Unavailable` is classified `Held`, keeps its binding, and is never revisited, so
its tree is never reaped. That is pre-existing #541 hold semantics meeting #332,
not a regression here, and the route never reaches `Orphaned` at all.

## Verification

On this exact head:

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | exit 0 |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo test --workspace --all-features` | exit 0 — **81 suites, 0 failed** |

The suite was re-run in full after the rebase onto current `main` (`b1c965bb`),
since the base moved four commits. All three gates still exit 0, and the four
#642 tests pass:

- `descendant_anchors_survive_the_durable_round_trip`
- `a_document_without_descendant_anchors_restores_an_empty_set`
- `an_orphan_does_not_take_the_same_restore_route_as_a_plain_dead_agent`
- `an_orphan_is_reaped_while_it_still_carries_its_anchors`

Full CI was green on the pre-rebase head
([30926325581](https://github.com/vybestack/llxprt-jefe/actions/runs/30926325581)):
Native Windows (MSVC + psmux), both coverage gates, and every policy check. It
re-runs here against the new base.

## Note on the refactor

Extracting `classify_agents_for_restore` was forced by the repo's 60-line
function gate, which fired once the orphan arm was added. The extraction keeps
the reap and the bury adjacent in one place rather than spread across the restore
entry point.

## Non-goals

Deriving descendants by walking the live process tree (the issue's alternative);
default-on logging; pruning superseded build-hash staging dirs; changing
`recover_server_lost_agents`; making `worker_identity_from_pane` return a worker
on Windows; any change to `reap_orphan_session` mechanics.
