### PR TITLE
Classify server health on the namespace token the probe already reports

### DIFF
--- a/project-plans/issue668-plan.md
+++ b/project-plans/issue668-plan.md
@@ -1,0 +1,82 @@
+# Issue #668 — server identity classification discards the psmux `server_instance` token
+
+Branch: `issue668` (from `origin/main` @ `0b39bd8c`).
+
+`parse_server_identity_output` already returns `ServerIdentity::with_instance(...)`
+when psmux answers the `#{server_instance}|#{pid}|#{version}` probe with a
+namespace token. `server_health_io::classify_observation` then rebuilds the
+current identity with `ServerIdentity::new`, which hardcodes `instance: None`,
+so the token never reaches `classify_server_health`. Its token-decisive branch
+is therefore dead on the production Windows path and every verdict falls
+through to the weaker `pid + started_at` comparison — the comparison that
+produced the impossible `Replaced` recorded in #664.
+
+## 1. Acceptance matrix
+
+| # | Actor / launch path | Inputs and boundary cases | Observable success | Observable failure + diagnostic location | Side effects allowed | Behavioral proof |
+|---|---|---|---|---|---|---|
+| A1 | Windows liveness cycle → `observe_server_liveness` → `classify_observation` | Probe stdout carries a non-empty `#{server_instance}` field; the answering pid is live so the OS supplies a real creation discriminator. Boundary: blank instance field (a multiplexer predating psmux#509) | The observed identity carries **both** the parsed `ServerInstanceToken` and the OS-resolved creation discriminator | A blank instance field yields `instance: None` and the pre-existing process-identity evidence only — never a synthesised token | None beyond the existing probe | `src/runtime/server_health_io_tests.rs` — pure `resolve_observed_identity` cases plus a Windows live-pid `classify_observation` case |
+| A2 | `classify_resolved_identity` (pure seam, token now present) | Same token + different pid; same token + different pid *and older* creation discriminator | `Healthy` — psmux answers from whichever per-session server of the namespace replied, so a different answering pid within one namespace is not a restart (#540) | A `Replaced`/`ConflictingIdentity` verdict here is the phantom-agent defect: agents under a live namespace would be declared `ServerLost` | None. The identity is pinned as healthy | `src/runtime/server_health_io_tests.rs` |
+| A3 | `classify_resolved_identity` (pure seam, token now present) | Different token + same pid, at the same creation discriminator and at a strictly newer one | A strictly newer process under a different namespace token is `Replaced` even though the pid was reused | An identical process (same pid, same creation discriminator) reporting a *different* token is contradictory evidence → `ConflictingIdentity`, warned from `server_health_io.rs` | None on the conflicting case; pin update on the genuine replacement | `src/runtime/server_health_io_tests.rs` |
+| A4 | `classify_resolved_identity` (pure seam, token on one side only) | Token on the prior only; token on the current only. Each with matching and with differing process identity | The comparison falls back to `pid + started_at`: matching → `Healthy`, differing → the #664-guarded `Replaced`/`ConflictingIdentity` | A one-sided token must never be treated as decisive in either direction (neither an automatic match nor an automatic mismatch) | None | `src/runtime/server_health_io_tests.rs` |
+| A5 | `classify_resolved_identity` — interaction of the two rules | Different tokens with a *non-monotonic* creation discriminator (the #664 shape, now on the token path) | The #664 monotonicity guard still refuses it: `ConflictingIdentity`, not `Replaced` | The token rule must not promote a non-monotonic answer to `Replaced`, and the guard must not demote a same-token answer away from `Healthy` | None | `src/runtime/server_health_io_tests.rs` |
+
+### Boundary decisions recorded
+
+- The token is preserved at the point the OS-resolved process identity is
+  merged with the parsed answer. The parser owns the namespace token (the OS
+  cannot know it); the OS owns the creation discriminator (the parser
+  hardcodes a placeholder `1`). Keeping only one half is what made the
+  decisive branch dead.
+- The two rules compose in one direction only, and deliberately:
+  `classify_server_health` decides *whether* the identities differ (token
+  first, process identity as fallback), and the #664 guard in
+  `classify_resolved_identity` then decides whether a claimed difference is
+  *orderable*. A same-token answer never reaches the guard, so an older
+  sibling server under one namespace stays `Healthy`.
+- A blank `#{server_instance}` field remains the capability signal for a build
+  predating psmux#509 and still yields `instance: None`. No token is invented.
+
+## 2. Non-goals
+
+- Making the `display-message` identity probe authoritative under concurrent
+  servers. Choosing *which* server answers is a separate problem from
+  correctly classifying the answer (issue #668 non-goal, related #540).
+- Changing `classify_server_health`, `parse_server_identity_output`, or the
+  `ServerInstanceToken` type. All three are already correct; the defect is
+  strictly the dropped field on the I/O path.
+- Changing `ServerLivenessObservation`, `plan_server_cycle`, or any agent
+  state transition. The verdict set is unchanged; only the evidence feeding it
+  is restored.
+- Persisting the namespace token across jefe restarts.
+- Coverage-gate work (#663) and observability work (#662).
+
+## 3. Slices
+
+| Slice | Acceptance rows | Owner / boundary | Allowed paths |
+|---|---|---|---|
+| S1 | A1 | Runtime server-health I/O boundary | `src/runtime/server_health_io.rs`, `src/runtime/server_health_io_tests.rs` |
+| S2 | A2–A5 | Runtime classification (pure seam) | `src/runtime/server_health_io_tests.rs` |
+
+Both slices stay inside one architectural layer and one orchestration route,
+so no child split is required.
+
+## 4. Scope ledger
+
+| Entry | Status | Justification |
+|---|---|---|
+| Crate-internal `resolve_observed_identity` helper in `server_health_io.rs` | Accepted | Required by A1. It is the exact expression the issue names as defective, lifted to a `pub(super)` pure function so token preservation has behavioral evidence on every platform rather than only where a live-pid probe succeeds. Mirrors the existing #664 split of `classify_resolved_identity`; no new public API. |
+| `project-plans/issue668-plan.md` | Accepted | Required by the delivery workflow. |
+
+## 5. Review counters
+
+- Local review runs used: 0 / 2
+- Post-PR OCR runs used: 0 / 2
+
+## 6. Verification evidence
+
+- [ ] `cargo xtask` gates
+- [ ] `cargo test --workspace --all-features --locked`
+- [ ] coverage gates
+- [ ] CI on the exact head
+- [ ] Ancestry / conflict check

--- a/project-plans/issue668-plan.md
+++ b/project-plans/issue668-plan.md
@@ -70,13 +70,24 @@ so no child split is required.
 
 ## 5. Review counters
 
-- Local review runs used: 0 / 2
+- Local review runs used: 1 / 2
 - Post-PR OCR runs used: 0 / 2
+
+### Local run 1 — `ocr review --from 0b39bd8c --to dd974734` (v1.8.8, stepfun/step-3.7-flash)
+
+Coverage: `complete_best_effort` — 2 selected, 2 completed, 0 failed, 0 waived.
+
+| Finding | Validity | Disposition |
+|---|---|---|
+| `server_health_io_tests.rs:274` (maintainability, low): the `observed` test helper panics through `let ... else` instead of `expect` | Partial — the panic is real, but the reviewer itself records it as acceptable and names no correctness or coverage defect | Reject — `expect` panics identically with a strictly less informative message, whereas `panic!("...got {stdout:?}")` names the offending probe answer; threading `Result` through a test helper adds noise without changing observable behavior. The no-`unwrap`/`expect` rule governs production paths, which this helper is not. |
 
 ## 6. Verification evidence
 
-- [ ] `cargo xtask` gates
-- [ ] `cargo test --workspace --all-features --locked`
-- [ ] coverage gates
+- [x] `cargo xtask` gates — `fmt`, `lint` (strict `clippy --workspace --all-targets --all-features -D warnings`), `check clippy-allows`, `check source-size`, `check architecture`, `complexity`, `build` all clean.
+- [x] `cargo test --workspace --all-features --locked` — 0 failures.
+- [x] coverage gates — `cargo xtask coverage`: total 71.21% lines against the 30% floor; `src/runtime/server_health_io.rs` rises to 84.75% lines / 82.16% regions from the documented 0/82 baseline. The first attempt aborted on `harness::tmux_driver::tests::real_psmux_runs_a_stable_native_process_when_available`, a real-psmux session start that timed out under llvm-cov instrumentation; it passes both unmutated and on the clean rerun, so it is environmental and unrelated to this change.
+- [x] `cargo xtask coverage-windows` per-module floors — every configured module clears its floor, no violations. `src/runtime/server_health_io.rs` reports 37.28% (44/118 lines) against its floor of 0 under the narrower Windows-only selection.
 - [ ] CI on the exact head
 - [ ] Ancestry / conflict check
+
+The Windows floor for `src/runtime/server_health_io.rs` stays at 0 on purpose: raising it is quality-tooling work owned by #663 and needs approval. This change only adds coverage, so the gate cannot regress.

--- a/project-plans/issue668-plan.md
+++ b/project-plans/issue668-plan.md
@@ -71,7 +71,7 @@ so no child split is required.
 ## 5. Review counters
 
 - Local review runs used: 1 / 2
-- Post-PR OCR runs used: 0 / 2
+- Post-PR OCR runs used: 1 / 2
 
 ### Local run 1 — `ocr review --from 0b39bd8c --to dd974734` (v1.8.8, stepfun/step-3.7-flash)
 
@@ -81,13 +81,19 @@ Coverage: `complete_best_effort` — 2 selected, 2 completed, 0 failed, 0 waived
 |---|---|---|
 | `server_health_io_tests.rs:274` (maintainability, low): the `observed` test helper panics through `let ... else` instead of `expect` | Partial — the panic is real, but the reviewer itself records it as acceptable and names no correctness or coverage defect | Reject — `expect` panics identically with a strictly less informative message, whereas `panic!("...got {stdout:?}")` names the offending probe answer; threading `Result` through a test helper adds noise without changing observable behavior. The no-`unwrap`/`expect` rule governs production paths, which this helper is not. |
 
+### Post-PR run 1 — `ocr review --from 0b39bd8c --to 1803da92` (v1.8.8, stepfun/step-3.7-flash)
+
+Coverage: `complete_best_effort` — 2 selected, 2 completed, 0 failed, 0 waived. **0 findings**, so nothing to triage. This run covers the final head including the test refactor, which means the sole finding from local run 1 was not re-raised. Its disposition stands unchanged.
+
+CI-side reviews on the same head — OpenCodeReview, CodeRabbit and the LLxprt review — all reported success, and `pr.reviews --actionable` returns no unresolved threads.
+
 ## 6. Verification evidence
 
 - [x] `cargo xtask` gates — `fmt`, `lint` (strict `clippy --workspace --all-targets --all-features -D warnings`), `check clippy-allows`, `check source-size`, `check architecture`, `complexity`, `build` all clean.
 - [x] `cargo test --workspace --all-features --locked` — 0 failures.
 - [x] coverage gates — `cargo xtask coverage`: total 71.21% lines against the 30% floor; `src/runtime/server_health_io.rs` rises to 84.75% lines / 82.16% regions from the documented 0/82 baseline. The first attempt aborted on `harness::tmux_driver::tests::real_psmux_runs_a_stable_native_process_when_available`, a real-psmux session start that timed out under llvm-cov instrumentation; it passes both unmutated and on the clean rerun, so it is environmental and unrelated to this change.
 - [x] `cargo xtask coverage-windows` per-module floors — every configured module clears its floor, no violations. `src/runtime/server_health_io.rs` reports 37.28% (44/118 lines) against its floor of 0 under the narrower Windows-only selection.
-- [ ] CI on the exact head
-- [ ] Ancestry / conflict check
+- [x] CI on the exact head — PR #673 @ `1803da92`: 19 checks pass, 0 fail, 2 skipped (the tmux smoke and the main flake baseline, neither of which runs on a PR). The first push failed `Lint (clippy)`, `Complexity checks` and `Coverage gate` on a single Linux-only diagnostic — `constant NAMESPACE_B is never used`, because the new tests re-spelled the tokens as literals so that constant had only a `#[cfg(windows)]` reader. Fixed at the source by rendering probe answers from the constants through an `answer` helper rather than by suppressing the lint.
+- [x] Ancestry / conflict check — `git merge-base --is-ancestor origin/main issue668` held at `0b39bd8c`; `origin/main` has since advanced to `8538fdd1`, and `git merge-tree --write-tree origin/main issue668` reports no conflicts. The branch is cut directly from `main`, not stacked on another PR.
 
 The Windows floor for `src/runtime/server_health_io.rs` stays at 0 on purpose: raising it is quality-tooling work owned by #663 and needs approval. This change only adds coverage, so the gate cannot regress.

--- a/src/runtime/server_health_io.rs
+++ b/src/runtime/server_health_io.rs
@@ -3,6 +3,8 @@
 use std::cell::RefCell;
 use std::process::Stdio;
 
+use crate::domain::{ProcessIdentity, ServerProcessIdentity};
+
 use super::liveness::run_tmux_with_timeout;
 use super::server_health::{
     ServerIdentity, ServerLivenessEvidence, ServerLivenessObservation, classify_server_health,
@@ -49,15 +51,31 @@ pub(super) fn classify_observation(
             // The parser only knows the PID the multiplexer printed; the
             // creation discriminator has to come from the operating system.
             let current = match capture_process_identity(parsed.process.pid()) {
-                Ok(process) => ServerIdentity::new(
-                    crate::domain::ServerProcessIdentity::from_identity(process),
-                    parsed.multiplexer,
-                ),
+                Ok(process) => resolve_observed_identity(parsed, process),
                 Err(_) => return ServerLivenessObservation::Unavailable,
             };
             classify_resolved_identity(prior, &current)
         }
         _ => super::classify_server_liveness(prior, evidence),
+    }
+}
+
+/// Merge the probe's parsed answer with the operating system's view of the
+/// process that answered.
+///
+/// Each side owns half the evidence: only the multiplexer can report the `-L`
+/// namespace token, and only the operating system can report the answering
+/// process's creation discriminator (the parser substitutes a placeholder).
+/// Keeping one half and discarding the other is what left the token-decisive
+/// comparison unreachable (issue #668).
+pub(super) fn resolve_observed_identity(
+    parsed: ServerIdentity,
+    process: ProcessIdentity,
+) -> ServerIdentity {
+    let process = ServerProcessIdentity::from_identity(process);
+    match parsed.instance {
+        Some(instance) => ServerIdentity::with_instance(process, parsed.multiplexer, instance),
+        None => ServerIdentity::new(process, parsed.multiplexer),
     }
 }
 

--- a/src/runtime/server_health_io_tests.rs
+++ b/src/runtime/server_health_io_tests.rs
@@ -6,9 +6,14 @@
 //! classification of every observation the probe can produce, starting with
 //! the `Replaced` branch and the conflicting-identity guard that now bounds it.
 
-use super::server_health::{ServerIdentity, ServerLivenessEvidence, ServerLivenessObservation};
-use super::server_health_io::{classify_observation, classify_resolved_identity};
-use crate::domain::ServerProcessIdentity;
+use super::server_health::{
+    ServerIdentity, ServerInstanceToken, ServerLivenessEvidence, ServerLivenessObservation,
+    parse_server_identity_output,
+};
+use super::server_health_io::{
+    classify_observation, classify_resolved_identity, resolve_observed_identity,
+};
+use crate::domain::{ProcessIdentity, ServerProcessIdentity};
 use crate::runtime::MultiplexerVersion;
 
 fn identity(pid: u32, started_at: u64) -> ServerIdentity {
@@ -241,4 +246,194 @@ fn identity_free_observations_are_not_exit_empty_targets() {
         super::server_health_io::exit_empty_target(&ServerLivenessObservation::Healthy(None)),
         None
     );
+}
+
+// --- Namespace-token classification (issue #668) -------------------------
+//
+// psmux runs one server *per session*, so a namespace can hold several live
+// servers and `display-message` answers with whichever one replied. The
+// `#{server_instance}` token identifies the namespace itself, and until #668
+// the I/O path parsed it and then dropped it, leaving every verdict to the
+// weaker pid comparison. These tests drive the production composition —
+// parse the probe answer, merge the operating system's view of the answering
+// process, classify — so the token is proven to survive that merge and to
+// decide the verdict once it does.
+
+/// One namespace's token, and a second, different namespace's token.
+const NAMESPACE_A: &str = "883b25f5379f199a";
+const NAMESPACE_B: &str = "f3cb9da032325298";
+
+/// Creation discriminators from the issue #664 production observation: 133
+/// seconds apart, `OLDER` belonging to the process that answered second.
+const OLDER: u64 = 134_304_226_880_092_839;
+const NEWER: u64 = 134_304_228_211_297_590;
+
+/// Build an identity exactly as the production path does: the multiplexer's
+/// parsed answer merged with the operating system's view of the process that
+/// answered. Each side owns half the evidence, so both halves must survive.
+fn observed(stdout: &str, started_at: u64) -> ServerIdentity {
+    let Some(parsed) = parse_server_identity_output(stdout) else {
+        panic!("a server identity probe answer must parse, got {stdout:?}")
+    };
+    let process = ProcessIdentity::new(parsed.process.pid(), started_at);
+    resolve_observed_identity(parsed, process)
+}
+
+/// Resolving an answer against the operating system keeps the namespace token
+/// the multiplexer reported and adopts the creation discriminator only the
+/// operating system can supply.
+#[test]
+fn resolving_an_answer_keeps_the_namespace_token_and_takes_the_real_start() {
+    let resolved = observed("883b25f5379f199a|656|3.3.7", NEWER);
+
+    assert_eq!(
+        resolved.instance.as_ref().map(ServerInstanceToken::as_str),
+        Some(NAMESPACE_A)
+    );
+    assert_eq!(resolved.process, ServerProcessIdentity::new(656, NEWER));
+    assert_eq!(resolved.multiplexer, MultiplexerVersion::new(3, 3, 7));
+}
+
+/// A multiplexer predating psmux#509 renders the token as empty text. That
+/// blank field stays absent rather than becoming a token, so such a server is
+/// still classified on process identity alone.
+#[test]
+fn resolving_a_tokenless_answer_yields_no_namespace_token() {
+    let resolved = observed("|656|3.3.7", NEWER);
+
+    assert_eq!(resolved.instance, None);
+    assert_eq!(resolved.process, ServerProcessIdentity::new(656, NEWER));
+}
+
+/// The same namespace answering from a different per-session server is not a
+/// replacement: adding a session to a live namespace changes which pid
+/// replies but nothing about the namespace (issue #540).
+#[test]
+fn the_same_namespace_token_at_a_different_pid_is_healthy() {
+    let prior = observed("883b25f5379f199a|9008|3.3.7", OLDER);
+    let current = observed("883b25f5379f199a|3832|3.3.7", NEWER);
+
+    assert_eq!(
+        classify_resolved_identity(Some(&prior), &current),
+        ServerLivenessObservation::Healthy(Some(current))
+    );
+}
+
+/// The issue #664 production shape, now carrying a token: the server that
+/// answered is 133 seconds *older* than the pinned one. Within one namespace
+/// that is an ordinary sibling server, so the token settles it as healthy and
+/// the monotonicity guard is never reached — the guard does not mask the
+/// token rule.
+#[test]
+fn the_same_namespace_token_at_an_older_sibling_server_is_healthy() {
+    let prior = observed("883b25f5379f199a|656|3.3.7", NEWER);
+    let current = observed("883b25f5379f199a|19948|3.3.7", OLDER);
+
+    assert_eq!(
+        classify_resolved_identity(Some(&prior), &current),
+        ServerLivenessObservation::Healthy(Some(current))
+    );
+}
+
+/// A different namespace token means the namespace itself changed. When the
+/// answering process is strictly newer the restart is orderable, so it is a
+/// genuine replacement even though the operating system reused the pid.
+#[test]
+fn a_different_namespace_token_at_a_reused_pid_is_replaced() {
+    let prior = observed("883b25f5379f199a|656|3.3.7", OLDER);
+    let current = observed("f3cb9da032325298|656|3.3.7", NEWER);
+
+    assert_eq!(
+        classify_resolved_identity(Some(&prior), &current),
+        ServerLivenessObservation::Replaced(current)
+    );
+}
+
+/// One process cannot belong to two namespaces. A different token on an
+/// identical process is contradictory rather than a restart, and the #664
+/// guard refuses it because nothing was created after anything else.
+#[test]
+fn a_different_namespace_token_on_an_identical_process_is_conflicting() {
+    let prior = observed("883b25f5379f199a|656|3.3.7", NEWER);
+    let current = observed("f3cb9da032325298|656|3.3.7", NEWER);
+
+    assert_eq!(
+        classify_resolved_identity(Some(&prior), &current),
+        ServerLivenessObservation::ConflictingIdentity(current)
+    );
+}
+
+/// A token on the pinned side only is not decisive in either direction: with
+/// nothing to compare it against, the verdict falls back to process identity.
+#[test]
+fn a_token_on_the_prior_only_falls_back_to_the_process_identity() {
+    let prior = observed("883b25f5379f199a|656|3.3.7", NEWER);
+
+    let same_process = observed("|656|3.3.7", NEWER);
+    assert_eq!(
+        classify_resolved_identity(Some(&prior), &same_process),
+        ServerLivenessObservation::Healthy(Some(same_process))
+    );
+
+    let newer_process = observed("|19948|3.3.7", NEWER + 1);
+    assert_eq!(
+        classify_resolved_identity(Some(&prior), &newer_process),
+        ServerLivenessObservation::Replaced(newer_process)
+    );
+}
+
+/// The mirror case: a token appearing on the fresh answer only cannot be
+/// matched against the pinned identity, so process identity decides again.
+#[test]
+fn a_token_on_the_current_only_falls_back_to_the_process_identity() {
+    let prior = observed("|656|3.3.7", NEWER);
+
+    let same_process = observed("883b25f5379f199a|656|3.3.7", NEWER);
+    assert_eq!(
+        classify_resolved_identity(Some(&prior), &same_process),
+        ServerLivenessObservation::Healthy(Some(same_process))
+    );
+
+    let newer_process = observed("883b25f5379f199a|19948|3.3.7", NEWER + 1);
+    assert_eq!(
+        classify_resolved_identity(Some(&prior), &newer_process),
+        ServerLivenessObservation::Replaced(newer_process)
+    );
+}
+
+/// The issue #664 guard survives the token path going live: a genuinely
+/// different namespace whose server predates the pinned one is still refused,
+/// so the token rule does not promote a non-monotonic answer to `Replaced`.
+#[test]
+fn a_non_monotonic_namespace_change_is_still_refused() {
+    let prior = observed("883b25f5379f199a|656|3.3.7", NEWER);
+    let current = observed("f3cb9da032325298|19948|3.3.7", OLDER);
+
+    assert_eq!(
+        classify_resolved_identity(Some(&prior), &current),
+        ServerLivenessObservation::ConflictingIdentity(current)
+    );
+}
+
+/// End to end on the platform where the defect was observed: a probe answer
+/// carrying a namespace token reaches the pinned identity with that token
+/// intact, alongside the operating system's creation discriminator.
+#[cfg(windows)]
+#[test]
+fn a_probed_namespace_token_reaches_the_pinned_identity() {
+    let pid = std::process::id();
+    let stdout = format!("{NAMESPACE_B}|{pid}|3.3.7");
+    let evidence = ServerLivenessEvidence::command_succeeded(&stdout, "");
+
+    match classify_observation(None, &evidence) {
+        ServerLivenessObservation::Healthy(Some(observed)) => {
+            assert_eq!(
+                observed.instance.as_ref().map(ServerInstanceToken::as_str),
+                Some(NAMESPACE_B)
+            );
+            assert_eq!(observed.process.pid(), pid);
+            assert!(observed.process.started_at().is_some());
+        }
+        other => panic!("expected a resolved healthy identity, got {other:?}"),
+    }
 }

--- a/src/runtime/server_health_io_tests.rs
+++ b/src/runtime/server_health_io_tests.rs
@@ -263,16 +263,26 @@ fn identity_free_observations_are_not_exit_empty_targets() {
 const NAMESPACE_A: &str = "883b25f5379f199a";
 const NAMESPACE_B: &str = "f3cb9da032325298";
 
+/// The multiplexer version every probe answer below reports.
+const VERSION: &str = "3.3.7";
+
 /// Creation discriminators from the issue #664 production observation: 133
 /// seconds apart, `OLDER` belonging to the process that answered second.
 const OLDER: u64 = 134_304_226_880_092_839;
 const NEWER: u64 = 134_304_228_211_297_590;
 
+/// Render a probe answer the way the multiplexer does. An empty `token`
+/// reproduces a multiplexer predating psmux#509.
+fn answer(token: &str, pid: u32) -> String {
+    format!("{token}|{pid}|{VERSION}")
+}
+
 /// Build an identity exactly as the production path does: the multiplexer's
 /// parsed answer merged with the operating system's view of the process that
 /// answered. Each side owns half the evidence, so both halves must survive.
-fn observed(stdout: &str, started_at: u64) -> ServerIdentity {
-    let Some(parsed) = parse_server_identity_output(stdout) else {
+fn observed(token: &str, pid: u32, started_at: u64) -> ServerIdentity {
+    let stdout = answer(token, pid);
+    let Some(parsed) = parse_server_identity_output(&stdout) else {
         panic!("a server identity probe answer must parse, got {stdout:?}")
     };
     let process = ProcessIdentity::new(parsed.process.pid(), started_at);
@@ -284,7 +294,7 @@ fn observed(stdout: &str, started_at: u64) -> ServerIdentity {
 /// operating system can supply.
 #[test]
 fn resolving_an_answer_keeps_the_namespace_token_and_takes_the_real_start() {
-    let resolved = observed("883b25f5379f199a|656|3.3.7", NEWER);
+    let resolved = observed(NAMESPACE_A, 656, NEWER);
 
     assert_eq!(
         resolved.instance.as_ref().map(ServerInstanceToken::as_str),
@@ -299,7 +309,7 @@ fn resolving_an_answer_keeps_the_namespace_token_and_takes_the_real_start() {
 /// still classified on process identity alone.
 #[test]
 fn resolving_a_tokenless_answer_yields_no_namespace_token() {
-    let resolved = observed("|656|3.3.7", NEWER);
+    let resolved = observed("", 656, NEWER);
 
     assert_eq!(resolved.instance, None);
     assert_eq!(resolved.process, ServerProcessIdentity::new(656, NEWER));
@@ -310,8 +320,8 @@ fn resolving_a_tokenless_answer_yields_no_namespace_token() {
 /// replies but nothing about the namespace (issue #540).
 #[test]
 fn the_same_namespace_token_at_a_different_pid_is_healthy() {
-    let prior = observed("883b25f5379f199a|9008|3.3.7", OLDER);
-    let current = observed("883b25f5379f199a|3832|3.3.7", NEWER);
+    let prior = observed(NAMESPACE_A, 9008, OLDER);
+    let current = observed(NAMESPACE_A, 3832, NEWER);
 
     assert_eq!(
         classify_resolved_identity(Some(&prior), &current),
@@ -326,8 +336,8 @@ fn the_same_namespace_token_at_a_different_pid_is_healthy() {
 /// token rule.
 #[test]
 fn the_same_namespace_token_at_an_older_sibling_server_is_healthy() {
-    let prior = observed("883b25f5379f199a|656|3.3.7", NEWER);
-    let current = observed("883b25f5379f199a|19948|3.3.7", OLDER);
+    let prior = observed(NAMESPACE_A, 656, NEWER);
+    let current = observed(NAMESPACE_A, 19948, OLDER);
 
     assert_eq!(
         classify_resolved_identity(Some(&prior), &current),
@@ -340,8 +350,8 @@ fn the_same_namespace_token_at_an_older_sibling_server_is_healthy() {
 /// genuine replacement even though the operating system reused the pid.
 #[test]
 fn a_different_namespace_token_at_a_reused_pid_is_replaced() {
-    let prior = observed("883b25f5379f199a|656|3.3.7", OLDER);
-    let current = observed("f3cb9da032325298|656|3.3.7", NEWER);
+    let prior = observed(NAMESPACE_A, 656, OLDER);
+    let current = observed(NAMESPACE_B, 656, NEWER);
 
     assert_eq!(
         classify_resolved_identity(Some(&prior), &current),
@@ -354,8 +364,8 @@ fn a_different_namespace_token_at_a_reused_pid_is_replaced() {
 /// guard refuses it because nothing was created after anything else.
 #[test]
 fn a_different_namespace_token_on_an_identical_process_is_conflicting() {
-    let prior = observed("883b25f5379f199a|656|3.3.7", NEWER);
-    let current = observed("f3cb9da032325298|656|3.3.7", NEWER);
+    let prior = observed(NAMESPACE_A, 656, NEWER);
+    let current = observed(NAMESPACE_B, 656, NEWER);
 
     assert_eq!(
         classify_resolved_identity(Some(&prior), &current),
@@ -367,15 +377,15 @@ fn a_different_namespace_token_on_an_identical_process_is_conflicting() {
 /// nothing to compare it against, the verdict falls back to process identity.
 #[test]
 fn a_token_on_the_prior_only_falls_back_to_the_process_identity() {
-    let prior = observed("883b25f5379f199a|656|3.3.7", NEWER);
+    let prior = observed(NAMESPACE_A, 656, NEWER);
 
-    let same_process = observed("|656|3.3.7", NEWER);
+    let same_process = observed("", 656, NEWER);
     assert_eq!(
         classify_resolved_identity(Some(&prior), &same_process),
         ServerLivenessObservation::Healthy(Some(same_process))
     );
 
-    let newer_process = observed("|19948|3.3.7", NEWER + 1);
+    let newer_process = observed("", 19948, NEWER + 1);
     assert_eq!(
         classify_resolved_identity(Some(&prior), &newer_process),
         ServerLivenessObservation::Replaced(newer_process)
@@ -386,15 +396,15 @@ fn a_token_on_the_prior_only_falls_back_to_the_process_identity() {
 /// matched against the pinned identity, so process identity decides again.
 #[test]
 fn a_token_on_the_current_only_falls_back_to_the_process_identity() {
-    let prior = observed("|656|3.3.7", NEWER);
+    let prior = observed("", 656, NEWER);
 
-    let same_process = observed("883b25f5379f199a|656|3.3.7", NEWER);
+    let same_process = observed(NAMESPACE_A, 656, NEWER);
     assert_eq!(
         classify_resolved_identity(Some(&prior), &same_process),
         ServerLivenessObservation::Healthy(Some(same_process))
     );
 
-    let newer_process = observed("883b25f5379f199a|19948|3.3.7", NEWER + 1);
+    let newer_process = observed(NAMESPACE_A, 19948, NEWER + 1);
     assert_eq!(
         classify_resolved_identity(Some(&prior), &newer_process),
         ServerLivenessObservation::Replaced(newer_process)
@@ -406,8 +416,8 @@ fn a_token_on_the_current_only_falls_back_to_the_process_identity() {
 /// so the token rule does not promote a non-monotonic answer to `Replaced`.
 #[test]
 fn a_non_monotonic_namespace_change_is_still_refused() {
-    let prior = observed("883b25f5379f199a|656|3.3.7", NEWER);
-    let current = observed("f3cb9da032325298|19948|3.3.7", OLDER);
+    let prior = observed(NAMESPACE_A, 656, NEWER);
+    let current = observed(NAMESPACE_B, 19948, OLDER);
 
     assert_eq!(
         classify_resolved_identity(Some(&prior), &current),
@@ -422,7 +432,7 @@ fn a_non_monotonic_namespace_change_is_still_refused() {
 #[test]
 fn a_probed_namespace_token_reaches_the_pinned_identity() {
     let pid = std::process::id();
-    let stdout = format!("{NAMESPACE_B}|{pid}|3.3.7");
+    let stdout = answer(NAMESPACE_B, pid);
     let evidence = ServerLivenessEvidence::command_succeeded(&stdout, "");
 
     match classify_observation(None, &evidence) {


### PR DESCRIPTION
Fixes #668.

## The defect

`parse_server_identity_output` already recovers the `#{server_instance}` namespace token from the probe answer (`"<instance_token>|<pid>|<version>"`). The I/O path then threw it away: `classify_observation` rebuilt the identity with `ServerIdentity::new(process, multiplexer)`, whose `instance` field is hardcoded to `None`.

So the token-decisive branch of `classify_server_health` was unreachable in production. Every verdict fell through to the weaker pid/`started_at` comparison, no matter what the multiplexer reported.

That matters because psmux runs one server per *session* (psmux/#540), so a single `-L` namespace can hold several live servers and the answering pid flips without anything having restarted. Combined with the #664 monotonicity guard, that produced the impossible verdict in the issue: a "replacement" whose creation time was 133 s *older* than its predecessor (pid 656 @ 134_304_228_211_297_590 vs pid 19948 @ 134_304_226_880_092_839).

## The fix

The two halves of the evidence live in different places, and the bug was dropping one of them:

- only the multiplexer knows the `-L` namespace token, and
- only the OS (`capture_process_identity`) knows the real creation discriminator — the parser substitutes a placeholder `1`.

`resolve_observed_identity` now merges both: it takes the process identity from the OS and preserves `parsed.instance` when the probe supplied one, falling back to `ServerIdentity::new` when it did not. A blank first field still yields `instance: None` and is never synthesised into a token, so multiplexers predating psmux/#509 keep the old pid-based behavior.

The token becomes decisive again, which leaves the #664 monotonicity guard bounding only *genuine* namespace changes rather than every pid flip.

The helper is `pub(super)` and pure, mirroring the existing #664 split of `classify_resolved_identity`. That gives token preservation behavioral evidence on every platform instead of only where a live-pid probe succeeds. No new public API.

## Tests

10 behavioral tests in `src/runtime/server_health_io_tests.rs` covering the acceptance matrix. 5 of them failed for the right reasons before the fix:

- the token and the real start survive resolution; a blank field yields no token
- the same token at a different pid — including an *older* sibling server — is `Healthy`
- a different token at a reused pid is `Replaced`; a different token on an identical process is `ConflictingIdentity`
- a one-sided token falls back to pid + `started_at`
- a non-monotonic namespace change is still refused, proving the token rule and the #664 guard do not mask each other

A Windows-gated test drives a real probed token through to the pinned identity.

## Verification

`cargo xtask` fmt / lint (strict `-D warnings`) / clippy-allows / source-size / architecture / complexity / build, plus the full workspace test run — all clean.

`cargo xtask coverage`: 71.21% lines overall against the 30% floor, with `src/runtime/server_health_io.rs` rising from the documented 0/82 baseline to 84.75% lines / 82.16% regions. `cargo xtask coverage-windows`: every configured module clears its floor.

The Windows floor for `server_health_io.rs` deliberately stays at 0 — raising it is quality-tooling work owned by #663. This change only adds coverage, so the gate cannot regress.

## Non-goals

Probe authority under concurrent servers; changing `classify_server_health`, `parse_server_identity_output` or `ServerInstanceToken`; changing `ServerLivenessObservation`, `plan_server_cycle` or agent state; token persistence across restarts; the #663 coverage work; #662 observability.

Plan and scope ledger: `project-plans/issue668-plan.md`.
