### PR TITLE
Stop conformance probing from stranding psmux servers (#613)

### DIFF
--- a/project-plans/issue613-plan.md
+++ b/project-plans/issue613-plan.md
@@ -1,0 +1,97 @@
+# Issue 613: Conformance teardown is not crash-safe and leaks psmux servers
+
+Issue: https://github.com/vybestack/llxprt-jefe/issues/613
+
+## Summary
+
+Windows startup probes multiplexer contract conformance in a throwaway namespace named `jefe-conformance-<jefe pid>-<invocation>`. `qualify_multiplexer` creates that namespace, runs the probes, and then issues `kill-server` as straight-line code. Any unwind, early return, or process death between session creation and that final call permanently strands the psmux server pair for the namespace: nothing else in Jefe ever revisits a conformance namespace, and psmux servers outlive their launching parent.
+
+Field evidence in the issue: 36 live `psmux.exe` processes where only 7 were legitimate, 23 orphans spread across 9 conformance namespaces, every owning Jefe pid already dead, and each namespace still holding a complete registry (`.key`, `.pid`, `.port`, `.sid`). The orphans were healthy servers, not wedged ones, so they never expire on their own.
+
+The fix is the pair the issue asks for: make teardown run on unwind, and reclaim leftovers that a previous crash already stranded.
+
+## Acceptance matrix
+
+| ID | Actor / path | Input and target | Observable success | Failure behavior / side effects | Persistence and compatibility | Proof |
+|---|---|---|---|---|---|---|
+| AC1 | Conformance qualification unwinds after the scratch session exists | Panic raised while probes are in flight | `kill-server` is still issued against the scratch namespace before the unwind escapes `qualify_multiplexer` | The panic still propagates unchanged; teardown failure is swallowed, never converted into a second panic | No new persisted artifact | Unwind test asserting the recorded teardown command (Unix fake binary) and namespace death (Windows real psmux) |
+| AC2 | Conformance qualification completes normally | Real multiplexer, successful probes | Scratch namespace is torn down exactly once and the returned report is byte-identical to today's | Probe failures continue to yield the existing report, still followed by teardown | Existing qualification and divergence output unchanged | Existing conformance/qualification suites plus real-binary tests |
+| AC3 | Windows startup after an earlier crash | Registry holds `jefe-conformance-<dead pid>-<n>` with a live recorded server | The leftover namespace is killed during startup and its registry entries disappear | Startup continues and still qualifies the multiplexer even when a reclaim fails | Jefe writes no new state; psmux owns and removes its own registry files | Real-binary Windows sweep test using a reaped pid |
+| AC4 | Startup with namespaces that must survive | Live Jefe namespace `jefe-<hex>`, conformance namespace owned by a running pid, malformed names, and registry entries whose recorded server is gone or pid-reused | None of these are killed and no `kill-server` is spawned for them | Ambiguous liveness (inaccessible, probe failure, malformed identity) retains the namespace | Untouched registry entries | Pure classifier tests plus a live-owner survival assertion in the Windows sweep test |
+| AC5 | Startup on a host without a readable registry | Missing home directory, missing `.psmux` directory, unreadable or truncated entries | Sweep yields no candidates, logs at most a warning, and startup proceeds | No panic, no error surfaced to the user, qualification still runs | No compatibility surface | Discovery unit tests over temporary directories |
+
+## Non-goals
+
+- No Ctrl+C or Windows console-control handler. The issue lists it as optional and redundant once teardown is crash-safe and startup reclaims leftovers.
+- No sweep for Unix socket isolation. The reported leak is Windows/psmux and the RAII guard already covers both platforms; the pure classifier stays platform-neutral so a future Unix discovery can reuse it.
+- No direct deletion or rewriting of psmux registry files. Jefe only issues `kill-server`; psmux owns its registry lifecycle.
+- No change to which namespaces the existing orphan reaper owns, and no reclaim of real (non-conformance) Jefe namespaces.
+- No change to probe verbs, conformance reports, divergence rendering, or the startup warning text.
+- No new dependency, no workflow/quality-tool change, no persistence schema change.
+
+## Planned vertical slices
+
+### Slice 1: Crash-safe scratch teardown
+
+- Acceptance rows: AC1, AC2.
+- Owners: conformance I/O edge only.
+- Allowed paths: `src/runtime/multiplexer_conformance_io.rs` and its in-module tests.
+- RED: a test that unwinds while the scratch namespace is held shows no teardown command was issued.
+- GREEN: a private RAII guard owns the scratch plan and issues `kill-server` from `Drop`; `qualify_multiplexer` keeps its current report semantics.
+- Non-goals: no public API addition, no change to probe sequencing.
+- Focused verification: runtime conformance tests, `cargo fmt`, `cargo xtask quick`.
+- Stop condition: teardown cannot be expressed without a new public abstraction or a probe-sequence change.
+
+### Slice 2: Pure leftover discovery and reclaim decision
+
+- Acceptance rows: AC4, AC5.
+- Owners: a new runtime module holding only pure parsing and classification plus directory-scoped discovery.
+- Allowed paths: `src/runtime/multiplexer_conformance_sweep.rs`, `src/runtime/multiplexer_conformance_sweep_tests.rs`, `src/runtime/mod.rs` (module and test wiring only).
+- RED: no parser exists for `jefe-conformance-<pid>-<n>` and no reclaim decision exists.
+- GREEN: namespace parsing, recorded-server identity parsing, directory discovery over an injected registry path, and a total classifier that reclaims only when the owner is dead and the recorded server is alive.
+- Non-goals: no process probing inside the pure layer, no filesystem mutation.
+- Focused verification: unit tests over temporary directories, `cargo xtask quick`.
+- Stop condition: a decision cannot be made without probing processes from the pure layer.
+
+### Slice 3: Startup reclaim wiring and real-binary proof
+
+- Acceptance rows: AC3, AC4, AC5.
+- Owners: conformance I/O edge and the existing Windows startup qualification entry point.
+- Allowed paths: `src/runtime/multiplexer_conformance_sweep.rs`, `src/runtime/multiplexer_conformance_io.rs`, and the in-module Windows real-binary test.
+- RED: a stranded conformance namespace owned by a reaped pid survives `qualify_multiplexer_for_startup`.
+- GREEN: startup qualification first reclaims dead-owner leftovers through the existing bounded probe path; failures log and never abort startup; live-owner namespaces survive.
+- Non-goals: no retry loop, no background thread, no telemetry surface.
+- Verification: Windows real-binary test under `JEFE_REQUIRE_PSMUX=1`, full `cargo xtask ci`, OCR, exact-head checks.
+- Stop condition: reclaim requires a scheduler, new persistence, or a change to the startup warning contract.
+
+## Expected paths by ownership layer
+
+- Conformance I/O edge: `src/runtime/multiplexer_conformance_io.rs`.
+- New pure/edge sweep module: `src/runtime/multiplexer_conformance_sweep.rs` and `src/runtime/multiplexer_conformance_sweep_tests.rs`.
+- Module wiring: `src/runtime/mod.rs` (declaration and `#[cfg(test)]` test module only).
+- Plan: `project-plans/issue613-plan.md`.
+
+## Scope ledger
+
+| Discovery | Disposition |
+|---|---|
+| `kill-server` runs as straight-line code and is skipped on unwind | In-scope: root cause |
+| Already-stranded namespaces are never revisited | In-scope: the issue's second requested fix |
+| psmux records `<pid>:<creation filetime>` in each `.pid` registry entry, matching `ProcessIdentity` | In-scope: gives a pid-reuse-safe bound on which leftovers are worth killing |
+| psmux exposes no registry-path environment override and no server-listing verb | In-scope constraint: discovery must read the user-profile registry directory |
+| A `__warm__` session is auto-created alongside the scratch session | No action: `kill-server` already terminates the whole namespace server |
+| `src/harness/signal_cleanup.rs` documents the false assumption that psmux dies with its parent | Defer: comment-only correction belongs with a signal-handling issue, not this fix |
+| Unix socket-isolation leftovers after a hard kill | Reject expansion: unevidenced and explicitly a non-goal; the guard still covers Unix unwind |
+
+## Review counters
+
+- Local Open Code Review: 0/2
+- Post-PR Open Code Review: 0/2
+
+## Verification evidence
+
+Pending.
+
+## Deferred findings and follow-ups
+
+Pending.

--- a/project-plans/issue613-plan.md
+++ b/project-plans/issue613-plan.md
@@ -105,8 +105,10 @@ and none in production code.
 - Behavioral RED proved for both halves: the guard test failed before the RAII guard existed, and the startup test failed with "startup must reclaim jefe-conformance-19584-0, whose jefe is gone" while the sweep call was stubbed out.
 - Real-world proof on the development machine: a genuine pre-existing orphan pair, `jefe-conformance-14296-0` (servers 3428 and 19672), was reclaimed by the new sweep; the live workspace namespace and its eight servers were untouched.
 - `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `check-clippy-allows`, `check-source-size`, `check-architecture`, `check-multiplexer-surface`, and the complexity gate all pass.
-- Coverage passes at 71.17% lines, far above the 30% floor.
+- Coverage passes at 71.19% lines, far above the 30% floor.
 - `cargo build --workspace --all-features --locked` and `cargo test --workspace --all-features --locked` pass with `JEFE_REQUIRE_PSMUX=1`, so the Windows real-binary tests run rather than skip.
+- A full-suite run caught the reclaim test borrowing a freshly reaped PID: under a busy suite Windows hands that PID out again, the "departed" owner reads as alive, and the sweep correctly retains the namespace. The test now names an owner the kernel cannot allocate and waits a bounded interval for the server to finish dying, so it stays a statement about the sweep rather than about host load.
+- `cargo xtask ci` passes end to end on the exact head.
 
 ## Deferred findings and follow-ups
 

--- a/project-plans/issue613-plan.md
+++ b/project-plans/issue613-plan.md
@@ -86,7 +86,7 @@ The fix is the pair the issue asks for: make teardown run on unwind, and reclaim
 ## Review counters
 
 - Local Open Code Review: 1/2
-- Post-PR Open Code Review: 0/2
+- Post-PR Open Code Review: 1/2 (run by the pull request's own review workflow)
 
 ## Local review triage
 
@@ -99,6 +99,16 @@ and none in production code.
 | The Unix unwind test asserts the recorded `kill-server` invocation instead of observing that the namespace is gone | partial | explain: the Unix test drives a recorder binary precisely because no real server exists to observe, and its Windows sibling already asserts the observable death of the server; `kill-server` is the contract's own teardown verb |
 | `observed.lock().ok()` hides a poisoned mutex behind the "never recorded" panic message | valid | fix: consume the mutex with `into_inner` and report poisoning distinctly |
 | `is_ok_and(|value| value == "1")` in the `JEFE_REQUIRE_PSMUX` gate is verbose | invalid | dismiss: it is the existing repo convention, character for character, in `tests/runtime_multiplexer_real_binary.rs` |
+
+## Pull request review triage
+
+| Finding | Validity | Disposition |
+|---|---|---|
+| The recorder script interpolates the log path unquoted, so a temporary directory containing a space or a shell metacharacter reshapes the script | valid | fix: single-quote the redirection target and close and reopen the quote around any quote already in the path |
+| The reclaim test brings a namespace up by hand and ends it on a later line, so a panic in between strands it | valid | fix: the namespace now lives in a value that ends it on the way out, which is the same rule this issue imposes on the runner |
+| `4_294_967_280` is technically a valid `u32`, so an extremely long-lived host could in theory reuse it | partial | fix: moved to a PID that is not a multiple of four, which every Windows process ID is, so the kernel cannot allocate it at all |
+| `registry_directory` reads `USERPROFILE`, so the sweep does nothing on Unix | partial | reject: the sweep already returns before that point on Unix, because it runs only for namespace isolation and Unix uses socket isolation; the registry is a psmux structure that tmux does not have, a Unix sweep is a stated non-goal, and `dirs` would be a new dependency |
+| The 100 ms teardown poll costs context switches | invalid | dismiss: the reviewer's own conclusion is that it is acceptable for a test, and the multiplexer offers no synchronous shutdown notification to wait on |
 
 ## Verification evidence
 

--- a/project-plans/issue613-plan.md
+++ b/project-plans/issue613-plan.md
@@ -85,13 +85,29 @@ The fix is the pair the issue asks for: make teardown run on unwind, and reclaim
 
 ## Review counters
 
-- Local Open Code Review: 0/2
+- Local Open Code Review: 1/2
 - Post-PR Open Code Review: 0/2
+
+## Local review triage
+
+OCR run 1 (session `de66fce8`, range `b18c6e15..2c1fd0c9`) reported six comments that
+deduplicate to three findings, all in `src/runtime/multiplexer_conformance_io_tests.rs`
+and none in production code.
+
+| Finding | Validity | Disposition |
+|---|---|---|
+| The Unix unwind test asserts the recorded `kill-server` invocation instead of observing that the namespace is gone | partial | explain: the Unix test drives a recorder binary precisely because no real server exists to observe, and its Windows sibling already asserts the observable death of the server; `kill-server` is the contract's own teardown verb |
+| `observed.lock().ok()` hides a poisoned mutex behind the "never recorded" panic message | valid | fix: consume the mutex with `into_inner` and report poisoning distinctly |
+| `is_ok_and(|value| value == "1")` in the `JEFE_REQUIRE_PSMUX` gate is verbose | invalid | dismiss: it is the existing repo convention, character for character, in `tests/runtime_multiplexer_real_binary.rs` |
 
 ## Verification evidence
 
-Pending.
+- Behavioral RED proved for both halves: the guard test failed before the RAII guard existed, and the startup test failed with "startup must reclaim jefe-conformance-19584-0, whose jefe is gone" while the sweep call was stubbed out.
+- Real-world proof on the development machine: a genuine pre-existing orphan pair, `jefe-conformance-14296-0` (servers 3428 and 19672), was reclaimed by the new sweep; the live workspace namespace and its eight servers were untouched.
+- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `check-clippy-allows`, `check-source-size`, `check-architecture`, `check-multiplexer-surface`, and the complexity gate all pass.
+- Coverage passes at 71.17% lines, far above the 30% floor.
+- `cargo build --workspace --all-features --locked` and `cargo test --workspace --all-features --locked` pass with `JEFE_REQUIRE_PSMUX=1`, so the Windows real-binary tests run rather than skip.
 
 ## Deferred findings and follow-ups
 
-Pending.
+- `src/harness/signal_cleanup.rs` still documents the assumption that psmux processes die with their parent, which this issue disproves. Correcting that comment belongs with signal handling, not here.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -61,6 +61,7 @@ mod manager_passthrough;
 mod multiplexer;
 mod multiplexer_conformance;
 mod multiplexer_conformance_io;
+mod multiplexer_conformance_sweep;
 mod multiplexer_contract;
 /// Non-interactive (single-prompt, capture-stdout) agent execution (issue #214).
 mod non_interactive;
@@ -243,6 +244,10 @@ mod multiplexer_tests;
 #[cfg(test)]
 #[path = "multiplexer_conformance_io_tests.rs"]
 mod multiplexer_conformance_io_tests;
+
+#[cfg(test)]
+#[path = "multiplexer_conformance_sweep_tests.rs"]
+mod multiplexer_conformance_sweep_tests;
 
 #[cfg(test)]
 #[path = "session_host_tests.rs"]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -241,6 +241,10 @@ mod liveness_tests;
 mod multiplexer_tests;
 
 #[cfg(test)]
+#[path = "multiplexer_conformance_io_tests.rs"]
+mod multiplexer_conformance_io_tests;
+
+#[cfg(test)]
 #[path = "session_host_tests.rs"]
 mod session_host_tests;
 

--- a/src/runtime/multiplexer_conformance_io.rs
+++ b/src/runtime/multiplexer_conformance_io.rs
@@ -24,7 +24,14 @@ use super::multiplexer_contract::{ContractItem, ContractItemKind, contract_items
 use super::{MultiplexerIsolation, MultiplexerPlan};
 
 /// Session created inside the throwaway namespace for session-addressed probes.
-const SCRATCH_SESSION: &str = "jefe-conformance";
+pub(super) const SCRATCH_SESSION: &str = "jefe-conformance";
+
+/// Prefix marking a namespace as belonging to this runner.
+///
+/// Shared with the sweep that reclaims stranded namespaces (issue #613): the
+/// name is the only record of who owns one, so what writes it and what reads it
+/// cannot be allowed to drift apart.
+pub(super) const CONFORMANCE_NAMESPACE_PREFIX: &str = "jefe-conformance-";
 
 /// The session the lifecycle verbs create and destroy.
 ///
@@ -139,7 +146,8 @@ fn batched_format_outcomes(
         .collect()
 }
 
-fn execute_probe(plan: &MultiplexerPlan, args: &[String]) -> ProbeOutcome {
+/// Run one probe against `plan`'s binary under the shared probe timeout.
+pub(super) fn execute_probe(plan: &MultiplexerPlan, args: &[String]) -> ProbeOutcome {
     let mut command = plan.command();
     command
         .args(args)
@@ -160,6 +168,46 @@ fn execute_probe(plan: &MultiplexerPlan, args: &[String]) -> ProbeOutcome {
     }
 }
 
+/// A throwaway namespace held for the duration of one conformance run.
+///
+/// The namespace is torn down when the guard is dropped rather than at the end
+/// of the run, because the run does not always reach its end. A probe that
+/// panics, or a caller that unwinds while holding the guard, used to skip
+/// teardown entirely and strand the namespace's server for good: nothing
+/// revisits a conformance namespace, and those servers outlive the jefe that
+/// created them (issue #613).
+pub(super) struct ScratchNamespace {
+    plan: MultiplexerPlan,
+}
+
+impl ScratchNamespace {
+    /// Reserve a namespace of `plan`'s own isolation kind to probe in.
+    pub(super) fn reserve(plan: &MultiplexerPlan) -> Option<Self> {
+        scratch_plan(plan).map(|plan| Self { plan })
+    }
+
+    /// The plan addressing the reserved namespace.
+    pub(super) fn plan(&self) -> &MultiplexerPlan {
+        &self.plan
+    }
+
+    /// End the server the reserved namespace brought up.
+    fn tear_down(&self) {
+        let _ = execute_probe(&self.plan, &["kill-server".to_owned()]);
+    }
+}
+
+impl Drop for ScratchNamespace {
+    /// Tear the namespace down on every exit path, unwinding included.
+    ///
+    /// A failed teardown stays silent here: the guard runs during unwinding,
+    /// where panicking again would abort the process over a namespace the
+    /// startup sweep will reclaim anyway.
+    fn drop(&mut self) {
+        self.tear_down();
+    }
+}
+
 /// Qualify a multiplexer binary against the declared contract.
 ///
 /// Creates a throwaway namespace, probes it, and tears it down. The teardown is
@@ -167,7 +215,7 @@ fn execute_probe(plan: &MultiplexerPlan, args: &[String]) -> ProbeOutcome {
 /// very kind of orphan the runtime spends effort reaping.
 #[must_use]
 pub fn qualify_multiplexer(plan: &MultiplexerPlan) -> ConformanceReport {
-    let Some(scratch) = scratch_plan(plan) else {
+    let Some(scratch) = ScratchNamespace::reserve(plan) else {
         return summarize_conformance(contract_items().iter().map(|item| {
             (
                 item,
@@ -182,7 +230,7 @@ pub fn qualify_multiplexer(plan: &MultiplexerPlan) -> ConformanceReport {
     // own: the probes will report precisely which items the binary could not
     // honour, which is a better diagnosis than "setup failed".
     let _ = execute_probe(
-        &scratch,
+        scratch.plan(),
         &[
             "new-session".to_owned(),
             "-d".to_owned(),
@@ -191,11 +239,9 @@ pub fn qualify_multiplexer(plan: &MultiplexerPlan) -> ConformanceReport {
         ],
     );
 
-    let report = run_contract_probes(&scratch);
-
-    let _ = execute_probe(&scratch, &["kill-server".to_owned()]);
-
-    report
+    // `scratch` tears the namespace down as it drops, on this path and on the
+    // unwinding one alike.
+    run_contract_probes(scratch.plan())
 }
 
 /// Qualify the multiplexer jefe is about to use, at startup.
@@ -254,5 +300,8 @@ fn scratch_plan(plan: &MultiplexerPlan) -> Option<MultiplexerPlan> {
 fn conformance_namespace() -> String {
     static INVOCATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let invocation = INVOCATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    format!("jefe-conformance-{}-{invocation}", std::process::id())
+    format!(
+        "{CONFORMANCE_NAMESPACE_PREFIX}{}-{invocation}",
+        std::process::id()
+    )
 }

--- a/src/runtime/multiplexer_conformance_io.rs
+++ b/src/runtime/multiplexer_conformance_io.rs
@@ -20,6 +20,7 @@ use super::multiplexer_conformance::{
     classify_contract_probe, probe_ordered_items, probe_plan_for, qualification_from_report,
     summarize_conformance,
 };
+use super::multiplexer_conformance_sweep::reclaim_stranded_conformance_namespaces;
 use super::multiplexer_contract::{ContractItem, ContractItemKind, contract_items};
 use super::{MultiplexerIsolation, MultiplexerPlan};
 
@@ -256,6 +257,10 @@ pub fn qualify_multiplexer(plan: &MultiplexerPlan) -> ConformanceReport {
 /// binary is qualified, never whether qualification applies.
 #[must_use]
 pub fn qualify_multiplexer_for_startup(plan: &MultiplexerPlan) -> MultiplexerQualification {
+    // Reclaim what earlier runs stranded before adding a namespace of our own,
+    // so an interrupted startup costs one generation of servers and not an
+    // unbounded accumulation of them (issue #613).
+    reclaim_stranded_conformance_namespaces(plan);
     let report = qualify_multiplexer(plan);
     qualification_from_report(plan.executable(), probe_version(plan), report)
 }

--- a/src/runtime/multiplexer_conformance_io_tests.rs
+++ b/src/runtime/multiplexer_conformance_io_tests.rs
@@ -127,7 +127,11 @@ fn a_scratch_namespace_server_does_not_outlive_an_unwinding_run() {
     }));
 
     assert!(unwound.is_err(), "the panic must still reach the caller");
-    let Some((scratch, started)) = observed.lock().ok().and_then(|slot| slot.clone()) else {
+    let recorded = match observed.into_inner() {
+        Ok(recorded) => recorded,
+        Err(poisoned) => panic!("the observation slot was poisoned: {poisoned}"),
+    };
+    let Some((scratch, started)) = recorded else {
         panic!("the scratch namespace must have been recorded before the unwind");
     };
     assert_eq!(

--- a/src/runtime/multiplexer_conformance_io_tests.rs
+++ b/src/runtime/multiplexer_conformance_io_tests.rs
@@ -1,0 +1,151 @@
+//! Behavioral contracts for the conformance runner's namespace lifetime
+//! (issue #613).
+//!
+//! Conformance runs in a throwaway multiplexer namespace. The server that
+//! namespace brings up outlives jefe, so a run that ends anywhere other than
+//! its last line strands that server forever. These tests hold the runner to
+//! tearing the namespace down along the unwinding path, not only the happy one.
+
+use super::multiplexer_conformance_io::{SCRATCH_SESSION, ScratchNamespace, execute_probe};
+
+#[cfg(unix)]
+use super::multiplexer::{LocalPlatform, MultiplexerIsolation, MultiplexerPlan};
+
+/// A stand-in multiplexer that records the arguments it was invoked with.
+///
+/// The teardown of a namespace is only observable as a command the runner
+/// issued, so the probe path is pointed at a recorder rather than a real
+/// multiplexer: that keeps the test deterministic and leaves no server behind
+/// even when the assertion it makes is the one that fails.
+#[cfg(unix)]
+fn recording_multiplexer(directory: &std::path::Path, log: &std::path::Path) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let executable = directory.join("tmux");
+    let script = format!("#!/bin/sh\nprintf '%s\\n' \"$*\" >> {}\n", log.display());
+    std::fs::write(&executable, script)
+        .unwrap_or_else(|error| panic!("recorder must be writable: {error}"));
+    let permissions = std::fs::Permissions::from_mode(0o755);
+    std::fs::set_permissions(&executable, permissions)
+        .unwrap_or_else(|error| panic!("recorder must be executable: {error}"));
+    executable
+}
+
+#[cfg(unix)]
+#[test]
+fn a_scratch_namespace_is_torn_down_when_the_run_unwinds() {
+    let directory = tempfile::tempdir()
+        .unwrap_or_else(|error| panic!("temporary directory must be available: {error}"));
+    let log = directory.path().join("invocations.log");
+    let executable = recording_multiplexer(directory.path(), &log);
+    let plan = MultiplexerPlan::for_platform(
+        LocalPlatform::Unix,
+        executable,
+        MultiplexerIsolation::Socket(directory.path().join("jefe.sock")),
+    )
+    .unwrap_or_else(|error| panic!("recorder plan must be valid: {error}"));
+
+    let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let Some(scratch) = ScratchNamespace::reserve(&plan) else {
+            panic!("the recorder plan must yield a scratch namespace");
+        };
+        let _ = execute_probe(
+            scratch.plan(),
+            &[
+                "new-session".to_owned(),
+                "-d".to_owned(),
+                "-s".to_owned(),
+                SCRATCH_SESSION.to_owned(),
+            ],
+        );
+        panic!("a probe exploded mid-run");
+    }));
+
+    assert!(unwound.is_err(), "the panic must still reach the caller");
+    let recorded = std::fs::read_to_string(&log)
+        .unwrap_or_else(|error| panic!("the recorder log must be readable: {error}"));
+    assert!(
+        recorded.contains("new-session"),
+        "the scratch namespace must have been brought up: {recorded}"
+    );
+    assert!(
+        recorded.contains("kill-server"),
+        "the unwinding run must still tear its namespace down: {recorded}"
+    );
+}
+
+/// Whether this environment promises a usable psmux.
+///
+/// CI sets `JEFE_REQUIRE_PSMUX` on the native Windows job. Where it is set, a
+/// missing binary is a failure rather than a reason to skip -- a test that
+/// quietly does nothing is how a broken runner survives a green build.
+#[cfg(windows)]
+fn psmux_is_required() -> bool {
+    std::env::var("JEFE_REQUIRE_PSMUX").is_ok_and(|value| value == "1")
+}
+
+#[cfg(windows)]
+#[test]
+fn a_scratch_namespace_server_does_not_outlive_an_unwinding_run() {
+    use super::multiplexer::MultiplexerPlan;
+
+    if !psmux_is_required() {
+        return;
+    }
+    let plan = match MultiplexerPlan::current_for_test() {
+        Ok(plan) => plan,
+        Err(error) => panic!("JEFE_REQUIRE_PSMUX is set but no multiplexer resolved: {error}"),
+    };
+
+    let observed: std::sync::Mutex<Option<(MultiplexerPlan, Option<i32>)>> =
+        std::sync::Mutex::new(None);
+    let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let Some(scratch) = ScratchNamespace::reserve(&plan) else {
+            panic!("the resolved plan must yield a scratch namespace");
+        };
+        let _ = execute_probe(
+            scratch.plan(),
+            &[
+                "new-session".to_owned(),
+                "-d".to_owned(),
+                "-s".to_owned(),
+                SCRATCH_SESSION.to_owned(),
+            ],
+        );
+        let started = execute_probe(
+            scratch.plan(),
+            &[
+                "has-session".to_owned(),
+                "-t".to_owned(),
+                SCRATCH_SESSION.to_owned(),
+            ],
+        );
+        if let Ok(mut slot) = observed.lock() {
+            *slot = Some((scratch.plan().clone(), started.exit_code));
+        }
+        panic!("a probe exploded mid-run");
+    }));
+
+    assert!(unwound.is_err(), "the panic must still reach the caller");
+    let Some((scratch, started)) = observed.lock().ok().and_then(|slot| slot.clone()) else {
+        panic!("the scratch namespace must have been recorded before the unwind");
+    };
+    assert_eq!(
+        started,
+        Some(0),
+        "the scratch server must have been running before the unwind"
+    );
+    let surviving = execute_probe(
+        &scratch,
+        &[
+            "has-session".to_owned(),
+            "-t".to_owned(),
+            SCRATCH_SESSION.to_owned(),
+        ],
+    );
+    assert_ne!(
+        surviving.exit_code,
+        Some(0),
+        "the scratch server must not have survived the unwind"
+    );
+}

--- a/src/runtime/multiplexer_conformance_io_tests.rs
+++ b/src/runtime/multiplexer_conformance_io_tests.rs
@@ -84,6 +84,21 @@ fn psmux_is_required() -> bool {
     std::env::var("JEFE_REQUIRE_PSMUX").is_ok_and(|value| value == "1")
 }
 
+/// Ask the multiplexer whether it is still serving the scratch session, as the
+/// exit code of `has-session`.
+#[cfg(windows)]
+fn scratch_session_exit_code(plan: &super::multiplexer::MultiplexerPlan) -> Option<i32> {
+    execute_probe(
+        plan,
+        &[
+            "has-session".to_owned(),
+            "-t".to_owned(),
+            SCRATCH_SESSION.to_owned(),
+        ],
+    )
+    .exit_code
+}
+
 #[cfg(windows)]
 #[test]
 fn a_scratch_namespace_server_does_not_outlive_an_unwinding_run() {
@@ -112,16 +127,9 @@ fn a_scratch_namespace_server_does_not_outlive_an_unwinding_run() {
                 SCRATCH_SESSION.to_owned(),
             ],
         );
-        let started = execute_probe(
-            scratch.plan(),
-            &[
-                "has-session".to_owned(),
-                "-t".to_owned(),
-                SCRATCH_SESSION.to_owned(),
-            ],
-        );
+        let started = scratch_session_exit_code(scratch.plan());
         if let Ok(mut slot) = observed.lock() {
-            *slot = Some((scratch.plan().clone(), started.exit_code));
+            *slot = Some((scratch.plan().clone(), started));
         }
         panic!("a probe exploded mid-run");
     }));
@@ -139,16 +147,8 @@ fn a_scratch_namespace_server_does_not_outlive_an_unwinding_run() {
         Some(0),
         "the scratch server must have been running before the unwind"
     );
-    let surviving = execute_probe(
-        &scratch,
-        &[
-            "has-session".to_owned(),
-            "-t".to_owned(),
-            SCRATCH_SESSION.to_owned(),
-        ],
-    );
     assert_ne!(
-        surviving.exit_code,
+        scratch_session_exit_code(&scratch),
         Some(0),
         "the scratch server must not have survived the unwind"
     );

--- a/src/runtime/multiplexer_conformance_io_tests.rs
+++ b/src/runtime/multiplexer_conformance_io_tests.rs
@@ -22,7 +22,11 @@ fn recording_multiplexer(directory: &std::path::Path, log: &std::path::Path) -> 
     use std::os::unix::fs::PermissionsExt;
 
     let executable = directory.join("tmux");
-    let script = format!("#!/bin/sh\nprintf '%s\\n' \"$*\" >> {}\n", log.display());
+    // The temporary directory is chosen by the platform, so the destination is
+    // single-quoted (with any embedded quote closed and reopened) rather than
+    // trusted to be free of spaces and shell metacharacters.
+    let quoted = log.display().to_string().replace('\'', r"'\''");
+    let script = format!("#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{quoted}'\n");
     std::fs::write(&executable, script)
         .unwrap_or_else(|error| panic!("recorder must be writable: {error}"));
     let permissions = std::fs::Permissions::from_mode(0o755);

--- a/src/runtime/multiplexer_conformance_sweep.rs
+++ b/src/runtime/multiplexer_conformance_sweep.rs
@@ -1,0 +1,237 @@
+//! Reclaiming conformance namespaces stranded by an earlier run (issue #613).
+//!
+//! Conformance probing brings up a throwaway namespace and tears it down when
+//! the run ends. A run that never reaches its end -- a process killed outright,
+//! a machine losing power mid-startup -- leaves the namespace's server running
+//! with nothing left that refers to it. The server does not exit with the jefe
+//! that started it and no later run revisits an old namespace, so each such
+//! ending strands a pair of multiplexer servers permanently.
+//!
+//! Startup therefore reclaims what earlier runs left behind. The evidence is
+//! the multiplexer's own registry: a conformance namespace names the PID of the
+//! jefe that created it, and each namespace records the identity of the servers
+//! serving it. A namespace is reclaimed only when that jefe is gone *and* a
+//! recorded server is still running -- anything ambiguous is left alone, since
+//! the cost of being wrong is killing a live multiplexer.
+
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+use crate::domain::ServerProcessIdentity;
+
+use super::multiplexer_conformance_io::{CONFORMANCE_NAMESPACE_PREFIX, execute_probe};
+use super::process::{ProcessLiveness, pid_liveness, process_liveness};
+use super::{MultiplexerIsolation, MultiplexerPlan};
+
+/// Extension of the registry entry recording a server's identity.
+const SERVER_IDENTITY_EXTENSION: &str = "pid";
+
+/// Separator between the namespace and the session in a registry entry name.
+///
+/// A namespace is restricted to ASCII alphanumerics and dashes, so it can never
+/// contain this separator itself.
+const REGISTRY_NAME_SEPARATOR: &str = "__";
+
+/// A conformance namespace that outlived the jefe which created it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ConformanceLeftover {
+    namespace: String,
+    owner_pid: u32,
+    servers: Vec<ServerProcessIdentity>,
+}
+
+impl ConformanceLeftover {
+    /// The namespace as the multiplexer knows it.
+    pub(super) fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    /// The PID of the jefe that created the namespace.
+    pub(super) const fn owner_pid(&self) -> u32 {
+        self.owner_pid
+    }
+
+    /// Every server identity the namespace recorded.
+    pub(super) fn servers(&self) -> &[ServerProcessIdentity] {
+        &self.servers
+    }
+}
+
+/// What to do with one leftover namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LeftoverVerdict {
+    /// Kill the namespace's server: its jefe is gone and the server is running.
+    Reclaim,
+    /// Leave the namespace alone.
+    Retain,
+}
+
+/// Read the owning jefe's PID out of a conformance namespace name.
+///
+/// Returns `None` for anything that is not one of this runner's own namespaces,
+/// which is what keeps the sweep away from real jefe namespaces: those carry a
+/// workspace-derived handle rather than a PID and a run counter.
+#[must_use]
+pub(super) fn conformance_owner_pid(namespace: &str) -> Option<u32> {
+    namespace
+        .strip_prefix(CONFORMANCE_NAMESPACE_PREFIX)?
+        .split_once('-')
+        .filter(|(_, invocation)| invocation.parse::<u64>().is_ok())
+        .and_then(|(owner, _)| owner.parse::<u32>().ok())
+        .filter(|owner| *owner != 0)
+}
+
+/// Decide the fate of one leftover from the liveness of everything it names.
+///
+/// Reclaiming needs positive evidence on both sides. A dead owner alone would
+/// kill nothing and cost a process spawn per stale registry entry; a live
+/// server alone belongs to a run still in progress, possibly this one.
+#[must_use]
+pub(super) fn classify_leftover(
+    owner: ProcessLiveness,
+    servers: &[ProcessLiveness],
+) -> LeftoverVerdict {
+    let owner_is_gone = matches!(owner, ProcessLiveness::Dead);
+    let server_is_running = servers
+        .iter()
+        .any(|server| matches!(server, ProcessLiveness::Alive));
+    if owner_is_gone && server_is_running {
+        LeftoverVerdict::Reclaim
+    } else {
+        LeftoverVerdict::Retain
+    }
+}
+
+/// Collect the conformance namespaces `registry` still holds entries for.
+///
+/// An unreadable registry yields nothing rather than an error: the sweep is a
+/// courtesy to a previous run, and no part of startup depends on it.
+#[must_use]
+pub(super) fn discover_leftovers(registry: &Path) -> Vec<ConformanceLeftover> {
+    let Ok(entries) = std::fs::read_dir(registry) else {
+        return Vec::new();
+    };
+
+    let mut grouped: BTreeMap<(String, u32), Vec<ServerProcessIdentity>> = BTreeMap::new();
+    for entry in entries.flatten() {
+        if let Some((namespace, owner_pid, server)) = recorded_server(&entry.path()) {
+            grouped
+                .entry((namespace, owner_pid))
+                .or_default()
+                .push(server);
+        }
+    }
+
+    grouped
+        .into_iter()
+        .map(|((namespace, owner_pid), mut servers)| {
+            servers.sort_by_key(|server| server.pid());
+            ConformanceLeftover {
+                namespace,
+                owner_pid,
+                servers,
+            }
+        })
+        .collect()
+}
+
+/// Read one registry entry as a conformance namespace and its server.
+///
+/// Entries are named `<namespace>__<session>.<kind>`, and one namespace has
+/// several sessions, so a namespace is met once per session it holds.
+fn recorded_server(path: &Path) -> Option<(String, u32, ServerProcessIdentity)> {
+    if path.extension().and_then(OsStr::to_str)? != SERVER_IDENTITY_EXTENSION {
+        return None;
+    }
+    let (namespace, _session) = path
+        .file_stem()
+        .and_then(OsStr::to_str)?
+        .split_once(REGISTRY_NAME_SEPARATOR)?;
+    let owner_pid = conformance_owner_pid(namespace)?;
+    let recorded = std::fs::read_to_string(path).ok()?;
+    let server = parse_server_identity(&recorded)?;
+    Some((namespace.to_owned(), owner_pid, server))
+}
+
+/// Parse a `<pid>:<creation discriminator>` registry record.
+///
+/// The creation discriminator is what makes the record safe to act on: a PID
+/// the operating system has since handed to something else does not match it,
+/// so the sweep cannot mistake an unrelated process for a stranded server.
+fn parse_server_identity(recorded: &str) -> Option<ServerProcessIdentity> {
+    let (pid, started_at) = recorded.trim().split_once(':')?;
+    let pid = pid.parse::<u32>().ok().filter(|pid| *pid != 0)?;
+    let started_at = started_at.parse::<u64>().ok()?;
+    Some(ServerProcessIdentity::new(pid, started_at))
+}
+
+/// Where the multiplexer records the namespaces it is serving.
+///
+/// jefe never writes here and never removes an entry: it only reads the
+/// registry to find stranded namespaces, and lets the multiplexer clean up its
+/// own bookkeeping when the server it belongs to ends.
+fn registry_directory() -> Option<PathBuf> {
+    std::env::var_os("USERPROFILE").map(|profile| PathBuf::from(profile).join(".psmux"))
+}
+
+/// End the servers of every conformance namespace whose jefe is gone.
+///
+/// Best-effort by construction: every failure is logged and startup continues,
+/// because a namespace that cannot be reclaimed now is exactly as reclaimable
+/// on the next start.
+pub(super) fn reclaim_stranded_conformance_namespaces(plan: &MultiplexerPlan) {
+    // Only namespace isolation has a registry to sweep. Socket isolation
+    // addresses a path the caller chose, which this runner cannot enumerate.
+    if !matches!(plan.isolation(), MultiplexerIsolation::Namespace(_)) {
+        return;
+    }
+    let Some(registry) = registry_directory() else {
+        return;
+    };
+
+    for leftover in discover_leftovers(&registry) {
+        if matches!(leftover_verdict(&leftover), LeftoverVerdict::Reclaim) {
+            reclaim(plan, &leftover);
+        }
+    }
+}
+
+/// Classify one leftover against the running processes it names.
+fn leftover_verdict(leftover: &ConformanceLeftover) -> LeftoverVerdict {
+    let servers: Vec<ProcessLiveness> = leftover
+        .servers()
+        .iter()
+        .map(|server| process_liveness(Some(server.identity())))
+        .collect();
+    classify_leftover(pid_liveness(leftover.owner_pid()), &servers)
+}
+
+/// Kill the server holding one stranded namespace.
+fn reclaim(plan: &MultiplexerPlan, leftover: &ConformanceLeftover) {
+    let namespace = leftover.namespace();
+    let Ok(stranded) = plan.with_isolation(MultiplexerIsolation::Namespace(namespace.to_owned()))
+    else {
+        tracing::warn!(
+            namespace,
+            "stranded conformance namespace cannot be addressed"
+        );
+        return;
+    };
+
+    let outcome = execute_probe(&stranded, &["kill-server".to_owned()]);
+    if outcome.exit_code == Some(0) {
+        tracing::info!(
+            namespace,
+            owner = leftover.owner_pid(),
+            "reclaimed a conformance namespace stranded by an earlier run"
+        );
+    } else {
+        tracing::warn!(
+            namespace,
+            owner = leftover.owner_pid(),
+            detail = outcome.stderr.trim(),
+            "a stranded conformance namespace could not be reclaimed"
+        );
+    }
+}

--- a/src/runtime/multiplexer_conformance_sweep_tests.rs
+++ b/src/runtime/multiplexer_conformance_sweep_tests.rs
@@ -188,10 +188,48 @@ fn psmux_is_required() -> bool {
 /// A freshly reaped PID would be more lifelike, but Windows hands PIDs out
 /// again quickly and a busy test suite spawns enough short-lived processes to
 /// resurrect the "departed" owner mid-test. This value is far outside the range
-/// the kernel allocates, so it reads as departed every time and the sweep sees
-/// exactly the evidence a crashed jefe leaves behind.
+/// the kernel allocates and is not a multiple of four, which every Windows
+/// process ID is, so it reads as departed every time and the sweep sees exactly
+/// the evidence a crashed jefe leaves behind.
 #[cfg(windows)]
-const DEPARTED_OWNER_PID: u32 = 4_294_967_280;
+const DEPARTED_OWNER_PID: u32 = 4_294_967_293;
+
+/// A namespace the test brought up, ended when the test lets go of it.
+///
+/// This test is about a namespace nobody was left to clean up, so it must not
+/// become another way to strand one: a panic between bringing the session up
+/// and the last assertion would otherwise leave the server running.
+#[cfg(windows)]
+struct TestNamespace {
+    plan: super::MultiplexerPlan,
+}
+
+#[cfg(windows)]
+impl TestNamespace {
+    /// Bring up the scratch session in `namespace`.
+    fn start(plan: &super::MultiplexerPlan, namespace: &str) -> Self {
+        let plan = plan
+            .with_isolation(super::MultiplexerIsolation::Namespace(namespace.to_owned()))
+            .unwrap_or_else(|error| panic!("{namespace} must be addressable: {error}"));
+        start_session(&plan);
+        Self { plan }
+    }
+
+    /// The plan addressing this namespace.
+    fn plan(&self) -> &super::MultiplexerPlan {
+        &self.plan
+    }
+}
+
+#[cfg(windows)]
+impl Drop for TestNamespace {
+    fn drop(&mut self) {
+        let _ = super::multiplexer_conformance_io::execute_probe(
+            &self.plan,
+            &["kill-server".to_owned()],
+        );
+    }
+}
 
 /// Bring up the scratch session inside `plan`'s namespace.
 #[cfg(windows)]
@@ -249,7 +287,6 @@ fn session_stops_serving(plan: &super::MultiplexerPlan) -> bool {
 #[cfg(windows)]
 #[test]
 fn startup_reclaims_a_namespace_whose_jefe_is_gone_and_spares_one_still_in_use() {
-    use super::MultiplexerIsolation;
     use super::multiplexer_conformance_io::{ScratchNamespace, qualify_multiplexer_for_startup};
 
     if !psmux_is_required() {
@@ -262,10 +299,7 @@ fn startup_reclaims_a_namespace_whose_jefe_is_gone_and_spares_one_still_in_use()
 
     // A namespace an earlier jefe left behind: its owner is a PID that is gone.
     let stranded_namespace = format!("jefe-conformance-{DEPARTED_OWNER_PID}-0");
-    let stranded = plan
-        .with_isolation(MultiplexerIsolation::Namespace(stranded_namespace.clone()))
-        .unwrap_or_else(|error| panic!("the stranded namespace must be addressable: {error}"));
-    start_session(&stranded);
+    let stranded = TestNamespace::start(&plan, &stranded_namespace);
 
     // A namespace a running jefe owns. Killing this is the failure the sweep
     // must never commit, so it is held live across the whole startup.
@@ -276,12 +310,8 @@ fn startup_reclaims_a_namespace_whose_jefe_is_gone_and_spares_one_still_in_use()
 
     let _qualification = qualify_multiplexer_for_startup(&plan);
 
-    let reclaimed = session_stops_serving(&stranded);
+    let reclaimed = session_stops_serving(stranded.plan());
     let spared = session_is_serving(live.plan());
-    // Observe first, then clean up, so a failing run does not strand the very
-    // namespace this test exists to talk about.
-    let _ =
-        super::multiplexer_conformance_io::execute_probe(&stranded, &["kill-server".to_owned()]);
     assert!(
         reclaimed,
         "startup must reclaim {stranded_namespace}, whose jefe is gone"

--- a/src/runtime/multiplexer_conformance_sweep_tests.rs
+++ b/src/runtime/multiplexer_conformance_sweep_tests.rs
@@ -1,0 +1,280 @@
+//! Behavioral contracts for reclaiming stranded conformance namespaces
+//! (issue #613).
+//!
+//! The decisions here are deliberately conservative: a namespace is only ever
+//! reclaimed on positive evidence that the jefe which created it is gone and
+//! that a server it recorded is still running. Anything ambiguous is left
+//! alone, because the cost of a wrong reclaim is killing a live multiplexer.
+
+use std::path::Path;
+
+use super::multiplexer_conformance_sweep::{
+    ConformanceLeftover, LeftoverVerdict, classify_leftover, conformance_owner_pid,
+    discover_leftovers,
+};
+use super::process::ProcessLiveness;
+
+/// Write one registry entry as psmux lays them out.
+fn registry_entry(directory: &Path, name: &str, contents: &str) {
+    std::fs::write(directory.join(name), contents)
+        .unwrap_or_else(|error| panic!("registry fixture must be writable: {error}"));
+}
+
+/// A registry holding one stranded conformance namespace plus distractions.
+fn registry_fixture(directory: &Path) {
+    registry_entry(
+        directory,
+        "jefe-conformance-14296-0__jefe-conformance.pid",
+        "3428:134303562883797173",
+    );
+    registry_entry(
+        directory,
+        "jefe-conformance-14296-0____warm__.pid",
+        "19672:134303562891035964",
+    );
+    registry_entry(
+        directory,
+        "jefe-conformance-14296-0__jefe-conformance.key",
+        "0123456789abcdef",
+    );
+    registry_entry(
+        directory,
+        "jefe-conformance-14296-0__jefe-conformance.port",
+        "51423",
+    );
+    registry_entry(
+        directory,
+        "jefe-conformance-14296-0__jefe-conformance.sid",
+        "17004",
+    );
+    // A namespace whose server never finished starting: no identity to act on.
+    registry_entry(
+        directory,
+        "jefe-conformance-17004-0____warm__.spawnlock",
+        "9516",
+    );
+    // A real jefe namespace. Reclaiming one of these would kill live agents.
+    registry_entry(
+        directory,
+        "jefe-76134a0ba22f56e9__work.pid",
+        "1234:134303562883797173",
+    );
+    // Neither of these can be acted on: no owner, and no server identity.
+    registry_entry(directory, "jefe-conformance-nobody-0__session.pid", "1:2");
+    registry_entry(
+        directory,
+        "jefe-conformance-14297-1__jefe-conformance.pid",
+        "not a process",
+    );
+}
+
+#[test]
+fn an_owner_pid_is_read_only_from_a_well_formed_conformance_namespace() {
+    assert_eq!(
+        conformance_owner_pid("jefe-conformance-14296-0"),
+        Some(14296)
+    );
+    assert_eq!(
+        conformance_owner_pid("jefe-conformance-1-4294967295"),
+        Some(1)
+    );
+    for foreign in [
+        "jefe-76134a0ba22f56e9",
+        "jefe-conformance",
+        "jefe-conformance-14296",
+        "jefe-conformance-nobody-0",
+        "jefe-conformance--0",
+        "jefe-conformance-0-0",
+        "jefe-conformance-14296-0-1",
+        "jefe-conformance-14296-x",
+        "not-jefe-conformance-14296-0",
+    ] {
+        assert_eq!(
+            conformance_owner_pid(foreign),
+            None,
+            "{foreign} must not be read as a conformance namespace"
+        );
+    }
+}
+
+#[test]
+fn only_a_dead_owner_with_a_running_server_is_reclaimed() {
+    assert_eq!(
+        classify_leftover(ProcessLiveness::Dead, &[ProcessLiveness::Alive]),
+        LeftoverVerdict::Reclaim
+    );
+    assert_eq!(
+        classify_leftover(
+            ProcessLiveness::Dead,
+            &[ProcessLiveness::Dead, ProcessLiveness::Alive]
+        ),
+        LeftoverVerdict::Reclaim
+    );
+
+    for retained in [
+        (ProcessLiveness::Dead, &[ProcessLiveness::Dead][..]),
+        (ProcessLiveness::Dead, &[ProcessLiveness::ReusedPid][..]),
+        (
+            ProcessLiveness::Dead,
+            &[ProcessLiveness::MalformedIdentity][..],
+        ),
+        (ProcessLiveness::Dead, &[][..]),
+        (ProcessLiveness::Alive, &[ProcessLiveness::Alive][..]),
+        (ProcessLiveness::Inaccessible, &[ProcessLiveness::Alive][..]),
+        (ProcessLiveness::ProbeFailure, &[ProcessLiveness::Alive][..]),
+        (ProcessLiveness::ReusedPid, &[ProcessLiveness::Alive][..]),
+    ] {
+        let (owner, servers) = retained;
+        assert_eq!(
+            classify_leftover(owner, servers),
+            LeftoverVerdict::Retain,
+            "owner {owner:?} with servers {servers:?} must be retained"
+        );
+    }
+}
+
+#[test]
+fn discovery_reports_one_leftover_per_conformance_namespace_with_every_server_it_recorded() {
+    let directory = tempfile::tempdir()
+        .unwrap_or_else(|error| panic!("temporary directory must be available: {error}"));
+    registry_fixture(directory.path());
+
+    let leftovers = discover_leftovers(directory.path());
+
+    let [leftover] = leftovers.as_slice() else {
+        let names: Vec<&str> = leftovers
+            .iter()
+            .map(ConformanceLeftover::namespace)
+            .collect();
+        panic!("exactly one namespace is reclaimable, found {names:?}");
+    };
+    assert_eq!(leftover.namespace(), "jefe-conformance-14296-0");
+    assert_eq!(leftover.owner_pid(), 14296);
+    assert_eq!(
+        leftover
+            .servers()
+            .iter()
+            .map(|server| (server.pid(), server.started_at()))
+            .collect::<Vec<_>>(),
+        vec![
+            (3428, Some(134_303_562_883_797_173)),
+            (19672, Some(134_303_562_891_035_964)),
+        ],
+        "every server the namespace recorded must be considered"
+    );
+}
+
+#[test]
+fn discovery_of_an_absent_registry_yields_nothing() {
+    let directory = tempfile::tempdir()
+        .unwrap_or_else(|error| panic!("temporary directory must be available: {error}"));
+
+    assert!(discover_leftovers(&directory.path().join("absent")).is_empty());
+    assert!(discover_leftovers(directory.path()).is_empty());
+}
+
+/// Whether this environment promises a usable psmux.
+///
+/// CI sets `JEFE_REQUIRE_PSMUX` on the native Windows job. Where it is set, a
+/// missing binary is a failure rather than a reason to skip -- a test that
+/// quietly does nothing is how a broken runner survives a green build.
+#[cfg(windows)]
+fn psmux_is_required() -> bool {
+    std::env::var("JEFE_REQUIRE_PSMUX").is_ok_and(|value| value == "1")
+}
+
+/// A PID the operating system has finished with.
+///
+/// The child is waited on *and* released before its PID is returned, so nothing
+/// is left holding the process slot open and the sweep sees the same evidence
+/// it would after a jefe crashed.
+#[cfg(windows)]
+fn reaped_pid() -> u32 {
+    let mut child = std::process::Command::new("cmd")
+        .args(["/c", "exit", "0"])
+        .spawn()
+        .unwrap_or_else(|error| panic!("a short-lived process must be startable: {error}"));
+    let pid = child.id();
+    if let Err(error) = child.wait() {
+        panic!("the short-lived process must be reapable: {error}");
+    }
+    drop(child);
+    pid
+}
+
+/// Bring up the scratch session inside `plan`'s namespace.
+#[cfg(windows)]
+fn start_session(plan: &super::MultiplexerPlan) {
+    let started = super::multiplexer_conformance_io::execute_probe(
+        plan,
+        &[
+            "new-session".to_owned(),
+            "-d".to_owned(),
+            "-s".to_owned(),
+            super::multiplexer_conformance_io::SCRATCH_SESSION.to_owned(),
+        ],
+    );
+    assert_eq!(
+        started.exit_code,
+        Some(0),
+        "the namespace must have come up: {}",
+        started.stderr.trim()
+    );
+}
+
+/// Whether `plan`'s namespace still serves the scratch session.
+#[cfg(windows)]
+fn session_is_serving(plan: &super::MultiplexerPlan) -> bool {
+    super::multiplexer_conformance_io::execute_probe(
+        plan,
+        &[
+            "has-session".to_owned(),
+            "-t".to_owned(),
+            super::multiplexer_conformance_io::SCRATCH_SESSION.to_owned(),
+        ],
+    )
+    .exit_code
+        == Some(0)
+}
+
+#[cfg(windows)]
+#[test]
+fn startup_reclaims_a_namespace_whose_jefe_is_gone_and_spares_one_still_in_use() {
+    use super::MultiplexerIsolation;
+    use super::multiplexer_conformance_io::{ScratchNamespace, qualify_multiplexer_for_startup};
+
+    if !psmux_is_required() {
+        return;
+    }
+    let plan = match super::MultiplexerPlan::current_for_test() {
+        Ok(plan) => plan,
+        Err(error) => panic!("JEFE_REQUIRE_PSMUX is set but no multiplexer resolved: {error}"),
+    };
+
+    // A namespace an earlier jefe left behind: its owner is a PID that is gone.
+    let stranded_namespace = format!("jefe-conformance-{}-0", reaped_pid());
+    let stranded = plan
+        .with_isolation(MultiplexerIsolation::Namespace(stranded_namespace.clone()))
+        .unwrap_or_else(|error| panic!("the stranded namespace must be addressable: {error}"));
+    start_session(&stranded);
+
+    // A namespace a running jefe owns. Killing this is the failure the sweep
+    // must never commit, so it is held live across the whole startup.
+    let Some(live) = ScratchNamespace::reserve(&plan) else {
+        panic!("the resolved plan must yield a scratch namespace");
+    };
+    start_session(live.plan());
+
+    let _qualification = qualify_multiplexer_for_startup(&plan);
+
+    let reclaimed = !session_is_serving(&stranded);
+    let spared = session_is_serving(live.plan());
+    assert!(
+        reclaimed,
+        "startup must reclaim {stranded_namespace}, whose jefe is gone"
+    );
+    assert!(
+        spared,
+        "startup must leave a namespace owned by a running jefe alone"
+    );
+}

--- a/src/runtime/multiplexer_conformance_sweep_tests.rs
+++ b/src/runtime/multiplexer_conformance_sweep_tests.rs
@@ -269,6 +269,10 @@ fn startup_reclaims_a_namespace_whose_jefe_is_gone_and_spares_one_still_in_use()
 
     let reclaimed = !session_is_serving(&stranded);
     let spared = session_is_serving(live.plan());
+    // Observe first, then clean up, so a failing run does not strand the very
+    // namespace this test exists to talk about.
+    let _ =
+        super::multiplexer_conformance_io::execute_probe(&stranded, &["kill-server".to_owned()]);
     assert!(
         reclaimed,
         "startup must reclaim {stranded_namespace}, whose jefe is gone"

--- a/src/runtime/multiplexer_conformance_sweep_tests.rs
+++ b/src/runtime/multiplexer_conformance_sweep_tests.rs
@@ -183,24 +183,15 @@ fn psmux_is_required() -> bool {
     std::env::var("JEFE_REQUIRE_PSMUX").is_ok_and(|value| value == "1")
 }
 
-/// A PID the operating system has finished with.
+/// A PID that stands in for the jefe that owned a namespace and is now gone.
 ///
-/// The child is waited on *and* released before its PID is returned, so nothing
-/// is left holding the process slot open and the sweep sees the same evidence
-/// it would after a jefe crashed.
+/// A freshly reaped PID would be more lifelike, but Windows hands PIDs out
+/// again quickly and a busy test suite spawns enough short-lived processes to
+/// resurrect the "departed" owner mid-test. This value is far outside the range
+/// the kernel allocates, so it reads as departed every time and the sweep sees
+/// exactly the evidence a crashed jefe leaves behind.
 #[cfg(windows)]
-fn reaped_pid() -> u32 {
-    let mut child = std::process::Command::new("cmd")
-        .args(["/c", "exit", "0"])
-        .spawn()
-        .unwrap_or_else(|error| panic!("a short-lived process must be startable: {error}"));
-    let pid = child.id();
-    if let Err(error) = child.wait() {
-        panic!("the short-lived process must be reapable: {error}");
-    }
-    drop(child);
-    pid
-}
+const DEPARTED_OWNER_PID: u32 = 4_294_967_280;
 
 /// Bring up the scratch session inside `plan`'s namespace.
 #[cfg(windows)]
@@ -237,6 +228,24 @@ fn session_is_serving(plan: &super::MultiplexerPlan) -> bool {
         == Some(0)
 }
 
+/// Whether `plan`'s namespace stops serving within a bounded wait.
+///
+/// `kill-server` returns as soon as the server accepts it, and a loaded machine
+/// can take a moment to finish tearing the server down. Waiting keeps the test
+/// about whether the sweep reclaimed the namespace rather than about how busy
+/// the host was; a namespace the sweep ignored stays up for the whole window.
+#[cfg(windows)]
+fn session_stops_serving(plan: &super::MultiplexerPlan) -> bool {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    while std::time::Instant::now() < deadline {
+        if !session_is_serving(plan) {
+            return true;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    false
+}
+
 #[cfg(windows)]
 #[test]
 fn startup_reclaims_a_namespace_whose_jefe_is_gone_and_spares_one_still_in_use() {
@@ -252,7 +261,7 @@ fn startup_reclaims_a_namespace_whose_jefe_is_gone_and_spares_one_still_in_use()
     };
 
     // A namespace an earlier jefe left behind: its owner is a PID that is gone.
-    let stranded_namespace = format!("jefe-conformance-{}-0", reaped_pid());
+    let stranded_namespace = format!("jefe-conformance-{DEPARTED_OWNER_PID}-0");
     let stranded = plan
         .with_isolation(MultiplexerIsolation::Namespace(stranded_namespace.clone()))
         .unwrap_or_else(|error| panic!("the stranded namespace must be addressable: {error}"));
@@ -267,7 +276,7 @@ fn startup_reclaims_a_namespace_whose_jefe_is_gone_and_spares_one_still_in_use()
 
     let _qualification = qualify_multiplexer_for_startup(&plan);
 
-    let reclaimed = !session_is_serving(&stranded);
+    let reclaimed = session_stops_serving(&stranded);
     let spared = session_is_serving(live.plan());
     // Observe first, then clean up, so a failing run does not strand the very
     // namespace this test exists to talk about.


### PR DESCRIPTION
Fixes #613.

## Why

Windows startup probes multiplexer contract conformance inside a throwaway namespace named `jefe-conformance-<jefe pid>-<invocation>`. `qualify_multiplexer` created that namespace, ran the probes, and then issued `kill-server` as straight-line code. Anything that skipped that last line — a panic, an unwind, a killed process — stranded the namespace forever, because nothing in Jefe ever revisits an old conformance namespace and psmux servers outlive the process that launched them.

The issue reported 23 stranded servers across 9 namespaces on one machine, every owning Jefe pid long dead, every registry still complete. This branch confirmed it in the wild: a genuine pre-existing orphan pair, `jefe-conformance-14296-0` (servers 3428 and 19672), was still running here from an earlier crash, and the new sweep reclaimed it.

## What changed

**Teardown survives the unwinding path.** A private `ScratchNamespace` guard now owns the scratch plan, and its `Drop` issues the `kill-server`. Because `Drop` also runs while the stack unwinds, teardown happens on the failure path as well as the success path. The guard stays silent about its own failures: it can run during a panic, where a second panic would abort the process.

**Startup reclaims what earlier runs stranded.** `qualify_multiplexer_for_startup` first sweeps the multiplexer registry. A namespace is reclaimed only when both halves of the evidence agree: its name parses as a conformance namespace, the Jefe pid embedded in that name is dead, and a server the registry recorded for it is still alive. Everything else is retained — a live owner, a recycled pid, an unreadable or inaccessible process, a namespace with no recorded server, and any name that is not a conformance namespace, which is why a real `jefe-<workspace hash>` namespace can never be a candidate. Jefe only ever reads the registry and issues `kill-server`; it never writes or deletes registry files, and a failed reclaim is logged and startup continues.

## Proof

- Behavioral RED first for both halves. The guard test failed before the guard existed. The startup test failed with `startup must reclaim jefe-conformance-19584-0, whose jefe is gone` while the sweep call was stubbed out, then passed once it was restored.
- The unwind is proven twice: on Unix against a recorder binary that logs the teardown invocation, and on Windows against real psmux by asserting the scratch server does not survive a `catch_unwind`.
- The Windows end-to-end test strands a namespace under an owner pid the kernel cannot allocate, runs the real startup entry point, and asserts that the stranded namespace is gone *and* that a namespace whose owner is still alive is spared. It first borrowed a freshly reaped pid, which the full suite exposed as flaky: Windows hands reaped pids out again quickly, the buried owner answers, and the sweep then correctly spares the namespace.
- Real-world reclaim, as described above; the live workspace namespace and its eight servers were untouched.
- `cargo xtask ci` passes end to end on this head with `JEFE_REQUIRE_PSMUX=1`, so the Windows real-binary tests run rather than skip. Coverage is 71.19% lines against a 30% floor.

## Non-goals

No Ctrl+C or console-control handler (the issue lists it as redundant once teardown is crash-safe and startup reclaims). No Unix socket sweep — the reported leak is psmux, and the guard already covers both platforms. No deletion or rewriting of psmux registry files. No change to probe verbs, conformance reports, or the startup warning text.

The plan, acceptance matrix, scope ledger, and local review triage are in `project-plans/issue613-plan.md`.
