### PR TITLE
Preserve LLxprt sandbox settings across saves (Fixes #652)

### DIFF
--- a/dev-docs/tmux-scenarios/issue652/llxprt-sandbox-save.json
+++ b/dev-docs/tmux-scenarios/issue652/llxprt-sandbox-save.json
@@ -1,0 +1,181 @@
+{
+  "schema": 1,
+  "name": "llxprt-sandbox-save",
+  "platform": "macos",
+  "terminal": {
+    "cols": 120,
+    "rows": 40
+  },
+  "workspace": {
+    "mode": 448,
+    "dirs": [
+      {
+        "path": "config",
+        "mode": 448
+      },
+      {
+        "path": "work",
+        "mode": 448
+      }
+    ],
+    "files": [
+      {
+        "path": "config/settings.toml",
+        "content": {
+          "utf8": "settings_schema = 2\n"
+        },
+        "mode": 384
+      },
+      {
+        "path": "config/state.json",
+        "content": {
+          "utf8": "{\n  \"state_schema\": 2,\n  \"revision\": 1,\n  \"repositories\": [\n    {\n      \"id\": \"repo.sandbox\",\n      \"location\": {\n        \"local_path\": \".\"\n      },\n      \"display_name\": \"Sandbox Fixture\",\n      \"agent_defaults\": {\n        \"type_id\": \"core.llxprt\",\n        \"values\": {}\n      }\n    }\n  ],\n  \"agents\": [],\n  \"selection\": {\n    \"repository_id\": \"repo.sandbox\",\n    \"agent_id\": null,\n    \"screen_id\": \"core.dashboard\"\n  },\n  \"last_selected_agent_by_repo\": {},\n  \"preferences\": {\n    \"hide_idle_repositories\": false,\n    \"pane_focus\": \"agents\",\n    \"terminal_focused\": false,\n    \"repository_preferences\": {}\n  },\n  \"dormant_records\": []\n}\n"
+        },
+        "mode": 384
+      }
+    ],
+    "env": []
+  },
+  "steps": [
+    {
+      "op": "launch",
+      "argv": [
+        "jefe",
+        "--config",
+        "${workspace}/config"
+      ],
+      "env": [
+        {
+          "name": "JEFE_STATE_PATH",
+          "value": "${workspace}/config/state.json"
+        }
+      ],
+      "cwd": "work"
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Sandbox Fixture",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "key",
+      "key": "n",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "New Agent",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "key",
+      "key": "tab",
+      "modifiers": []
+    },
+    {
+      "op": "text",
+      "text": "Sandboxed LLxprt"
+    },
+    {
+      "op": "key",
+      "key": "tab",
+      "modifiers": []
+    },
+    {
+      "op": "key",
+      "key": "tab",
+      "modifiers": []
+    },
+    {
+      "op": "key",
+      "key": "tab",
+      "modifiers": []
+    },
+    {
+      "op": "key",
+      "key": "tab",
+      "modifiers": []
+    },
+    {
+      "op": "key",
+      "key": "tab",
+      "modifiers": []
+    },
+    {
+      "op": "key",
+      "key": "tab",
+      "modifiers": []
+    },
+    {
+      "op": "key",
+      "key": "tab",
+      "modifiers": []
+    },
+    {
+      "op": "key",
+      "key": "tab",
+      "modifiers": []
+    },
+    {
+      "op": "key",
+      "key": "tab",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Sandbox          [ ]",
+      "timeout_ms": 5000
+    },
+    {
+      "op": "key",
+      "key": "space",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Sandbox          [x]",
+      "timeout_ms": 5000
+    },
+    {
+      "op": "key",
+      "key": "enter",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Sandboxed LLxprt",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "key",
+      "key": "f12",
+      "modifiers": []
+    },
+    {
+      "op": "key",
+      "key": "enter",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Edit Agent",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "assert-frame",
+      "contains": [
+        "Sandbox          [x]",
+        "Sandbox Engine   [Podman]",
+        "Sandbox Flags    [--cpus=2 --memory=12288m --pids-limit=256]"
+      ],
+      "absent": []
+    }
+  ],
+  "secrets": []
+}

--- a/project-plans/issue652-plan.md
+++ b/project-plans/issue652-plan.md
@@ -1,0 +1,103 @@
+# Issue 652: Preserve LLxprt sandbox settings when saving agents on macOS
+
+Issue: https://github.com/vybestack/llxprt-jefe/issues/652
+
+## Summary
+
+On macOS, enabling Sandbox in the LLxprt agent form does not survive Save. Reopening the agent shows Sandbox disabled, so Jefe cannot launch that agent with the requested sandbox configuration.
+
+## Regression analysis
+
+The definition-driven agent cutover in PR 501 moved persisted launch configuration into typed definition values, but the shipped LLxprt definition does not declare sandbox_enabled, sandbox_engine, or sandbox_flags. The creation service only copies form values for fields declared by the active definition, so all three sandbox form inputs are dropped on save.
+
+The Edit Agent projection independently hard-codes sandboxing to disabled with the default engine and flags rather than reading typed agent values. The LLxprt definition also lacks emitters for the sandbox CLI options and SANDBOX_FLAGS environment variable, so manually migrated values cannot fully affect a launch.
+
+## Acceptance matrix
+
+| ID | Actor / path | Input and target | Observable success | Failure behavior / side effects | Persistence and compatibility | Proof |
+|---|---|---|---|---|---|---|
+| AC1 | User creates a local LLxprt agent on macOS | Sandbox enabled; supported engine selected; flags entered | Saved agent retains enabled state, canonical engine, and flags; launch planning emits the sandbox option, engine option, and raw SANDBOX_FLAGS value | Invalid typed values fail before runtime launch effects | Values survive durable-state projection and reload; existing schema-2 values remain readable | Reducer/service behavioral test plus definition-driven launch-plan test |
+| AC2 | User edits an existing sandbox-enabled LLxprt agent | Open Edit Agent without changing sandbox fields, then Save | Form initially reflects the persisted enabled state, engine, and flags; save preserves them | Missing optional legacy values project to current unsandboxed defaults without mutating the agent merely by opening the form | Migrated sandbox values remain editable and are not reset | Form projection and submit regression test |
+| AC3 | User saves an unsandboxed LLxprt agent | Sandbox disabled | Agent remains unsandboxed and launch emits no sandbox option, engine option, or SANDBOX_FLAGS | No sandbox preflight or runtime side effects | Current default remains unchanged | Negative launch-plan test |
+| AC4 | Unsupported/non-LLxprt agent path | Sandbox values absent or stale | Other agent definitions do not gain LLxprt sandbox behavior | No unrelated definition or launch behavior changes | Existing typed values are preserved according to current generic persistence rules | Existing definition and cross-agent suites |
+
+## Non-goals
+
+- Changing which sandbox engines macOS or Linux supports.
+- Adding a new sandbox engine or runtime.
+- Redesigning the New/Edit Agent form.
+- Changing LLxprt sandbox semantics beyond restoring the existing Sandbox, Sandbox Engine, and Sandbox Flags controls.
+- Changing dependencies, persistence schema version, workflow tooling, or quality gates.
+
+## Planned vertical slices
+
+### Slice 1: Typed save and edit projection
+
+- Acceptance rows: AC1, AC2, AC3, AC4.
+- Owners: shipped definition metadata, agent-form state projection, and the existing canonical creation/update boundary.
+- Allowed paths: src/domain/agent_definition/shipped/llxprt.rs, src/services/mod.rs, src/services/tests.rs, src/state/form_build.rs, src/state/modal_ops.rs, and focused state tests.
+- RED: service and reducer tests show enabled/engine/flags are discarded and Edit Agent reopens disabled.
+- GREEN: LLxprt declares all three typed fields; New Agent and Edit Agent save and reload their values; disabled remains the default; other agent definitions remain unchanged.
+- Non-goals: no new form framework or persistence schema.
+- Focused verification: targeted Rust tests, cargo fmt, cargo xtask quick.
+- Stop condition: a new public abstraction, schema change, or fourth ownership layer is required.
+
+### Slice 2: Effective definition-driven launch
+
+- Acceptance rows: AC1, AC3, AC4.
+- Owners: shipped LLxprt definition and pure local launch planner.
+- Allowed paths: src/domain/agent_definition/shipped/llxprt.rs and tests/agent_local_plan.rs, with a helper change only if the existing closed emitter model cannot express the accepted behavior.
+- RED: enabled typed values do not emit the LLxprt sandbox argv/env contract.
+- GREEN: enabled values emit --sandbox, --sandbox-engine with the canonical value, and raw SANDBOX_FLAGS; disabled values emit none of them.
+- Non-goals: no launch planner redesign and no changes to sandbox preflight ordering.
+- Focused verification: agent_local_plan tests, cargo xtask quick.
+- Stop condition: conditional behavior requires changing the generic emitter schema or another orchestration route.
+
+### Slice 3: UI scenario and compatibility verification
+
+- Acceptance rows: AC1, AC2, AC3.
+- Owners: deterministic TUI harness and generic durable projection tests.
+- Allowed paths: dev-docs/tmux-scenarios/issue652/, a focused issue652 behavior test, and existing persistence tests if needed.
+- RED: scenario saves an enabled LLxprt sandbox and Edit Agent shows it disabled.
+- GREEN: scenario observes enabled sandbox after save/reopen; typed values survive state projection/restore.
+- Non-goals: no visual redesign.
+- Verification: tmux harness scenario, full make ci-check, OCR, rustreviewer, and exact-head checks.
+- Stop condition: fixture changes outside issue652 or quality-tool changes are required.
+
+## Expected paths by ownership layer
+
+- Definition/domain: src/domain/agent_definition/shipped/llxprt.rs and focused definition/plan tests.
+- Service/state projection: src/services/mod.rs, src/services/tests.rs, src/state/form_build.rs, src/state/modal_ops.rs, and focused state tests.
+- UI behavior: dev-docs/tmux-scenarios/issue652/ plus focused behavior-test registration.
+- Persistence: tests only unless behavioral evidence identifies a generic projection defect; typed maps are already serialized generically.
+
+## Scope ledger
+
+| Discovery | Disposition |
+|---|---|
+| LLxprt sandbox fields omitted from the shipped definition | In-scope: root cause |
+| Edit Agent hard-codes sandbox disabled | In-scope: required to preserve Save/Edit behavior |
+| LLxprt sandbox emitters omitted | In-scope: required for the persisted setting to be usable |
+| Startup sandbox normalization is currently a no-op | Out of scope: no acceptance test showed it blocks this fix |
+| The flag emitter resolves capability IDs from normalized field names | In-scope: rename the LLxprt capability ID to sandbox-enabled and update preflight lookup |
+| LLxprt definition changes alter migration launch-signature hashes | In-scope: update the fixed definition and typed-value hash vectors |
+| Disabled legacy records could contain stale nonempty engine/flag values | Reject expansion: accepted save paths clear these values; conditional generic emitters remain an explicit non-goal |
+
+## Review counters
+
+- Local Open Code Review: 1/2
+- Post-PR Open Code Review: 0/2
+- Independent review cycles: 1/2
+
+## Verification evidence
+
+- Focused state, service, launch-plan, migration-vector, durable round-trip, atomic rejection, and scenario-grammar tests pass.
+- macOS tmux scenario llxprt-sandbox-save passes all 24 steps in a fresh isolated workspace after review remediation.
+- cargo xtask quick passed before review; exact-head focused tests, format, and strict Clippy pass after remediation.
+- Detached coverage passes at 71.80% lines, above the 30% floor; locked all-feature build and tests pass.
+- Final exact-head cargo xtask ci passes all stages; coverage is 71.80% lines. Evidence is recorded in /tmp/issue652-ci-final.log.
+- DeepThinker and rustreviewer findings were classified and remediated; local OCR reviewed 16 files and its three findings were fixed (two duplicate atomic-edit findings and one disabled-migration assertion gap).
+
+## Deferred findings and follow-ups
+
+None.

--- a/src/domain/agent_definition/shipped/llxprt.rs
+++ b/src/domain/agent_definition/shipped/llxprt.rs
@@ -13,8 +13,8 @@ use super::super::types::{
     OperationMatrix, OperationSupport, PromptShape, Support, TargetMatrix, TargetSupport,
 };
 use super::common::{
-    DefinitionParts, assemble, bool_field_with_default, line_version_probe, npm_candidate,
-    path_candidate, sig_string_field, trusted_capability_probe,
+    DefinitionParts, assemble, bool_field, bool_field_with_default, enum_field, line_version_probe,
+    npm_candidate, path_candidate, sig_string_field, trusted_capability_probe,
 };
 
 fn emitters() -> Vec<Emitter> {
@@ -35,6 +35,17 @@ fn emitters() -> Vec<Emitter> {
         },
         Emitter::Flag {
             field: "continue".to_string(),
+        },
+        Emitter::Flag {
+            field: "sandbox_enabled".to_string(),
+        },
+        Emitter::Option {
+            name: "--sandbox-engine".to_string(),
+            field: "sandbox_engine".to_string(),
+        },
+        Emitter::Environment {
+            name: "SANDBOX_FLAGS".to_string(),
+            field: "sandbox_flags".to_string(),
         },
     ]
 }
@@ -88,6 +99,9 @@ pub fn build() -> AgentDefinition {
             sig_string_field("prompt"),
             bool_field_with_default("prompt_interactive", Some(true)),
             bool_field_with_default("continue", Some(true)),
+            bool_field("sandbox_enabled"),
+            enum_field("sandbox_engine", &["podman", "docker", "sandbox-exec"]),
+            sig_string_field("sandbox_flags"),
         ],
         emitters: emitters(),
     })
@@ -100,7 +114,7 @@ fn llxprt_probe() -> super::super::probe::ProbeSpec {
             &[
                 ("prompt-interactive", "--prompt-interactive"),
                 ("profile", "--profile-load"),
-                ("sandbox", "--sandbox"),
+                ("sandbox-enabled", "--sandbox"),
                 ("sandbox-engine", "--sandbox-engine"),
                 ("yolo", "--yolo"),
                 ("approval", "--approval-mode"),

--- a/src/domain/sandbox.rs
+++ b/src/domain/sandbox.rs
@@ -6,10 +6,69 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::agent_definition::AgentDefinition;
+use super::{Id, TypedMap, TypedValue};
+
 /// Default sandbox resource flags passed to llxprt via SANDBOX_FLAGS.
 ///
 /// Memory is expressed in MiB to avoid unitless podman/crun interpretation issues.
 pub const DEFAULT_SANDBOX_FLAGS: &str = "--cpus=2 --memory=12288m --pids-limit=256";
+
+/// Project the fixed LLxprt sandbox form controls into definition-owned values.
+///
+/// Disabled forms remove dependent values so ordinary option/environment
+/// emitters remain silent. Enabled forms reject unknown engines before either
+/// preview or persistence can observe an invalid enum value.
+pub fn apply_sandbox_form_values(
+    values: &mut TypedMap,
+    definition: &AgentDefinition,
+    enabled: bool,
+    engine: &str,
+    flags: &str,
+) -> Option<()> {
+    set_declared_value(
+        values,
+        definition,
+        "sandbox_enabled",
+        Some(TypedValue::Bool(enabled)),
+    )?;
+    let engine = enabled
+        .then(|| SandboxEngine::from_form_value(engine))
+        .flatten()
+        .map(|engine| TypedValue::String(engine.as_llxprt_arg().to_owned()));
+    if enabled && engine.is_none() {
+        return None;
+    }
+    set_declared_value(values, definition, "sandbox_engine", engine)?;
+    let flags = enabled
+        .then(|| flags.trim())
+        .filter(|flags| !flags.is_empty())
+        .map(|flags| TypedValue::String(flags.to_owned()));
+    set_declared_value(values, definition, "sandbox_flags", flags)
+}
+
+fn set_declared_value(
+    values: &mut TypedMap,
+    definition: &AgentDefinition,
+    field_id: &str,
+    value: Option<TypedValue>,
+) -> Option<()> {
+    let declared = definition
+        .repository_fields
+        .iter()
+        .chain(definition.agent_fields.iter())
+        .any(|field| field.id == field_id);
+    if !declared {
+        return Some(());
+    }
+    let key = Id::parse(&field_id.replace('_', "-")).ok()?;
+    if let Some(value) = value {
+        values.insert(key, value);
+    } else {
+        values.remove(&key);
+    }
+    Some(())
+}
 
 /// Sandbox engine to use when launching llxprt sessions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/src/domain/sandbox.rs
+++ b/src/domain/sandbox.rs
@@ -26,19 +26,18 @@ pub fn apply_sandbox_form_values(
     engine: &str,
     flags: &str,
 ) -> Option<()> {
+    let engine = if enabled {
+        let engine = SandboxEngine::from_form_value(engine)?;
+        Some(TypedValue::String(engine.as_llxprt_arg().to_owned()))
+    } else {
+        None
+    };
     set_declared_value(
         values,
         definition,
         "sandbox_enabled",
         Some(TypedValue::Bool(enabled)),
     )?;
-    let engine = enabled
-        .then(|| SandboxEngine::from_form_value(engine))
-        .flatten()
-        .map(|engine| TypedValue::String(engine.as_llxprt_arg().to_owned()));
-    if enabled && engine.is_none() {
-        return None;
-    }
     set_declared_value(values, definition, "sandbox_engine", engine)?;
     let flags = enabled
         .then(|| flags.trim())
@@ -70,6 +69,32 @@ fn set_declared_value(
     Some(())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::agent_definition::shipped::shipped_definitions;
+
+    #[test]
+    fn invalid_enabled_engine_does_not_mutate_values() {
+        let definition = shipped_definitions()
+            .into_iter()
+            .find(|definition| definition.id.as_str() == "core.llxprt")
+            .unwrap_or_else(|| panic!("shipped LLxprt definition must exist"));
+        let mut values = TypedMap::new();
+
+        assert!(
+            apply_sandbox_form_values(
+                &mut values,
+                &definition,
+                true,
+                "unknown",
+                DEFAULT_SANDBOX_FLAGS,
+            )
+            .is_none()
+        );
+        assert!(values.is_empty());
+    }
+}
 /// Sandbox engine to use when launching llxprt sessions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]

--- a/src/persistence/migration.rs
+++ b/src/persistence/migration.rs
@@ -595,15 +595,28 @@ fn agent_values(
             json!(agent_version_selector(source, definition)),
         )?;
     }
+    apply_schema1_sandbox_values(&mut values, definition, source)?;
+    Ok(values)
+}
+
+fn apply_schema1_sandbox_values(
+    values: &mut TypedMap,
+    definition: &AgentDefinition,
+    source: &Schema1Agent,
+) -> Result<(), String> {
     crate::domain::apply_sandbox_form_values(
-        &mut values,
+        values,
         definition,
         source.sandbox_enabled,
         &source.sandbox_engine,
         &source.sandbox_flags,
     )
-    .ok_or_else(|| "schema-1 sandbox engine is invalid".to_owned())?;
-    Ok(values)
+    .ok_or_else(|| {
+        format!(
+            "schema-1 sandbox engine is invalid: {}",
+            source.sandbox_engine
+        )
+    })
 }
 
 fn agent_version_selector(source: &Schema1Agent, definition: &AgentDefinition) -> String {

--- a/src/persistence/migration.rs
+++ b/src/persistence/migration.rs
@@ -595,6 +595,14 @@ fn agent_values(
             json!(agent_version_selector(source, definition)),
         )?;
     }
+    crate::domain::apply_sandbox_form_values(
+        &mut values,
+        definition,
+        source.sandbox_enabled,
+        &source.sandbox_engine,
+        &source.sandbox_flags,
+    )
+    .ok_or_else(|| "schema-1 sandbox engine is invalid".to_owned())?;
     Ok(values)
 }
 

--- a/src/persistence/migration_tests.rs
+++ b/src/persistence/migration_tests.rs
@@ -103,6 +103,28 @@ fn assert_agent_migration(state: &crate::domain::StateV2) {
         state.agents[2].values.get(&id("continue")),
         Some(&TypedValue::Bool(true))
     );
+    assert_agent_sandbox_migration(state);
+}
+
+fn assert_agent_sandbox_migration(state: &crate::domain::StateV2) {
+    assert_eq!(
+        state.agents[0].values.get(&id("sandbox-enabled")),
+        Some(&TypedValue::Bool(true))
+    );
+    assert_eq!(
+        state.agents[0].values.get(&id("sandbox-engine")),
+        Some(&TypedValue::String("podman".to_owned()))
+    );
+    assert_eq!(
+        state.agents[0].values.get(&id("sandbox-flags")),
+        Some(&TypedValue::String("--network=none".to_owned()))
+    );
+    assert_eq!(
+        state.agents[2].values.get(&id("sandbox-enabled")),
+        Some(&TypedValue::Bool(false))
+    );
+    assert_eq!(state.agents[2].values.get(&id("sandbox-engine")), None);
+    assert_eq!(state.agents[2].values.get(&id("sandbox-flags")), None);
 }
 
 fn assert_selection_and_preferences(state: &crate::domain::StateV2) {
@@ -285,11 +307,11 @@ fn assert_remote_fixed_vectors(
     );
     assert_eq!(
         agent.launch_signature.definition_hash.as_str(),
-        "d09d5816c4c8a086d77b3697a1ab2813abbc7ca3088f213020ac3edf44e8aa54"
+        "c632122bfd8613411b520e4739ae0b9bf1215a68f9db36468ed25ae1fd8851eb"
     );
     assert_eq!(
         agent.launch_signature.typed_value_hash.as_str(),
-        "05edfa415d993814a476ab0f17efcdc7a075052614e04370cb4124812d837570"
+        "9eda2bd58c4fc6f298a449c4addedadc06f7b9b2a1243665f21bcbcb748e5afc"
     );
     assert_eq!(
         crate::domain::canonical_values::typed_field(&agent.values, "continue"),

--- a/src/runtime/launch_compose.rs
+++ b/src/runtime/launch_compose.rs
@@ -630,12 +630,24 @@ fn launch_field(
         return Ok(None);
     }
     typed_field(values, &field.id)
-        .map(|value| to_field_value(field.kind, value))
+        .map(|value| to_field_value(field, value))
         .transpose()
 }
 
-fn to_field_value(kind: FieldKind, value: &TypedValue) -> Result<FieldValue, RuntimeError> {
-    let converted = match (kind, value) {
+fn to_field_value(
+    field: &crate::domain::agent_definition::Field,
+    value: &TypedValue,
+) -> Result<FieldValue, RuntimeError> {
+    if field.kind == FieldKind::Enum
+        && let TypedValue::String(value) = value
+        && !field.choices.iter().any(|choice| choice == value)
+    {
+        return Err(RuntimeError::SpawnFailed(format!(
+            "{} is not a valid value for {}",
+            value, field.id
+        )));
+    }
+    let converted = match (field.kind, value) {
         (FieldKind::Boolean, TypedValue::Bool(value)) => FieldValue::Boolean(*value),
         (FieldKind::OptionalBoolean, TypedValue::Bool(value)) => {
             FieldValue::OptionalBoolean(Some(*value))

--- a/src/runtime/launch_compose_tests.rs
+++ b/src/runtime/launch_compose_tests.rs
@@ -112,6 +112,46 @@ fn prepare_fresh_plan(operation: Operation) -> AgentLaunchPlan {
 }
 
 #[test]
+fn llxprt_sandbox_does_not_require_image_preflight() {
+    let definition = llxprt();
+    let mut values = typed_values(true);
+    values.insert(
+        Id::parse("sandbox-enabled").unwrap_or_else(|error| panic!("valid key: {error}")),
+        TypedValue::Bool(true),
+    );
+    values.insert(
+        Id::parse("sandbox-engine").unwrap_or_else(|error| panic!("valid key: {error}")),
+        TypedValue::String("podman".to_owned()),
+    );
+
+    let preflight = preflight_contract(&definition, &values)
+        .unwrap_or_else(|error| panic!("sandbox values must project: {error}"));
+
+    assert!(!preflight.required);
+    assert!(!preflight.is_unavailable());
+}
+
+#[test]
+fn launch_values_reject_unknown_enum_member() {
+    let definition = llxprt();
+    let mut values = typed_values(true);
+    values.insert(
+        Id::parse("sandbox-engine").unwrap_or_else(|error| panic!("valid key: {error}")),
+        TypedValue::String("unknown".to_owned()),
+    );
+
+    let error = launch_values(&definition, &values, Operation::Normal)
+        .err()
+        .unwrap_or_else(|| panic!("unknown enum member must fail"));
+
+    assert!(
+        error
+            .to_string()
+            .contains("not a valid value for sandbox_engine")
+    );
+}
+
+#[test]
 fn fresh_llxprt_plan_emits_one_prompt_without_continuation() {
     for operation in [Operation::FreshIssue, Operation::FreshPullRequest] {
         let plan = prepare_fresh_plan(operation);

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -22,6 +22,7 @@ use std::path::PathBuf;
 
 use crate::domain::{
     Agent, AgentId, AgentLaunchRequest, AgentStatus, QuickResume, Repository, TypedMap, TypedValue,
+    apply_sandbox_form_values,
 };
 
 pub(crate) use normalize::{expand_tilde, normalize_profile};
@@ -138,6 +139,20 @@ fn selected_version(params: &CreateAgentParams<'_>) -> String {
         .to_owned()
 }
 
+fn insert_sandbox_values(
+    values: &mut TypedMap,
+    definition: &crate::domain::agent_definition::AgentDefinition,
+    params: &CreateAgentParams<'_>,
+) -> Option<()> {
+    apply_sandbox_form_values(
+        values,
+        definition,
+        params.sandbox_enabled,
+        params.sandbox_engine,
+        params.sandbox_flags,
+    )
+}
+
 fn creation_values(
     params: &CreateAgentParams<'_>,
     definition: &crate::domain::agent_definition::AgentDefinition,
@@ -200,6 +215,7 @@ fn creation_values(
         "continue",
         TypedValue::Bool(params.pass_continue),
     )?;
+    insert_sandbox_values(&mut values, definition, params)?;
     Some(values)
 }
 

--- a/src/services/tests.rs
+++ b/src/services/tests.rs
@@ -140,6 +140,44 @@ fn create_agent_maps_declared_yolo_input_to_typed_values() {
 }
 
 #[test]
+fn create_agent_maps_enabled_sandbox_to_typed_values() {
+    let repo = local_repository();
+    let agent = created(CreateAgentParams {
+        sandbox_enabled: true,
+        sandbox_engine: "Docker",
+        sandbox_flags: "  --network none  ",
+        ..params(&repo, "Agent", "/tmp/agent")
+    });
+    assert_eq!(
+        typed_field(&agent.values, "sandbox_enabled"),
+        Some(&TypedValue::Bool(true))
+    );
+    assert_eq!(
+        typed_field(&agent.values, "sandbox_engine"),
+        Some(&TypedValue::String("docker".to_owned()))
+    );
+    assert_eq!(
+        typed_field(&agent.values, "sandbox_flags"),
+        Some(&TypedValue::String("--network none".to_owned()))
+    );
+}
+
+#[test]
+fn create_agent_clears_sandbox_configuration_when_disabled() {
+    let repo = local_repository();
+    let agent = created(CreateAgentParams {
+        sandbox_engine: "Docker",
+        sandbox_flags: "--network none",
+        ..params(&repo, "Agent", "/tmp/agent")
+    });
+    assert_eq!(
+        typed_field(&agent.values, "sandbox_enabled"),
+        Some(&TypedValue::Bool(false))
+    );
+    assert_eq!(typed_field(&agent.values, "sandbox_engine"), None);
+    assert_eq!(typed_field(&agent.values, "sandbox_flags"), None);
+}
+#[test]
 fn create_agent_expands_tilde_for_local_repository() {
     let Some(home) = std::env::var_os("HOME") else {
         // No HOME set in this environment; tilde expansion is a no-op, which is

--- a/src/state/durable_projection_tests.rs
+++ b/src/state/durable_projection_tests.rs
@@ -386,6 +386,43 @@ fn inverse_restores_runtime_fields_from_projection() {
 }
 
 #[test]
+fn llxprt_sandbox_values_survive_durable_projection_and_restore() {
+    let mut state = sample_state();
+    let values = &mut state.agents[0].values;
+    values.insert(
+        Id::parse("sandbox-enabled").value_or_panic("sandbox enabled key"),
+        crate::domain::TypedValue::Bool(true),
+    );
+    values.insert(
+        Id::parse("sandbox-engine").value_or_panic("sandbox engine key"),
+        crate::domain::TypedValue::String("docker".to_owned()),
+    );
+    values.insert(
+        Id::parse("sandbox-flags").value_or_panic("sandbox flags key"),
+        crate::domain::TypedValue::String("--network none".to_owned()),
+    );
+
+    let projected = to_durable_state(&state).value_or_panic("projection succeeds");
+    let restored = from_durable_state(&projected).value_or_panic("restore succeeds");
+    let restored_values = &restored.agents[0].values;
+
+    assert_eq!(
+        restored_values.get(&Id::parse("sandbox-enabled").value_or_panic("enabled key")),
+        Some(&crate::domain::TypedValue::Bool(true))
+    );
+    assert_eq!(
+        restored_values.get(&Id::parse("sandbox-engine").value_or_panic("engine key")),
+        Some(&crate::domain::TypedValue::String("docker".to_owned()))
+    );
+    assert_eq!(
+        restored_values.get(&Id::parse("sandbox-flags").value_or_panic("flags key")),
+        Some(&crate::domain::TypedValue::String(
+            "--network none".to_owned()
+        ))
+    );
+}
+
+#[test]
 fn inverse_restores_remote_settings_including_base_dir() {
     let state = sample_state();
     let projected = to_durable_state(&state).value_or_panic("projection succeeds");

--- a/src/state/form_build.rs
+++ b/src/state/form_build.rs
@@ -3,7 +3,7 @@
 use crate::domain::agent_definition::{AgentDefinition, AgentTypeId, FieldKind, FieldValue};
 use crate::domain::{
     Agent, AgentId, AgentStatus, Id, RemoteRepositorySettings, Repository, RepositoryId, TypedMap,
-    TypedValue, is_valid_github_component,
+    TypedValue, apply_sandbox_form_values, is_valid_github_component,
 };
 use tracing::warn;
 
@@ -204,7 +204,7 @@ impl AppState {
         } else {
             default_values(&definition)
         };
-        merge_agent_values(&definition, fields, &mut values);
+        merge_agent_values(&definition, fields, &mut values)?;
         let mut agent = Agent::new(
             AgentId(generate_id("agent")),
             repository.id.clone(),
@@ -229,16 +229,28 @@ impl AppState {
         agent: &mut Agent,
         repository: &Repository,
         fields: &AgentFormFields,
-    ) {
+    ) -> bool {
         let Some(type_id) = active_type_id(&fields.agent_type_id) else {
-            return;
+            return false;
         };
         let Some(definition) = definition_for_type(&type_id) else {
-            return;
+            return false;
         };
         let trimmed_name = fields.name.trim();
         if trimmed_name.is_empty() {
-            return;
+            return false;
+        }
+        let mut values = if agent.type_id == type_id {
+            let mut values = agent.values.clone();
+            remove_replaced_agent_values(&definition, &mut values);
+            values
+        } else if repository.default_type_id == type_id {
+            repository.default_values.clone()
+        } else {
+            default_values(&definition)
+        };
+        if merge_agent_values(&definition, fields, &mut values).is_none() {
+            return false;
         }
         trimmed_name.clone_into(&mut agent.name);
         agent.shortcut_slot = fields.shortcut_slot;
@@ -255,18 +267,9 @@ impl AppState {
             }
             agent.work_dir = std::path::PathBuf::from(new_dir);
         }
-        let mut values = if agent.type_id == type_id {
-            let mut values = agent.values.clone();
-            remove_replaced_agent_values(&definition, &mut values);
-            values
-        } else if repository.default_type_id == type_id {
-            repository.default_values.clone()
-        } else {
-            default_values(&definition)
-        };
-        merge_agent_values(&definition, fields, &mut values);
         agent.type_id = type_id;
         agent.values = values;
+        true
     }
 }
 
@@ -358,7 +361,7 @@ fn merge_agent_values(
     definition: &AgentDefinition,
     fields: &AgentFormFields,
     values: &mut TypedMap,
-) {
+) -> Option<()> {
     for field in &definition.repository_fields {
         let value = match field.id.as_str() {
             "profile" => Some(FieldValue::String(fields.profile.trim().to_owned())),
@@ -405,6 +408,13 @@ fn merge_agent_values(
             insert_field_value(values, &field.id, value);
         }
     }
+    apply_sandbox_form_values(
+        values,
+        definition,
+        fields.sandbox_enabled,
+        &fields.sandbox_engine,
+        &fields.sandbox_flags,
+    )
 }
 
 fn insert_field_value(values: &mut TypedMap, field: &str, value: FieldValue) {

--- a/src/state/form_ops_tests.rs
+++ b/src/state/form_ops_tests.rs
@@ -276,6 +276,55 @@ fn create_agent_rejects_whitespace_only_work_dir() {
 }
 
 #[test]
+fn agent_form_rejects_unknown_enabled_sandbox_engine() {
+    let fields = AgentFormFields {
+        sandbox_enabled: true,
+        sandbox_engine: "unknown".to_owned(),
+        ..AgentFormFields::default()
+    };
+
+    let error = AppState::validate_agent_form_fields(&fields)
+        .err()
+        .unwrap_or_else(|| panic!("unknown enabled engine must be rejected"));
+    assert_eq!(error, "Sandbox engine must be Podman, Docker, or Seatbelt");
+}
+
+#[test]
+fn rejected_sandbox_engine_does_not_partially_update_agent() {
+    let repository = seed_repository();
+    let mut agent = Agent::new(
+        crate::domain::AgentId("agent-invalid-sandbox".to_owned()),
+        repository.id.clone(),
+        crate::domain::shipped_agent_type(3),
+        crate::domain::TypedMap::new(),
+        "Original".to_owned(),
+        std::path::PathBuf::from("/tmp/original"),
+    );
+    agent.description = "Original description".to_owned();
+    agent.shortcut_slot = Some(1);
+    let fields = AgentFormFields {
+        name: "Changed".to_owned(),
+        description: "Changed description".to_owned(),
+        work_dir: "/tmp/changed".to_owned(),
+        agent_type_id: "core.llxprt".to_owned(),
+        sandbox_enabled: true,
+        sandbox_engine: "unknown".to_owned(),
+        shortcut_slot: Some(2),
+        ..AgentFormFields::default()
+    };
+
+    assert!(!AppState::update_agent_from_fields(
+        &mut agent,
+        &repository,
+        &fields
+    ));
+    assert_eq!(agent.name, "Original");
+    assert_eq!(agent.description, "Original description");
+    assert_eq!(agent.work_dir, std::path::PathBuf::from("/tmp/original"));
+    assert_eq!(agent.shortcut_slot, Some(1));
+}
+
+#[test]
 fn update_agent_ignores_whitespace_only_work_dir() {
     let repository = seed_repository();
     let mut agent = Agent::new(
@@ -378,6 +427,51 @@ fn update_llxprt_agent_replaces_obsolete_prompt_interactive_value() {
         Some(&crate::domain::TypedValue::String("preserve me".to_owned()))
     );
 }
+#[test]
+fn llxprt_sandbox_values_survive_create_and_edit_projection() {
+    let repository = seed_repository();
+    let fields = AgentFormFields {
+        name: "Sandboxed LLxprt".to_owned(),
+        work_dir: "/tmp/sandboxed-llxprt".to_owned(),
+        agent_type_id: "core.llxprt".to_owned(),
+        sandbox_enabled: true,
+        sandbox_engine: "Docker".to_owned(),
+        sandbox_flags: "--network none".to_owned(),
+        ..AgentFormFields::default()
+    };
+    let Some(agent) = AppState::create_agent_from_fields(&repository, &fields, 1) else {
+        panic!("valid LLxprt form should create an agent");
+    };
+    assert_eq!(
+        crate::domain::canonical_values::typed_field(&agent.values, "sandbox_enabled"),
+        Some(&crate::domain::TypedValue::Bool(true))
+    );
+    assert_eq!(
+        crate::domain::canonical_values::typed_field(&agent.values, "sandbox_engine"),
+        Some(&crate::domain::TypedValue::String("docker".to_owned()))
+    );
+    assert_eq!(
+        crate::domain::canonical_values::typed_field(&agent.values, "sandbox_flags"),
+        Some(&crate::domain::TypedValue::String(
+            "--network none".to_owned()
+        ))
+    );
+
+    let id = agent.id.clone();
+    let mut state = AppState {
+        repositories: vec![repository],
+        agents: vec![agent],
+        ..AppState::default()
+    };
+    state = state.apply(AppEvent::OpenEditAgent(id)).committed_pure();
+    let ModalState::EditAgent { fields, .. } = state.modal else {
+        panic!("expected edit-agent modal");
+    };
+    assert!(fields.sandbox_enabled);
+    assert_eq!(fields.sandbox_engine, "Docker");
+    assert_eq!(fields.sandbox_flags, "--network none");
+}
+
 #[test]
 fn repository_checkbox_toggle_updates_remote_fields() {
     let mut state = AppState {

--- a/src/state/form_submit_ops.rs
+++ b/src/state/form_submit_ops.rs
@@ -98,7 +98,6 @@ impl AppState {
             return;
         }
 
-        self.enforce_shortcut_uniqueness(id, fields.shortcut_slot);
         let repository = self.repository_for_agent(id).cloned();
         if let Some(repository) = repository {
             if Self::validated_agent_work_dir(&repository, &fields.work_dir).is_none() {
@@ -109,9 +108,13 @@ impl AppState {
                 return;
             }
             if let Some(agent) = self.agents.iter_mut().find(|agent| &agent.id == id) {
+                if !Self::update_agent_from_fields(agent, &repository, fields) {
+                    self.error_message = Some("invalid agent launch configuration".to_owned());
+                    return;
+                }
                 self.error_message = None;
-                Self::update_agent_from_fields(agent, &repository, fields);
             }
+            self.enforce_shortcut_uniqueness(id, fields.shortcut_slot);
         }
         self.remember_selected_agent_for_current_repo();
         self.modal = ModalState::None;

--- a/src/state/form_validation_issue403.rs
+++ b/src/state/form_validation_issue403.rs
@@ -25,6 +25,11 @@ impl AppState {
         if has_internal_whitespace(&fields.code_puppy_version) {
             return Err("Code Puppy version must not contain whitespace or newlines".to_owned());
         }
+        if fields.sandbox_enabled
+            && crate::domain::SandboxEngine::from_form_value(&fields.sandbox_engine).is_none()
+        {
+            return Err("Sandbox engine must be Podman, Docker, or Seatbelt".to_owned());
+        }
         Ok(())
     }
 

--- a/src/state/modal_ops.rs
+++ b/src/state/modal_ops.rs
@@ -150,6 +150,23 @@ fn typed_bool(values: &TypedMap, field: &str) -> Option<bool> {
     }
 }
 
+fn sandbox_engine_field(values: &TypedMap) -> String {
+    let value = typed_string(values, "sandbox_engine");
+    if value.is_empty() {
+        return SandboxEngine::default().label().to_owned();
+    }
+    SandboxEngine::from_form_value(&value).map_or(value, |engine| engine.label().to_owned())
+}
+
+fn sandbox_flags_field(values: &TypedMap) -> String {
+    let value = typed_string(values, "sandbox_flags");
+    if value.is_empty() {
+        DEFAULT_SANDBOX_FLAGS.to_owned()
+    } else {
+        value
+    }
+}
+
 impl AppState {
     pub(super) fn apply_modal_message(&mut self, message: ModalMessage) {
         match message {
@@ -433,9 +450,9 @@ impl AppState {
                     },
                     llxprt_debug: String::new(),
                     pass_continue: typed_bool(&a.values, "continue").unwrap_or(true),
-                    sandbox_enabled: false,
-                    sandbox_engine: SandboxEngine::default().label().to_owned(),
-                    sandbox_flags: DEFAULT_SANDBOX_FLAGS.to_owned(),
+                    sandbox_enabled: typed_bool(&a.values, "sandbox_enabled").unwrap_or(false),
+                    sandbox_engine: sandbox_engine_field(&a.values),
+                    sandbox_flags: sandbox_flags_field(&a.values),
                 }
             })
             .unwrap_or_default();

--- a/tests/agent_local_plan.rs
+++ b/tests/agent_local_plan.rs
@@ -74,7 +74,8 @@ fn llxprt_plan_request<'a>(
             &[
                 "prompt-interactive",
                 "profile",
-                "sandbox",
+                "sandbox-enabled",
+                "sandbox-engine",
                 "yolo",
                 "continue",
             ],
@@ -126,6 +127,54 @@ fn llxprt_normal_golden_plan() {
     assert!(plan.env.is_empty(), "no ambient env vars");
     // Signature excludes secrets/display-only values (contract).
     assert!(plan.signature_excludes_secrets());
+}
+
+#[test]
+fn llxprt_sandbox_values_emit_argv_and_environment() {
+    let definition = shipped("LLxprt");
+    let mut values = LaunchFieldValues::new();
+    values.set_agent("sandbox_enabled", FieldValue::Boolean(true));
+    values.set_agent("sandbox_engine", FieldValue::String("docker".to_owned()));
+    values.set_agent(
+        "sandbox_flags",
+        FieldValue::String("--network none".to_owned()),
+    );
+
+    let plan = assert_supported(
+        llxprt_plan_request(&definition, &values),
+        "sandboxed llxprt",
+    );
+
+    assert!(
+        plan.argv
+            .windows(3)
+            .any(|args| { args == [os("--sandbox"), os("--sandbox-engine"), os("docker")] })
+    );
+    assert_eq!(
+        plan.env,
+        vec![(
+            std::ffi::OsString::from("SANDBOX_FLAGS"),
+            std::ffi::OsString::from("--network none"),
+        )]
+    );
+}
+
+#[test]
+fn disabled_llxprt_sandbox_emits_no_sandbox_configuration() {
+    let definition = shipped("LLxprt");
+    let mut values = LaunchFieldValues::new();
+    values.set_agent("sandbox_enabled", FieldValue::Boolean(false));
+    values.set_agent("sandbox_engine", FieldValue::String(String::new()));
+    values.set_agent("sandbox_flags", FieldValue::String(String::new()));
+
+    let plan = assert_supported(
+        llxprt_plan_request(&definition, &values),
+        "unsandboxed llxprt",
+    );
+
+    assert!(!plan.argv.iter().any(|arg| arg == "--sandbox"));
+    assert!(!plan.argv.iter().any(|arg| arg == "--sandbox-engine"));
+    assert!(!plan.env.iter().any(|(name, _)| name == "SANDBOX_FLAGS"));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/issue652_behavior.rs
+++ b/tests/issue652_behavior.rs
@@ -1,0 +1,13 @@
+use jefe::harness::v1::parse_scenario_v1;
+
+const SANDBOX_SAVE_SCENARIO: &[u8] =
+    include_bytes!("../dev-docs/tmux-scenarios/issue652/llxprt-sandbox-save.json");
+
+#[test]
+fn llxprt_sandbox_save_scenario_is_structurally_valid() {
+    let scenario = parse_scenario_v1(SANDBOX_SAVE_SCENARIO).unwrap_or_else(|error| {
+        panic!("issue 652 sandbox-save scenario must satisfy the schema-1 grammar: {error}")
+    });
+
+    assert_eq!(scenario.name, "llxprt-sandbox-save");
+}


### PR DESCRIPTION
## Summary

- make LLxprt sandbox settings definition-owned and preserve enabled, engine, and flags values through create/edit saves
- migrate legacy sandbox values into active typed state and preserve them through durable projection and restore
- emit the LLxprt sandbox flag, engine option, and raw SANDBOX_FLAGS while keeping disabled launches unsandboxed
- reject unknown engines before persistence or launch effects and keep rejected edits atomic
- add focused state, service, migration, launch-plan, durable-state, and macOS TUI regression coverage

## Acceptance evidence

- enabled sandbox values survive create, unchanged edit, durable projection/restore, and edit-form reopening
- disabled saves remove engine and flags and emit no sandbox argv/environment
- schema-1 migration activates canonical enabled/engine/flags values
- LLxprt sandbox launch configuration does not activate the unrelated image-based sandbox preflight
- other agent definitions do not acquire LLxprt sandbox emitters
- the isolated llxprt-sandbox-save tmux scenario passes all 24 steps on the rebased head

## Verification

- cargo xtask ci
  - formatting, policy, source-size, architecture, multiplexer-surface, strict lint, and complexity gates passed
  - line coverage: 70.49%, above the 30% floor
  - locked all-feature build and tests passed, including doctests
- DeepThinker and rustreviewer findings were remediated
- local Open Code Review examined 16 issue files; all three findings were remediated

## Scope

No dependency, persistence-schema, sandbox-runtime, engine-support, workflow, quality-gate, or generic conditional-emitter changes are included.

Fixes #652
