### PR TITLE
Send Ctrl+Enter as the byte psmux recognises (Fixes #692)

### DIFF
--- a/project-plans/issue692-plan.md
+++ b/project-plans/issue692-plan.md
@@ -1,0 +1,138 @@
+# Issue #692 — `Ctrl+Enter` nudges never reach the agent when jefe runs on Windows
+
+> `Ctrl+Enter` is llxprt's "nudge"/steering chord. It works for llxprt launched
+> directly in PowerShell, and it works for llxprt hosted by jefe on macOS and
+> Linux. Only the Windows-hosted-by-jefe combination loses it. That shape — one
+> platform, one transport — points at the one hop the platforms do not share:
+> the byte encoding jefe writes into the multiplexer client's PTY.
+
+## Topology
+
+A keystroke reaches a hosted agent through three hops:
+
+| Hop | Windows | Unix |
+|---|---|---|
+| 1. host terminal → jefe | Windows console API via crossterm 0.28 | escape sequences via crossterm 0.28 |
+| 2. jefe → multiplexer attach client | bytes written to a ConPTY (`portable_pty`) | bytes written to a Unix PTY |
+| 3. multiplexer → pane child | psmux writes a **console input record** into the pane's ConPTY | tmux writes **escape-sequence bytes** into the pane's PTY |
+
+Hop 3 is where the two platforms genuinely diverge, and it is why an encoding
+chosen for tmux does not automatically survive on psmux.
+
+## Measured behavior of the transport
+
+Recorded on Windows against the supported multiplexer (`psmux 3.3.7`, tmux
+3.3.7 fork) in jefe's own topology — an outer ConPTY running
+`psmux attach-session`, with the probe target in the pane, inside a throwaway
+`-L` namespace. Reproduction scripts are throwaway probes. Two independent
+measurements were taken for each candidate encoding: what the *attach client*
+recognises (read back through a `bind-key -n` that stores the key name in a
+server option), and what the *pane child* actually receives (a
+`[Console]::ReadKey($true)` logger reporting key, modifiers and char code).
+
+| Bytes jefe writes to the client PTY | Key the client recognises | What the pane child receives |
+|---|---|---|
+| `CR` (`\r`) | `Enter` | `key=Enter mods=None char=13` |
+| `LF` (`\n`) | **`C-Enter`** | **`key=Enter mods=Control char=10`** |
+| `CSI 13 ; 5 u` — *what jefe sends today* | **none — silently discarded** | **nothing at all** |
+| `CSI 27 ; 5 ; 13 ~` (modifyOtherKeys form) | none — silently discarded | nothing at all |
+| win32-input-mode (`CSI 13;28;10;1;8;1_` + key-up) | `C-Enter` | `key=Enter mods=Control char=10` |
+
+Supporting observations:
+
+| Question | Measured answer |
+|---|---|
+| Does `set-option -s extended-keys on` (issue #627) change any row above? | **No.** The table is identical with the option `on` and `off`. On Windows the pane child is fed a console input record, not an escape sequence, so the option that governs tmux's escape-sequence downgrade has nothing to act on |
+| Does the attach client ask for a richer encoding? | Yes — it emits `CSI ? 9001 h` (win32-input-mode) on attach, which jefe's embedded terminal currently ignores |
+| What does llxprt see for `Ctrl+Enter` in a straight PowerShell? | `VK_RETURN` with the Ctrl modifier and `uChar = 0x0A` — byte-for-byte the record the `LF` row produces |
+| Does jefe already emit `LF` for something else? | Yes: `Ctrl+J` has always encoded to `0x0A`. On Windows `Ctrl+J` therefore already arrives as `Ctrl+Enter`, before and after this change |
+
+The third row is the decisive one: `LF` does not approximate the native
+behavior, it reproduces it exactly. The working case (llxprt in PowerShell) and
+the fixed case (llxprt under jefe) deliver the identical console record, which
+is why the agent cannot tell them apart.
+
+## Root cause
+
+| # | Defect | Location | Effect |
+|---|---|---|---|
+| 1 | `Ctrl+Enter` is encoded as `CSI 13 ; 5 u` on every platform | `src/pty_encoding.rs` `enter_bytes` | psmux's input parser has no CSI-u branch, so on Windows the sequence is consumed and dropped. The chord is not downgraded, not mis-delivered — it vanishes between jefe and the pane, and the agent's nudge binding can never fire |
+
+Issue #627 chose CSI-u correctly *for tmux*, where it is parsed as a modified
+Enter and re-encoded per-pane. The defect is that the choice was made
+unconditionally for a transport that was never measured.
+
+## Why `LF` rather than win32-input-mode
+
+Both encodings were measured working end-to-end. `LF` is chosen because:
+
+- it is one byte and needs no handshake, whereas win32-input-mode is only
+  legitimate once jefe honours the client's `CSI ? 9001 h` request — a
+  negotiation jefe's embedded terminal does not implement, and implementing it
+  would change how *every* key is written, not just this one;
+- it produces exactly the console record the native path produces, so the fix
+  is verifiable against a known-good reference rather than against a spec;
+- the ambiguity it reintroduces (`Ctrl+J` ≡ `Ctrl+Enter`) already exists on
+  Windows today via the `Ctrl+J` path and is not made worse. On Unix, where the
+  ambiguity was the actual complaint in #627, nothing changes.
+
+## Acceptance matrix
+
+| # | Actor / launch path | Input / boundary | Targets | Observable success | Observable failure / diagnostic | Side effects before failure | Persistence / compatibility | Proof |
+|---|---|---|---|---|---|---|---|---|
+| A1 | User presses `Ctrl+Enter` with the agent terminal focused | `KeyCode::Enter` + `CONTROL` | Windows | jefe writes `LF`; the attach client recognises `C-Enter`; the pane child receives `Enter` with the Control modifier and char `0x0A` | Chord silently absent at the pane, as today | None | Matches what the child receives from a native Windows console, so no agent needs to change | Encoder unit test, plus a real-psmux integration test that reads the chord back at the pane |
+| A2 | Same | `KeyCode::Enter` + `CONTROL` | macOS / Linux | `CSI 13 ; 5 u`, byte-for-byte unchanged from #627 | n/a | None | Unchanged | Encoder unit test |
+| A3 | Same | `CONTROL` combined with `ALT` | Windows | `ESC` + `LF` — the Alt prefix jefe applies to every other unencoded chord | n/a | None | Consistent with `Alt+Enter` | Encoder unit test |
+| A4 | Same | `CONTROL` combined with `ALT` | macOS / Linux | `CSI 13 ; 7 u`, unchanged | n/a | None | Unchanged | Encoder unit test |
+| A5 | Same, plain `Enter` | `Enter`, no modifiers | All platforms | `CR`, unchanged | n/a | None | Unchanged | Encoder unit test |
+| A6 | Same, `Shift+Enter` / `Alt+Enter` / `Shift+Alt+Enter` | `Enter` + those modifiers | All platforms | Byte-for-byte unchanged, so the issue #1 contract holds | n/a | None | Unchanged | Encoder unit test |
+| A7 | Every other key — characters, control chars, navigation, function keys, mouse | Any | All platforms | Byte-for-byte unchanged | n/a | None | Unchanged | Existing whole-family encoder tests |
+| A8 | `Ctrl+J` | `KeyCode::Char('j')` + `CONTROL` | All platforms | `0x0A`, unchanged | n/a | None | On Windows it continues to reach the pane as `Ctrl+Enter`, exactly as before this change | Encoder unit test |
+| A9 | Windows CI / developer machine without psmux installed | Integration test run | Windows | The real-transport test skips cleanly | With `JEFE_REQUIRE_PSMUX=1` the same condition is a hard failure naming the missing binary | None | Matches the existing conformance-test convention | Test gating asserted by construction |
+
+## Non-goals
+
+- Implementing the win32-input-mode handshake (`CSI ? 9001 h`) in jefe's
+  embedded terminal. It is the more expressive encoding and it was measured
+  working, but it changes the encoding of every key and is a subsystem of its
+  own. Recorded as a follow-up, not folded in here.
+- Disambiguating `Ctrl+J` from `Ctrl+Enter` on Windows. That collision predates
+  this issue, is not what #692 reports, and cannot be resolved without the
+  handshake above.
+- Implementing the kitty keyboard protocol, which the multiplexer ignores on
+  both platforms (#627 non-goal, still true).
+- Changing `set-option -s extended-keys on`. It was measured irrelevant on
+  Windows but it is load-bearing on tmux, so it stays exactly as #627 left it.
+- Changing the `Shift+Enter` backslash-`CR` compatibility form (issue #1).
+- Changing hop 1. crossterm 0.28 already delivers `KeyCode::Enter` +
+  `CONTROL` on Windows; that hop was verified healthy and is untouched.
+
+## Slices
+
+1. **RED — encoder.** Extend `src/pty_encoding_tests.rs` with the
+   platform-conditional expectation for `Ctrl+Enter` and `Ctrl+Alt+Enter`
+   (A1–A4), leaving A5–A8 asserting the unchanged encodings. Fails on Windows
+   against today's unconditional CSI-u.
+2. **RED — real transport.** `src/pty_encoding_transport_tests.rs`, a
+   Windows-gated test that owns a throwaway `-L` namespace (modelled on
+   `src/runtime/multiplexer_conformance_io.rs`), attaches a real psmux client
+   through `portable_pty`, writes the bytes jefe's encoder produces for
+   `Ctrl+Enter`, and asserts the client recognises the chord. Skips without
+   psmux unless `JEFE_REQUIRE_PSMUX=1` (A1, A9). Fails today because nothing
+   arrives.
+
+   It sits beside the encoder in the binary crate rather than under
+   `src/runtime/`, because the subject under test is `key_to_bytes` itself and
+   that lives in the binary crate — a copy of the expected bytes would test
+   nothing, since the whole defect was jefe confidently emitting bytes nobody
+   consumed. The cost is that the attach command is rebuilt from the plan's own
+   `executable()` and `base_args()` instead of calling the private production
+   builder. The isolation flags come from the plan itself, and the scrub list is
+   restated to match `scrub_inherited_multiplexer_env` variable for variable, so
+   the rebuild can be checked against the original; what is asserted is the byte
+   payload, not the argv. Unifying the two lists behind one exported helper is a
+   follow-up, because the production builder is not reachable from this crate.
+3. **GREEN.** Make the `CONTROL` branch of `enter_bytes` platform-conditional:
+   `cfg!(windows)` yields `LF` with Alt-prefixing left to the caller; every
+   other platform keeps the CSI-u form. Document the measured reason inline.
+4. **Verify.** `cargo fmt --all --check`, clippy gates, build, full test run.

--- a/project-plans/issue692-plan.md
+++ b/project-plans/issue692-plan.md
@@ -52,6 +52,41 @@ behavior, it reproduces it exactly. The working case (llxprt in PowerShell) and
 the fixed case (llxprt under jefe) deliver the identical console record, which
 is why the agent cannot tell them apart.
 
+### Client registration is not client readiness
+
+CI reported the transport test failing on the exact bytes the table above says
+work (`[10]`, observed as `nothing`). Investigation ruled out the encoding and
+found two facts worth recording, because both would mislead the next reader.
+
+First, `psmux -V` is not a version. The binary CI installs (the pinned v3.3.7
+release, build `05cc5d4`, 2026-07-20) and the locally built binary the table was
+measured against (`cb098c0`, 2026-08-03) both print `psmux 3.3.7`, and they do
+not behave identically. Any future transport measurement should record the build
+hash, not the version string.
+
+Second, the real fault was in the test, not the product. `list-clients` reports
+a client as soon as it registers with the server, which is earlier than the
+moment its terminal begins delivering keystrokes; bytes written into that window
+are discarded. The release build leaves that window open long enough to lose the
+chord whenever the machine is loaded, which is why the failure appeared only in
+CI and only in the full parallel suite:
+
+| psmux build | test alone | full parallel suite |
+|---|---|---|
+| `cb098c0` (local) | passes | passes |
+| `05cc5d4` (CI release) | passes | **loses the chord** |
+
+The test now writes a probe `CR` repeatedly until it is *observed*, which is the
+only evidence the path under test is live, then clears the record and waits for
+it to stay clear so an in-flight probe cannot be misread as the chord's result.
+Re-running with the encoder reverted to `CSI 13 ; 5 u` still fails against the
+release build, so the gate did not make the assertion vacuous — silence is now
+attributable to the encoding rather than to startup timing.
+
+This is a test-fidelity fix, not a product concession: in production the chord
+is sent in response to a keypress in a session the user is already attached to,
+so the startup window does not exist.
+
 ## Root cause
 
 | # | Defect | Location | Effect |

--- a/src/pty_encoding.rs
+++ b/src/pty_encoding.rs
@@ -101,10 +101,26 @@ fn function_key_to_bytes(n: u8, modifier: Option<u8>) -> Option<Vec<u8>> {
 /// for one that did not. Jefe therefore does not have to guess what the child
 /// understands (issue #627).
 ///
-/// The other chords keep their existing encodings: unmodified Enter is `CR`
-/// because that is what "submit" means everywhere, and `Shift+Enter` keeps the
-/// backslash-CR form that made it distinguishable before extended keys were
-/// available (issue #1).
+/// That reasoning holds only for tmux. Windows runs psmux, whose input parser
+/// has no CSI-u branch at all: it consumes `CSI 13 ; 5 u` and discards it, so
+/// the chord reached no agent on Windows whatsoever (issue #692). Measured
+/// against a real psmux client in jefe's own topology, the encoding it does
+/// recognise as `C-Enter` is a bare `LF`, which it then delivers to the pane
+/// child as a genuine Enter-plus-Control console key record. That record is
+/// byte-for-byte what an agent sees when it runs in a plain Windows console,
+/// which is why the chord works there and is the reason `LF` is the right
+/// answer rather than an approximation of one.
+///
+/// `LF` is also `Ctrl+J`, so the two chords are indistinguishable on Windows.
+/// That collision predates this encoding — `Ctrl+J` has always been sent as
+/// `0x0A` — and an ambiguous chord that arrives beats an unambiguous one that
+/// is thrown away. Resolving it needs psmux's win32-input-mode handshake,
+/// which jefe's embedded terminal does not yet answer.
+///
+/// The other chords keep their existing encodings on every platform:
+/// unmodified Enter is `CR` because that is what "submit" means everywhere,
+/// and `Shift+Enter` keeps the backslash-CR form that made it distinguishable
+/// before extended keys were available (issue #1).
 fn enter_bytes(modifiers: KeyModifiers) -> (Vec<u8>, bool) {
     if modifiers.contains(KeyModifiers::SHIFT) {
         if modifiers.contains(KeyModifiers::ALT) {
@@ -113,9 +129,15 @@ fn enter_bytes(modifiers: KeyModifiers) -> (Vec<u8>, bool) {
             (b"\\\r".to_vec(), false)
         }
     } else if modifiers.contains(KeyModifiers::CONTROL) {
-        match modifiers_to_param(modifiers) {
-            Some(param) => (format!("\x1b[13;{param}u").into_bytes(), true),
-            None => (vec![b'\r'], false),
+        if cfg!(windows) {
+            // `false` leaves Alt to the shared ESC-prefix path, so
+            // `Ctrl+Alt+Enter` stays `ESC LF` rather than losing its Alt.
+            (vec![b'\n'], false)
+        } else {
+            match modifiers_to_param(modifiers) {
+                Some(param) => (format!("\x1b[13;{param}u").into_bytes(), true),
+                None => (vec![b'\r'], false),
+            }
         }
     } else {
         (vec![b'\r'], false)
@@ -329,3 +351,9 @@ pub fn mouse_event_to_bytes(event: &iocraft::FullscreenMouseEvent) -> Option<Vec
 #[cfg(test)]
 #[path = "pty_encoding_tests.rs"]
 mod tests;
+
+// Windows is the only platform whose multiplexer is psmux, and the transport
+// defect this covers is psmux's alone (issue #692).
+#[cfg(all(test, windows))]
+#[path = "pty_encoding_transport_tests.rs"]
+mod transport_tests;

--- a/src/pty_encoding_tests.rs
+++ b/src/pty_encoding_tests.rs
@@ -347,10 +347,17 @@ mod key_tests {
     // byte sequence that could express `Ctrl+Enter` at all. It is now sent in
     // CSI-u form, which the multiplexer parses as a modified Enter and then
     // delivers to each pane child in the form that child negotiated.
+    //
+    // That reasoning holds for tmux only. Windows uses psmux, whose input
+    // parser has no CSI-u branch: it consumes and discards the sequence, so the
+    // chord never reaches the pane at all. There `LF` is the encoding psmux
+    // parses as `C-Enter`, and the console record it then writes into the pane
+    // is the same one a natively launched agent sees (issue #692).
 
     /// `Ctrl+Enter` is expressible at all, and is not the `Ctrl+J` alias that
     /// made agents insert a newline instead of steering.
     #[test]
+    #[cfg(not(windows))]
     fn ctrl_enter_is_distinguishable_from_ctrl_j() {
         let ctrl_enter = key_event(KeyCode::Enter, KeyModifiers::CONTROL);
         let ctrl_j = key_event(KeyCode::Char('j'), KeyModifiers::CONTROL);
@@ -370,9 +377,39 @@ mod key_tests {
 
     /// Combined modifiers accumulate into the one CSI-u parameter.
     #[test]
+    #[cfg(not(windows))]
     fn ctrl_alt_enter_combines_modifier_bits_in_one_parameter() {
         let key = key_event(KeyCode::Enter, KeyModifiers::CONTROL | KeyModifiers::ALT);
         assert_eq!(key_to_bytes(&key), Some(b"\x1b[13;7u".to_vec()));
+    }
+
+    /// On Windows `Ctrl+Enter` must be the `LF` psmux recognises as `C-Enter`.
+    /// The CSI-u form is silently discarded there, which is why the nudge chord
+    /// never reached the agent (issue #692).
+    #[test]
+    #[cfg(windows)]
+    fn ctrl_enter_uses_the_encoding_psmux_recognises() {
+        let ctrl_enter = key_event(KeyCode::Enter, KeyModifiers::CONTROL);
+        assert_eq!(key_to_bytes(&ctrl_enter), Some(vec![b'\n']));
+    }
+
+    /// `Ctrl+J` is unchanged. Its collision with `Ctrl+Enter` on Windows
+    /// predates issue #692 — `Ctrl+J` has always been `0x0A` — so encoding
+    /// `Ctrl+Enter` as `LF` does not make any agent worse off than it was.
+    #[test]
+    #[cfg(windows)]
+    fn ctrl_j_keeps_its_control_byte_on_windows() {
+        let ctrl_j = key_event(KeyCode::Char('j'), KeyModifiers::CONTROL);
+        assert_eq!(key_to_bytes(&ctrl_j), Some(vec![b'\n']));
+    }
+
+    /// `Ctrl+Alt+Enter` on Windows takes the same `ESC` prefix Jefe puts in
+    /// front of every other chord it cannot encode inline.
+    #[test]
+    #[cfg(windows)]
+    fn ctrl_alt_enter_prefixes_escape_before_lf() {
+        let key = key_event(KeyCode::Enter, KeyModifiers::CONTROL | KeyModifiers::ALT);
+        assert_eq!(key_to_bytes(&key), Some(vec![0x1b, b'\n']));
     }
 
     /// Unmodified Enter stays a bare CR: "submit" means CR everywhere, and the

--- a/src/pty_encoding_transport_tests.rs
+++ b/src/pty_encoding_transport_tests.rs
@@ -1,0 +1,347 @@
+//! Real-multiplexer transport test for the `Ctrl+Enter` nudge chord (issue #692).
+//!
+//! `Ctrl+Enter` is the chord hosted agents bind to "steer"/"nudge" a prompt
+//! that is already running. Jefe's whole part in delivering it is the bytes
+//! `key_to_bytes` writes into the multiplexer client's PTY, so that is what
+//! this test exercises: the encoder's real output, written to a real
+//! `attach-session` client, in jefe's own topology.
+//!
+//! The encoder unit tests next door assert that jefe emits the bytes it
+//! intended to emit. That is not the same claim, and the difference is the
+//! whole bug: psmux has no CSI-u branch, so the `CSI 13 ; 5 u` form chosen for
+//! tmux in issue #627 was consumed and dropped, and the chord reached no agent
+//! on Windows at all while the unit tests stayed green. Only a test with a real
+//! client on the far end can tell "jefe wrote the bytes" apart from "the chord
+//! arrived".
+//!
+//! What the client made of the bytes is read back through root key bindings
+//! that record the recognised key's own name in a server option. Binding the
+//! neighbouring keys as well as `C-Enter` is deliberate: the regression this
+//! guards against is not only "nothing arrived" but "a bare `Enter` arrived",
+//! which would submit the prompt instead of steering it — a worse outcome than
+//! silence, and one a boolean flag could not distinguish.
+//!
+//! Windows-only, because Windows is the only platform whose multiplexer is
+//! psmux and the defect is psmux's alone.
+
+use std::ffi::OsString;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use iocraft::prelude::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+
+use jefe::runtime::{LocalPlatform, MultiplexerIsolation, MultiplexerPlan};
+
+use super::key_to_bytes;
+
+/// Server option the root bindings record the observed key name in.
+const OBSERVED_KEY_OPTION: &str = "@jefe-observed-key";
+
+/// Value the option holds before any key has been recognised.
+const NOTHING_OBSERVED: &str = "nothing";
+
+/// Session the attach client connects to.
+const SESSION: &str = "jefe-ctrl-enter";
+
+/// How long the client is given to attach, and the chord to arrive.
+const SETTLE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Gap between polls while waiting on the client or the chord.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Session-routing variables that must never be inherited by a client jefe
+/// starts. The test process itself frequently runs *inside* a jefe-managed
+/// pane, and a client that looks nested refuses to attach at all — which would
+/// turn a transport failure into a silent no-op.
+///
+/// This mirrors the production list in `runtime::attach`'s
+/// `scrub_inherited_multiplexer_env`. That function is not reachable from this
+/// crate, so the list is restated here; keeping it identical — including
+/// `TMUX_TMPDIR`, which is socket routing rather than session routing — is what
+/// stops the rebuilt attach command from drifting away from the real one.
+const INHERITED_SESSION_VARS: [&str; 5] = [
+    "TMUX",
+    "TMUX_PANE",
+    "TMUX_TMPDIR",
+    "PSMUX_SESSION",
+    "PSMUX_TARGET_SESSION",
+];
+
+/// Panic helpers that keep the test clippy-clean under `unwrap_used` /
+/// `expect_used`, matching the convention in `prefix_passthrough_tests.rs`.
+trait PanicResult<T> {
+    fn or_panic(self, context: &str) -> T;
+}
+
+impl<T, E: std::fmt::Debug> PanicResult<T> for Result<T, E> {
+    fn or_panic(self, context: &str) -> T {
+        match self {
+            Ok(value) => value,
+            Err(error) => panic!("{context}: {error:?}"),
+        }
+    }
+}
+
+impl<T> PanicResult<T> for Option<T> {
+    fn or_panic(self, context: &str) -> T {
+        match self {
+            Some(value) => value,
+            None => panic!("{context}"),
+        }
+    }
+}
+
+/// Whether this environment promises a usable multiplexer.
+///
+/// CI sets `JEFE_REQUIRE_PSMUX` on the native Windows job. Where it is set, an
+/// unresolvable multiplexer is a failure rather than a reason to skip: a test
+/// that quietly does nothing is how a broken transport survives a green build.
+fn psmux_is_required() -> bool {
+    std::env::var("JEFE_REQUIRE_PSMUX").is_ok_and(|value| value == "1")
+}
+
+/// The multiplexer binary to probe: the same override variable production
+/// honours, falling back to the platform's first candidate name on `PATH`.
+fn resolve_multiplexer_binary(platform: LocalPlatform) -> PathBuf {
+    let override_name = match platform {
+        LocalPlatform::Unix => "JEFE_TMUX_BIN",
+        LocalPlatform::Windows => "JEFE_PSMUX_BIN",
+    };
+    if let Some(explicit) = std::env::var_os(override_name).filter(|value| !value.is_empty()) {
+        return PathBuf::from(explicit);
+    }
+    match platform {
+        LocalPlatform::Unix => PathBuf::from("tmux"),
+        LocalPlatform::Windows => PathBuf::from("psmux.exe"),
+    }
+}
+
+/// A throwaway namespace, torn down on every exit path including unwinding.
+struct ScratchServer {
+    plan: MultiplexerPlan,
+}
+
+impl ScratchServer {
+    /// Reserve a namespace no other test or live session can be addressing.
+    ///
+    /// The plan is built from the platform policy and the resolved binary
+    /// directly rather than from `MultiplexerPlan::current`, because the
+    /// production handle is only available once startup has resolved the
+    /// effective config — and a transport test wants a server it owns outright
+    /// in any case, so that `kill-server` teardown can never reach a live one.
+    fn reserve() -> Result<Self, String> {
+        let platform = LocalPlatform::current();
+        let executable = resolve_multiplexer_binary(platform);
+        let namespace = format!("jefe-ctrl-enter-{}", std::process::id());
+        MultiplexerPlan::for_platform(
+            platform,
+            executable,
+            MultiplexerIsolation::Namespace(namespace),
+        )
+        .map(|plan| Self { plan })
+        .map_err(|error| format!("{error}"))
+    }
+
+    fn plan(&self) -> &MultiplexerPlan {
+        &self.plan
+    }
+}
+
+impl Drop for ScratchServer {
+    /// A failed teardown stays silent: this runs during unwinding, where
+    /// panicking again would abort the process over a scratch server.
+    fn drop(&mut self) {
+        let _ = run(&self.plan, &["kill-server"]);
+    }
+}
+
+/// Run one multiplexer control command and return its trimmed stdout.
+///
+/// `MultiplexerPlan::command` is the production constructor, so the isolation
+/// flags and the native session-variable scrubbing are the real ones.
+fn run(plan: &MultiplexerPlan, args: &[&str]) -> String {
+    let mut command: Command = plan.command();
+    command.args(args);
+    match command.output() {
+        Ok(output) => String::from_utf8_lossy(&output.stdout).trim().to_owned(),
+        Err(_) => String::new(),
+    }
+}
+
+/// Bind `key` at the root table so that pressing it records its own name.
+///
+/// Recording the name rather than a bare flag is what lets the assertion say
+/// which key arrived, not merely that one did.
+fn record_key(plan: &MultiplexerPlan, key: &str) {
+    let _ = run(
+        plan,
+        &[
+            "bind-key",
+            "-n",
+            key,
+            "set-option",
+            "-g",
+            OBSERVED_KEY_OPTION,
+            key,
+        ],
+    );
+}
+
+/// The key name the client has recognised so far.
+fn observed_key(plan: &MultiplexerPlan) -> String {
+    run(plan, &["show-options", "-gqv", OBSERVED_KEY_OPTION])
+}
+
+/// Poll `probe` until it reports ready, or the settle timeout expires.
+fn wait_until(mut probe: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + SETTLE_TIMEOUT;
+    loop {
+        if probe() {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// The attach command jefe runs, built from the same resolved executable,
+/// isolation flags and environment scrubbing the production path uses.
+fn attach_command(plan: &MultiplexerPlan) -> CommandBuilder {
+    let mut cmd = CommandBuilder::new(plan.executable());
+    for arg in plan.base_args() {
+        cmd.arg(arg);
+    }
+    cmd.arg("attach-session");
+    cmd.arg("-t");
+    cmd.arg(SESSION);
+    for variable in INHERITED_SESSION_VARS {
+        cmd.env_remove(OsString::from(variable));
+    }
+    cmd.env("TERM", "xterm-256color");
+    cmd
+}
+
+/// Reap the attach client on every exit path, so a failed assertion cannot
+/// leave a client holding the scratch server open against its teardown.
+struct AttachClientGuard {
+    child: Option<Box<dyn portable_pty::Child + Send + Sync>>,
+}
+
+impl AttachClientGuard {
+    fn kill_now(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+impl Drop for AttachClientGuard {
+    fn drop(&mut self) {
+        self.kill_now();
+    }
+}
+
+/// Write `bytes` to a live attach client and return the key it recognised.
+fn key_recognised_for(plan: &MultiplexerPlan, bytes: &[u8]) -> String {
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 120,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .or_panic("open a pty for the attach client");
+
+    let child = pair
+        .slave
+        .spawn_command(attach_command(plan))
+        .or_panic("spawn the attach client");
+    let mut guard = AttachClientGuard { child: Some(child) };
+
+    let mut writer = pair
+        .master
+        .take_writer()
+        .or_panic("take the attach client's pty writer");
+
+    let attached = wait_until(|| !run(plan, &["list-clients", "-t", SESSION]).is_empty());
+    assert!(
+        attached,
+        "the attach client never attached, so nothing about the chord could be observed"
+    );
+
+    writer
+        .write_all(bytes)
+        .or_panic("write the chord to the attach client");
+    writer.flush().or_panic("flush the attach client's pty");
+
+    wait_until(|| observed_key(plan) != NOTHING_OBSERVED);
+    let observed = observed_key(plan);
+
+    drop(writer);
+    drop(pair);
+    guard.kill_now();
+
+    observed
+}
+
+/// The bytes jefe's encoder produces for `Ctrl+Enter` must be a chord the
+/// multiplexer client actually recognises as `Ctrl+Enter`.
+///
+/// Before issue #692 they were `CSI 13 ; 5 u`, which psmux discards outright:
+/// the option stayed at `nothing` because no binding ever fired, and every
+/// agent bound to the nudge chord was unreachable through jefe on Windows.
+#[test]
+fn ctrl_enter_reaches_the_multiplexer_as_ctrl_enter() {
+    let scratch = match ScratchServer::reserve() {
+        Ok(scratch) => scratch,
+        Err(error) => {
+            assert!(
+                !psmux_is_required(),
+                "JEFE_REQUIRE_PSMUX is set but no multiplexer resolved: {error}"
+            );
+            return;
+        }
+    };
+    let plan = scratch.plan();
+
+    let _ = run(
+        plan,
+        &[
+            "new-session",
+            "-d",
+            "-s",
+            SESSION,
+            "-x",
+            "120",
+            "-y",
+            "24",
+            "cmd.exe",
+        ],
+    );
+    let _ = run(
+        plan,
+        &["set-option", "-g", OBSERVED_KEY_OPTION, NOTHING_OBSERVED],
+    );
+    // The chord under test, plus every neighbour it could be mistaken for.
+    for key in ["C-Enter", "Enter", "C-j", "C-m"] {
+        record_key(plan, key);
+    }
+
+    let mut ctrl_enter = KeyEvent::new(KeyEventKind::Press, KeyCode::Enter);
+    ctrl_enter.modifiers = KeyModifiers::CONTROL;
+    let bytes = key_to_bytes(&ctrl_enter).or_panic("the encoder must produce bytes for Ctrl+Enter");
+
+    let observed = key_recognised_for(plan, &bytes);
+
+    assert_eq!(
+        observed, "C-Enter",
+        "the multiplexer client must recognise jefe's Ctrl+Enter bytes ({bytes:?}) as C-Enter, \
+         but it saw {observed:?}; an agent bound to the nudge chord never sees the chord"
+    );
+}

--- a/src/pty_encoding_transport_tests.rs
+++ b/src/pty_encoding_transport_tests.rs
@@ -52,6 +52,13 @@ const SETTLE_TIMEOUT: Duration = Duration::from_secs(20);
 /// Gap between polls while waiting on the client or the chord.
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Byte written to prove the client's input path is live before the chord is
+/// sent. `CR` is the plainest key there is and is bound alongside the chord.
+const PROBE_BYTE: &[u8] = b"\r";
+
+/// Consecutive quiet polls that prove every probe byte has drained.
+const QUIET_POLLS: u32 = 5;
+
 /// Session-routing variables that must never be inherited by a client jefe
 /// starts. The test process itself frequently runs *inside* a jefe-managed
 /// pane, and a client that looks nested refuses to attach at all — which would
@@ -136,13 +143,28 @@ impl ScratchServer {
         let platform = LocalPlatform::current();
         let executable = resolve_multiplexer_binary(platform);
         let namespace = format!("jefe-ctrl-enter-{}", std::process::id());
-        MultiplexerPlan::for_platform(
+        let plan = MultiplexerPlan::for_platform(
             platform,
-            executable,
+            executable.clone(),
             MultiplexerIsolation::Namespace(namespace),
         )
-        .map(|plan| Self { plan })
-        .map_err(|error| format!("{error}"))
+        .map_err(|error| format!("{error}"))?;
+
+        // `for_platform` validates the executable's *name*, not its presence, so
+        // a plan for a multiplexer that was never installed builds cleanly and
+        // only fails later inside the pty spawn — as an `os error 2` that reads
+        // like a defect in the transport rather than a missing dependency. Jobs
+        // that do not install a multiplexer have to reach the skip path here.
+        let mut probe = plan.command();
+        probe.arg("-V");
+        if !probe.output().is_ok_and(|output| output.status.success()) {
+            return Err(format!(
+                "`{}` is not runnable on this machine",
+                executable.display()
+            ));
+        }
+
+        Ok(Self { plan })
     }
 
     fn plan(&self) -> &MultiplexerPlan {
@@ -206,6 +228,57 @@ fn wait_until(mut probe: impl FnMut() -> bool) -> bool {
             return false;
         }
         std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Drive the client with a probe key until one actually reaches a binding.
+///
+/// `list-clients` reports a client the moment it registers with the server,
+/// which is earlier than the moment its terminal starts delivering keystrokes.
+/// Bytes written into that window are discarded, so a test that trusts
+/// registration alone reports "nothing arrived" for a chord that was in fact
+/// encoded correctly — the released psmux build loses the chord this way
+/// whenever the machine is loaded enough to widen the window. A probe key that
+/// has been *observed* is the only evidence that the path under test is live,
+/// so it is written repeatedly rather than once.
+fn wait_for_live_input(plan: &MultiplexerPlan, writer: &mut Box<dyn Write + Send>) -> bool {
+    wait_until(|| {
+        if writer.write_all(PROBE_BYTE).is_err() || writer.flush().is_err() {
+            return false;
+        }
+        observed_key(plan) != NOTHING_OBSERVED
+    })
+}
+
+/// Clear the observed key and wait until it stays cleared.
+///
+/// A probe byte still in flight would otherwise land after the reset and be
+/// read as the chord's result, reporting `Enter` for a chord that was never
+/// delivered. Requiring a run of quiet polls drains them before the real
+/// measurement starts.
+fn settle_after_probe(plan: &MultiplexerPlan) -> bool {
+    let deadline = Instant::now() + SETTLE_TIMEOUT;
+    loop {
+        let _ = run(
+            plan,
+            &["set-option", "-g", OBSERVED_KEY_OPTION, NOTHING_OBSERVED],
+        );
+
+        let mut quiet = 0;
+        while quiet < QUIET_POLLS {
+            std::thread::sleep(POLL_INTERVAL);
+            if observed_key(plan) != NOTHING_OBSERVED {
+                break;
+            }
+            quiet += 1;
+        }
+
+        if quiet >= QUIET_POLLS {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
     }
 }
 
@@ -273,6 +346,19 @@ fn key_recognised_for(plan: &MultiplexerPlan, bytes: &[u8]) -> String {
     assert!(
         attached,
         "the attach client never attached, so nothing about the chord could be observed"
+    );
+
+    let live = wait_for_live_input(plan, &mut writer);
+    assert!(
+        live,
+        "the attach client never delivered even a plain Enter, so a silent chord \
+         would prove nothing about its encoding"
+    );
+
+    let settled = settle_after_probe(plan);
+    assert!(
+        settled,
+        "the probe keys never drained, so the chord could not be measured on its own"
     );
 
     writer


### PR DESCRIPTION
Fixes #692.

`Ctrl+Enter` is the chord agents bind to steer a running turn — llxprt calls it a nudge. It worked for llxprt in a plain PowerShell, and for llxprt hosted by jefe on macOS and Linux. Only Windows-hosted-by-jefe lost it, and lost it silently: no error, no stray character, nothing.

## Why

Issue #627 chose CSI-u (`ESC [ 13 ; 5 u`) for the chord because that is what tmux parses. Windows does not run tmux — it runs **psmux**, a 3.3.7 fork whose input parser has **no CSI-u branch at all**. It consumes the sequence and discards it, so the chord reached no agent.

Measured against a real psmux client in jefe's own topology (an outer ConPTY running `attach-session`, agent in the pane):

| bytes written to the client | key psmux recognised | what the pane child received |
|---|---|---|
| `CR` | `Enter` | Enter / None / char=13 |
| `LF` | **`C-Enter`** | **Enter / Control / char=10** |
| `ESC [ 13;5u` *(what jefe sent)* | **nothing — discarded** | **nothing** |
| `ESC [ 27;5;13~` | nothing — discarded | nothing |
| win32-input-mode `CSI 13;28;10;1;8;1_` | `C-Enter` | Enter / Control / char=10 |

`set-option -s extended-keys`, which #627 added and which is what makes the tmux path work, was measured to change nothing here on either setting.

## What changed

On Windows the chord is now a bare `LF`. That is not an approximation: a plain Windows console reports `VK_RETURN` with Ctrl held and `uChar = 0x0A`, so `LF` is byte-for-byte what an agent already sees when nothing is hosting it. Every other platform keeps CSI-u, and no other key changes on any platform.

Alt is deliberately left to the shared ESC-prefix path, so `Ctrl+Alt+Enter` is `ESC LF` rather than a second encoding to keep in step:

| chord | Windows (new) | Windows (old) | Unix (unchanged) |
|---|---|---|---|
| `Ctrl+Enter` | `0A` | `ESC [ 13;5u` *(discarded)* | `ESC [ 13;5u` |
| `Ctrl+Shift+Enter` | `5C 0D` | `5C 0D` | `5C 0D` |
| `Ctrl+Alt+Enter` | `1B 0A` | `ESC [ 13;7u` *(discarded)* | `ESC [ 13;7u` |
| `Ctrl+Alt+Shift+Enter` | `5C 1B 0D` | `5C 1B 0D` | `5C 1B 0D` |

Shift is matched before the CONTROL branch, so the issue #1 `Shift+Enter` form is untouched. No combination is worse than before.

## Known limitation

`LF` is also `Ctrl+J`, so on Windows the two chords are now indistinguishable to an agent. **That collision predates this change** — `Ctrl+J` has always been sent as `0x0A` — and an ambiguous chord that arrives beats an unambiguous one that is thrown away. Removing the ambiguity means answering psmux's win32-input-mode request (`CSI ? 9001 h`), which jefe's embedded terminal currently ignores; that is a subsystem of its own and is left to a follow-up.

## Test

The regression test writes whatever `key_to_bytes` actually produces into a real psmux client on a throwaway `-L` namespace, then asks the multiplexer which key it saw. Its oracle is **psmux's own parser**, not a copy of the expected bytes — which is the only kind of test that could have caught this. The defect was jefe confidently emitting a sequence nobody consumed, so any assertion written against jefe's own constant would have passed throughout.

`Enter`, `C-j` and `C-m` are bound alongside `C-Enter` so the worse regression — a bare Enter arriving, submitting the turn instead of steering it — is distinguishable from silence. It skips where psmux is absent and hard-fails under `JEFE_REQUIRE_PSMUX=1`, matching the existing conformance tests.

RED was confirmed genuine before the fix: `left: "nothing", right: "C-Enter"`.

The test sits beside the encoder in the binary crate rather than under `src/runtime/`, because the subject under test is `key_to_bytes` and that lives in the binary crate. The cost is that the attach command is rebuilt from the plan's own `executable()`/`base_args()` instead of the private production builder; the scrub list is restated to match `scrub_inherited_multiplexer_env` variable for variable so the rebuild can be checked against the original. Unifying the two behind one exported helper is #697.

### Client registration is not client readiness

The test first shipped here trusting `list-clients` as its readiness signal. That was wrong, and CI caught it. A client appears in `list-clients` the moment it registers with the server, which is earlier than the moment its terminal begins delivering keystrokes; bytes written into that window are discarded, so the test reported "nothing arrived" for a chord that had been encoded correctly.

The window is invisible locally and open on CI because **`psmux -V` is not a build identity**. Two binaries both answer `psmux 3.3.7`:

| binary | build |
|---|---|
| my local dev build | `cb098c0` (2026-08-03) |
| pinned release v3.3.7, which CI installs | `05cc5d4` (2026-07-20) |

Against the release binary the test passed in isolation (1.8s) and failed under the full parallel suite (24.8s, deadline hit). Against the dev build it passed both ways. The variable was the binary, not the load.

The fix writes a probe key until it is *observed* rather than merely written, then requires a run of quiet polls so an in-flight probe cannot be misread as the chord's result. Reverting the encoder to CSI-u still fails against the release binary, so the readiness gate has not made the assertion vacuous — worth stating, because a readiness loop is exactly the kind of change that can quietly turn a real test into a tautology.

Separately, `for_platform` validates the executable's *name*, not its presence, so jobs with no multiplexer installed died inside the pty spawn with an `os error 2` that read like a transport defect. The binary is now probed while reserving the server, so those jobs reach the intended skip path; `JEFE_REQUIRE_PSMUX` still turns that skip into a hard failure wherever the dependency is expected.

## Verification

Against the **release binary CI installs**, not a local build:

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features --locked` — **0 failures** (lib 4317, bins 887)
- Transport test **5/5 green** under the full parallel suite, repeated

An earlier revision of this description claimed seven tests failed on this host and were pre-existing on `main`. **That claim was wrong and is retracted.** They did reproduce on a clean checkout, but the variable I had failed to control was the psmux binary rather than the source tree — the same `-V` ambiguity described above. Against the binary CI installs, all seven pass. Issue #696 was filed on that bad evidence and has been closed as not planned.