### PR TITLE
Keep New Issue form fields on screen after focus moves (Fixes #693)

### DIFF
--- a/dev-docs/tmux-scenarios/issues-new-issue-typing.json
+++ b/dev-docs/tmux-scenarios/issues-new-issue-typing.json
@@ -94,13 +94,6 @@
       "timeout_ms": 15000
     },
     {
-      "op": "assert-frame",
-      "contains": [
-        "HelloTitle"
-      ],
-      "absent": []
-    },
-    {
       "op": "key",
       "key": "tab",
       "modifiers": []

--- a/dev-docs/tmux-scenarios/issues-new-issue-typing.json
+++ b/dev-docs/tmux-scenarios/issues-new-issue-typing.json
@@ -139,6 +139,13 @@
       "absent": []
     },
     {
+      "op": "assert-frame",
+      "contains": [
+        "HelloTitle"
+      ],
+      "absent": []
+    },
+    {
       "op": "key",
       "key": "backspace",
       "modifiers": []

--- a/project-plans/issue693-plan.md
+++ b/project-plans/issue693-plan.md
@@ -1,0 +1,136 @@
+# Issue #693 — New Issue form swallows the first line (the subject)
+
+## Report
+
+> First line of new issue is swallowed on windows. When I typed that subject the
+> first time it went away.. I hit enter and typed it again. It shouldn't get
+> swallowed the first time. I do not think this happens on Mac.
+> So apparently the first line doesn't go away it just isn't visible after you
+> type it...it does become the subject....but disappearing is confusing.
+
+The reporter's own correction is the important part: the text is **not lost**, it
+becomes the subject. It stops being **visible**.
+
+## Root cause
+
+The New Issue form has eight fields (`NewIssueFormState`), but the detail pane
+renders only two things:
+
+1. `build_new_issue_content` — a fixed four-line document
+   (`"New Issue"`, a stale `Title: first line | Body: remaining lines` hint from
+   before #407 split the draft into fields, a blank line, `[Composer input]`).
+   It ignores the form entirely.
+2. one embedded `TextBox` composer whose text comes from
+   `new_issue_composer_from_form`, which renders **only the currently focused
+   field**.
+
+So the repro chain is:
+
+- the form opens focused on Title (#454);
+- the user types the subject — visible in the composer;
+- the user presses Enter, which on Title dispatches `NewIssueFocusNext` (#480);
+- focus becomes Body, so the composer now renders the empty `body_text`;
+- the typed title vanishes from the screen even though `form.title_text` still
+  holds it and it does become the created issue's subject.
+
+This is a **rendering** defect and is platform-independent; nothing in the path
+is Windows-specific. The "not on Mac" impression is incidental (it depends on
+whether the user pressed Enter after the subject). Chasing a Windows input bug
+is explicitly **out of scope** — no evidence supports one.
+
+## Acceptance matrix
+
+| # | Actor / input | Boundary cases | Success behavior | Failure behavior | Proof |
+|---|---|---|---|---|---|
+| A1 | User types a title, then moves focus off Title (Enter or Tab) | focus = Body, Labels, Milestone, Project, Assignees, Template, Type | the typed title text stays visible in the New Issue document | n/a (pure projection) | unit test on the content builder for every focus value |
+| A2 | User types a body, then moves focus off Body | single-line and multi-line body; template scaffold body | the typed body stays visible, continuation lines indented under the label | n/a | unit test |
+| A3 | Any focus | each of the 8 `NewIssueFormFocus` values | exactly one rendered field row is marked focused (`> `), all others `  ` | n/a | unit test |
+| A4 | Unset optional fields | type/labels/milestone/project/assignees empty | render a stable `(none)` placeholder rather than a ragged empty row | n/a | unit test |
+| A5 | Rendered rows | any field content | rows are ASCII-only (no emoji), consistent with the New PR composer | n/a | unit test mirroring `the_composer_text_is_emoji_free` |
+| A6 | Detail pane render with the form open, focus = Body | title typed earlier | the title text appears in the rendered pane output | n/a | render test in `issue_detail_render_tests.rs` |
+| A7 | TUI harness, Issues → `n` → type title → `tab` → type body | 120x40 pinned terminal | the title is still present in the frame after focus leaves Title | scenario assertion fails | `dev-docs/tmux-scenarios/issues-new-issue-typing.json` |
+| A8 | State/UI line-count invariant | any form | the document the state layer counts is the same document the UI renders (one builder, one caller) | n/a | preserved by construction; `build_new_issue_content` keeps its single call site |
+
+## Non-goals
+
+- No keymap, event, message, or reducer changes. The focus/Enter semantics of
+  #480 stay exactly as they are.
+- No Windows-specific input handling (`KeyEventKind`, ConPTY) changes — no
+  evidence of a platform defect.
+- Not making the picker fields (Type/Labels/Milestone/Project/Assignees)
+  editable, and not changing `new_issue_composer_from_form`'s picker→Title
+  composer fallback.
+- No new overlay, component, or public abstraction; no change to the New PR
+  form; no `form.error` / `options_loading` surfacing (separate concern).
+- No windowing/scrolling scheme for the New Issue document beyond the existing
+  `new_issue_composer_rows` math.
+- No dependency, workflow, quality-gate, or agent-memory changes.
+
+## Slices
+
+### S1 — the form becomes visible in the document (A1–A5)
+
+- Owner: content projection (`src/issue_detail_content.rs`).
+- RED: new `src/issue_detail_content_tests.rs` asserting the title survives a
+  focus change, body continuation rows, focus marking, placeholders, ASCII.
+- GREEN: `build_new_issue_content` takes `Option<&NewIssueFormState>` and emits
+  one row per field in tab order, mirroring `new_pr_form_rows`, before the
+  `[Composer input]` anchor.
+
+### S2 — wire the form through the render path (A6, A8)
+
+- Owner: UI component (`src/ui/components/issue_detail.rs`).
+- RED: render test proving the typed title is present with focus on Body.
+- GREEN: `new_issue_composer_content` accepts the form and forwards it; the
+  existing `build_new_issue_content_renders_static_prompt_only` unit test is
+  rewritten to the new contract.
+
+### S3 — regression scenario (A7)
+
+- Owner: TUI harness scenario.
+- The existing `issues-new-issue-typing.json` types `HelloTitle`, presses `tab`,
+  and never re-asserts the title. Add that assertion.
+
+## Scope ledger
+
+| File | Acceptance rows |
+|---|---|
+| `src/issue_detail_content.rs` | A1–A5, A8 |
+| `src/issue_detail_content_tests.rs` (new, test-only) | A1–A5 |
+| `src/ui/components/issue_detail.rs` | A6, A8 |
+| `src/ui/components/issue_detail_render_tests.rs` | A6 |
+| `dev-docs/tmux-scenarios/issues-new-issue-typing.json` | A7 |
+
+## Review counters
+
+- Local OCR runs: 1 / 2 (self review of the full production diff + new test file)
+- PR OCR runs: 0 / 2
+
+## Verification evidence
+
+Candidate head, run on `issue693`:
+
+- `cargo fmt --all --check` — exit 0.
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0, no
+  diagnostics.
+- `cargo test --workspace --all-features --locked` — every unit/lib suite green; the
+  integration suite reports `421 passed; 1 failed`. The single failure is
+  `ui::dashboard_reorder_tui::guarded_dashboard_reorder_tui_scenario`
+  (`HarnessError E006: frame did not contain 'alpha' within 15000ms`), reproduced on a
+  clean `git stash -u` tree at the same merge base, so it is pre-existing and unrelated
+  to this change.
+- `cargo xtask ci` — fmt, check-clippy-allows, check-source-size (warnings only, all
+  pre-existing >750-line files), check-architecture, check-multiplexer-surface, lint and
+  complexity all pass; `coverage` exits 1 solely because the pre-existing failure above
+  makes `cargo llvm-cov --fail-under-lines 30` exit 101.
+
+Behavioral evidence per acceptance row lives in
+`src/issue_detail_content_new_issue_tests.rs` (projection), 
+`src/ui/components/issue_detail_render_tests.rs` (render path), and
+`dev-docs/tmux-scenarios/issues-new-issue-typing.json` (TUI scenario).
+
+## Deferred findings
+
+- `ui::dashboard_reorder_tui::guarded_dashboard_reorder_tui_scenario` fails on main at
+  this merge base. Out of scope for #693; needs its own issue rather than a drive-by fix
+  here.

--- a/src/issue_detail_content.rs
+++ b/src/issue_detail_content.rs
@@ -5,7 +5,9 @@
 //! limits.
 
 use crate::domain::{IssueComment, IssueDetail};
-use crate::state::{ComposerTarget, DetailSubfocus, EditorTarget, InlineState};
+use crate::state::{
+    ComposerTarget, DetailSubfocus, EditorTarget, InlineState, NewIssueFormFocus, NewIssueFormState,
+};
 
 /// Stable anchor rendered where a reply TextBox is logically attached.
 pub(crate) const ISSUE_REPLY_ANCHOR: &str = "    [Composer input]";
@@ -155,22 +157,133 @@ pub fn build_detail_content(
     builder.finish()
 }
 
+/// Placeholder for an optional New Issue field the user has not set yet.
+const NEW_ISSUE_UNSET: &str = "(none)";
+
 /// Build a full-screen content block for creating a new issue.
 ///
-/// The editor text itself is rendered by the embedded wrapping `TextBox`
-/// (issue #212), so this document only carries the static prompt lines.
+/// Every field of the form is summarised here, so text the user already typed
+/// stays on screen once focus moves on (issue #693): the embedded `TextBox`
+/// only ever shows the *focused* field, which made a typed subject appear to
+/// vanish the moment Enter advanced focus to the body.
+///
+/// The editable text itself is still rendered by that wrapping `TextBox`
+/// (issue #212); these rows are a read-only summary and own no cursor.
 #[must_use]
-pub fn build_new_issue_content(_inline_state: &InlineState) -> DetailContent {
+pub fn build_new_issue_content(form: Option<&NewIssueFormState>) -> DetailContent {
     let mut builder = ContentBuilder::new();
 
     builder.lines.push("New Issue".to_string());
-    builder
-        .lines
-        .push("Title: first line | Body: remaining lines".to_string());
+    if let Some(form) = form {
+        push_new_issue_form_rows(&mut builder.lines, form);
+    }
     builder.lines.push(String::new());
 
     builder.lines.push("[Composer input]".to_string());
     builder.finish()
+}
+
+/// One row per New Issue field, in Tab order, with the focused row marked.
+fn push_new_issue_form_rows(rows: &mut Vec<String>, form: &NewIssueFormState) {
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Template,
+        "Template",
+        form.template.label(),
+    );
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Type,
+        "Type",
+        &optional_new_issue_value(form.type_name.as_deref()),
+    );
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Title,
+        "Title",
+        &form.title_text,
+    );
+    push_new_issue_body_rows(rows, form);
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Labels,
+        "Labels",
+        &joined_new_issue_values(&form.labels),
+    );
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Milestone,
+        "Milestone",
+        &optional_new_issue_value(form.milestone.as_deref()),
+    );
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Project,
+        "Project",
+        &joined_new_issue_values(&form.project_ids),
+    );
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Assignees,
+        "Assignees",
+        &joined_new_issue_values(&form.assignees),
+    );
+}
+
+/// Push one labelled single-line field row.
+fn push_new_issue_field(
+    rows: &mut Vec<String>,
+    form: &NewIssueFormState,
+    focus: NewIssueFormFocus,
+    label: &str,
+    value: &str,
+) {
+    let marker = new_issue_focus_marker(form, focus);
+    rows.push(format!("{marker}{label}: {value}").trim_end().to_string());
+}
+
+/// Push the body field, one row per logical line, continuations aligned under
+/// the label so a multi-line draft still reads as one field.
+fn push_new_issue_body_rows(rows: &mut Vec<String>, form: &NewIssueFormState) {
+    let marker = new_issue_focus_marker(form, NewIssueFormFocus::Body);
+    let label = "Body: ";
+    let indent = " ".repeat(marker.len() + label.len());
+    let mut lines = form.body_text.split('\n');
+    let first = lines.next().unwrap_or_default();
+    rows.push(format!("{marker}{label}{first}").trim_end().to_string());
+    for line in lines {
+        rows.push(format!("{indent}{line}").trim_end().to_string());
+    }
+}
+
+/// `"> "` for the focused field, `"  "` otherwise — the marker convention this
+/// module already uses for issue-detail subfocus.
+fn new_issue_focus_marker(form: &NewIssueFormState, focus: NewIssueFormFocus) -> &'static str {
+    if form.focus == focus { "> " } else { "  " }
+}
+
+/// Render an optional field value, or the unset placeholder.
+fn optional_new_issue_value(value: Option<&str>) -> String {
+    value
+        .filter(|value| !value.is_empty())
+        .unwrap_or(NEW_ISSUE_UNSET)
+        .to_string()
+}
+
+/// Render a multi-value field, or the unset placeholder when it is empty.
+fn joined_new_issue_values(values: &[String]) -> String {
+    if values.is_empty() {
+        NEW_ISSUE_UNSET.to_string()
+    } else {
+        values.join(", ")
+    }
 }
 
 fn build_detail_lines(
@@ -727,3 +840,7 @@ comment 1 line 2",
         );
     }
 }
+
+#[cfg(test)]
+#[path = "issue_detail_content_new_issue_tests.rs"]
+mod new_issue_tests;

--- a/src/issue_detail_content.rs
+++ b/src/issue_detail_content.rs
@@ -5,9 +5,12 @@
 //! limits.
 
 use crate::domain::{IssueComment, IssueDetail};
-use crate::state::{
-    ComposerTarget, DetailSubfocus, EditorTarget, InlineState, NewIssueFormFocus, NewIssueFormState,
-};
+use crate::state::{ComposerTarget, DetailSubfocus, EditorTarget, InlineState};
+
+#[path = "issue_detail_content_new_issue.rs"]
+mod new_issue;
+
+pub use new_issue::build_new_issue_content;
 
 /// Stable anchor rendered where a reply TextBox is logically attached.
 pub(crate) const ISSUE_REPLY_ANCHOR: &str = "    [Composer input]";
@@ -155,135 +158,6 @@ pub fn build_detail_content(
         &mut builder,
     );
     builder.finish()
-}
-
-/// Placeholder for an optional New Issue field the user has not set yet.
-const NEW_ISSUE_UNSET: &str = "(none)";
-
-/// Build a full-screen content block for creating a new issue.
-///
-/// Every field of the form is summarised here, so text the user already typed
-/// stays on screen once focus moves on (issue #693): the embedded `TextBox`
-/// only ever shows the *focused* field, which made a typed subject appear to
-/// vanish the moment Enter advanced focus to the body.
-///
-/// The editable text itself is still rendered by that wrapping `TextBox`
-/// (issue #212); these rows are a read-only summary and own no cursor.
-#[must_use]
-pub fn build_new_issue_content(form: Option<&NewIssueFormState>) -> DetailContent {
-    let mut builder = ContentBuilder::new();
-
-    builder.lines.push("New Issue".to_string());
-    if let Some(form) = form {
-        push_new_issue_form_rows(&mut builder.lines, form);
-    }
-    builder.lines.push(String::new());
-
-    builder.lines.push("[Composer input]".to_string());
-    builder.finish()
-}
-
-/// One row per New Issue field, in Tab order, with the focused row marked.
-fn push_new_issue_form_rows(rows: &mut Vec<String>, form: &NewIssueFormState) {
-    push_new_issue_field(
-        rows,
-        form,
-        NewIssueFormFocus::Template,
-        "Template",
-        form.template.label(),
-    );
-    push_new_issue_field(
-        rows,
-        form,
-        NewIssueFormFocus::Type,
-        "Type",
-        &optional_new_issue_value(form.type_name.as_deref()),
-    );
-    push_new_issue_field(
-        rows,
-        form,
-        NewIssueFormFocus::Title,
-        "Title",
-        &form.title_text,
-    );
-    push_new_issue_body_rows(rows, form);
-    push_new_issue_field(
-        rows,
-        form,
-        NewIssueFormFocus::Labels,
-        "Labels",
-        &joined_new_issue_values(&form.labels),
-    );
-    push_new_issue_field(
-        rows,
-        form,
-        NewIssueFormFocus::Milestone,
-        "Milestone",
-        &optional_new_issue_value(form.milestone.as_deref()),
-    );
-    push_new_issue_field(
-        rows,
-        form,
-        NewIssueFormFocus::Project,
-        "Project",
-        &joined_new_issue_values(&form.project_ids),
-    );
-    push_new_issue_field(
-        rows,
-        form,
-        NewIssueFormFocus::Assignees,
-        "Assignees",
-        &joined_new_issue_values(&form.assignees),
-    );
-}
-
-/// Push one labelled single-line field row.
-fn push_new_issue_field(
-    rows: &mut Vec<String>,
-    form: &NewIssueFormState,
-    focus: NewIssueFormFocus,
-    label: &str,
-    value: &str,
-) {
-    let marker = new_issue_focus_marker(form, focus);
-    rows.push(format!("{marker}{label}: {value}").trim_end().to_string());
-}
-
-/// Push the body field, one row per logical line, continuations aligned under
-/// the label so a multi-line draft still reads as one field.
-fn push_new_issue_body_rows(rows: &mut Vec<String>, form: &NewIssueFormState) {
-    let marker = new_issue_focus_marker(form, NewIssueFormFocus::Body);
-    let label = "Body: ";
-    let indent = " ".repeat(marker.len() + label.len());
-    let mut lines = form.body_text.split('\n');
-    let first = lines.next().unwrap_or_default();
-    rows.push(format!("{marker}{label}{first}").trim_end().to_string());
-    for line in lines {
-        rows.push(format!("{indent}{line}").trim_end().to_string());
-    }
-}
-
-/// `"> "` for the focused field, `"  "` otherwise — the marker convention this
-/// module already uses for issue-detail subfocus.
-fn new_issue_focus_marker(form: &NewIssueFormState, focus: NewIssueFormFocus) -> &'static str {
-    if form.focus == focus { "> " } else { "  " }
-}
-
-/// Render an optional field value, or the unset placeholder.
-fn optional_new_issue_value(value: Option<&str>) -> String {
-    value
-        .filter(|value| !value.is_empty())
-        .unwrap_or(NEW_ISSUE_UNSET)
-        .to_string()
-}
-
-/// Render a multi-value field, or the unset placeholder when it is empty.
-fn joined_new_issue_values(values: &[String]) -> String {
-    if values.is_empty() {
-        NEW_ISSUE_UNSET.to_string()
-    } else {
-        values.join(", ")
-    }
 }
 
 fn build_detail_lines(
@@ -840,7 +714,3 @@ comment 1 line 2",
         );
     }
 }
-
-#[cfg(test)]
-#[path = "issue_detail_content_new_issue_tests.rs"]
-mod new_issue_tests;

--- a/src/issue_detail_content_new_issue.rs
+++ b/src/issue_detail_content_new_issue.rs
@@ -1,0 +1,142 @@
+//! The New Issue document projection (issue #693).
+//!
+//! The pane used to render a fixed four-line prompt plus one embedded `TextBox`
+//! that only ever showed the *focused* field, so a typed subject vanished the
+//! moment focus advanced to the body. Summarising every field here keeps what
+//! the user typed on screen.
+
+use super::{ContentBuilder, DetailContent};
+use crate::state::{NewIssueFormFocus, NewIssueFormState};
+
+/// Placeholder for an optional New Issue field the user has not set yet.
+const NEW_ISSUE_UNSET: &str = "(none)";
+
+/// Build a full-screen content block for creating a new issue.
+///
+/// Every field of the form is summarised here, so text the user already typed
+/// stays on screen once focus moves on (issue #693): the embedded `TextBox`
+/// only ever shows the *focused* field, which made a typed subject appear to
+/// vanish the moment Enter advanced focus to the body.
+///
+/// The editable text itself is still rendered by that wrapping `TextBox`
+/// (issue #212); these rows are a read-only summary and own no cursor.
+#[must_use]
+pub fn build_new_issue_content(form: Option<&NewIssueFormState>) -> DetailContent {
+    let mut builder = ContentBuilder::new();
+
+    builder.lines.push("New Issue".to_string());
+    if let Some(form) = form {
+        push_new_issue_form_rows(&mut builder.lines, form);
+    }
+    builder.lines.push(String::new());
+
+    builder.lines.push("[Composer input]".to_string());
+    builder.finish()
+}
+
+/// One row per New Issue field, in Tab order, with the focused row marked.
+fn push_new_issue_form_rows(rows: &mut Vec<String>, form: &NewIssueFormState) {
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Template,
+        "Template",
+        form.template.label(),
+    );
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Type,
+        "Type",
+        &optional_new_issue_value(form.type_name.as_deref()),
+    );
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Title,
+        "Title",
+        &form.title_text,
+    );
+    push_new_issue_body_rows(rows, form);
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Labels,
+        "Labels",
+        &joined_new_issue_values(&form.labels),
+    );
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Milestone,
+        "Milestone",
+        &optional_new_issue_value(form.milestone.as_deref()),
+    );
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Project,
+        "Project",
+        &joined_new_issue_values(&form.project_ids),
+    );
+    push_new_issue_field(
+        rows,
+        form,
+        NewIssueFormFocus::Assignees,
+        "Assignees",
+        &joined_new_issue_values(&form.assignees),
+    );
+}
+
+/// Push one labelled single-line field row.
+fn push_new_issue_field(
+    rows: &mut Vec<String>,
+    form: &NewIssueFormState,
+    focus: NewIssueFormFocus,
+    label: &str,
+    value: &str,
+) {
+    let marker = new_issue_focus_marker(form, focus);
+    rows.push(format!("{marker}{label}: {value}").trim_end().to_string());
+}
+
+/// Push the body field, one row per logical line, continuations aligned under
+/// the label so a multi-line draft still reads as one field.
+fn push_new_issue_body_rows(rows: &mut Vec<String>, form: &NewIssueFormState) {
+    let marker = new_issue_focus_marker(form, NewIssueFormFocus::Body);
+    let label = "Body: ";
+    let indent = " ".repeat(marker.len() + label.len());
+    let mut lines = form.body_text.split('\n');
+    let first = lines.next().unwrap_or_default();
+    rows.push(format!("{marker}{label}{first}").trim_end().to_string());
+    for line in lines {
+        rows.push(format!("{indent}{line}").trim_end().to_string());
+    }
+}
+
+/// `"> "` for the focused field, `"  "` otherwise — the marker convention the
+/// parent module already uses for issue-detail subfocus.
+fn new_issue_focus_marker(form: &NewIssueFormState, focus: NewIssueFormFocus) -> &'static str {
+    if form.focus == focus { "> " } else { "  " }
+}
+
+/// Render an optional field value, or the unset placeholder.
+fn optional_new_issue_value(value: Option<&str>) -> String {
+    value
+        .filter(|value| !value.is_empty())
+        .unwrap_or(NEW_ISSUE_UNSET)
+        .to_string()
+}
+
+/// Render a multi-value field, or the unset placeholder when it is empty.
+fn joined_new_issue_values(values: &[String]) -> String {
+    if values.is_empty() {
+        NEW_ISSUE_UNSET.to_string()
+    } else {
+        values.join(", ")
+    }
+}
+
+#[cfg(test)]
+#[path = "issue_detail_content_new_issue_tests.rs"]
+mod tests;

--- a/src/issue_detail_content_new_issue_tests.rs
+++ b/src/issue_detail_content_new_issue_tests.rs
@@ -1,0 +1,259 @@
+//! Behavioral tests for the New Issue document projection (issue #693).
+//!
+//! The New Issue form has eight fields but the pane used to render a fixed
+//! four-line prompt plus one composer showing only the *focused* field. Typing
+//! a subject and then advancing focus made the subject disappear even though it
+//! was still stored and still became the created issue's title. These tests
+//! pin the document to the form so every field stays visible.
+
+use super::build_new_issue_content;
+use crate::state::{NewIssueFormFocus, NewIssueFormState};
+
+/// Every focus value, so a test can prove a field survives any focus change.
+const ALL_FOCUS: [NewIssueFormFocus; 8] = [
+    NewIssueFormFocus::Template,
+    NewIssueFormFocus::Type,
+    NewIssueFormFocus::Title,
+    NewIssueFormFocus::Body,
+    NewIssueFormFocus::Labels,
+    NewIssueFormFocus::Milestone,
+    NewIssueFormFocus::Project,
+    NewIssueFormFocus::Assignees,
+];
+
+fn form_with_title(title: &str, focus: NewIssueFormFocus) -> NewIssueFormState {
+    NewIssueFormState {
+        title_text: title.to_string(),
+        title_cursor: title.chars().count(),
+        focus,
+        ..NewIssueFormState::default()
+    }
+}
+
+fn lines(form: Option<&NewIssueFormState>) -> Vec<String> {
+    build_new_issue_content(form)
+        .text
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+/// A1 — the reported bug. The subject is typed on Title, focus advances (bare
+/// Enter dispatches `NewIssueFocusNext`, issue #480), and the subject must
+/// still be on screen for every focus the user can reach.
+#[test]
+fn typed_title_stays_visible_for_every_focus() {
+    for focus in ALL_FOCUS {
+        let form = form_with_title("Fix the widget", focus);
+        let rendered = build_new_issue_content(Some(&form)).text;
+        assert!(
+            rendered.contains("Title: Fix the widget"),
+            "the typed title must stay visible with focus {focus:?}: {rendered}"
+        );
+    }
+}
+
+/// A2 — the same guarantee for the body: typed body text stays visible after
+/// focus moves on to the picker fields.
+#[test]
+fn typed_body_stays_visible_for_every_focus() {
+    for focus in ALL_FOCUS {
+        let form = NewIssueFormState {
+            body_text: "steps to reproduce".to_string(),
+            focus,
+            ..NewIssueFormState::default()
+        };
+        let rendered = build_new_issue_content(Some(&form)).text;
+        assert!(
+            rendered.contains("Body: steps to reproduce"),
+            "the typed body must stay visible with focus {focus:?}: {rendered}"
+        );
+    }
+}
+
+/// A2 — a multi-line body renders one row per line, with continuation rows
+/// indented under the label so the block reads as one field.
+#[test]
+fn multi_line_body_renders_indented_continuation_rows() {
+    let form = NewIssueFormState {
+        body_text: "first line\nsecond line".to_string(),
+        focus: NewIssueFormFocus::Body,
+        ..NewIssueFormState::default()
+    };
+    let rendered = lines(Some(&form));
+    assert!(
+        rendered.iter().any(|line| line == "> Body: first line"),
+        "focused body must render its first line: {rendered:?}"
+    );
+    assert!(
+        rendered.iter().any(|line| line == "        second line"),
+        "body continuation must align under the label: {rendered:?}"
+    );
+}
+
+/// A2 — an empty body still renders its labelled row, so Tab order and the
+/// document line count stay stable while the user types.
+#[test]
+fn empty_body_still_renders_its_row() {
+    let form = NewIssueFormState::default();
+    let rendered = lines(Some(&form));
+    assert!(
+        rendered.iter().any(|line| line == "  Body:"),
+        "an empty body keeps a labelled row: {rendered:?}"
+    );
+}
+
+/// A3 — exactly one field row is marked as focused, and it is the focused one.
+#[test]
+fn exactly_one_row_is_marked_focused() {
+    for focus in ALL_FOCUS {
+        let form = form_with_title("subject", focus);
+        let rendered = lines(Some(&form));
+        let marked = rendered
+            .iter()
+            .filter(|line| line.starts_with("> "))
+            .count();
+        assert_eq!(
+            marked, 1,
+            "exactly one row must be marked focused for {focus:?}: {rendered:?}"
+        );
+    }
+}
+
+/// A3 — the focus marker tracks the field the user is editing.
+#[test]
+fn the_focus_marker_names_the_focused_field() {
+    let cases = [
+        (NewIssueFormFocus::Template, "> Template:"),
+        (NewIssueFormFocus::Type, "> Type:"),
+        (NewIssueFormFocus::Title, "> Title:"),
+        (NewIssueFormFocus::Body, "> Body:"),
+        (NewIssueFormFocus::Labels, "> Labels:"),
+        (NewIssueFormFocus::Milestone, "> Milestone:"),
+        (NewIssueFormFocus::Project, "> Project:"),
+        (NewIssueFormFocus::Assignees, "> Assignees:"),
+    ];
+    for (focus, expected_prefix) in cases {
+        let form = NewIssueFormState {
+            focus,
+            ..NewIssueFormState::default()
+        };
+        let rendered = lines(Some(&form));
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line.starts_with(expected_prefix)),
+            "focus {focus:?} must mark {expected_prefix}: {rendered:?}"
+        );
+    }
+}
+
+/// A4 — unset optional fields render a stable placeholder instead of a ragged
+/// empty row, so the form reads as a list of decisions still to make.
+#[test]
+fn unset_optional_fields_render_a_placeholder() {
+    let form = NewIssueFormState::default();
+    let rendered = lines(Some(&form));
+    for expected in [
+        "  Type: (none)",
+        "  Labels: (none)",
+        "  Milestone: (none)",
+        "  Project: (none)",
+        "  Assignees: (none)",
+    ] {
+        assert!(
+            rendered.iter().any(|line| line == expected),
+            "missing placeholder row {expected}: {rendered:?}"
+        );
+    }
+}
+
+/// A4 — set optional fields render their values rather than the placeholder.
+#[test]
+fn set_optional_fields_render_their_values() {
+    let form = NewIssueFormState {
+        type_name: Some("Bug".to_string()),
+        labels: vec!["bug".to_string(), "ui".to_string()],
+        milestone: Some("v1.2".to_string()),
+        project_ids: vec!["PVT_1".to_string()],
+        assignees: vec!["acoliver".to_string()],
+        ..NewIssueFormState::default()
+    };
+    let rendered = lines(Some(&form));
+    for expected in [
+        "  Type: Bug",
+        "  Labels: bug, ui",
+        "  Milestone: v1.2",
+        "  Project: PVT_1",
+        "  Assignees: acoliver",
+    ] {
+        assert!(
+            rendered.iter().any(|line| line == expected),
+            "missing value row {expected}: {rendered:?}"
+        );
+    }
+}
+
+/// A4 — the template choice is shown by its human label.
+#[test]
+fn the_template_row_shows_the_selected_template_label() {
+    let form = NewIssueFormState {
+        template: crate::state::NewIssueTemplate::Bug,
+        focus: NewIssueFormFocus::Title,
+        ..NewIssueFormState::default()
+    };
+    let rendered = lines(Some(&form));
+    assert!(
+        rendered.iter().any(|line| line == "  Template: Bug"),
+        "the template row must name the selection: {rendered:?}"
+    );
+}
+
+/// A5 — rendered rows stay emoji-free ASCII, as the New PR composer does.
+#[test]
+fn the_new_issue_document_is_emoji_free() {
+    let form = form_with_title("subject", NewIssueFormFocus::Title);
+    let rendered = build_new_issue_content(Some(&form)).text;
+    assert!(
+        rendered.is_ascii(),
+        "the New Issue document must stay ASCII: {rendered}"
+    );
+}
+
+/// A8 — the composer anchor stays, because the editable text is still rendered
+/// by the embedded wrapping `TextBox` (issue #212); the document must not
+/// flatten a cursor of its own.
+#[test]
+fn the_document_keeps_the_composer_anchor_and_owns_no_cursor() {
+    let form = form_with_title("subject", NewIssueFormFocus::Title);
+    let content = build_new_issue_content(Some(&form));
+    assert!(
+        content.text.contains("[Composer input]"),
+        "the composer anchor must remain: {}",
+        content.text
+    );
+    assert!(
+        content.cursor.is_none(),
+        "the caret belongs to the embedded TextBox, not the document"
+    );
+}
+
+/// A8 — with no form open the document degrades to the bare prompt rather than
+/// panicking or rendering stale field rows.
+#[test]
+fn without_a_form_only_the_prompt_and_anchor_render() {
+    let rendered = lines(None);
+    assert_eq!(
+        rendered.first().map(String::as_str),
+        Some("New Issue"),
+        "the prompt header must lead: {rendered:?}"
+    );
+    assert!(
+        rendered.iter().any(|line| line == "[Composer input]"),
+        "the composer anchor must remain without a form: {rendered:?}"
+    );
+    assert!(
+        !rendered.iter().any(|line| line.contains("Title:")),
+        "no field rows may render without a form: {rendered:?}"
+    );
+}

--- a/src/issue_detail_content_new_issue_tests.rs
+++ b/src/issue_detail_content_new_issue_tests.rs
@@ -211,7 +211,7 @@ fn the_template_row_shows_the_selected_template_label() {
 
 /// A5 — rendered rows stay emoji-free ASCII, as the New PR composer does.
 #[test]
-fn the_new_issue_document_is_emoji_free() {
+fn the_new_issue_document_is_ascii_only() {
     let form = form_with_title("subject", NewIssueFormFocus::Title);
     let rendered = build_new_issue_content(Some(&form)).text;
     assert!(

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -157,7 +157,9 @@ fn build_header_rows(
 
 /// Resolve the content + header for the "new issue composer" branch (title
 /// "New Issue", state "Draft", bright state color).
-fn new_issue_composer_content(inline_state: &InlineState) -> (Vec<DetailHeaderRow>, DetailContent) {
+fn new_issue_composer_content(
+    form: Option<&crate::state::NewIssueFormState>,
+) -> (Vec<DetailHeaderRow>, DetailContent) {
     let rows = build_header_rows(
         "New Issue".to_string(),
         "Draft".to_string(),
@@ -165,7 +167,7 @@ fn new_issue_composer_content(inline_state: &InlineState) -> (Vec<DetailHeaderRo
         String::new(),
         DetailHeaderColor::Bright,
     );
-    (rows, build_new_issue_content(inline_state))
+    (rows, build_new_issue_content(form))
 }
 
 /// Resolve the content + header for a loaded issue detail.
@@ -263,7 +265,7 @@ pub fn issue_detail_props(inputs: IssueDetailProjectionInputs<'_>) -> DetailPane
     let content_width = detail_content_width(inputs.available_width);
 
     let (header_rows, detail_content) = if showing_new_issue_composer {
-        new_issue_composer_content(inputs.inline_state)
+        new_issue_composer_content(inputs.new_issue_form)
     } else if let Some(detail) = inputs.issue_detail {
         loaded_issue_content(
             detail,
@@ -349,7 +351,6 @@ fn new_issue_composer_from_form(
 mod tests {
     use super::{DetailContent, build_new_issue_content, issue_detail_header_view};
     use crate::domain::{IssueDetail, IssueState, IssueStateReason};
-    use crate::state::{ComposerTarget, InlineState};
 
     fn detail_with_state(state: IssueState, state_reason: Option<IssueStateReason>) -> IssueDetail {
         IssueDetail {
@@ -424,26 +425,16 @@ mod tests {
         assert!(view.state.contains("OPEN"));
     }
 
+    /// Without a form there is nothing to summarise, so the document is just
+    /// the prompt and the composer anchor — and the stale inline draft text is
+    /// still never flattened into it (issue #212).
     #[test]
-    fn build_new_issue_content_renders_static_prompt_only() {
-        let inline = InlineState::Composer {
-            target: ComposerTarget::NewIssue,
-            text: "Issue title\nIssue body".to_string(),
-            cursor: "Issue title\nIssue body".len(),
-        };
-
-        let DetailContent { text, cursor } = build_new_issue_content(&inline);
+    fn build_new_issue_content_without_a_form_renders_prompt_and_anchor() {
+        let DetailContent { text, cursor } = build_new_issue_content(None);
 
         assert!(text.contains("New Issue"));
-        assert!(text.contains("Title: first line | Body: remaining lines"));
         assert!(text.contains("[Composer input]"));
         assert!(!text.contains("Alt+Enter submit"));
-        // The editor text is rendered by the embedded wrapping TextBox, so it
-        // must NOT be flattened into the read-only document (issue #212).
-        assert!(
-            !text.contains("Issue title"),
-            "editor text must not be flattened into the document: {text}"
-        );
         assert!(
             cursor.is_none(),
             "the TextBox owns the caret; the document must carry no cursor"

--- a/src/ui/components/issue_detail_render_tests.rs
+++ b/src/ui/components/issue_detail_render_tests.rs
@@ -514,3 +514,72 @@ fn new_issue_composer_renders_focused_form_field_text() {
         "new-issue composer must render the typed body text: {rendered_body}"
     );
 }
+
+/// Regression for issue #693: the reported "swallowed" subject. The user types
+/// a title and presses Enter, which advances focus to Body (issue #480). The
+/// embedded TextBox then shows the *body*, so before this fix the typed title
+/// disappeared from the screen even though it was still stored and still became
+/// the created issue's subject. The rendered pane must keep showing it.
+#[test]
+fn typed_new_issue_title_stays_rendered_after_focus_advances_to_body() {
+    let detail = issue_detail_with_comment();
+    let inline = InlineState::Composer {
+        target: ComposerTarget::NewIssue,
+        text: String::new(),
+        cursor: 0,
+    };
+    let form = NewIssueFormState {
+        title_text: "HelloTitle".to_string(),
+        title_cursor: "HelloTitle".chars().count(),
+        focus: NewIssueFormFocus::Body,
+        ..NewIssueFormState::default()
+    };
+    let rendered = render_detail(RenderParams {
+        detail: &detail,
+        subfocus: DetailSubfocus::Body,
+        inline_state: &inline,
+        new_issue_form: Some(&form),
+        scroll_offset: 0,
+        pane_height: 24,
+        cols: 80,
+    });
+    assert!(
+        rendered.contains("HelloTitle"),
+        "the typed title must stay visible once focus advances to the body: {rendered}"
+    );
+}
+
+/// Companion to the regression above: a typed body must likewise survive focus
+/// moving on to a picker field, so no field is left with the same defect.
+#[test]
+fn typed_new_issue_body_stays_rendered_after_focus_advances_to_labels() {
+    let detail = issue_detail_with_comment();
+    let inline = InlineState::Composer {
+        target: ComposerTarget::NewIssue,
+        text: String::new(),
+        cursor: 0,
+    };
+    let form = NewIssueFormState {
+        title_text: "HelloTitle".to_string(),
+        body_text: "BodyLineOne".to_string(),
+        focus: NewIssueFormFocus::Labels,
+        ..NewIssueFormState::default()
+    };
+    let rendered = render_detail(RenderParams {
+        detail: &detail,
+        subfocus: DetailSubfocus::Body,
+        inline_state: &inline,
+        new_issue_form: Some(&form),
+        scroll_offset: 0,
+        pane_height: 24,
+        cols: 80,
+    });
+    assert!(
+        rendered.contains("HelloTitle"),
+        "the typed title must stay visible on a picker field: {rendered}"
+    );
+    assert!(
+        rendered.contains("BodyLineOne"),
+        "the typed body must stay visible on a picker field: {rendered}"
+    );
+}

--- a/tests/text_box_layout.rs
+++ b/tests/text_box_layout.rs
@@ -7,11 +7,12 @@ use jefe::ui::components::{IssueDetailProjectionInputs, issue_detail_props};
 
 /// The New Issue composer is only ever open alongside a form, and the document
 /// summarises that form's fields (issue #693), so the layout contract is
-/// measured against a form whose title is long enough to wrap when narrow.
+/// measured against a form carrying real text. The title is deliberately short
+/// enough that no row wraps at the wide width and long enough that it must wrap
+/// at the narrow one, which is exactly what the two widths are contrasting.
 fn new_issue_form() -> NewIssueFormState {
     NewIssueFormState {
-        title_text: "a fairly long new issue subject that has to wrap when the pane is narrow"
-            .to_string(),
+        title_text: "a subject that wraps when narrow".to_string(),
         ..NewIssueFormState::default()
     }
 }

--- a/tests/text_box_layout.rs
+++ b/tests/text_box_layout.rs
@@ -1,9 +1,20 @@
 //! Behavioral layout contracts for parent-sized text boxes (issue #408).
 
-use jefe::state::{ComposerTarget, DetailSubfocus, InlineState};
+use jefe::state::{ComposerTarget, DetailSubfocus, InlineState, NewIssueFormState};
 use jefe::text_box_view::build_text_box_view;
 use jefe::theme::ThemeColors;
 use jefe::ui::components::{IssueDetailProjectionInputs, issue_detail_props};
+
+/// The New Issue composer is only ever open alongside a form, and the document
+/// summarises that form's fields (issue #693), so the layout contract is
+/// measured against a form whose title is long enough to wrap when narrow.
+fn new_issue_form() -> NewIssueFormState {
+    NewIssueFormState {
+        title_text: "a fairly long new issue subject that has to wrap when the pane is narrow"
+            .to_string(),
+        ..NewIssueFormState::default()
+    }
+}
 
 fn new_issue_props(pane_height: u16) -> jefe::ui::components::DetailPaneProps {
     new_issue_props_at_width(pane_height, 80)
@@ -18,11 +29,12 @@ fn new_issue_props_at_width(
         text: String::new(),
         cursor: 0,
     };
+    let form = new_issue_form();
     issue_detail_props(IssueDetailProjectionInputs {
         issue_detail: None,
         detail_subfocus: DetailSubfocus::Body,
         inline_state: &inline,
-        new_issue_form: None,
+        new_issue_form: Some(&form),
         comments_loading: false,
         focused: true,
         scroll_offset: 0,
@@ -38,7 +50,8 @@ fn new_issue_composer_uses_all_rows_after_static_guidance() {
     let pane_height = 28;
     let props = new_issue_props(pane_height);
     let body_rows = jefe::layout::detail_body_viewport_rows(usize::from(pane_height));
-    let guidance_rows = jefe::issue_detail_content::build_new_issue_content(&InlineState::None)
+    let form = new_issue_form();
+    let guidance_rows = jefe::issue_detail_content::build_new_issue_content(Some(&form))
         .text
         .lines()
         .count()
@@ -68,12 +81,12 @@ fn narrow_new_issue_reserves_wrapped_guidance_rows() {
     let pane_height = 28;
     let props = new_issue_props_at_width(pane_height, 20);
     let body_rows = jefe::layout::detail_body_viewport_rows(usize::from(pane_height));
-    let logical_guidance_rows =
-        jefe::issue_detail_content::build_new_issue_content(&InlineState::None)
-            .text
-            .lines()
-            .count()
-            .max(1);
+    let form = new_issue_form();
+    let logical_guidance_rows = jefe::issue_detail_content::build_new_issue_content(Some(&form))
+        .text
+        .lines()
+        .count()
+        .max(1);
 
     assert!(
         props.viewport_rows > logical_guidance_rows,


### PR DESCRIPTION
Fixes #693.

## The report

> When I typed that subject the first time it went away.. I hit enter and typed it again. [...] apparently the first line doesn't go away it just isn't visible after you type it...it does become the subject....but disappearing is confusing.

## Root cause

The New Issue pane rendered two things: a fixed four-line prompt document (`build_new_issue_content`, which ignored the form entirely) and one embedded `TextBox`. That `TextBox` is fed by `new_issue_composer_from_form`, which returns **only the currently focused field's** text.

The form opens focused on Title (#454). Bare Enter on Title dispatches `NewIssueFocusNext` (#480), moving focus to Body. The composer then renders the empty `body_text`, so the typed title disappeared from the screen — even though `form.title_text` still held it and it still became the created issue's subject. That matches the report exactly, including "it does become the subject".

This is platform-independent; the "not on Mac" detail is incidental, and no Windows-specific input defect is involved. No key handling, event, or reducer code is touched.

## The fix

`build_new_issue_content` now takes `Option<&NewIssueFormState>` instead of `&InlineState` and emits one read-only summary row per field, in Tab order:

```
New Issue
  Template: Blank
  Type: (none)
> Title: HelloTitle
  Body: first line
        second line
  Labels: (none)
  Milestone: (none)
  Project: (none)
  Assignees: (none)

[Composer input]
```

- The focused row is marked `> `, matching the marker convention this module already uses for issue-detail subfocus; every other row gets `  `.
- Unset optional fields render `(none)`; multi-value fields join with `, `.
- Multi-line bodies get continuation rows aligned under the label.
- The embedded `TextBox` keeps ownership of the editable text and the caret (#212), so the document still returns `cursor: None` and editing behaviour is unchanged.

This follows the existing in-repo pattern for a multi-field composer projection, `new_pr_form_rows` in `src/ui/components/new_pr_form.rs`.

## Tests

- `src/issue_detail_content_new_issue_tests.rs` (new, 12 tests) — pure projection: the typed title stays in the document for *every* focus value, likewise the body; continuation rows; exactly one focused marker; placeholders; ASCII-only rows; the anchor is kept and the document owns no cursor.
- `src/ui/components/issue_detail_render_tests.rs` — two regression tests through the real render path: the typed title is still rendered once focus advances to Body, and title + body are both still rendered once focus advances to Labels.
- `dev-docs/tmux-scenarios/issues-new-issue-typing.json` — the scenario typed a title, pressed Tab, typed a body, and never re-asserted the title. Added the missing `assert-frame` for `HelloTitle` after the body lines, which is precisely the #693 regression.

## Verification

- `cargo fmt --all --check` — pass.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — pass, no diagnostics.
- `cargo test --workspace --all-features --locked` — all lib/unit suites green; integration reports `421 passed; 1 failed`.
- `cargo xtask ci` — fmt, clippy-allows, source-size, architecture, multiplexer-surface, lint and complexity pass.

The one integration failure is `ui::dashboard_reorder_tui::guarded_dashboard_reorder_tui_scenario` (`HarnessError E006`). It reproduces on a clean `git stash -u` tree at the same merge base, so it is pre-existing and unrelated; it is the sole reason the coverage gate exits non-zero. Recorded as a deferred finding rather than fixed here.

## Scope

Non-goals held: no keymap, event, or reducer changes; picker fields are not made editable; `new_issue_composer_from_form`'s picker→Title fallback is unchanged; `form.error` surfacing and the New PR form are untouched.
