### PR TITLE
Replace status-bar error text with a persistent error count

### DIFF
--- a/dev-docs/tmux-scenarios/issue435/status-bar-error-count.json
+++ b/dev-docs/tmux-scenarios/issue435/status-bar-error-count.json
@@ -1,0 +1,118 @@
+{
+  "schema": 1,
+  "name": "status-bar-error-count",
+  "platform": "macos",
+  "terminal": {
+    "cols": 100,
+    "rows": 24
+  },
+  "workspace": {
+    "mode": 448,
+    "dirs": [
+      {
+        "path": "config",
+        "mode": 448
+      },
+      {
+        "path": "work",
+        "mode": 448
+      }
+    ],
+    "files": [
+      {
+        "path": "config/settings.toml",
+        "content": {
+          "utf8": "settings_schema = 2\n"
+        },
+        "mode": 384
+      }
+    ],
+    "env": []
+  },
+  "steps": [
+    {
+      "op": "launch",
+      "argv": [
+        "jefe",
+        "--config",
+        "${workspace}/config"
+      ],
+      "env": [],
+      "cwd": "work"
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "LLxprt Jefe",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "assert-frame",
+      "contains": [
+        "repos |",
+        "running"
+      ],
+      "absent": [
+        "ERR:"
+      ]
+    },
+    {
+      "op": "assert-frame",
+      "contains": [],
+      "absent": [
+        "errors"
+      ]
+    },
+    {
+      "op": "key",
+      "key": "e",
+      "modifiers": []
+    },
+    {
+      "op": "wait",
+      "source": "frame",
+      "literal": "Errors",
+      "timeout_ms": 15000
+    },
+    {
+      "op": "assert-frame",
+      "contains": [
+        "No errors recorded"
+      ],
+      "absent": []
+    },
+    {
+      "op": "key",
+      "key": "escape",
+      "modifiers": []
+    },
+    {
+      "op": "assert-frame",
+      "contains": [
+        "repos |"
+      ],
+      "absent": [
+        "ERR:"
+      ]
+    },
+    {
+      "op": "key",
+      "key": "q",
+      "modifiers": []
+    },
+    {
+      "op": "key",
+      "key": "q",
+      "modifiers": []
+    },
+    {
+      "op": "key",
+      "key": "q",
+      "modifiers": []
+    },
+    {
+      "op": "finish"
+    }
+  ],
+  "secrets": []
+}

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -932,8 +932,11 @@ fn apply_restored_state(
 
     state.rebuild_repository_agent_ids();
     state.normalize_selection_indices();
-    if let Some(warning) = runtime_warning {
-        append_warning(state, warning);
+    if let Some(report) = runtime_warning {
+        // Issue #435: reclaim reports list every unmatched session and cannot
+        // fit the single-line warning slot, so they go to Errors where the full
+        // list is readable and copyable.
+        jefe::state::capture_reclaim_report(state, &report);
     }
 }
 

--- a/src/app_input/transient_issue_send.rs
+++ b/src/app_input/transient_issue_send.rs
@@ -343,18 +343,29 @@ fn launch_transient_issue_agent(
         spawn_and_attach_fresh_for_issue(app_state, ctx, &agent_id, &work_dir, &launch_sig);
     let launched_ok = launched.is_ok();
     let identities = super::process_on_success(ctx, &agent_id, launched_ok);
-    if launched_ok {
-        let mut state = app_state.write();
-        persist_issue_agent_launch_success(&mut state, &agent_id, launch_sig, identities);
-        let persisted = durable_save_request(&mut state);
-        drop(state);
-        schedule_durable_save(ctx, persisted);
-    } else {
-        // Surface the failure, then remove the transient agent and clean up
-        // its temp directory via fail_transient_agent.
-        let error_msg = format!("Failed to launch transient {} agent", launch_sig.type_id);
-        apply_send_to_agent_failed(app_state, ctx, error_msg);
-        fail_transient_agent(app_state, ctx, &agent_id);
+    match launched {
+        Ok(()) => {
+            let mut state = app_state.write();
+            persist_issue_agent_launch_success(&mut state, &agent_id, launch_sig, identities);
+            let persisted = durable_save_request(&mut state);
+            drop(state);
+            schedule_durable_save(ctx, persisted);
+        }
+        Err(error) => {
+            // Issue #435: this path used to substitute a generic "Failed to
+            // launch transient <type> agent" string and drop the RuntimeError,
+            // leaving the Errors screen with a message that named no cause.
+            // Carry the real diagnostic through so the entry is actionable.
+            apply_send_to_agent_failed(
+                app_state,
+                ctx,
+                format!(
+                    "Failed to launch transient {} agent: {error}",
+                    launch_sig.type_id
+                ),
+            );
+            fail_transient_agent(app_state, ctx, &agent_id);
+        }
     }
     apply_assignment_action(
         app_state,

--- a/src/state/errors_ops.rs
+++ b/src/state/errors_ops.rs
@@ -197,6 +197,23 @@ pub fn capture_worker_panic(state: &mut AppState, detail: &str) {
     );
 }
 
+/// Record a startup session-reclaim report in the errors ring (issue #435).
+///
+/// Reclaim reports enumerate every unmatched session, so they routinely run to
+/// hundreds of characters and used to be crammed into the single-line status-bar
+/// warning slot, where they were unreadable and buried every other warning. They
+/// are recorded silently: the operator gets a count as their cue and the full,
+/// copyable list on the Errors screen, without the report stealing a selection
+/// they were already working with.
+pub fn capture_reclaim_report(state: &mut AppState, report: &str) {
+    state.errors_state.push_silent(
+        "Session reclaim report".to_string(),
+        report.to_string(),
+        crate::domain::ErrorSource::Other,
+        now_timestamp(),
+    );
+}
+
 /// Capture runtime errors into the errors ring buffer (issue #292).
 ///
 /// Called from `finalize_message` after every reducer step. Inspects all known

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -164,7 +164,7 @@ mod types;
 mod util;
 mod workbench_filter;
 mod workbench_reducers;
-pub use errors_ops::{capture_runtime_errors, capture_worker_panic};
+pub use errors_ops::{capture_reclaim_report, capture_runtime_errors, capture_worker_panic};
 pub use errors_types::{ErrorsFocus, ErrorsState};
 pub use events::*;
 pub use issues_close_reason_ops::filter_duplicate_candidates;

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -174,7 +174,7 @@ pub use selectable_list::{
     SpanColor, SpanRole, selectable_list_element,
 };
 pub use sidebar::{Sidebar, SidebarProps, sidebar_list_props};
-pub use status_bar::{StatusBar, StatusBarProps};
+pub use status_bar::{StatusBar, StatusBarProps, status_bar_stats};
 pub use terminal_view::{TerminalView, TerminalViewProps, terminal_empty_message};
 pub use terminal_viewport::{TerminalViewportProjection, build_terminal_viewport};
 /// @plan PLAN-20260624-PR-MODE.P14

--- a/src/ui/components/status_bar.rs
+++ b/src/ui/components/status_bar.rs
@@ -25,14 +25,41 @@ pub struct StatusBarProps {
     pub kennel_mode: bool,
     /// Optional warning text shown in the center status area.
     pub warning_message: Option<String>,
-    /// Last error title (issue #292). Shown in the center area with precedence
-    /// below warnings (ssh agent socket) so legacy warnings still surface.
-    pub last_error: Option<String>,
+    /// Number of outstanding entries on the Errors screen (issue #435).
+    /// Rendered as a bare count, never as error text: the bar is a clue that
+    /// something failed, and the Errors screen holds the copyable detail.
+    pub error_count: usize,
     /// Theme colors.
     pub colors: ThemeColors,
     /// Active text selection, if any. When it targets this pane the whole
     /// single-line bar is painted in inverse-video.
     pub selection: Option<TextSelection>,
+}
+
+/// Build the center segment of the status bar.
+///
+/// Issue #435: this used to render `ERR: <first 50 chars>…`, which was too short
+/// to diagnose anything, hid the running summary while displayed, and gave the
+/// operator nowhere to go. It now reports only how many errors are outstanding,
+/// leaving the full text to the Errors screen. Transient warnings keep their
+/// slot — they are short and self-contained — but no longer suppress the clue.
+#[must_use]
+pub fn status_bar_stats(
+    warning_message: Option<&str>,
+    repo_count: usize,
+    running_count: usize,
+    agent_count: usize,
+    error_count: usize,
+) -> String {
+    let base = match warning_message {
+        Some(warning) => format!("WARN: {warning}"),
+        None => format!("{repo_count} repos | {running_count}/{agent_count} running"),
+    };
+    if error_count == 0 {
+        return base;
+    }
+    let noun = if error_count == 1 { "error" } else { "errors" };
+    format!("{base} | {error_count} {noun}")
 }
 
 /// Status bar showing app title and statistics.
@@ -54,25 +81,13 @@ pub fn StatusBar(props: &StatusBarProps) -> impl Into<AnyElement<'static>> {
     } else {
         ""
     };
-    let stats = if let Some(warning) = &props.warning_message {
-        format!("WARN: {warning}")
-    } else if let Some(error) = &props.last_error {
-        // Truncate to keep the single-line bar readable (issue #292).
-        // Use char-based truncation to avoid splitting multi-byte UTF-8.
-        let max_chars = 50;
-        let display = if error.chars().count() > max_chars {
-            let truncated: String = error.chars().take(max_chars).collect();
-            format!("{truncated}…")
-        } else {
-            error.clone()
-        };
-        format!("ERR: {display}")
-    } else {
-        format!(
-            "{} repos | {}/{} running",
-            props.repo_count, props.running_count, props.agent_count
-        )
-    };
+    let stats = status_bar_stats(
+        props.warning_message.as_deref(),
+        props.repo_count,
+        props.running_count,
+        props.agent_count,
+        props.error_count,
+    );
 
     element! {
         Box(

--- a/src/ui/screens/actions.rs
+++ b/src/ui/screens/actions.rs
@@ -137,7 +137,7 @@ pub fn ActionsScreen(props: &ActionsScreenProps) -> impl Into<AnyElement<'static
                 theme_name: props.theme_name.clone(),
                 version: crate::VERSION.to_owned(),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
-                last_error: state.and_then(AppState::last_error_title),
+                error_count: state.map_or(0, |s| s.errors_state.count()),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/dashboard.rs
+++ b/src/ui/screens/dashboard.rs
@@ -291,7 +291,7 @@ pub fn Dashboard(props: &DashboardProps) -> impl Into<AnyElement<'static>> {
                 version: crate::VERSION.to_owned(),
                 kennel_mode: state.is_some_and(crate::state::AppState::is_kennel_mode),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
-                last_error: state.and_then(AppState::last_error_title),
+                error_count: state.map_or(0, |s| s.errors_state.count()),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/errors.rs
+++ b/src/ui/screens/errors.rs
@@ -191,7 +191,7 @@ pub fn ErrorsScreen(props: &ErrorsScreenProps) -> impl Into<AnyElement<'static>>
                 theme_name: props.theme_name.clone(),
                 version: crate::VERSION.to_owned(),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
-                last_error: state.and_then(AppState::last_error_title),
+                error_count: state.map_or(0, |s| s.errors_state.count()),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/issues.rs
+++ b/src/ui/screens/issues.rs
@@ -251,7 +251,7 @@ pub fn IssuesScreen(props: &IssuesScreenProps) -> impl Into<AnyElement<'static>>
                 version: crate::VERSION.to_owned(),
                 kennel_mode: state.is_some_and(crate::state::AppState::is_kennel_mode),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
-                last_error: state.and_then(AppState::last_error_title),
+                error_count: state.map_or(0, |s| s.errors_state.count()),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/pull_requests.rs
+++ b/src/ui/screens/pull_requests.rs
@@ -269,7 +269,7 @@ pub fn PullRequestsScreen(props: &PullRequestsScreenProps) -> impl Into<AnyEleme
                 version: crate::VERSION.to_owned(),
                 kennel_mode: state.is_some_and(crate::state::AppState::is_kennel_mode),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
-                last_error: state.and_then(AppState::last_error_title),
+                error_count: state.map_or(0, |s| s.errors_state.count()),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/settings.rs
+++ b/src/ui/screens/settings.rs
@@ -68,7 +68,7 @@ pub fn SettingsScreen(props: &SettingsScreenProps) -> impl Into<AnyElement<'stat
                 theme_name: props.theme_name.clone(),
                 version: crate::VERSION.to_owned(),
                 warning_message: props.state.as_ref().and_then(|s| s.warning_message.clone()),
-                last_error: props.state.as_ref().and_then(AppState::last_error_title),
+                error_count: props.state.as_ref().map_or(0, |s| s.errors_state.count()),
                 colors: colors.clone(),
                 selection: props.state.as_ref().and_then(|s| s.selection),
             )

--- a/src/ui/screens/split.rs
+++ b/src/ui/screens/split.rs
@@ -124,7 +124,7 @@ pub fn SplitScreen(props: &SplitScreenProps) -> impl Into<AnyElement<'static>> {
                 version: crate::VERSION.to_owned(),
                 kennel_mode: state.is_some_and(crate::state::AppState::is_kennel_mode),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
-                last_error: state.and_then(AppState::last_error_title),
+                error_count: state.map_or(0, |s| s.errors_state.count()),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/src/ui/screens/terminal_manager.rs
+++ b/src/ui/screens/terminal_manager.rs
@@ -175,7 +175,7 @@ pub fn TerminalManagerScreen(props: &TerminalManagerScreenProps) -> impl Into<An
                 theme_name: props.theme_name.clone(),
                 version: crate::VERSION.to_owned(),
                 warning_message: state.and_then(|s| s.warning_message.clone()),
-                last_error: state.and_then(AppState::last_error_title),
+                error_count: state.map_or(0, |s| s.errors_state.count()),
                 colors: colors.clone(),
                 selection: selection,
             )

--- a/tests/issue435_behavior.rs
+++ b/tests/issue435_behavior.rs
@@ -1,0 +1,118 @@
+//! Behavioral coverage for issue #435.
+//!
+//! Launch failures (and startup session-reclaim reports) must not dead-end in a
+//! truncated status-bar line, and must not steal the screen with a modal. The
+//! status bar carries only a persistent *count* of outstanding errors; the full
+//! text lives on the Errors screen where it is already selectable and copyable.
+
+use jefe::domain::ErrorSource;
+use jefe::state::{AppState, capture_reclaim_report};
+use jefe::ui::components::status_bar_stats;
+
+/// A realistic reclaim report: long, and enumerating far more sessions than a
+/// single status-bar line could ever hold.
+const RECLAIM_REPORT: &str = "21 live jefe session(s) match no agent and were left running: \
+jefe-a1, jefe-a2, jefe-a3, jefe-a4, jefe-a5, jefe-a6, jefe-a7, jefe-a8, jefe-a9, jefe-a10, \
+jefe-a11, jefe-a12, jefe-a13, jefe-a14, jefe-a15, jefe-a16, jefe-a17, jefe-a18, jefe-a19, \
+jefe-a20, jefe-a21";
+
+#[test]
+fn a_clean_status_bar_shows_only_the_running_summary() {
+    let stats = status_bar_stats(None, 4, 4, 9, 0);
+    assert_eq!(stats, "4 repos | 4/9 running");
+}
+
+#[test]
+fn outstanding_errors_appear_as_a_count_beside_the_summary() {
+    let stats = status_bar_stats(None, 4, 4, 9, 3);
+    assert_eq!(stats, "4 repos | 4/9 running | 3 errors");
+}
+
+#[test]
+fn a_single_outstanding_error_is_not_pluralised() {
+    let stats = status_bar_stats(None, 4, 4, 9, 1);
+    assert_eq!(stats, "4 repos | 4/9 running | 1 error");
+}
+
+/// The whole point of the change: the bar is a *clue*, never a transcript. No
+/// amount of error text may reach it, so there is nothing left to truncate.
+#[test]
+fn the_status_bar_never_carries_error_text() {
+    let stats = status_bar_stats(None, 4, 4, 9, 21);
+    assert!(
+        !stats.contains("ERR:"),
+        "status bar must not render error text: {stats}"
+    );
+    assert!(
+        !stats.contains("jefe-a1"),
+        "status bar must not render error detail: {stats}"
+    );
+    assert!(stats.ends_with("| 21 errors"), "{stats}");
+}
+
+/// Transient warnings (shell closed, theme resolve failed) are short, actionable
+/// and still belong in the bar, but they must not hide the error clue.
+#[test]
+fn a_transient_warning_still_shows_the_error_count() {
+    let stats = status_bar_stats(Some("Selected shell no longer exists."), 4, 4, 9, 2);
+    assert_eq!(stats, "WARN: Selected shell no longer exists. | 2 errors");
+}
+
+#[test]
+fn a_transient_warning_alone_shows_no_count() {
+    let stats = status_bar_stats(Some("Selected shell no longer exists."), 4, 4, 9, 0);
+    assert_eq!(stats, "WARN: Selected shell no longer exists.");
+}
+
+/// The reclaim report is the case that prompted this: it fired on startup,
+/// listed 21 sessions in a 50-character slot, and buried everything else.
+#[test]
+fn the_reclaim_report_goes_to_the_errors_screen_not_the_status_bar() {
+    let mut state = AppState::default();
+    capture_reclaim_report(&mut state, RECLAIM_REPORT);
+
+    assert_eq!(
+        state.warning_message, None,
+        "the reclaim report must not occupy the status-bar warning slot"
+    );
+    assert_eq!(
+        state
+            .errors_state
+            .last_error()
+            .map(|entry| entry.detail.as_str()),
+        Some(RECLAIM_REPORT),
+        "the full report must be recorded in the errors ring"
+    );
+    assert!(
+        state
+            .errors_state
+            .last_error()
+            .is_some_and(|entry| entry.source == ErrorSource::Other),
+        "the reclaim report is not attributable to a single subsystem"
+    );
+}
+
+/// It is recorded *silently*: it must count toward the clue without hijacking
+/// the user's current selection on the Errors screen.
+#[test]
+fn the_reclaim_report_counts_without_stealing_the_errors_selection() {
+    let mut state = AppState::default();
+    capture_reclaim_report(&mut state, RECLAIM_REPORT);
+
+    assert_eq!(state.errors_state.count(), 1);
+    assert_eq!(
+        state.last_error_title(),
+        None,
+        "a silent entry must not drive the status-bar error projection"
+    );
+}
+
+/// The count is what the bar renders, so a reclaim report must move it.
+#[test]
+fn a_recorded_reclaim_report_drives_the_status_bar_count() {
+    let mut state = AppState::default();
+    capture_reclaim_report(&mut state, RECLAIM_REPORT);
+
+    let rendered = status_bar_stats(None, 4, 4, 9, state.errors_state.count());
+    assert_eq!(rendered, "4 repos | 4/9 running | 1 error");
+}


### PR DESCRIPTION
Fixes #435.

## What changed

The status bar used to hand its centre over to the newest error, printing `ERR: ` plus the first 50 characters of the message. That was the worst of both worlds: too little text to diagnose anything, and enough to evict the `N repos | X/Y running` summary that tells the user the system is alive. The startup session-reclaim report made it plain — twenty-one session names arrived as a single warning line with room for maybe two of them.

Errors belong on the Errors screen, which already stores them in full and lets the user select and copy them. The status bar only needs to say that there is something to go and read:

```
4 repos | 4/9 running | 3 errors
```

The count is suppressed at zero, so an untroubled session reads exactly as it did before. Transient warnings keep their precedence over the summary but no longer hide the count.

## Detail

- Rendering moves into a pure `status_bar_stats` function, so the format is testable without standing up a terminal.
- `StatusBarProps` swaps `last_error: Option<String>` for `error_count: usize` — the component can no longer be handed error text it has no business displaying. All eight screen call sites updated.
- New `capture_reclaim_report` routes the session-reclaim report into the errors ring using `push_silent`, so the full report is readable on the Errors screen without stealing the Errors selection or the status-bar error projection. It still moves the count, so the user is told to look.
- The transient issue launcher no longer discards its diagnostic. It was replacing the `RuntimeError` with `Failed to launch transient <type> agent`, a message naming no cause. Now that errors are read on the Errors screen rather than glimpsed in the status bar, a message that explains nothing is worse than none.

## Note on the previous revision

This PR previously implemented a dismissable launch-failure modal. That design was rejected in review: it imposed a dismissal on every failure while carrying nothing the Errors screen did not already hold, and it was mine to begin with — the acceptance criteria mandating it were written into #435 by me, not requested. #435 has been rewritten to the direction actually wanted, and #676 (modal scrolling) is closed as moot. The old commits are preserved on `issue435-modal-archive`.

## Not addressed here

The reclaim report fires spuriously on macOS — sessions declared unmatched that the agents then reconnect to. That is a detection bug rather than a presentation one, and is filed as #689.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo xtask check source-size|architecture|clippy-allows|observation-coercion`, and `cargo test --workspace --all-features --locked` all pass. Nine new behavioural tests in `tests/issue435_behavior.rs` cover the format, the plural/singular boundary, suppression at zero, warning coexistence, the absence of error text, and the reclaim-report routing. A TUI scenario is added at `dev-docs/tmux-scenarios/issue435/status-bar-error-count.json`.