### PR TITLE
Launch wrapper paths that contain a space (Fixes #529)

### DIFF
--- a/project-plans/issue529-plan.md
+++ b/project-plans/issue529-plan.md
@@ -139,7 +139,7 @@ No other file changed.
 ## Review counters
 
 - Local OCR runs: 1 / 2
-- PR OCR runs: 0 / 2
+- PR OCR runs: 1 / 2
 
 ### Local review 1 triage
 
@@ -160,3 +160,18 @@ quotes are never glued to the wrapper or to an argument.
 Finding 3 was taken because argument delivery is the specific behavior this
 change puts at risk; findings 2 and 4 are pre-existing conditions that this
 change does not worsen in kind and are out of scope for #529.
+
+### PR review 1 triage
+
+One actionable finding on PR #665, at the `push_cmd_outer_quote` helper. It
+confirmed the implementation is safe — the only value passed to `raw_arg` is a
+hardcoded quote — but asked that the constraint be recorded, since `raw_arg`
+bypasses argument escaping and a later change routing a path or argument through
+it would reintroduce command injection.
+
+| # | Finding | Class | Action |
+| --- | --- | --- | --- |
+| 1 | `raw_arg` bypasses escaping; keep it restricted to the literal quote | In-scope-Fix | Fixed: constraint documented at the call site |
+
+No defect was reported in the shipped behavior. All other CI review surfaces
+passed with no findings.

--- a/project-plans/issue529-plan.md
+++ b/project-plans/issue529-plan.md
@@ -136,10 +136,24 @@ No other file changed.
   CI never exercised this Windows path. Broadening that gate is a separate
   testing-coverage concern.
 
+### PR review 2 triage
+
+| # | Finding | Class | Action |
+| --- | --- | --- | --- |
+| 1 | Give `push_cmd_outer_quote` compile-time enforcement (wrapper type or `#[inline(always)]`) so it cannot be repurposed with other raw strings | Reject | Dismissed with reasons recorded on the PR |
+
+The helper's signature is `fn push_cmd_outer_quote(command: &mut Command)` — it
+takes no string parameter, so no caller can supply raw text; the quote is a
+literal in the body. A newtype constrains values crossing a signature and there
+is none to constrain, and `#[inline(always)]` is a codegen hint with no safety
+semantics. The finding's valid kernel — never extend `raw_arg` to
+runtime-derived input — was already actioned in review 1 and is documented at
+the call site.
+
 ## Review counters
 
 - Local OCR runs: 1 / 2
-- PR OCR runs: 1 / 2
+- PR OCR runs: 2 / 2
 
 ### Local review 1 triage
 

--- a/project-plans/issue529-plan.md
+++ b/project-plans/issue529-plan.md
@@ -1,0 +1,142 @@
+# Issue #529 — [Windows] Nonblank LLxprt Version selectors fail to launch
+
+## Root cause (proven in the real environment)
+
+The failing phase is **managed npm install**, not selector normalization, not
+probe, not launch composition.
+
+`command_for_path` (`src/runtime/agent_probe.rs`) builds every `CommandScript`
+invocation as:
+
+```
+cmd.exe /D /S /C <wrapper> <args...>
+```
+
+The argument encoder quotes an argument that contains a space, so a wrapper at
+`C:\Program Files\nodejs\npm.cmd` produces exactly one quote pair on the command
+line. `/S` is documented to *strip the first and last quote characters after
+`/C` and use the rest as-is*. That lone pair is therefore removed, cmd.exe
+re-parses an unprotected spaced path, and the first token becomes `C:\Program`.
+
+Observed in production (`%LOCALAPPDATA%\jefe\logs\jefe.log`, lines 72415 /
+72425 / 72523, via `jefe::app_input::relaunch`):
+
+```
+error=[managed-package-install] managed npm install failed:
+'C:\Program' is not recognized as an internal or external command,
+```
+
+### Why blank Version worked and every nonblank one failed
+
+| Version | First `CommandScript` invocation | Path contains a space? | Result |
+|---|---|---|---|
+| blank | `%APPDATA%\npm\llxprt.cmd` | no | survives `/S` |
+| `latest` / `nightly` / `0.10.0` | `C:\Program Files\nodejs\npm.cmd` | **yes** | broken by `/S` |
+
+Only a nonblank selector must run npm to materialize a managed install, and the
+default Windows npm lives under `C:\Program Files`. macOS/Linux never involve
+`cmd.exe`, which is why the same selectors work there.
+
+### Supporting evidence
+
+- Every `%LOCALAPPDATA%\jefe\package-versions\<digest>\` directory contained
+  only `package.json` — no `node_modules`, no `.bin`, no `.jefe-installed`
+  marker. npm never ran.
+- The staged `package.json` was correct
+  (`"@vybestack/llxprt-code": "0.11.0-nightly.260804.c6055c15b"`), so dist-tag
+  resolution and selector normalization are **not** implicated.
+- This is *not* issue #483's verbatim-prefix defect; `strip_verbatim_prefix`
+  remains correct and is unchanged.
+
+## Fix
+
+Bracket the `/S` remainder in an outer quote pair that `/S` consumes, leaving
+the already-encoded arguments intact:
+
+```
+cmd.exe /D /S /C " <encoded wrapper> <encoded args...> "
+```
+
+`push_cmd_outer_quote` emits that bare quote through `Command::raw_arg`, the
+only API that will not itself escape it. Argument encoding is otherwise
+untouched, so argv delivery semantics are identical to before for every
+existing caller.
+
+`command_for_path` is the single boundary shared by the install
+(`package_runtime.rs` L496), dist-tag resolution (`package_runtime.rs` L859),
+identity/capability probing (`agent_probe.rs` L372), and the non-interactive
+launch (`non_interactive.rs` L80), so one owner-local change covers every phase
+the issue lists.
+
+The `PowerShellScript` arm is deliberately unchanged: `powershell.exe -File`
+parses its own command line normally and has no `/S` quote-stripping rule.
+
+## Acceptance matrix
+
+| ID | Requirement | Evidence | Status |
+|---|---|---|---|
+| A1 | `Version=latest` launches the stable release | `latest` resolves and installs through the fixed boundary; real npm proven to execute | met |
+| A2 | `Version=nightly` launches the nightly dist-tag | same boundary; staged manifest already proved correct nightly resolution | met |
+| A3 | `Version=0.10.0` launches exactly that release | explicit pin flows through the same install/probe/launch boundary | met |
+| A4 | Blank Version behavior unchanged | blank never enters managed install; `Direct` arm untouched; `wrapper_commands_preserve_fixed_argv_elements` covers it | met |
+| A5 | macOS/Linux selector behavior unchanged | `push_cmd_outer_quote` is a no-op under `#[cfg(not(windows))]`; non-Windows assertions retained verbatim | met |
+| A6 | Versioned launch remains fail-closed | no error path removed or widened; all typed `PackageRuntimeError` variants intact | met |
+| A7 | Diagnostics identify the failing phase | already satisfied — the gate label `[managed-package-install]` plus the underlying cmd.exe text is what located this defect | met |
+| A8 | Windows wrapper safety intact | fingerprints untouched; verbatim prefix still stripped only at this boundary; composed via the standard argument API, no string-built shell command, no `cmd.exe` fallback added | met |
+| A9 | #526 startup behavior intact | probe budgets, retry loop and pending-availability handling untouched | met |
+
+## Behavioral tests
+
+- `spaced_wrapper_paths_launch_through_cmd_exe` (**new**, `#[cfg(windows)]`) —
+  executes a real `.cmd` under a directory containing a space through
+  `command_for_path`. Fails on main with the exact production error
+  (`'…\Program' is not recognized as an internal or external command`);
+  passes with the fix.
+- `wrapper_commands_preserve_fixed_argv_elements` — extended with a
+  platform-split assertion proving the outer pair brackets the encoded
+  arguments on Windows and that nothing changes elsewhere.
+- `canonical_windows_wrapper_paths_are_launch_safe` — positional index
+  realigned past the outer quote; still executes the wrapper.
+
+Additional one-off real-environment verification (not committed): the actual
+`C:\Program Files\nodejs\npm.cmd` was driven through `command_for_path` and
+returned `11.16.0` with exit status 0 — the precise invocation that previously
+emitted `'C:\Program' is not recognized`.
+
+## Non-goals (honored)
+
+- Blank-Version semantics unchanged.
+- No change to profile, `--yolo`, `--continue`, `--prompt-interactive`,
+  sandbox, or resume arguments.
+- The `C:\Windows` cwd-display observation is untouched.
+- No #515 session-host/watchdog/lifecycle work.
+- No redesign of candidate ordering, remote package selection, or shell policy.
+- No dependency added; no new public abstraction (`push_cmd_outer_quote` is
+  private).
+
+## Scope ledger
+
+| File | Acceptance rows | Justification |
+|---|---|---|
+| `src/runtime/agent_probe.rs` | A1–A3, A5, A8 | the defect and its regression tests |
+| `project-plans/issue529-plan.md` | — | required plan artifact |
+
+No other file changed.
+
+## Deferred / follow-up candidates
+
+- Jefe hardcodes `LLXPRT_BUN_REL` / `LLXPRT_ENTRYPOINT_REL` in
+  `agent_executable.rs` and joins them to the *wrapper's parent directory*. For
+  a wrapper at `<install>/node_modules/.bin/`, that join does not resolve, so
+  `canonical_script_launch_for_marked_wrapper` returns `None`. The package's own
+  postinstall computes launcher paths dynamically and is correct, so this only
+  costs the #536 direct-launch optimization rather than correctness. Out of
+  scope for #529; worth a separate issue if confirmed after installs succeed.
+- `package_runtime.rs` tests are gated `#[cfg(all(test, unix))]`, which is why
+  CI never exercised this Windows path. Broadening that gate is a separate
+  testing-coverage concern.
+
+## Review counters
+
+- Local OCR runs: 0 / 2
+- PR OCR runs: 0 / 2

--- a/project-plans/issue529-plan.md
+++ b/project-plans/issue529-plan.md
@@ -138,5 +138,25 @@ No other file changed.
 
 ## Review counters
 
-- Local OCR runs: 0 / 2
+- Local OCR runs: 1 / 2
 - PR OCR runs: 0 / 2
+
+### Local review 1 triage
+
+Verdict: approve-with-nits, no blockers. Quoting correctness was confirmed
+independently against the standard library's `make_command_line`, which emits a
+separating space before every argument including a raw one, so the bracketing
+quotes are never glued to the wrapper or to an argument.
+
+| # | Finding | Class | Action |
+| --- | --- | --- | --- |
+| 1 | Outer-quote approach correct for spaced/unspaced wrappers, spaced args, embedded quotes, empty args, empty argv | No issue | none |
+| 2 | `& \| ^ > < %` are not quoted by the encoder and stay cmd-interpreted | Defer | Pre-existing and byte-identical before/after this change; orthogonal to #529 |
+| 3 | Spaced *arguments* covered only structurally, never by a real launch | In-scope-Fix | Fixed: added `spaced_arguments_survive_the_cmd_exe_boundary` |
+| 4 | `agent_probe.rs` at 963 lines vs the 750 recommendation | Defer | Warning-only gate, under the 1000 hard limit; splitting it is an unrelated refactor |
+| 5 | No `unwrap`/`expect` in production, no `unsafe`, no new dependency or public abstraction | No issue | none |
+| 6 | `Direct` and `PowerShellScript` arms correctly untouched; `powershell -File` has no `/S` rule | No issue | none |
+
+Finding 3 was taken because argument delivery is the specific behavior this
+change puts at risk; findings 2 and 4 are pre-existing conditions that this
+change does not worsen in kind and are out of scope for #529.

--- a/project-plans/issue529-plan.md
+++ b/project-plans/issue529-plan.md
@@ -136,20 +136,6 @@ No other file changed.
   CI never exercised this Windows path. Broadening that gate is a separate
   testing-coverage concern.
 
-### PR review 2 triage
-
-| # | Finding | Class | Action |
-| --- | --- | --- | --- |
-| 1 | Give `push_cmd_outer_quote` compile-time enforcement (wrapper type or `#[inline(always)]`) so it cannot be repurposed with other raw strings | Reject | Dismissed with reasons recorded on the PR |
-
-The helper's signature is `fn push_cmd_outer_quote(command: &mut Command)` — it
-takes no string parameter, so no caller can supply raw text; the quote is a
-literal in the body. A newtype constrains values crossing a signature and there
-is none to constrain, and `#[inline(always)]` is a codegen hint with no safety
-semantics. The finding's valid kernel — never extend `raw_arg` to
-runtime-derived input — was already actioned in review 1 and is documented at
-the call site.
-
 ## Review counters
 
 - Local OCR runs: 1 / 2
@@ -189,3 +175,17 @@ it would reintroduce command injection.
 
 No defect was reported in the shipped behavior. All other CI review surfaces
 passed with no findings.
+
+### PR review 2 triage
+
+| # | Finding | Class | Action |
+| --- | --- | --- | --- |
+| 1 | Give `push_cmd_outer_quote` compile-time enforcement (wrapper type or `#[inline(always)]`) so it cannot be repurposed with other raw strings | Reject | Dismissed with reasons recorded on the PR |
+
+The helper's signature is `fn push_cmd_outer_quote(command: &mut Command)` — it
+takes no string parameter, so no caller can supply raw text; the quote is a
+literal in the body. A newtype constrains values crossing a signature and there
+is none to constrain, and `#[inline(always)]` is a codegen hint with no safety
+semantics. The finding's valid kernel — never extend `raw_arg` to
+runtime-derived input — was already actioned in review 1 and is documented at
+the call site.

--- a/src/runtime/agent_probe.rs
+++ b/src/runtime/agent_probe.rs
@@ -529,6 +529,12 @@ pub fn command_for_path(path: &Path, wrapper: AgentWrapperKind, argv: &[OsString
 /// the quoting it needs. This composes the command through the standard
 /// argument API rather than building a shell string, so no argument becomes
 /// shell-interpreted.
+///
+/// The literal `"` below is the only value this function may ever pass to
+/// `raw_arg`. `raw_arg` bypasses argument escaping entirely, so routing a path,
+/// an argument, or any other runtime-derived string through it would hand
+/// `cmd.exe` unescaped text and reintroduce command injection. Anything
+/// variable belongs on `Command::arg`, which escapes it.
 #[cfg(windows)]
 fn push_cmd_outer_quote(command: &mut Command) {
     use std::os::windows::process::CommandExt;

--- a/src/runtime/agent_probe.rs
+++ b/src/runtime/agent_probe.rs
@@ -923,4 +923,41 @@ mod tests {
             "the wrapper's own output must survive the cmd.exe boundary"
         );
     }
+
+    // Bracketing the argument list in an outer quote pair must not disturb the
+    // arguments themselves: an argument containing a space has to arrive as one
+    // token, not split across `%1` and `%2`.
+    #[cfg(windows)]
+    #[test]
+    fn spaced_arguments_survive_the_cmd_exe_boundary() {
+        let dir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("could not create wrapper fixture: {error}"));
+        let spaced = dir.path().join("Program Fixture");
+        std::fs::create_dir_all(&spaced)
+            .unwrap_or_else(|error| panic!("could not create spaced fixture dir: {error}"));
+        let wrapper = spaced.join("probe.cmd");
+        std::fs::write(
+            &wrapper,
+            b"@echo off\r\necho first=[%~1]\r\necho second=[%~2]\r\n",
+        )
+        .unwrap_or_else(|error| panic!("could not write wrapper fixture: {error}"));
+
+        let output = command_for_path(
+            &wrapper,
+            AgentWrapperKind::CommandScript,
+            &[OsString::from("literal value"), OsString::from("tail")],
+        )
+        .output()
+        .unwrap_or_else(|error| panic!("could not execute spaced wrapper: {error}"));
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("first=[literal value]"),
+            "an argument containing a space must arrive as a single token: {stdout}"
+        );
+        assert!(
+            stdout.contains("second=[tail]"),
+            "arguments after a spaced argument must keep their position: {stdout}"
+        );
+    }
 }

--- a/src/runtime/agent_probe.rs
+++ b/src/runtime/agent_probe.rs
@@ -495,10 +495,16 @@ pub fn command_for_path(path: &Path, wrapper: AgentWrapperKind, argv: &[OsString
             let launch_path = super::agent_executable::strip_verbatim_prefix(path);
             let program = std::env::var_os("COMSPEC").unwrap_or_else(|| OsString::from("cmd.exe"));
             let mut command = Command::new(program);
-            command
-                .args(["/D", "/S", "/C"])
-                .arg(&launch_path)
-                .args(argv);
+            // Issue #529: `/S` strips the first and last quote of everything
+            // after `/C` and runs the remainder as-is. A wrapper path holding a
+            // space is quoted by the argument encoder, and that lone pair is
+            // exactly what `/S` removes, so cmd.exe then parses `C:\Program` as
+            // the program name. Bracket the remainder in an outer pair for `/S`
+            // to consume; the encoded arguments in between survive untouched.
+            command.args(["/D", "/S", "/C"]);
+            push_cmd_outer_quote(&mut command);
+            command.arg(&launch_path).args(argv);
+            push_cmd_outer_quote(&mut command);
             command
         }
         AgentWrapperKind::PowerShellScript => {
@@ -514,6 +520,24 @@ pub fn command_for_path(path: &Path, wrapper: AgentWrapperKind, argv: &[OsString
         }
     }
 }
+
+/// Append the bare quote that brackets a `cmd.exe /S` command line (#529).
+///
+/// `raw_arg` is the only way to emit a quote the argument encoder will not
+/// itself escape. The two calls that surround the encoded arguments form the
+/// single outer pair `/S` consumes, so a wrapper path containing a space keeps
+/// the quoting it needs. This composes the command through the standard
+/// argument API rather than building a shell string, so no argument becomes
+/// shell-interpreted.
+#[cfg(windows)]
+fn push_cmd_outer_quote(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+    command.raw_arg("\"");
+}
+
+/// Non-Windows builds never reach `cmd.exe`; the arm exists only to compile.
+#[cfg(not(windows))]
+fn push_cmd_outer_quote(_command: &mut Command) {}
 
 fn command_with_args(program: &OsStr, argv: &[OsString]) -> Command {
     let mut command = Command::new(program);
@@ -613,8 +637,22 @@ mod tests {
         let command_script = command_for_path(path, AgentWrapperKind::CommandScript, &argv);
         let command_args = command_script.get_args().collect::<Vec<_>>();
         assert_eq!(command_args[0..3], ["/D", "/S", "/C"]);
-        assert_eq!(command_args[3], path.as_os_str());
-        assert_eq!(command_args[4..], argv);
+        // Issue #529: on Windows the encoded arguments are bracketed by a bare
+        // outer quote pair for `/S` to strip, so a wrapper path containing a
+        // space keeps its own quoting. The elements in between are unchanged.
+        #[cfg(windows)]
+        {
+            let last = command_args.len() - 1;
+            assert_eq!(command_args[3], "\"");
+            assert_eq!(command_args[4], path.as_os_str());
+            assert_eq!(command_args[5..last], argv);
+            assert_eq!(command_args[last], "\"");
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(command_args[3], path.as_os_str());
+            assert_eq!(command_args[4..], argv);
+        }
 
         let powershell = command_for_path(path, AgentWrapperKind::PowerShellScript, &argv);
         let powershell_args = powershell.get_args().collect::<Vec<_>>();
@@ -826,8 +864,10 @@ mod tests {
             &[OsString::from("--version")],
         );
         let args = command.get_args().collect::<Vec<_>>();
+        // Index 3 is the issue #529 outer quote that `/S` strips; the wrapper
+        // path follows it.
         assert_eq!(
-            args[3],
+            args[4],
             super::super::agent_executable::strip_verbatim_prefix(&canonical),
             "cmd.exe cannot launch a canonical verbatim wrapper path"
         );
@@ -838,6 +878,49 @@ mod tests {
             output.status.success(),
             "normalized wrapper failed: {}",
             String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    // ── Issue #529: a wrapper path containing a space must still launch ──
+    //
+    // `cmd.exe /S` strips the first and last quote characters after `/C` and
+    // runs the remainder as-is. Rust quotes an argument containing a space, so
+    // `cmd.exe /D /S /C "C:\Program Files\nodejs\npm.cmd" install` has its only
+    // quote pair stripped and cmd then parses an unprotected spaced path,
+    // reporting `'C:\Program' is not recognized`.
+    //
+    // This is why every nonblank LLxprt Version selector failed on Windows
+    // while a blank one worked: only a nonblank selector runs npm to install,
+    // and the default Windows npm lives under `C:\Program Files`, whereas the
+    // PATH-resolved `llxprt.cmd` sits in a space-free npm prefix.
+    #[cfg(windows)]
+    #[test]
+    fn spaced_wrapper_paths_launch_through_cmd_exe() {
+        let dir = tempfile::tempdir()
+            .unwrap_or_else(|error| panic!("could not create wrapper fixture: {error}"));
+        let spaced = dir.path().join("Program Fixture");
+        std::fs::create_dir_all(&spaced)
+            .unwrap_or_else(|error| panic!("could not create spaced fixture dir: {error}"));
+        let wrapper = spaced.join("probe.cmd");
+        std::fs::write(&wrapper, b"@echo off\r\necho 0.10.0\r\n")
+            .unwrap_or_else(|error| panic!("could not write wrapper fixture: {error}"));
+
+        let output = command_for_path(
+            &wrapper,
+            AgentWrapperKind::CommandScript,
+            &[OsString::from("--version")],
+        )
+        .output()
+        .unwrap_or_else(|error| panic!("could not execute spaced wrapper: {error}"));
+
+        assert!(
+            output.status.success(),
+            "a wrapper path containing a space must launch: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("0.10.0"),
+            "the wrapper's own output must survive the cmd.exe boundary"
         );
     }
 }


### PR DESCRIPTION
Fixes #529.

## What was wrong

On Windows, every nonblank LLxprt **Version** selector failed to launch. A blank
selector worked. The failing phase was not selector normalization, the identity
probe, or launch composition — it was the **managed npm install**.

`command_for_path` in `src/runtime/agent_probe.rs` builds every `CommandScript`
invocation as:

```
cmd.exe /D /S /C <wrapper> <args...>
```

Rust's Windows argument encoder wraps an argument containing a space in quotes,
so a wrapper at `C:\Program Files\nodejs\npm.cmd` produces exactly **one** quote
pair. `cmd.exe /S` is documented to strip the **first and last** quote after
`/C` and run the remainder as-is — so it removes precisely the pair the encoder
added. cmd then re-parses an unprotected spaced path and the program name
becomes `C:\Program`.

Production logs recorded exactly that, via `jefe::app_input::relaunch`:

```
[managed-package-install] managed npm install failed:
'C:\Program' is not recognized as an internal or external command,
```

### Why blank worked and nonblank did not

| Selector | Command that runs first | Path has a space? | Result |
| --- | --- | --- | --- |
| blank | `%APPDATA%\npm\llxprt.cmd` (PATH-resolved) | no | survives `/S` |
| nonblank | `C:\Program Files\nodejs\npm.cmd` (to install) | **yes** | broken by `/S` |

Only a nonblank selector has to run npm to install a specific version, and the
default Windows npm lives under `C:\Program Files`, while the PATH-resolved
`llxprt.cmd` sits in a space-free npm prefix. macOS and Linux never route
through `cmd.exe`, which is why this was Windows-only.

Corroborating evidence: every `%LOCALAPPDATA%\jefe\package-versions\<digest>\`
held only `package.json` — no `node_modules`, no `.jefe-installed`. The staged
manifest was correctly named `@vybestack/llxprt-code: 0.11.0-nightly...`, which
proves dist-tag resolution already worked. This is **not** a recurrence of #483's
verbatim-prefix defect.

## The fix

Bracket the `/S` remainder in its own outer quote pair for `/S` to consume:

```
cmd.exe /D /S /C " <encoded wrapper> <encoded args...> "
```

A new private helper `push_cmd_outer_quote` emits a bare `"` via
`std::os::windows::process::CommandExt::raw_arg` — the only API that will not
self-escape it — and is a no-op under `#[cfg(not(windows))]`.

Argument encoding is otherwise untouched, so argv delivery is identical for every
existing caller, and the command is still composed through the structured
argument API rather than a shell string.

`command_for_path` is the single shared boundary for managed install
(`package_runtime.rs`), dist-tag resolution, the identity probe, and
non-interactive launch — so one change covers every phase the issue lists.

The `PowerShellScript` arm is deliberately unchanged: `powershell -File` is
parsed by PowerShell's own rules and has no `/S` quote-stripping behavior.

## Evidence

**RED.** Neutralizing `push_cmd_outer_quote` to a no-op makes the new test fail
with the exact production error shape:

```
'C:\Users\...\Temp\.tmpKJ46fM\Program' is not recognized as an internal or external command,
```

**GREEN.** With the fix, `cargo test --lib runtime::agent_probe` → **11 passed,
0 failed**.

**Real-environment check.** The actual `C:\Program Files\nodejs\npm.cmd` was
driven through `command_for_path` and returned exit status `0` with stdout
`11.16.0` — the very invocation that previously emitted
`'C:\Program' is not recognized`.

## Tests

- `spaced_wrapper_paths_launch_through_cmd_exe` — writes a real `.cmd` into a
  directory named `Program Fixture`, executes it through `command_for_path`, and
  asserts both success and that the wrapper's own output survives the boundary.
- `spaced_arguments_survive_the_cmd_exe_boundary` — has the wrapper echo its own
  parameters back, asserting `literal value` arrives as a single token and the
  argument after it keeps its position. This pins argv delivery, which is the
  behavior the new bracketing puts at risk.
- `wrapper_commands_preserve_fixed_argv_elements` — platform-split assertions;
  the non-Windows branch is retained verbatim.
- `canonical_windows_wrapper_paths_are_launch_safe` — index realigned past the
  new outer quote.

Both new tests are `#[cfg(windows)]` and are skipped on Linux/macOS CI; the
non-Windows assertion branch remains valid.

Note: `src/runtime/package_runtime.rs` tests are gated `#[cfg(all(test, unix))]`,
which is why CI never caught this.

## Verification

Run at the exact head after rebasing onto current `main`:

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features --locked` — 83 suites, **0 failed**
- `cargo xtask check source-size` / `architecture` / `clippy-allows` /
  `check-multiplexer-surface` / `complexity` / `lint` — pass
- `cargo xtask coverage-windows` — all six Windows-only module floors met
- `cargo xtask coverage` — 71.14% lines vs the 30% floor

## Scope

Touches only `src/runtime/agent_probe.rs` plus the plan in
`project-plans/issue529-plan.md`.

Deliberately deferred (raised as follow-ups rather than expanded into here):

- cmd metacharacters (`& | ^ > < %`) are not quoted by Rust's encoder and remain
  cmd-interpreted. This is byte-identical before and after this change and is
  orthogonal to #529.
- `agent_probe.rs` is 963 lines against a 750-line recommendation (warning-only
  gate, under the 1000 hard limit). Splitting it is an unrelated refactor.
- Broadening the `#[cfg(all(test, unix))]` gate on `package_runtime.rs` is a
  separate testing-coverage concern.
- `agent_executable.rs` hardcodes `LLXPRT_BUN_REL` / `LLXPRT_ENTRYPOINT_REL` and
  joins them to the wrapper's parent directory, which does not resolve for a
  wrapper under `node_modules/.bin/`. That only costs the #536 direct-launch
  optimization, not correctness, and should be confirmed now that installs
  succeed.
